### PR TITLE
Hide the PostAuthor block behind the Gutenberg experimental flag

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -183,7 +183,6 @@ export const __experimentalGetCoreBlocks = () => [
 
 	postTitle,
 	postContent,
-	postAuthor,
 	postDate,
 	postExcerpt,
 	postFeaturedImage,
@@ -243,6 +242,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 					...( enableFSEBlocks
 						? [
 								templatePart,
+								postAuthor,
 								postComment,
 								postCommentAuthor,
 								postCommentContent,


### PR DESCRIPTION
Related #24952 

After the discussions about the state of the PostAuthor here #24952 it's becoming clear that this block needs more polish/time before considering it stable and we might not have the necessary time to do the required change on time for 5.8. 

This PR restores the block behind the plugin flag in order to avoid including it into Core for 5.8.