### PR TITLE
Writing flow: extract and simplify "select all"

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, reverse, first, last } from 'lodash';
+import { find, reverse } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,10 +14,9 @@ import {
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
-	isEntirelySelected,
 	isRTL,
 } from '@wordpress/dom';
-import { UP, DOWN, LEFT, RIGHT, isKeyboardEvent } from '@wordpress/keycodes';
+import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
@@ -28,6 +27,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import { isInSameBlock } from '../../utils/dom';
 import useMultiSelection from './use-multi-selection';
 import useTabNav from './use-tab-nav';
+import useSelectAll from './use-select-all';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -131,7 +131,6 @@ export function getClosestTabbable(
  */
 export default function WritingFlow( { children } ) {
 	const container = useRef();
-	const entirelySelected = useRef();
 
 	// Here a DOMRect is stored while moving the caret vertically so vertical
 	// position of the start position can be restored. This is to recreate
@@ -150,7 +149,6 @@ export default function WritingFlow( { children } ) {
 		getNextBlockClientId,
 		getFirstMultiSelectedBlockClientId,
 		getLastMultiSelectedBlockClientId,
-		getBlockOrder,
 		getSettings,
 	} = useSelect( blockEditorStore );
 	const { multiSelect, selectBlock } = useDispatch( blockEditorStore );
@@ -265,36 +263,7 @@ export default function WritingFlow( { children } ) {
 			verticalRect.current = computeCaretRect( defaultView );
 		}
 
-		// This logic inside this condition needs to be checked before
-		// the check for event.nativeEvent.defaultPrevented.
-		// The logic handles meta+a keypress and this event is default prevented
-		// by RichText.
 		if ( ! isNav ) {
-			// Set immediately before the meta+a combination can be pressed.
-			if ( isKeyboardEvent.primary( event ) ) {
-				entirelySelected.current = isEntirelySelected( target );
-			}
-
-			if ( isKeyboardEvent.primary( event, 'a' ) ) {
-				// When the target is contentEditable, selection will already
-				// have been set by the browser earlier in this call stack. We
-				// need check the previous result, otherwise all blocks will be
-				// selected right away.
-				if (
-					target.isContentEditable
-						? entirelySelected.current
-						: isEntirelySelected( target )
-				) {
-					const blocks = getBlockOrder();
-					multiSelect( first( blocks ), last( blocks ) );
-					event.preventDefault();
-				}
-
-				// After pressing primary + A we can assume isEntirelySelected is true.
-				// Calling right away isEntirelySelected after primary + A may still return false on some browsers.
-				entirelySelected.current = true;
-			}
-
 			return;
 		}
 
@@ -382,7 +351,12 @@ export default function WritingFlow( { children } ) {
 		<>
 			{ before }
 			<div
-				ref={ useMergeRefs( [ ref, container, useMultiSelection() ] ) }
+				ref={ useMergeRefs( [
+					ref,
+					container,
+					useMultiSelection(),
+					useSelectAll(),
+				] ) }
 				className="block-editor-writing-flow"
 				onKeyDown={ onKeyDown }
 				onMouseDown={ onMouseDown }

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { first, last } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { isEntirelySelected } from '@wordpress/dom';
+import { isKeyboardEvent } from '@wordpress/keycodes';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useRefEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export default function useSelectAll() {
+	const { getBlockOrder } = useSelect( blockEditorStore );
+	const { multiSelect } = useDispatch( blockEditorStore );
+
+	return useRefEffect( ( node ) => {
+		function onKeyDown( event ) {
+			if (
+				isKeyboardEvent.primary( event, 'a' ) &&
+				isEntirelySelected( event.target )
+			) {
+				const blocks = getBlockOrder();
+				multiSelect( first( blocks ), last( blocks ) );
+				event.preventDefault();
+			}
+		}
+
+		node.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			node.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This simplifies the select all (cmd+a) logic because native events are not executed AFTER the browser sets selection, unlike React events, which are [delayed](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) until the event is bubbled to the root.

We need this simplification to expand select all behaviour to only gradually select inner blocks wrappers instead of selecting all content on the page, which is useful for site/template editing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
