### PR TITLE
Blocks: Deprecate `registerBlockTypeFromMetadata` in favor of `registerBlockType`

### DIFF
--- a/docs/how-to-guides/backward-compatibility/deprecations.md
+++ b/docs/how-to-guides/backward-compatibility/deprecations.md
@@ -2,6 +2,10 @@
 
 For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 11.0.0
+
+-   `wp.blocks.registerBlockTypeFromMetadata` method has been removed. Use `wp.blocks.registerBlockType` method instead.
+
 ## 10.3.0
 
 -   Passing a tuple of components with `as` prop to `ActionItem.Slot` component is no longer supported. Please pass a component with `as` prop instead. Example:

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -470,16 +470,16 @@ Implementation follows the existing [get_plugin_data](https://codex.wordpress.or
 
 ### JavaScript
 
-In JavaScript, you need to use `registerBlockTypeFromMetadata` method from `@wordpress/blocks` package to process loaded block metadata. All localized properties get automatically wrapped in `_x` (from `@wordpress/i18n` package) function calls similar to how it works in PHP.
+In JavaScript, you can use `registerBlockType` method from `@wordpress/blocks` package and pass the metadata object loaded from `block.json` as the first param. All localized properties get automatically wrapped in `_x` (from `@wordpress/i18n` package) function calls similar to how it works in PHP.
 
 **Example:**
 
 ```js
-import { registerBlockTypeFromMetadata } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
 import metadata from './block.json';
 
-registerBlockTypeFromMetadata( metadata, {
+registerBlockType( metadata, {
 	edit: Edit,
 	// ...other client-side settings
 } );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -4,7 +4,7 @@
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
 import {
-	registerBlockTypeFromMetadata,
+	registerBlockType,
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
@@ -105,7 +105,7 @@ const registerBlock = ( block ) => {
 		return;
 	}
 	const { metadata, settings, name } = block;
-	registerBlockTypeFromMetadata( { name, ...metadata }, settings );
+	registerBlockType( { name, ...metadata }, settings );
 };
 
 /**

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -10,7 +10,6 @@ import { sortBy } from 'lodash';
 import {
 	hasBlockSupport,
 	registerBlockType,
-	registerBlockTypeFromMetadata,
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
@@ -128,7 +127,7 @@ const registerBlock = ( block ) => {
 		return;
 	}
 	const { metadata, settings, name } = block;
-	registerBlockTypeFromMetadata(
+	registerBlockType(
 		{
 			name,
 			...metadata,

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New API
+
+-   `registerBlockType` method can be used to register a block type using the metadata loaded from `block.json` file ([#32030](https://github.com/WordPress/gutenberg/pull/32030)).
+
+### Deprecations
+
+-   `registerBlockTypeFromMetadata` was deprecated in favor of `registerBlockType` that support now the same functionality ([#32030](https://github.com/WordPress/gutenberg/pull/32030)).
+
 ## 9.0.0 (2021-05-14)
 
 ### Breaking Changes

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -706,7 +706,7 @@ editor interface where blocks are implemented.
 
 _Parameters_
 
--   _name_ `string`: Block name.
+-   _blockNameOrMetadata_ `string|Object`: Block type name or its metadata.
 -   _settings_ `Object`: Block settings.
 
 _Returns_
@@ -715,18 +715,13 @@ _Returns_
 
 <a name="registerBlockTypeFromMetadata" href="#registerBlockTypeFromMetadata">#</a> **registerBlockTypeFromMetadata**
 
+> **Deprecated** Use `registerBlockType` instead.
+
 Registers a new block provided from metadata stored in `block.json` file.
-It uses `registerBlockType` internally.
-
-_Related_
-
--   registerBlockType
 
 _Parameters_
 
 -   _metadata_ `Object`: Block metadata loaded from `block.json`.
--   _metadata.name_ `string`: Block name.
--   _metadata.textdomain_ `string`: Textdomain to use with translations.
 -   _additionalSettings_ `Object`: Additional block settings.
 
 _Returns_

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -17,7 +17,6 @@ import { blockDefault as blockIcon } from '@wordpress/icons';
  */
 import {
 	registerBlockType,
-	registerBlockTypeFromMetadata,
 	registerBlockCollection,
 	unregisterBlockCollection,
 	unregisterBlockType,
@@ -801,12 +800,10 @@ describe( 'blocks', () => {
 				expect( block1.attributes ).not.toEqual( block2.attributes );
 			} );
 		} );
-	} );
 
-	describe( 'registerBlockTypeFromMetadata', () => {
 		test( 'registers block from metadata', () => {
 			const Edit = () => 'test';
-			const block = registerBlockTypeFromMetadata(
+			const block = registerBlockType(
 				{
 					name: 'test/block-from-metadata',
 					title: 'Block from metadata',
@@ -859,7 +856,7 @@ describe( 'blocks', () => {
 			);
 
 			const Edit = () => 'test';
-			const block = registerBlockTypeFromMetadata(
+			const block = registerBlockType(
 				{
 					name: 'test/block-from-metadata-i18n',
 					title: 'I18n title from metadata',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Props to @mtias for the proposal. Rather than using two distinct methods to register block types in the block editor, let's make `registerBlockType` the canonical method to deal with all use cases. In practice, the PR proposed extends its usage to work as a proxy the former `registerBlockTypeFromMetadata`. It should remove some confusion that we observed and let us be more explicit what's the latest recommendation. It will also allow us to better communicate what's the preferred way to register block types in the context of WordPress.

We have already applied a similar change in WordPress core:
https://github.com/WordPress/wordpress-develop/commit/6ad4e34c540f7596c9b5cfe8bc9b7db94a1ef72a

## Dev Note

_This is the updated note from #30293:_

In JavaScript, you can use now `registerBlockType` method from `@wordpress/blocks` package to register a  block type using the metadata loaded from `block.json` file. All localized properties get automatically wrapped in `_x` (from `@wordpress/i18n` package) function calls similar to how it works in PHP with `register_block_type`. The only requirement is to set the `textdomain` property in the `block.json` file.

 **Example:**

`block.json`
```json
{
	"name": "my-plugin/translatable-block",
	"title": "My translatable block",
	"description": "My block with translatable metadata",
	"keywords": [ "translatable" ],
	"textdomain": "my-plugin"
}
```

`index.js`
```js
import { registerBlockType } from '@wordpress/blocks';
import Edit from './edit';
import metadata from './block.json';

registerBlockType( metadata, {
	edit: Edit,
	// ...other client-side settings
} );
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Unit tests were updated.

I also tested deprecations for `wp.blocks.registerBlockTypeFromMetadata` in the Browser Console:

```js
wp.blocks.registerBlockTypeFromMetadata( { name: 'test/block', title: 'Test block' } );
```

## Screenshots <!-- if applicable -->

<img width="1034" alt="Screen Shot 2021-05-20 at 10 28 14" src="https://user-images.githubusercontent.com/699132/118945838-1ffe0800-b956-11eb-9496-bd76401758e7.png">


## Types of changes

API change and deprecation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
