### PR TITLE
Babel Preset Default: Configure @babel/preset-env preset to respect a local Browserslist configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24806,26 +24806,31 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
-			"integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+			"version": "4.16.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001214",
+				"caniuse-lite": "^1.0.30001219",
 				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.719",
+				"electron-to-chromium": "^1.3.723",
 				"escalade": "^3.1.1",
 				"node-releases": "^1.1.71"
 			},
 			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30001228",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+					"integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
+				},
 				"colorette": {
 					"version": "1.2.2",
 					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
 					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.720",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
-					"integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
+					"version": "1.3.730",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
+					"integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA=="
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -24784,11 +24784,6 @@
 				"node-releases": "^1.1.71"
 			},
 			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001228",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-					"integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
-				},
 				"colorette": {
 					"version": "1.2.2",
 					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -25146,9 +25141,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001214",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
-			"integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
+			"version": "1.0.30001228",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+			"integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13160,7 +13160,41 @@
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/warning": "file:packages/warning",
+				"browserslist": "^4.16.6",
 				"core-js": "^3.6.4"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.16.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001219",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.723",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.71"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001228",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+					"integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+					"dev": true
+				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.728",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
+					"integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/base-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13162,39 +13162,6 @@
 				"@wordpress/warning": "file:packages/warning",
 				"browserslist": "^4.16.6",
 				"core-js": "^3.6.4"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "4.16.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-					"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30001219",
-						"colorette": "^1.2.2",
-						"electron-to-chromium": "^1.3.723",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.71"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001228",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-					"integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
-					"dev": true
-				},
-				"colorette": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.728",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
-					"integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/base-styles": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
 		"babel-plugin-react-native-platform-specific-extensions": "1.1.1",
 		"babel-plugin-transform-remove-console": "6.9.4",
 		"benchmark": "2.1.4",
-		"browserslist": "4.16.5",
+		"browserslist": "4.16.6",
 		"chalk": "4.0.0",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Configure `@babel/preset-env` preset to respect a local Browserslist configuration.
+
 ## 6.0.0 (2021-05-14)
 
 ### Breaking Changes

--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -16,13 +16,13 @@ npm install @wordpress/babel-preset-default --save-dev
 
 ### Usage
 
-There are a number of methods to configure Babel. See [Babel's Configuration documentation](https://babeljs.io/docs/en/configuration) for more information. To use this preset, simply reference `@wordpress/default` in the `presets` option in your Babel configuration.
+There are a number of methods to configure Babel. See [Babel's Configuration documentation](https://babeljs.io/docs/en/configuration) for more information. To use this preset, simply reference `@wordpress/babel-preset-default` in the `presets` option in your Babel configuration.
 
 For example, using `.babelrc`:
 
 ```json
 {
-	"presets": [ "@wordpress/default" ]
+	"presets": [ "@wordpress/babel-preset-default" ]
 }
 ```
 

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -31,7 +31,8 @@ module.exports = ( api ) => {
 			};
 		} else {
 			opts.modules = false;
-			const localBrowserslistConfig = browserslist.findConfig( '.' ) || {};
+			const localBrowserslistConfig =
+				browserslist.findConfig( '.' ) || {};
 			opts.targets = {
 				browsers:
 					localBrowserslistConfig.defaults ||

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -31,10 +31,10 @@ module.exports = ( api ) => {
 			};
 		} else {
 			opts.modules = false;
-			const browserslistConfig = browserslist.findConfig( '.' ) || {};
+			const localBrowserslistConfig = browserslist.findConfig( '.' ) || {};
 			opts.targets = {
 				browsers:
-					browserslistConfig.defaults ||
+					localBrowserslistConfig.defaults ||
 					require( '@wordpress/browserslist-config' ),
 			};
 		}

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -31,9 +31,10 @@ module.exports = ( api ) => {
 			};
 		} else {
 			opts.modules = false;
+			const browserslistConfig = browserslist.findConfig( '.' ) || {};
 			opts.targets = {
 				browsers:
-					browserslist.findConfig( '.' )?.defaults ||
+					browserslistConfig.defaults ||
 					require( '@wordpress/browserslist-config' ),
 			};
 		}

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+const browserslist = require( 'browserslist' );
+
 module.exports = ( api ) => {
 	let wpBuildOpts = {};
 	const isWPBuild = ( name ) =>
@@ -27,7 +32,9 @@ module.exports = ( api ) => {
 		} else {
 			opts.modules = false;
 			opts.targets = {
-				browsers: require( '@wordpress/browserslist-config' ),
+				browsers:
+					browserslist.findConfig( '.' )?.defaults ||
+					require( '@wordpress/browserslist-config' ),
 			};
 		}
 

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -38,6 +38,7 @@
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/element": "file:../element",
 		"@wordpress/warning": "file:../warning",
+		"browserslist": "^4.16.6",
 		"core-js": "^3.6.4"
 	},
 	"publishConfig": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   The default Babel configuration has changed to respect a local Browserslist configuration.
+
 ## 16.0.0 (2021-05-14)
 
 ### Breaking Changes


### PR DESCRIPTION
## Description
This uses [browserslist.findConfig()](https://github.com/browserslist/browserslist/blob/209adf9e0051fa39a2b25354cffd493300f34b02/node.js#L301) to first search for a local config before falling back to `@wordpress/browserslist-config`. 

Fixes #31857.

## How has this been tested?
To verify what targets are used you can set `opts.debug = true`  after line 37

Before:
```
Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
@babel/preset-env: `DEBUG` option

Using targets:
{
  "android": "90",
  "chrome": "89",
  "edge": "89",
  "firefox": "87",
  "ios": "14",
  "opera": "74",
  "safari": "14",
  "samsung": "13"
}
```

After (with `@wearerequired/browserslist-config`):
```
Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
@babel/preset-env: `DEBUG` option

Using targets:
{
  "chrome": "89",
  "edge": "89",
  "firefox": "87",
  "ie": "11",
  "ios": "14",
  "opera": "74",
  "safari": "14"
}
```

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
