### PR TITLE
Clarify 'Applying styles from a stylesheet' how-to guide

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -13,15 +13,10 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 	apiVersion: 2,
-
 	title: 'Example: Stylesheets',
-
 	icon: 'universal-access-alt',
-
 	category: 'design',
-
 	example: {},
-
 	edit() {
 		const blockProps = useBlockProps();
 
@@ -31,7 +26,6 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 			</p>
 		);
 	},
-
 	save() {
 		const blockProps = useBlockProps.save();
 

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -1,8 +1,8 @@
 # Applying Styles From a Stylesheet
 
-In the previous step, the block had applied its own styles by an inline `style` attribute. While this might be adequate for very simple components, you will quickly find that it becomes easier to write your styles by extracting them to a separate stylesheet file.
+In the previous section, the block had applied its own styles by an inline `style` attribute. While this might be adequate for very simple components, you will quickly find that it becomes easier to write your styles by extracting them to a separate stylesheet file.
 
-The editor will automatically generate a class name for each block type to simplify styling. It can be accessed from the object argument passed to the edit and save functions. In step 2, we will create a stylesheet to use that class name.
+The editor will automatically generate a class name for each block type to simplify styling. It can be accessed from the object argument passed to the edit and save functions. In this section, we will create a stylesheet to use that class name.
 
 {% codetabs %}
 {% ESNext %}

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -22,7 +22,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 		return (
 			<p { ...blockProps }>
-				Hello World, step 2 (from the editor, in green).
+				Hello World (from the editor, in green).
 			</p>
 		);
 	},
@@ -31,7 +31,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 		return (
 			<p { ...blockProps }>
-				Hello World, step 2 (from the frontend, in red).
+				Hello World (from the frontend, in red).
 			</p>
 		);
 	},
@@ -55,7 +55,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 			return el(
 				'p',
 				blockProps,
-				'Hello World, step 2 (from the editor, in green).'
+				'Hello World (from the editor, in green).'
 			);
 		},
 		save: function () {
@@ -63,7 +63,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 			return el(
 				'p',
 				blockProps,
-				'Hello World, step 2 (from the frontend, in red).'
+				'Hello World (from the frontend, in red).'
 			);
 		},
 	} );

--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -1,6 +1,6 @@
 # Applying Styles From a Stylesheet
 
-In the previous section, the block had applied its own styles by an inline `style` attribute. While this might be adequate for very simple components, you will quickly find that it becomes easier to write your styles by extracting them to a separate stylesheet file.
+In the [previous section](/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md), the block had applied its own styles by an inline `style` attribute. While this might be adequate for very simple components, you will quickly find that it becomes easier to write your styles by extracting them to a separate stylesheet file.
 
 The editor will automatically generate a class name for each block type to simplify styling. It can be accessed from the object argument passed to the edit and save functions. In this section, we will create a stylesheet to use that class name.
 

--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -70,7 +70,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 		const blockProps = useBlockProps( { style: blockStyle } );
 
 		return (
-			<div { ...blockProps }>Hello World, step 1 (from the editor).</div>
+			<div { ...blockProps }>Hello World (from the editor).</div>
 		);
 	},
 	save() {
@@ -78,7 +78,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 
 		return (
 			<div { ...blockProps }>
-				Hello World, step 1 (from the frontend).
+				Hello World (from the frontend).
 			</div>
 		);
 	},
@@ -109,7 +109,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 			return el(
 				'p',
 				blockProps,
-				'Hello World, step 1 (from the editor).'
+				'Hello World (from the editor).'
 			);
 		},
 		save: function () {
@@ -117,7 +117,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 			return el(
 				'p',
 				blockProps,
-				'Hello World, step 1 (from the frontend).'
+				'Hello World (from the frontend).'
 			);
 		},
 	} );
@@ -126,7 +126,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 
 {% end %}
 
-_By now you should be able to see `Hello World, step 1 (from the editor).` in the admin side and `Hello World, step 1 (from the frontend).` on the frontend side._
+_By now you should be able to see `Hello World (from the editor).` in the admin side and `Hello World (from the frontend).` on the frontend side._
 
 Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](/docs/reference-guides/block-api/block-registration.md#icon-optional).
 


### PR DESCRIPTION
This change is motivated by [a topic in the Developing with WordPress forum](https://wordpress.org/support/topic/documentation-issue-2/), where the user mentions being confused by the reference to *step 2*, in the [Applying Styles From a Stylesheet guide](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/applying-styles-with-stylesheets/):

> What is "step 2"?
> If there is "step 2" there must be "step 1"? Where is it?

The guide states:

> In the **previous step**, the block had applied its own styles by an inline style attribute.

> (...)

> The editor will automatically generate a class name for each block type to simplify styling. (...) **In step 2**, we will create a stylesheet to use that class name.

--------
I think the user is correct: it's not clear what *step 2* refers to, nor what the *previous step* is, specially for someone who lands directly on this page, as opposed to following the guide.

This PR removes references to *steps*, instead using the terminology *section*, which is the term used throughout the Handbook. In addition, a link is added to the *previous step*.


