### PR TITLE
Icons: allow creation of icons from SVG string

### DIFF
--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -8,7 +8,6 @@ import { share as icon } from '@wordpress/icons';
  */
 import edit from './edit';
 import metadata from './block.json';
-import variations from './variations';
 
 const { name } = metadata;
 
@@ -17,5 +16,4 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
-	variations,
 };

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -52,10 +52,24 @@ function render_block_core_social_link( $attributes, $content, $block ) {
  * Registers the `core/social-link` blocks.
  */
 function register_block_core_social_link() {
+	$variations = array();
+	// TODO: see if we can move services array to const instead of building it on each function call.
+	$services = array_keys( block_core_social_link_services() );
+	// TODO: was there a preferred variations sort?
+	foreach ( $services as $service ) {
+		$variations[] = array(
+			'isDefault'  => 'wordpress' === $service,
+			'name'       => $service,
+			'attributes' => array( 'service' => $service ),
+			'title'      => block_core_social_link_get_name( $service ),
+			'icon'       => block_core_social_link_get_icon( $service ),
+		);
+	}
 	register_block_type_from_metadata(
 		__DIR__ . '/social-link',
 		array(
 			'render_callback' => 'render_block_core_social_link',
+			'variations'      => $variations,
 		)
 	);
 }
@@ -242,7 +256,7 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 		),
 		'tumblr'        => array(
 			'name' => 'Tumblr',
-			'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path d="M17.04 21.28h-3.28c-2.84 0-4.94-1.37-4.94-5.02v-5.67H6.08V7.5c2.93-.73 4.11-3.3 4.3-5.48h3.01v4.93h3.47v3.65H13.4v4.93c0 1.47.73 2.01 1.92 2.01h1.73v3.75z" /></path></svg>',
+			'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path d="M17.04 21.28h-3.28c-2.84 0-4.94-1.37-4.94-5.02v-5.67H6.08V7.5c2.93-.73 4.11-3.3 4.3-5.48h3.01v4.93h3.47v3.65H13.4v4.93c0 1.47.73 2.01 1.92 2.01h1.73v3.75z" /></svg>',
 		),
 		'twitch'        => array(
 			'name' => 'Twitch',


### PR DESCRIPTION
Very early WIP, explores allowing variation icons to set values with an SVG String. This would allow custom variations to register custom icons, and would remove the need for a hook.js file on server registered variations like in (navigation-links and template parts, and social icons).

Currently variation icons support the following values:
- Dashicon name (string)
- A React Component (function), usually mapped from `packages/icons/src/library`

While it's natural to want to extend support for an icon name mapping to the new icon library package, this approach is **blocked** by the fact that we'd end up **bloating bundle sizes**. (Eg any icon import would pull in all other icons). As far as I examined this, supporting this sort of API without bundle bloat is not technically possible without changing our icon approach to a different technique, such as using an icon font.

This PR explores adding support by passing back simple SVG strings: eg `<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,8.236l-8,4.882 L4,8.236V6h16V8.236z" /></svg>`

A good first use case of this support is the social-icons block which currently duplicates svg definitions, and does not allow new social icons to be added.

Challenges here include:
- Making sure the parser works in all environments: react native vs web
- Making sure we don't open a new XSS hole