### PR TITLE
Babel Preset Default: Introduce ignoreBrowserslistConfig option

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added `ignoreBrowserslistConfig` option to enable searching for any browserslist files or referencing the browserslist key inside package.json.
+
 ## 6.0.0 (2021-05-14)
 
 ### Breaking Changes

--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -16,17 +16,23 @@ npm install @wordpress/babel-preset-default --save-dev
 
 ### Usage
 
-There are a number of methods to configure Babel. See [Babel's Configuration documentation](https://babeljs.io/docs/en/configuration) for more information. To use this preset, simply reference `@wordpress/default` in the `presets` option in your Babel configuration.
+There are a number of methods to configure Babel. See [Babel's Configuration documentation](https://babeljs.io/docs/en/configuration) for more information. To use this preset, simply reference `@wordpress/babel-preset-default` in the `presets` option in your Babel configuration.
 
 For example, using `.babelrc`:
 
 ```json
 {
-	"presets": [ "@wordpress/default" ]
+	"presets": [ "@wordpress/babel-preset-default" ]
 }
 ```
 
-#### Extending Configuration
+### Options
+
+#### `ignoreBrowserslistConfig` (`boolean`, default `true`)
+
+Set to `false` to to enable searching for any browserslist files or referencing the browserslist key inside `package.json`. By default `@wordpress/browserslist-config` is used.
+
+### Extending Configuration
 
 This preset is an opinionated configuration. If you would like to add to or change this configuration, you can do so by expanding your Babel configuration to include plugins or presets which override those included through this preset. It may help to familiarize yourself [the implementation of the configuration](https://github.com/WordPress/gutenberg/blob/HEAD/packages/babel-preset-default/index.js) to see which specific plugins are enabled by default through this preset.
 


### PR DESCRIPTION
## Description
See https://github.com/WordPress/gutenberg/issues/31857.

## How has this been tested?
In a project with a custom browserslist config I've used the new option like this:
```json
  "babel": {
    "presets": [
      [
        "@wordpress/babel-preset-default",
        {
          "ignoreBrowserslistConfig": false
        }
      ]
    ]
  }
```

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
