### PR TITLE
Iframed editor: support scripts

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -740,16 +740,27 @@ function gutenberg_extend_block_editor_styles_html() {
 	wp_styles()->do_items( $handles );
 	wp_styles()->done = $done;
 
+	$styles = ob_get_clean();
+
 	$script_handles = array_unique( $script_handles );
 	$done           = wp_scripts()->done;
+
+	ob_start();
 
 	wp_scripts()->done = array();
 	wp_scripts()->do_items( $script_handles );
 	wp_scripts()->done = $done;
 
-	$editor_styles = wp_json_encode( array( 'html' => ob_get_clean() ) );
+	$scripts = ob_get_clean();
 
-	echo "<script>window.__editorStyles = $editor_styles</script>";
+	$editor_styles = wp_json_encode(
+		array(
+			'styles'  => $styles,
+			'scripts' => $scripts,
+		)
+	);
+
+	echo "<script>window.__editorAssets = $editor_styles</script>";
 }
 add_action( 'admin_footer-toplevel_page_gutenberg-edit-site', 'gutenberg_extend_block_editor_styles_html' );
 add_action( 'admin_footer-post.php', 'gutenberg_extend_block_editor_styles_html' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -753,14 +753,14 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	$scripts = ob_get_clean();
 
-	$editor_styles = wp_json_encode(
+	$editor_assets = wp_json_encode(
 		array(
 			'styles'  => $styles,
 			'scripts' => $scripts,
 		)
 	);
 
-	echo "<script>window.__editorAssets = $editor_styles</script>";
+	echo "<script>window.__editorAssets = $editor_assets</script>";
 }
 add_action( 'admin_footer-toplevel_page_gutenberg-edit-site', 'gutenberg_extend_block_editor_styles_html' );
 add_action( 'admin_footer-post.php', 'gutenberg_extend_block_editor_styles_html' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -709,7 +709,7 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
  */
 function gutenberg_extend_block_editor_styles_html() {
 	$script_handles = array();
-	$handles        = array(
+	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',
 		'wp-edit-blocks',
@@ -719,11 +719,11 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	foreach ( $block_registry->get_all_registered() as $block_type ) {
 		if ( ! empty( $block_type->style ) ) {
-			$handles[] = $block_type->style;
+			$style_handles[] = $block_type->style;
 		}
 
 		if ( ! empty( $block_type->editor_style ) ) {
-			$handles[] = $block_type->editor_style;
+			$style_handles[] = $block_type->editor_style;
 		}
 
 		if ( ! empty( $block_type->script ) ) {
@@ -731,13 +731,13 @@ function gutenberg_extend_block_editor_styles_html() {
 		}
 	}
 
-	$handles = array_unique( $handles );
-	$done    = wp_styles()->done;
+	$style_handles = array_unique( $style_handles );
+	$done          = wp_styles()->done;
 
 	ob_start();
 
 	wp_styles()->done = array();
-	wp_styles()->do_items( $handles );
+	wp_styles()->do_items( $style_handles );
 	wp_styles()->done = $done;
 
 	$styles = ob_get_clean();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -708,7 +708,8 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
  * Sets the editor styles to be consumed by JS.
  */
 function gutenberg_extend_block_editor_styles_html() {
-	$handles = array(
+	$script_handles = array();
+	$handles        = array(
 		'wp-block-editor',
 		'wp-block-library',
 		'wp-edit-blocks',
@@ -724,6 +725,10 @@ function gutenberg_extend_block_editor_styles_html() {
 		if ( ! empty( $block_type->editor_style ) ) {
 			$handles[] = $block_type->editor_style;
 		}
+
+		if ( ! empty( $block_type->script ) ) {
+			$script_handles[] = $block_type->script;
+		}
 	}
 
 	$handles = array_unique( $handles );
@@ -734,6 +739,13 @@ function gutenberg_extend_block_editor_styles_html() {
 	wp_styles()->done = array();
 	wp_styles()->do_items( $handles );
 	wp_styles()->done = $done;
+
+	$script_handles = array_unique( $script_handles );
+	$done           = wp_scripts()->done;
+
+	wp_scripts()->done = array();
+	wp_scripts()->do_items( $script_handles );
+	wp_scripts()->done = $done;
 
 	$editor_styles = wp_json_encode( array( 'html' => ob_get_clean() ) );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -6,7 +6,7 @@ import {
 	createPortal,
 	useCallback,
 	forwardRef,
-	useLayoutEffect,
+	useEffect,
 	useMemo,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -197,7 +197,7 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 		} );
 	}, [] );
 
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if ( iframeDocument ) {
 			styleSheetsCompat( iframeDocument );
 		}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -187,14 +187,15 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 	head = (
 		<>
 			<style>{ 'body{margin:0}' }</style>
-			{ assets.map(
-				( { tagName: TagName, src, href, id, rel, media }, index ) => (
+			{ assets.map( ( { tagName, src, href, id, rel, media }, index ) => {
+				const TagName = tagName.toLowerCase();
+				return (
 					<TagName
 						{ ...{ src, href, id, rel, media } }
 						key={ index }
 					/>
-				)
-			) }
+				);
+			} ) }
 			{ head }
 		</>
 	);

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -6,6 +6,8 @@ import {
 	createPortal,
 	useCallback,
 	forwardRef,
+	useLayoutEffect,
+	useMemo,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
@@ -126,19 +128,7 @@ function setBodyClassName( doc ) {
 	}
 }
 
-/**
- * Sets the document head and default styles.
- *
- * @param {Document} doc  Document to set the head for.
- * @param {string}   head HTML to set as the head.
- */
-function setHead( doc, head ) {
-	doc.head.innerHTML =
-		// Body margin must be overridable by themes.
-		'<style>body{margin:0}</style>' + head;
-}
-
-function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
+function Iframe( { contentRef, children, head, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 
 	const clearerRef = useBlockSelectionClearer();
@@ -161,9 +151,7 @@ function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
 				contentRef.current = body;
 			}
 
-			setHead( contentDocument, headHTML );
 			setBodyClassName( contentDocument );
-			styleSheetsCompat( contentDocument );
 			bubbleEvents( contentDocument );
 			setBodyClassName( contentDocument );
 			setIframeDocument( contentDocument );
@@ -182,6 +170,34 @@ function Iframe( { contentRef, children, head, headHTML, ...props }, ref ) {
 			setDocumentIfReady();
 		} );
 	}, [] );
+
+	useLayoutEffect( () => {
+		if ( iframeDocument ) {
+			styleSheetsCompat( iframeDocument );
+		}
+	}, [ iframeDocument ] );
+
+	const { html } = window.__editorStyles;
+	const assets = useMemo( () => {
+		const doc = document.implementation.createHTMLDocument( '' );
+		doc.body.innerHTML = html;
+		return Array.from( doc.body.children );
+	}, [ html ] );
+
+	head = (
+		<>
+			<style>{ 'body{margin:0}' }</style>
+			{ assets.map(
+				( { tagName: TagName, src, href, id, rel, media }, index ) => (
+					<TagName
+						{ ...{ src, href, id, rel, media } }
+						key={ index }
+					/>
+				)
+			) }
+			{ head }
+		</>
+	);
 
 	return (
 		<iframe

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -140,9 +140,13 @@ async function loadScript( doc, { id, src } ) {
 	return new Promise( ( resolve, reject ) => {
 		const script = doc.createElement( 'script' );
 		script.id = id;
-		script.src = src;
-		script.onload = () => resolve();
-		script.onerror = () => reject();
+		if ( src ) {
+			script.src = src;
+			script.onload = () => resolve();
+			script.onerror = () => reject();
+		} else {
+			resolve();
+		}
 		doc.head.appendChild( script );
 	} );
 }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -70,7 +70,6 @@ function MaybeIframe( {
 
 	return (
 		<Iframe
-			headHTML={ window.__editorStyles.html }
 			head={ <EditorStyles styles={ styles } /> }
 			ref={ ref }
 			contentRef={ contentRef }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -87,7 +87,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<BlockTools __unstableContentRef={ contentRef }>
 					<Iframe
 						style={ resizedCanvasStyles }
-						headHTML={ window.__editorStyles.html }
 						head={ <EditorStyles styles={ settings.styles } /> }
 						ref={ ref }
 						contentRef={ mergedRefs }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #31873.

Adds support for scripts to the iframed editor. See https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script.

## How has this been tested?

Created a block with a script (front-end and editor) https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
