### PR TITLE
Update Site Editor’s reset of navigation panel menu

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -24,6 +24,7 @@ export default function Navigation( {
 	activeMenu = ROOT_MENU,
 	children,
 	className,
+	skipAnimation,
 	onActivateMenu = noop,
 } ) {
 	const [ menu, setMenu ] = useState( activeMenu );
@@ -73,7 +74,8 @@ export default function Navigation( {
 			<div
 				key={ menu }
 				className={ classnames( {
-					[ animateClassName ]: isMounted.current && slideOrigin,
+					[ animateClassName ]:
+						isMounted.current && ! skipAnimation && slideOrigin,
 				} ) }
 			>
 				<NavigationContext.Provider value={ context }>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -10,6 +10,7 @@ import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationBackButton as NavigationBackButton,
 } from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -76,6 +77,17 @@ const NavigationPanel = ( { isOpen } ) => {
 		}
 	}, [ activeMenu, isOpen ] );
 
+	// Sets active menu to root after the closing transition ends
+	const onTransitionEnd = ( event ) => {
+		if ( event.target === panelRef.current && ! isOpen ) {
+			setActive( MENU_ROOT );
+		}
+	};
+
+	// Skips menu slide animation if the panel has just opened or is closed
+	const wasOpen = usePrevious( isOpen );
+	const skipAnimation = ( isOpen && ! wasOpen ) || ! isOpen;
+
 	const closeOnEscape = ( event ) => {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
@@ -92,6 +104,7 @@ const NavigationPanel = ( { isOpen } ) => {
 			ref={ panelRef }
 			tabIndex="-1"
 			onKeyDown={ closeOnEscape }
+			onTransitionEnd={ onTransitionEnd }
 		>
 			<div className="edit-site-navigation-panel__inner">
 				<div className="edit-site-navigation-panel__site-title-container">
@@ -104,6 +117,7 @@ const NavigationPanel = ( { isOpen } ) => {
 						activeItem={ activeItem }
 						activeMenu={ activeMenu }
 						onActivateMenu={ setActive }
+						skipAnimation={ skipAnimation }
 					>
 						{ activeMenu === MENU_ROOT && (
 							<MainDashboardButton.Slot>

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -142,19 +142,16 @@ export function navigationPanel(
 		case 'SET_IS_NAVIGATION_PANEL_OPENED':
 			return {
 				...state,
-				menu: ! action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
 				isOpen: action.isOpen,
 			};
 		case 'SET_IS_LIST_VIEW_OPENED':
 			return {
 				...state,
-				menu: state.isOpen && action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
 				isOpen: action.isOpen ? false : state.isOpen,
 			};
 		case 'SET_IS_INSERTER_OPENED':
 			return {
 				...state,
-				menu: state.isOpen && action.value ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
 				isOpen: action.value ? false : state.isOpen,
 			};
 	}

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -180,22 +180,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should change the menu to root when closing the panel', () => {
-			const state = navigationPanel(
-				undefined,
-				openNavigationPanelToMenu( 'test-menu' )
-			);
-
-			expect( state.menu ).toEqual( 'test-menu' );
-			expect(
-				navigationPanel( state, setIsNavigationPanelOpened( false ) )
-			).toEqual( {
-				isOpen: false,
-				menu: 'root',
-			} );
-		} );
-
-		it( 'should close the navigation panel when opening the inserter and change the menu to root', () => {
+		it( 'should close the navigation panel when opening the inserter', () => {
 			const state = navigationPanel(
 				undefined,
 				openNavigationPanelToMenu( 'test-menu' )
@@ -206,11 +191,11 @@ describe( 'state', () => {
 				navigationPanel( state, setIsInserterOpened( true ) )
 			).toEqual( {
 				isOpen: false,
-				menu: 'root',
+				menu: 'test-menu',
 			} );
 		} );
 
-		it( 'should close the navigation panel when opening the list view and change the menu to root', () => {
+		it( 'should close the navigation panel when opening the list view', () => {
 			const state = navigationPanel(
 				undefined,
 				openNavigationPanelToMenu( 'test-menu' )
@@ -221,7 +206,7 @@ describe( 'state', () => {
 				navigationPanel( state, setIsListViewOpened( true ) )
 			).toEqual( {
 				isOpen: false,
-				menu: 'root',
+				menu: 'test-menu',
 			} );
 		} );
 


### PR DESCRIPTION
Currently, the navigation menu is set back to the root menu via the store’s reducer whenever the panel is closed. This doesn't seem necessary after #30098 and it does have side-effects—one that is desirable and the other undesirable. In order to keep former and loose the latter, this PR still sets the menu back to root when the panel closes but only after the navigation panel has fully closed (after its transition). This avoids seeing the menu change as the panel is closing and preserves canceling the search state. Still, it might be better to consider a separate mechanism to cancel the search state.

Additionally, to prevent seeing the menu change as the panel opens, a new prop `skipAnimation` on the `Navigation` component is added/utilized. As an alternative to adding this prop, the navigation can be unmounted once the panel has closed as it will already avoid animation upon mount.

## How has this been tested?
In the site editor opening and closing the navigation panel. Also opening it by using the "browse all templates" button in the header template dropdown and closing it by opening the inserter.

## Screenshots
### Before
menu changes as panel closes (animation speed is slowed)

https://user-images.githubusercontent.com/9000376/118928618-5311ae80-b8f8-11eb-88df-caba976bc8f5.mp4

### After
menu stays put while panel closes and search still ends up canceled  (animation speed is slowed)

https://user-images.githubusercontent.com/9000376/118928645-5e64da00-b8f8-11eb-9c87-8b3041ab5fcc.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
