### PR TITLE
Display block anchor in List View when set.

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -65,6 +65,11 @@ function BlockNavigationBlockSelectButton(
 				<Indentation level={ level } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<BlockTitle clientId={ clientId } />
+				{ blockInformation?.anchor && (
+					<span className="block-editor-block-navigation-block-select-button__anchor">
+						{ blockInformation.anchor }
+					</span>
+				) }
 				{ isSelected && (
 					<VisuallyHidden>
 						{ __( '(selected block)' ) }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -243,6 +243,18 @@
 			color: $white;
 		}
 	}
+
+	.block-editor-block-navigation-block-select-button__anchor {
+		background: rgba(30, 30, 30, 0.1);
+		border-radius: 2px;
+		display: inline-block;
+		padding: 2px 6px;
+		margin: 0 8px;
+	}
+
+	&.is-selected .block-editor-block-navigation-block-select-button__anchor {
+		background: rgba(30, 30, 30, 0.3);
+	}
 }
 
 .block-editor-block-navigation-block-slot__description,

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -245,11 +245,14 @@
 	}
 
 	.block-editor-block-navigation-block-select-button__anchor {
-		background: rgba(30, 30, 30, 0.1);
+		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
 		margin: 0 $grid-unit-10;
+		max-width: 120px;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	&.is-selected .block-editor-block-navigation-block-select-button__anchor {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -246,14 +246,14 @@
 
 	.block-editor-block-navigation-block-select-button__anchor {
 		background: rgba(30, 30, 30, 0.1);
-		border-radius: 2px;
+		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
-		margin: 0 8px;
+		margin: 0 $grid-unit-10;
 	}
 
 	&.is-selected .block-editor-block-navigation-block-select-button__anchor {
-		background: rgba(30, 30, 30, 0.3);
+		background: rgba($black, 0.3);
 	}
 }
 

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -49,14 +49,16 @@ export default function useBlockDisplayInformation( clientId ) {
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) return null;
+			const attributes = getBlockAttributes( clientId );
+			const match = getActiveBlockVariation( blockName, attributes );
 			const blockTypeInfo = {
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
+				anchor: attributes?.anchor,
 			};
-			const attributes = getBlockAttributes( clientId );
-			const match = getActiveBlockVariation( blockName, attributes );
 			if ( ! match ) return blockTypeInfo;
+
 			return {
 				title: match.title || blockType.title,
 				icon: match.icon || blockType.icon,


### PR DESCRIPTION
Closes #16307.
See #16296.

When an anchor is set on a block this displays it on the List View. It should help both naming blocks and identifying an important aspect of the site structure. (We should probably truncate long names.)

![image](https://user-images.githubusercontent.com/548849/118815950-03a88f80-b8b2-11eb-8122-61ae253f7e27.png)

Video: https://user-images.githubusercontent.com/548849/118816212-3bafd280-b8b2-11eb-9fb7-31d942d606bf.mov

