### PR TITLE
Template Mode: Don't display snackbar with the Welcome Guide

### DIFF
--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -35,6 +35,8 @@ const disableTemplateWelcomeGuide = async () => {
 };
 
 const switchToTemplateMode = async () => {
+	await disableTemplateWelcomeGuide();
+
 	// Switch to template mode.
 	await openDocumentSettingsSidebar();
 	await openSidebarPanelWithTitle( 'Template' );
@@ -52,11 +54,11 @@ const switchToTemplateMode = async () => {
 		( el ) => el.innerText
 	);
 	expect( title ).toContain( 'About\n' );
-
-	await disableTemplateWelcomeGuide();
 };
 
 const createNewTemplate = async ( templateName ) => {
+	await disableTemplateWelcomeGuide();
+
 	// Create a new custom template.
 	await openDocumentSettingsSidebar();
 	await openSidebarPanelWithTitle( 'Template' );
@@ -76,8 +78,6 @@ const createNewTemplate = async ( templateName ) => {
 	await page.waitForXPath(
 		'//*[contains(@class, "components-snackbar")]/*[text()="Custom template created. You\'re in template mode now."]'
 	);
-
-	await disableTemplateWelcomeGuide();
 };
 
 describe( 'Post Editor Template mode', () => {

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -488,12 +488,20 @@ export function* __unstableSwitchToTemplateMode( template ) {
 
 	yield setIsEditingTemplate( true );
 
-	const message = !! template
-		? __( "Custom template created. You're in template mode now." )
-		: __(
-				'Editing template. Changes made here affect all posts and pages that use the template.'
-		  );
-	yield controls.dispatch( noticesStore, 'createSuccessNotice', message, {
-		type: 'snackbar',
-	} );
+	const isWelcomeGuideActive = yield controls.select(
+		'core/edit-post',
+		'isFeatureActive',
+		'welcomeGuideTemplate'
+	);
+
+	if ( ! isWelcomeGuideActive ) {
+		const message = !! template
+			? __( "Custom template created. You're in template mode now." )
+			: __(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+			  );
+		yield controls.dispatch( noticesStore, 'createSuccessNotice', message, {
+			type: 'snackbar',
+		} );
+	}
 }


### PR DESCRIPTION
## Description
Don't show template mode snackbar when the Welcome Guide is displayed. Based on feedback from FSE Outreach Program - https://github.com/WordPress/gutenberg/issues/29031#issuecomment-845616210.

## How has this been tested?
1. Create a new page/post.
2. Clear local storage e.g. by running `localStorage.clear()`.
3. Refresh the page.
4. Edit or add a new template.
5. Snackbar isn't displayed in the template mode, only the Welcome Guide.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
