### PR TITLE
Patterns: provide a way to opt-out of Gutenberg patterns and core patterns updates

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -239,8 +239,16 @@ add_action(
 		if ( ! get_theme_support( 'core-block-patterns' ) || ! function_exists( 'unregister_block_pattern' ) ) {
 			return;
 		}
-		remove_core_patterns();
-		register_gutenberg_patterns();
+
+		// Provides a way to opt-out of removing core patterns.
+		if ( apply_filters( 'remove_core_patterns', true ) ) {
+			remove_core_patterns();
+		}
+
+		// Provides a way to opt-out of pattern registration.
+		if ( apply_filters( 'register_gutenberg_patterns', true ) ) {
+			register_gutenberg_patterns();
+		}
 	}
 );
 
@@ -248,6 +256,11 @@ add_action(
 	'current_screen',
 	function( $current_screen ) {
 		if ( ! get_theme_support( 'core-block-patterns' ) ) {
+			return;
+		}
+
+		// Provides a way to opt-out of remotely loading core patterns.
+		if ( ! apply_filters( 'load_remote_patterns', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

This PR is a proof of concept (POC) to test a feature proposal. 

This PR provides filters to opt out of:

1. removing core patterns, in case Gutenberg users want to use Core patterns
2. adding Gutenberg patterns
3. loading core patterns from remote source

See the issue for more context: https://github.com/WordPress/gutenberg/issues/31922

## How has this been tested?

By default all Gutenberg patterns should be available in the inserter. 

To test the filters add the following block to the end of [lib/init.php](https://github.com/WordPress/gutenberg/blob/cbfcbda08ab1b01b3fd6f8affb11138af453dc17/lib/init.php)

```php
/* TEST CODE START - DELETE ME */

function should_register_gutenberg_patterns() {
	return false;
}
add_filter( 'register_gutenberg_patterns', 'should_register_gutenberg_patterns' );

function should_remove_core_patterns() {
	return false;
}
add_filter( 'remove_core_patterns', 'should_remove_core_patterns' );

function should_load_remote_patterns() {
	return false;
}
add_filter( 'load_remote_patterns', 'should_load_remote_patterns' );

/* TEST CODE END - DELETE ME */
```
Returning `false` from `should_register_gutenberg_patterns()` should remove Gutenberg patterns.

With Gutenberg patterns | Without
------------ | -------------
<img width="307" alt="Screen Shot 2021-05-18 at 2 46 48 pm" src="https://user-images.githubusercontent.com/6458278/118591892-5ae22d80-b7e8-11eb-84e0-c9407d129cc1.png">|<img width="310" alt="Screen Shot 2021-05-18 at 2 47 32 pm" src="https://user-images.githubusercontent.com/6458278/118591976-8533eb00-b7e8-11eb-93bc-dce9345764f5.png">

Returning `false` from `should_update_core_patterns()` should not replace/update core patterns

With updated core patterns | Without updated core patterns
------------ | -------------
<img width="342" alt="Screen Shot 2021-05-18 at 2 49 31 pm" src="https://user-images.githubusercontent.com/6458278/118591883-56b61000-b7e8-11eb-9b62-1626b7827b3d.png">|<img width="360" alt="Screen Shot 2021-05-18 at 2 49 09 pm" src="https://user-images.githubusercontent.com/6458278/118592110-c5936900-b7e8-11eb-91f1-d4b4774f9609.png">

## Types of changes
Non-breaking additional functionality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
