### PR TITLE
Global inserter library: focus content on Escape

### DIFF
--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -59,23 +59,6 @@ export async function toggleGlobalBlockInserter() {
 }
 
 /**
- * Moves focus to the selected block.
- */
-async function focusSelectedBlock() {
-	// Ideally there shouuld be a UI way to do this. (Focus the selected block)
-	await page.evaluate( () => {
-		wp.data
-			.dispatch( 'core/block-editor' )
-			.selectBlock(
-				wp.data
-					.select( 'core/block-editor' )
-					.getSelectedBlockClientId(),
-				0
-			);
-	} );
-}
-
-/**
  * Retrieves the document container by css class and checks to make sure the document's active element is within it
  */
 async function waitForInserterCloseAndContentFocus() {
@@ -156,7 +139,7 @@ export async function insertBlock( searchTerm ) {
 		`//button//span[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
-	await focusSelectedBlock();
+	await page.keyboard.press( 'Escape' );
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }
@@ -173,7 +156,7 @@ export async function insertPattern( searchTerm ) {
 		`//div[@role = 'option']//div[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
-	await focusSelectedBlock();
+	await page.keyboard.press( 'Escape' );
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }
@@ -191,7 +174,7 @@ export async function insertReusableBlock( searchTerm ) {
 		`//button//span[contains(text(), '${ searchTerm }')]`
 	);
 	await insertButton.click();
-	await focusSelectedBlock();
+	await page.keyboard.press( 'Escape' );
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 	// We should wait until the block is loaded
@@ -221,7 +204,7 @@ export async function insertBlockDirectoryBlock( searchTerm ) {
 				'.block-directory-downloadable-blocks-list button:first-child.is-busy'
 			)
 	);
-	await focusSelectedBlock();
+	await page.keyboard.press( 'Escape' );
 	// We should wait until the inserter closes and the focus moves to the content.
 	await waitForInserterCloseAndContentFocus();
 }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -17,6 +17,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockBreadcrumb,
 	__experimentalLibrary as Library,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import {
@@ -69,6 +70,8 @@ const interfaceLabels = {
 function Layout( { styles } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
+	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const {
 		openGeneralSidebar,
 		closeGeneralSidebar,
@@ -172,7 +175,10 @@ function Layout( { styles } ) {
 		[ entitiesSavedStatesCallback ]
 	);
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
+		onClose: () => {
+			setIsInserterOpened( false );
+			selectBlock( getSelectedBlockClientId(), 0 );
+		},
 	} );
 
 	return (

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -3,7 +3,10 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
-import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import {
+	__experimentalLibrary as Library,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { close } from '@wordpress/icons';
 import {
 	useViewportMatch,
@@ -21,10 +24,14 @@ export default function InserterSidebar() {
 		( select ) => select( editSiteStore ).__experimentalGetInsertionPoint(),
 		[]
 	);
-
+	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
+		onClose: () => {
+			setIsInserterOpened( false );
+			selectBlock( getSelectedBlockClientId(), 0 );
+		},
 	} );
 
 	return (

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -7,7 +7,10 @@ import {
 	useViewportMatch,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
-import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import {
+	__experimentalLibrary as Library,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -41,7 +44,8 @@ function Interface( { blockEditorSettings } ) {
 		editWidgetsStore
 	);
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
-
+	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const { hasSidebarEnabled, isInserterOpened } = useSelect(
 		( select ) => ( {
 			hasSidebarEnabled: !! select(
@@ -66,7 +70,10 @@ function Interface( { blockEditorSettings } ) {
 	}, [ isInserterOpened, isHugeViewport ] );
 
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
+		onClose: () => {
+			setIsInserterOpened( false );
+			selectBlock( getSelectedBlockClientId(), 0 );
+		},
 	} );
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently there's no easy way to move to the content with the keyboard and when you press Escape focus is lost after the inserter disappears. We should move focus to the freshly inserted block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
