### PR TITLE
Animate menu exit in Navigation component

### DIFF
--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -48,6 +48,10 @@ export function getAnimateClassName( options ) {
 			'is-from-' + origin
 		);
 	}
+
+	if ( type === 'slide-out' ) {
+		return classnames( 'components-animate__slide-out', 'is-to-' + origin );
+	}
 }
 
 // @ts-ignore Reason: Planned for deprecation

--- a/packages/components/src/animate/style.scss
+++ b/packages/components/src/animate/style.scss
@@ -48,6 +48,26 @@
 	}
 }
 
+.components-animate__slide-out {
+	animation: components-animate__slide-out-animation 0.1s cubic-bezier(0, 0, 0.2, 1);
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+
+	&.is-to-left {
+		transform: translateX(-100%);
+	}
+
+	&.is-to-right {
+		transform: translateX(100%);
+	}
+}
+
+@keyframes components-animate__slide-out-animation {
+	0% {
+		transform: translateX(0%);
+	}
+}
+
 .components-animate__loading {
 	animation: components-animate__loading 1.6s ease-in-out infinite;
 }

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -26,6 +26,7 @@ function MenuIndex( {
 	menu,
 	onAnimationEnd,
 	onMenuChange,
+	isPresentational,
 } ) {
 	const navigationTree = useCreateNavigationTree();
 	const context = {
@@ -40,8 +41,9 @@ function MenuIndex( {
 	};
 	return (
 		<div
-			key={ menu }
+			aria-hidden={ isPresentational }
 			className={ className || '' }
+			key={ menu }
 			onAnimationEnd={ onAnimationEnd }
 		>
 			<NavigationContext.Provider value={ context }>
@@ -75,6 +77,7 @@ export default function Navigation( {
 					type: 'slide-out',
 					origin: slideInOrigin,
 				} ),
+				isPresentational: true,
 				onAnimationEnd: () => setPrevious( null ),
 			};
 			setPrevious( <MenuIndex { ...props } /> );

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -21,8 +21,15 @@ export const NavigationUI = styled.div`
 	background-color: ${ G2.darkGray.primary };
 	box-sizing: border-box;
 	color: #f0f0f0;
-	padding: 0 ${ space( 2 ) };
-	overflow: hidden;
+	display: grid;
+	grid-template: 1fr/1fr;
+	> * {
+		padding: 0 ${ space( 2 ) };
+		grid-area: 1/1;
+	}
+	> .components-animate__slide-out {
+		pointer-events: none;
+	}
 `;
 
 export const MenuUI = styled.div`


### PR DESCRIPTION
This PR started for the use case of enabling sticky positioned elements within `Navigation`. Currently, the `overflow: hidden` style of `Navigation` prevents sticky positioning so this PR changes it to only hide the overflow during transitions. The exit animation for the menu is actually secondary but it is the bulk of the changes. If for some reason we don't want that, the PR can be scaled back to just the overflow change.

## Screenshots

### In Site Editor 
Before | After
-------|-------
![nav-animate-site-editor-beforish](https://user-images.githubusercontent.com/9000376/118436440-acc66e80-b695-11eb-8429-9d2532e04972.gif) | ![nav-animate-site-editor-after](https://user-images.githubusercontent.com/9000376/118436474-b7810380-b695-11eb-89ea-36204cd74f9b.gif)

### In preferences modal (< medium breakpoint)
https://user-images.githubusercontent.com/9000376/118437237-214ddd00-b697-11eb-815b-0becea747b82.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
