### PR TITLE
Try fixing inserting cover block intermittent failure

### DIFF
--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -298,19 +298,8 @@ describe( 'Inserting blocks', () => {
 			'button.block-editor-inserter__quick-inserter-expand'
 		);
 		await browseAll.click();
-		const inserterMenuInputSelector =
-			'.edit-post-editor__inserter-panel .block-editor-inserter__search-input';
-		const inserterMenuSearchInput = await page.waitForSelector(
-			inserterMenuInputSelector
-		);
-		inserterMenuSearchInput.type( 'cover' );
-		await page.waitForSelector(
-			'.block-editor-block-types-list .editor-block-list-item-cover'
-		);
-		// clicking may be too quick and may select a detached node.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Enter' );
+		// `insertBlock` uses the currently open panel.
+		await insertBlock( 'Cover' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This failure is common, especially when Github Actions is running slow.

https://github.com/WordPress/gutenberg/runs/2622677177

Using keyboard navigation in the test doesn't seem stable here. We should use `insertBlock` instead, which uses the currently open panel. It is used in other tests in the same file as well:

https://github.com/WordPress/gutenberg/blob/a9311d57655f3b71718523caacff8f47721b7c86/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js#L354-L366

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
