### PR TITLE
Fix nav placeholder colors and height.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -181,6 +181,13 @@ $color-control-label-height: 20px;
 	.components-placeholder__fieldset .components-button {
 		margin-bottom: 0;
 	}
+
+	// For the placeholder indicators to colorize correctly, colors need to be inherited unless selected.
+	color: inherit;
+
+	.is-selected & {
+		color: $gray-900;
+	}
 }
 
 // Spinner.
@@ -225,19 +232,23 @@ $color-control-label-height: 20px;
 		opacity: 0.3;
 	}
 
-	// Don't show the preview boxes for an empty nav block.
-	// Needs specificity to work for the navigation screen.
-	.wp-block-navigation.is-selected &.wp-block-navigation-placeholder__preview {
-		display: none;
-	}
-
-	// ... but be present in larger contexts to size it correctly.
-	.wp-block-navigation.is-selected .is-large & {
+	// Don't show the preview boxes for an empty nav block,
+	// but be technically present to help size the empty state.
+	.wp-block-navigation.is-selected & {
 		display: flex;
 		opacity: 0;
 		width: 0;
 		overflow: hidden;
 		flex-wrap: nowrap;
+	}
+
+	// .. but hide entirely when the placeholder can still be toggled.
+	.wp-block-navigation.is-selected .is-small & {
+		display: none;
+	}
+
+	.wp-block-navigation.is-selected .is-medium & {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #31841.

This PR fixes a regression with the placeholder state of the navigation block, where colors weren't inherited.

It also fixes a small edgecase where the setup state would jump.

## How has this been tested?

- Insert a group with a black background.
- Inside that group, insert a navigation block, but don't fill in items.
- Deselect the navigation block and verify that it still looks correct.

Before:

![issue](https://user-images.githubusercontent.com/1204802/118454369-94d40680-b6f8-11eb-9d32-14fe65650500.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/118454376-969dca00-b6f8-11eb-8b5c-da5888e2e333.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
