### PR TITLE
Compose: add useLatestRef (internally)

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -89,10 +89,10 @@ function BlockPopover( {
 
 	useShortcut(
 		'core/block-editor/focus-toolbar',
-		useCallback( () => {
+		() => {
 			setIsToolbarForced( true );
 			stopTyping( true );
-		}, [] ),
+		},
 		{
 			bindGlobal: true,
 			eventName: 'keydown',

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -5,7 +5,7 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useShortcut,
@@ -45,26 +45,20 @@ function KeyboardShortcuts() {
 	// Moves selected block/blocks up
 	useShortcut(
 		'core/block-editor/move-up',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				moveBlocksUp( clientIds, rootClientId );
-			},
-			[ clientIds, moveBlocksUp ]
-		),
+		( event ) => {
+			event.preventDefault();
+			moveBlocksUp( clientIds, rootClientId );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
 	// Moves selected block/blocks up
 	useShortcut(
 		'core/block-editor/move-down',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				moveBlocksDown( clientIds, rootClientId );
-			},
-			[ clientIds, moveBlocksDown ]
-		),
+		( event ) => {
+			event.preventDefault();
+			moveBlocksDown( clientIds, rootClientId );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
@@ -72,13 +66,10 @@ function KeyboardShortcuts() {
 	// Prevents reposition Chrome devtools pane shortcut when devtools are open.
 	useShortcut(
 		'core/block-editor/duplicate',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				duplicateBlocks( clientIds );
-			},
-			[ clientIds, duplicateBlocks ]
-		),
+		( event ) => {
+			event.preventDefault();
+			duplicateBlocks( clientIds );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
@@ -86,13 +77,10 @@ function KeyboardShortcuts() {
 	// is used to prevent any obscure unknown shortcuts from triggering.
 	useShortcut(
 		'core/block-editor/remove',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				removeBlocks( clientIds );
-			},
-			[ clientIds, removeBlocks ]
-		),
+		( event ) => {
+			event.preventDefault();
+			removeBlocks( clientIds );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
@@ -100,53 +88,41 @@ function KeyboardShortcuts() {
 	// is used to prevent any obscure unknown shortcuts from triggering.
 	useShortcut(
 		'core/block-editor/insert-after',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				insertAfterBlock( last( clientIds ) );
-			},
-			[ clientIds, insertAfterBlock ]
-		),
+		( event ) => {
+			event.preventDefault();
+			insertAfterBlock( last( clientIds ) );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
 	// Prevent 'view recently closed tabs' in Opera using preventDefault.
 	useShortcut(
 		'core/block-editor/insert-before',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				insertBeforeBlock( first( clientIds ) );
-			},
-			[ clientIds, insertBeforeBlock ]
-		),
+		( event ) => {
+			event.preventDefault();
+			insertBeforeBlock( first( clientIds ) );
+		},
 		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
 	);
 
 	useShortcut(
 		'core/block-editor/delete-multi-selection',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				removeBlocks( clientIds );
-			},
-			[ clientIds, removeBlocks ]
-		),
+		( event ) => {
+			event.preventDefault();
+			removeBlocks( clientIds );
+		},
 		{ isDisabled: clientIds.length < 2 }
 	);
 
 	useShortcut(
 		'core/block-editor/unselect',
-		useCallback(
-			( event ) => {
-				event.preventDefault();
-				clearSelectedBlock();
-				event.target.ownerDocument.defaultView
-					.getSelection()
-					.removeAllRanges();
-			},
-			[ clientIds, clearSelectedBlock ]
-		),
+		( event ) => {
+			event.preventDefault();
+			clearSelectedBlock();
+			event.target.ownerDocument.defaultView
+				.getSelection()
+				.removeAllRanges();
+		},
 		{ isDisabled: clientIds.length < 2 }
 	);
 

--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -95,9 +95,9 @@ function useToolbarFocus(
 	const [ initialFocusOnMount ] = useState( focusOnMount );
 	const [ initialIndex ] = useState( defaultIndex );
 
-	const focusToolbar = useCallback( () => {
+	const focusToolbar = () => {
 		focusFirstTabbableIn( ref.current );
-	}, [] );
+	};
 
 	// Focus on toolbar when pressing alt+F10 when the toolbar is visible
 	useShortcut( 'core/block-editor/focus-toolbar', focusToolbar, {

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -7,7 +7,7 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { isEntirelySelected } from '@wordpress/dom';
-import { useRef, useCallback } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
@@ -25,7 +25,7 @@ export default function useSelectAll() {
 	} = useSelect( blockEditorStore );
 	const { multiSelect } = useDispatch( blockEditorStore );
 
-	const callback = useCallback( ( event ) => {
+	const callback = ( event ) => {
 		const selectedClientIds = getSelectedBlockClientIds();
 
 		if ( ! selectedClientIds.length ) {
@@ -60,7 +60,7 @@ export default function useSelectAll() {
 
 		multiSelect( firstClientId, lastClientId );
 		event.preventDefault();
-	}, [] );
+	};
 
 	useShortcut( 'core/block-editor/select-all', callback, {
 		target: ref,

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	createHigherOrderComponent,
 	useKeyboardShortcut,
@@ -37,8 +37,8 @@ export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
 		nextRegion.focus();
 		setIsFocusingRegions( true );
 	}
-	const focusPrevious = useCallback( () => focusRegion( -1 ), [] );
-	const focusNext = useCallback( () => focusRegion( 1 ), [] );
+	const focusPrevious = () => focusRegion( -1 );
+	const focusNext = () => focusRegion( 1 );
 
 	useKeyboardShortcut( shortcuts.previous, focusPrevious, {
 		bindGlobal: true,

--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.js
@@ -4,22 +4,12 @@
 import Clipboard from 'clipboard';
 
 /**
- * WordPress dependencies
- */
-import { useRef } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import useRefEffect from '../use-ref-effect';
+import useFreshRef from '../use-fresh-ref';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
-
-function useUpdatedRef( value ) {
-	const ref = useRef( value );
-	ref.current = value;
-	return ref;
-}
 
 /**
  * Copies the given text to the clipboard when the element is clicked.
@@ -33,8 +23,8 @@ function useUpdatedRef( value ) {
 export default function useCopyToClipboard( text, onSuccess ) {
 	// Store the dependencies as refs and continuesly update them so they're
 	// fresh when the callback is called.
-	const textRef = useUpdatedRef( text );
-	const onSuccesRef = useUpdatedRef( onSuccess );
+	const textRef = useFreshRef( text );
+	const onSuccesRef = useFreshRef( onSuccess );
 	return useRefEffect( ( node ) => {
 		// Clipboard listens to click events.
 		const clipboard = new Clipboard( node, {

--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.js
@@ -7,7 +7,7 @@ import Clipboard from 'clipboard';
  * Internal dependencies
  */
 import useRefEffect from '../use-ref-effect';
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -23,8 +23,8 @@ import useFreshRef from '../use-fresh-ref';
 export default function useCopyToClipboard( text, onSuccess ) {
 	// Store the dependencies as refs and continuesly update them so they're
 	// fresh when the callback is called.
-	const textRef = useFreshRef( text );
-	const onSuccesRef = useFreshRef( onSuccess );
+	const textRef = useLatestRef( text );
+	const onSuccesRef = useLatestRef( onSuccess );
 	return useRefEffect( ( node ) => {
 		// Clipboard listens to click events.
 		const clipboard = new Clipboard( node, {

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -12,7 +12,7 @@ import useFocusOnMount from '../use-focus-on-mount';
 import useFocusReturn from '../use-focus-return';
 import useFocusOutside from '../use-focus-outside';
 import useMergeRefs from '../use-merge-refs';
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /**
  * Returns a ref and props to apply to a dialog wrapper to enable the following behaviors:
@@ -24,7 +24,7 @@ import useFreshRef from '../use-fresh-ref';
  * @param {Object} options Dialog Options.
  */
 function useDialog( options ) {
-	const onClose = useFreshRef( options.onClose );
+	const onClose = useLatestRef( options.onClose );
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusOnMountRef = useFocusOnMount();
 	const focusReturnRef = useFocusReturn();

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
@@ -12,6 +12,7 @@ import useFocusOnMount from '../use-focus-on-mount';
 import useFocusReturn from '../use-focus-return';
 import useFocusOutside from '../use-focus-outside';
 import useMergeRefs from '../use-merge-refs';
+import useFreshRef from '../use-fresh-ref';
 
 /**
  * Returns a ref and props to apply to a dialog wrapper to enable the following behaviors:
@@ -23,10 +24,7 @@ import useMergeRefs from '../use-merge-refs';
  * @param {Object} options Dialog Options.
  */
 function useDialog( options ) {
-	const onClose = useRef();
-	useEffect( () => {
-		onClose.current = options.onClose;
-	}, [ options.onClose ] );
+	const onClose = useFreshRef( options.onClose );
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusOnMountRef = useFocusOnMount();
 	const focusReturnRef = useFocusReturn();

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import useRefEffect from '../use-ref-effect';
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /** @typedef {import('@wordpress/element').RefCallback} RefCallback */
 
@@ -29,12 +29,12 @@ export default function useDropZone( {
 	onDragEnd: _onDragEnd,
 	onDragOver: _onDragOver,
 } ) {
-	const onDropRef = useFreshRef( _onDrop );
-	const onDragStartRef = useFreshRef( _onDragStart );
-	const onDragEnterRef = useFreshRef( _onDragEnter );
-	const onDragLeaveRef = useFreshRef( _onDragLeave );
-	const onDragEndRef = useFreshRef( _onDragEnd );
-	const onDragOverRef = useFreshRef( _onDragOver );
+	const onDropRef = useLatestRef( _onDrop );
+	const onDragStartRef = useLatestRef( _onDragStart );
+	const onDragEnterRef = useLatestRef( _onDragEnter );
+	const onDragLeaveRef = useLatestRef( _onDragLeave );
+	const onDragEndRef = useLatestRef( _onDragEnd );
+	const onDragOverRef = useLatestRef( _onDragOver );
 
 	return useRefEffect(
 		( element ) => {

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -1,20 +1,10 @@
 /**
- * WordPress dependencies
- */
-import { useRef } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import useRefEffect from '../use-ref-effect';
+import useFreshRef from '../use-fresh-ref';
 
 /** @typedef {import('@wordpress/element').RefCallback} RefCallback */
-
-function useFreshRef( value ) {
-	const ref = useRef();
-	ref.current = value;
-	return ref;
-}
 
 /**
  * A hook to facilitate drag and drop handling.

--- a/packages/compose/src/hooks/use-focus-outside/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.js
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /**
  * Input types which are classified as button types, for use in considering
@@ -97,7 +97,7 @@ function isFocusNormalizedButton( eventTarget ) {
  *                                   outside that element.
  */
 export default function useFocusOutside( onFocusOutside ) {
-	const currentOnFocusOutside = useFreshRef( onFocusOutside );
+	const currentOnFocusOutside = useLatestRef( onFocusOutside );
 
 	const preventBlurCheck = useRef( false );
 

--- a/packages/compose/src/hooks/use-focus-outside/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.js
@@ -9,6 +9,11 @@ import { includes } from 'lodash';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import useFreshRef from '../use-fresh-ref';
+
+/**
  * Input types which are classified as button types, for use in considering
  * whether element is a (focus-normalized) button.
  *
@@ -92,10 +97,7 @@ function isFocusNormalizedButton( eventTarget ) {
  *                                   outside that element.
  */
 export default function useFocusOutside( onFocusOutside ) {
-	const currentOnFocusOutside = useRef( onFocusOutside );
-	useEffect( () => {
-		currentOnFocusOutside.current = onFocusOutside;
-	}, [ onFocusOutside ] );
+	const currentOnFocusOutside = useFreshRef( onFocusOutside );
 
 	const preventBlurCheck = useRef( false );
 

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -6,7 +6,7 @@ import { useRef, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /**
  * When opening modals/sidebars/dialogs, the focus
@@ -35,7 +35,7 @@ import useFreshRef from '../use-fresh-ref';
 function useFocusReturn( onFocusReturn ) {
 	const ref = useRef();
 	const focusedBeforeMount = useRef();
-	const onFocusReturnRef = useFreshRef( onFocusReturn );
+	const onFocusReturnRef = useLatestRef( onFocusReturn );
 
 	return useCallback( ( node ) => {
 		if ( node ) {

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useRef, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useFreshRef from '../use-fresh-ref';
 
 /**
  * When opening modals/sidebars/dialogs, the focus
@@ -30,10 +35,7 @@ import { useRef, useEffect, useCallback } from '@wordpress/element';
 function useFocusReturn( onFocusReturn ) {
 	const ref = useRef();
 	const focusedBeforeMount = useRef();
-	const onFocusReturnRef = useRef( onFocusReturn );
-	useEffect( () => {
-		onFocusReturnRef.current = onFocusReturn;
-	}, [ onFocusReturn ] );
+	const onFocusReturnRef = useFreshRef( onFocusReturn );
 
 	return useCallback( ( node ) => {
 		if ( node ) {

--- a/packages/compose/src/hooks/use-fresh-ref/index.js
+++ b/packages/compose/src/hooks/use-fresh-ref/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * A ref that always contains the lastest value.
+ *
+ * @param {any} value The value to store in the ref.
+ *
+ * @return {import('react').RefObject} A ref object with the value.
+ */
+export default function useFreshRef( value ) {
+	const ref = useRef();
+	ref.current = value;
+	return ref;
+}

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -13,7 +13,7 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useFreshRef from '../use-fresh-ref';
+import useLatestRef from '../use-latest-ref';
 
 /**
  * A block selection object.
@@ -59,7 +59,7 @@ function useKeyboardShortcut(
 		target,
 	} = {}
 ) {
-	const currentCallback = useFreshRef( callback );
+	const currentCallback = useLatestRef( callback );
 
 	useEffect( () => {
 		if ( isDisabled ) {

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -8,7 +8,12 @@ import { includes, castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useFreshRef from '../use-fresh-ref';
 
 /**
  * A block selection object.
@@ -54,10 +59,7 @@ function useKeyboardShortcut(
 		target,
 	} = {}
 ) {
-	const currentCallback = useRef( callback );
-	useEffect( () => {
-		currentCallback.current = callback;
-	}, [ callback ] );
+	const currentCallback = useFreshRef( callback );
 
 	useEffect( () => {
 		if ( isDisabled ) {

--- a/packages/compose/src/hooks/use-latest-ref/index.js
+++ b/packages/compose/src/hooks/use-latest-ref/index.js
@@ -10,8 +10,11 @@ import { useRef } from '@wordpress/element';
  *
  * @return {import('react').RefObject} A ref object with the value.
  */
-export default function useFreshRef( value ) {
+export default function useLatestRef( value ) {
 	const ref = useRef();
+	// Assignment MUST happen on render, otherwise the value is not up-to-date
+	// for ref callbacks. Assignment with `useEffect` or `useLayoutEffect` won't
+	// work because ref callbacks are called before effect callbacks.
 	ref.current = value;
 	return ref;
 }

--- a/packages/compose/src/hooks/use-latest-ref/test/index.js
+++ b/packages/compose/src/hooks/use-latest-ref/test/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import ReactDOM from 'react-dom';
+
+/**
+ * Internal dependencies
+ */
+import useLatestRef from '../';
+
+describe( 'useLatestRef', () => {
+	let refCallbackValue;
+
+	function ComponentWithRefCallback( { value } ) {
+		const lastestRef = useLatestRef( value );
+
+		function refCallback() {
+			refCallbackValue = lastestRef.current;
+		}
+
+		return <div ref={ refCallback } />;
+	}
+
+	beforeEach( () => {
+		const rootElement = document.createElement( 'div' );
+		rootElement.id = 'root';
+		document.body.appendChild( rootElement );
+	} );
+
+	afterEach( () => {
+		refCallbackValue = undefined;
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should be up-to-date for ref callbacks', () => {
+		const rootElement = document.getElementById( 'root' );
+
+		ReactDOM.render( <ComponentWithRefCallback value="1" />, rootElement );
+
+		// Should be correct after mount.
+		expect( refCallbackValue ).toEqual( '1' );
+
+		ReactDOM.render( <ComponentWithRefCallback value="2" />, rootElement );
+
+		// Should be correct after a re-render.
+		expect( refCallbackValue ).toEqual( '2' );
+	} );
+} );

--- a/packages/edit-navigation/src/components/layout/shortcuts.js
+++ b/packages/edit-navigation/src/components/layout/shortcuts.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import {
 	useShortcut,
@@ -12,10 +12,10 @@ import { __ } from '@wordpress/i18n';
 function NavigationEditorShortcuts( { saveBlocks } ) {
 	useShortcut(
 		'core/edit-navigation/save-menu',
-		useCallback( ( event ) => {
+		( event ) => {
 			event.preventDefault();
 			saveBlocks();
-		} ),
+		},
 		{
 			bindGlobal: true,
 		}

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import {
 	useShortcut,
 	store as keyboardShortcutsStore,
@@ -55,9 +55,9 @@ function KeyboardShortcuts() {
 
 	useShortcut(
 		'core/edit-site/toggle-list-view',
-		useCallback( () => {
+		() => {
 			setIsListViewOpened( ! isListViewOpen );
-		}, [ isListViewOpen, setIsListViewOpened ] ),
+		},
 		{ bindGlobal: true }
 	);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This is a common piece that is used by quite a few hooks. It generally allows us to write much simpler hook APIs as we don't have to require passed functions to be wrapper in `useCallback`. `useFreshRef` ensure that the value is always fresh whenever it will be used.

The biggest benefit can be seen in `useKeyboardShortcut` and `useShortcut`. Implementors no longer have wrap callbacks in `useCallback`. I saw a lot of cases in the codebase where it was already forgotten.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
