### PR TITLE
Templates: Remove now-obsolete `gutenberg_get_template_paths()`

### DIFF
--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -6,25 +6,6 @@
  */
 
 /**
- * Returns all block template file path of the current theme and its parent theme.
- * Includes demo block template files if demo experiment is enabled.
- *
- * @return array $block_template_files A list of paths to all template files.
- */
-function gutenberg_get_template_paths() {
-	$block_template_files = glob( get_stylesheet_directory() . '/block-templates/*.html' );
-	$block_template_files = is_array( $block_template_files ) ? $block_template_files : array();
-
-	if ( is_child_theme() ) {
-		$child_block_template_files = glob( get_template_directory() . '/block-templates/*.html' );
-		$child_block_template_files = is_array( $child_block_template_files ) ? $child_block_template_files : array();
-		$block_template_files       = array_merge( $block_template_files, $child_block_template_files );
-	}
-
-	return $block_template_files;
-}
-
-/**
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {


### PR DESCRIPTION
## Description
Discovered while working on https://github.com/WordPress/wordpress-develop/pull/1267.

First introduced in `lib/template-loader.php` in https://github.com/WordPress/gutenberg/pull/25739.
No longer used per #26650 (where its callsites started using [`_gutenberg_get_template_paths`](https://github.com/WordPress/gutenberg/pull/26650/files#diff-f5b03c388f81fea69d0ababd289047e20deaad43084ad6e00ec14a5613e25136R60) in `lib/templates-sync.php` -- now in [`lib/full-site-editing/block-templates.php`](https://github.com/WordPress/gutenberg/blob/d7714aa8adf19277da1f0ea83b20be1cf234e50c/lib/full-site-editing/block-templates.php#L17)).

## How has this been tested?
Verify that FSE still works as before.