### PR TITLE
Polish nav vertical placeholder.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -292,6 +292,7 @@ $color-control-label-height: 20px;
 	// Both selected and vertical.
 	.is-selected.is-vertical & {
 		display: inline-flex; // This makes the white box not take up all available space.
+		padding: $grid-unit-15;
 	}
 
 	.wp-block-navigation-placeholder__icon {


### PR DESCRIPTION
## Description

The vertical placeholder was missing some padding:

<img width="972" alt="Screenshot 2021-05-18 at 10 26 36" src="https://user-images.githubusercontent.com/1204802/118619399-d6ca7e80-b7c4-11eb-8097-dbca6193d8bb.png">

This PR fixes that:

<img width="807" alt="Screenshot 2021-05-18 at 10 28 58" src="https://user-images.githubusercontent.com/1204802/118619421-daf69c00-b7c4-11eb-9b66-9ffd5c97ce52.png">

## How has this been tested?

Insert a vertical nav block and verify it looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
