### PR TITLE
compose: Add types to `usePrevious`

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -367,7 +367,7 @@ _Parameters_
 
 _Returns_
 
--   `T|undefined`: The value from the previous render.
+-   `T | undefined`: The value from the previous render.
 
 <a name="useReducedMotion" href="#useReducedMotion">#</a> **useReducedMotion**
 

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -11,14 +11,14 @@ import { useEffect, useRef } from '@wordpress/element';
  *
  * @param {T} value The value to track.
  *
- * @return {T|undefined} The value from the previous render.
+ * @return {T | undefined} The value from the previous render.
  */
 export default function usePrevious( value ) {
 	// Disable reason: without an explicit type detail, the type of ref will be
 	// inferred based on the initial useRef argument, which is undefined.
 	// https://github.com/WordPress/gutenberg/pull/22597#issuecomment-633588366
 	/* eslint-disable jsdoc/no-undefined-types */
-	const ref = useRef( /** @type {T|undefined} */ ( undefined ) );
+	const ref = useRef( /** @type {T | undefined} */ ( undefined ) );
 	/* eslint-enable jsdoc/no-undefined-types */
 
 	// Store current value in ref.

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -19,6 +19,7 @@
 		"src/hooks/use-debounce/**/*",
 		"src/hooks/use-instance-id/**/*",
 		"src/hooks/use-focus-return/**/*",
+		"src/hooks/use-previous/**/*",
 		"src/utils/**/*"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Really just adds type-checking to `usePrevious` as the hook already had good types. I did some reformatting of the types to make them slightly more readable and to fall inline with the style we use elsewhere.

Part of #18838

## How has this been tested?
Type checks pass

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
