### PR TITLE
Workflows: Fix "Stable tag:" readme.txt field in SVN upload

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -104,9 +104,7 @@ jobs:
 
             - name: Get previous stable version
               id: get_previous_stable_version
-              env:
-                  STABLE_TAG_REGEX: 'Stable tag: \K${{ env.STABLE_VERSION_REGEX }}'
-              run: echo ::set-output name=stable_version::$(grep -oP "${STABLE_TAG_REGEX}" ./trunk/readme.txt)
+              run: echo ::set-output name=stable_version::$(awk -F ':\ ' '$1 == "Stable tag" {print $2}' ./trunk/readme.txt)
 
             - name: Delete everything
               working-directory: ./trunk


### PR DESCRIPTION
## Description
Fixes #31357.

Our SVN plugin upload workflow currently clears the `Stable tag:` field in `readme.txt` when preparing the plugin for upload to SVN. 

This PR fixes the issue by using `awk` rather than `grep` + a RegEx. Another advantage of the new solution is that it can be easily tested on a non-bash shell (e.g. on macOS).

## How has this been tested?
I cherry-picked the commit to [my fork](https://github.com/ockham/gutenberg)'s `trunk` and `release/10.6` branches, and created a [(fake) 10.6.1 release](https://github.com/ockham/gutenberg/releases/tag/v10.6.1) there. This triggered the relevant [workflow](https://github.com/ockham/gutenberg/runs/2602181521?check_suite_focus=true) -- see screenshots below.

## Screenshots

Note the value of the `STABLE_TAG` env var:

### Before

![image](https://user-images.githubusercontent.com/96308/116607667-8f25a500-a932-11eb-9a31-a0b64a76d706.png)

(from https://github.com/WordPress/gutenberg/runs/2239867087?check_suite_focus=true, via https://github.com/WordPress/gutenberg/issues/31357#issuecomment-829530633)

### After

![image](https://user-images.githubusercontent.com/96308/118517780-ce783200-b737-11eb-90ba-b5baf5689931.png)

(from https://github.com/ockham/gutenberg/runs/2602181521?check_suite_focus=true)

## Types of changes
Bug fix.