### PR TITLE
Global Styles: Allow custom properties to merge

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1073,7 +1073,6 @@ class WP_Theme_JSON_Gutenberg {
 		// For leaf values that are arrays it will use the numeric indexes for replacement.
 		// In those cases, we want to replace the existing with the incoming value, if it exists.
 		$to_replace   = array();
-		$to_replace[] = array( 'custom' );
 		$to_replace[] = array( 'spacing', 'units' );
 		$to_replace[] = array( 'color', 'duotone' );
 		foreach ( self::VALID_ORIGINS as $origin ) {


### PR DESCRIPTION
This is more a question/discussion than a proposal.

I am modifying the user data for theme.json (the CPT) from outside of the Site Editor (using the Customizer), by adding properties to `settings.custom`. When I do this I want `settings.custom` from the theme.json itself to be merged with the settings from the CPT. This line wipes out the contents of settings.custom from theme.json and replaces it with the data in the CPT. I assume it's here for a good reason though.