### PR TITLE
Nav block: remove list markup

### DIFF
--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -56,7 +56,7 @@ export default function HomeEdit( {
 
 	return (
 		<>
-			<li { ...blockProps }>
+			<div { ...blockProps }>
 				<a
 					className="wp-block-home-link__content"
 					href={ homeUrl }
@@ -80,7 +80,7 @@ export default function HomeEdit( {
 						] }
 					/>
 				</a>
-			</li>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -127,7 +127,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 	$wrapper_attributes = block_core_home_link_build_li_wrapper_attributes( $block->context );
 
-	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content"';
+	$html = '<div ' . $wrapper_attributes . '><a class="wp-block-home-link__content"';
 
 	// Start appending HTML attributes to anchor tag.
 	$html .= ' href="' . esc_url( home_url() ) . '"';
@@ -157,7 +157,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 		);
 	}
 
-	$html .= '</a></li>';
+	$html .= '</a></div>';
 	return $html;
 }
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -507,7 +507,7 @@ export default function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...blockProps }>
+			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
@@ -611,8 +611,8 @@ export default function NavigationLinkEdit( {
 						<ItemSubmenuIcon />
 					</span>
 				) }
-				<ul { ...innerBlocksProps } />
-			</li>
+				<div { ...innerBlocksProps } />
+			</div>
 		</Fragment>
 	);
 }

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -146,7 +146,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 			'style' => $style_attribute,
 		)
 	);
-	$html               = '<li ' . $wrapper_attributes . '>' .
+	$html               = '<div ' . $wrapper_attributes . '>' .
 		'<a class="wp-block-navigation-link__content" ';
 
 	// Start appending HTML attributes to anchor tag.
@@ -214,12 +214,12 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		}
 
 		$html .= sprintf(
-			'<ul class="wp-block-navigation-link__container">%s</ul>',
+			'<div class="wp-block-navigation-link__container">%s</div>',
 			$inner_blocks_html
 		);
 	}
 
-	$html .= '</li>';
+	$html .= '</div>';
 
 	return $html;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -2,17 +2,6 @@
  * Editor only CSS.
  */
 
-// Undo default editor styles.
-// These need extra specificity.
-.editor-styles-wrapper .wp-block-navigation {
-	ul {
-		margin-top: 0;
-		margin-bottom: 0;
-		margin-left: 0;
-		padding-left: 0;
-	}
-}
-
 
 /**
  * Submenus.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -166,7 +166,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// return early if they don't.
 	if ( ! isset( $attributes['isResponsive'] ) || false === $attributes['isResponsive'] ) {
 		return sprintf(
-			'<nav %1$s><ul class="wp-block-navigation__container">%2$s</ul></nav>',
+			'<nav %1$s><div class="wp-block-navigation__container">%2$s</div></nav>',
 			$wrapper_attributes,
 			$inner_blocks_html
 		);
@@ -179,7 +179,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 					<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-%1$s-title" >
 							<button aria-label="%4$s" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 						<div class="wp-block-navigation__responsive-container-content" id="modal-%1$s-content">
-							<ul class="wp-block-navigation__container">%2$s</ul>
+							<div class="wp-block-navigation__container">%2$s</div>
 						</div>
 					</div>
 				</div>

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -5,14 +5,6 @@
 // Page List block inside your navigation block.
 .wp-block-navigation {
 	position: relative;
-	// Normalize list styles.
-	ul,
-	ul li {
-		list-style: none;
-
-		// Overrides generic ".entry-content li" styles on the front end.
-		padding: 0;
-	}
 
 	// Menu item container.
 	.wp-block-pages-list__item,
@@ -299,11 +291,6 @@
 	// Vertically center child blocks, like Social Links or Search.
 	align-items: center;
 
-	// Reset the default list styles
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-
 	// Only hide the menu by default if responsiveness is active.
 	.is-responsive {
 		display: none;
@@ -338,11 +325,11 @@
 }
 
 // Vertical justification.
-.is-vertical.items-justified-center > ul {
+.is-vertical.items-justified-center > div {
 	align-items: center;
 }
 
-.is-vertical.items-justified-right > ul {
+.is-vertical.items-justified-right > div {
 	align-items: flex-end;
 
 	.wp-block-navigation-link,

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -102,16 +102,16 @@ function render_nested_page_list( $nested_pages ) {
 		if ( isset( $page['children'] ) ) {
 			$css_class .= ' has-child';
 		}
-		$markup .= '<li class="' . $css_class . '">';
+		$markup .= '<div class="' . $css_class . '">';
 		$markup .= '<a class="wp-block-pages-list__item__link" href="' . esc_url( $page['link'] ) . '">' . wp_kses(
 			$page['title'],
 			wp_kses_allowed_html( 'post' )
 		) . '</a>';
 		if ( isset( $page['children'] ) ) {
 			$markup .= '<span class="wp-block-page-list__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
-			$markup .= '<ul class="submenu-container">' . render_nested_page_list( $page['children'] ) . '</ul>';
+			$markup .= '<div class="submenu-container">' . render_nested_page_list( $page['children'] ) . '</div>';
 		}
-		$markup .= '</li>';
+		$markup .= '</div>';
 	}
 	return $markup;
 }
@@ -182,7 +182,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = nest_pages( $top_level_pages, $pages_with_children );
 
-	$wrapper_markup = '<ul %1$s>%2$s</ul>';
+	$wrapper_markup = '<div %1$s>%2$s</div>';
 
 	$items_markup = render_nested_page_list( $nested_pages );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

We're shooting ourselves in the foot by making the navigation block markup overly complex. Using lists in navigation elements is [not even necessary](https://css-tricks.com/navigation-in-lists-to-be-or-not-to-be/). It's not because we've always been doing it that way that it is the correct way. I believe the the navigation links will be announced just fine, and if we need to be more descriptive somewhere, we can always add labels (list count and order comes to mind).

**Rule of thumb: if you have to completely remove list styling, you should probably not be using lists.**

For example, it does make sense to use list if it's a big table of contents of the site, but that's not how this menu will be used I believe.

It's not too late to change since we haven't released the navigation block yet.

While it doesn't really matter if a navigation section uses lists or not, it *does* matter for us because we're making the navigation overly complex by having to manage the lists. Without lists, you can potentially embed *any* block in the navigation block without it needing a list item wrapper.

I just removed the list markup here, but otherwise left the structure intact so I don't need to change CSS. However, with the `ul` element gone, the replacement `div` should probably be removed in a follow-up.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
