### PR TITLE
Navigation Editor: Move modal state to ManageLocations component

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -69,9 +69,6 @@ export default function Layout( { blockEditorSettings } ) {
 		isMenuBeingDeleted,
 		selectMenu,
 		deleteMenu,
-		openManageLocationsModal,
-		closeManageLocationsModal,
-		isManageLocationsModalOpen,
 		isMenuSelected,
 	} = useNavigationEditor();
 
@@ -193,15 +190,6 @@ export default function Layout( { blockEditorSettings } ) {
 							onDeleteMenu={ deleteMenu }
 							isMenuBeingDeleted={ isMenuBeingDeleted }
 							hasPermanentSidebar={ hasPermanentSidebar }
-							isManageLocationsModalOpen={
-								isManageLocationsModalOpen
-							}
-							openManageLocationsModal={
-								openManageLocationsModal
-							}
-							closeManageLocationsModal={
-								closeManageLocationsModal
-							}
 						/>
 					</IsMenuNameControlFocusedContext.Provider>
 					<UnsavedChangesWarning />

--- a/packages/edit-navigation/src/components/sidebar/index.js
+++ b/packages/edit-navigation/src/components/sidebar/index.js
@@ -29,9 +29,6 @@ export default function Sidebar( {
 	isMenuBeingDeleted,
 	onDeleteMenu,
 	onSelectMenu,
-	isManageLocationsModalOpen,
-	closeManageLocationsModal,
-	openManageLocationsModal,
 	hasPermanentSidebar,
 } ) {
 	const { sidebar, hasBlockSelection, hasSidebarEnabled } = useSelect(
@@ -94,9 +91,6 @@ export default function Sidebar( {
 						menus={ menus }
 						selectedMenuId={ menuId }
 						onSelectMenu={ onSelectMenu }
-						isModalOpen={ isManageLocationsModalOpen }
-						closeModal={ closeManageLocationsModal }
-						openModal={ openManageLocationsModal }
 					/>
 					<DeleteMenu
 						onDeleteMenu={ onDeleteMenu }

--- a/packages/edit-navigation/src/components/sidebar/manage-locations.js
+++ b/packages/edit-navigation/src/components/sidebar/manage-locations.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import {
 	Button,
 	CheckboxControl,
@@ -17,18 +18,18 @@ import {
 import { useMenuLocations } from '../../hooks';
 
 export default function ManageLocations( {
-	onSelectMenu,
-	isModalOpen,
-	openModal,
-	closeModal,
 	menus,
 	selectedMenuId,
+	onSelectMenu,
 } ) {
 	const {
 		menuLocations,
 		assignMenuToLocation,
 		toggleMenuLocationAssignment,
 	} = useMenuLocations();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const openModal = () => setIsModalOpen( true );
+	const closeModal = () => setIsModalOpen( false );
 
 	if ( ! menuLocations || ! menus?.length ) {
 		return <Spinner />;

--- a/packages/edit-navigation/src/hooks/use-navigation-editor.js
+++ b/packages/edit-navigation/src/hooks/use-navigation-editor.js
@@ -24,14 +24,6 @@ const getMenusData = ( select ) => {
 	};
 };
 export default function useNavigationEditor() {
-	const [
-		isManageLocationsModalOpen,
-		setIsManageLocationsModalOpen,
-	] = useState( false );
-	const [ openManageLocationsModal, closeManageLocationsModal ] = [
-		true,
-		false,
-	].map( ( bool ) => () => setIsManageLocationsModalOpen( bool ) );
 	const { deleteMenu: _deleteMenu } = useDispatch( coreStore );
 	const [ selectedMenuId, setSelectedMenuId ] = useSelectedMenuId();
 	const [ hasFinishedInitialLoad, setHasFinishedInitialLoad ] = useState(
@@ -101,9 +93,6 @@ export default function useNavigationEditor() {
 		isMenuBeingDeleted,
 		selectMenu: setSelectedMenuId,
 		deleteMenu,
-		openManageLocationsModal,
-		closeManageLocationsModal,
-		isManageLocationsModalOpen,
 		isMenuSelected: !! selectedMenuId,
 	};
 }


### PR DESCRIPTION
## Description
Moves modal state from `useNavigationEditor ` to `ManageLocations` component and manage it locally.

Fixes #31837.

## How has this been tested?
1. Go to the new experimental Navigation screen.
2. Create or select a menu.
3. Open the Locations modal by clicking the "Manage locations" button in the sidebar.
4. Modal can be opened and closed without issues.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
