### PR TITLE
Fix toolbar alignment in widget block editor

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -18,22 +18,35 @@ import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
-	const { blockType, hasParents } = useSelect( ( select ) => {
-		const {
-			getBlockName,
-			getBlockParents,
-			getSelectedBlockClientIds,
-		} = select( blockEditorStore );
-		const { getBlockType } = select( blocksStore );
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-		return {
-			blockType:
-				selectedBlockClientId &&
-				getBlockType( getBlockName( selectedBlockClientId ) ),
-			hasParents: getBlockParents( selectedBlockClientId ).length,
-		};
-	}, [] );
+	const { blockType, hasParents, showParentSelector } = useSelect(
+		( select ) => {
+			const {
+				getBlockName,
+				getBlockParents,
+				getSelectedBlockClientIds,
+			} = select( blockEditorStore );
+			const { getBlockType } = select( blocksStore );
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+			const parents = getBlockParents( selectedBlockClientId );
+			const firstParentClientId = parents[ parents.length - 1 ];
+			const parentBlockName = getBlockName( firstParentClientId );
+			const parentBlockType = getBlockType( parentBlockName );
+
+			return {
+				blockType:
+					selectedBlockClientId &&
+					getBlockType( getBlockName( selectedBlockClientId ) ),
+				hasParents: getBlockParents( selectedBlockClientId ).length,
+				showParentSelector: hasBlockSupport(
+					parentBlockType,
+					'__experimentalParentSelector',
+					true
+				),
+			};
+		},
+		[]
+	);
 	if ( blockType ) {
 		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
 			return null;
@@ -42,7 +55,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = classnames( 'block-editor-block-contextual-toolbar', {
-		'has-parent': hasParents,
+		'has-parent': hasParents && showParentSelector,
 		'is-fixed': isFixed,
 	} );
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -37,7 +37,7 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 				blockType:
 					selectedBlockClientId &&
 					getBlockType( getBlockName( selectedBlockClientId ) ),
-				hasParents: getBlockParents( selectedBlockClientId ).length,
+				hasParents: parents.length,
 				showParentSelector: hasBlockSupport(
 					parentBlockType,
 					'__experimentalParentSelector',


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/31021.

Don't apply the `has-parent` CSS class to the toolbar if the `__experimentalParentSelector` flag is set. This class was applying the left margin to the toolbar when a block was selected in the widget area.

## How has this been tested?

1. In _Appearance_ > _Widgets_, select a top level block in a widget area and ensure toolbar alignment is correct.
2. Add the Navigation block to a page.
3. Click _Add all pages_.
4. Select the inner Page List block and ensure the `block-editor-block-contextual-toolbar` element has the `has-parent` class, and that the toolbar alignment is correct.

## Screenshots <!-- if applicable -->
![Screen Shot 2021-05-11 at 7 33 52 AM](https://user-images.githubusercontent.com/1190420/117808755-453e9800-b22b-11eb-9497-92061f05b5ee.jpg)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->