### PR TITLE
UnitControl: Fixed documentation for `units` attribute

### DIFF
--- a/packages/components/src/unit-control/README.md
+++ b/packages/components/src/unit-control/README.md
@@ -104,21 +104,23 @@ Collection of available units.
 Example:
 
 ```jsx
-import { __experimentalUnitControl as UnitControl } from '@wordpress/block-editor/';
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 const Example = () => {
 	const [ value, setValue ] = useState( '10px' );
+
 	const units = [
 		{ value: 'px', label: 'px', default: 0 },
 		{ value: '%', label: '%', default: 10 },
 		{ value: 'em', label: 'em', default: 0 },
 	];
 
-	return <UnitControl onChange={ setValue } value={ value } />;
+	return <UnitControl onChange={ setValue } value={ value } units={units} />;
 };
 ```
 
-A `default` value for (in the example above, `10` for `%`), if defined, is set as the new `value` when a unit changes. This is helpful in scenarios where changing a unit may cause drastic results, such as changing from `px` to `vh`.
+A `default` value (in the example above, `10` for `%`), if defined, is set as the new `value` when a unit changes. This is helpful in scenarios where changing a unit may cause drastic results, such as changing from `px` to `vh`.
 
 ### value
 

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text, object } from '@storybook/addon-knobs';
 import styled from '@emotion/styled';
 
 /**
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import UnitControl from '../';
+import { CSS_UNITS } from '../utils';
 
 export default {
 	title: 'Components/UnitControl',
@@ -41,6 +42,7 @@ function Example() {
 			'default'
 		),
 		step: number( 'step', 1 ),
+		units: object( 'units', CSS_UNITS ),
 	};
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR fixes typos and omissions in documentation and Storybook to properly document the property `units` of the UnitControl component.

Problem solved: When looking at storybook & docs, it was unclear if/how we could define the units available in the component `<UnitControl/>`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I created a demo here to make sure the syntax is correct: https://codesandbox.io/s/beautiful-burnell-3d4gm?file=/src/App.js and ran `npm run storybook:dev` to test the Storybook result (see screenshots).

## Screenshots
See it in action: https://user-images.githubusercontent.com/5040227/118523628-3711df80-b735-11eb-9623-3d698a7137f9.mp4

![gutenberg-unitcontrol-units](https://user-images.githubusercontent.com/5040227/118523511-1a75a780-b735-11eb-98fe-dbcab606bb7f.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Documentation fixes (non-breaking)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
