### PR TITLE
Fix typo: "packages" -> "package"

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,6 +1,6 @@
 # Component Reference
 
-This packages includes a library of generic WordPress components to be used for creating common UI elements shared between screens and features of the WordPress dashboard.
+This package includes a library of generic WordPress components to be used for creating common UI elements shared between screens and features of the WordPress dashboard.
 
 ## Installation
 


### PR DESCRIPTION
Looks like the intention was to write `package` instead of `packages` here.