### PR TITLE
Image block: try caption as inner block

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -12,15 +12,15 @@
 		outline: 1px solid transparent;
 	}
 
-	.block-editor-default-block-appender__content {
-		// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
-		opacity: 0.62;
-	}
-
 	// Dropzone.
 	.components-drop-zone__content-icon {
 		display: none;
 	}
+}
+
+.block-editor-default-block-appender__content {
+	// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
+	opacity: 0.62;
 }
 
 // Empty / default block side inserter.

--- a/packages/block-editor/src/components/inner-blocks/default-block-appender.js
+++ b/packages/block-editor/src/components/inner-blocks/default-block-appender.js
@@ -16,13 +16,8 @@ import BaseDefaultBlockAppender from '../default-block-appender';
 import withClientId from './with-client-id';
 import { store as blockEditorStore } from '../../store';
 
-export const DefaultBlockAppender = ( { clientId, lastBlockClientId } ) => {
-	return (
-		<BaseDefaultBlockAppender
-			rootClientId={ clientId }
-			lastBlockClientId={ lastBlockClientId }
-		/>
-	);
+export const DefaultBlockAppender = ( props ) => {
+	return <BaseDefaultBlockAppender { ...props } />;
 };
 
 export default compose( [

--- a/packages/block-library/src/caption/block.json
+++ b/packages/block-library/src/caption/block.json
@@ -1,0 +1,23 @@
+{
+	"apiVersion": 2,
+	"name": "core/caption",
+	"title": "Caption",
+	"category": "design",
+	"parent": [
+		"core/image"
+	],
+	"description": "A caption for a figure.",
+	"textdomain": "default",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "figcaption",
+			"default": ""
+		}
+	},
+	"supports": {
+		"reusable": false,
+		"html": false
+	}
+}

--- a/packages/block-library/src/caption/edit.js
+++ b/packages/block-library/src/caption/edit.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RichText, useBlockProps, store } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+
+export default function CaptionEdit( {
+	attributes,
+	setAttributes,
+	onRemove,
+	clientId,
+} ) {
+	const { content } = attributes;
+	const blockProps = useBlockProps();
+	const { getBlockRootClientId, getBlockIndex } = useSelect( store );
+	const { insertBlocks } = useDispatch( store );
+
+	return (
+		<RichText
+			{ ...blockProps }
+			identifier="content"
+			tagName="figcaption"
+			value={ content }
+			onChange={ ( newContent ) =>
+				setAttributes( { content: newContent } )
+			}
+			placeholder={ __( 'Caption text' ) }
+			onRemove={ onRemove }
+			__unstableOnSplitAtEnd={ () => {
+				const parentClientId = getBlockRootClientId( clientId );
+				const rootClientId = getBlockRootClientId( parentClientId );
+				const index = getBlockIndex( parentClientId, rootClientId );
+				insertBlocks(
+					createBlock( 'core/paragraph' ),
+					index + 1,
+					rootClientId
+				);
+			} }
+		/>
+	);
+}

--- a/packages/block-library/src/caption/index.js
+++ b/packages/block-library/src/caption/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { comment as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+	save,
+};

--- a/packages/block-library/src/caption/save.js
+++ b/packages/block-library/src/caption/save.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	return (
+		<figcaption { ...useBlockProps.save() }>
+			<RichText.Content value={ attributes.content } />
+		</figcaption>
+	);
+}

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isEmpty, omit } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 
 const blockAttributes = {
 	align: {
@@ -69,6 +71,93 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		attributes: blockAttributes,
+		migrate( attributes ) {
+			return [
+				omit( attributes, 'caption' ),
+				[
+					createBlock( 'core/caption', {
+						content: attributes.caption,
+						fontSize: 'large',
+					} ),
+				],
+			];
+		},
+		save( { attributes } ) {
+			const {
+				url,
+				alt,
+				caption,
+				align,
+				href,
+				rel,
+				linkClass,
+				width,
+				height,
+				id,
+				linkTarget,
+				sizeSlug,
+				title,
+			} = attributes;
+
+			const newRel = isEmpty( rel ) ? undefined : rel;
+
+			const classes = classnames( {
+				[ `align${ align }` ]: align,
+				[ `size-${ sizeSlug }` ]: sizeSlug,
+				'is-resized': width || height,
+			} );
+
+			const image = (
+				<img
+					src={ url }
+					alt={ alt }
+					className={ id ? `wp-image-${ id }` : null }
+					width={ width }
+					height={ height }
+					title={ title }
+				/>
+			);
+
+			const figure = (
+				<>
+					{ href ? (
+						<a
+							className={ linkClass }
+							href={ href }
+							target={ linkTarget }
+							rel={ newRel }
+						>
+							{ image }
+						</a>
+					) : (
+						image
+					) }
+					{ ! RichText.isEmpty( caption ) && (
+						<RichText.Content
+							tagName="figcaption"
+							value={ caption }
+						/>
+					) }
+				</>
+			);
+
+			if ( 'left' === align || 'right' === align || 'center' === align ) {
+				return (
+					<div { ...useBlockProps.save() }>
+						<figure className={ classes }>{ figure }</figure>
+					</div>
+				);
+			}
+
+			return (
+				<figure { ...useBlockProps.save( { className: classes } ) }>
+					{ figure }
+				</figure>
+			);
+		},
+	},
 	{
 		attributes: blockAttributes,
 		save( { attributes } ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -17,6 +17,8 @@ import {
 	MediaPlaceholder,
 	useBlockProps,
 	store as blockEditorStore,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -80,6 +82,7 @@ export function ImageEdit( {
 	insertBlocksAfter,
 	noticeOperations,
 	onReplace,
+	clientId,
 } ) {
 	const {
 		url = '',
@@ -286,8 +289,30 @@ export function ImageEdit( {
 		className: classes,
 	} );
 
+	const hasInnerBlocks = useSelect(
+		( select ) =>
+			!! select( blockEditorStore ).getBlocks( clientId ).length,
+		[ clientId ]
+	);
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/caption' ],
+		renderAppender:
+			hasInnerBlocks || ! isSelected
+				? false
+				: () => (
+						<InnerBlocks.DefaultBlockAppender
+							rootClientId={ clientId }
+							tagName="figcaption"
+							withInserter={ false }
+							blockName={ 'core/caption' }
+							placeholder={ __( 'Caption text' ) }
+						/>
+				  ),
+	} );
+
 	return (
-		<figure { ...blockProps }>
+		<figure { ...innerBlocksProps }>
 			{ ( temporaryURL || url ) && (
 				<Image
 					temporaryURL={ temporaryURL }
@@ -300,6 +325,7 @@ export function ImageEdit( {
 					onSelectURL={ onSelectURL }
 					onUploadError={ onUploadError }
 					containerRef={ ref }
+					clientId={ clientId }
 				/>
 			) }
 			{ ! url && (
@@ -322,6 +348,7 @@ export function ImageEdit( {
 				mediaPreview={ mediaPreview }
 				disableMediaButtons={ temporaryURL || url }
 			/>
+			{ innerBlocksProps.children }
 		</figure>
 	);
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -30,7 +30,7 @@ figure.wp-block-image:not(.wp-block) {
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
 .wp-block-image .components-resizable-box__container {
-	display: inline-block;
+	display: block;
 	img {
 		display: block;
 		width: inherit;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -16,27 +16,22 @@ import {
 	TextControl,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useViewportMatch, usePrevious } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
 	InspectorControls,
 	InspectorAdvancedControls,
-	RichText,
 	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	MediaReplaceFlow,
 	store as blockEditorStore,
 	BlockAlignmentControl,
 } from '@wordpress/block-editor';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
-import {
-	createBlock,
-	getBlockType,
-	switchToBlockType,
-} from '@wordpress/blocks';
+import { getBlockType, switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -66,7 +61,6 @@ export default function Image( {
 	attributes: {
 		url = '',
 		alt,
-		caption,
 		align,
 		id,
 		href,
@@ -81,15 +75,12 @@ export default function Image( {
 	},
 	setAttributes,
 	isSelected,
-	insertBlocksAfter,
 	onReplace,
 	onSelectImage,
 	onSelectURL,
 	onUploadError,
 	containerRef,
 } ) {
-	const captionRef = useRef();
-	const prevUrl = usePrevious( url );
 	const { block, currentId, image, multiImageSelection } = useSelect(
 		( select ) => {
 			const { getMedia } = select( coreStore );
@@ -107,8 +98,8 @@ export default function Image( {
 				multiImageSelection:
 					multiSelectedClientIds.length &&
 					multiSelectedClientIds.every(
-						( clientId ) =>
-							getBlockName( clientId ) === 'core/image'
+						( _clientId ) =>
+							getBlockName( _clientId ) === 'core/image'
 					),
 			};
 		},
@@ -159,16 +150,6 @@ export default function Image( {
 			.then( ( response ) => response.blob() )
 			.then( ( blob ) => setExternalBlob( blob ) );
 	}, [ id, url, isSelected, externalBlob ] );
-
-	// Focus the caption after inserting an image from the placeholder. This is
-	// done to preserve the behaviour of focussing the first tabbable element
-	// when a block is mounted. Previously, the image block would remount when
-	// the placeholder is removed. Maybe this behaviour could be removed.
-	useEffect( () => {
-		if ( url && ! prevUrl && isSelected ) {
-			captionRef.current.focus();
-		}
-	}, [ url, prevUrl ] );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -537,22 +518,6 @@ export default function Image( {
 				which causes duplicated image upload. */ }
 			{ ! temporaryURL && controls }
 			{ img }
-			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-				<RichText
-					ref={ captionRef }
-					tagName="figcaption"
-					aria-label={ __( 'Image caption text' ) }
-					placeholder={ __( 'Add caption' ) }
-					value={ caption }
-					onChange={ ( value ) =>
-						setAttributes( { caption: value } )
-					}
-					inlineToolbar
-					__unstableOnSplitAtEnd={ () =>
-						insertBlocksAfter( createBlock( 'core/paragraph' ) )
-					}
-				/>
-			) }
 		</ImageEditingProvider>
 	);
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -7,13 +7,12 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
 		url,
 		alt,
-		caption,
 		align,
 		href,
 		rel,
@@ -59,9 +58,7 @@ export default function save( { attributes } ) {
 			) : (
 				image
 			) }
-			{ ! RichText.isEmpty( caption ) && (
-				<RichText.Content tagName="figcaption" value={ caption } />
-			) }
+			<InnerBlocks.Content />
 		</>
 	);
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -57,7 +57,8 @@
 	// Supply caption styles to images, even if the theme hasn't opted in.
 	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
 	// so we supply the styles so as to not appear broken or unstyled in those themes.
-	figcaption {
+	// Specificity needed to override default block margins. Should be fixed...
+	.wp-block-caption[data-block] {
 		@include caption-style();
 	}
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -16,6 +16,7 @@ import {
  */
 import * as paragraph from './paragraph';
 import * as image from './image';
+import * as caption from './caption';
 import * as heading from './heading';
 import * as quote from './quote';
 import * as gallery from './gallery';
@@ -123,6 +124,7 @@ export const __experimentalGetCoreBlocks = () => [
 	// in various contexts — like the inserter and auto-complete components.
 	paragraph,
 	image,
+	caption,
 	heading,
 	gallery,
 	list,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

![caption-as-block-2](https://user-images.githubusercontent.com/4710635/118256513-3ae3fe80-b4b6-11eb-8d4d-ef44c7364a8f.gif)

Having a caption as a block would mean it's super easy to add alignment and typography controls.
This also means we no longer need the horrible `inlineToolbar` rich text API.

Code-wise it's a pretty easy change to make.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
