### PR TITLE
Add more menu to customize widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13493,6 +13493,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
+				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/widgets": "file:packages/widgets",

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -141,6 +141,7 @@ $z-layers: (
 	".components-popover.block-editor-inserter__popover": 99999,
 	".components-popover.table-of-contents__popover": 99998,
 	".components-popover.block-editor-block-navigation__popover": 99998,
+	".components-popover.customize-widgets-more-menu__content": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,
 	".components-popover.edit-site-more-menu__content": 99998,
 	".components-popover.edit-widgets-more-menu__content": 99998,

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
+		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/widgets": "file:../widgets",

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -11,6 +11,7 @@ import { plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import Inserter from '../inserter';
+import MoreMenu from '../more-menu';
 
 function Header( { inserter, isInserterOpened, setIsInserterOpened } ) {
 	return (
@@ -34,6 +35,7 @@ function Header( { inserter, isInserterOpened, setIsInserterOpened } ) {
 							setIsInserterOpened( ( isOpen ) => ! isOpen );
 						} }
 					/>
+					<MoreMenu />
 				</NavigableToolbar>
 			</div>
 

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { createPortal } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { Button, ToolbarItem } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
 import { plus } from '@wordpress/icons';
 
@@ -35,8 +35,7 @@ function Header( {
 					className="customize-widgets-header-toolbar"
 					aria-label={ __( 'Document tools' ) }
 				>
-					<ToolbarItem
-						as={ Button }
+					<ToolbarButton
 						className="customize-widgets-header-toolbar__inserter-toggle"
 						isPressed={ isInserterOpened }
 						isPrimary

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { createPortal } from '@wordpress/element';
@@ -13,10 +18,19 @@ import { plus } from '@wordpress/icons';
 import Inserter from '../inserter';
 import MoreMenu from '../more-menu';
 
-function Header( { inserter, isInserterOpened, setIsInserterOpened } ) {
+function Header( {
+	inserter,
+	isInserterOpened,
+	setIsInserterOpened,
+	isFixedToolbarActive,
+} ) {
 	return (
 		<>
-			<div className="customize-widgets-header">
+			<div
+				className={ classnames( 'customize-widgets-header', {
+					'is-fixed-toolbar-active': isFixedToolbarActive,
+				} ) }
+			>
 				<NavigableToolbar
 					className="customize-widgets-header-toolbar"
 					aria-label={ __( 'Document tools' ) }

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -9,10 +9,12 @@
 		margin-bottom: 0;
 	}
 
+	display: flex;
+	justify-content: flex-end;
+
 	// Offset the customizer's sidebar padding.
 	// Zero bottom margin so that the fixed toolbar is right under the header.
 	margin: -15px ( -$grid-unit-15 ) ( 0 ) ( -$grid-unit-15 );
-	padding: $grid-unit-15;
 
 	// Match the customizer grey background.
 	background: #f0f0f1;
@@ -31,7 +33,7 @@
 		padding: 0;
 		min-width: $grid-unit-30;
 		height: $grid-unit-30;
-		margin-left: auto;
+		margin: $grid-unit-15 0 $grid-unit-15;
 
 		&::before {
 			content: none;

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,11 +1,16 @@
 .customize-widgets-header {
 	@include break-medium() {
-		// The mobile fixed block toolbar should be snug under the header.
+		// Make space for the floating toolbar.
 		margin-bottom: $grid-unit-60 + $default-block-margin;
 	}
 
+	&.is-fixed-toolbar-active {
+		// Top toolbar mode toolbar should be right under the header.
+		margin-bottom: 0;
+	}
+
 	// Offset the customizer's sidebar padding.
-	// Provide enough bottom margin to ensure the floating block toolbar isn't overlapped.
+	// Zero bottom margin so that the fixed toolbar is right under the header.
 	margin: -15px ( -$grid-unit-15 ) ( 0 ) ( -$grid-unit-15 );
 	padding: $grid-unit-15;
 

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const textFormattingShortcuts = [
+	{
+		keyCombination: { modifier: 'primary', character: 'b' },
+		description: __( 'Make the selected text bold.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'i' },
+		description: __( 'Make the selected text italic.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'k' },
+		description: __( 'Convert the selected text into a link.' ),
+	},
+	{
+		keyCombination: { modifier: 'primaryShift', character: 'k' },
+		description: __( 'Remove a link.' ),
+	},
+	{
+		keyCombination: { modifier: 'primary', character: 'u' },
+		description: __( 'Underline the selected text.' ),
+	},
+];

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+
+/**
+ * Internal dependencies
+ */
+import Shortcut from './shortcut';
+
+function DynamicShortcut( { name } ) {
+	const { keyCombination, description, aliases } = useSelect( ( select ) => {
+		const {
+			getShortcutKeyCombination,
+			getShortcutDescription,
+			getShortcutAliases,
+		} = select( keyboardShortcutsStore );
+
+		return {
+			keyCombination: getShortcutKeyCombination( name ),
+			aliases: getShortcutAliases( name ),
+			description: getShortcutDescription( name ),
+		};
+	} );
+
+	if ( ! keyCombination ) {
+		return null;
+	}
+
+	return (
+		<Shortcut
+			keyCombination={ keyCombination }
+			description={ description }
+			aliases={ aliases }
+		/>
+	);
+}
+
+export default DynamicShortcut;

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { isString } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { textFormattingShortcuts } from './config';
+import Shortcut from './shortcut';
+import DynamicShortcut from './dynamic-shortcut';
+
+const ShortcutList = ( { shortcuts } ) => (
+	/*
+	 * Disable reason: The `list` ARIA role is redundant but
+	 * Safari+VoiceOver won't announce the list otherwise.
+	 */
+	/* eslint-disable jsx-a11y/no-redundant-roles */
+	<ul
+		className="customize-widgets-keyboard-shortcut-help-modal__shortcut-list"
+		role="list"
+	>
+		{ shortcuts.map( ( shortcut, index ) => (
+			<li
+				className="customize-widgets-keyboard-shortcut-help-modal__shortcut"
+				key={ index }
+			>
+				{ isString( shortcut ) ? (
+					<DynamicShortcut name={ shortcut } />
+				) : (
+					<Shortcut { ...shortcut } />
+				) }
+			</li>
+		) ) }
+	</ul>
+	/* eslint-enable jsx-a11y/no-redundant-roles */
+);
+
+const ShortcutSection = ( { title, shortcuts, className } ) => (
+	<section
+		className={ classnames(
+			'customize-widgets-keyboard-shortcut-help-modal__section',
+			className
+		) }
+	>
+		{ !! title && (
+			<h2 className="customize-widgets-keyboard-shortcut-help-modal__section-title">
+				{ title }
+			</h2>
+		) }
+		<ShortcutList shortcuts={ shortcuts } />
+	</section>
+);
+
+const ShortcutCategorySection = ( {
+	title,
+	categoryName,
+	additionalShortcuts = [],
+} ) => {
+	const categoryShortcuts = useSelect(
+		( select ) => {
+			return select( keyboardShortcutsStore ).getCategoryShortcuts(
+				categoryName
+			);
+		},
+		[ categoryName ]
+	);
+
+	return (
+		<ShortcutSection
+			title={ title }
+			shortcuts={ categoryShortcuts.concat( additionalShortcuts ) }
+		/>
+	);
+};
+
+export default function KeyboardShortcutHelpModal( {
+	isModalActive,
+	toggleModal,
+} ) {
+	useShortcut( 'core/customize-widgets/keyboard-shortcuts', toggleModal, {
+		bindGlobal: true,
+	} );
+
+	if ( ! isModalActive ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="customize-widgets-keyboard-shortcut-help-modal"
+			title={ __( 'Keyboard shortcuts' ) }
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ toggleModal }
+		>
+			<ShortcutSection
+				className="customize-widgets-keyboard-shortcut-help-modal__main-shortcuts"
+				shortcuts={ [ 'core/customize-widgets/keyboard-shortcuts' ] }
+			/>
+			<ShortcutCategorySection
+				title={ __( 'Global shortcuts' ) }
+				categoryName="global"
+			/>
+
+			<ShortcutCategorySection
+				title={ __( 'Selection shortcuts' ) }
+				categoryName="selection"
+			/>
+
+			<ShortcutCategorySection
+				title={ __( 'Block shortcuts' ) }
+				categoryName="block"
+				additionalShortcuts={ [
+					{
+						keyCombination: { character: '/' },
+						description: __(
+							'Change the block type after adding a new paragraph.'
+						),
+						/* translators: The forward-slash character. e.g. '/'. */
+						ariaLabel: __( 'Forward-slash' ),
+					},
+				] }
+			/>
+			<ShortcutSection
+				title={ __( 'Text formatting' ) }
+				shortcuts={ textFormattingShortcuts }
+			/>
+		</Modal>
+	);
+}

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -13,7 +13,7 @@ import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -90,6 +90,17 @@ export default function KeyboardShortcutHelpModal( {
 	isModalActive,
 	toggleModal,
 } ) {
+	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
+	registerShortcut( {
+		name: 'core/customize-widgets/keyboard-shortcuts',
+		category: 'main',
+		description: __( 'Display these keyboard shortcuts.' ),
+		keyCombination: {
+			modifier: 'access',
+			character: 'h',
+		},
+	} );
+
 	useShortcut( 'core/customize-widgets/keyboard-shortcuts', toggleModal, {
 		bindGlobal: true,
 	} );

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { displayShortcutList, shortcutAriaLabel } from '@wordpress/keycodes';
+
+function KeyCombination( { keyCombination, forceAriaLabel } ) {
+	const shortcut = keyCombination.modifier
+		? displayShortcutList[ keyCombination.modifier ](
+				keyCombination.character
+		  )
+		: keyCombination.character;
+	const ariaLabel = keyCombination.modifier
+		? shortcutAriaLabel[ keyCombination.modifier ](
+				keyCombination.character
+		  )
+		: keyCombination.character;
+
+	return (
+		<kbd
+			className="customize-widgets-keyboard-shortcut-help-modal__shortcut-key-combination"
+			aria-label={ forceAriaLabel || ariaLabel }
+		>
+			{ castArray( shortcut ).map( ( character, index ) => {
+				if ( character === '+' ) {
+					return <Fragment key={ index }>{ character }</Fragment>;
+				}
+
+				return (
+					<kbd
+						key={ index }
+						className="customize-widgets-keyboard-shortcut-help-modal__shortcut-key"
+					>
+						{ character }
+					</kbd>
+				);
+			} ) }
+		</kbd>
+	);
+}
+
+function Shortcut( { description, keyCombination, aliases = [], ariaLabel } ) {
+	return (
+		<>
+			<div className="customize-widgets-keyboard-shortcut-help-modal__shortcut-description">
+				{ description }
+			</div>
+			<div className="customize-widgets-keyboard-shortcut-help-modal__shortcut-term">
+				<KeyCombination
+					keyCombination={ keyCombination }
+					forceAriaLabel={ ariaLabel }
+				/>
+				{ aliases.map( ( alias, index ) => (
+					<KeyCombination
+						keyCombination={ alias }
+						forceAriaLabel={ ariaLabel }
+						key={ index }
+					/>
+				) ) }
+			</div>
+		</>
+	);
+}
+
+export default Shortcut;

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,0 +1,66 @@
+.customize-widgets-keyboard-shortcut-help-modal {
+	&__section {
+		margin: 0 0 2rem 0;
+	}
+
+	&__main-shortcuts .customize-widgets-keyboard-shortcut-help-modal__shortcut-list {
+		// Push the shortcut to be flush with top modal header.
+		margin-top: -$grid-unit-30 -$border-width;
+	}
+
+	&__section-title {
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+
+	&__shortcut {
+		display: flex;
+		align-items: baseline;
+		padding: 0.6rem 0;
+		border-top: 1px solid $gray-300;
+		margin-bottom: 0;
+
+		&:last-child {
+			border-bottom: 1px solid $gray-300;
+		}
+
+		&:empty {
+			display: none;
+		}
+	}
+
+	&__shortcut-term {
+		font-weight: 600;
+		margin: 0 0 0 1rem;
+		text-align: right;
+	}
+
+	&__shortcut-description {
+		flex: 1;
+		margin: 0;
+
+		// IE 11 flex item fix - ensure the item does not collapse.
+		flex-basis: auto;
+	}
+
+	&__shortcut-key-combination {
+		display: block;
+		background: none;
+		margin: 0;
+		padding: 0;
+
+		& + .customize-widgets-keyboard-shortcut-help-modal__shortcut-key-combination {
+			margin-top: 10px;
+		}
+	}
+
+	&__shortcut-key {
+		padding: 0.25rem 0.5rem;
+		border-radius: 8%;
+		margin: 0 0.2rem 0 0.2rem;
+
+		&:last-child {
+			margin: 0 0 0 0.2rem;
+		}
+	}
+}

--- a/packages/customize-widgets/src/components/more-menu/feature-toggle.js
+++ b/packages/customize-widgets/src/components/more-menu/feature-toggle.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import { store as customizeWidgetsStore } from '../../store';
+
+export default function FeatureToggle( {
+	label,
+	info,
+	messageActivated,
+	messageDeactivated,
+	shortcut,
+	feature,
+} ) {
+	const isActive = useSelect(
+		( select ) =>
+			select( customizeWidgetsStore ).__unstableIsFeatureActive(
+				feature
+			),
+		[ feature ]
+	);
+	const { __unstableToggleFeature: toggleFeature } = useDispatch(
+		customizeWidgetsStore
+	);
+	const speakMessage = () => {
+		if ( isActive ) {
+			speak( messageDeactivated || __( 'Feature deactivated' ) );
+		} else {
+			speak( messageActivated || __( 'Feature activated' ) );
+		}
+	};
+
+	return (
+		<MenuItem
+			icon={ isActive && check }
+			isSelected={ isActive }
+			onClick={ () => {
+				toggleFeature( feature );
+				speakMessage();
+			} }
+			role="menuitemcheckbox"
+			info={ info }
+			shortcut={ shortcut }
+		>
+			{ label }
+		</MenuItem>
+	);
+}

--- a/packages/customize-widgets/src/components/more-menu/index.js
+++ b/packages/customize-widgets/src/components/more-menu/index.js
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	VisuallyHidden,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
+import { external, moreVertical } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+
+/**
+ * Internal dependencies
+ */
+import FeatureToggle from './feature-toggle';
+// import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
+
+const POPOVER_PROPS = {
+	className: 'customize-widgets-more-menu__content',
+	position: 'bottom left',
+};
+const TOGGLE_PROPS = {
+	tooltipPosition: 'bottom',
+};
+
+export default function MoreMenu() {
+	const [
+		isKeyboardShortcutsModalActive,
+		setIsKeyboardShortcutsModalVisible,
+	] = useState( false );
+	const toggleKeyboardShortcutsModal = () =>
+		setIsKeyboardShortcutsModalVisible( ! isKeyboardShortcutsModalActive );
+
+	useShortcut(
+		'core/customize-widgets/keyboard-shortcuts',
+		toggleKeyboardShortcutsModal,
+		{
+			bindGlobal: true,
+		}
+	);
+
+	return (
+		<>
+			<DropdownMenu
+				className="customize-widgets-more-menu"
+				icon={ moreVertical }
+				/* translators: button label text should, if possible, be under 16 characters. */
+				label={ __( 'Options' ) }
+				popoverProps={ POPOVER_PROPS }
+				toggleProps={ TOGGLE_PROPS }
+			>
+				{ () => (
+					<>
+						<MenuGroup label={ _x( 'View', 'noun' ) }>
+							<FeatureToggle
+								feature="fixedToolbar"
+								label={ __( 'Top toolbar' ) }
+								info={ __(
+									'Access all block and document tools in a single place'
+								) }
+								messageActivated={ __(
+									'Top toolbar activated'
+								) }
+								messageDeactivated={ __(
+									'Top toolbar deactivated'
+								) }
+							/>
+						</MenuGroup>
+						<MenuGroup label={ __( 'Tools' ) }>
+							<MenuItem
+								onClick={ () => {
+									setIsKeyboardShortcutsModalVisible( true );
+								} }
+								shortcut={ displayShortcut.access( 'h' ) }
+							>
+								{ __( 'Keyboard shortcuts' ) }
+							</MenuItem>
+							<FeatureToggle
+								feature="welcomeGuide"
+								label={ __( 'Welcome Guide' ) }
+							/>
+							<MenuItem
+								role="menuitem"
+								icon={ external }
+								href={ __(
+									'https://wordpress.org/support/article/wordpress-editor/'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Help' ) }
+								<VisuallyHidden as="span">
+									{
+										/* translators: accessibility text */
+										__( '(opens in a new tab)' )
+									}
+								</VisuallyHidden>
+							</MenuItem>
+						</MenuGroup>
+						<MenuGroup>
+							<FeatureToggle
+								feature="keepCaretInsideBlock"
+								label={ __(
+									'Contain text cursor inside block'
+								) }
+								info={ __(
+									'Aids screen readers by stopping text caret from leaving blocks.'
+								) }
+								messageActivated={ __(
+									'Contain text cursor inside block activated'
+								) }
+								messageDeactivated={ __(
+									'Contain text cursor inside block deactivated'
+								) }
+							/>
+						</MenuGroup>
+					</>
+				) }
+			</DropdownMenu>
+			{ /* <KeyboardShortcutHelpModal
+				isModalActive={ isKeyboardShortcutsModalActive }
+				toggleModal={ toggleKeyboardShortcutsModal }
+			/> */ }
+		</>
+	);
+}

--- a/packages/customize-widgets/src/components/more-menu/index.js
+++ b/packages/customize-widgets/src/components/more-menu/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	DropdownMenu,
+	ToolbarDropdownMenu,
 	MenuGroup,
 	MenuItem,
 	VisuallyHidden,
@@ -45,7 +45,7 @@ export default function MoreMenu() {
 
 	return (
 		<>
-			<DropdownMenu
+			<ToolbarDropdownMenu
 				className="customize-widgets-more-menu"
 				icon={ moreVertical }
 				/* translators: button label text should, if possible, be under 16 characters. */
@@ -120,7 +120,7 @@ export default function MoreMenu() {
 						</MenuGroup>
 					</>
 				) }
-			</DropdownMenu>
+			</ToolbarDropdownMenu>
 			<KeyboardShortcutHelpModal
 				isModalActive={ isKeyboardShortcutsModalActive }
 				toggleModal={ toggleKeyboardShortcutsModal }

--- a/packages/customize-widgets/src/components/more-menu/index.js
+++ b/packages/customize-widgets/src/components/more-menu/index.js
@@ -17,7 +17,7 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import FeatureToggle from './feature-toggle';
-// import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
+import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 
 const POPOVER_PROPS = {
 	className: 'customize-widgets-more-menu__content',
@@ -121,10 +121,10 @@ export default function MoreMenu() {
 					</>
 				) }
 			</DropdownMenu>
-			{ /* <KeyboardShortcutHelpModal
+			<KeyboardShortcutHelpModal
 				isModalActive={ isKeyboardShortcutsModalActive }
 				toggleModal={ toggleKeyboardShortcutsModal }
-			/> */ }
+			/>
 		</>
 	);
 }

--- a/packages/customize-widgets/src/components/more-menu/style.scss
+++ b/packages/customize-widgets/src/components/more-menu/style.scss
@@ -1,0 +1,35 @@
+.customize-widgets-more-menu {
+	margin-left: -4px;
+
+	// the padding and margin of the more menu is intentionally non-standard
+	.components-button {
+		width: auto;
+		padding: 0 2px;
+	}
+
+	@include break-small() {
+		margin-left: 0;
+
+		.components-button {
+			padding: 0 4px;
+		}
+	}
+}
+
+.customize-widgets-more-menu__content .components-popover__content {
+	min-width: 280px;
+
+	// Let the menu scale to fit items.
+	@include break-mobile() {
+		width: auto;
+		max-width: $break-mobile;
+	}
+
+	.components-dropdown-menu__menu {
+		padding: 0;
+	}
+}
+
+.components-popover.customize-widgets-more-menu__content {
+	z-index: z-index(".components-popover.customize-widgets-more-menu__content");
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -28,6 +28,7 @@ import BlockInspectorButton from '../block-inspector-button';
 import Header from '../header';
 import useInserter from '../inserter/use-inserter';
 import SidebarEditorProvider from './sidebar-editor-provider';
+import { store as customizeWidgetsStore } from '../../store';
 
 export default function SidebarBlockEditor( {
 	blockEditorSettings,
@@ -36,11 +37,24 @@ export default function SidebarBlockEditor( {
 	inspector,
 } ) {
 	const [ isInserterOpened, setIsInserterOpened ] = useInserter( inserter );
-	const hasUploadPermissions = useSelect(
-		( select ) =>
-			defaultTo( select( coreStore ).canUser( 'create', 'media' ), true ),
-		[]
-	);
+	const {
+		hasUploadPermissions,
+		isFixedToolbarActive,
+		keepCaretInsideBlock,
+	} = useSelect( ( select ) => {
+		return {
+			hasUploadPermissions: defaultTo(
+				select( coreStore ).canUser( 'create', 'media' ),
+				true
+			),
+			isFixedToolbarActive: select(
+				customizeWidgetsStore
+			).__unstableIsFeatureActive( 'fixedToolbar' ),
+			keepCaretInsideBlock: select(
+				customizeWidgetsStore
+			).__unstableIsFeatureActive( 'keepCaretInsideBlock' ),
+		};
+	}, [] );
 	const settings = useMemo( () => {
 		let mediaUploadBlockEditor;
 		if ( hasUploadPermissions ) {
@@ -57,8 +71,15 @@ export default function SidebarBlockEditor( {
 			...blockEditorSettings,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			mediaUpload: mediaUploadBlockEditor,
+			hasFixedToolbar: isFixedToolbarActive,
+			keepCaretInsideBlock,
 		};
-	}, [ hasUploadPermissions, blockEditorSettings ] );
+	}, [
+		hasUploadPermissions,
+		blockEditorSettings,
+		isFixedToolbarActive,
+		keepCaretInsideBlock,
+	] );
 
 	return (
 		<>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -89,6 +89,7 @@ export default function SidebarBlockEditor( {
 				<BlockEditorKeyboardShortcuts />
 
 				<Header
+					isFixedToolbarActive={ isFixedToolbarActive }
 					inserter={ inserter }
 					isInserterOpened={ isInserterOpened }
 					setIsInserterOpened={ setIsInserterOpened }

--- a/packages/customize-widgets/src/store/actions.js
+++ b/packages/customize-widgets/src/store/actions.js
@@ -1,0 +1,17 @@
+/**
+ * Returns an action object used to toggle a feature flag.
+ *
+ * This function is unstable, as it is mostly copied from the edit-post
+ * package. Editor features and preferences have a lot of scope for
+ * being generalized and refactored.
+ *
+ * @param {string} feature Feature name.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableToggleFeature( feature ) {
+	return {
+		type: 'TOGGLE_FEATURE',
+		feature,
+	};
+}

--- a/packages/customize-widgets/src/store/constants.js
+++ b/packages/customize-widgets/src/store/constants.js
@@ -1,0 +1,4 @@
+/**
+ * Module Constants
+ */
+export const STORE_NAME = 'core/customize-widgets';

--- a/packages/customize-widgets/src/store/defaults.js
+++ b/packages/customize-widgets/src/store/defaults.js
@@ -1,0 +1,6 @@
+export const PREFERENCES_DEFAULTS = {
+	features: {
+		fixedToolbar: false,
+		welcomeGuide: true,
+	},
+};

--- a/packages/customize-widgets/src/store/index.js
+++ b/packages/customize-widgets/src/store/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import { STORE_NAME } from './constants';
+
+/**
+ * Block editor data store configuration.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#registerStore
+ *
+ * @type {Object}
+ */
+const storeConfig = {
+	reducer,
+	selectors,
+	actions,
+	persist: [ 'preferences' ],
+};
+
+/**
+ * Store definition for the edit widgets namespace.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
+ *
+ * @type {Object}
+ */
+export const store = createReduxStore( STORE_NAME, storeConfig );
+
+// Once we build a more generic persistence plugin that works across types of stores
+// we'd be able to replace this with a register call.
+registerStore( STORE_NAME, storeConfig );

--- a/packages/customize-widgets/src/store/reducer.js
+++ b/packages/customize-widgets/src/store/reducer.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { flow } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_DEFAULTS } from './defaults';
+
+/**
+ * Higher-order reducer creator which provides the given initial state for the
+ * original reducer.
+ *
+ * @param {*} initialState Initial state to provide to reducer.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+const createWithInitialState = ( initialState ) => ( reducer ) => {
+	return ( state = initialState, action ) => reducer( state, action );
+};
+
+/**
+ * Reducer returning the user preferences.
+ *
+ * @param {Object}  state                           Current state.
+ * @param {Object}  action                          Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const preferences = flow( [
+	combineReducers,
+	createWithInitialState( PREFERENCES_DEFAULTS ),
+] )( {
+	features( state, action ) {
+		if ( action.type === 'TOGGLE_FEATURE' ) {
+			return {
+				...state,
+				[ action.feature ]: ! state[ action.feature ],
+			};
+		}
+
+		return state;
+	},
+} );
+
+export default combineReducers( {
+	preferences,
+} );

--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns whether the given feature is enabled or not.
+ *
+ * This function is unstable, as it is mostly copied from the edit-post
+ * package. Editor features and preferences have a lot of scope for
+ * being generalized and refactored.
+ *
+ * @param {Object} state   Global application state.
+ * @param {string} feature Feature slug.
+ *
+ * @return {boolean} Is active.
+ */
+export function __unstableIsFeatureActive( state, feature ) {
+	return get( state.preferences.features, [ feature ], false );
+}

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -2,4 +2,5 @@
 @import "./components/block-inspector-button/style.scss";
 @import "./components/header/style.scss";
 @import "./components/inserter/style.scss";
+@import "./components/more-menu/style.scss";
 @import "./controls/style.scss";

--- a/packages/customize-widgets/src/style.scss
+++ b/packages/customize-widgets/src/style.scss
@@ -2,5 +2,11 @@
 @import "./components/block-inspector-button/style.scss";
 @import "./components/header/style.scss";
 @import "./components/inserter/style.scss";
+@import "./components/keyboard-shortcut-help-modal/style.scss";
 @import "./components/more-menu/style.scss";
 @import "./controls/style.scss";
+
+// Modals need a higher z-index in the customizer.
+.components-modal__screen-overlay {
+	z-index: 999999;
+}


### PR DESCRIPTION
## Description
Closes #30886

Adds the editor 'more menu' to the customize editor.

I haven't added 'Copy all content' yet, as the post editor version copies post content. I think this should be possible (would need to serialize blocks), but I'd like to address it in a follow-up.

## How has this been tested?
1. Test that the preferences work (except for the welcome guide, which is being implemented in a separate PR).

## Screenshots <!-- if applicable -->
<img width="633" alt="Screenshot 2021-05-19 at 1 21 50 pm" src="https://user-images.githubusercontent.com/677833/118760387-49129000-b8a5-11eb-8d0c-5c83956c2143.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
