### PR TITLE
[RN Mobile] Audio Block: Add from URL - Refactor Prompt component [WIP]

### DIFF
--- a/packages/block-editor/src/components/media-upload/add-from-url-bottom-sheet.native.js
+++ b/packages/block-editor/src/components/media-upload/add-from-url-bottom-sheet.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -27,18 +22,10 @@ const AddFromUrlBottomSheet = ( { value, onClose, isVisible } ) => {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	function onCloseWithUrl() {
-		if ( ! isEmpty( url ) ) {
-			if ( isURL( url ) ) {
-				onClose( { url } );
-				console.log(url);
-
-			} else {
-				createErrorNotice(
-					__( 'Invalid URL. Please enter a valid URL.' )
-				);
-				onClose( {} );
-			}
+		if ( isURL( url ) ) {
+			onClose( { url } );
 		} else {
+			createErrorNotice( __( 'Invalid URL. Please enter a valid URL.' ) );
 			onClose( {} );
 		}
 	}

--- a/packages/block-editor/src/components/media-upload/add-from-url-bottom-sheet.native.js
+++ b/packages/block-editor/src/components/media-upload/add-from-url-bottom-sheet.native.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { LinkSettingsNavigation } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { isURL } from '@wordpress/url';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+const linkSettingsOptions = {
+	url: {
+		label: __( 'Insert from URL' ),
+		placeholder: __( 'Add link' ),
+		autoFocus: true,
+		autoFill: true,
+	},
+};
+
+const AddFromUrlBottomSheet = ( { value, onClose, isVisible } ) => {
+	const [ url, setUrl ] = useState( value );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	function onCloseWithUrl() {
+		if ( ! isEmpty( url ) ) {
+			if ( isURL( url ) ) {
+				onClose( { url } );
+				console.log(url);
+
+			} else {
+				createErrorNotice(
+					__( 'Invalid URL. Please enter a valid URL.' )
+				);
+				onClose( {} );
+			}
+		} else {
+			onClose( {} );
+		}
+	}
+
+	return (
+		<LinkSettingsNavigation
+			isVisible={ isVisible }
+			url={ url }
+			setAttributes={ ( attributes ) => setUrl( attributes.url ) }
+			onClose={ onCloseWithUrl }
+			options={ linkSettingsOptions }
+			withBottomSheet
+			showIcon
+		/>
+	);
+};
+
+export default AddFromUrlBottomSheet;

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -7,7 +7,7 @@ import AddFromUrlBottomSheet from './add-from-url-bottom-sheet';
  */
 import { View, Platform } from 'react-native';
 
-import { delay, isEmpty } from 'lodash';
+import { delay } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -181,37 +181,12 @@ export class MediaUpload extends Component {
 	}
 
 	onPickerSelect( value ) {
-		const {
-			allowedTypes = [],
-			onSelect,
-			onSelectURL,
-			multiple = false,
-		} = this.props;
+		const { allowedTypes = [], onSelect, multiple = false } = this.props;
 
 		if ( value === 'URL' ) {
 			this.setState( { isAddFromUrlBottomsheetVisible: true } );
 			return;
 		}
-		// if ( value === 'URL' ) {
-		// 	prompt(
-		// 		__( 'Type a URL' ), // title
-		// 		undefined, // message
-		// 		[
-		// 			{
-		// 				text: __( 'Cancel' ),
-		// 				style: 'cancel',
-		// 			},
-		// 			{
-		// 				text: __( 'Apply' ),
-		// 				onPress: ( url ) => onSelectURL( url ),
-		// 			},
-		// 		], // buttons
-		// 		'plain-text', // type
-		// 		undefined, // defaultValue
-		// 		'url' // keyboardType
-		// 	);
-		// 	return;
-		// }
 
 		const mediaSource = this.getAllSources()
 			.filter( ( source ) => source.value === value )
@@ -285,11 +260,11 @@ export class MediaUpload extends Component {
 			<View>
 				{ this.state.isAddFromUrlBottomsheetVisible && (
 					<AddFromUrlBottomSheet
-						onClose={ ( {url} ) => {
+						onClose={ ( { url } ) => {
 							this.setState( {
 								isAddFromUrlBottomsheetVisible: false,
 							} );
-							onSelectURL(url);
+							onSelectURL( url );
 						} }
 						isVisible={ this.state.isAddFromUrlBottomsheetVisible }
 					/>

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -1,11 +1,13 @@
 /**
+ * Internal dependencies
+ */
+import AddFromUrlBottomSheet from './add-from-url-bottom-sheet';
+/**
  * External dependencies
  */
-import { Platform } from 'react-native';
+import { View, Platform } from 'react-native';
 
-import { delay } from 'lodash';
-
-import prompt from 'react-native-prompt-android';
+import { delay, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,6 +48,7 @@ export class MediaUpload extends Component {
 		this.getAllSources = this.getAllSources.bind( this );
 		this.state = {
 			otherMediaOptions: [],
+			isAddFromUrlBottomsheetVisible: false,
 		};
 	}
 
@@ -186,25 +189,29 @@ export class MediaUpload extends Component {
 		} = this.props;
 
 		if ( value === 'URL' ) {
-			prompt(
-				__( 'Type a URL' ), // title
-				undefined, // message
-				[
-					{
-						text: __( 'Cancel' ),
-						style: 'cancel',
-					},
-					{
-						text: __( 'Apply' ),
-						onPress: ( url ) => onSelectURL( url ),
-					},
-				], // buttons
-				'plain-text', // type
-				undefined, // defaultValue
-				'url' // keyboardType
-			);
+			this.setState( { isAddFromUrlBottomsheetVisible: true } );
 			return;
 		}
+		// if ( value === 'URL' ) {
+		// 	prompt(
+		// 		__( 'Type a URL' ), // title
+		// 		undefined, // message
+		// 		[
+		// 			{
+		// 				text: __( 'Cancel' ),
+		// 				style: 'cancel',
+		// 			},
+		// 			{
+		// 				text: __( 'Apply' ),
+		// 				onPress: ( url ) => onSelectURL( url ),
+		// 			},
+		// 		], // buttons
+		// 		'plain-text', // type
+		// 		undefined, // defaultValue
+		// 		'url' // keyboardType
+		// 	);
+		// 	return;
+		// }
 
 		const mediaSource = this.getAllSources()
 			.filter( ( source ) => source.value === value )
@@ -221,7 +228,12 @@ export class MediaUpload extends Component {
 	}
 
 	render() {
-		const { allowedTypes = [], isReplacingMedia, multiple } = this.props;
+		const {
+			allowedTypes = [],
+			isReplacingMedia,
+			multiple,
+			onSelectURL,
+		} = this.props;
 		const isOneType = allowedTypes.length === 1;
 		const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );
 		const isVideo = isOneType && allowedTypes.includes( MEDIA_TYPE_VIDEO );
@@ -270,13 +282,26 @@ export class MediaUpload extends Component {
 		}
 
 		const getMediaOptions = () => (
-			<Picker
-				title={ pickerTitle }
-				hideCancelButton
-				ref={ ( instance ) => ( this.picker = instance ) }
-				options={ this.getMediaOptionsItems() }
-				onChange={ this.onPickerSelect }
-			/>
+			<View>
+				{ this.state.isAddFromUrlBottomsheetVisible && (
+					<AddFromUrlBottomSheet
+						onClose={ ( {url} ) => {
+							this.setState( {
+								isAddFromUrlBottomsheetVisible: false,
+							} );
+							onSelectURL(url);
+						} }
+						isVisible={ this.state.isAddFromUrlBottomsheetVisible }
+					/>
+				) }
+				<Picker
+					title={ pickerTitle }
+					hideCancelButton
+					ref={ ( instance ) => ( this.picker = instance ) }
+					options={ this.getMediaOptionsItems() }
+					onChange={ this.onPickerSelect }
+				/>
+			</View>
 		);
 
 		return this.props.render( {

--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -31,7 +31,6 @@ import { audio as icon, replace } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -78,11 +77,7 @@ function AudioEdit( {
 
 	function onSelectURL( newSrc ) {
 		if ( newSrc !== src ) {
-			if ( isURL( newSrc ) ) {
-				setAttributes( { src: newSrc, id: undefined } );
-			} else {
-				createErrorNotice( __( 'Invalid URL. Audio file not found.' ) );
-			}
+			setAttributes( { src: newSrc, id: undefined } );
 		}
 	}
 


### PR DESCRIPTION
Draft mode - I will create the GB Mobile PR in short order. 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The purpose of this PR is to migrate from the `prompt` component in https://github.com/WordPress/gutenberg/pull/27817 to the `link settings` bottom sheet behavior. This move was inspired by the implementation done in [Embed Block Bottom Sheet to set a link](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3436). The current implementation of the prompt component that creates a polyfill so there can be Android support for the `Alert.prompt` API is causing crashes related to Hermes and so far it has been difficult to debug the issue, hence the usage of a component that is already cross-platform. 

## How has this been tested?

1. Add an Audio Block to the canvas. 
2. Click Add Audio. 
3. Select "Insert From URL". 
4. Notice the bottom sheet is opened. 
5. Add a valid URL and notice that it is set. 

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

Android | iOS 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/118343813-bc588280-b4f0-11eb-901f-11e26d391461.gif" width="320"></kbd>     | <kbd><img src="https://user-images.githubusercontent.com/1509205/118343814-bfec0980-b4f0-11eb-9c17-6c7c167c2995.gif" width="320"></kbd>

## Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- [x] Refactored the prompt behavior. 
- [ ]  Remove React Native Prompt Android implementation

## Issues Noticed

Some issues have been noticed that may be as a result of how the Link component is built. 

1. When the audio block has a URL attribute and you set an incorrect value, it does not show error, the previous link remains. Not overwriting the working link is fine but it seems we aren’t able to determine when an error has taken place.
2. If there was a link previously set in another block and you try to add an invalid URL or an empty URL, the previous URL is set. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
