### PR TITLE
Skip unstable e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -39,7 +39,7 @@ describe( 'Meta boxes', () => {
 		await page.waitForSelector( '.editor-post-save-draft' );
 	} );
 
-	it( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async () => {
+	it.skip( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async () => {
 		// Publish a post so there's something for the latest posts dynamic block to render.
 		await page.type( '.editor-post-title__input', 'A published post' );
 		await insertBlock( 'Paragraph' );

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -420,7 +420,7 @@ describe( 'Navigation editor', () => {
 			expect( navigatorNameEditor ).toBeDefined();
 		} );
 
-		it( 'saves menu name upon clicking save button', async () => {
+		it.skip( 'saves menu name upon clicking save button', async () => {
 			const newName = 'newName';
 			const menuPostResponse = {
 				id: 4,
@@ -557,7 +557,7 @@ describe( 'Navigation editor', () => {
 			assertIsDirty( false );
 		} );
 
-		it( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
+		it.skip( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
 			await page.type(
 				'.edit-navigation-name-editor__text-control input',
 				' Menu'

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -553,7 +553,7 @@ describe( 'Navigation editor', () => {
 			}
 		}
 
-		it( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
+		it.skip( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
 			assertIsDirty( false );
 		} );
 


### PR DESCRIPTION
These two e2e tests are failing too often in trunk and PRs. To avoid confusing contributors, I'm skipping them right now but we should investigate them if possible.

cc @Mamaduka @ellatrix 