### PR TITLE
Navigation Editor: Fix failing e2e tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -553,17 +553,17 @@ describe( 'Navigation editor', () => {
 			}
 		}
 
-		it.skip( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
-			assertIsDirty( false );
+		it( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
+			await assertIsDirty( false );
 		} );
 
-		it.skip( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
+		it( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
 			await page.type(
 				'.edit-navigation-name-editor__text-control input',
 				' Menu'
 			);
 
-			assertIsDirty( true );
+			await assertIsDirty( true );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -3,6 +3,7 @@
  */
 import {
 	createJSONResponse,
+	pressKeyTimes,
 	pressKeyWithModifier,
 	setUpResponseMocking,
 	visitAdminPage,
@@ -384,10 +385,9 @@ describe( 'Navigation editor', () => {
 
 	describe( 'Menu name editor', () => {
 		const initialMenuName = 'Main Menu';
-		const navigationNameEditorSelector =
-			'.edit-navigation-name-editor__text-control';
-		const inputSelector = `${ navigationNameEditorSelector } input`;
-		let navigatorNameEditor, input;
+		const nameEditorSelector = '.edit-navigation-name-editor__text-control';
+		const inputSelector = `${ nameEditorSelector } input`;
+
 		beforeEach( async () => {
 			const menuPostResponse = {
 				id: 4,
@@ -408,8 +408,8 @@ describe( 'Navigation editor', () => {
 
 			await visitNavigationEditor();
 
-			navigatorNameEditor = await page.$( navigationNameEditorSelector );
-			input = await page.$( inputSelector );
+			// Wait for the navigation setting sidebar.
+			await page.waitForSelector( '.edit-navigation-sidebar' );
 		} );
 
 		afterEach( async () => {
@@ -417,10 +417,11 @@ describe( 'Navigation editor', () => {
 		} );
 
 		it( 'is displayed in inspector additions', async () => {
-			expect( navigatorNameEditor ).toBeDefined();
+			const nameControl = await page.$( nameEditorSelector );
+			expect( nameControl ).toBeDefined();
 		} );
 
-		it.skip( 'saves menu name upon clicking save button', async () => {
+		it( 'saves menu name upon clicking save button', async () => {
 			const newName = 'newName';
 			const menuPostResponse = {
 				id: 4,
@@ -439,17 +440,10 @@ describe( 'Navigation editor', () => {
 				...getMenuItemMocks( { GET: [] } ),
 			] );
 
-			await input.focus();
-
-			// clear input
-			const oldName = await page.$eval(
-				inputSelector,
-				( el ) => el.value
-			);
-			for ( let i = 0; i < oldName.length; i++ ) {
-				await page.keyboard.press( 'Backspace' );
-			}
-			await input.type( newName );
+			// Ensure there is focus.
+			await page.focus( inputSelector );
+			await pressKeyTimes( 'Backspace', initialMenuName.length );
+			await page.keyboard.type( newName );
 
 			const saveButton = await page.$(
 				'.edit-navigation-toolbar__save-button'
@@ -483,14 +477,11 @@ describe( 'Navigation editor', () => {
 				} ),
 				...getMenuItemMocks( { GET: [] } ),
 			] );
-			await input.focus();
-			const oldName = await page.$eval(
-				inputSelector,
-				( el ) => el.value
-			);
-			for ( let i = 0; i < oldName.length; i++ ) {
-				await page.keyboard.press( 'Backspace' );
-			}
+
+			// Ensure there is focus.
+			await page.focus( inputSelector );
+			await pressKeyTimes( 'Backspace', initialMenuName.length );
+
 			const saveButton = await page.$(
 				'.edit-navigation-toolbar__save-button'
 			);
@@ -503,7 +494,9 @@ describe( 'Navigation editor', () => {
 			const headerSubtitleText = await headerSubtitle.evaluate(
 				( element ) => element.innerText
 			);
-			expect( headerSubtitleText ).toBe( `Editing: ${ oldName }` );
+			expect( headerSubtitleText ).toBe(
+				`Editing: ${ initialMenuName }`
+			);
 		} );
 	} );
 


### PR DESCRIPTION
## Description
I did minor refactoring and tracked down issues with the "name editing" e2e tests.

Tests were failing primarily in two scenarios:
1. Failed focus on name input.
2. Save button stayed disabled after the change.

I can't 100% point my finger on the cause of the last one, but I think it's an issue with response mocking. I could only reproduce this when running tests in headless mode or with only the `--puppeteer-devtools` flag.

Fixes #32033.

## How has this been tested?
1. Make sure the `wp-env` package is up to date.
2. Run `npm run test-e2e -- packages/e2e-tests/specs/experiments/navigation-editor.test.js` few times.
3. Confirm that e2e tests for navigation aren't failing.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
