### PR TITLE
Update tests for changes in core logic

### DIFF
--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -576,7 +576,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'padding' => array(
 							'top'    => '1px',
 							'right'  => '1px',
-							'bottom' => 'var(--unsafe-var-toplevel)',
+							'bottom' => 'var(--bottom, var(--unsafe-fallback))',
 							'left'   => '1px',
 						),
 					),
@@ -586,7 +586,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 								'padding' => array(
 									'top'    => '2px',
 									'right'  => '2px',
-									'bottom' => 'var(--unsafe-var-elements)',
+									'bottom' => 'var(--bottom, var(--unsafe-fallback))',
 									'left'   => '2px',
 								),
 							),
@@ -598,7 +598,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 								'padding' => array(
 									'top'    => '3px',
 									'right'  => '3px',
-									'bottom' => 'var(--unsafe-var-block)',
+									'bottom' => 'var(bottom, var(--unsafe-fallback))',
 									'left'   => '3px',
 								),
 							),
@@ -608,7 +608,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 										'padding' => array(
 											'top'    => '4px',
 											'right'  => '4px',
-											'bottom' => 'var(--unsafe-var-block-elements)',
+											'bottom' => 'var(--bottom, var(--unsafe-fallback))',
 											'left'   => '4px',
 										),
 									),
@@ -801,7 +801,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 							array(
 								'name'  => 'Blue',
 								'slug'  => 'blue',
-								'color' => 'var(--custom-v1)',
+								'color' => 'var(--color, var(--unsafe-fallback))',
 							),
 							array(
 								'name'  => 'Pink',
@@ -830,7 +830,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 							array(
 								'name'       => 'Helvetica Arial',
 								'slug'       => 'helvetica-arial',
-								'fontFamily' => 'var(--custom-var-1)',
+								'fontFamily' => 'var(--fontFamily, var(--unsafe-fallback))',
 							),
 						),
 					),
@@ -851,7 +851,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 									array(
 										'name'  => 'Blue',
 										'slug'  => 'blue',
-										'color' => 'var(--custom-v1)',
+										'color' => 'var(--color, var(--unsafe--falback))',
 									),
 									array(
 										'name'  => 'Pink',


### PR DESCRIPTION
Core got support for `var()` and `calc()` in https://github.com/WordPress/wordpress-develop/commit/8e498a831472cd0413ea0068480616fd5a0d5fe4 Because we don't pin the core versions, this has resulted in failures in our tests. This PR updates the tests to the new core code.

Props to @ellatrix and @ockham for the sleuthing.