### PR TITLE
Docs: Switch quick start to match gutenpride name in example

### DIFF
--- a/docs/getting-started/tutorials/create-block/README.md
+++ b/docs/getting-started/tutorials/create-block/README.md
@@ -15,10 +15,10 @@ The `@wordpress/create-block` package exists to create the necessary block scaff
 From your plugins directory, to create your block run:
 
 ```sh
-npx @wordpress/create-block starter-block
+npx @wordpress/create-block gutenpride
 ```
 
-The above command creates a new directory called `starter-block`, installs the necessary files, and builds the block plugin. If you want an interactive mode that prompts you for details, run the command without the `starter-block` name.
+The above command creates a new directory called `gutenpride`, installs the necessary files, and builds the block plugin. If you want an interactive mode that prompts you for details, run the command without the `gutenpride` name.
 
 You now need to activate the plugin from inside wp-admin plugins page.
 


### PR DESCRIPTION
## Description

Switches the quick start to use the same `gutenpride` app name used later in the tutorial.


## How has this been tested?

Documentation, confirm name matches.



