### PR TITLE
compose: Add types to `useFocusReturn`

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -255,11 +255,11 @@ const WithFocusReturn = () => {
 
 _Parameters_
 
--   _onFocusReturn_ `Function?`: Overrides the default return behavior.
+-   _onFocusReturn_ `[() => void]`: Overrides the default return behavior.
 
 _Returns_
 
--   `Function`: Element Ref.
+-   `import('react').RefCallback<HTMLElement>`: Element Ref.
 
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -28,10 +28,10 @@ import { useRef, useEffect, useCallback } from '@wordpress/element';
  * ```
  */
 function useFocusReturn( onFocusReturn ) {
-	/** @type {import('react').MutableRefObject<undefined | HTMLElement>} */
-	const ref = useRef();
-	/** @type {import('react').MutableRefObject<undefined | HTMLElement>} */
-	const focusedBeforeMount = useRef();
+	/** @type {import('react').MutableRefObject<null | HTMLElement>} */
+	const ref = useRef( null );
+	/** @type {import('react').MutableRefObject<null | Element>} */
+	const focusedBeforeMount = useRef( null );
 	const onFocusReturnRef = useRef( onFocusReturn );
 	useEffect( () => {
 		onFocusReturnRef.current = onFocusReturn;
@@ -47,12 +47,10 @@ function useFocusReturn( onFocusReturn ) {
 				return;
 			}
 
-			focusedBeforeMount.current =
-				/** @type {HTMLElement | null} */ ( node.ownerDocument
-					.activeElement ) || undefined;
+			focusedBeforeMount.current = node.ownerDocument.activeElement;
 		} else if ( focusedBeforeMount.current ) {
 			const isFocused = ref.current?.contains(
-				ref.current?.ownerDocument.activeElement ?? null
+				ref.current?.ownerDocument.activeElement
 			);
 
 			if ( ref.current?.isConnected && ! isFocused ) {
@@ -66,7 +64,7 @@ function useFocusReturn( onFocusReturn ) {
 			if ( onFocusReturnRef.current ) {
 				onFocusReturnRef.current();
 			} else {
-				focusedBeforeMount.current?.focus();
+				/** @type {HTMLElement} */ ( focusedBeforeMount.current )?.focus();
 			}
 		}
 	}, [] );

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -64,7 +64,7 @@ function useFocusReturn( onFocusReturn ) {
 			if ( onFocusReturnRef.current ) {
 				onFocusReturnRef.current();
 			} else {
-				/** @type {HTMLElement} */ ( focusedBeforeMount.current )?.focus();
+				/** @type {null | HTMLElement} */ ( focusedBeforeMount.current )?.focus();
 			}
 		}
 	}, [] );

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -28,7 +28,7 @@ import { useRef, useEffect, useCallback } from '@wordpress/element';
  * ```
  */
 function useFocusReturn( onFocusReturn ) {
-	/** @type {import('react').MutableRefObject<undefined | Node>} */
+	/** @type {import('react').MutableRefObject<undefined | HTMLElement>} */
 	const ref = useRef();
 	/** @type {import('react').MutableRefObject<undefined | HTMLElement>} */
 	const focusedBeforeMount = useRef();
@@ -52,7 +52,7 @@ function useFocusReturn( onFocusReturn ) {
 					.activeElement ) || undefined;
 		} else if ( focusedBeforeMount.current ) {
 			const isFocused = ref.current?.contains(
-				ref.current?.ownerDocument?.activeElement ?? null
+				ref.current?.ownerDocument.activeElement ?? null
 			);
 
 			if ( ref.current?.isConnected && ! isFocused ) {

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -9,8 +9,8 @@ import { useRef, useEffect, useCallback } from '@wordpress/element';
  * previously focused element when closed.
  * The current hook implements the returning behavior.
  *
- * @param {Function?} onFocusReturn Overrides the default return behavior.
- * @return {Function} Element Ref.
+ * @param {() => void} [onFocusReturn] Overrides the default return behavior.
+ * @return {import('react').RefCallback<HTMLElement>} Element Ref.
  *
  * @example
  * ```js
@@ -28,7 +28,9 @@ import { useRef, useEffect, useCallback } from '@wordpress/element';
  * ```
  */
 function useFocusReturn( onFocusReturn ) {
+	/** @type {import('react').MutableRefObject<undefined | Node>} */
 	const ref = useRef();
+	/** @type {import('react').MutableRefObject<undefined | HTMLElement>} */
 	const focusedBeforeMount = useRef();
 	const onFocusReturnRef = useRef( onFocusReturn );
 	useEffect( () => {
@@ -45,13 +47,15 @@ function useFocusReturn( onFocusReturn ) {
 				return;
 			}
 
-			focusedBeforeMount.current = node.ownerDocument.activeElement;
+			focusedBeforeMount.current =
+				/** @type {HTMLElement | null} */ ( node.ownerDocument
+					.activeElement ) || undefined;
 		} else if ( focusedBeforeMount.current ) {
-			const isFocused = ref.current.contains(
-				ref.current.ownerDocument.activeElement
+			const isFocused = ref.current?.contains(
+				ref.current?.ownerDocument?.activeElement ?? null
 			);
 
-			if ( ref.current.isConnected && ! isFocused ) {
+			if ( ref.current?.isConnected && ! isFocused ) {
 				return;
 			}
 
@@ -62,7 +66,7 @@ function useFocusReturn( onFocusReturn ) {
 			if ( onFocusReturnRef.current ) {
 				onFocusReturnRef.current();
 			} else {
-				focusedBeforeMount.current.focus();
+				focusedBeforeMount.current?.focus();
 			}
 		}
 	}, [] );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -17,6 +17,7 @@
 		"src/hooks/use-async-list/**/*",
 		"src/hooks/use-constrained-tabbing/**/*",
 		"src/hooks/use-instance-id/**/*",
+		"src/hooks/use-focus-return/**/*",
 		"src/utils/**/*"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useFocusReturn`.

It's a little messy I think and I'm unsure of the return type, whether it should be `HTMLElement` or potentially even just generic. I don't think it can be `Node` though otherwise you'll get a type error when you actually try to apply the `ref` that's returned 🤔 

Part of #18838

## How has this been tested?
Type checks pass. Also tested inline with a component that just uses the function and it works fine:

```jsx
const Comp = () => {
  const ref = useFocusReturn();
  return <div ref={ ref } />;
}
```

The above produces no errors when typechecked.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
