### PR TITLE
Augment and improve Nav Editor (and block) documentation 

### DIFF
--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -22,12 +22,14 @@ initialize( '#navigation-editor-root', blockEditorSettings );
 
 ## Purpose
 
-By default, the Navigation Editor screen creates block based representations of menus allows users to create and edit complex menus using block-based UI.
+By default, the Navigation Editor screen allows users to create and edit complex navigations using a block-based UI. The aim is to supercede the current Menus screen by providing a superior experience whilst retaining backwards compatibility.
 
-In addition to this the Navigation Editor has two "modes" for _persistence_ ("saving" navigations) and _rendering_:
+## Modes
 
-1. Default - navigations are saved to the _existing_ (post type powered) Menus system and rendered using standard Walker classes.
-2. Block-based - navigations continue to be _saved_ using the existing post type system, but non-link blocks are saved (see technical implementation) and _rendered_ as blocks to provide access to the full power of the Navigation block (with some tradeoffs in terms of backwards compatibility).
+The Navigation Editor has two "modes" for _persistence_ ("saving" navigations) and _rendering_:
+
+1. **Default** - navigations are saved to the _existing_ (post type powered) Menus system and rendered using standard Walker classes.
+2. **Block-based** (opt _in_) - navigations continue to be _saved_ using the existing post type system, but non-link blocks are saved (see technical implementation) and _rendered_ as blocks to provide access to the full power of the Navigation block (with some tradeoffs in terms of backwards compatibility).
 
 ### Default Mode
 
@@ -37,15 +39,15 @@ Moreover, when the navigation is rendered on the front of the site the system co
 
 ### Block-based Mode
 
-If desired, themes are able to opt into _rendering_ complete block-based menus. This allows for arbitrarily complex Navigation block structures to be used in an existing theme whilst still ensuring the navigation data is still _saved_ to the existing (post type powered) Menus system.
+If desired, themes are able to opt into _rendering_ complete block-based menus using the Navigation Editor. This allows for arbitrarily complex navigation block structures to be used in an existing theme whilst still ensuring the navigation data is still _saved_ to the existing (post type powered) Menus system.
 
-Themes can opt into this by declaring:
+Themes can opt into this behaviour by declaring:
 
 ```php
 add_theme_support( 'block-nav-menus' );
 ```
 
-This unlocks significant additional capabilities in the Navigation Editor. For example, by default, the Navigation Editor screen only allows link blocks to be inserted into a navigation. When a theme opts into `block-nav-menus` however, users are able to add non-link blocks to a navigation using the Navigation Editor screen, including:
+This unlocks significant additional capabilities in the Navigation Editor. For example, by default, [the Navigation Editor screen only allows _link_ (`core/navigation-link`) blocks to be inserted into a navigation](https://github.com/WordPress/gutenberg/blob/7fcd57c9a62c232899e287f6d96416477d810d5e/packages/edit-navigation/src/filters/disable-inserting-non-navigation-blocks.js). When a theme opts into `block-nav-menus` however, users are able to add non-link blocks to a navigation using the Navigation Editor screen, including:
 
 -   `core/navigation-link`.
 -   `core/social`.
@@ -55,11 +57,11 @@ These are persisted as a `nav_menu_item` post with a type of `block` and when re
 
 #### Technical Implementation details
 
-By default, `core/navigation-link` items are serialized and persisted as `nav_menu_item` posts. No serialized block HTML is stored for link blocks.
+By default, `core/navigation-link` items are serialized and persisted as `nav_menu_item` posts. No serialized block HTML is stored for these standard link blocks.
 
-Non-link navigation items however, are persisted as `nav_menu_items` with a special `type` of `block`. These items have an _additional_ `content` field which is used to store the serialized block markup.
+_Non_-link navigation items however, are [persisted as `nav_menu_items` with a special `type` of `block`](https://github.com/WordPress/gutenberg/blob/7fcd57c9a62c232899e287f6d96416477d810d5e/packages/edit-navigation/src/store/utils.js#L159-L166). These items have an [_additional_ `content` field which is used to store the serialized block markup](https://github.com/WordPress/gutenberg/blob/7fcd57c9a62c232899e287f6d96416477d810d5e/lib/navigation.php#L71-L101).
 
-When rendered on the front-end, the blocks are `parse`d from the `content` field and rendered as blocks.
+When rendered on the front-end, the blocks are [`parse`d from the `content` field](https://github.com/WordPress/gutenberg/blob/7fcd57c9a62c232899e287f6d96416477d810d5e/lib/navigation.php#L191-L203) and [rendered as blocks](https://github.com/WordPress/gutenberg/blob/7fcd57c9a62c232899e287f6d96416477d810d5e/lib/navigation.php#L103-L135).
 
 If the user switches to a theme that does not support block menus, or disables this functionality, non-link blocks are no longer rendered on the frontend. Care is taken, however, to ensure that users can still see their data on the existing Menus screen.
 
@@ -101,6 +103,12 @@ return (
 	</BlockEditorProvider>
 );
 ```
+
+## Glossary
+
+-   Link block - refers to the basic `core/navigation-link` block which is the standard block used to add links within navigations.
+-   Navigation block - refers to the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
+-   Navigation Editor screen - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
 

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -22,7 +22,7 @@ initialize( '#navigation-editor-root', blockEditorSettings );
 
 ## Purpose
 
-By default, the Navigation Editor screen allows users to create and edit complex navigations using a block-based UI. The aim is to supercede the current Menus screen by providing a superior experience whilst retaining backwards compatibility.
+By default, the Navigation Editor screen allows users to create and edit complex navigations using a block-based UI. The aim is to supercede [the current Menus screen](https://codex.wordpress.org/WordPress_Menu_User_Guide) by providing a superior experience whilst retaining backwards compatibility.
 
 ## Modes
 
@@ -159,7 +159,7 @@ return (
 -   **Link block** - the basic `core/navigation-link` block which is the standard block used to add links within navigations.
 -   **Navigation block** - the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
 -   **Navigation editor / screen** - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
-
-_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
+-   **Menus screen** - the current/existing [interface/screen for managing Menus](https://codex.wordpress.org/WordPress_Menu_User_Guide) in WordPress WPAdmin.
+    _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -24,6 +24,8 @@ initialize( '#navigation-editor-root', blockEditorSettings );
 
 By default, the Navigation Editor screen allows users to create and edit complex navigations using a block-based UI. The aim is to supercede [the current Menus screen](https://codex.wordpress.org/WordPress_Menu_User_Guide) by providing a superior experience whilst retaining backwards compatibility.
 
+The editing experience is provided as a block editor wrapper around the core functionality of the **Navigation _block_**. Features of the block are disabled/enhanced as necessary to provide an experience appropriate to editing a navigation outside of a Full Site Editing context.
+
 ## Modes
 
 The Navigation Editor has two "modes" for _persistence_ ("saving" navigations) and _rendering_:

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -53,8 +53,6 @@ This unlocks significant additional capabilities in the Navigation Editor. For e
 -   `core/social`.
 -   `core/search`.
 
-These are persisted as a `nav_menu_item` post with a type of `block` and when rendered on the frontend these are parsed and rendered as _blocks_.
-
 #### Technical Implementation details
 
 By default, `core/navigation-link` items are serialized and persisted as `nav_menu_item` posts. No serialized block HTML is stored for these standard link blocks.
@@ -106,9 +104,9 @@ return (
 
 ## Glossary
 
--   Link block - refers to the basic `core/navigation-link` block which is the standard block used to add links within navigations.
--   Navigation block - refers to the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
--   Navigation Editor screen - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
+-   **Link block** - the basic `core/navigation-link` block which is the standard block used to add links within navigations.
+-   **Navigation block** - the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
+-   **Navigation Editor screen** - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
 

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -20,6 +20,49 @@ import blockEditorSettings from './block-editor-settings';
 initialize( '#navigation-editor-root', blockEditorSettings );
 ```
 
+## Purpose
+
+By default, the Navigation Editor screen creates block based representations of menus allows users to create and edit complex menus using block-based UI.
+
+In addition to this the Navigation Editor has two "modes" for _persistence_ ("saving" navigations) and _rendering_:
+
+1. Default - navigations are saved to the _existing_ (post type powered) Menus system and rendered using standard Walker classes.
+2. Block-based - navigations continue to be _saved_ using the existing post type system, but non-link blocks are saved (see technical implementation) and _rendered_ as blocks to provide access to the full power of the Navigation block (with some tradeoffs in terms of backwards compatibility).
+
+### Default Mode
+
+In this mode, navigations created in the Navigation Editor are stored using the _existing Menu post type_ (`nav_menu_item`) system. As this method matches that used in the _existing_ Menus screen, there is a smooth upgrade path to using new Navigation Editor screen to edit navigations.
+
+Moreover, when the navigation is rendered on the front of the site the system continues to use [the classic Navigation "Walker" class](https://developer.wordpress.org/reference/classes/walker_nav_menu/), thereby ensuring the HTML markup remains the same when using a classic Theme.
+
+### Block-based Mode
+
+If desired, themes are able to opt into _rendering_ complete block-based menus. This allows for arbitrarily complex Navigation block structures to be used in an existing theme whilst still ensuring the navigation data is still _saved_ to the existing (post type powered) Menus system.
+
+Themes can opt into this by declaring:
+
+```php
+add_theme_support( 'block-nav-menus' );
+```
+
+This unlocks significant additional capabilities in the Navigation Editor. For example, by default, the Navigation Editor screen only allows link blocks to be inserted into a navigation. When a theme opts into `block-nav-menus` however, users are able to add non-link blocks to a navigation using the Navigation Editor screen, including:
+
+-   `core/navigation-link`.
+-   `core/social`.
+-   `core/search`.
+
+These are persisted as a `nav_menu_item` post with a type of `block` and when rendered on the frontend these are parsed and rendered as _blocks_.
+
+#### Technical Implementation details
+
+By default, `core/navigation-link` items are serialized and persisted as `nav_menu_item` posts. No serialized block HTML is stored for link blocks.
+
+Non-link navigation items however, are persisted as `nav_menu_items` with a special `type` of `block`. These items have an _additional_ `content` field which is used to store the serialized block markup.
+
+When rendered on the front-end, the blocks are `parse`d from the `content` field and rendered as blocks.
+
+If the user switches to a theme that does not support block menus, or disables this functionality, non-link blocks are no longer rendered on the frontend. Care is taken, however, to ensure that users can still see their data on the existing Menus screen.
+
 ## Hooks
 
 `useMenuItems` and `useNavigationBlock` hooks are the central part of this package. They bridge the gap between the API and the block editor interface:

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -162,6 +162,7 @@ return (
 -   **Navigation block** - the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
 -   **Navigation editor / screen** - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
 -   **Menus screen** - the current/existing [interface/screen for managing Menus](https://codex.wordpress.org/WordPress_Menu_User_Guide) in WordPress WPAdmin.
-    _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -63,6 +63,38 @@ When rendered on the front-end, the blocks are [`parse`d from the `content` fiel
 
 If the user switches to a theme that does not support block menus, or disables this functionality, non-link blocks are no longer rendered on the frontend. Care is taken, however, to ensure that users can still see their data on the existing Menus screen.
 
+## Block to Menu Item mapping
+
+The Navigation Editor needs to be able to map navigation items in two directions:
+
+1. `nav_menu_item`s to Blocks - when displaying an existing navigation.
+2. Blocks to `nav_menu_item`s - when _saving_ an navigation being editing in the Navigation screen.
+
+To understand this fully, one must first appreciate that WordPress maps raw `nav_menu_item` posts to Menu item _objects_. These have various properties which map to block attributes as follows:
+
+| Property           |                                                Description                                                |               Equivalent Block Attribute               |
+| :----------------- | :-------------------------------------------------------------------------------------------------------: | :----------------------------------------------------: |
+| `ID`               |                         The term_id if the menu item represents a taxonomy term.                          |                      Not mapped.                       |
+| `attr_title`       |                        The title attribute of the link element for this menu item.                        |                        `title`                         |
+| `classes`          |                The array of class attribute values for the link element of this menu item.                |                      `classNames`                      |
+| `db_id`            |          The DB ID of this item as a nav_menu_item object, if it exists (0 if it doesn't exist).          |                      Not mapped.                       |
+| `description`      |                                    The description of this menu item.                                     |                     `description`                      |
+| `menu_item_parent` |           The DB ID of the nav_menu_item that is this item's menu parent, if any. 0 otherwise.            | Not mapped.<sup>[1](#menu_item_menu_item_parent)</sup> |
+| `object`           |          The type of object originally represented, such as 'category', 'post', or 'attachment'.          |                         `type`                         |
+| `object_id`        | The DB ID of the original object this menu item represents, e.g. ID for posts and term_id for categories. |                          `id`                          |
+| `post_parent`      |                  The DB ID of the original object's parent object, if any (0 otherwise).                  |                      Not mapped.                       |
+| `post_title`       |                   A "no title" label if menu item represents a post that lacks a title.                   |                      Not mapped.                       |
+| `target`           |                       The target attribute of the link element for this menu item.                        |    `opensInNewTab`<sup>[2](#menu_item_target)</sup>    |
+| `title`            |                                       The title of this menu item.                                        |                        `label`                         |
+| `type`             |             The family of objects originally represented, such as 'post_type' or 'taxonomy'.              |                         `kind`                         |
+| `type_label`       |                        The singular label used to describe this type of menu item.                        |                      Not mapped.                       |
+| `url`              |                                  The URL to which this menu item points.                                  |                         `url`                          |
+| `xfn`              |                       The XFN relationship expressed in the link of this menu item.                       |                         `rel`                          |
+| `\_invalid`        |                     Whether the menu item represents an object that no longer exists.                     |                      Not mapped.                       |
+
+-   [<a name="menu_item_menu_item_parent">1</a>] - the parent -> child relationship is expressed in block via the `innerBlocks` attribute and is therefore not required as a explicit block attribute.
+-   [<a name="menu_item_target">2</a>] - applies only if the value of the `target` field is `_blank`.
+
 ## Hooks
 
 `useMenuItems` and `useNavigationBlock` hooks are the central part of this package. They bridge the gap between the API and the block editor interface:
@@ -106,7 +138,7 @@ return (
 
 -   **Link block** - the basic `core/navigation-link` block which is the standard block used to add links within navigations.
 -   **Navigation block** - the root `core/navigation` block which can be used both with the Navigation Editor and outside (eg: Post / Site Editor).
--   **Navigation Editor screen** - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
+-   **Navigation editor / screen** - the new screen provided by Gutenberg to allow the user to edit navigations using a block-based UI.
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as IE browsers then using [core-js](https://github.com/zloirock/core-js) will add polyfills for these methods._
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Since the `README` for the Navigation Editor was created it has evolved _significantly_.

This an effort to provide high level documentation of its behaviour (and the decisions that have guided us), in the hope that we can transfer the project's domain knowledge into written form (and out of contributors' heads!).

If there is any information missing that you feel ought to be documented here please say and I will investigate and write it.

## How has this been tested?
Reading words. Comparing against implementation.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
