### PR TITLE
Enable justification for burger menu.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -375,7 +375,7 @@ $color-control-label-height: 20px;
 	// That means we only have to consider the big adminbar height (<783px).
 	// And in that view we also know that the toolbar is stacked.
 	body.admin-bar & {
-		top: $admin-bar-height-big + $header-height + $block-toolbar-height;
+		top: $admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 		@include break-medium() {
 			top: $header-height + $border-width;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -187,7 +187,8 @@
 	// This needs high specificity.
 	&.wp-block-navigation.items-justified-space-between > .submenu-container > .has-child:last-child,
 	&.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-	&.wp-block-navigation.items-justified-right .has-child {
+	&.wp-block-navigation.items-justified-right > .submenu-container .has-child,
+	&.wp-block-navigation.items-justified-right > .wp-block-navigation__container .has-child {
 
 		// First submenu.
 		.submenu-container,

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -352,6 +352,7 @@
 	}
 }
 
+
 /**
  * Mobile menu.
  */
@@ -472,7 +473,11 @@
 	z-index: 2; // Needs to be above the modal z index itself.
 }
 
-// The menu adds a wrapping container.
+// The menu adds wrapping containers.
+.wp-block-navigation__responsive-close {
+	width: 100%;
+}
+
 .is-menu-open .wp-block-navigation__responsive-close,
 .is-menu-open .wp-block-navigation__responsive-dialog,
 .is-menu-open .wp-block-navigation__responsive-container-content {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -460,8 +460,26 @@
 
 // Button to open the menu.
 .wp-block-navigation__responsive-container-open {
+	display: flex;
+
 	@include break-small {
 		display: none;
+	}
+
+	// Justify the button.
+	.items-justified-left & {
+		margin-left: 0;
+		margin-right: auto;
+	}
+
+	.items-justified-center & {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.items-justified-right & {
+		margin-left: auto;
+		margin-right: 0;
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #31845.

The recently landed burger menu feature adds a few containers. Some of these containers broke the justification. This PR fixes that:

<img width="792" alt="Screenshot 2021-05-17 at 10 27 44" src="https://user-images.githubusercontent.com/1204802/118458236-d2d22a00-b6fa-11eb-8fa6-0dbebee87046.png">

## How has this been tested?

Please insert a navigation block. Enable responsiveness in the inspector. Try the various alignments, left, center, right, justify. Verify they look correct on the frontend and editor. Please try also the responsive feature, with the menu open and closed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
