### PR TITLE
Code Quality: Rename `construct_wp_query_args` to `build_query_vars_from_query_block`

### DIFF
--- a/lib/compat/wordpress-5.8.php
+++ b/lib/compat/wordpress-5.8.php
@@ -7,7 +7,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'construct_wp_query_args' ) ) {
+if ( ! function_exists( 'build_query_vars_from_query_block' ) ) {
 	/**
 	 * Helper function that constructs a WP_Query args array from
 	 * a `Query` block properties.
@@ -19,7 +19,7 @@ if ( ! function_exists( 'construct_wp_query_args' ) ) {
 	 *
 	 * @return array Returns the constructed WP_Query arguments.
 	 */
-	function construct_wp_query_args( $block, $page ) {
+	function build_query_vars_from_query_block( $block, $page ) {
 		$query = array(
 			'post_type'    => 'post',
 			'order'        => 'DESC',

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -18,7 +18,7 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
 
-	$query_args = construct_wp_query_args( $block, $page );
+	$query_args = build_query_vars_from_query_block( $block, $page );
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -39,7 +39,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$content = get_next_posts_link( $label, $max_page );
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query = new WP_Query( construct_wp_query_args( $block, $page ) );
+		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		if ( (int) $custom_query->max_num_pages !== $page ) {
 			$content = sprintf(
 				'<a href="%1$s" %2$s>%3$s</a>',

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -32,7 +32,7 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 		);
 		$content       = paginate_links( $paginate_args );
 	} else {
-		$block_query = new WP_Query( construct_wp_query_args( $block, $page ) );
+		$block_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		// `paginate_links` works with the global $wp_query, so we have to
 		// temporarily switch it with our custom query.
 		$prev_wp_query = $wp_query;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

A simple rename refactoring to give a function a less generic name. It still needs to be backported to WordPress core.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Ensure all tests pass and Query blocks work as before.