### PR TITLE
Remove Widgets Customizer experimental flag

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -51,17 +51,6 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-navigation',
 		)
 	);
-	add_settings_field(
-		'gutenberg-widgets-in-customizer',
-		__( 'Widgets', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable Widgets screen in Customizer', 'gutenberg' ),
-			'id'    => 'gutenberg-widgets-in-customizer',
-		)
-	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -75,7 +75,7 @@ function gutenberg_widgets_customize_register( $manager ) {
  * @param string $id   Widget setting ID.
  */
 function gutenberg_widgets_customize_add_unstable_instance( $args, $id ) {
-	if ( preg_match( '/^widget_(?P<id_base>.+?)(?:\[(?P<widget_number>\d+)\])?$/', $id, $matches ) ) {
+	if ( gutenberg_use_widgets_block_editor() && preg_match( '/^widget_(?P<id_base>.+?)(?:\[(?P<widget_number>\d+)\])?$/', $id, $matches ) ) {
 		$id_base = $matches['id_base'];
 
 		$args['sanitize_callback'] = function( $value ) use ( $id_base ) {
@@ -166,9 +166,7 @@ function gutenberg_widgets_customize_load_block_editor_scripts_and_styles( $is_b
 	return $is_block_editor_screen;
 }
 
-if ( gutenberg_is_experiment_enabled( 'gutenberg-widgets-in-customizer' ) ) {
-	add_action( 'customize_register', 'gutenberg_widgets_customize_register' );
-	add_filter( 'widget_customizer_setting_args', 'gutenberg_widgets_customize_add_unstable_instance', 10, 2 );
-	add_action( 'customize_controls_enqueue_scripts', 'gutenberg_customize_widgets_init' );
-	add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_customize_load_block_editor_scripts_and_styles' );
-}
+add_action( 'customize_register', 'gutenberg_widgets_customize_register' );
+add_filter( 'widget_customizer_setting_args', 'gutenberg_widgets_customize_add_unstable_instance', 10, 2 );
+add_action( 'customize_controls_enqueue_scripts', 'gutenberg_customize_widgets_init' );
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_customize_load_block_editor_scripts_and_styles' );

--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -28,7 +28,6 @@ describe( 'Widgets Customizer', () => {
 		await deactivatePlugin(
 			'gutenberg-test-plugin-disables-the-css-animations'
 		);
-		await setWidgetsCustomizerExperiment( true );
 	} );
 
 	afterAll( async () => {
@@ -36,7 +35,6 @@ describe( 'Widgets Customizer', () => {
 			'gutenberg-test-plugin-disables-the-css-animations'
 		);
 		await activateTheme( 'twentytwentyone' );
-		await setWidgetsCustomizerExperiment( false );
 	} );
 
 	it( 'should add blocks', async () => {
@@ -499,28 +497,6 @@ describe( 'Widgets Customizer', () => {
 		);
 	} );
 } );
-
-async function setWidgetsCustomizerExperiment( enabled ) {
-	await visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
-
-	const checkbox = await find( {
-		role: 'checkbox',
-		name: 'Enable Widgets screen in Customizer',
-	} );
-
-	const snapshot = await page.accessibility.snapshot( { root: checkbox } );
-
-	if ( snapshot.checked !== enabled ) {
-		await checkbox.click();
-	}
-
-	const submitButton = await find( {
-		role: 'button',
-		name: 'Save Changes',
-	} );
-
-	await Promise.all( [ submitButton.click(), page.waitForNavigation() ] );
-}
 
 /**
  * TODO: Deleting widgets in the new widgets screen seems to be unreliable.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Originally introduced in #28618. Remove the experimental flag as it's getting matured and help for the [Call for Testing](https://make.wordpress.org/core/2021/05/12/help-test-the-widgets-editor-for-wordpress-5-8/).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Go to Appearance -> Customize -> Widgets. It should load the Widgets block editor.
- Install and activate the [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) plugin. It should take us back the the classic widgets editor in customizer.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
