### PR TITLE
E2e inserter util: directly focus the selected block

### DIFF
--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -62,17 +62,9 @@ export async function toggleGlobalBlockInserter() {
  * Moves focus to the selected block.
  */
 async function focusSelectedBlock() {
-	// Ideally there shouuld be a UI way to do this. (Focus the selected block)
-	await page.evaluate( () => {
-		wp.data
-			.dispatch( 'core/block-editor' )
-			.selectBlock(
-				wp.data
-					.select( 'core/block-editor' )
-					.getSelectedBlockClientId(),
-				0
-			);
-	} );
+	// Wait for the block to be inserted and selected.
+	await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+	await canvas().focus( '.is-selected' );
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -64,19 +64,7 @@ export async function toggleGlobalBlockInserter() {
 async function focusSelectedBlock() {
 	// Wait for the block to be inserted and selected.
 	await page.evaluate( () => new Promise( window.requestIdleCallback ) );
-	await canvas().focus( '.is-selected' );
-}
-
-/**
- * Retrieves the document container by css class and checks to make sure the document's active element is within it
- */
-async function waitForInserterCloseAndContentFocus() {
-	await canvas().waitForFunction(
-		() =>
-			document.activeElement.closest(
-				'.block-editor-block-list__layout'
-			) !== null
-	);
+	await canvas().click( '.is-selected' );
 }
 
 /**
@@ -149,8 +137,6 @@ export async function insertBlock( searchTerm ) {
 	);
 	await insertButton.click();
 	await focusSelectedBlock();
-	// We should wait until the inserter closes and the focus moves to the content.
-	await waitForInserterCloseAndContentFocus();
 }
 
 /**
@@ -166,8 +152,6 @@ export async function insertPattern( searchTerm ) {
 	);
 	await insertButton.click();
 	await focusSelectedBlock();
-	// We should wait until the inserter closes and the focus moves to the content.
-	await waitForInserterCloseAndContentFocus();
 }
 
 /**
@@ -184,8 +168,6 @@ export async function insertReusableBlock( searchTerm ) {
 	);
 	await insertButton.click();
 	await focusSelectedBlock();
-	// We should wait until the inserter closes and the focus moves to the content.
-	await waitForInserterCloseAndContentFocus();
 	// We should wait until the block is loaded
 	await page.waitForXPath(
 		'//*[@class="block-library-block__reusable-block-container"]'
@@ -214,6 +196,4 @@ export async function insertBlockDirectoryBlock( searchTerm ) {
 			)
 	);
 	await focusSelectedBlock();
-	// We should wait until the inserter closes and the focus moves to the content.
-	await waitForInserterCloseAndContentFocus();
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Currently the test focusses the block through the data API, while it should do so directly.

This also tries to stabilise this test:

```
FAIL specs/editor/plugins/meta-boxes.test.js (57.542 s)
  ● Meta boxes › Should render dynamic blocks when the meta box uses the excerpt for front end rendering

    TimeoutError: waiting for function failed: timeout 30000ms exceeded
      at new WaitTask (../../node_modules/puppeteer-core/src/common/DOMWorld.ts:780:28)
      at DOMWorld.waitForFunction (../../node_modules/puppeteer-core/src/common/DOMWorld.ts:702:22)
      at Frame.waitForFunction (../../node_modules/puppeteer-core/src/common/FrameManager.ts:1241:28)
      at Page.waitForFunction (../../node_modules/puppeteer-core/src/common/Page.ts:2122:29)
      at waitForInserterCloseAndContentFocus (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/inserter.js:82:8)
      at insertBlock (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/inserter.js:161:8)
      at Object.<anonymous> (specs/editor/plugins/meta-boxes.test.js:52:3)
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
