### PR TITLE
Fix image width for wide aligned Post featured image

### DIFF
--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -8,4 +8,9 @@
 		max-width: 100%;
 		height: auto;
 	}
+
+	&.alignwide img,
+	&.alignfull img {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Description
The Post Featured Image block relies on figure > img to display the image. The block supports wide and full alignment.

This PR adds some CSS to ensure the image spans the entire width of the container when alignment is set on the block. This is similar to what's done for the image block: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/image/style.scss#L16-L19

(This is a duplicate of #31940 which I couldn't get to pass checks during yesterday's Github outage / backlog)

## How has this been tested?
Using emptytheme, add a featured image block, set its alignment to full or wide.

## Screenshots <!-- if applicable -->
Before | After
------ | -------
<img width="1904" alt="Screen Shot 2021-05-18 at 10 55 24 AM" src="https://user-images.githubusercontent.com/5375500/118674243-7f211880-b7ae-11eb-9609-6789e43b611c.png"> | <img width="1904" alt="Screen Shot 2021-05-18 at 10 55 17 AM" src="https://user-images.githubusercontent.com/5375500/118674260-81837280-b7ae-11eb-9a37-a501bb49d534.png">

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
