### PR TITLE
Use mobile context in settings request & global styles

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -129,9 +129,9 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				),
 
 				'__experimentalFeatures'                 => array(
-					'description' => __( 'Active theme settings and default values.', 'gutenberg' ),
+					'description' => __( 'Settings consolidated from core, theme, and user origins.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
 				),
 
 				'__experimentalGlobalStylesUserEntityId' => array(
@@ -144,6 +144,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'description' => __( 'Global styles settings.', 'gutenberg' ),
 					'type'        => 'object',
 					'context'     => array( 'site-editor' ),
+				),
+
+				'__experimentalStyles'                 => array(
+					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'mobile' ),
 				),
 
 				'alignWide'                              => array(

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -88,9 +88,12 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'site-editor';
 	}
 
-	// So far, only mobile will use the endpoint.
-	// However, we should be more specific here.
-	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+	if (
+		defined( 'REST_REQUEST' ) &&
+		REST_REQUEST &&
+		isset( $_GET['context'] ) &&
+		'mobile' === $_GET['context']
+	) {
 		$context = 'mobile';
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -88,8 +88,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'site-editor';
 	}
 
+	// So far, only mobile will use the endpoint.
+	// However, we should be more specific here.
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-		$context = 'rest-request';
+		$context = 'mobile';
 	}
 
 	$origin = 'theme';
@@ -102,7 +104,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 	$consolidated = WP_Theme_JSON_Resolver::get_merged_data( $settings, $origin );
 
-	if ( 'rest-request' === $context ) {
+	if ( 'mobile' === $context ) {
 		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
 	}
 
@@ -116,7 +118,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if (
 		'site-editor' !== $context &&
-		'rest-request' !== $context &&
+		'mobile' !== $context &&
 		( WP_Theme_JSON_Resolver::theme_has_support() || get_theme_support( 'experimental-link-color' ) )
 	) {
 		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'block_styles' ) );


### PR DESCRIPTION
Follows up to https://github.com/WordPress/gutenberg/pull/31762 and https://github.com/WordPress/gutenberg/pull/29969#discussion_r631772812

We're defining some "contexts" to provide settings to, including `post-editor`, `site-editor`, or `widgets-editor`. We'll use those contexts to filter what kind of data we pass through the REST request. We also plan to move the settings retrieval to use the REST request.

This PR adds a new context, `mobile`, and declares its specific data requests.

