### PR TITLE
Compose: useMergeRefs: add test for disabling refs + better docs

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -305,13 +305,42 @@ _Returns_
 
 <a name="useMergeRefs" href="#useMergeRefs">#</a> **useMergeRefs**
 
-Merges refs into one ref callback. Ensures the merged ref callbacks are only
-called when it changes (as a result of a `useCallback` dependency update) or
-when the ref value changes. If you don't wish a ref callback to be called on
-every render, wrap it with `useCallback( ref, [] )`.
-Dependencies can be added, but when a dependency changes, the old ref
-callback will be called with `null` and the new ref callback will be called
-with the same node.
+Merges refs into one ref callback.
+
+It also ensures that the merged ref callbacks are only called when they
+change (as a result of a `useCallback` dependency update) OR when the ref
+value changes, just as React does when passing a single ref callback to the
+component.
+
+As expected, if you pass a new function on every render, the ref callback
+will be called after every render.
+
+If you don't wish a ref callback to be called after every render, wrap it
+with `useCallback( callback, dependencies )`. When a dependency changes, the
+old ref callback will be called with `null` and the new ref callback will be
+called with the same value.
+
+To make ref callbacks easier to use, you can also pass the result of
+`useRefEffect`, which makes cleanup easier by allowing you to return a
+cleanup function instead of handling `null`.
+
+It's also possible to _disable_ a ref (and its behaviour) by simply not
+passing the ref.
+
+```jsx
+const ref = useRefEffect( ( node ) => {
+  node.addEventListener( ... );
+  return () => {
+    node.removeEventListener( ... );
+  };
+}, [ ...dependencies ] );
+const otherRef = useRef();
+const mergedRefs useMergeRefs( [
+  enabled && ref,
+  otherRef,
+] );
+return <div ref={ mergedRefs } />;
+```
 
 _Parameters_
 

--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -15,13 +15,42 @@ function assignRef( ref, value ) {
 }
 
 /**
- * Merges refs into one ref callback. Ensures the merged ref callbacks are only
- * called when it changes (as a result of a `useCallback` dependency update) or
- * when the ref value changes. If you don't wish a ref callback to be called on
- * every render, wrap it with `useCallback( ref, [] )`.
- * Dependencies can be added, but when a dependency changes, the old ref
- * callback will be called with `null` and the new ref callback will be called
- * with the same node.
+ * Merges refs into one ref callback.
+ *
+ * It also ensures that the merged ref callbacks are only called when they
+ * change (as a result of a `useCallback` dependency update) OR when the ref
+ * value changes, just as React does when passing a single ref callback to the
+ * component.
+ *
+ * As expected, if you pass a new function on every render, the ref callback
+ * will be called after every render.
+ *
+ * If you don't wish a ref callback to be called after every render, wrap it
+ * with `useCallback( callback, dependencies )`. When a dependency changes, the
+ * old ref callback will be called with `null` and the new ref callback will be
+ * called with the same value.
+ *
+ * To make ref callbacks easier to use, you can also pass the result of
+ * `useRefEffect`, which makes cleanup easier by allowing you to return a
+ * cleanup function instead of handling `null`.
+ *
+ * It's also possible to _disable_ a ref (and its behaviour) by simply not
+ * passing the ref.
+ *
+ * ```jsx
+ * const ref = useRefEffect( ( node ) => {
+ *   node.addEventListener( ... );
+ *   return () => {
+ *     node.removeEventListener( ... );
+ *   };
+ * }, [ ...dependencies ] );
+ * const otherRef = useRef();
+ * const mergedRefs useMergeRefs( [
+ *   enabled && ref,
+ *   otherRef,
+ * ] );
+ * return <div ref={ mergedRefs } />;
+ * ```
  *
  * @param {Array<RefObject|RefCallback>} refs The refs to be merged.
  *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Adds a test for disabling refs through `useMergeRefs`. This didn't work until #31714 because it would throw an error `TypeError: previousRef is not a function`, which is why I'm adding a test now to avoid regressing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
