### PR TITLE
Drop indicator: show around dragged block and show above selected block for file drop

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -14,12 +14,17 @@ import { InsertionPointOpenRef } from '../block-tools/insertion-point';
 
 export function useInBetweenInserter() {
 	const openRef = useContext( InsertionPointOpenRef );
+	const hasReducedUI = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().hasReducedUI,
+		[]
+	);
 	const {
 		getBlockListSettings,
 		getBlockRootClientId,
 		getBlockIndex,
 		isBlockInsertionPointVisible,
 		isMultiSelecting,
+		getSelectedBlockClientIds,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
@@ -27,12 +32,12 @@ export function useInBetweenInserter() {
 
 	return useRefEffect(
 		( node ) => {
+			if ( hasReducedUI ) {
+				return;
+			}
+
 			function onMouseMove( event ) {
 				if ( openRef.current ) {
-					return;
-				}
-
-				if ( isMultiSelecting() ) {
 					return;
 				}
 
@@ -98,6 +103,12 @@ export function useInBetweenInserter() {
 					return;
 				}
 
+				// Don't show the inserter when hovering above (conflicts with
+				// block toolbar) or inside selected block(s).
+				if ( getSelectedBlockClientIds().includes( clientId ) ) {
+					return;
+				}
+
 				const elementRect = element.getBoundingClientRect();
 
 				if (
@@ -145,6 +156,7 @@ export function useInBetweenInserter() {
 			isMultiSelecting,
 			showInsertionPoint,
 			hideInsertionPoint,
+			getSelectedBlockClientIds,
 		]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -41,6 +41,10 @@ export function useInBetweenInserter() {
 					return;
 				}
 
+				if ( isMultiSelecting() ) {
+					return;
+				}
+
 				if (
 					! event.target.classList.contains(
 						'block-editor-block-list__layout'

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -34,7 +34,6 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
-		isBlockInsertionPointVisible,
 	} = select( blockEditorStore );
 	return {
 		isNavigationMode: isNavigationMode(),
@@ -44,7 +43,6 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: getLastMultiSelectedBlockClientId(),
-		isInsertionPointVisible: isBlockInsertionPointVisible(),
 	};
 }
 
@@ -65,8 +63,25 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 		lastClientId,
-		isInsertionPointVisible,
 	} = useSelect( selector, [] );
+	const isInsertionPointVisible = useSelect(
+		( select ) => {
+			const {
+				isBlockInsertionPointVisible,
+				getBlockInsertionPoint,
+				getBlockOrder,
+			} = select( blockEditorStore );
+
+			if ( ! isBlockInsertionPointVisible() ) {
+				return false;
+			}
+
+			const insertionPoint = getBlockInsertionPoint();
+			const order = getBlockOrder( insertionPoint.rootClientId );
+			return order[ insertionPoint.index ] === clientId;
+		},
+		[ clientId ]
+	);
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -34,6 +34,7 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
+		isBlockInsertionPointVisible,
 	} = select( blockEditorStore );
 	return {
 		isNavigationMode: isNavigationMode(),
@@ -43,6 +44,7 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: getLastMultiSelectedBlockClientId(),
+		isInsertionPointVisible: isBlockInsertionPointVisible(),
 	};
 }
 
@@ -63,6 +65,7 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 		lastClientId,
+		isInsertionPointVisible,
 	} = useSelect( selector, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
@@ -184,7 +187,9 @@ function BlockPopover( {
 			position={ popoverPosition }
 			focusOnMount={ false }
 			anchorRef={ anchorRef }
-			className="block-editor-block-list__block-popover"
+			className={ classnames( 'block-editor-block-list__block-popover', {
+				'is-insertion-point-visible': isInsertionPointVisible,
+			} ) }
 			__unstableStickyBoundaryElement={ stickyBoundaryElement }
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the the default popover slot).

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -36,7 +36,6 @@ function InsertionPointPopover( {
 	const ref = useRef();
 	const {
 		orientation,
-		isHidden,
 		previousClientId,
 		nextClientId,
 		rootClientId,
@@ -45,10 +44,6 @@ function InsertionPointPopover( {
 		const {
 			getBlockOrder,
 			getBlockListSettings,
-			getMultiSelectedBlockClientIds,
-			getSelectedBlockClientId,
-			hasMultiSelection,
-			getSettings,
 			getBlockInsertionPoint,
 		} = select( blockEditorStore );
 		const insertionPoint = getBlockInsertionPoint();
@@ -66,9 +61,6 @@ function InsertionPointPopover( {
 		const next = isLast
 			? null
 			: blockOrder[ blockOrder.indexOf( previous ) + 1 ];
-		const { hasReducedUI } = getSettings();
-		const multiSelectedBlockClientIds = getMultiSelectedBlockClientIds();
-		const selectedBlockClientId = getSelectedBlockClientId();
 		const blockOrientation =
 			getBlockListSettings( targetRootClientId )?.orientation ||
 			'vertical';
@@ -76,13 +68,6 @@ function InsertionPointPopover( {
 		return {
 			previousClientId: previous,
 			nextClientId: next,
-			isHidden:
-				hasReducedUI ||
-				( hasMultiSelection()
-					? next && multiSelectedBlockClientIds.includes( next )
-					: next &&
-					  blockOrientation === 'vertical' &&
-					  next === selectedBlockClientId ),
 			orientation: blockOrientation,
 			clientId: targetClientId,
 			rootClientId: targetRootClientId,
@@ -193,14 +178,7 @@ function InsertionPointPopover( {
 	// Only show the inserter when there's a `nextElement` (a block after the
 	// insertion point). At the end of the block list the trailing appender
 	// should serve the purpose of inserting blocks.
-	const showInsertionPointInserter =
-		! isHidden && nextElement && isInserterShown;
-
-	// Show the indicator if the insertion point inserter is visible, or if
-	// the `showInsertionPoint` state is `true`. The latter is generally true
-	// when hovering blocks for insertion in the block library.
-	const showInsertionPointIndicator =
-		showInsertionPointInserter || ! isHidden;
+	const showInsertionPointInserter = nextElement && isInserterShown;
 
 	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	// While ideally it would be enough to capture the
@@ -231,9 +209,7 @@ function InsertionPointPopover( {
 				} ) }
 				style={ style }
 			>
-				{ showInsertionPointIndicator && (
-					<div className="block-editor-block-list__insertion-point-indicator" />
-				) }
+				<div className="block-editor-block-list__insertion-point-indicator" />
 				{ showInsertionPointInserter && (
 					<div
 						className={ classnames(
@@ -266,11 +242,7 @@ export default function InsertionPoint( {
 	__unstableContentRef,
 } ) {
 	const isVisible = useSelect( ( select ) => {
-		const { isMultiSelecting, isBlockInsertionPointVisible } = select(
-			blockEditorStore
-		);
-
-		return isBlockInsertionPointVisible() && ! isMultiSelecting();
+		return select( blockEditorStore ).isBlockInsertionPointVisible();
 	}, [] );
 
 	return (

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -45,32 +45,35 @@ function InsertionPointPopover( {
 			getBlockOrder,
 			getBlockListSettings,
 			getBlockInsertionPoint,
+			isBlockBeingDragged,
+			getPreviousBlockClientId,
+			getNextBlockClientId,
 		} = select( blockEditorStore );
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );
-		const targetClientId = order[ insertionPoint.index - 1 ];
-		const targetRootClientId = insertionPoint.rootClientId;
-		const blockOrder = getBlockOrder( targetRootClientId );
-		if ( ! blockOrder.length ) {
+
+		if ( ! order.length ) {
 			return {};
 		}
-		const previous = targetClientId
-			? targetClientId
-			: blockOrder[ blockOrder.length - 1 ];
-		const isLast = previous === blockOrder[ blockOrder.length - 1 ];
-		const next = isLast
-			? null
-			: blockOrder[ blockOrder.indexOf( previous ) + 1 ];
-		const blockOrientation =
-			getBlockListSettings( targetRootClientId )?.orientation ||
-			'vertical';
+
+		let _previousClientId = order[ insertionPoint.index - 1 ];
+		let _nextClientId = order[ insertionPoint.index ];
+
+		while ( isBlockBeingDragged( _previousClientId ) ) {
+			_previousClientId = getPreviousBlockClientId( _previousClientId );
+		}
+
+		while ( isBlockBeingDragged( _nextClientId ) ) {
+			_nextClientId = getNextBlockClientId( _nextClientId );
+		}
 
 		return {
-			previousClientId: previous,
-			nextClientId: next,
-			orientation: blockOrientation,
-			clientId: targetClientId,
-			rootClientId: targetRootClientId,
+			previousClientId: _previousClientId,
+			nextClientId: _nextClientId,
+			orientation:
+				getBlockListSettings( insertionPoint.rootClientId )
+					?.orientation || 'vertical',
+			rootClientId: insertionPoint.rootClientId,
 			isInserterShown: insertionPoint?.__unstableWithInserter,
 		};
 	}, [] );

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -321,7 +321,11 @@
 		}
 	}
 
-	&.is-insertion-point-visible,
+	// Hide the block toolbar if the insertion point is shown.
+	&.is-insertion-point-visible {
+		visibility: hidden;
+	}
+
 	.is-dragging-components-draggable & {
 		opacity: 0;
 		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -321,6 +321,7 @@
 		}
 	}
 
+	&.is-insertion-point-visible,
 	.is-dragging-components-draggable & {
 		opacity: 0;
 		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -59,16 +59,7 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 			// If the user is dropping to the trailing edge of the block
 			// add 1 to the index to represent dragging after.
 			const isTrailingEdge = edge === 'bottom' || edge === 'right';
-			let offset = isTrailingEdge ? 1 : 0;
-
-			// If the target is the dragged block itself and another 1 to
-			// index as the dragged block is set to `display: none` and
-			// should be skipped in the calculation.
-			const isTargetDraggedBlock =
-				isTrailingEdge &&
-				elements[ index + 1 ] &&
-				elements[ index + 1 ].classList.contains( 'is-dragging' );
-			offset += isTargetDraggedBlock ? 1 : 0;
+			const offset = isTrailingEdge ? 1 : 0;
 
 			// Update the currently known best candidate.
 			candidateDistance = distance;

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -144,6 +144,11 @@ export default function useBlockDropZone( {
 			// https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
 			throttled( event, event.currentTarget );
 		},
+		onDragLeave() {
+			throttled.cancel();
+			hideInsertionPoint();
+			setTargetBlockIndex( null );
+		},
 		onDragEnd() {
 			throttled.cancel();
 			hideInsertionPoint();

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -209,27 +209,6 @@ describe( 'getNearestBlockIndex', () => {
 
 			expect( result ).toBe( 4 );
 		} );
-
-		it( 'skips the block being dragged by checking for the `is-dragging` classname', () => {
-			const position = { x: 0, y: 450 };
-
-			const verticalElementsWithDraggedBlock = [
-				...verticalElements.slice( 0, 2 ),
-				{
-					...verticalElements[ 2 ],
-					classList: createMockClassList( 'wp-block is-dragging' ),
-				},
-				...verticalElements.slice( 3, 4 ),
-			];
-
-			const result = getNearestBlockIndex(
-				verticalElementsWithDraggedBlock,
-				position,
-				orientation
-			);
-
-			expect( result ).toBe( 3 );
-		} );
 	} );
 
 	describe( 'Horizontal block lists', () => {
@@ -341,27 +320,6 @@ describe( 'getNearestBlockIndex', () => {
 			);
 
 			expect( result ).toBe( 4 );
-		} );
-
-		it( 'skips the block being dragged by checking for the `is-dragging` classname', () => {
-			const position = { x: 450, y: 0 };
-
-			const horizontalElementsWithDraggedBlock = [
-				...horizontalElements.slice( 0, 2 ),
-				{
-					...horizontalElements[ 2 ],
-					classList: createMockClassList( 'wp-block is-dragging' ),
-				},
-				...horizontalElements.slice( 3, 4 ),
-			];
-
-			const result = getNearestBlockIndex(
-				horizontalElementsWithDraggedBlock,
-				position,
-				orientation
-			);
-
-			expect( result ).toBe( 3 );
 		} );
 	} );
 } );

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -82,6 +82,13 @@ export default function useDropZone( {
 					maybeDragStart
 				);
 
+				// Note that `dragend` doesn't fire consistently for file and
+				// HTML drag events where the drag origin is outside the browser
+				// window. In Firefox it may also not fire if the originating
+				// node is removed.
+				ownerDocument.addEventListener( 'dragend', maybeDragEnd );
+				ownerDocument.addEventListener( 'mousemove', maybeDragEnd );
+
 				if ( onDragStartRef.current ) {
 					onDragStartRef.current( event );
 				}
@@ -168,6 +175,8 @@ export default function useDropZone( {
 				isDragging = false;
 
 				ownerDocument.addEventListener( 'dragenter', maybeDragStart );
+				ownerDocument.removeEventListener( 'dragend', maybeDragEnd );
+				ownerDocument.removeEventListener( 'mousemove', maybeDragEnd );
 
 				if ( onDragEndRef.current ) {
 					onDragEndRef.current( event );
@@ -178,12 +187,6 @@ export default function useDropZone( {
 			element.addEventListener( 'dragenter', onDragEnter );
 			element.addEventListener( 'dragover', onDragOver );
 			element.addEventListener( 'dragleave', onDragLeave );
-			// Note that `dragend` doesn't fire consistently for file and HTML
-			// drag events where the drag origin is outside the browser window.
-			// In Firefox it may also not fire if the originating node is
-			// removed.
-			ownerDocument.addEventListener( 'dragend', maybeDragEnd );
-			ownerDocument.addEventListener( 'mouseup', maybeDragEnd );
 			// The `dragstart` event doesn't fire if the drag started outside
 			// the document.
 			ownerDocument.addEventListener( 'dragenter', maybeDragStart );
@@ -194,7 +197,7 @@ export default function useDropZone( {
 				element.removeEventListener( 'dragover', onDragOver );
 				element.removeEventListener( 'dragleave', onDragLeave );
 				ownerDocument.removeEventListener( 'dragend', maybeDragEnd );
-				ownerDocument.removeEventListener( 'mouseup', maybeDragEnd );
+				ownerDocument.removeEventListener( 'mousemove', maybeDragEnd );
 				ownerDocument.addEventListener( 'dragenter', maybeDragStart );
 			};
 		},

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -70,6 +70,30 @@ export default function useDropZone( {
 
 			const { ownerDocument } = element;
 
+			/**
+			 * Checks if an element is in the drop zone.
+			 *
+			 * @param {HTMLElement|null} elementToCheck
+			 *
+			 * @return {boolean} True if in drop zone, false if not.
+			 */
+			function isElementInZone( elementToCheck ) {
+				if (
+					! elementToCheck ||
+					! element.contains( elementToCheck )
+				) {
+					return false;
+				}
+
+				do {
+					if ( elementToCheck.dataset.isDropZone ) {
+						return elementToCheck === element;
+					}
+				} while ( ( elementToCheck = elementToCheck.parentElement ) );
+
+				return false;
+			}
+
 			function maybeDragStart( /** @type {DragEvent} */ event ) {
 				if ( isDragging ) {
 					return;
@@ -132,8 +156,8 @@ export default function useDropZone( {
 				// (element that has been entered) should be outside the drop
 				// zone.
 				if (
-					element.contains(
-						/** @type {Node} */ ( event.relatedTarget )
+					isElementInZone(
+						/** @type {HTMLElement|null} */ ( event.relatedTarget )
 					)
 				) {
 					return;
@@ -183,6 +207,7 @@ export default function useDropZone( {
 				}
 			}
 
+			element.dataset.isDropZone = 'true';
 			element.addEventListener( 'drop', onDrop );
 			element.addEventListener( 'dragenter', onDragEnter );
 			element.addEventListener( 'dragover', onDragOver );
@@ -192,6 +217,7 @@ export default function useDropZone( {
 			ownerDocument.addEventListener( 'dragenter', maybeDragStart );
 
 			return () => {
+				delete element.dataset.isDropZone;
 				element.removeEventListener( 'drop', onDrop );
 				element.removeEventListener( 'dragenter', onDragEnter );
 				element.removeEventListener( 'dragover', onDragOver );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Since the drop indicator refactor, we no longer show the indicator around the dragged block. This PR fixes that.

|Before|After|
|-|-|
|![drop-indicator-dragged-block-before](https://user-images.githubusercontent.com/4710635/119021939-b1966580-b9a8-11eb-8827-e79245cab4d9.gif)|![drop-indicator-dragged-block-after](https://user-images.githubusercontent.com/4710635/119021967-b8bd7380-b9a8-11eb-9bc2-9c822997175a.gif)|

We also don't show a drop indicator above the selected block for files drop.

|Before|After|
|-|-|
|![files-drop-indicator-before](https://user-images.githubusercontent.com/4710635/118515523-23b74200-b73e-11eb-9e37-f2ca68d63450.gif)|![files-drop-indicator-after](https://user-images.githubusercontent.com/4710635/118519610-f2d90c00-b741-11eb-992e-50c02f6b8d41.gif)|

It also fixes the drop indicator not showing even when the toolbar is fixed.

Before:
![files-drop-indicator-fixed](https://user-images.githubusercontent.com/4710635/118525511-f1aadd80-b747-11eb-97c2-731f14521ef1.gif)

There's a few thing happening:

* Adjust the previous and next client ID if it is being dragged.
* Instead of the insertion point deciding whether or not it should show, the component showing and hiding the point should decide in what circumstances it should show. We hid the insertion point so the in-between inserter wouldn't show under the block toolbar, but instead we should not show the insertion point in the first place. There are cases where we _do_ want to show the insertion point like for drag and drop.
* Hides the block toolbar if the insertion point is visible.
* Show the in-between inserter even if there is multi-selection, but not _inside_ the selection.
* Hides the drop zone indicator when leaving the drop zone, not just on drag end.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

See above recordings.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
