### PR TITLE
Correctly read rawRequest for frontend ESM

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -114,6 +114,7 @@ build_files=$(
 	build/block-library/blocks/*.php \
 	build/block-library/blocks/*/block.json \
 	build/block-library/blocks/*/*.css \
+	build/block-library/blocks/*/*.js \
 	build/edit-widgets/blocks/*/block.json \
 )
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,16 +135,19 @@ module.exports = {
 	entry: createEntrypoints(),
 	output: {
 		devtoolNamespace: 'wp',
-		filename: ( data ) => {
-			const { chunk } = data;
+		filename: ( pathData ) => {
+			const { chunk } = pathData;
 			const { entryModule } = chunk;
-			const { rawRequest } = entryModule;
+			const { rawRequest, rootModule } = entryModule;
 
-			/*
-			 * If the file being built is a Core Block's frontend file,
-			 * we build it in the block's directory.
-			 */
-			if ( rawRequest && rawRequest.includes( '/frontend.js' ) ) {
+			// When processing ESM files, the requested path
+			// is defined in `entryModule.rootModule.rawRequest`, instead of
+			// being present in `entryModule.rawRequest`.
+			// In the context of frontend files, they would be processed
+			// as ESM if they use `import` or `export` within it.
+			const request = rootModule?.rawRequest || rawRequest;
+
+			if ( request.includes( '/frontend.js' ) ) {
 				return `./build/block-library/blocks/[name]/frontend.js`;
 			}
 


### PR DESCRIPTION
# Description

Fixes https://github.com/WordPress/gutenberg/issues/31909
Fixes https://github.com/WordPress/gutenberg/issues/32050

When processing ESM files, the requested path is defined in `entryModule.rootModule.rawRequest`, instead of being present in `entryModule.rawRequest`.

In the context of frontend files, they would be processed as ESM if they use `import` or `export` within it.

This issue is not being flagged by the e2e pipeline, which indicates it might be dependant on the environment somehow. For example, I can reproduce this in my system by running `npm run build` but if I use `npm run dev`, everything is built correctly. e2e tests are ran on the production build, so I'm not entirely sure where the difference actually is.


