### PR TITLE
Proof of concept: No in-canvas appender.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,6 +1,8 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
+	display: none !important;
+
 	align-self: center;
 	padding: 0;
 	list-style: none;


### PR DESCRIPTION
**Don't merge this, it's purely a proof of concept**. The goal of this is to explore alternatives to the current in-canvas appender — the black plus — which causes a big layout shift when appearing:

![yes appender](https://user-images.githubusercontent.com/1204802/118480680-dd98b900-b712-11eb-8342-a432da765283.gif)

This PR simply forces that black plus to never be shown, eliminating that layout shift entirely:

![no appender](https://user-images.githubusercontent.com/1204802/118480744-ee492f00-b712-11eb-9f92-50546d94ace6.gif)

This PR is not meant to be merged as is, it's only meant to explore a new baseline of [no layout shift ever](https://github.com/WordPress/gutenberg/issues/26404#issuecomment-842225881). In that vein, this is already wildly successful, especially in the site editor:

![site editor](https://user-images.githubusercontent.com/1204802/118481261-90691700-b713-11eb-8345-61a2c2a11c53.gif)

Here's before 🙈:

![before](https://user-images.githubusercontent.com/1204802/118481381-b8587a80-b713-11eb-9c23-207813043d6c.gif)

A few take-aways that are immediately evident:

- Don't underestimate the value of zero layout shift.
- We do need a way to insert blocks in nesting containers. That can potentially be a more discoverable sibling inserter, or something else. 
- Which ever it is, it will be in a popover, which means it won't be subject to CSS bleed from the theme. That's another benefit.