### PR TITLE
Update the title area in the template editor

### DIFF
--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -53,7 +53,7 @@ const switchToTemplateMode = async () => {
 		'.edit-post-template-top-area',
 		( el ) => el.innerText
 	);
-	expect( title ).toContain( 'About\n' );
+	expect( title ).toContain( 'Just an FSE Post\n' );
 };
 
 const createNewTemplate = async ( templateName ) => {

--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -1,28 +1,38 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Dropdown, ToolbarItem, Button } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 import DeleteTemplate from './delete-template';
 import EditTemplateTitle from './edit-template-title';
 
 function TemplateTitle() {
-	const { template, isEditing } = useSelect( ( select ) => {
+	const { template, isEditing, title } = useSelect( ( select ) => {
 		const { isEditingTemplate, getEditedPostTemplate } = select(
 			editPostStore
 		);
+		const { getEditedPostAttribute } = select( editorStore );
+
 		const _isEditing = isEditingTemplate();
+
 		return {
 			template: _isEditing ? getEditedPostTemplate() : null,
 			isEditing: _isEditing,
+			title: getEditedPostAttribute( 'title' ),
 		};
 	}, [] );
+
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+	const { setIsEditingTemplate } = useDispatch( editPostStore );
 
 	if ( ! isEditing || ! template ) {
 		return null;
@@ -45,13 +55,31 @@ function TemplateTitle() {
 						contentClassName="edit-post-template-top-area__popover"
 						renderToggle={ ( { onToggle } ) => (
 							<>
-								<div>{ __( 'About' ) }</div>
 								<Button
 									{ ...toolbarItemHTMLProps }
-									isSmall
-									variant="tertiary"
+									className="edit-post-template-post-title"
+									isLink
+									showTooltip
+									label={ sprintf(
+										/* translators: %s: Title of the referring post, e.g: "Hello World!" */
+										__( 'Edit %s' ),
+										title
+									) }
+									onClick={ () => {
+										clearSelectedBlock();
+										setIsEditingTemplate( false );
+									} }
+								>
+									{ title }
+								</Button>
+								<Button
+									{ ...toolbarItemHTMLProps }
+									className="edit-post-template-title"
+									isLink
+									icon={ chevronDown }
+									showTooltip
 									onClick={ onToggle }
-									aria-label={ __( 'Template Options' ) }
+									label={ __( 'Template Options' ) }
 								>
 									{ templateTitle }
 								</Button>

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -4,8 +4,35 @@
 	align-content: space-between;
 	width: 100%;
 	align-items: center;
-	.components-button.is-small {
-		height: $button-size-small;
+
+	.edit-post-template-title,
+	.edit-post-template-post-title {
+		padding: 0;
+		text-decoration: none;
+
+		&.has-icon {
+			svg {
+				order: 1;
+				margin-right: 0;
+			}
+		}
+	}
+
+	.edit-post-template-title {
+		color: $gray-900;
+	}
+
+	.edit-post-template-post-title {
+		margin-top: $grid-unit-05;
+		max-width: 160px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		display: block;
+
+		@include break-xlarge() {
+			max-width: none;
+		}
 	}
 }
 

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -9,6 +9,11 @@
 	.edit-post-template-post-title {
 		padding: 0;
 		text-decoration: none;
+		height: auto;
+
+		&::before {
+			height: 100%;
+		}
 
 		&.has-icon {
 			svg {
@@ -29,6 +34,11 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		display: block;
+
+		&::before {
+			left: 0;
+			right: 0;
+		}
 
 		@include break-xlarge() {
 			max-width: none;


### PR DESCRIPTION
Here's the current title area in the template editor:

<img width="1726" alt="Screenshot 2021-05-20 at 12 08 31" src="https://user-images.githubusercontent.com/846565/118968725-298e6c80-b964-11eb-8928-10145fe79800.png">

Aside from the styling issues, the "About" title is hard coded. It seems this was an oversight in https://github.com/WordPress/gutenberg/pull/31678.

This PR updates that "About" text to highlight the referring post title, and serve as an escape hatch back to the post editor. It also adds tooltips to each link, and icons to help clarify which is which in situations where a post may have a similarly named template.

Here's the after:


https://user-images.githubusercontent.com/846565/118969045-868a2280-b964-11eb-902e-3544efda8da0.mp4

