### PR TITLE
Add widgets editor more menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13786,6 +13786,7 @@
 			"version": "file:packages/edit-widgets",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
+				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/block-library": "file:packages/block-library",

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -143,6 +143,7 @@ $z-layers: (
 	".components-popover.block-editor-block-navigation__popover": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,
 	".components-popover.edit-site-more-menu__content": 99998,
+	".components-popover.edit-widgets-more-menu__content": 99998,
 	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
 	".components-popover.block-editor-warning__dropdown": 99998,
 	".components-popover.edit-navigation-header__menu-switcher-dropdown": 99998,

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -27,6 +27,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",
+		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/block-library": "file:../block-library",

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -19,6 +19,7 @@ import { useRef } from '@wordpress/element';
 import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
+import MoreMenu from '../more-menu';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 import { store as editWidgetsStore } from '../../store';
 
@@ -96,6 +97,7 @@ function Header() {
 				<div className="edit-widgets-header__actions">
 					<SaveButton />
 					<PinnedItems.Slot scope="core/edit-widgets" />
+					<MoreMenu />
 				</div>
 			</div>
 		</>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -12,6 +12,7 @@ import {
 import { PinnedItems } from '@wordpress/interface';
 import { plus } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area
 import { store as editWidgetsStore } from '../../store';
 
 function Header() {
+	const isWideViewport = useViewportMatch( 'wide' );
 	const inserterButton = useRef();
 	const widgetAreaClientId = useLastSelectedWidgetArea();
 	const isLastSelectedWidgetAreaOpen = useSelect(
@@ -89,9 +91,13 @@ function Header() {
 								'Generic label for block inserter button'
 							) }
 						/>
-						<UndoButton />
-						<RedoButton />
-						<ToolbarItem as={ BlockNavigationDropdown } />
+						{ isWideViewport && (
+							<>
+								<UndoButton />
+								<RedoButton />
+								<ToolbarItem as={ BlockNavigationDropdown } />
+							</>
+						) }
 					</NavigableToolbar>
 				</div>
 				<div className="edit-widgets-header__actions">

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
-import { Button, ToolbarItem } from '@wordpress/components';
+import { Button, ToolbarItem, VisuallyHidden } from '@wordpress/components';
 import {
 	BlockNavigationDropdown,
 	NavigableToolbar,
@@ -25,7 +25,7 @@ import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area
 import { store as editWidgetsStore } from '../../store';
 
 function Header() {
-	const isWideViewport = useViewportMatch( 'wide' );
+	const isMediumViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef();
 	const widgetAreaClientId = useLastSelectedWidgetArea();
 	const isLastSelectedWidgetAreaOpen = useSelect(
@@ -66,9 +66,19 @@ function Header() {
 		<>
 			<div className="edit-widgets-header">
 				<div className="edit-widgets-header__navigable-toolbar-wrapper">
-					<h1 className="edit-widgets-header__title">
-						{ __( 'Widgets' ) }
-					</h1>
+					{ isMediumViewport && (
+						<h1 className="edit-widgets-header__title">
+							{ __( 'Widgets' ) }
+						</h1>
+					) }
+					{ ! isMediumViewport && (
+						<VisuallyHidden
+							as="h1"
+							className="edit-widgets-header__title"
+						>
+							{ __( 'Widgets' ) }
+						</VisuallyHidden>
+					) }
 					<NavigableToolbar
 						className="edit-widgets-header-toolbar"
 						aria-label={ __( 'Document tools' ) }
@@ -91,7 +101,7 @@ function Header() {
 								'Generic label for block inserter button'
 							) }
 						/>
-						{ isWideViewport && (
+						{ isMediumViewport && (
 							<>
 								<UndoButton />
 								<RedoButton />

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const textFormattingShortcuts = [
+	{
+		keyCombination: { modifier: 'primary', character: 'b' },
+		description: __( 'Make the selected text bold.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'i' },
+		description: __( 'Make the selected text italic.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'k' },
+		description: __( 'Convert the selected text into a link.' ),
+	},
+	{
+		keyCombination: { modifier: 'primaryShift', character: 'k' },
+		description: __( 'Remove a link.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'u' },
+		description: __( 'Underline the selected text.' ),
+	},
+];

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+
+/**
+ * Internal dependencies
+ */
+import Shortcut from './shortcut';
+
+function DynamicShortcut( { name } ) {
+	const { keyCombination, description, aliases } = useSelect( ( select ) => {
+		const {
+			getShortcutKeyCombination,
+			getShortcutDescription,
+			getShortcutAliases,
+		} = select( keyboardShortcutsStore );
+
+		return {
+			keyCombination: getShortcutKeyCombination( name ),
+			aliases: getShortcutAliases( name ),
+			description: getShortcutDescription( name ),
+		};
+	} );
+
+	if ( ! keyCombination ) {
+		return null;
+	}
+
+	return (
+		<Shortcut
+			keyCombination={ keyCombination }
+			description={ description }
+			aliases={ aliases }
+		/>
+	);
+}
+
+export default DynamicShortcut;

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -29,12 +29,12 @@ const ShortcutList = ( { shortcuts } ) => (
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
 	<ul
-		className="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+		className="edit-widgets-keyboard-shortcut-help-modal__shortcut-list"
 		role="list"
 	>
 		{ shortcuts.map( ( shortcut, index ) => (
 			<li
-				className="edit-post-keyboard-shortcut-help-modal__shortcut"
+				className="edit-widgets-keyboard-shortcut-help-modal__shortcut"
 				key={ index }
 			>
 				{ isString( shortcut ) ? (
@@ -51,12 +51,12 @@ const ShortcutList = ( { shortcuts } ) => (
 const ShortcutSection = ( { title, shortcuts, className } ) => (
 	<section
 		className={ classnames(
-			'edit-post-keyboard-shortcut-help-modal__section',
+			'edit-widgets-keyboard-shortcut-help-modal__section',
 			className
 		) }
 	>
 		{ !! title && (
-			<h2 className="edit-post-keyboard-shortcut-help-modal__section-title">
+			<h2 className="edit-widgets-keyboard-shortcut-help-modal__section-title">
 				{ title }
 			</h2>
 		) }
@@ -90,7 +90,7 @@ export default function KeyboardShortcutHelpModal( {
 	isModalActive,
 	toggleModal,
 } ) {
-	useShortcut( 'core/edit-post/keyboard-shortcuts', toggleModal, {
+	useShortcut( 'core/edit-widgets/keyboard-shortcuts', toggleModal, {
 		bindGlobal: true,
 	} );
 
@@ -100,13 +100,13 @@ export default function KeyboardShortcutHelpModal( {
 
 	return (
 		<Modal
-			className="edit-post-keyboard-shortcut-help-modal"
+			className="edit-widgets-keyboard-shortcut-help-modal"
 			title={ __( 'Keyboard shortcuts' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ toggleModal }
 		>
 			<ShortcutSection
-				className="edit-post-keyboard-shortcut-help-modal__main-shortcuts"
+				className="edit-widgets-keyboard-shortcut-help-modal__main-shortcuts"
 				shortcuts={ [ 'core/edit-widgets/keyboard-shortcuts' ] }
 			/>
 			<ShortcutCategorySection

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -107,7 +107,7 @@ export default function KeyboardShortcutHelpModal( {
 		>
 			<ShortcutSection
 				className="edit-post-keyboard-shortcut-help-modal__main-shortcuts"
-				shortcuts={ [ 'core/edit-post/keyboard-shortcuts' ] }
+				shortcuts={ [ 'core/edit-widgets/keyboard-shortcuts' ] }
 			/>
 			<ShortcutCategorySection
 				title={ __( 'Global shortcuts' ) }

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { isString } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { textFormattingShortcuts } from './config';
+import Shortcut from './shortcut';
+import DynamicShortcut from './dynamic-shortcut';
+
+const ShortcutList = ( { shortcuts } ) => (
+	/*
+	 * Disable reason: The `list` ARIA role is redundant but
+	 * Safari+VoiceOver won't announce the list otherwise.
+	 */
+	/* eslint-disable jsx-a11y/no-redundant-roles */
+	<ul
+		className="edit-post-keyboard-shortcut-help-modal__shortcut-list"
+		role="list"
+	>
+		{ shortcuts.map( ( shortcut, index ) => (
+			<li
+				className="edit-post-keyboard-shortcut-help-modal__shortcut"
+				key={ index }
+			>
+				{ isString( shortcut ) ? (
+					<DynamicShortcut name={ shortcut } />
+				) : (
+					<Shortcut { ...shortcut } />
+				) }
+			</li>
+		) ) }
+	</ul>
+	/* eslint-enable jsx-a11y/no-redundant-roles */
+);
+
+const ShortcutSection = ( { title, shortcuts, className } ) => (
+	<section
+		className={ classnames(
+			'edit-post-keyboard-shortcut-help-modal__section',
+			className
+		) }
+	>
+		{ !! title && (
+			<h2 className="edit-post-keyboard-shortcut-help-modal__section-title">
+				{ title }
+			</h2>
+		) }
+		<ShortcutList shortcuts={ shortcuts } />
+	</section>
+);
+
+const ShortcutCategorySection = ( {
+	title,
+	categoryName,
+	additionalShortcuts = [],
+} ) => {
+	const categoryShortcuts = useSelect(
+		( select ) => {
+			return select( keyboardShortcutsStore ).getCategoryShortcuts(
+				categoryName
+			);
+		},
+		[ categoryName ]
+	);
+
+	return (
+		<ShortcutSection
+			title={ title }
+			shortcuts={ categoryShortcuts.concat( additionalShortcuts ) }
+		/>
+	);
+};
+
+export default function KeyboardShortcutHelpModal( {
+	isModalActive,
+	toggleModal,
+} ) {
+	useShortcut( 'core/edit-post/keyboard-shortcuts', toggleModal, {
+		bindGlobal: true,
+	} );
+
+	if ( ! isModalActive ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="edit-post-keyboard-shortcut-help-modal"
+			title={ __( 'Keyboard shortcuts' ) }
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ toggleModal }
+		>
+			<ShortcutSection
+				className="edit-post-keyboard-shortcut-help-modal__main-shortcuts"
+				shortcuts={ [ 'core/edit-post/keyboard-shortcuts' ] }
+			/>
+			<ShortcutCategorySection
+				title={ __( 'Global shortcuts' ) }
+				categoryName="global"
+			/>
+
+			<ShortcutCategorySection
+				title={ __( 'Selection shortcuts' ) }
+				categoryName="selection"
+			/>
+
+			<ShortcutCategorySection
+				title={ __( 'Block shortcuts' ) }
+				categoryName="block"
+				additionalShortcuts={ [
+					{
+						keyCombination: { character: '/' },
+						description: __(
+							'Change the block type after adding a new paragraph.'
+						),
+						/* translators: The forward-slash character. e.g. '/'. */
+						ariaLabel: __( 'Forward-slash' ),
+					},
+				] }
+			/>
+			<ShortcutSection
+				title={ __( 'Text formatting' ) }
+				shortcuts={ textFormattingShortcuts }
+			/>
+		</Modal>
+	);
+}

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { displayShortcutList, shortcutAriaLabel } from '@wordpress/keycodes';
+
+function KeyCombination( { keyCombination, forceAriaLabel } ) {
+	const shortcut = keyCombination.modifier
+		? displayShortcutList[ keyCombination.modifier ](
+				keyCombination.character
+		  )
+		: keyCombination.character;
+	const ariaLabel = keyCombination.modifier
+		? shortcutAriaLabel[ keyCombination.modifier ](
+				keyCombination.character
+		  )
+		: keyCombination.character;
+
+	return (
+		<kbd
+			className="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+			aria-label={ forceAriaLabel || ariaLabel }
+		>
+			{ castArray( shortcut ).map( ( character, index ) => {
+				if ( character === '+' ) {
+					return <Fragment key={ index }>{ character }</Fragment>;
+				}
+
+				return (
+					<kbd
+						key={ index }
+						className="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+					>
+						{ character }
+					</kbd>
+				);
+			} ) }
+		</kbd>
+	);
+}
+
+function Shortcut( { description, keyCombination, aliases = [], ariaLabel } ) {
+	return (
+		<>
+			<div className="edit-post-keyboard-shortcut-help-modal__shortcut-description">
+				{ description }
+			</div>
+			<div className="edit-post-keyboard-shortcut-help-modal__shortcut-term">
+				<KeyCombination
+					keyCombination={ keyCombination }
+					forceAriaLabel={ ariaLabel }
+				/>
+				{ aliases.map( ( alias, index ) => (
+					<KeyCombination
+						keyCombination={ alias }
+						forceAriaLabel={ ariaLabel }
+						key={ index }
+					/>
+				) ) }
+			</div>
+		</>
+	);
+}
+
+export default Shortcut;

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -23,7 +23,7 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 
 	return (
 		<kbd
-			className="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+			className="edit-widgets-keyboard-shortcut-help-modal__shortcut-key-combination"
 			aria-label={ forceAriaLabel || ariaLabel }
 		>
 			{ castArray( shortcut ).map( ( character, index ) => {
@@ -34,7 +34,7 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 				return (
 					<kbd
 						key={ index }
-						className="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+						className="edit-widgets-keyboard-shortcut-help-modal__shortcut-key"
 					>
 						{ character }
 					</kbd>
@@ -47,10 +47,10 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 function Shortcut( { description, keyCombination, aliases = [], ariaLabel } ) {
 	return (
 		<>
-			<div className="edit-post-keyboard-shortcut-help-modal__shortcut-description">
+			<div className="edit-widgets-keyboard-shortcut-help-modal__shortcut-description">
 				{ description }
 			</div>
-			<div className="edit-post-keyboard-shortcut-help-modal__shortcut-term">
+			<div className="edit-widgets-keyboard-shortcut-help-modal__shortcut-term">
 				<KeyCombination
 					keyCombination={ keyCombination }
 					forceAriaLabel={ ariaLabel }

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,9 +1,9 @@
-.edit-post-keyboard-shortcut-help-modal {
+.edit-widgets-keyboard-shortcut-help-modal {
 	&__section {
 		margin: 0 0 2rem 0;
 	}
 
-	&__main-shortcuts .edit-post-keyboard-shortcut-help-modal__shortcut-list {
+	&__main-shortcuts .edit-widgets-keyboard-shortcut-help-modal__shortcut-list {
 		// Push the shortcut to be flush with top modal header.
 		margin-top: -$grid-unit-30 -$border-width;
 	}
@@ -49,7 +49,7 @@
 		margin: 0;
 		padding: 0;
 
-		& + .edit-post-keyboard-shortcut-help-modal__shortcut-key-combination {
+		& + .edit-widgets-keyboard-shortcut-help-modal__shortcut-key-combination {
 			margin-top: 10px;
 		}
 	}

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,0 +1,66 @@
+.edit-post-keyboard-shortcut-help-modal {
+	&__section {
+		margin: 0 0 2rem 0;
+	}
+
+	&__main-shortcuts .edit-post-keyboard-shortcut-help-modal__shortcut-list {
+		// Push the shortcut to be flush with top modal header.
+		margin-top: -$grid-unit-30 -$border-width;
+	}
+
+	&__section-title {
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+
+	&__shortcut {
+		display: flex;
+		align-items: baseline;
+		padding: 0.6rem 0;
+		border-top: 1px solid $gray-300;
+		margin-bottom: 0;
+
+		&:last-child {
+			border-bottom: 1px solid $gray-300;
+		}
+
+		&:empty {
+			display: none;
+		}
+	}
+
+	&__shortcut-term {
+		font-weight: 600;
+		margin: 0 0 0 1rem;
+		text-align: right;
+	}
+
+	&__shortcut-description {
+		flex: 1;
+		margin: 0;
+
+		// IE 11 flex item fix - ensure the item does not collapse.
+		flex-basis: auto;
+	}
+
+	&__shortcut-key-combination {
+		display: block;
+		background: none;
+		margin: 0;
+		padding: 0;
+
+		& + .edit-post-keyboard-shortcut-help-modal__shortcut-key-combination {
+			margin-top: 10px;
+		}
+	}
+
+	&__shortcut-key {
+		padding: 0.25rem 0.5rem;
+		border-radius: 8%;
+		margin: 0 0.2rem 0 0.2rem;
+
+		&:last-child {
+			margin: 0 0 0 0.2rem;
+		}
+	}
+}

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -81,6 +81,16 @@ function KeyboardShortcutsRegister() {
 				character: 's',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/edit-widgets/keyboard-shortcuts',
+			category: 'main',
+			description: __( 'Display these keyboard shortcuts.' ),
+			keyCombination: {
+				modifier: 'access',
+				character: 'h',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/edit-widgets/src/components/more-menu/feature-toggle.js
+++ b/packages/edit-widgets/src/components/more-menu/feature-toggle.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
+export default function FeatureToggle( {
+	label,
+	info,
+	messageActivated,
+	messageDeactivated,
+	shortcut,
+	feature,
+} ) {
+	const isActive = useSelect(
+		( select ) =>
+			select( editWidgetsStore ).__unstableIsFeatureActive( feature ),
+		[ feature ]
+	);
+	const { __unstableToggleFeature: toggleFeature } = useDispatch(
+		editWidgetsStore
+	);
+	const speakMessage = () => {
+		if ( isActive ) {
+			speak( messageDeactivated || __( 'Feature deactivated' ) );
+		} else {
+			speak( messageActivated || __( 'Feature activated' ) );
+		}
+	};
+
+	return (
+		<MenuItem
+			icon={ isActive && check }
+			isSelected={ isActive }
+			onClick={ () => {
+				toggleFeature( feature );
+				speakMessage();
+			} }
+			role="menuitemcheckbox"
+			info={ info }
+			shortcut={ shortcut }
+		>
+			{ label }
+		</MenuItem>
+	);
+}

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -7,7 +7,6 @@ import {
 	MenuItem,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { external, moreVertical } from '@wordpress/icons';
@@ -19,7 +18,6 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
  */
 import FeatureToggle from './feature-toggle';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
-import { store as editWidgetsStore } from '../../store';
 
 const POPOVER_PROPS = {
 	className: 'edit-widgets-more-menu__content',
@@ -34,13 +32,6 @@ export default function MoreMenu() {
 		isKeyboardShortcutsModalActive,
 		setIsKeyboardShortcutsModalVisible,
 	] = useState( false );
-	const showIconLabels = useSelect(
-		( select ) =>
-			select( editWidgetsStore ).__unstableIsFeatureActive(
-				'showIconLabels'
-			),
-		[]
-	);
 	const toggleKeyboardShortcutsModal = () =>
 		setIsKeyboardShortcutsModalVisible( ! isKeyboardShortcutsModalActive );
 
@@ -60,11 +51,7 @@ export default function MoreMenu() {
 				/* translators: button label text should, if possible, be under 16 characters. */
 				label={ __( 'Options' ) }
 				popoverProps={ POPOVER_PROPS }
-				toggleProps={ {
-					showTooltip: ! showIconLabels,
-					isTertiary: showIconLabels,
-					...TOGGLE_PROPS,
-				} }
+				toggleProps={ TOGGLE_PROPS }
 			>
 				{ () => (
 					<>

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -79,6 +79,10 @@ export default function MoreMenu() {
 							>
 								{ __( 'Keyboard shortcuts' ) }
 							</MenuItem>
+							<FeatureToggle
+								feature="welcomeGuide"
+								label={ __( 'Welcome Guide' ) }
+							/>
 							<MenuItem
 								role="menuitem"
 								icon={ external }

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -1,15 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { DropdownMenu, MenuGroup } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { moreVertical } from '@wordpress/icons';
+import { external, moreVertical } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
 import FeatureToggle from './feature-toggle';
+import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import { store as editWidgetsStore } from '../../store';
 
 const POPOVER_PROPS = {
@@ -21,12 +30,26 @@ const TOGGLE_PROPS = {
 };
 
 export default function MoreMenu() {
+	const [
+		isKeyboardShortcutsModalActive,
+		setIsKeyboardShortcutsModalVisible,
+	] = useState( false );
 	const showIconLabels = useSelect(
 		( select ) =>
 			select( editWidgetsStore ).__unstableIsFeatureActive(
 				'showIconLabels'
 			),
 		[]
+	);
+	const toggleKeyboardShortcutsModal = () =>
+		setIsKeyboardShortcutsModalVisible( ! isKeyboardShortcutsModalActive );
+
+	useShortcut(
+		'core/edit-post/keyboard-shortcuts',
+		toggleKeyboardShortcutsModal,
+		{
+			bindGlobal: true,
+		}
 	);
 
 	return (
@@ -44,21 +67,56 @@ export default function MoreMenu() {
 				} }
 			>
 				{ () => (
-					<MenuGroup label={ _x( 'View', 'noun' ) }>
-						<FeatureToggle
-							feature="fixedToolbar"
-							label={ __( 'Top toolbar' ) }
-							info={ __(
-								'Access all block and document tools in a single place'
-							) }
-							messageActivated={ __( 'Top toolbar activated' ) }
-							messageDeactivated={ __(
-								'Top toolbar deactivated'
-							) }
-						/>
-					</MenuGroup>
+					<>
+						<MenuGroup label={ _x( 'View', 'noun' ) }>
+							<FeatureToggle
+								feature="fixedToolbar"
+								label={ __( 'Top toolbar' ) }
+								info={ __(
+									'Access all block and document tools in a single place'
+								) }
+								messageActivated={ __(
+									'Top toolbar activated'
+								) }
+								messageDeactivated={ __(
+									'Top toolbar deactivated'
+								) }
+							/>
+						</MenuGroup>
+						<MenuGroup label={ __( 'Tools' ) }>
+							<MenuItem
+								onClick={ () => {
+									setIsKeyboardShortcutsModalVisible( true );
+								} }
+								shortcut={ displayShortcut.access( 'h' ) }
+							>
+								{ __( 'Keyboard shortcuts' ) }
+							</MenuItem>
+							<MenuItem
+								role="menuitem"
+								icon={ external }
+								href={ __(
+									'https://wordpress.org/support/article/wordpress-editor/'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Help' ) }
+								<VisuallyHidden as="span">
+									{
+										/* translators: accessibility text */
+										__( '(opens in a new tab)' )
+									}
+								</VisuallyHidden>
+							</MenuItem>
+						</MenuGroup>
+					</>
 				) }
 			</DropdownMenu>
+			<KeyboardShortcutHelpModal
+				isModalActive={ isKeyboardShortcutsModalActive }
+				toggleModal={ toggleKeyboardShortcutsModal }
+			/>
 		</>
 	);
 }

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -45,7 +45,7 @@ export default function MoreMenu() {
 		setIsKeyboardShortcutsModalVisible( ! isKeyboardShortcutsModalActive );
 
 	useShortcut(
-		'core/edit-post/keyboard-shortcuts',
+		'core/edit-widgets/keyboard-shortcuts',
 		toggleKeyboardShortcutsModal,
 		{
 			bindGlobal: true,

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+
+const POPOVER_PROPS = {
+	className: 'edit-widgets-more-menu__content',
+	position: 'bottom left',
+};
+const TOGGLE_PROPS = {
+	tooltipPosition: 'bottom',
+};
+
+export default function MoreMenu( { showIconLabels } ) {
+	return (
+		<DropdownMenu
+			className="edit-post-more-menu"
+			icon={ moreVertical }
+			/* translators: button label text should, if possible, be under 16 characters. */
+			label={ __( 'Options' ) }
+			popoverProps={ POPOVER_PROPS }
+			toggleProps={ {
+				showTooltip: ! showIconLabels,
+				isTertiary: showIconLabels,
+				...TOGGLE_PROPS,
+			} }
+		></DropdownMenu>
+	);
+}

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -1,9 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { DropdownMenu } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import FeatureToggle from './feature-toggle';
+import { store as editWidgetsStore } from '../../store';
 
 const POPOVER_PROPS = {
 	className: 'edit-widgets-more-menu__content',
@@ -13,19 +20,45 @@ const TOGGLE_PROPS = {
 	tooltipPosition: 'bottom',
 };
 
-export default function MoreMenu( { showIconLabels } ) {
+export default function MoreMenu() {
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( editWidgetsStore ).__unstableIsFeatureActive(
+				'showIconLabels'
+			),
+		[]
+	);
+
 	return (
-		<DropdownMenu
-			className="edit-post-more-menu"
-			icon={ moreVertical }
-			/* translators: button label text should, if possible, be under 16 characters. */
-			label={ __( 'Options' ) }
-			popoverProps={ POPOVER_PROPS }
-			toggleProps={ {
-				showTooltip: ! showIconLabels,
-				isTertiary: showIconLabels,
-				...TOGGLE_PROPS,
-			} }
-		></DropdownMenu>
+		<>
+			<DropdownMenu
+				className="edit-widgets-more-menu"
+				icon={ moreVertical }
+				/* translators: button label text should, if possible, be under 16 characters. */
+				label={ __( 'Options' ) }
+				popoverProps={ POPOVER_PROPS }
+				toggleProps={ {
+					showTooltip: ! showIconLabels,
+					isTertiary: showIconLabels,
+					...TOGGLE_PROPS,
+				} }
+			>
+				{ () => (
+					<MenuGroup label={ _x( 'View', 'noun' ) }>
+						<FeatureToggle
+							feature="fixedToolbar"
+							label={ __( 'Top toolbar' ) }
+							info={ __(
+								'Access all block and document tools in a single place'
+							) }
+							messageActivated={ __( 'Top toolbar activated' ) }
+							messageDeactivated={ __(
+								'Top toolbar deactivated'
+							) }
+						/>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+		</>
 	);
 }

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -110,6 +110,23 @@ export default function MoreMenu() {
 								</VisuallyHidden>
 							</MenuItem>
 						</MenuGroup>
+						<MenuGroup>
+							<FeatureToggle
+								feature="keepCaretInsideBlock"
+								label={ __(
+									'Contain text cursor inside block'
+								) }
+								info={ __(
+									'Aids screen readers by stopping text caret from leaving blocks.'
+								) }
+								messageActivated={ __(
+									'Contain text cursor inside block activated'
+								) }
+								messageDeactivated={ __(
+									'Contain text cursor inside block deactivated'
+								) }
+							/>
+						</MenuGroup>
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-widgets/src/components/more-menu/style.scss
+++ b/packages/edit-widgets/src/components/more-menu/style.scss
@@ -31,5 +31,5 @@
 }
 
 .components-popover.edit-widgets-more-menu__content {
-	z-index: z-index(".components-popover.edit-post-more-menu__content");
+	z-index: z-index(".components-popover.edit-widgets-more-menu__content");
 }

--- a/packages/edit-widgets/src/components/more-menu/style.scss
+++ b/packages/edit-widgets/src/components/more-menu/style.scss
@@ -1,0 +1,35 @@
+.edit-widgets-more-menu {
+	margin-left: -4px;
+
+	// the padding and margin of the more menu is intentionally non-standard
+	.components-button {
+		width: auto;
+		padding: 0 2px;
+	}
+
+	@include break-small() {
+		margin-left: 0;
+
+		.components-button {
+			padding: 0 4px;
+		}
+	}
+}
+
+.edit-widgets-more-menu__content .components-popover__content {
+	min-width: 280px;
+
+	// Let the menu scale to fit items.
+	@include break-mobile() {
+		width: auto;
+		max-width: $break-mobile;
+	}
+
+	.components-dropdown-menu__menu {
+		padding: 0;
+	}
+}
+
+.components-popover.edit-widgets-more-menu__content {
+	z-index: z-index(".components-popover.edit-post-more-menu__content");
+}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -30,7 +30,11 @@ export default function WidgetAreasBlockEditorProvider( {
 	children,
 	...props
 } ) {
-	const { hasUploadPermissions, reusableBlocks } = useSelect(
+	const {
+		hasUploadPermissions,
+		reusableBlocks,
+		isFixedToolbarActive,
+	} = useSelect(
 		( select ) => ( {
 			hasUploadPermissions: defaultTo(
 				select( 'core' ).canUser( 'create', 'media' ),
@@ -42,6 +46,9 @@ export default function WidgetAreasBlockEditorProvider( {
 				'postType',
 				'wp_block'
 			),
+			isFixedToolbarActive: select(
+				editWidgetsStore
+			).__unstableIsFeatureActive( 'fixedToolbar' ),
 		} ),
 		[]
 	);
@@ -61,12 +68,14 @@ export default function WidgetAreasBlockEditorProvider( {
 		return {
 			...blockEditorSettings,
 			__experimentalReusableBlocks: reusableBlocks,
+			hasFixedToolbar: isFixedToolbarActive,
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 		};
 	}, [
 		blockEditorSettings,
+		isFixedToolbarActive,
 		hasUploadPermissions,
 		reusableBlocks,
 		setIsInserterOpened,

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -34,6 +34,7 @@ export default function WidgetAreasBlockEditorProvider( {
 		hasUploadPermissions,
 		reusableBlocks,
 		isFixedToolbarActive,
+		keepCaretInsideBlock,
 	} = useSelect(
 		( select ) => ( {
 			hasUploadPermissions: defaultTo(
@@ -49,6 +50,9 @@ export default function WidgetAreasBlockEditorProvider( {
 			isFixedToolbarActive: select(
 				editWidgetsStore
 			).__unstableIsFeatureActive( 'fixedToolbar' ),
+			keepCaretInsideBlock: select(
+				editWidgetsStore
+			).__unstableIsFeatureActive( 'keepCaretInsideBlock' ),
 		} ),
 		[]
 	);
@@ -69,6 +73,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			...blockEditorSettings,
 			__experimentalReusableBlocks: reusableBlocks,
 			hasFixedToolbar: isFixedToolbarActive,
+			keepCaretInsideBlock,
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
@@ -76,6 +81,7 @@ export default function WidgetAreasBlockEditorProvider( {
 	}, [
 		blockEditorSettings,
 		isFixedToolbarActive,
+		keepCaretInsideBlock,
 		hasUploadPermissions,
 		reusableBlocks,
 		setIsInserterOpened,

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -416,3 +416,21 @@ export function* moveBlockToWidgetArea( clientId, widgetAreaId ) {
 		destinationIndex
 	);
 }
+
+/**
+ * Returns an action object used to toggle a feature flag.
+ *
+ * This function is unstable, as it is mostly copied from the edit-post
+ * package. Editor features and preferences have a lot of scope for
+ * being generalized and refactored.
+ *
+ * @param {string} feature Feature name.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableToggleFeature( feature ) {
+	return {
+		type: 'TOGGLE_FEATURE',
+		feature,
+	};
+}

--- a/packages/edit-widgets/src/store/defaults.js
+++ b/packages/edit-widgets/src/store/defaults.js
@@ -3,5 +3,4 @@ export const PREFERENCES_DEFAULTS = {
 		fixedToolbar: false,
 		welcomeGuide: true,
 	},
-	hiddenBlockTypes: [],
 };

--- a/packages/edit-widgets/src/store/defaults.js
+++ b/packages/edit-widgets/src/store/defaults.js
@@ -2,7 +2,6 @@ export const PREFERENCES_DEFAULTS = {
 	features: {
 		fixedToolbar: false,
 		welcomeGuide: true,
-		showIconLabels: false,
 	},
 	hiddenBlockTypes: [],
 };

--- a/packages/edit-widgets/src/store/defaults.js
+++ b/packages/edit-widgets/src/store/defaults.js
@@ -1,0 +1,8 @@
+export const PREFERENCES_DEFAULTS = {
+	features: {
+		fixedToolbar: false,
+		welcomeGuide: true,
+		showIconLabels: false,
+	},
+	hiddenBlockTypes: [],
+};

--- a/packages/edit-widgets/src/store/index.js
+++ b/packages/edit-widgets/src/store/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -27,6 +27,7 @@ const storeConfig = {
 	selectors,
 	resolvers,
 	actions,
+	persist: [ 'preferences' ],
 };
 
 /**
@@ -38,7 +39,9 @@ const storeConfig = {
  */
 export const store = createReduxStore( STORE_NAME, storeConfig );
 
-register( store );
+// Once we build a more generic persistence plugin that works across types of stores
+// we'd be able to replace this with a register call.
+registerStore( STORE_NAME, storeConfig );
 
 // This package uses a few in-memory post types as wrappers for convenience.
 // This middleware prevents any network requests related to these types as they are

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, union, without } from 'lodash';
+import { flow } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -83,17 +83,6 @@ export const preferences = flow( [
 				...state,
 				[ action.feature ]: ! state[ action.feature ],
 			};
-		}
-
-		return state;
-	},
-	hiddenBlockTypes( state, action ) {
-		switch ( action.type ) {
-			case 'SHOW_BLOCK_TYPES':
-				return without( state, ...action.blockNames );
-
-			case 'HIDE_BLOCK_TYPES':
-				return union( state, action.blockNames );
 		}
 
 		return state;

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -1,7 +1,29 @@
 /**
+ * External dependencies
+ */
+import { flow, union, without } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_DEFAULTS } from './defaults';
+
+/**
+ * Higher-order reducer creator which provides the given initial state for the
+ * original reducer.
+ *
+ * @param {*} initialState Initial state to provide to reducer.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+const createWithInitialState = ( initialState ) => ( reducer ) => {
+	return ( state = initialState, action ) => reducer( state, action );
+};
 
 /**
  * Controls the open state of the widget areas.
@@ -43,7 +65,43 @@ function blockInserterPanel( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the user preferences.
+ *
+ * @param {Object}  state                           Current state.
+ * @param {Object}  action                          Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const preferences = flow( [
+	combineReducers,
+	createWithInitialState( PREFERENCES_DEFAULTS ),
+] )( {
+	features( state, action ) {
+		if ( action.type === 'TOGGLE_FEATURE' ) {
+			return {
+				...state,
+				[ action.feature ]: ! state[ action.feature ],
+			};
+		}
+
+		return state;
+	},
+	hiddenBlockTypes( state, action ) {
+		switch ( action.type ) {
+			case 'SHOW_BLOCK_TYPES':
+				return without( state, ...action.blockNames );
+
+			case 'HIDE_BLOCK_TYPES':
+				return union( state, action.blockNames );
+		}
+
+		return state;
+	},
+} );
+
 export default combineReducers( {
 	blockInserterPanel,
 	widgetAreasOpenState,
+	preferences,
 } );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy } from 'lodash';
+import { get, keyBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -220,3 +220,19 @@ export const canInsertBlockInWidgetArea = createRegistrySelector(
 		);
 	}
 );
+
+/**
+ * Returns whether the given feature is enabled or not.
+ *
+ * This function is unstable, as it is mostly copied from the edit-post
+ * package. Editor features and preferences have a lot of scope for
+ * being generalized and refactored.
+ *
+ * @param {Object} state   Global application state.
+ * @param {string} feature Feature slug.
+ *
+ * @return {boolean} Is active.
+ */
+export function __unstableIsFeatureActive( state, feature ) {
+	return get( state.preferences.features, [ feature ], false );
+}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -3,6 +3,7 @@
 @import "./blocks/widget-area/editor.scss";
 @import "./components/header/style.scss";
 @import "./components/keyboard-shortcut-help-modal/style.scss";
+@import "./components/more-menu/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/notices/style.scss";
 @import "./components/layout/style.scss";

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -2,6 +2,7 @@
 
 @import "./blocks/widget-area/editor.scss";
 @import "./components/header/style.scss";
+@import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/notices/style.scss";
 @import "./components/layout/style.scss";


### PR DESCRIPTION
## Description
Closes #27564

Adds the more menu to the standalone widget editor. Follows the suggestion in https://github.com/WordPress/gutenberg/issues/27564#issuecomment-842387178.

The code is a lot of copy and paste, because preferences are implemented in the `edit-post` package and not reusable across editors. There's a lot of scope for refactor of these preferences (either into their own package, or perhaps `interface`?).

## How has this been tested?
1. Try the various options and check they work (except for the welcome guide, which will be in https://github.com/WordPress/gutenberg/pull/31925)

## Screenshots <!-- if applicable -->
<img width="240" alt="Screenshot 2021-05-18 at 3 08 59 pm" src="https://user-images.githubusercontent.com/677833/118607328-055b5000-b7eb-11eb-8d8e-a9a6963a8b49.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
