### PR TITLE
Fix nav block hover z index.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -43,6 +43,7 @@ $z-layers: (
 
 	// Navigation menu dropdown.
 	".has-child .wp-block-navigation-link__container": 28,
+	".has-child:hover .wp-block-navigation-link__container": 29,
 
 	// Active pill button
 	".components-button {:focus or .is-primary}": 1,

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -20,6 +20,13 @@
 		z-index: z-index(".has-child .wp-block-navigation-link__container");
 	}
 
+	&:hover {
+		.submenu-container,
+		.wp-block-navigation-link__container {
+			z-index: z-index(".has-child:hover .wp-block-navigation-link__container");
+		}
+	}
+
 	// Show on editor selected, even if on frontend it only stays open on focus-within.
 	&.is-selected,
 	&.has-child-selected {


### PR DESCRIPTION
## Description

In the editor, you can click to open submenus and they will stay open. You can also hover to open submenus. So if you have one open, then hover another, you'll show two submenus. That's fine, but the z-index was wrong:

<img width="777" alt="Screenshot 2021-05-18 at 10 39 58" src="https://user-images.githubusercontent.com/1204802/118621301-86ecb700-b7c6-11eb-9222-da996ed20caf.png">

This PR fixes it:

<img width="653" alt="Screenshot 2021-05-18 at 10 46 40" src="https://user-images.githubusercontent.com/1204802/118621323-8b18d480-b7c6-11eb-9006-e02362b4f6e3.png">

## How has this been tested?

Insert a navibation menu where two adjacent menu items have submenus.

Click inside one submenu to "pin it" open.

Then hover the adjacent submenu, and verify that it _overlays_ the pinned open menu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
