### PR TITLE
Navigation: Fix text color

### DIFF
--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -169,6 +169,14 @@ export const ItemBaseUI = styled.li`
 		&:focus:not( [aria-disabled='true'] ):active,
 		&:active:not( [aria-disabled='true'] ):active {
 			color: #ddd;
+
+			span {
+				color: #ddd;
+			}
+		}
+
+		span {
+			color: ${ G2.lightGray.ui };
 		}
 	}
 
@@ -179,6 +187,10 @@ export const ItemBaseUI = styled.li`
 		button,
 		a {
 			color: ${ UI.textDark };
+
+			span {
+				color: ${ UI.textDark };
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
https://github.com/WordPress/gutenberg/pull/31291 made some changes to the `Text` component which resulted in different styling. `Text` styles are now overriding our styles specified for `ItemBaseUI`. This change overrides the text color of the `Text` (`span`).

## How has this been tested?
1. Open Site Editor
2. Open Browsing Sidebar
3. Make sure text colors working fine

## Screenshots <!-- if applicable -->

## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
