### PR TITLE
Block Supports: Allow skipping spacing support serialization

### DIFF
--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -35,8 +35,12 @@ function gutenberg_register_spacing_support( $block_type ) {
  * @return array Block spacing CSS classes and inline styles.
  */
 function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
-	$has_padding_support = gutenberg_has_spacing_feature_support( $block_type, 'padding' );
-	$has_margin_support  = gutenberg_has_spacing_feature_support( $block_type, 'margin' );
+	if ( gutenberg_skip_spacing_serialization( $block_type ) ) {
+		return array();
+	}
+
+	$has_padding_support = gutenberg_block_has_support( $block_type, array( 'spacing', 'padding' ), false );
+	$has_margin_support  = gutenberg_block_has_support( $block_type, array( 'spacing', 'margin' ), false );
 	$styles              = array();
 
 	if ( $has_padding_support ) {
@@ -61,18 +65,19 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 }
 
 /**
- * Checks whether the current block type supports the spacing feature requested.
+ * Checks whether serialization of the current block's spacing properties should
+ * occur.
  *
- * @param WP_Block_Type $block_type Block type to check for support.
- * @param string        $feature    Name of the feature to check support for.
- * @param mixed         $default    Fallback value for feature support, defaults to false.
+ * @param WP_Block_type $block_type Block type.
  *
- * @return boolean                  Whether or not the feature is supported.
+ * @return boolean Whether to serialize spacing support styles & classes.
  */
-function gutenberg_has_spacing_feature_support( $block_type, $feature, $default = false ) {
-	// Check if the specific feature has been opted into individually
-	// via nested flag under `spacing`.
-	return gutenberg_block_has_support( $block_type, array( 'spacing', $feature ), $default );
+function gutenberg_skip_spacing_serialization( $block_type ) {
+	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
+
+	return is_array( $spacing_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
+		$spacing_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -140,6 +140,9 @@ const skipSerializationPaths = {
 	[ `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		COLOR_SUPPORT_KEY,
 	],
+	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+		'spacing',
+	],
 	[ `__experimentalSkipFontSizeSerialization` ]: [ 'typography', 'fontSize' ],
 	[ `__experimentalSkipTypographySerialization` ]: without(
 		TYPOGRAPHY_SUPPORT_KEYS,


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/24874

## Description

#### Background
As part of looking to add custom margins (gutters) to the column/s blocks, we run into an issue with the spacing block support styles being added as inline styles. This won't play nice with the CSS media queries that stack the columns at different viewports. These queries look to set a `flex-basis` for the column width taking into account margins so they stack correctly.

This highlighted the fact that the option to skip serialization of the padding and margin block support styles wasn't available. This PR allows for that skipping of serialization.

## How has this been tested?
Manually.

#### Test Notes
- The test instructions are just for testing that the serialization is skipped. This PR doesn't update any blocks.
- If testing with group block, block patterns with existing padding will throw block errors.

#### Test Instructions
1. Turn on `customMargin` under the `spacing` support in your theme.json
2. Update the Group block's `block.json` to enable both padding and margin support while skipping serialization - [gist](https://gist.github.com/aaronrobertshaw/5694d90c2aa1207b8abe1d30b2677ce9)
3. Create a new post and add a group block to it. (setting background color can help testing)
4. Adjust the block's padding and margin values in the sidebar
    The block's spacing shouldn't change although color selections etc should be applied and the block visually update
5. Switch to the code editor view
6. Confirm the padding and margin attributes reflect the values set
7. Confirm that the block's markup does not contain inline styles for either padding or margins
8. Save the post and view on the frontend. Confirm there are no padding or margin styles
9. Update the Site Title block's `block.json` file to skip serialization (or any other dynamic block with spacing support) - [gist](https://gist.github.com/aaronrobertshaw/316a54a2aeeaa88343de8701c7abc588)
10. Add Site Title block to the post and set padding and margin
11. Save the post and confirm that there are no padding and margin inline styles on the site title on the frontend

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/60436221/118767271-de6f4d80-b8c0-11eb-83f2-1d4ee65aea37.gif" width="600"/>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
