### PR TITLE
Gallery: Fix Image Size regression

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -111,7 +111,7 @@ function GalleryEdit( props ) {
 		};
 	} );
 
-	const { resizedImages } = useMemo( () => {
+	const resizedImages = useMemo( () => {
 		if ( isSelected ) {
 			return reduce(
 				attributes.ids,


### PR DESCRIPTION
## Description
PR fixes recent minor regression where "Gallery Block did not display image Size" control.

Fixes #31880.

## How has this been tested?
1. Create a post/page.
2. Add the Gallery block.
3. Add images.
4. Select an image.
5. Sidebar should display "Image Size" control.

## Screenshots <!-- if applicable -->
![CleanShot 2021-05-17 at 14 59 47](https://user-images.githubusercontent.com/240569/118478136-94e7fc80-b720-11eb-80f4-7b5457e4518e.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
