### PR TITLE
Post content block: apply the_content filter before checking if content is empty

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -51,14 +51,13 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$content = get_the_content( null, false, $post_id );
 	/** This filter is documented in wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
+	unset( $seen_ids[ $post_id ] );
 
 	if ( empty( $content ) ) {
-		unset( $seen_ids[ $post_id ] );
 		return '';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
-	unset( $seen_ids[ $post_id ] );
 
 	return (
 		'<div ' . $wrapper_attributes . '>' .

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -49,6 +49,8 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	}
 
 	$content = get_the_content( null, false, $post_id );
+	/** This filter is documented in wp-includes/post-template.php */
+	$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 
 	if ( empty( $content ) ) {
 		unset( $seen_ids[ $post_id ] );
@@ -56,8 +58,6 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
-	/** This filter is documented in wp-includes/post-template.php */
-	$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 	unset( $seen_ids[ $post_id ] );
 
 	return (


### PR DESCRIPTION
Closes #31995.

## Description
This PR reorders the render logic of the Post content block so `the_content` filter is applied before the early return for empty content.

## How has this been tested?

1. The testing steps include a minimal setup to reproduce the issue and verify the fix.
2. WooCommerce relies on `the_content` filter to append the Shop page contents. I tested that when the page has no text, Shop contents are displayed.

## Step-by-step reproduction instructions

1. Add a filter like this:
```PHP
function filter_function_name( $excerpt ) {
	return "Filtered -- $excerpt";
}
add_filter( 'the_content', 'filter_function_name' );
```
2. Create a page without any text.
3. Using a block-based theme, verify the page content has the `Filtered --` prefix.