### PR TITLE
Mobile: update image size picker

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { View, TouchableWithoutFeedback, Platform } from 'react-native';
-import { isEmpty, get, find, map , filter } from 'lodash';
+import { isEmpty, get, find, map, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -123,11 +123,15 @@ export class ImageEdit extends Component {
 		// Only map available image sizes.
 		this.sizeOptions = map(
 			filter( this.props.imageSizes, ( { slug } ) =>
-				get( this.props.image, [ 'media_details', 'sizes', slug, 'source_url' ] )
+				get( this.props.image, [
+					'media_details',
+					'sizes',
+					slug,
+					'source_url',
+				] )
 			),
 			( { name, slug } ) => ( { value: slug, label: name } )
 		);
-
 	}
 
 	componentDidMount() {
@@ -504,16 +508,13 @@ export class ImageEdit extends Component {
 			sizeSlug || imageDefaultSize,
 		] );
 
-
 		// By default, it's only possible to set images that have been uploaded to a site's library as featured.
 		// Images that haven't been uploaded to a site's library have an id of 'undefined', which the 'canImageBeFeatured' check filters out.
 		const canImageBeFeatured = typeof attributes.id !== 'undefined';
-		if ( ! sizeOptionsValid ) { 
+
+		if ( ! sizeOptionsValid ) {
 			// Default to 'full' size if the default large size is not available.
-			sizeOptionsValid = find( this.sizeOptions, [
-				'value',
-				'full',
-			] );
+			sizeOptionsValid = find( this.sizeOptions, [ 'value', 'full' ] );
 			selectedSizeOption = 'full';
 		}
 
@@ -546,15 +547,16 @@ export class ImageEdit extends Component {
 					<BlockStyles clientId={ clientId } url={ url } />
 				</PanelBody>
 				<PanelBody>
-					{ image && sizeOptionsValid (
-						<BottomSheetSelectControl
-							icon={ expand }
-							label={ __( 'Size' ) }
-							options={ this.sizeOptions }
-							onChange={ this.onSizeChangeValue }
-							value={ selectedSizeOption }
-						/>
-					) }
+					{ image &&
+						sizeOptionsValid(
+							<BottomSheetSelectControl
+								icon={ expand }
+								label={ __( 'Size' ) }
+								options={ this.sizeOptions }
+								onChange={ this.onSizeChangeValue }
+								value={ selectedSizeOption }
+							/>
+						) }
 					{ this.getAltTextSettings() }
 				</PanelBody>
 				<PanelBody title={ __( 'Link Settings' ) }>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -49,7 +49,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import {
 	image as placeholderIcon,
 	replace,
-	expand,
+	fullscreen,
 	textColor,
 } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
@@ -552,7 +552,7 @@ export class ImageEdit extends Component {
 				<PanelBody>
 					{ image && sizeOptionsValid && (
 						<BottomSheetSelectControl
-							icon={ expand }
+							icon={ fullscreen }
 							label={ __( 'Size' ) }
 							options={ sizeOptions }
 							onChange={ this.onSizeChangeValue }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -493,10 +493,12 @@ export class ImageEdit extends Component {
 			imageDefaultSize,
 			featuredImageId,
 			wasBlockJustInserted,
-			imageSizes,
 		} = this.props;
 		const { align, url, alt, id, sizeSlug, className } = attributes;
 
+		const imageSizes = Array.isArray( this.props.imageSizes )
+			? this.props.imageSizes
+			: [];
 		// Only map available image sizes for the user to choose.
 		const sizeOptions = imageSizes
 			.filter( ( { slug } ) => getUrlForSlug( image, slug ) )

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -548,7 +548,7 @@ export class ImageEdit extends Component {
 				</PanelBody>
 				<PanelBody>
 					{ image &&
-						sizeOptionsValid(
+						sizeOptionsValid && (
 							<BottomSheetSelectControl
 								icon={ expand }
 								label={ __( 'Size' ) }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -547,16 +547,15 @@ export class ImageEdit extends Component {
 					<BlockStyles clientId={ clientId } url={ url } />
 				</PanelBody>
 				<PanelBody>
-					{ image &&
-						sizeOptionsValid && (
-							<BottomSheetSelectControl
-								icon={ expand }
-								label={ __( 'Size' ) }
-								options={ this.sizeOptions }
-								onChange={ this.onSizeChangeValue }
-								value={ selectedSizeOption }
-							/>
-						) }
+					{ image && sizeOptionsValid && (
+						<BottomSheetSelectControl
+							icon={ expand }
+							label={ __( 'Size' ) }
+							options={ this.sizeOptions }
+							onChange={ this.onSizeChangeValue }
+							value={ selectedSizeOption }
+						/>
+					) }
 					{ this.getAltTextSettings() }
 				</PanelBody>
 				<PanelBody title={ __( 'Link Settings' ) }>

--- a/packages/components/src/mobile/bottom-sheet-select-control/README.md
+++ b/packages/components/src/mobile/bottom-sheet-select-control/README.md
@@ -88,3 +88,10 @@ Can be used to externally control the value of the control, like in the `MyContr
 
 -   Type: `Object`
 -   Required: No
+
+#### icon
+
+The icon for the control.
+
+-   Type: `Icon component`
+-   Required: No

--- a/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
@@ -18,6 +18,7 @@ import styles from './style.scss';
 
 const BottomSheetSelectControl = ( {
 	label,
+	icon,
 	options: items,
 	onChange,
 	value: selectedValue,
@@ -52,6 +53,7 @@ const BottomSheetSelectControl = ( {
 				<BottomSheet.Cell
 					label={ label }
 					separatorType="none"
+					icon={ icon }
 					value={ selectedOption.label }
 					onPress={ openSubSheet }
 					accessibilityRole={ 'button' }


### PR DESCRIPTION
## Description
This PR updates the image size picker to use Bottom Sheet Control instead of the current cycle control
This helps the user pick the right size of image that they want to use. Without cycling though all of the image size and downloading all the different images. 

It also fixes an issue where we are only making the image sizes that are selectable available to be selected.

## How has this been tested?
1. Add an image block to your post. 
2. Try to switch between the different image sizes by using the size picker. 
Did it work as expected? 
Does it work the same way on the web. If you upload a smaller image then you should only see some of the sizes and not all. 

## Screenshots <!-- if applicable -->
### Before

<img src="https://user-images.githubusercontent.com/115071/118744071-7f4e0200-b808-11eb-823b-b072f94e346b.png" width="200" />

### After
<img src="https://user-images.githubusercontent.com/115071/118743708-b96ad400-b807-11eb-9850-9299a304ef70.png" width="200" />
<img src="https://user-images.githubusercontent.com/115071/118743706-b7087a00-b807-11eb-971e-7c7d78da4bd9.png" width=200 />


## Types of changes
UI update

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
