### PR TITLE
Improves title and icon parsing for PR 31763

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -214,8 +214,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Parses the <title> contents from the provided HTML
 	 *
-	 * @param string $html the HTML from the remote website at URL.
-	 * @return string the title tag contents (maybe empty).
+	 * @param string $html The HTML from the remote website at URL.
+	 * @return string The title tag contents on success; else empty string.
 	 */
 	private function get_title( $html ) {
 		preg_match( '|<title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
@@ -230,7 +230,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 *
 	 * @param string $html The HTML from the remote website at URL.
 	 * @param string $url  The target website URL.
-	 * @return string The icon URI (maybe empty).
+	 * @return string The icon URI on success; else empty string.
 	 */
 	private function get_icon( $html, $url ) {
 		// Grab the icon's link element.

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -234,7 +234,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 */
 	private function get_icon( $html, $url ) {
 		// Grab the icon's link element.
-		$pattern = '#<link\s[^>]*rel="\s*(?:icon|shortcut icon|icon shortcut)\s*"[^>]*\/?>#is';
+		$pattern = '#<link\s[^>]*rel=(?:[\"\']??)\s*(?:icon|shortcut icon|icon shortcut)\s*(?:[\"\']??)[^>]*\/?>#isU';
 		preg_match( $pattern, $html, $element );
 		$element = ! empty( $element[0] ) && is_string( $element[0] ) ? trim( $element[0] ) : '';
 		if ( empty( $element ) ) {
@@ -242,9 +242,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		}
 
 		// Get the icon's href value.
-		$pattern = '#href="(.*?)"#is';
+		$pattern = '#href=([\"\']??)([^\" >]*?)\\1[^>]*#isU';
 		preg_match( $pattern, $element, $icon );
-		$icon = ! empty( $icon[1] ) && is_string( $icon[1] ) ? trim( $icon[1] ) : '';
+		$icon = ! empty( $icon[2] ) && is_string( $icon[2] ) ? trim( $icon[2] ) : '';
 		if ( empty( $icon ) ) {
 			return '';
 		}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -218,7 +218,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string the title tag contents (maybe empty).
 	 */
 	private function get_title( $html ) {
-		preg_match( '|<\s*title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
+		preg_match( '|<title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
 
 		$title = isset( $match_title[1] ) && is_string( $match_title[1] ) ? trim( $match_title[1] ) : '';
 
@@ -241,7 +241,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		if ( ! empty( $icon ) ) {
 			$parsed_url = parse_url( $url );
 			$root_url   = $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/';
-			$icon = \WP_Http::make_absolute_url( $icon, $root_url );
+			$icon       = \WP_Http::make_absolute_url( $icon, $root_url );
 		}
 
 		return $icon;

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -494,27 +494,43 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	/**
 	 * @dataProvider provide_get_title_data
 	 */
-	public function test_get_title( $html, $expected_title ) {
-
+	public function test_get_title( $html, $expected ) {
 		$controller = new WP_REST_URL_Details_Controller();
 		$method     = $this->get_reflective_method( 'get_title' );
-		$result     = $method->invoke(
+
+		$actual = $method->invoke(
 			$controller,
-			$this->wrap_html_in_doc( $html ),
+			$this->wrap_html_in_doc( $html )
 		);
-		$this->assertEquals( $expected_title, $result );
+		$this->assertSame( $expected, $actual );
 	}
 
 
 	public function provide_get_title_data() {
 		return array(
-			'no_attributes'   => array(
-				'<title>Testing the title</title>',
-				'Testing the title',
+			'no attributes'                  => array(
+				'<title>Testing &lt;title&gt;:</title>',
+				'Testing &lt;title&gt;:',
 			),
-			'with_attributes' => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing the title</title>',
-				'Testing the title',
+			'with attributes'                => array(
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;:</title>',
+				'Testing &lt;title&gt;:',
+			),
+			'with text whitespace'           => array(
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;:	</title>',
+				'Testing &lt;title&gt;:',
+			),
+			'when opening tag is malformed'  => array(
+				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
+				'',
+			),
+			'with whitespace in opening tag' => array(
+				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
+				'Testing &lt;title&gt;: with whitespace in opening tag',
+			),
+			'when whitepace in closing tag'  => array(
+				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
+				'Testing &lt;title&gt;: with whitespace in closing tag',
 			),
 		);
 	}
@@ -711,18 +727,20 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-	private function wrap_html_in_doc( $html ) {
+	private function wrap_html_in_doc( $html, $with_body = false ) {
 		$doc = '<!DOCTYPE html>
 				<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
-				<head>
-					%%HEAD_CONTENT%%
-				</head>
+				<head>' . $html . '</head>';
+		if ( $with_body ) {
+			$doc .= '
 				<body>
 					<h1>Example Website</h1>
 					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 				</body>
-				</html>';
-		return str_replace( '%%HEAD_CONTENT%%', $html, $doc );
+			</html>';
+		}
+
+		return $doc;
 	}
 
 	/**

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -578,6 +578,10 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'<link type="image/png" href="https://wordpress.org/favicon.png" rel="icon" />',
 				'https://wordpress.org/favicon.png',
 			),
+			'default with single quotes'            => array(
+				'<link type="image/png" href=\'https://wordpress.org/favicon.png\' rel=\'icon\' />',
+				'https://wordpress.org/favicon.png',
+			),
 
 			// Happy paths.
 			'with query string'                     => array(


### PR DESCRIPTION
## Description
Collaboration with PR #31763 to improve title and icon parsing as well as adding both happy and unhappy test data for each.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [na] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [na] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [na] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [na] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
