### PR TITLE
Try stabilizing customize widgets e2e tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/experiments/customizing-widgets.test.js
@@ -562,6 +562,16 @@ async function addBlock( blockName ) {
 	);
 	await addBlockButton.click();
 
+	// TODO - remove this timeout when the test plugin for disabling CSS
+	// animations in tests works properly.
+	//
+	// This waits for the inserter panel animation to finish before
+	// attempting to insert a block. If the panel is still animating
+	// puppeteer can click on the wrong block.
+	//
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitForTimeout( 300 );
+
 	const blockOption = await find( {
 		role: 'option',
 		name: blockName,


### PR DESCRIPTION
## Description
Attempts to solve the intermittent failure in the customize widgets tests observed here - https://github.com/WordPress/gutenberg/runs/2620274056.

The test attempts to insert a paragraph and a heading, and then use the trailing appender to add a Search block.

But the test failure snapshots show that the test is sometimes inserting two paragraphs instead. 

My guess is that the Paragraph is incorrectly inserted due to the animation the block library panel has in the customizer. The test is attempting to click the Heading block while the animation is happening, but clicks the Paragraph block that's next to it.

There isn't a trailing appender in this situation, because the appender doesn't appear after paragraphs, so the test fails.

This PR adds a timeout to wait for the animation to finish. The animation is 0.18 seconds, so waiting 300ms should be plenty.

(edit: animations could be disabled entirely in e2e tests when this issue is solved - https://github.com/WordPress/gutenberg/issues/32024)