### PR TITLE
[Block Library - Post Comments Count]: Fix attributes declaration

### DIFF
--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -38,11 +38,6 @@ function register_block_core_post_comments_count() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comments-count',
 		array(
-			'attributes'      => array(
-				'className' => array(
-					'type' => 'string',
-				),
-			),
 			'render_callback' => 'render_block_core_post_comments_count',
 		)
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
While reviewing another PR I spotted this bug where `Post Comments Count` wouldn't save the `textAlign` attribute. This PR just fixes that.

## Testing instructions

1. Add `Post Comments Count` block and change text align.
2. Save and view front-end or just reload the editor.
