### PR TITLE
compose: Add types to useReducedMotion and useMediaQuery

### DIFF
--- a/packages/compose/src/hooks/use-media-query/index.js
+++ b/packages/compose/src/hooks/use-media-query/index.js
@@ -33,5 +33,5 @@ export default function useMediaQuery( query ) {
 		};
 	}, [ query ] );
 
-	return query && match;
+	return !! query && match;
 }

--- a/packages/compose/src/hooks/use-media-query/test/index.js
+++ b/packages/compose/src/hooks/use-media-query/test/index.js
@@ -138,7 +138,8 @@ describe( 'useMediaQuery', () => {
 		await act( async () => {
 			root = create( <TestComponent /> );
 		} );
-		expect( root.toJSON() ).toBe( 'useMediaQuery: undefined' );
+		// query will be case to a boolean to simplify the return type.
+		expect( root.toJSON() ).toBe( 'useMediaQuery: false' );
 
 		await act( async () => {
 			root.update( <TestComponent query={ false } /> );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"declarationDir": "build-types",
+		"types": [ "gutenberg-env" ],
 	},
 	"references": [
 		{ "path": "../element" },
@@ -20,6 +21,8 @@
 		"src/hooks/use-instance-id/**/*",
 		"src/hooks/use-focus-return/**/*",
 		"src/hooks/use-previous/**/*",
+		"src/hooks/use-media-query/**/*",
+		"src/hooks/use-reduced-motion/**/*",
 		"src/utils/**/*"
 	]
 }

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,6 +1,7 @@
 interface Environment {
 	NODE_ENV: unknown;
 	COMPONENT_SYSTEM_PHASE: number | undefined;
+	FORCE_REDUCED_MOTION: boolean | undefined;
 }
 interface Process {
 	env: Environment;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useMediaQuery` and `useReducedMotion`. Only one runtime change was necessary to cast the return type of `useMediaQuery` to a boolean.

Also required adding a new variable to `gutenberg-env` and adding the reference to it to the `types` property of `compose`'s `tsconfig.json`.

Part of #18838

## How has this been tested?
Type checks pass and unit tests pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
