### PR TITLE
compose: Add types to useMergeRefs

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -354,7 +354,7 @@ _Parameters_
 
 _Returns_
 
--   `import('react').Ref<TypeFromRef<T>>`: The merged ref callback.
+-   `import('react').RefCallback<TypeFromRef<T>>`: The merged ref callback.
 
 <a name="usePrevious" href="#usePrevious">#</a> **usePrevious**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -350,11 +350,11 @@ return <div ref={ mergedRefs } />;
 
 _Parameters_
 
--   _refs_ `Array<RefObject|RefCallback>`: The refs to be merged.
+-   _refs_ `Array<T>`: The refs to be merged.
 
 _Returns_
 
--   `RefCallback`: The merged ref callback.
+-   `import('react').Ref<TypeFromRef<T>>`: The merged ref callback.
 
 <a name="usePrevious" href="#usePrevious">#</a> **usePrevious**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -350,11 +350,11 @@ return <div ref={ mergedRefs } />;
 
 _Parameters_
 
--   _refs_ `Array<T>`: The refs to be merged.
+-   _refs_ `Array<TRef>`: The refs to be merged.
 
 _Returns_
 
--   `import('react').RefCallback<TypeFromRef<T>>`: The merged ref callback.
+-   `import('react').RefCallback<TypeFromRef<TRef>>`: The merged ref callback.
 
 <a name="usePrevious" href="#usePrevious">#</a> **usePrevious**
 

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -63,16 +63,16 @@ function assignRef( ref, value ) {
  * return <div ref={ mergedRefs } />;
  * ```
  *
- * @template {import('react').Ref<any>} T
- * @param {Array<T>} refs The refs to be merged.
+ * @template {import('react').Ref<any>} TRef
+ * @param {Array<TRef>} refs The refs to be merged.
  *
- * @return {import('react').RefCallback<TypeFromRef<T>>} The merged ref callback.
+ * @return {import('react').RefCallback<TypeFromRef<TRef>>} The merged ref callback.
  */
 export default function useMergeRefs( refs ) {
 	const element = useRef();
 	const didElementChange = useRef( false );
 	/* eslint-disable jsdoc/no-undefined-types */
-	/** @type {import('react').MutableRefObject<T[]>} */
+	/** @type {import('react').MutableRefObject<TRef[]>} */
 	/* eslint-enable jsdoc/no-undefined-types */
 	const previousRefs = useRef( [] );
 	const currentRefs = useRef( refs );

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -3,14 +3,25 @@
  */
 import { useRef, useCallback, useLayoutEffect } from '@wordpress/element';
 
-/** @typedef {import('@wordpress/element').RefObject} RefObject */
-/** @typedef {import('@wordpress/element').RefCallback} RefCallback */
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @template T
+ * @typedef {T extends import('react').Ref<infer R> ? R : never} TypeFromRef
+ */
+/* eslint-enable jsdoc/valid-types */
 
+/**
+ * @template T
+ * @param {import('react').Ref<T>} ref
+ * @param {T} value
+ */
 function assignRef( ref, value ) {
 	if ( typeof ref === 'function' ) {
 		ref( value );
 	} else if ( ref && ref.hasOwnProperty( 'current' ) ) {
-		ref.current = value;
+		/* eslint-disable jsdoc/no-undefined-types */
+		/** @type {import('react').MutableRefObject<T>} */ ( ref ).current = value;
+		/* eslint-enable jsdoc/no-undefined-types */
 	}
 }
 
@@ -52,13 +63,17 @@ function assignRef( ref, value ) {
  * return <div ref={ mergedRefs } />;
  * ```
  *
- * @param {Array<RefObject|RefCallback>} refs The refs to be merged.
+ * @template {import('react').Ref<any>} T
+ * @param {Array<T>} refs The refs to be merged.
  *
- * @return {RefCallback} The merged ref callback.
+ * @return {import('react').Ref<TypeFromRef<T>>} The merged ref callback.
  */
 export default function useMergeRefs( refs ) {
 	const element = useRef();
 	const didElementChange = useRef( false );
+	/* eslint-disable jsdoc/no-undefined-types */
+	/** @type {import('react').MutableRefObject<T[]>} */
+	/* eslint-enable jsdoc/no-undefined-types */
 	const previousRefs = useRef( [] );
 	const currentRefs = useRef( refs );
 

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -66,7 +66,7 @@ function assignRef( ref, value ) {
  * @template {import('react').Ref<any>} T
  * @param {Array<T>} refs The refs to be merged.
  *
- * @return {import('react').Ref<TypeFromRef<T>>} The merged ref callback.
+ * @return {import('react').RefCallback<TypeFromRef<T>>} The merged ref callback.
  */
 export default function useMergeRefs( refs ) {
 	const element = useRef();

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -23,6 +23,7 @@
 		"src/hooks/use-previous/**/*",
 		"src/hooks/use-media-query/**/*",
 		"src/hooks/use-reduced-motion/**/*",
+		"src/hooks/use-merge-refs/**/*",
 		"src/utils/**/*"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useMergeRefs`. No runtime changes required, just some type casts.

Part of #18838

## How has this been tested?
I wrote a quick test to ensure that the types work as expected:
<img width="493" alt="Captura de Tela 2021-05-18 às 07 41 30" src="https://user-images.githubusercontent.com/24264157/118673678-0cb03880-b7ae-11eb-8b48-228c8e98ffda.png">
<img width="598" alt="Captura de Tela 2021-05-18 às 07 41 40" src="https://user-images.githubusercontent.com/24264157/118673687-0fab2900-b7ae-11eb-89fe-b8815b3d5d79.png">
The pictures show it working perfectly.

Additionally, if the type of ref is mixed (i.e., one for HTMLInputElement and another for HTMLDivElement), the return type is correctly inferred as the union of those types passed to `RefCallback`. This should practically never happen but it's a nice bonus that it works.

Otherwise as long as the type checks pass this should be good.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
