### PR TITLE
Fix block ref when multiple useBlockProps hooks are called

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
@@ -2,13 +2,13 @@
  * WordPress dependencies
  */
 import {
-	useCallback,
 	useContext,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ export function useBlockRefProvider( clientId ) {
 			refs.delete( ref );
 		};
 	}, [ clientId ] );
-	return useCallback(
+	return useRefEffect(
 		( element ) => {
 			// Update the ref in the provider.
 			ref.current = element;
@@ -93,8 +93,7 @@ function useBlockRef( clientId ) {
  */
 function useBlockElement( clientId ) {
 	const { callbacks } = useContext( BlockRefs );
-	const ref = useBlockRef( clientId );
-	const [ element, setElement ] = useState( null );
+	const [ element, setElement ] = useState( useBlockRef( clientId ).current );
 
 	useLayoutEffect( () => {
 		if ( ! clientId ) {
@@ -107,7 +106,7 @@ function useBlockElement( clientId ) {
 		};
 	}, [ clientId ] );
 
-	return ref.current || element;
+	return element;
 }
 
 export { useBlockRef as __unstableUseBlockRef };

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
@@ -93,7 +93,8 @@ function useBlockRef( clientId ) {
  */
 function useBlockElement( clientId ) {
 	const { callbacks } = useContext( BlockRefs );
-	const [ element, setElement ] = useState( useBlockRef( clientId ).current );
+	const ref = useBlockRef( clientId );
+	const [ element, setElement ] = useState( null );
 
 	useLayoutEffect( () => {
 		if ( ! clientId ) {
@@ -106,7 +107,7 @@ function useBlockElement( clientId ) {
 		};
 	}, [ clientId ] );
 
-	return element;
+	return ref.current || element;
 }
 
 export { useBlockRef as __unstableUseBlockRef };

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-refs.js
@@ -29,21 +29,24 @@ export function useBlockRefProvider( clientId ) {
 	const { refs, callbacks } = useContext( BlockRefs );
 	const ref = useRef();
 	useLayoutEffect( () => {
-		refs.set( clientId, ref );
+		refs.set( ref, clientId );
 		return () => {
-			refs.delete( clientId );
+			refs.delete( ref );
 		};
-	}, [] );
-	return useCallback( ( element ) => {
-		// Update the ref in the provider.
-		ref.current = element;
-		// Call any update functions.
-		callbacks.forEach( ( id, setElement ) => {
-			if ( clientId === id ) {
-				setElement( element );
-			}
-		} );
-	}, [] );
+	}, [ clientId ] );
+	return useCallback(
+		( element ) => {
+			// Update the ref in the provider.
+			ref.current = element;
+			// Call any update functions.
+			callbacks.forEach( ( id, setElement ) => {
+				if ( clientId === id ) {
+					setElement( element );
+				}
+			} );
+		},
+		[ clientId ]
+	);
 }
 
 /**
@@ -63,7 +66,17 @@ function useBlockRef( clientId ) {
 	return useMemo(
 		() => ( {
 			get current() {
-				return refs.get( freshClientId.current )?.current || null;
+				let element = null;
+
+				// Multiple refs may be created for a single block. Find the
+				// first that has an element set.
+				for ( const [ ref, id ] of refs.entries() ) {
+					if ( id === freshClientId.current && ref.current ) {
+						element = ref.current;
+					}
+				}
+
+				return element;
 			},
 		} ),
 		[]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

If multiple `useBlockProps()` are called for a single block, currently we only look at the ref of the last call because all previous refs would be overridden (refs are stored by client ID). The solution is to store refs by ref instead and allow multiple refs to be stored for one client ID. When we need the ref, we can check which one is set.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
