### PR TITLE
compose: Add types to `useDebounce`

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -196,7 +196,9 @@ render in components in `useCallback`.
 
 _Parameters_
 
--   _args_ `[TFunc, ...DebounceTailParameters]`: Arguments passed to Lodash's `debounce`.
+-   _fn_ `TFunc`: 
+-   _wait_ `[number]`: 
+-   _options_ `[import('lodash').DebounceSettings]`: 
 
 _Returns_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -194,11 +194,15 @@ be returned and any scheduled calls cancelled if any of the arguments change,
 including the function to debounce, so please wrap functions created on
 render in components in `useCallback`.
 
+_Related_
+
+-   <https://docs-lodash.com/v4/debounce/>
+
 _Parameters_
 
--   _fn_ `TFunc`: 
--   _wait_ `[number]`: 
--   _options_ `[import('lodash').DebounceSettings]`: 
+-   _fn_ `TFunc`: The function to debounce.
+-   _wait_ `[number]`: The number of milliseconds to delay.
+-   _options_ `[import('lodash').DebounceSettings]`: The options object.
 
 _Returns_
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -196,11 +196,11 @@ render in components in `useCallback`.
 
 _Parameters_
 
--   _args_ `...any`: Arguments passed to Lodash's `debounce`.
+-   _args_ `[TFunc, ...DebounceTailParameters]`: Arguments passed to Lodash's `debounce`.
 
 _Returns_
 
--   `Function`: Debounced function.
+-   `TFunc & import('lodash').Cancelable`: Debounced function.
 
 <a name="useFocusOnMount" href="#useFocusOnMount">#</a> **useFocusOnMount**
 

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -16,11 +16,13 @@ import { useEffect } from '@wordpress/element';
  * including the function to debounce, so please wrap functions created on
  * render in components in `useCallback`.
  *
+ * @see https://docs-lodash.com/v4/debounce/
+ *
  * @template {(...args: any[]) => void} TFunc
  *
- * @param {TFunc} fn
- * @param {number} [wait]
- * @param {import('lodash').DebounceSettings} [options]
+ * @param {TFunc} fn The function to debounce.
+ * @param {number} [wait] The number of milliseconds to delay.
+ * @param {import('lodash').DebounceSettings} [options] The options object.
  * @return {TFunc & import('lodash').Cancelable} Debounced function.
  */
 export default function useDebounce( fn, wait, options ) {

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -11,30 +11,25 @@ import { useEffect } from '@wordpress/element';
 
 /* eslint-disable jsdoc/valid-types */
 /**
- * @template T
- * @typedef {T extends [any, ...infer R] ? R : never} TailParameters
- */
-
-// We want to keep the type of the function that is passed in but the rest we don't
-// really care about, so this allows us to ignore the details of the rest of the paramters
-// while still maintaining the proper generic type for `debounce` where the returned
-// function matchest the signature of the passed in function.
-/** @typedef {TailParameters<Parameters<typeof debounce>>} DebounceTailParameters */
-
-/**
  * Debounces a function with Lodash's `debounce`. A new debounced function will
  * be returned and any scheduled calls cancelled if any of the arguments change,
  * including the function to debounce, so please wrap functions created on
  * render in components in `useCallback`.
  *
  * @template {(...args: any[]) => void} TFunc
- * @param {[TFunc, ...DebounceTailParameters]} args Arguments passed to Lodash's `debounce`.
  *
+ * @param {TFunc} fn
+ * @param {number} [wait]
+ * @param {import('lodash').DebounceSettings} [options]
  * @return {TFunc & import('lodash').Cancelable} Debounced function.
  */
-export default function useDebounce( ...args ) {
+export default function useDebounce( fn, wait, options ) {
 	/* eslint-enable jsdoc/valid-types */
-	const debounced = useMemoOne( () => debounce( ...args ), args );
+	const debounced = useMemoOne( () => debounce( fn, wait, options ), [
+		fn,
+		wait,
+		options,
+	] );
 	useEffect( () => () => debounced.cancel(), [ debounced ] );
 	return debounced;
 }

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -9,17 +9,31 @@ import { useMemoOne } from 'use-memo-one';
  */
 import { useEffect } from '@wordpress/element';
 
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @template T
+ * @typedef {T extends [any, ...infer R] ? R : never} TailParameters
+ */
+
+// We want to keep the type of the function that is passed in but the rest we don't
+// really care about, so this allows us to ignore the details of the rest of the paramters
+// while still maintaining the proper generic type for `debounce` where the returned
+// function matchest the signature of the passed in function.
+/** @typedef {TailParameters<Parameters<typeof debounce>>} DebounceTailParameters */
+
 /**
  * Debounces a function with Lodash's `debounce`. A new debounced function will
  * be returned and any scheduled calls cancelled if any of the arguments change,
  * including the function to debounce, so please wrap functions created on
  * render in components in `useCallback`.
  *
- * @param {...any} args Arguments passed to Lodash's `debounce`.
+ * @template {(...args: any[]) => void} TFunc
+ * @param {[TFunc, ...DebounceTailParameters]} args Arguments passed to Lodash's `debounce`.
  *
- * @return {Function} Debounced function.
+ * @return {TFunc & import('lodash').Cancelable} Debounced function.
  */
 export default function useDebounce( ...args ) {
+	/* eslint-enable jsdoc/valid-types */
 	const debounced = useMemoOne( () => debounce( ...args ), args );
 	useEffect( () => () => debounced.cancel(), [ debounced ] );
 	return debounced;

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -16,6 +16,7 @@
 		"src/higher-order/with-instance-id/**/*",
 		"src/hooks/use-async-list/**/*",
 		"src/hooks/use-constrained-tabbing/**/*",
+		"src/hooks/use-debounce/**/*",
 		"src/hooks/use-instance-id/**/*",
 		"src/utils/**/*"
 	]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Add types to `useDebounce`. No runtime changes.

One question I have is that this basically replicates the "we don't care about these arguments" approach from before but it makes the documentation pretty bad. So the alternative is to explicitly document each of the parameters to `debounce`. It's highly unlikely that the parameters to `debounce` are going to change so I think it's safe to do so. What do y'all think? I think it would be a big improvement over what we have now.

Part of #18838

## How has this been tested?
Type checks pass.
<img width="462" alt="Captura de Tela 2021-05-19 às 11 44 52" src="https://user-images.githubusercontent.com/24264157/118868210-c388e300-b898-11eb-9868-7f5677c18dc6.png">

<img width="459" alt="Captura de Tela 2021-05-19 às 11 45 01" src="https://user-images.githubusercontent.com/24264157/118868203-c2f04c80-b898-11eb-83d4-cda34a07601c.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
