### PR TITLE
Search: Make custom widths work with float alignments

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -353,10 +353,11 @@ export default function SearchEdit( {
 	const blockProps = useBlockProps( {
 		className: getBlockClassNames(),
 		style: alignedStyles,
+		ref: searchRef,
 	} );
 
 	return (
-		<div { ...blockProps } ref={ searchRef }>
+		<div { ...blockProps }>
 			{ resizeListener }
 			{ controls }
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -191,9 +191,7 @@ function styles_for_block_core_search( $attributes ) {
 		if ( $has_side_alignment ) {
 			// If block is aligned the width style must go on the root block
 			// element for it to be the correct size.
-			//
-			// To enforce user's width selection adjust max-width as well.
-			$block_styles = sprintf( 'width: %s; max-width: %s;', $width, $width );
+			$block_styles = sprintf( 'width: %s;', $width );
 		} else {
 			$wrapper_styles[] = sprintf( 'width: %s;', $width );
 		}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -93,7 +93,12 @@ function render_block_core_search( $attributes ) {
 		$inline_styles['wrapper'],
 		$input_markup . $button_markup
 	);
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class' => $classnames,
+			'style' => $inline_styles['block'],
+		)
+	);
 
 	return sprintf(
 		'<form role="search" method="get" action="%s" %s>%s</form>',
@@ -169,19 +174,33 @@ function classnames_for_block_core_search( $attributes ) {
  * @return array Style HTML attribute.
  */
 function styles_for_block_core_search( $attributes ) {
+	$block_styles   = '';
 	$shared_styles  = array();
 	$wrapper_styles = array();
+
+	$has_side_alignment = ! empty( $attributes['align'] ) &&
+		( 'left' === $attributes['align'] || 'right' === $attributes['align'] );
 
 	// Add width styles.
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
 	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
 
 	if ( $has_width && ! $button_only ) {
-		$wrapper_styles[] = sprintf(
-			'width: %d%s;',
-			esc_attr( $attributes['width'] ),
-			esc_attr( $attributes['widthUnit'] )
-		);
+		if ( $has_side_alignment ) {
+			// If block is aligned the width style must go on the root block
+			// element for it to be the correct size.
+			$block_styles = sprintf(
+				'width: %d%s;',
+				esc_attr( $attributes['width'] ),
+				esc_attr( $attributes['widthUnit'] )
+			);
+		} else {
+			$wrapper_styles[] = sprintf(
+				'width: %d%s;',
+				esc_attr( $attributes['width'] ),
+				esc_attr( $attributes['widthUnit'] )
+			);
+		}
 	}
 
 	// Add border radius styles.
@@ -207,6 +226,7 @@ function styles_for_block_core_search( $attributes ) {
 	}
 
 	return array(
+		'block'   => $block_styles,
 		'shared'  => ! empty( $shared_styles ) ? sprintf( ' style="%s"', implode( ' ', $shared_styles ) ) : '',
 		'wrapper' => ! empty( $wrapper_styles ) ? sprintf( ' style="%s"', implode( ' ', $wrapper_styles ) ) : '',
 	);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -186,20 +186,16 @@ function styles_for_block_core_search( $attributes ) {
 	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
 
 	if ( $has_width && ! $button_only ) {
+		$width = esc_attr( $attributes['width'] . $attributes['widthUnit'] );
+
 		if ( $has_side_alignment ) {
 			// If block is aligned the width style must go on the root block
 			// element for it to be the correct size.
-			$block_styles = sprintf(
-				'width: %d%s;',
-				esc_attr( $attributes['width'] ),
-				esc_attr( $attributes['widthUnit'] )
-			);
+			//
+			// To enforce user's width selection adjust max-width as well.
+			$block_styles = sprintf( 'width: %s; max-width: %s;', $width, $width );
 		} else {
-			$wrapper_styles[] = sprintf(
-				'width: %d%s;',
-				esc_attr( $attributes['width'] ),
-				esc_attr( $attributes['widthUnit'] )
-			);
+			$wrapper_styles[] = sprintf( 'width: %s;', $width );
 		}
 	}
 

--- a/packages/block-library/src/search/utils.js
+++ b/packages/block-library/src/search/utils.js
@@ -16,3 +16,105 @@ export const MIN_WIDTH_UNIT = 'px';
 export function isPercentageUnit( unit ) {
 	return unit === '%';
 }
+
+/**
+ * Returns the computed styles for the supplied DOM element.
+ *
+ * @param  {Object} node DOM element
+ *
+ * @return {Object}      Computed Styles
+ */
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
+/**
+ * Calculates the available width within search block's parent.
+ *
+ * @param {Object} searchElement Search block's DOM element.
+ *
+ * @return {number}              Available width within search block's parent.
+ */
+function getParentWidth( searchElement ) {
+	// This is used when search block is aligned. This means there is a
+	// temporary wrapper element between the search block and its actual parent.
+	const searchParent = searchElement?.parentNode?.parentNode;
+
+	if ( ! searchParent ) {
+		return;
+	}
+
+	const parentStyles = getComputedStyle( searchParent );
+
+	const availableWidth =
+		searchParent.clientWidth -
+		parseFloat( parentStyles.paddingLeft ) -
+		parseFloat( parentStyles.paddingRight );
+
+	return `${ availableWidth }px`;
+}
+
+/**
+ * Determines if block has a percentage based width while aligned left or right.
+ *
+ * @param {Object} attributes           Search block attributes
+ * @param {string} attributes.align     Block alignment attribute.
+ * @param {number} attributes.width     Block's width value.
+ * @param {string} attributes.widthUnit Block's width unit.
+ *
+ * @return {boolean} Whether the block has percentage aligned width.
+ */
+export function hasAlignedWidth( { align, width, widthUnit } ) {
+	const isAlignedToSide = align === 'left' || align === 'right';
+
+	return !! width && widthUnit === '%' && isAlignedToSide;
+}
+
+/**
+ * Determines styles to apply to the root search block element when it is
+ * aligned with a percentage width value in the editor.
+ *
+ * @param {Object} searchElement Search block DOM element from ref.
+ * @param {Object} attributes    Search block attributes.
+ *
+ * @return {Object}              Inline styles to force proper width in editor.
+ */
+export function getAlignedStyles( searchElement, attributes ) {
+	if ( ! searchElement ) {
+		return;
+	}
+
+	const { align, width, widthUnit } = attributes;
+	const isAlignedToSide = align === 'left' || align === 'right';
+
+	if ( ! isAlignedToSide || widthUnit !== '%' ) {
+		return;
+	}
+
+	// Get max width of current element if applied via custom layout on nested
+	// group block.
+	const { maxWidth } = getComputedStyle( searchElement );
+	const hasPercentageMaxWidth = maxWidth.includes( '%' );
+
+	// Get the parent block, or editor's, available width.
+	const parentWidth = getParentWidth( searchElement );
+
+	// Default to parent's available width.
+	let availableWidth = parentWidth;
+
+	// If explicit max width. Available width is min between max width and parent available width.
+	if ( maxWidth !== 'none' && ! hasPercentageMaxWidth ) {
+		availableWidth = `min(${ maxWidth }, ${ parentWidth })`;
+	}
+
+	// If percentage max width, apply that percentage to the parent's available width.
+	if ( maxWidth !== 'none' && hasPercentageMaxWidth ) {
+		const maxValue = parseFloat( maxWidth ) / 100;
+		availableWidth = `calc(${ parentWidth } * ${ maxValue })`;
+	}
+
+	return {
+		width: `calc(${ availableWidth } * ${ width / 100 })`,
+		minWidth: MIN_WIDTH,
+	};
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/31517
Related: https://github.com/WordPress/gutenberg/pull/31812

## Description
PoC for alternate approach to applying widths to search blocks which are aligned left/right (using floated wrapper element).
- Avoids having to change alignment to be flex based.
- Simple change to frontend
- Editor requires accessing parent element to calculate an appropriate width to set

## Possible Next Steps
- Refine behaviour when resetting width field
- Add flex justification alongside the current floated alignment options, perhaps via block support?

## How has this been tested?

1. Checkout this PR, create post and paste in test block code below (contains search within nested group blocks)
2. Try various alignments and widths for the search block
3. Save and confirm the block is rendered correctly on the frontend
4. Adjust the root group block's alignment to wide or full, ensure search block percentage widths adjust accordingly
5. Select the nested group block and give it a custom layout via the sidebar options
6. Ensure that the search block behaves properly within the custom group block layout

#### Test Block Code
```html
<!-- wp:group {"backgroundColor":"gray"} -->
<div class="wp-block-group has-gray-background-color has-background"><!-- wp:group {"align":"full","backgroundColor":"purple","layout":{"inherit":false}} -->
<div class="wp-block-group alignfull has-purple-background-color has-background"><!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/60436221/118603582-6f79f200-b7f7-11eb-8646-4ec88da4da9c.gif" width="500" />

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
