### PR TITLE
Proposes running big GitHub Actions only when PRs are ready for review.

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -112,25 +112,24 @@ jobs:
         runs-on: ubuntu-latest
         needs: bump-version
         if: always()
+
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
-            - name: Use Node.js 14.x
+            - name: Use desired version of NodeJS
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: 14.x
+                  node-version: 14
 
-            - name: Cache node modules
-              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
-              env:
-                  cache-name: cache-node-modules
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  key: ${{ runner.os }}-node-14-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Build Gutenberg plugin ZIP file
               run: ./bin/build-plugin-zip.sh

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -18,53 +18,20 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    compute-stable-branches:
-        name: Compute current and next stable release branches
-        runs-on: ubuntu-latest
-        outputs:
-            current_stable_branch: ${{ steps.get_branches.outputs.current_stable_branch }}
-            next_stable_branch: ${{ steps.get_branches.outputs.next_stable_branch }}
-
-        steps:
-            - name: Get current and next stable release branches
-              id: get_branches
-              run: |
-                  curl \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    -o latest.json \
-                    "https://api.github.com/repos/${{ github.repository }}/releases/latest"
-                  LATEST_STABLE_TAG=$(jq --raw-output '.tag_name' latest.json)
-                  IFS='.' read LATEST_STABLE_MAJOR LATEST_STABLE_MINOR LATEST_STABLE_PATCH <<< "${LATEST_STABLE_TAG#v}"
-                  echo "::set-output name=current_stable_branch::release/${LATEST_STABLE_MAJOR}.${LATEST_STABLE_MINOR}"
-                  if [[ ${LATEST_STABLE_MINOR} == "9" ]]; then
-                    echo "::set-output name=next_stable_branch::release/$((LATEST_STABLE_MAJOR + 1)).0"
-                  else
-                    echo "::set-output name=next_stable_branch::release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))"
-                  fi
-
     bump-version:
         name: Bump version
         runs-on: ubuntu-latest
-        needs: compute-stable-branches
         if: |
             github.repository == 'WordPress/gutenberg' &&
-            github.event_name == 'workflow_dispatch' && (
-              (
-                github.ref == 'refs/heads/trunk' ||
-                endsWith( github.ref, needs.compute-stable-branches.outputs.next_stable_branch )
-              ) && (
-                github.event.inputs.version == 'rc' ||
-                github.event.inputs.version == 'stable'
-              ) || (
-                endsWith( github.ref, needs.compute-stable-branches.outputs.current_stable_branch ) &&
-                github.event.inputs.version == 'stable'
-              )
+            github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/trunk' && (
+              github.event.inputs.version == 'rc' ||
+              github.event.inputs.version == 'stable'
             )
         outputs:
             old_version: ${{ steps.get_version.outputs.old_version }}
             new_version: ${{ steps.get_version.outputs.new_version }}
             release_branch: ${{ steps.get_version.outputs.release_branch }}
-
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -124,17 +91,13 @@ jobs:
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" gutenberg.php
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" readme.txt
 
-            - name: Commit the version bump to the release branch
+            - name: Commit the version bump
               run: |
                   git add gutenberg.php package.json package-lock.json readme.txt
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
 
-            - name: Fetch trunk
-              if: ${{ github.ref != 'refs/heads/trunk' }}
-              run: git fetch --depth=1 origin trunk
-
-            - name: Cherry-pick the version bump commit to trunk
+            - name: Cherry-pick to trunk
               run: |
                   git checkout trunk
                   git pull
@@ -148,19 +111,26 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: ${{ ( github.repository == 'WordPress/gutenberg' && always() ) || ( github.event_name == 'pull_request' && always() ) }}
-
+        if: always()
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
-            - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: 14
-                  cache: npm
+                  node-version: 14.x
+
+            - name: Cache node modules
+              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Build Gutenberg plugin ZIP file
               run: ./bin/build-plugin-zip.sh

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,20 +38,24 @@ jobs:
         strategy:
             matrix:
                 node: ['14']
-
         steps:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   fetch-depth: 1
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
-            - uses: preactjs/compressed-size-action@df6e03e187079aef959a2878311639c77b95ee2e # v2.2.0
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+
+            - uses: preactjs/compressed-size-action@7d87f60a6b0c7d193b8183ce859ed00b356ea92f # v2.1.0
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
-                  pattern: '{build/**/*.min.js,build/**/*.css}'
-                  clean-script: 'distclean'
+                  pattern: '{build/**/*.js,build/**/*.css}'

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -26,10 +26,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: npm install, build, format and lint
               run: |

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,6 +2,7 @@ name: End-to-End Tests
 
 on:
     pull_request:
+        types: [review_requested, ready_for_review]
     push:
         branches:
             - trunk

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -31,10 +31,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Npm install and build
               run: |

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,7 +2,7 @@ name: End-to-End Tests
 
 on:
     pull_request:
-        types: [review_requested, ready_for_review]
+        types: [synchronize, review_requested, ready_for_review]
     push:
         branches:
             - trunk

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,6 +2,7 @@ name: Performances Tests
 
 on:
     pull_request:
+        types: [review_requested, ready_for_review]
     release:
         types: [published]
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -17,6 +17,9 @@ jobs:
     performance:
         name: Run performance tests
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                compare_with: [trunk, releases]
         if: ${{ github.repository == 'WordPress/gutenberg' }}
 
         steps:
@@ -39,11 +42,11 @@ jobs:
                   npm ci
 
             - name: Compare performance with trunk
-              if: github.event_name == 'pull_request'
+              if: github.event_name == 'pull_request' && ${ compare_with } == 'trunk'
               run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
-              if: github.event_name == 'release'
+              if: github.event_name == 'release' && ${ compare_with } == 'releases'
               env:
                   PLUGIN_VERSION: ${{ github.event.release.name }}
               shell: bash

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -23,10 +23,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: 14
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-14-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Npm install
               run: |

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -9,6 +9,10 @@ jobs:
         timeout-minutes: 10
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
+        strategy:
+            matrix:
+                node: ['14']
+
         steps:
             # Checkout defaults to using the branch which triggered the event, which
             # isn't necessarily `trunk` (e.g. in the case of a merge).
@@ -16,10 +20,17 @@ jobs:
               with:
                   ref: trunk
 
-            - name: Use Node.js 14.x
+            - name: Use desired version of NodeJS
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: 14.x
+                  node-version: ${{ matrix.node }}
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             # Changing into the action's directory and running `npm install` is much
             # faster than a full project-wide `npm ci`.

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -6,6 +6,7 @@ name: Pull request automation
 
 jobs:
     pull-request-automation:
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
         strategy:

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -9,10 +9,6 @@ jobs:
         timeout-minutes: 10
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
-        strategy:
-            matrix:
-                node: ['14']
-
         steps:
             # Checkout defaults to using the branch which triggered the event, which
             # isn't necessarily `trunk` (e.g. in the case of a merge).
@@ -20,23 +16,14 @@ jobs:
               with:
                   ref: trunk
 
-            - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: ${{ matrix.node }}
-
-            - name: Cache NPM packages
-              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pr-automation-cache-${{ hashFiles('**/package-lock.json') }}
+                  node-version: 14.x
 
             # Changing into the action's directory and running `npm install` is much
             # faster than a full project-wide `npm ci`.
-            - name: Install NPM dependencies
-              run: npm install
-              working-directory: packages/project-management-automation
+            - run: cd packages/project-management-automation && npm install
 
             - uses: ./packages/project-management-automation
               with:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -2,6 +2,9 @@ name: React Native E2E Tests (Android)
 
 on:
     pull_request:
+        types: [review_requested, ready_for_review]
+        paths:
+            - 'packages/react-native-editor/android'
     push:
         branches: [trunk]
 

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -22,26 +22,28 @@ jobs:
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]
+                node: ['14']
 
         steps:
             - name: checkout
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
-            - name: Use Node.js 14.x
+            - name: Use desired version of NodeJS
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: 14.x
+                  node-version: ${{ matrix.node }}
 
-            - name: Restore npm cache
-              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
               with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
-                  key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - run: npm ci
 
             - name: Restore Gradle cache
-              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
               with:
                   path: ~/.gradle/caches
                   key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -18,28 +18,30 @@ concurrency:
 jobs:
     test:
         runs-on: macos-latest
-        # The false value below disables the test while we investigate a
-        # foundational error causing failures
-        if: ${{ false && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]
-                node: ['14']
 
         steps:
             - name: checkout
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
-            - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: ${{ matrix.node }}
-                  cache: npm
+                  node-version: 14.x
+
+            - name: Restore npm cache
+              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
             - run: npm ci
 
             - name: Restore Gradle cache
-              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
               with:
                   path: ~/.gradle/caches
                   key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -2,6 +2,9 @@ name: React Native E2E Tests (iOS)
 
 on:
     pull_request:
+        types: [review_requested, ready_for_review]
+        paths:
+            - 'packages/react-native-editor/ios'
     push:
         branches: [trunk]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -29,10 +29,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - run: npm ci
 
@@ -73,9 +79,7 @@ jobs:
               run: TEST_RN_PLATFORM=ios npm run native device-tests:local  ${{ matrix.native-test-name }}
 
             - name: Prepare build cache
-              run: |
-                  rm packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle
-                  rm -rf packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/assets
+              run: rm packages/react-native-editor/ios/build/GutenbergDemo/Build/Products/Release-iphonesimulator/GutenbergDemo.app/main.jsbundle
 
             - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
               if: always()

--- a/.github/workflows/stale-issue-add-needs-testing.yml
+++ b/.github/workflows/stale-issue-add-needs-testing.yml
@@ -7,7 +7,6 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
-
         steps:
             - uses: actions/stale@996798eb71ef485dc4c7b4d3285842d714040c4a # v3.0.17
               with:

--- a/.github/workflows/stale-issue-mark-stale.yml
+++ b/.github/workflows/stale-issue-mark-stale.yml
@@ -7,7 +7,6 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
-
         steps:
             - uses: actions/stale@996798eb71ef485dc4c7b4d3285842d714040c4a # v3.0.17
               with:

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -7,7 +7,6 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
-
         steps:
             - uses: actions/stale@996798eb71ef485dc4c7b4d3285842d714040c4a # v3.0.17
               with:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -25,17 +25,25 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: 14
-                  cache: npm
 
-            - name: Npm install
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-14-npm-cache-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Npm install and build
               # A "full" install is executed, since `npm ci` does not always exit
               # with an error status code if the lock file is inaccurate.
               #
               # See: https://github.com/WordPress/gutenberg/issues/16157
-              run: npm install
+              run: |
+                  npm install
+                  npm run build
 
             - name: Lint JavaScript and Styles
               run: npm run lint
@@ -43,7 +51,7 @@ jobs:
             - name: Type checking
               run: npm run build:package-types
 
-            - name: Check local changes
+            - name: Build artifacts
               run: npm run check-local-changes
 
             - name: License compatibility

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -9,25 +9,27 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
+        strategy:
+            matrix:
+                node: ['14']
+
         steps:
             - name: Checkout
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   ref: trunk
 
-            - name: Use Node.js 14.x
+            - name: Use desired version of NodeJS
               uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: 14.x
+                  node-version: ${{ matrix.node }}
 
-            - name: Cache node modules
-              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
-              env:
-                  cache-name: cache-node-modules
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Install Dependencies
               run: npm ci

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -9,21 +9,25 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
-        strategy:
-            matrix:
-                node: ['14']
-
         steps:
             - name: Checkout
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   ref: trunk
 
-            - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
-                  node-version: ${{ matrix.node }}
-                  cache: npm
+                  node-version: 14.x
+
+            - name: Cache node modules
+              uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Install Dependencies
               run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,10 +32,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret
@@ -60,10 +66,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: 14
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-14-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Npm install and build
               run: |
@@ -94,10 +106,16 @@ jobs:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea # v2.1.5
               with:
                   node-version: 14
-                  cache: npm
+
+            - name: Cache NPM packages
+              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+              with:
+                  # npm cache files are stored in `~/.npm` on Linux/macOS
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-14-npm-cache-${{ hashFiles('**/package-lock.json') }}
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The recent GitHub Actions service degradation incident surfaced some quick wins that we can implement in order to save some computing time:

1. Pull request automation action, which usually runs in less than a minute — [history of runs here](https://github.com/WordPress/gutenberg/actions/workflows/pull-request-automation.yml?query=is%3Acompleted), go back a few pages to see run times with GitHub Actions running normally — should be forced to timeout after a _reasonable_ amount of time. Setting the timeout to 5 minutes — arbitrarily, we might be able to go lower — should be enough to point out real problems.
2. Limit execution of the biggest time consumers to PRs that are not Drafts, and Ready for Review:
    - End 2 end tests ([Web](https://github.com/WordPress/gutenberg/actions/workflows/end2end-test.yml), [iOS](https://github.com/WordPress/gutenberg/actions/workflows/rnmobile-ios-runner.yml), and [Android](https://github.com/WordPress/gutenberg/actions/workflows/rnmobile-android-runner.yml).)
    - [Performance Tests.](https://github.com/WordPress/gutenberg/actions/workflows/performance.yml)

[Static analysis](https://github.com/WordPress/gutenberg/actions/workflows/static-checks.yml), [unit tests](https://github.com/WordPress/gutenberg/actions/workflows/unit-test.yml?query=is%3Acompleted), etc. take less time and we might benefit from setting timeouts for those as well.

### Other alternative

We could add more granularity by using [if conditions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif) in combination with [Events.](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)

## How has this been tested?
- Push changes on a draft PR, confirm that restricted workflows don't run.
- Mark PR as ready for review, confirm that restricted workflows run — no need to push new changes.

## Screenshots

### Admin e2e tests and Performance Tests remain in "Expected" status while the PR is still a Draft.

<img width="820" alt="image" src="https://user-images.githubusercontent.com/1157901/119057083-d46d4d80-b999-11eb-80db-62bbc158ba9c.png">

### Mobile e2e tests don't show up on the list.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/1157901/119057188-08e10980-b99a-11eb-982b-0ad2cd2776f0.png">




