### PR TITLE
[DO NOT MERGE][RNMobile] Fixes Gallery Image Caption text formatting options visibility issue

### DIFF
--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -39,7 +39,6 @@ const Caption = ( {
 			__unstableMobileNoFocusOnMount
 			fontSize={ style && style.fontSize ? style.fontSize : 14 }
 			inlineToolbar={ inlineToolbar }
-			isSelected={ isSelected }
 			onBlur={ onBlur }
 			onChange={ onChange }
 			placeholder={ placeholder }

--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -39,6 +39,7 @@ const Caption = ( {
 			__unstableMobileNoFocusOnMount
 			fontSize={ style && style.fontSize ? style.fontSize : 14 }
 			inlineToolbar={ inlineToolbar }
+			isSelected={ isSelected }
 			onBlur={ onBlur }
 			onChange={ onChange }
 			placeholder={ placeholder }

--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -14,7 +14,6 @@ const Caption = ( {
 	accessibilityLabelCreator,
 	accessible,
 	inlineToolbar,
-	isSelected,
 	onBlur,
 	onChange,
 	onFocus,

--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -14,6 +14,7 @@ const Caption = ( {
 	accessibilityLabelCreator,
 	accessible,
 	inlineToolbar,
+	isSelected,
 	onBlur,
 	onChange,
 	onFocus,

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -14,6 +14,8 @@ import { createPortal, useLayoutEffect, useRef } from '@wordpress/element';
 import SlotFillContext from './context';
 import useSlot from './use-slot';
 
+let occurrences = 0;
+
 function FillComponent( { name, children, registerFill, unregisterFill } ) {
 	const slot = useSlot( name );
 
@@ -21,6 +23,10 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		name,
 		children,
 	} );
+
+	if ( ! ref.current.occurrence ) {
+		ref.current.occurrence = ++occurrences;
+	}
 
 	useLayoutEffect( () => {
 		registerFill( name, ref.current );

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -14,8 +14,6 @@ import { createPortal, useLayoutEffect, useRef } from '@wordpress/element';
 import SlotFillContext from './context';
 import useSlot from './use-slot';
 
-let occurrences = 0;
-
 function FillComponent( { name, children, registerFill, unregisterFill } ) {
 	const slot = useSlot( name );
 
@@ -23,10 +21,6 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		name,
 		children,
 	} );
-
-	if ( ! ref.current.occurrence ) {
-		ref.current.occurrence = ++occurrences;
-	}
 
 	useLayoutEffect( () => {
 		registerFill( name, ref.current );

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -62,6 +62,7 @@ class SlotComponent extends Component {
 		const { children, name, fillProps = {}, getFills } = this.props;
 
 		const fills = map( getFills( name, this ), ( fill ) => {
+			const fillKey = fill.occurrence;
 			const fillChildren = isFunction( fill.children )
 				? fill.children( fillProps )
 				: fill.children;
@@ -71,7 +72,7 @@ class SlotComponent extends Component {
 					return child;
 				}
 
-				const childKey = child.key || childIndex;
+				const childKey = `${ fillKey }---${ child.key || childIndex }`;
 				return cloneElement( child, { key: childKey } );
 			} );
 		} ).filter(

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -62,7 +62,6 @@ class SlotComponent extends Component {
 		const { children, name, fillProps = {}, getFills } = this.props;
 
 		const fills = map( getFills( name, this ), ( fill ) => {
-			const fillKey = fill.occurrence;
 			const fillChildren = isFunction( fill.children )
 				? fill.children( fillProps )
 				: fill.children;
@@ -72,7 +71,7 @@ class SlotComponent extends Component {
 					return child;
 				}
 
-				const childKey = `${ fillKey }---${ child.key || childIndex }`;
+				const childKey = child.key || childIndex;
 				return cloneElement( child, { key: childKey } );
 			} );
 		} ).filter(

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -150,31 +150,12 @@ exports[`Slot should render empty Fills without HTML wrapper when render props u
 </div>
 `;
 
-exports[`Slot should render in expected order when fills always mounted 1`] = `
+exports[`Slot should render in expected order 1`] = `
 <div>
   <div>
-    first (rerendered)
+    first
     second
-    third
-    fourth (new)
   </div>
-</div>
-`;
-
-exports[`Slot should render in expected order when fills unmounted 1`] = `
-<div>
-  <div>
-    second
-    third
-    first (rerendered)
-    fourth (new)
-  </div>
-  <button
-    type="button"
-  />
-  <button
-    type="button"
-  />
   <button
     type="button"
   />

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -150,12 +150,31 @@ exports[`Slot should render empty Fills without HTML wrapper when render props u
 </div>
 `;
 
-exports[`Slot should render in expected order 1`] = `
+exports[`Slot should render in expected order when fills always mounted 1`] = `
 <div>
   <div>
-    first
+    first (rerendered)
     second
+    third
+    fourth (new)
   </div>
+</div>
+`;
+
+exports[`Slot should render in expected order when fills unmounted 1`] = `
+<div>
+  <div>
+    second
+    third
+    first (rerendered)
+    fourth (new)
+  </div>
+  <button
+    type="button"
+  />
+  <button
+    type="button"
+  />
   <button
     type="button"
   />

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -167,7 +167,68 @@ describe( 'Slot', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should render in expected order', () => {
+	it( 'should render in expected order when fills always mounted', () => {
+		const { container, rerender } = render(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first">
+					first
+				</Fill>
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first" />
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+				<Fill name="egg" key="third">
+					third
+				</Fill>
+			</Provider>
+		);
+
+		rerender(
+			<Provider>
+				<div key="slot">
+					<Slot name="egg" />
+				</div>
+				<Fill name="egg" key="first">
+					first (rerendered)
+				</Fill>
+				<Fill name="egg" key="second">
+					second
+				</Fill>
+				<Fill name="egg" key="third">
+					third
+				</Fill>
+				<Fill name="egg" key="fourth">
+					fourth (new)
+				</Fill>
+			</Provider>
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'should render in expected order when fills unmounted', () => {
 		const { container, rerender } = render(
 			<Provider>
 				<div key="slot">
@@ -192,6 +253,7 @@ describe( 'Slot', () => {
 					<Slot name="egg" />
 				</div>
 				<Filler name="egg" key="second" text="second" />
+				<Filler name="egg" key="third" text="third" />
 			</Provider>
 		);
 
@@ -200,8 +262,10 @@ describe( 'Slot', () => {
 				<div key="slot">
 					<Slot name="egg" />
 				</div>
-				<Filler name="egg" key="first" text="first" />
+				<Filler name="egg" key="first" text="first (rerendered)" />
 				<Filler name="egg" key="second" text="second" />
+				<Filler name="egg" key="third" text="third" />
+				<Filler name="egg" key="fourth" text="fourth (new)" />
 			</Provider>
 		);
 

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -167,68 +167,7 @@ describe( 'Slot', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should render in expected order when fills always mounted', () => {
-		const { container, rerender } = render(
-			<Provider>
-				<div key="slot">
-					<Slot name="egg" />
-				</div>
-			</Provider>
-		);
-
-		rerender(
-			<Provider>
-				<div key="slot">
-					<Slot name="egg" />
-				</div>
-				<Fill name="egg" key="first">
-					first
-				</Fill>
-				<Fill name="egg" key="second">
-					second
-				</Fill>
-			</Provider>
-		);
-
-		rerender(
-			<Provider>
-				<div key="slot">
-					<Slot name="egg" />
-				</div>
-				<Fill name="egg" key="first" />
-				<Fill name="egg" key="second">
-					second
-				</Fill>
-				<Fill name="egg" key="third">
-					third
-				</Fill>
-			</Provider>
-		);
-
-		rerender(
-			<Provider>
-				<div key="slot">
-					<Slot name="egg" />
-				</div>
-				<Fill name="egg" key="first">
-					first (rerendered)
-				</Fill>
-				<Fill name="egg" key="second">
-					second
-				</Fill>
-				<Fill name="egg" key="third">
-					third
-				</Fill>
-				<Fill name="egg" key="fourth">
-					fourth (new)
-				</Fill>
-			</Provider>
-		);
-
-		expect( container ).toMatchSnapshot();
-	} );
-
-	it( 'should render in expected order when fills unmounted', () => {
+	it( 'should render in expected order', () => {
 		const { container, rerender } = render(
 			<Provider>
 				<div key="slot">
@@ -253,7 +192,6 @@ describe( 'Slot', () => {
 					<Slot name="egg" />
 				</div>
 				<Filler name="egg" key="second" text="second" />
-				<Filler name="egg" key="third" text="third" />
 			</Provider>
 		);
 
@@ -262,10 +200,8 @@ describe( 'Slot', () => {
 				<div key="slot">
 					<Slot name="egg" />
 				</div>
-				<Filler name="egg" key="first" text="first (rerendered)" />
+				<Filler name="egg" key="first" text="first" />
 				<Filler name="egg" key="second" text="second" />
-				<Filler name="egg" key="third" text="third" />
-				<Filler name="egg" key="fourth" text="fourth (new)" />
 			</Provider>
 		);
 


### PR DESCRIPTION
**Fixes**: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3511

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3531

## Description
This PR tries to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/3511 by reverting the `SlotFill` changes introduced by https://github.com/WordPress/gutenberg/pull/29287.
The change introduced by the above PR seems to affect the [`nestedIsSelected` component value](https://github.com/WordPress/gutenberg/blob/b4f0d82aa2f19d5205f83ceccffde623350aae8c/packages/block-editor/src/components/rich-text/index.native.js#L610) when the visibility of the toolbar is set.
Some of the other approaches that have been tested:
* Removing [the `nestedIsSelected`](https://github.com/WordPress/gutenberg/blob/b4f0d82aa2f19d5205f83ceccffde623350aae8c/packages/block-editor/src/components/rich-text/index.native.js#L610) check only hides the issue since it persisted outside the gallery block(step 9 from the issue).
* Removing the [`isSelected` attribute from the Caption block](https://github.com/WordPress/gutenberg/pull/31993/commits/f90b078c8a30b6e4315d10c676acabf9ea37ca7d) causes the caption to [not be deselected properly](https://github.com/WordPress/gutenberg/pull/31993#issuecomment-844980734).

## How has this been tested?
Follow the steps at https://github.com/wordpress-mobile/gutenberg-mobile/issues/3511 and verify that the issue is fixed.

### Sanity
Verify that the blocks using `BlockCaption` did not change behavior:
* Image
* Video
* Audio
* Gallery (note that this [known crash](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3510) has not been merged)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
