### PR TITLE
Add some padding to the "click plus to add".

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -72,6 +72,7 @@
 	margin-top: auto;
 	margin-bottom: auto;
 	cursor: default;
+	padding-right: $grid-unit-10;
 
 	& + .block-list-appender {
 		margin-right: $grid-unit-10;


### PR DESCRIPTION
## Description

This one is a bit hard to reproduce. Basically in super tight contexts, the absence of padding on the social links click prompt can cause this:

<img width="518" alt="Screen Shot 2021-05-17 at 1 29 15 PM" src="https://user-images.githubusercontent.com/1204802/118617596-11cbb280-b7c3-11eb-8c9c-6cb6e8888a45.png">

This PR just adds a teensy bit of padding so that won't happen:

<img width="289" alt="Screenshot 2021-05-18 at 10 21 59" src="https://user-images.githubusercontent.com/1204802/118617618-1728fd00-b7c3-11eb-9524-cf58f2b1966f.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
