### PR TITLE
Ignore data-no-store-string-literals rule for native files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,7 @@ module.exports = {
 				'import/no-extraneous-dependencies': 'off',
 				'import/no-unresolved': 'off',
 				'import/named': 'off',
+				'@wordpress/data-no-store-string-literals': 'off',
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Came up in a discussion with @gziolo after the comment on https://github.com/WordPress/gutenberg/pull/31934#issuecomment-843106167

Ignoring the rule for native files will prevent the next person from making the same mistake I did.

## How has this been tested?
Running `npm run lint-js` no longer throws warnings for native files for the `data-no-store-string-literals` check.

## Types of changes
Turned off the `@wordpress/data-no-store-string-literals` rule for native files in the `.eslintrc.js` file. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
