### PR TITLE
Fix unregister_block_pattern notices

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -202,7 +202,10 @@ function remove_core_patterns() {
 	);
 
 	foreach ( $core_block_patterns as $core_block_pattern ) {
-		unregister_block_pattern( 'core/' . $core_block_pattern );
+		$name = 'core/' . $core_block_pattern;
+		if ( WP_Block_Patterns_Registry::get_instance()->is_registered( $name ) ) {
+			unregister_block_pattern( $name );
+		}
 	}
 }
 
@@ -212,7 +215,7 @@ function remove_core_patterns() {
 function load_remote_patterns() {
 	$patterns = get_transient( 'gutenberg_remote_block_patterns' );
 	if ( ! $patterns ) {
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request         = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
 		$core_keyword_id = 11; // 11 is the ID for "core".
 		$request->set_param( 'keyword', $core_keyword_id );
 		$response = rest_do_request( $request );


### PR DESCRIPTION
## Description

https://github.com/WordPress/gutenberg/pull/28800 introduced some PHP warnings which I missed while testing:

<img width="1792" alt="Screen Shot 2021-05-20 at 13 58 10" src="https://user-images.githubusercontent.com/612155/118917704-ceb14100-b974-11eb-9d00-736061c00081.png">

This fixes them by checking to see if the pattern is registered before unregistering it.

## How has this been tested?

1. Navigate to a WP Admin page that doesn't have a block editor.
2. There should be no PHP notices.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->