### PR TITLE
Fix native Gallery block crash

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../../store';
  */
 export function useFocusHandler( clientId ) {
 	const { isBlockSelected } = useSelect( blockEditorStore );
-	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
@@ -33,10 +33,6 @@ export function useFocusHandler( clientId ) {
 				// Check synchronously because a non-selected block might be
 				// getting data through `useSelect` asynchronously.
 				if ( isBlockSelected( clientId ) ) {
-					// Potentially change selection away from rich text.
-					if ( ! event.target.isContentEditable ) {
-						selectionChange( clientId );
-					}
 					return;
 				}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -295,6 +295,10 @@ function GalleryEdit( props ) {
 			: __( 'Thumbnails are not cropped.' );
 	}
 
+	function onFocusGalleryCaption() {
+		setSelectedImage();
+	}
+
 	function setImageAttributes( index, newAttributes ) {
 		if ( ! images[ index ] ) {
 			return;
@@ -462,6 +466,7 @@ function GalleryEdit( props ) {
 				onSelectImage={ onSelectImage }
 				onDeselectImage={ onDeselectImage }
 				onSetImageAttributes={ setImageAttributes }
+				onFocusGalleryCaption={ onFocusGalleryCaption }
 				blockProps={ blockProps }
 			/>
 		</>

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -44,6 +44,7 @@ class GalleryImage extends Component {
 		super( ...arguments );
 
 		this.onSelectImage = this.onSelectImage.bind( this );
+		this.onSelectCaption = this.onSelectCaption.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 		this.onEdit = this.onEdit.bind( this );
@@ -52,6 +53,7 @@ class GalleryImage extends Component {
 		);
 		this.onSelectCustomURL = this.onSelectCustomURL.bind( this );
 		this.state = {
+			captionSelected: false,
 			isEditing: false,
 		};
 	}
@@ -60,9 +62,27 @@ class GalleryImage extends Component {
 		this.container = ref;
 	}
 
+	onSelectCaption() {
+		if ( ! this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: true,
+			} );
+		}
+
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+	}
+
 	onSelectImage() {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
+		}
+
+		if ( this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
 		}
 	}
 
@@ -84,8 +104,9 @@ class GalleryImage extends Component {
 		} );
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		const {
+			isSelected,
 			image,
 			url,
 			__unstableMarkNextChangeAsNotPersistent,
@@ -95,6 +116,18 @@ class GalleryImage extends Component {
 			this.props.setAttributes( {
 				url: image.source_url,
 				alt: image.alt_text,
+			} );
+		}
+
+		// unselect the caption so when the user selects other image and comeback
+		// the caption is not immediately selected
+		if (
+			this.state.captionSelected &&
+			! isSelected &&
+			prevProps.isSelected
+		) {
+			this.setState( {
+				captionSelected: false,
 			} );
 		}
 	}
@@ -183,6 +216,8 @@ class GalleryImage extends Component {
 					src={ url }
 					alt={ alt }
 					data-id={ id }
+					onClick={ this.onSelectImage }
+					onFocus={ this.onSelectImage }
 					onKeyDown={ this.onRemoveImage }
 					tabIndex="0"
 					aria-label={ ariaLabel }
@@ -199,12 +234,7 @@ class GalleryImage extends Component {
 		} );
 
 		return (
-			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-			<figure
-				className={ className }
-				onClick={ this.onSelectImage }
-				onFocus={ this.onSelectImage }
-			>
+			<figure className={ className }>
 				{ ! isEditing && ( href ? <a href={ href }>{ img }</a> : img ) }
 				{ isEditing && (
 					<MediaPlaceholder
@@ -253,9 +283,11 @@ class GalleryImage extends Component {
 						aria-label={ __( 'Image caption text' ) }
 						placeholder={ isSelected ? __( 'Add caption' ) : null }
 						value={ caption }
+						isSelected={ this.state.captionSelected }
 						onChange={ ( newCaption ) =>
 							setAttributes( { caption: newCaption } )
 						}
+						unstableOnFocus={ this.onSelectCaption }
 						inlineToolbar
 					/>
 				) }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -30,6 +30,7 @@ export const Gallery = ( props ) => {
 		onSelectImage,
 		onDeselectImage,
 		onSetImageAttributes,
+		onFocusGalleryCaption,
 		insertBlocksAfter,
 		blockProps,
 	} = props;
@@ -98,6 +99,7 @@ export const Gallery = ( props ) => {
 				aria-label={ __( 'Gallery caption text' ) }
 				placeholder={ __( 'Write gallery caption…' ) }
 				value={ caption }
+				unstableOnFocus={ onFocusGalleryCaption }
 				onChange={ ( value ) => setAttributes( { caption: value } ) }
 				inlineToolbar
 				__unstableOnSplitAtEnd={ () =>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -130,6 +130,7 @@ export default function Image( {
 		noticesStore
 	);
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const [ captionFocused, setCaptionFocused ] = useState( false );
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
 	const [ { naturalWidth, naturalHeight }, setNaturalSize ] = useState( {} );
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
@@ -145,6 +146,12 @@ export default function Image( {
 
 	// Check if the cover block is registered.
 	const coverBlockExists = !! getBlockType( 'core/cover' );
+
+	useEffect( () => {
+		if ( ! isSelected ) {
+			setCaptionFocused( false );
+		}
+	}, [ isSelected ] );
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,
@@ -194,6 +201,18 @@ export default function Image( {
 		// This is the HTML title attribute, separate from the media object
 		// title.
 		setAttributes( { title: value } );
+	}
+
+	function onFocusCaption() {
+		if ( ! captionFocused ) {
+			setCaptionFocused( true );
+		}
+	}
+
+	function onImageClick() {
+		if ( captionFocused ) {
+			setCaptionFocused( false );
+		}
 	}
 
 	function updateAlt( newAlt ) {
@@ -398,6 +417,7 @@ export default function Image( {
 			<img
 				src={ temporaryURL || url }
 				alt={ defaultedAlt }
+				onClick={ onImageClick }
 				onError={ () => onImageError() }
 				onLoad={ ( event ) => {
 					setNaturalSize(
@@ -544,9 +564,11 @@ export default function Image( {
 					aria-label={ __( 'Image caption text' ) }
 					placeholder={ __( 'Add caption' ) }
 					value={ caption }
+					unstableOnFocus={ onFocusCaption }
 					onChange={ ( value ) =>
 						setAttributes( { caption: value } )
 					}
+					isSelected={ captionFocused }
 					inlineToolbar
 					__unstableOnSplitAtEnd={ () =>
 						insertBlocksAfter( createBlock( 'core/paragraph' ) )


### PR DESCRIPTION
## Description
Fixes [a crash in the Image Gallery block when adding a caption](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3510) by reverting [this commit](https://github.com/WordPress/gutenberg/commit/9a6e3fcbc927791d7fb70f35ba88da1ef2d83acb). 

## How has this been tested?
1. Add a Gallery block
1. Add some images from the device or media library
1. Tap on the gallery caption
1. The app should not crash. 

## Screenshots 
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
