### PR TITLE
Fix intermittent failure of rich text e2e test

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -27,8 +27,12 @@ export default function useSelectAll() {
 				isEntirelySelected( event.target )
 			) {
 				const blocks = getBlockOrder();
-				multiSelect( first( blocks ), last( blocks ) );
-				event.preventDefault();
+				const firstClientId = first( blocks );
+				const lastClientId = last( blocks );
+				if ( firstClientId !== lastClientId ) {
+					multiSelect( firstClientId, lastClientId );
+					event.preventDefault();
+				}
 			}
 		}
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -70,6 +70,16 @@ exports[`Multi-block selection should cut and paste 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Multi-block selection should not multi select single block 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Multi-block selection should only trigger multi-selection when at the end 1`] = `
 "<!-- wp:paragraph -->
 <p>1.</p>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -590,4 +590,15 @@ describe( 'Multi-block selection', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	// Previously we would unexpectedly duplicated the block on Enter.
+	it( 'should not multi select single block', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -402,7 +402,6 @@ describe( 'RichText', () => {
 
 		// Navigate to the block.
 		await page.keyboard.press( 'Tab' );
-		await pressKeyWithModifier( 'primary', 'a' );
 
 		// Copy the colored text.
 		await pressKeyWithModifier( 'primary', 'c' );

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -300,7 +300,7 @@ _Parameters_
 
 _Returns_
 
--   `Array<RichTextValue>`: An array of new values.
+-   `Array<RichTextValue>|undefined`: An array of new values.
 
 <a name="store" href="#store">#</a> **store**
 

--- a/packages/rich-text/src/split.js
+++ b/packages/rich-text/src/split.js
@@ -14,7 +14,7 @@ import { replace } from './replace';
  * @param {RichTextValue} value
  * @param {number|string} [string] Start index, or string at which to split.
  *
- * @return {Array<RichTextValue>} An array of new values.
+ * @return {Array<RichTextValue>|undefined} An array of new values.
  */
 export function split( { formats, replacements, text, start, end }, string ) {
 	if ( typeof string !== 'string' ) {
@@ -59,6 +59,10 @@ function splitAtSelection(
 	startIndex = start,
 	endIndex = end
 ) {
+	if ( start === undefined || end === undefined ) {
+		return;
+	}
+
 	const before = {
 		formats: formats.slice( 0, startIndex ),
 		replacements: replacements.slice( 0, startIndex ),

--- a/packages/rich-text/src/test/split.js
+++ b/packages/rich-text/src/test/split.js
@@ -258,4 +258,13 @@ describe( 'split', () => {
 			);
 		} );
 	} );
+
+	it( 'should not split without selection', () => {
+		const record = {
+			formats: [],
+			replacements: [],
+			text: '',
+		};
+		expect( split( deepFreeze( record ) ) ).toBe( undefined );
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The problem here is that we were pressing cmd+A on an already fully selected text, trigger multi selection, which was setting a multi selection on a single block, which doesn't work.

There's a problem on a few levels:

`split` from rich text returns the given value twice when splitting with an `undefined` selection. That's at all not expected, so we should either return nothing or (type) error. If we had done that, the problem would be more obvious.

Multi selection should not be possible on a single block. Ideally we should error in `multiSelect` (I think), but I opted here for checking before calling `multiSelect`. Worth noting that in the future we might want to allow a "full" selection of a single block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
