### PR TITLE
Fix intermittent embeds failure

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
@@ -51,8 +51,8 @@ https://www.youtube.com/watch?v=lXMskKTw3Bc
 </div></figure>
 <!-- /wp:embed -->
 
-<!-- wp:embed {\\"url\\":\\"https://cloudup.com/cQFlxqtY4ob\\"} -->
-<figure class=\\"wp-block-embed\\"><div class=\\"wp-block-embed__wrapper\\">
+<!-- wp:embed {\\"url\\":\\"https://cloudup.com/cQFlxqtY4ob\\",\\"type\\":\\"photo\\",\\"providerNameSlug\\":\\"cloudup\\",\\"responsive\\":true} -->
+<figure class=\\"wp-block-embed is-type-photo is-provider-cloudup wp-block-embed-cloudup\\"><div class=\\"wp-block-embed__wrapper\\">
 https://cloudup.com/cQFlxqtY4ob
 </div></figure>
 <!-- /wp:embed -->"

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -33,6 +33,15 @@ const MOCK_EMBED_RICH_SUCCESS_RESPONSE = {
 	version: '1.0',
 };
 
+const MOCK_EMBED_PHOTO_SUCCESS_RESPONSE = {
+	url: 'https://cloudup.com/cQFlxqtY4ob',
+	html: '<p>Mock success response.</p>',
+	type: 'photo',
+	provider_name: 'Cloudup',
+	provider_url: 'https://cloudup.com',
+	version: '1.0',
+};
+
 const MOCK_EMBED_VIDEO_SUCCESS_RESPONSE = {
 	url: 'https://www.youtube.com/watch?v=lXMskKTw3Bc',
 	html: '<iframe width="16" height="9"></iframe>',
@@ -123,7 +132,7 @@ const MOCK_RESPONSES = [
 	},
 	{
 		match: createEmbeddingMatcher( 'https://cloudup.com/cQFlxqtY4ob' ),
-		onRequestMatch: createJSONResponse( MOCK_EMBED_RICH_SUCCESS_RESPONSE ),
+		onRequestMatch: createJSONResponse( MOCK_EMBED_PHOTO_SUCCESS_RESPONSE ),
 	},
 	{
 		match: createEmbeddingMatcher( 'https://twitter.com/notnownikki' ),
@@ -208,6 +217,10 @@ describe( 'Embedding content', () => {
 
 		// Photo content. Should render valid figure element.
 		await insertEmbed( 'https://cloudup.com/cQFlxqtY4ob' );
+		await page.waitForSelector(
+			'iframe[title="Embedded content from cloudup"'
+		);
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Waiting for the embed (selector) to load was missing for the last embed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
