### PR TITLE
Chore: Update skip failing template mode end to end test

### DIFF
--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -80,7 +80,7 @@ const createNewTemplate = async ( templateName ) => {
 	await disableTemplateWelcomeGuide();
 };
 
-describe( 'Post Editor Template mode', () => {
+describe.skip( 'Post Editor Template mode', () => {
 	beforeAll( async () => {
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );


### PR DESCRIPTION
Temporarily skip a failing end-to-end test introduced in https://github.com/WordPress/gutenberg/pull/31678 while a fix is being worked on.
