### PR TITLE
Revert "Replace string literals with store definitions in block-library"

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -14,7 +14,7 @@ import {
 	VisuallyHidden,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect, store as dataStore } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
@@ -27,7 +27,7 @@ export default function CategoriesEdit( {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 	const { categories, isRequesting } = useSelect( ( select ) => {
 		const { getEntityRecords } = select( coreStore );
-		const { isResolving } = select( dataStore );
+		const { isResolving } = select( 'core/data' );
 		const query = { per_page: -1, hide_empty: true };
 		return {
 			categories: getEntityRecords( 'taxonomy', 'category', query ),

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -24,7 +24,7 @@ import classnames from 'classnames';
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, Platform } from '@wordpress/element';
-import { useDispatch, useSelect, store as dataStore } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { View } from '@wordpress/primitives';
@@ -64,7 +64,7 @@ const EmbedEdit = ( props ) => {
 
 	const [ url, setURL ] = useState( attributesUrl );
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
-	const { invalidateResolution } = useDispatch( dataStore );
+	const { invalidateResolution } = useDispatch( 'core/data' );
 
 	const {
 		preview,


### PR DESCRIPTION
Reverts WordPress/gutenberg#31933

Broke an e2e embed test.