### PR TITLE
Mobile - fix default inserter for tablet

### DIFF
--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -73,7 +73,7 @@ export class BlockListItem extends Component {
 		) {
 			const isScreenWidthEqual = parentWidth === screenWidth;
 			if ( isScreenWidthEqual || isWider( screenWidth, 'mobile' ) ) {
-				return marginHorizontal * 2;
+				return marginHorizontal;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -193,7 +193,7 @@ class BlockListBlock extends Component {
 			attributes,
 			order + 1
 		);
-		const { isFullWidth, isWider, isContainerRelated } = alignmentHelpers;
+		const { isFullWidth, isContainerRelated } = alignmentHelpers;
 		const accessible = ! ( isSelected || isInnerBlockSelected );
 		const screenWidth = Math.floor( Dimensions.get( 'window' ).width );
 		const isScreenWidthEqual = blockWidth === screenWidth;
@@ -257,13 +257,7 @@ class BlockListBlock extends Component {
 							/>
 						) }
 						<View
-							style={ [
-								styles.neutralToolbar,
-								! isFullWidthToolbar &&
-									isContainerRelated( name ) &&
-									isWider( screenWidth, 'mobile' ) &&
-									styles.containerToolbar,
-							] }
+							style={ styles.neutralToolbar }
 							ref={ this.anchorNodeRef }
 						>
 							{ isSelected && (

--- a/packages/block-editor/src/components/block-list/block.native.scss
+++ b/packages/block-editor/src/components/block-list/block.native.scss
@@ -56,11 +56,6 @@
 	margin-right: -$block-edge-to-content;
 }
 
-.containerToolbar {
-	width: 100%;
-	align-self: center;
-}
-
 .solidBorder {
 	position: absolute;
 	top: -$solid-border-space;

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -70,6 +70,7 @@
 
 .defaultAppender {
 	margin: $block-edge-to-content;
+	width: 100%;
 }
 
 .innerAppender {

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -58,6 +58,8 @@
 
 .containerStyleAddHere {
 	flex-direction: row;
+	padding-left: 12px;
+	padding-right: 12px;
 }
 
 .blockListFooter {

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -69,7 +69,8 @@
 }
 
 .defaultAppender {
-	margin: $block-edge-to-content;
+	margin-top: $block-edge-to-content;
+	margin-bottom: $block-edge-to-content;
 	width: 100%;
 }
 

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -17,6 +17,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  * Internal dependencies
  */
 import BlockInsertionPoint from '../block-list/insertion-point';
+import styles from './style.scss';
 import { store as blockEditorStore } from '../../store';
 
 export function DefaultBlockAppender( {
@@ -39,7 +40,10 @@ export function DefaultBlockAppender( {
 	return (
 		<TouchableWithoutFeedback onPress={ onAppend }>
 			<View
-				style={ [ showSeparator && containerStyle ] }
+				style={ [
+					styles.blockHolder,
+					showSeparator && containerStyle,
+				] }
 				pointerEvents="box-only"
 			>
 				{ showSeparator ? (

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -17,7 +17,6 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  * Internal dependencies
  */
 import BlockInsertionPoint from '../block-list/insertion-point';
-import styles from './style.scss';
 import { store as blockEditorStore } from '../../store';
 
 export function DefaultBlockAppender( {
@@ -40,10 +39,7 @@ export function DefaultBlockAppender( {
 	return (
 		<TouchableWithoutFeedback onPress={ onAppend }>
 			<View
-				style={ [
-					styles.blockHolder,
-					showSeparator && containerStyle,
-				] }
+				style={ [ showSeparator && containerStyle ] }
 				pointerEvents="box-only"
 			>
 				{ showSeparator ? (

--- a/packages/block-editor/src/components/default-block-appender/style.native.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.native.scss
@@ -2,6 +2,8 @@
 
 .blockHolder {
 	flex: 1 1 auto;
+	padding-left: 16;
+	padding-right: 16;
 }
 
 .blockContainer {

--- a/packages/block-editor/src/components/default-block-appender/style.native.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.native.scss
@@ -1,5 +1,10 @@
 // @format
 
+.blockHolder {
+	padding-left: 16;
+	padding-right: 16;
+}
+
 .blockContainer {
 	padding-top: 0;
 	padding-left: 16px;

--- a/packages/block-editor/src/components/default-block-appender/style.native.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.native.scss
@@ -1,8 +1,8 @@
 // @format
 
 .blockHolder {
-	padding-left: 16;
-	padding-right: 16;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 
 .blockContainer {

--- a/packages/block-editor/src/components/default-block-appender/style.native.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.native.scss
@@ -1,11 +1,5 @@
 // @format
 
-.blockHolder {
-	flex: 1 1 auto;
-	padding-left: 16;
-	padding-right: 16;
-}
-
 .blockContainer {
 	padding-top: 0;
 	padding-left: 16px;

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -113,18 +113,18 @@ function ColumnEdit( {
 
 	const renderAppender = useCallback( () => {
 		const { width: columnWidth } = contentStyle[ clientId ];
-		const isScreenWidthEqual = columnWidth === screenWidth; // full width??
+		const isFullWidth = columnWidth === screenWidth;
 
 		if ( isSelected ) {
 			return (
 				<View
 					style={ [
 						styles.columnAppender,
-						isScreenWidthEqual && styles.fullwidthColumnAppender,
-						isScreenWidthEqual &&
+						isFullWidth && styles.fullwidthColumnAppender,
+						isFullWidth &&
 							hasChildren &&
 							styles.fullwidthHasInnerColumnAppender,
-						! isScreenWidthEqual &&
+						! isFullWidth &&
 							hasChildren &&
 							styles.hasInnerColumnAppender,
 					] }

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -22,7 +22,6 @@ import {
 	FooterMessageControl,
 	UnitControl,
 	getValueAndUnit,
-	alignmentHelpers,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -36,8 +35,6 @@ import {
 	getWidthWithUnit,
 	isPercentageUnit,
 } from '../columns/utils';
-
-const { isWider } = alignmentHelpers;
 
 function ColumnEdit( {
 	attributes,
@@ -116,18 +113,21 @@ function ColumnEdit( {
 
 	const renderAppender = useCallback( () => {
 		const { width: columnWidth } = contentStyle[ clientId ];
-		const isScreenWidthEqual = columnWidth === screenWidth;
+		const isScreenWidthEqual = columnWidth === screenWidth; // full width??
 
 		if ( isSelected ) {
 			return (
 				<View
-					style={
-						( isWider( screenWidth, 'mobile' ) ||
-							isScreenWidthEqual ) &&
-						( hasChildren
-							? styles.columnAppender
-							: styles.wideColumnAppender )
-					}
+					style={ [
+						styles.columnAppender,
+						isScreenWidthEqual && styles.fullwidthColumnAppender,
+						isScreenWidthEqual &&
+							hasChildren &&
+							styles.fullwidthHasInnerColumnAppender,
+						! isScreenWidthEqual &&
+							hasChildren &&
+							styles.hasInnerColumnAppender,
+					] }
 				>
 					<InnerBlocks.ButtonBlockAppender />
 				</View>

--- a/packages/block-library/src/column/editor.native.scss
+++ b/packages/block-library/src/column/editor.native.scss
@@ -59,8 +59,20 @@
 }
 
 .columnAppender {
-	margin-left: $grid-unit-20;
-	margin-right: $grid-unit-20;
+	margin-left: $grid-unit-10;
+	margin-right: $grid-unit-10;
+}
+.fullwidthColumnAppender {
+	margin-left: $grid-unit * 2.5;
+	margin-right: $grid-unit * 2.5;
+}
+.fullwidthHasInnerColumnAppender {
+	margin-left: $grid-unit-15;
+	margin-right: $grid-unit-15;
+}
+.hasInnerColumnAppender {
+	margin-left: 0;
+	margin-right: 0;
 }
 
 .wideColumnAppender {

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -85,7 +85,7 @@ const DEFAULT_COLUMNS_NUM = 2;
  */
 const MIN_COLUMNS_NUM = 1;
 
-const { isWider, isFullWidth } = alignmentHelpers;
+const { isFullWidth } = alignmentHelpers;
 
 function ColumnsEditContainer( {
 	attributes,
@@ -132,16 +132,9 @@ function ColumnsEditContainer( {
 	}, [ width, columnCount ] );
 
 	const renderAppender = () => {
-		const isEqualWidth = width === screenWidth;
-
 		if ( isSelected ) {
 			return (
-				<View
-					style={
-						( isWider( screenWidth, 'mobile' ) || isEqualWidth ) &&
-						styles.columnAppender
-					}
-				>
+				<View style={ isFullWidth( align ) && styles.columnAppender }>
 					<InnerBlocks.ButtonBlockAppender
 						onAddBlock={ onAddBlock }
 					/>

--- a/packages/block-library/src/columns/editor.native.scss
+++ b/packages/block-library/src/columns/editor.native.scss
@@ -12,6 +12,6 @@
 }
 
 .columnAppender {
-	margin-left: $grid-unit-20;
-	margin-right: $grid-unit-20;
+	margin-left: $grid-unit-15;
+	margin-right: $grid-unit-15;
 }

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -49,7 +49,7 @@ function GroupEdit( {
 						styles.fullwidthGroupAppender,
 					isFullWidth( align ) &&
 						hasInnerBlocks &&
-						styles.fullwidthMobileGroupAppender,
+						styles.fullwidthHasInnerGroupAppender,
 				] }
 			>
 				<InnerBlocks.ButtonBlockAppender />

--- a/packages/block-library/src/group/edit.native.js
+++ b/packages/block-library/src/group/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Dimensions } from 'react-native';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -24,7 +24,7 @@ import { alignmentHelpers } from '@wordpress/components';
  */
 import styles from './editor.scss';
 
-const { isWider, isFullWidth } = alignmentHelpers;
+const { isFullWidth } = alignmentHelpers;
 
 function GroupEdit( {
 	attributes,
@@ -38,25 +38,24 @@ function GroupEdit( {
 	const { align } = attributes;
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const { width } = sizes || { width: 0 };
-	const screenWidth = Math.floor( Dimensions.get( 'window' ).width );
-	const isEqualWidth = width === screenWidth;
 
 	const renderAppender = useCallback(
 		() => (
 			<View
-				style={
-					( isWider( screenWidth, 'mobile' ) ||
-						isEqualWidth ||
-						isFullWidth( align ) ) &&
-					( hasInnerBlocks
-						? styles.groupAppender
-						: styles.wideGroupAppender )
-				}
+				style={ [
+					! hasInnerBlocks && styles.groupAppender,
+					isFullWidth( align ) &&
+						! hasInnerBlocks &&
+						styles.fullwidthGroupAppender,
+					isFullWidth( align ) &&
+						hasInnerBlocks &&
+						styles.fullwidthMobileGroupAppender,
+				] }
 			>
 				<InnerBlocks.ButtonBlockAppender />
 			</View>
 		),
-		[ align, hasInnerBlocks, width ]
+		[ align, hasInnerBlocks ]
 	);
 
 	if ( ! isSelected && ! hasInnerBlocks ) {

--- a/packages/block-library/src/group/editor.native.scss
+++ b/packages/block-library/src/group/editor.native.scss
@@ -42,7 +42,7 @@
 	margin-right: $grid-unit * 2.5;
 }
 
-.fullwidthMobileGroupAppender {
+.fullwidthHasInnerGroupAppender {
 	margin-left: $grid-unit-15;
 	margin-right: $grid-unit-15;
 }

--- a/packages/block-library/src/group/editor.native.scss
+++ b/packages/block-library/src/group/editor.native.scss
@@ -33,13 +33,18 @@
 }
 
 .groupAppender {
-	margin-left: $grid-unit-20;
-	margin-right: $grid-unit-20;
-}
-
-.wideGroupAppender {
 	margin-left: $grid-unit-10;
 	margin-right: $grid-unit-10;
+}
+
+.fullwidthGroupAppender {
+	margin-left: $grid-unit * 2.5;
+	margin-right: $grid-unit * 2.5;
+}
+
+.fullwidthMobileGroupAppender {
+	margin-left: $grid-unit-15;
+	margin-right: $grid-unit-15;
 }
 
 .hasBackgroundAppender {


### PR DESCRIPTION
Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3602

## Description
This PR fixes the alignment of the default inserter on tablets in the Native Editor.

It also fixes some spacing issues that we found while testing things on the tablet.

The spacing of the inserter button that is currently present on the Group, Column, and Columns blocks. 

In this PR we made sure that the spacing looks uniform and aligns to the dashed border and is consistent across the different devices, block alignments and if there are any differences if the block has children or not.

## Screenshots <!-- if applicable -->

<table width="450">
<tr>
<td>
Before:
</td>
<td>
After:
</td>
</tr>

<tr>
<td>

https://user-images.githubusercontent.com/115071/119045326-27320f80-b970-11eb-9a4a-70ed94296e4f.mov

</td>
<td>

https://user-images.githubusercontent.com/115071/119048636-5b0f3400-b974-11eb-9544-f256a3ab2bc7.mov

</td>
</tr>

<tr>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441869-6c2dde00-c93f-11eb-8ed0-b6002335ce2d.png" />


</td>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441913-79e36380-c93f-11eb-8f2e-ee7caa6e3fbf.png" />
</td>
</tr>

<tr>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441784-4accf200-c93f-11eb-91de-f35e0e7e1721.png" />
</td>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441766-41dc2080-c93f-11eb-9c8a-3ec67563df58.png" />
</td>
</tr>

<tr>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441656-10fbeb80-c93f-11eb-93d8-334c128cca57.png">

</td>
<td>
<Img width="400" src="https://user-images.githubusercontent.com/115071/121441670-16f1cc80-c93f-11eb-9d25-01e0e644d3c9.png">

</td>
</tr>
</table>

## How has this been tested?
On an iOS tablet simulator notice that the inserter doesn't move once you tap to start creating content. 

I also tested this on the iPhone and Pixel 4 simulators. To make sure that I don't introduce any regressions.

iPhone 11
<img src="https://user-images.githubusercontent.com/115071/119048691-695d5000-b974-11eb-9acd-896f09ebfc58.png" width="200" />

Pixel 4
<img width="200" alt="Screen Shot 2021-05-20 at 2 06 07 PM" src="https://user-images.githubusercontent.com/115071/119048762-86921e80-b974-11eb-8967-7d9ae77f6f45.png">

## Types of changes
Fixes display issue. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
