### PR TITLE
Add Text Alignment Support to the Pullquote Block

### DIFF
--- a/packages/block-editor/src/components/alignment-control/README.md
+++ b/packages/block-editor/src/components/alignment-control/README.md
@@ -44,6 +44,13 @@ _Note:_ In this example that we render `AlignmentControl` as a child of the `Blo
 
 The current value of the alignment setting. You may only choose from the `Options` listed above.
 
+### `placeholder`
+-   **Type:** `String`
+-   **Default:** `left` for left-to-right languages, `right` for right-to-left languages
+-   **Options:**: `left`, `center`, `right`
+
+The placeholder alignment value that will be reflected by the toolbar icon when the value is `undefined`. If the content inside your block is aligned to center when no specific `value` is defined, you should set `placeholder` to `center`.
+
 ### `onChange`
 
 -   **Type:** `Function`

--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AlignmentUI should allow a custom placeholder to be specified 1`] = `
+<ToolbarDropdownMenu
+  controls={
+    Array [
+      Object {
+        "align": "left",
+        "icon": <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
+            d="M4 19.8h8.9v-1.5H4v1.5zm8.9-15.6H4v1.5h8.9V4.2zm-8.9 7v1.5h16v-1.5H4z"
+          />
+        </SVG>,
+        "isActive": false,
+        "onClick": [Function],
+        "role": "menuitemradio",
+        "title": "Align text left",
+      },
+      Object {
+        "align": "center",
+        "icon": <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
+            d="M16.4 4.2H7.6v1.5h8.9V4.2zM4 11.2v1.5h16v-1.5H4zm3.6 8.6h8.9v-1.5H7.6v1.5z"
+          />
+        </SVG>,
+        "isActive": false,
+        "onClick": [Function],
+        "role": "menuitemradio",
+        "title": "Align text center",
+      },
+      Object {
+        "align": "right",
+        "icon": <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
+            d="M11.1 19.8H20v-1.5h-8.9v1.5zm0-15.6v1.5H20V4.2h-8.9zM4 12.8h16v-1.5H4v1.5z"
+          />
+        </SVG>,
+        "isActive": false,
+        "onClick": [Function],
+        "role": "menuitemradio",
+        "title": "Align text right",
+      },
+    ]
+  }
+  icon={
+    <SVG
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <Path
+        d="M16.4 4.2H7.6v1.5h8.9V4.2zM4 11.2v1.5h16v-1.5H4zm3.6 8.6h8.9v-1.5H7.6v1.5z"
+      />
+    </SVG>
+  }
+  label="Align"
+  popoverProps={
+    Object {
+      "isAlternate": true,
+      "position": "bottom right",
+    }
+  }
+  toggleProps={
+    Object {
+      "describedBy": "Change text alignment",
+    }
+  }
+/>
+`;
+
 exports[`AlignmentUI should allow custom alignment controls to be specified 1`] = `
 <ToolbarGroup
   controls={

--- a/packages/block-editor/src/components/alignment-control/test/index.js
+++ b/packages/block-editor/src/components/alignment-control/test/index.js
@@ -51,6 +51,17 @@ describe( 'AlignmentUI', () => {
 		expect( onChangeSpy ).toHaveBeenCalledWith( 'center' );
 	} );
 
+	test( 'should allow a custom placeholder to be specified', () => {
+		const wrapperPlaceholder = shallow(
+			<AlignmentUI placeholder="center" />
+		);
+		expect( wrapperPlaceholder ).toMatchSnapshot();
+
+		const wrapperIllegalPlaceholder = () =>
+			shallow( <AlignmentUI placeholder="illegal-value" /> );
+		expect( wrapperIllegalPlaceholder ).not.toThrowError();
+	} );
+
 	test( 'should allow custom alignment controls to be specified', () => {
 		const wrapperCustomControls = shallow(
 			<AlignmentUI

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -35,6 +35,7 @@ const POPOVER_PROPS = {
 
 function AlignmentUI( {
 	value,
+	placeholder,
 	onChange,
 	alignmentControls = DEFAULT_ALIGNMENT_CONTROLS,
 	label = __( 'Align' ),
@@ -51,8 +52,15 @@ function AlignmentUI( {
 		( control ) => control.align === value
 	);
 
+	const placeholderAlignment = find(
+		alignmentControls,
+		( control ) => control.align === placeholder
+	);
+
 	function setIcon() {
 		if ( activeAlignment ) return activeAlignment.icon;
+		if ( placeholderAlignment ) return placeholderAlignment.icon;
+
 		return isRTL() ? alignRight : alignLeft;
 	}
 

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -20,6 +20,9 @@
 			"default": "",
 			"__experimentalRole": "content"
 		},
+		"textAlign": {
+			"type": "string"
+		},
 		"mainColor": {
 			"type": "string"
 		},

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -7,7 +7,7 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Platform, useEffect, useRef } from '@wordpress/element';
 import {
 	RichText,
@@ -57,6 +57,15 @@ function PullQuoteEdit( {
 			? { ...style, backgroundColor: mainColor.color }
 			: { ...style, borderColor: mainColor.color },
 	};
+
+	// The default and the solid color styles align text differently when `textAlign`
+	// is undefined, so we need to make sure the placeholder icon on the `AlignmentToolbar`
+	// reflects with the default alignment properly.
+	function pullQuoteTextAlignPlaceholder() {
+		// The solid color style aligns text to the side, not center.
+		const solidColorStyleAlign = isRTL() ? 'right' : 'left';
+		return isSolidColorStyle ? solidColorStyleAlign : 'center';
+	}
 
 	function pullQuoteMainColorSetter( colorValue ) {
 		const needTextColor =
@@ -163,6 +172,7 @@ function PullQuoteEdit( {
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }
+					placeholder={ pullQuoteTextAlignPlaceholder() }
 					onChange={ ( nextTextAlign ) =>
 						setAttributes( { textAlign: nextTextAlign } )
 					}

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -12,6 +12,8 @@ import { Platform, useEffect, useRef } from '@wordpress/element';
 import {
 	RichText,
 	ContrastChecker,
+	AlignmentToolbar,
+	BlockControls,
 	InspectorControls,
 	withColors,
 	PanelColorSettings,
@@ -33,7 +35,7 @@ import { SOLID_COLOR_CLASS } from './shared';
 function PullQuoteEdit( {
 	colorUtils,
 	textColor,
-	attributes: { value, citation },
+	attributes: { value, citation, textAlign },
 	setAttributes,
 	setTextColor,
 	setMainColor,
@@ -108,12 +110,13 @@ function PullQuoteEdit( {
 					style={ {
 						color: textColor.color,
 					} }
-					className={
-						textColor.color &&
-						classnames( 'has-text-color', {
+					className={ classnames( {
+						[ `has-text-align-${ textAlign }` ]: textAlign,
+						...( textColor.color && {
+							'has-text-color': true,
 							[ textColor.class ]: textColor.class,
-						} )
-					}
+						} ),
+					} ) }
 				>
 					<RichText
 						identifier="value"
@@ -157,6 +160,14 @@ function PullQuoteEdit( {
 					) }
 				</BlockQuote>
 			</Figure>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextTextAlign ) =>
+						setAttributes( { textAlign: nextTextAlign } )
+					}
+				/>
+			</BlockControls>
 			{ Platform.OS === 'web' && (
 				<InspectorControls>
 					<PanelColorSettings

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -58,13 +58,14 @@ export default function save( { attributes } ) {
 	}
 
 	const blockquoteTextColorClass = getColorClassName( 'color', textColor );
-	const blockquoteClasses = classnames( {
-		[ `has-text-align-${ textAlign }` ]: textAlign,
-		...( isTextColorSet && {
-			'has-text-color': true,
-			[ blockquoteTextColorClass ]: blockquoteTextColorClass,
-		} ),
-	} );
+	const blockquoteClasses =
+		classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+			...( isTextColorSet && {
+				'has-text-color': true,
+				[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+			} ),
+		} ) || undefined;
 
 	const blockquoteStyles = blockquoteTextColorClass
 		? undefined

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -26,10 +26,12 @@ export default function save( { attributes } ) {
 		customTextColor,
 		value,
 		citation,
+		textAlign,
 		className,
 	} = attributes;
 
 	const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+	const isTextColorSet = Boolean( textColor || customTextColor );
 
 	let figureClasses, figureStyles;
 
@@ -56,11 +58,13 @@ export default function save( { attributes } ) {
 	}
 
 	const blockquoteTextColorClass = getColorClassName( 'color', textColor );
-	const blockquoteClasses =
-		( textColor || customTextColor ) &&
-		classnames( 'has-text-color', {
+	const blockquoteClasses = classnames( {
+		[ `has-text-align-${ textAlign }` ]: textAlign,
+		...( isTextColorSet && {
+			'has-text-color': true,
 			[ blockquoteTextColorClass ]: blockquoteTextColorClass,
-		} );
+		} ),
+	} );
 
 	const blockquoteStyles = blockquoteTextColorClass
 		? undefined

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -21,6 +21,7 @@
 	footer {
 		position: relative;
 	}
+
 	.has-text-color a {
 		color: inherit;
 	}
@@ -30,14 +31,31 @@
 	background: none;
 }
 
+/*
+ * 1. Defining `text-align` on the parent would get overwritten by the theme’s
+*     defintion of the default style.
+ * 2. When no text alignment is set, the solid color style aligns text to the
+ *    side, not center.
+ * 3. Twenty Twenty-One has a hardcoded `text-align` on `blockquote::before`.
+ *    The only way to make the decorative quotation mark follow the same
+ *    alignment as its parent (both in the editor and on the front-end) is
+ *    by resetting the property with `!important`.
+ */
 .wp-block-pullquote.is-style-solid-color {
 	border: none;
+
 	blockquote {
 		margin-left: auto;
 		margin-right: auto;
-		text-align: left;
-
 		max-width: 60%;
+
+		&:not([class*="has-text-align-"]) { /* 1 */
+			text-align: left; /* 2 */
+		}
+
+		&::before {
+			text-align: inherit !important; /* 3 */
+		}
 
 		p {
 			margin-top: 0;

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.html
@@ -1,8 +1,8 @@
-<!-- wp:core/pullquote -->
+<!-- wp:pullquote {"textAlign":"right"} -->
 <figure class="wp-block-pullquote">
-    <blockquote class="has-text-align-right">
-    <p>This pullquote has text aligned to right.</p>
-    <cite>So does the citation.</cite>
-    </blockquote>
+	<blockquote class="has-text-align-right">
+		<p>This pullquote has text aligned to right.</p>
+		<cite>So does the citation.</cite>
+	</blockquote>
 </figure>
-<!-- /wp:core/pullquote -->
+<!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.html
@@ -1,0 +1,8 @@
+<!-- wp:core/pullquote -->
+<figure class="wp-block-pullquote">
+    <blockquote class="has-text-align-right">
+    <p>This pullquote has text aligned to right.</p>
+    <cite>So does the citation.</cite>
+    </blockquote>
+</figure>
+<!-- /wp:core/pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.json
@@ -9,6 +9,6 @@
 			"textAlign": "right"
 		},
 		"innerBlocks": [],
-		"originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>"
+		"originalContent": "<figure class=\"wp-block-pullquote\">\n\t<blockquote class=\"has-text-align-right\">\n\t\t<p>This pullquote has text aligned to right.</p>\n\t\t<cite>So does the citation.</cite>\n\t</blockquote>\n</figure>"
 	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.json
@@ -1,0 +1,14 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "core/pullquote",
+		"isValid": true,
+		"attributes": {
+			"value": "<p>This pullquote has text aligned to right.</p>",
+			"citation": "So does the citation.",
+			"textAlign": "right"
+		},
+		"innerBlocks": [],
+		"originalContent": "<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>"
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.parsed.json
@@ -1,11 +1,13 @@
 [
 	{
 		"blockName": "core/pullquote",
-		"attrs": {},
+		"attrs": {
+			"textAlign": "right"
+		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-pullquote\">\n\t<blockquote class=\"has-text-align-right\">\n\t\t<p>This pullquote has text aligned to right.</p>\n\t\t<cite>So does the citation.</cite>\n\t</blockquote>\n</figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>\n"
+			"\n<figure class=\"wp-block-pullquote\">\n\t<blockquote class=\"has-text-align-right\">\n\t\t<p>This pullquote has text aligned to right.</p>\n\t\t<cite>So does the citation.</cite>\n\t</blockquote>\n</figure>\n"
 		]
 	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.parsed.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/pullquote",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-pullquote\">\n    <blockquote class=\"has-text-align-right\">\n    <p>This pullquote has text aligned to right.</p>\n    <cite>So does the citation.</cite>\n    </blockquote>\n</figure>\n"
+		]
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote -->
+<!-- wp:pullquote {"textAlign":"right"} -->
 <figure class="wp-block-pullquote"><blockquote class="has-text-align-right"><p>This pullquote has text aligned to right.</p><cite>So does the citation.</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__text-alignment.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote class="has-text-align-right"><p>This pullquote has text aligned to right.</p><cite>So does the citation.</cite></blockquote></figure>
+<!-- /wp:pullquote -->


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/2060580/118862569-2d77ab80-b8de-11eb-9d20-b35173fbe588.png)

## Description

This PR adds support for specifying text alignment inside the Pullquote block using a block toolbar control.

Our users expect the center alignment option to be available (#22784, #31558, Automattic/wp-calypso#52519), because it used to also align the text inside the quote to center. That option was removed probably with the introduction of the Solid Color block style which aligned text to the side. This PR allows the user to overwrite the default alignment defined by any of the available block styles.

Behind the scenes, this PR also adds support for the `placeholder` attribute in the standard `AlignmentToolbar` control. This allows the control to reflect the currently used setting without explicitly setting the value. 

## How has this been tested?

* Pull the changes.
* `npm run test-unit`
* Open the editor.
* Insert an instance of the Pullquote block.
* Set the block style to Solid Color.
* Use the new toolbar control to overwrite the default text alignment.
* Make sure the custom text alignment option works intact with any other block alignment and block style option available—both in the editor and on the preview.

## Screenshots

![](https://user-images.githubusercontent.com/2060580/118862448-08833880-b8de-11eb-811c-47256eb294ec.png)

![](https://user-images.githubusercontent.com/2060580/118862455-09b46580-b8de-11eb-9dba-cf1290199a40.png)

## Types of changes

New feature

## Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] I’ve tested my changes with keyboard and screen readers.
- [x] My code has proper inline documentation.
- [x] I’ve included developer documentation if appropriate.
- [ ] I’ve updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).
