### PR TITLE
Columns block: Add stack on mobile setting to allow for columns without mobile breakpoints

### DIFF
--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -8,6 +8,10 @@
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"
+		},
+		"isStackedOnMobile": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/columns/deprecated.js
+++ b/packages/block-library/src/columns/deprecated.js
@@ -52,6 +52,7 @@ const migrateCustomColors = ( attributes ) => {
 	return {
 		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
 		style,
+		isStackedOnMobile: true,
 	};
 };
 
@@ -166,7 +167,13 @@ export default [
 				createBlock( 'core/column', {}, columnBlocks )
 			);
 
-			return [ omit( attributes, [ 'columns' ] ), migratedInnerBlocks ];
+			return [
+				{
+					...omit( attributes, [ 'columns' ] ),
+					isStackedOnMobile: true,
+				},
+				migratedInnerBlocks,
+			];
 		},
 		save( { attributes } ) {
 			const { columns } = attributes;
@@ -186,7 +193,10 @@ export default [
 			},
 		},
 		migrate( attributes, innerBlocks ) {
-			attributes = omit( attributes, [ 'columns' ] );
+			attributes = {
+				...omit( attributes, [ 'columns' ] ),
+				isStackedOnMobile: true,
+			};
 
 			return [ attributes, innerBlocks ];
 		},

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -8,7 +8,12 @@ import { dropRight, get, times } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, RangeControl, Notice } from '@wordpress/components';
+import {
+	Notice,
+	PanelBody,
+	RangeControl,
+	ToggleControl,
+} from '@wordpress/components';
 
 import {
 	InspectorControls,
@@ -49,11 +54,12 @@ const ALLOWED_BLOCKS = [ 'core/column' ];
 
 function ColumnsEditContainer( {
 	attributes,
+	setAttributes,
 	updateAlignment,
 	updateColumns,
 	clientId,
 } ) {
-	const { verticalAlignment } = attributes;
+	const { isStackedOnMobile, verticalAlignment } = attributes;
 
 	const { count } = useSelect(
 		( select ) => {
@@ -66,6 +72,7 @@ function ColumnsEditContainer( {
 
 	const classes = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
 	} );
 
 	const blockProps = useBlockProps( {
@@ -101,6 +108,15 @@ function ColumnsEditContainer( {
 							) }
 						</Notice>
 					) }
+					<ToggleControl
+						label={ __( 'Stack on mobile' ) }
+						checked={ isStackedOnMobile }
+						onChange={ () =>
+							setAttributes( {
+								isStackedOnMobile: ! isStackedOnMobile,
+							} )
+						}
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,10 +9,11 @@ import classnames from 'classnames';
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { verticalAlignment } = attributes;
+	const { isStackedOnMobile, verticalAlignment } = attributes;
 
 	const className = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
 	} );
 
 	return (

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -79,20 +79,24 @@
 		}
 	}
 
-	&.is-not-stacked-on-mobile > .wp-block-column {
-		// Available space should be divided equally amongst columns.
-		flex-basis: 0;
-		flex-grow: 1;
+	&.is-not-stacked-on-mobile {
+		flex-wrap: nowrap;
 
-		// Columns with an explicitly-assigned width should maintain their
-		// `flex-basis` width and not grow.
-		&[style*="flex-basis"] {
-			flex-grow: 0;
-		}
+		> .wp-block-column {
+			// Available space should be divided equally amongst columns.
+			flex-basis: 0;
+			flex-grow: 1;
 
-		// When columns are in a single row, add space before all except the first.
-		&:not(:first-child) {
-			margin-left: 2em;
+			// Columns with an explicitly-assigned width should maintain their
+			// `flex-basis` width and not grow.
+			&[style*="flex-basis"] {
+				flex-grow: 0;
+			}
+
+			// When columns are in a single row, add space before all except the first.
+			&:not(:first-child) {
+				margin-left: 2em;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -28,51 +28,59 @@
 	&.are-vertically-aligned-bottom {
 		align-items: flex-end;
 	}
-}
 
-.wp-block-column {
-	flex-grow: 1;
-
-	@media (max-width: #{ ($break-small - 1) }) {
-		// Responsiveness: Show at most one columns on mobile. This must be
-		// important since the Column assigns its own width as an inline style.
-		flex-basis: 100% !important;
-	}
-
-	// Prevent the columns from growing wider than their distributed sizes.
-	min-width: 0;
-
-	// Prevent long unbroken words from overflowing.
-	word-break: break-word; // For back-compat.
-	overflow-wrap: break-word; // New standard.
-
-	// Between mobile and large viewports, allow 2 columns.
-	@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
-		// Only add two column styling if there are two or more columns
-		&:not(:only-child) {
-			// As with mobile styles, this must be important since the Column
-			// assigns its own width as an inline style, which should take effect
-			// starting at `break-medium`.
-			flex-basis: calc(50% - 1em) !important;
-			flex-grow: 0;
+	&:not(.is-not-stacked-on-mobile) .wp-block-column {
+		@media (max-width: #{ ($break-small - 1) }) {
+			// Responsiveness: Show at most one columns on mobile. This must be
+			// important since the Column assigns its own width as an inline style.
+			flex-basis: 100% !important;
 		}
 
-		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
-		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-		&:nth-child(even) {
-			margin-left: 2em;
+		// Between mobile and large viewports, allow 2 columns.
+		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+			// Only add two column styling if there are two or more columns
+			&:not(:only-child) {
+				// As with mobile styles, this must be important since the Column
+				// assigns its own width as an inline style, which should take effect
+				// starting at `break-medium`.
+				flex-basis: calc(50% - 1em) !important;
+				flex-grow: 0;
+			}
+
+			// Add space between the multiple columns. Themes can customize this if they wish to work differently.
+			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+			&:nth-child(even) {
+				margin-left: 2em;
+			}
+		}
+
+		// At large viewports, show all columns horizontally.
+		@include break-medium() {
+			// Available space should be divided equally amongst columns without an
+			// assigned width. This is achieved by assigning a flex basis that is
+			// consistent (equal), would not cause the sum total of column widths to
+			// exceed 100%, and which would cede to a column with an assigned width.
+			// The `flex-grow` allows columns to maximally and equally occupy space
+			// remaining after subtracting the space occupied by columns with
+			// explicit widths (if any exist).
+			flex-basis: 0;
+			flex-grow: 1;
+
+			// Columns with an explicitly-assigned width should maintain their
+			// `flex-basis` width and not grow.
+			&[style*="flex-basis"] {
+				flex-grow: 0;
+			}
+
+			// When columns are in a single row, add space before all except the first.
+			&:not(:first-child) {
+				margin-left: 2em;
+			}
 		}
 	}
 
-	// At large viewports, show all columns horizontally.
-	@include break-medium() {
-		// Available space should be divided equally amongst columns without an
-		// assigned width. This is achieved by assigning a flex basis that is
-		// consistent (equal), would not cause the sum total of column widths to
-		// exceed 100%, and which would cede to a column with an assigned width.
-		// The `flex-grow` allows columns to maximally and equally occupy space
-		// remaining after subtracting the space occupied by columns with
-		// explicit widths (if any exist).
+	&.is-not-stacked-on-mobile .wp-block-column {
+		// Available space should be divided equally amongst columns.
 		flex-basis: 0;
 		flex-grow: 1;
 
@@ -87,6 +95,17 @@
 			margin-left: 2em;
 		}
 	}
+}
+
+.wp-block-column {
+	flex-grow: 1;
+
+	// Prevent the columns from growing wider than their distributed sizes.
+	min-width: 0;
+
+	// Prevent long unbroken words from overflowing.
+	word-break: break-word; // For back-compat.
+	overflow-wrap: break-word; // New standard.
 
 	/**
 	* Individual Column Alignment

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -29,7 +29,7 @@
 		align-items: flex-end;
 	}
 
-	&:not(.is-not-stacked-on-mobile) .wp-block-column {
+	&:not(.is-not-stacked-on-mobile) > .wp-block-column {
 		@media (max-width: #{ ($break-small - 1) }) {
 			// Responsiveness: Show at most one columns on mobile. This must be
 			// important since the Column assigns its own width as an inline style.
@@ -79,7 +79,7 @@
 		}
 	}
 
-	&.is-not-stacked-on-mobile .wp-block-column {
+	&.is-not-stacked-on-mobile > .wp-block-column {
 		// Available space should be divided equally amongst columns.
 		flex-basis: 0;
 		flex-grow: 1;

--- a/packages/e2e-tests/fixtures/blocks/core__columns__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__columns__deprecated.json
@@ -3,7 +3,9 @@
 		"clientId": "_clientId_0",
 		"name": "core/columns",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"isStackedOnMobile": true
+		},
 		"innerBlocks": [
 			{
 				"clientId": "_clientId_0",

--- a/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.html
+++ b/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.html
@@ -1,0 +1,24 @@
+<!-- wp:columns {"isStackedOnMobile":false,"backgroundColor":"secondary"} -->
+<div class="wp-block-columns is-not-stacked-on-mobile has-secondary-background-color has-background">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph One</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column One, Paragraph Two</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph -->
+		<p>Column Two, Paragraph One</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>Column Three, Paragraph One</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->

--- a/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.json
+++ b/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.json
@@ -4,7 +4,7 @@
 		"name": "core/columns",
 		"isValid": true,
 		"attributes": {
-			"isStackedOnMobile": true,
+			"isStackedOnMobile": false,
 			"backgroundColor": "secondary"
 		},
 		"innerBlocks": [
@@ -71,6 +71,6 @@
 				"originalContent": "<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>"
 			}
 		],
-		"originalContent": "<div class=\"wp-block-columns has-background has-secondary-background-color\">\n\t\n\t\n</div>"
+		"originalContent": "<div class=\"wp-block-columns is-not-stacked-on-mobile has-secondary-background-color has-background\">\n\t\n\t\n</div>"
 	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.parsed.json
@@ -1,0 +1,83 @@
+[
+	{
+		"blockName": "core/columns",
+		"attrs": {
+			"isStackedOnMobile": false,
+			"backgroundColor": "secondary"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/column",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Column One, Paragraph One</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Column One, Paragraph One</p>\n\t\t"
+						]
+					},
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Column One, Paragraph Two</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Column One, Paragraph Two</p>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-column\">\n\t\t",
+					null,
+					"\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			},
+			{
+				"blockName": "core/column",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Column Two, Paragraph One</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Column Two, Paragraph One</p>\n\t\t"
+						]
+					},
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Column Three, Paragraph One</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Column Three, Paragraph One</p>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div class=\"wp-block-column\">\n\t\t\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-column\">\n\t\t",
+					null,
+					"\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-columns is-not-stacked-on-mobile has-secondary-background-color has-background\">\n\t\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-columns is-not-stacked-on-mobile has-secondary-background-color has-background\">\n\t",
+			null,
+			"\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__columns__is-not-stacked-on-mobile.serialized.html
@@ -1,0 +1,21 @@
+<!-- wp:columns {"isStackedOnMobile":false,"backgroundColor":"secondary"} -->
+<div class="wp-block-columns is-not-stacked-on-mobile has-secondary-background-color has-background"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>Column One, Paragraph One</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Column One, Paragraph Two</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>Column Two, Paragraph One</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Column Three, Paragraph One</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Proposal to fix https://github.com/WordPress/gutenberg/issues/31248

## Description
<!-- Please describe what you have changed or added -->

This PR adds a stack on mobile setting to the Columns block, set to true by default, so that it can be disabled for cases where we don't want the stacked behaviour. Good examples could include logo / social media links in a footer or header.

* Add a "stack on mobile" setting to the Columns block, and default to `true`
* Re-arrange the CSS for the Column block so that it's targeted as a child of the Columns block, and set the mobile breakpoint styling to apply only when the `.is-not-stacked-on-mobile` class isn't present.

There are some double negatives here, which might be confusing to read, however it helps us to ensure that we treat all existing Column(s) blocks as stacked on mobile, by default.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

* Add a couple of columns blocks to a post (e.g. a 2 column block and a 3 column block).
* Test that the existing breakpoints work by default.
* Toggle the `stack on mobile` flag, and check that the `.is-not-stacked-on-mobile` class is being added to the parent Columns block.
* Publish the post, and test in the editor and in the front end of the site in a range of viewports that the columns are not being stacked

## Screenshots <!-- if applicable -->

| Mobile width | Intermediate width | Desktop |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/118234033-1dbf2800-b4d6-11eb-8da4-071420d7e5aa.png) | ![image](https://user-images.githubusercontent.com/14988353/118234044-244d9f80-b4d6-11eb-9f4c-e54253ea3b57.png) | ![image](https://user-images.githubusercontent.com/14988353/118234064-2b74ad80-b4d6-11eb-9f52-467d3fbe3538.png) | 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested. (Added test fixtures)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
