### PR TITLE
Popover: remove unused `content` property from types definitions

### DIFF
--- a/packages/components/src/ui/popover/types.ts
+++ b/packages/components/src/ui/popover/types.ts
@@ -4,7 +4,7 @@
 // eslint-disable-next-line no-restricted-imports
 import type { PopoverStateReturn } from 'reakit';
 // eslint-disable-next-line no-restricted-imports
-import type { CSSProperties, FunctionComponentElement, ReactNode } from 'react';
+import type { CSSProperties, FunctionComponentElement } from 'react';
 
 /**
  * Internal dependencies
@@ -35,10 +35,6 @@ export type Props = PopperProps & {
 	 * @see https://reakit.io/docs/popover/#usepopoverstate
 	 */
 	baseId?: string;
-	/**
-	 * Content to render within the `Popover` floating label.
-	 */
-	content?: ReactNode;
 	/**
 	 * Renders `Elevation` styles for the `Popover`.
 	 *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Remove the `content` prop from the `<Popover />` component (the _g2_ version), since it doesn't seem to be used anywhere (and was not documented anyway).

I tried to look in the `g2` repo's history, but I couldn't find any usages.

## Testing instructions
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [ ] The `@wordpress/components` package builds correctly and all unit tests pass
- [ ] THe storybook example works as expected

## Screenshots <!-- if applicable -->

N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Refactor (dead code removal)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- N/A I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
