### PR TITLE
Allow block attributes passed to block renderer by way of wp_nav_menu.

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -299,9 +299,14 @@ function gutenberg_output_block_nav_menu( $output, $args ) {
 		$menu_items_by_parent_id[ $menu_item->menu_item_parent ][] = $menu_item;
 	}
 
+	$block_attributes = array();
+	if ( isset( $args->block_attributes ) ) {
+		$block_attributes = $args->block_attributes;
+	}
+
 	$navigation_block = array(
 		'blockName'   => 'core/navigation',
-		'attrs'       => array(),
+		'attrs'       => $block_attributes,
 		'innerBlocks' => gutenberg_convert_menu_items_to_blocks(
 			isset( $menu_items_by_parent_id[0] )
 				? $menu_items_by_parent_id[0]


### PR DESCRIPTION
## Description

With the introduction of the block-nav-menus theme support, themes can specify whether to use the navigation block to render classic menus (created via wp_nav_menu). It would be useful to theme developers to be able to set the attributes of the navigation block, e.g. responsiveness.

This change enables block attributes to be passed when calling wp_nav_menu() with block-nav-menus theme support enabled.

## How has this been tested?
This change is leveraged by Quadrat.  [This PR ](https://github.com/Automattic/themes/pull/3870) for that theme is passing the value as we [expect to be able to](https://github.com/Automattic/themes/pull/3870/files#diff-ee8f0fc00c772d51e645ecbeb1dea27e89e9635b3d3bafcd8a138d59c6f9e862R15).

## Types of changes
This simple change passes on to the Navigation Block renderer any attributes passed via the wp_nav_menu function instead of an empty array.
