### PR TITLE
Submenus shouldn't take space unless they're actually open.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -43,6 +43,7 @@
 	&.is-selected,
 	&.has-child-selected {
 		> .wp-block-navigation-link__container {
+			display: flex;
 			opacity: 1;
 			visibility: visible;
 		}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -97,12 +97,12 @@
 			color: inherit;
 			position: absolute;
 			z-index: 2;
-			display: flex;
 			flex-direction: column;
 			align-items: normal;
 			min-width: 200px;
 
 			// Hide until hover or focus within.
+			display: none;
 			opacity: 0;
 			transition: opacity 0.1s linear;
 			visibility: hidden;
@@ -146,17 +146,19 @@
 		}
 
 		// Separating out hover and focus-within so hover works again on IE: https://davidwalsh.name/css-focus-within#comment-513401
-		// We will need to replace focus-within with a JS solution for IE keyboard support.
+		// We don't actually have to support this anymore, but it's easy to keep for now.
 
 		// Custom menu items.
 		// Show submenus on hover.
 		&:hover > .wp-block-navigation-link__container {
+			display: flex;
 			visibility: visible;
 			opacity: 1;
 		}
 
 		// Keep submenus open when focus is within.
 		&:focus-within > .wp-block-navigation-link__container {
+			display: flex;
 			visibility: visible;
 			opacity: 1;
 		}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -168,6 +168,7 @@
 			cursor: pointer;
 
 			> .submenu-container {
+				display: flex;
 				visibility: visible;
 				opacity: 1;
 			}
@@ -177,6 +178,7 @@
 			cursor: pointer;
 
 			> .submenu-container {
+				display: flex;
 				visibility: visible;
 				opacity: 1;
 			}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -253,10 +253,18 @@
 		}
 
 		// Submenu indentation when there's no background.
+		// It should align with the text above.
 		left: -1em;
 		top: 100%;
 
-		// Indentation for all submenus.
+		// Indentation when no background on small viewports.
+		// It should align with the parent menu above.
+		.submenu-container,
+		.wp-block-navigation-link__container {
+			left: -1px;
+		}
+
+		// Indentation for all submenus on large viewports.
 		@include break-medium {
 			.submenu-container,
 			.wp-block-navigation-link__container {
@@ -267,10 +275,18 @@
 	}
 
 	// Submenu indentation when there's a background.
+	// It should align with menu item itself.
 	&.has-background .has-child .submenu-container,
 	&.has-background .has-child .wp-block-navigation-link__container {
 		left: 0;
 		top: 100%;
+
+		// Indentation when there's a background on small viewports.
+		// It should align with the parent menu above.
+		.submenu-container,
+		.wp-block-navigation-link__container {
+			left: 0;
+		}
 
 		// There's no border on submenus when there are backgrounds.
 		@include break-medium {


### PR DESCRIPTION
## Description

Currently submenus in the navigation block are `visibility: hidden;` until you tab or click into them. That, however, means they still take up space in the viewport, as opposed to `display: none;`, which actually makes it disappear.

This particular behavior meant you could have a horizontal scrollbar appear for no reason:

<img width="1138" alt="Screenshot 2021-05-17 at 12 25 47" src="https://user-images.githubusercontent.com/1204802/118474134-061cb500-b70b-11eb-9d0a-9d2b3aadc73a.png">

This PR fixes that:

![scrollbar](https://user-images.githubusercontent.com/1204802/118474163-0ddc5980-b70b-11eb-9bc7-df1a486eb325.gif)

On smaller viewports, nested submenus don't open rightwards, they open downwards and "stack". The alignment was off, though:

<img width="591" alt="Screenshot 2021-05-17 at 11 59 40" src="https://user-images.githubusercontent.com/1204802/118474359-45e39c80-b70b-11eb-9eec-efe9ada680c7.png">

That's fixed too:

<img width="396" alt="Screenshot 2021-05-17 at 12 19 24" src="https://user-images.githubusercontent.com/1204802/118474373-4845f680-b70b-11eb-96b0-8620f46c98ae.png">

When menus have color, those rules are different, so that's tweaked too:

<img width="342" alt="Screenshot 2021-05-17 at 12 19 54" src="https://user-images.githubusercontent.com/1204802/118474411-51cf5e80-b70b-11eb-9839-ed4aaf25928e.png">

## How has this been tested?

Please insert a navigation menu that has a bunch of nested submenu items.

Then test it with and without background colors, on small and medium (600px plus) viewport breakpoints. 

Menus should look good, and there shouldn't be a horizontal scrollbar when submenu items aren't open.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
