### PR TITLE
Rich text (core): onFocus method can be replaced with HTMLElement.focus

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -224,7 +224,7 @@ function RichTextWrapper(
 		);
 	}
 
-	const { value, onChange, onFocus, ref: richTextRef } = useRichText( {
+	const { value, onChange, ref: richTextRef } = useRichText( {
 		value: adjustedValue,
 		onChange( html, { __unstableFormats, __unstableText } ) {
 			adjustedOnChange( html );
@@ -295,6 +295,10 @@ function RichTextWrapper(
 
 			event.preventDefault();
 		}
+	}
+
+	function onFocus() {
+		anchorRef.current.focus();
 	}
 
 	const TagName = tagName;

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -178,11 +178,6 @@ export function useRichText( {
 		hadSelectionUpdate.current = false;
 	}, [ hadSelectionUpdate.current ] );
 
-	function focus() {
-		ref.current.focus();
-		applyRecord( record.current );
-	}
-
 	const mergedRefs = useMergeRefs( [
 		ref,
 		useDefaultStyle(),
@@ -218,7 +213,6 @@ export function useRichText( {
 	return {
 		value: record.current,
 		onChange: handleChange,
-		onFocus: focus,
 		ref: mergedRefs,
 	};
 }

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -120,6 +120,7 @@ export function useRichText( {
 	 * @param {Object} newRecord The record to sync and apply.
 	 */
 	function handleChange( newRecord ) {
+		record.current = newRecord;
 		applyRecord( newRecord );
 
 		if ( disableFormats ) {
@@ -136,8 +137,6 @@ export function useRichText( {
 				preserveWhiteSpace,
 			} );
 		}
-
-		record.current = newRecord;
 
 		const { start, end, formats, text } = newRecord;
 

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -224,7 +224,12 @@ export function useInputAndSelection( props ) {
 		}
 
 		function onFocus() {
-			const { record, isSelected, onSelectionChange } = propsRef.current;
+			const {
+				record,
+				isSelected,
+				onSelectionChange,
+				applyRecord,
+			} = propsRef.current;
 
 			if ( ! isSelected ) {
 				// We know for certain that on focus, the old selection is invalid.
@@ -241,6 +246,7 @@ export function useInputAndSelection( props ) {
 				onSelectionChange( index, index );
 			} else {
 				onSelectionChange( record.current.start, record.current.end );
+				applyRecord( record.current );
 			}
 
 			// Update selection as soon as possible, which is at the next animation

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -245,8 +245,8 @@ export function useInputAndSelection( props ) {
 				};
 				onSelectionChange( index, index );
 			} else {
-				onSelectionChange( record.current.start, record.current.end );
 				applyRecord( record.current );
+				onSelectionChange( record.current.start, record.current.end );
 			}
 
 			// Update selection as soon as possible, which is at the next animation


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The core rich text API (not exposed right now) can be simplified by removing `onFocus` in favour for the simpler `HTMLElement.focus()` DOM API.

Reapplying selection to the DOM is now built-in. Previously focus would be lost after setting focus directly through `HTMLElement.focus()`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
