### PR TITLE
Block Support: Set border style none when border width zero

### DIFF
--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -25,20 +25,31 @@ const MIN_BORDER_WIDTH = 0;
  */
 export const BorderWidthEdit = ( props ) => {
 	const {
-		attributes: { style },
+		attributes: { borderColor, style },
 		setAttributes,
 	} = props;
 
-	const { width, style: borderStyle } = style?.border || {};
+	const { width, color: customBorderColor, style: borderStyle } =
+		style?.border || {};
 	const [ styleSelection, setStyleSelection ] = useState();
+	const [ colorSelection, setColorSelection ] = useState();
 
-	// Temporarily track previous border style selection to be able to restore
-	// it when border width changes from zero value.
+	// Temporarily track previous border color & style selections to be able to
+	// restore them when border width changes from zero value.
 	useEffect( () => {
 		if ( borderStyle !== 'none' ) {
 			setStyleSelection( borderStyle );
 		}
 	}, [ borderStyle ] );
+
+	useEffect( () => {
+		if ( borderColor || customBorderColor ) {
+			setColorSelection( {
+				name: !! borderColor ? borderColor : undefined,
+				color: !! customBorderColor ? customBorderColor : undefined,
+			} );
+		}
+	}, [ borderColor, customBorderColor ] );
 
 	const onChange = ( newWidth ) => {
 		let newStyle = {
@@ -49,12 +60,16 @@ export const BorderWidthEdit = ( props ) => {
 			},
 		};
 
+		// Used to clear named border color attribute.
+		let borderPaletteColor = borderColor;
+
 		const hasZeroWidth = parseFloat( newWidth ) === 0;
 
 		// Setting the border width explicitly to zero will also set the
-		// border style prop to `none`. This style will only be applied if
-		// border style support has also been opted into.
+		// border style to `none` and clear border color attributes.
 		if ( hasZeroWidth ) {
+			borderPaletteColor = undefined;
+			newStyle.border.color = undefined;
 			newStyle.border.style = 'none';
 		}
 
@@ -66,12 +81,22 @@ export const BorderWidthEdit = ( props ) => {
 			newStyle.border.style = styleSelection;
 		}
 
+		// Restore previous border color selection if width is no longer zero
+		// and current border color is undefined.
+		if ( ! hasZeroWidth && borderColor === undefined ) {
+			borderPaletteColor = colorSelection?.name;
+			newStyle.border.color = colorSelection?.color;
+		}
+
 		// If width was reset, clean out undefined styles.
 		if ( newWidth === undefined || newWidth === '' ) {
 			newStyle = cleanEmptyObject( newStyle );
 		}
 
-		setAttributes( { style: newStyle } );
+		setAttributes( {
+			borderColor: borderPaletteColor,
+			style: newStyle,
+		} );
 	};
 
 	const units = useCustomUnits( {

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -5,6 +5,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,6 +29,17 @@ export const BorderWidthEdit = ( props ) => {
 		setAttributes,
 	} = props;
 
+	const { width, style: borderStyle } = style?.border || {};
+	const [ styleSelection, setStyleSelection ] = useState();
+
+	// Temporarily track previous border style selection to be able to restore
+	// it when border width changes from zero value.
+	useEffect( () => {
+		if ( borderStyle !== 'none' ) {
+			setStyleSelection( borderStyle );
+		}
+	}, [ borderStyle ] );
+
 	const onChange = ( newWidth ) => {
 		let newStyle = {
 			...style,
@@ -37,6 +49,24 @@ export const BorderWidthEdit = ( props ) => {
 			},
 		};
 
+		const hasZeroWidth = parseFloat( newWidth ) === 0;
+
+		// Setting the border width explicitly to zero will also set the
+		// border style prop to `none`. This style will only be applied if
+		// border style support has also been opted into.
+		if ( hasZeroWidth ) {
+			newStyle.border.style = 'none';
+		}
+
+		// Restore previous border style selection if width is now not zero and
+		// border style was 'none'. This is to support changes to the UI which
+		// change the border style UI to a segmented control without a "none"
+		// option.
+		if ( ! hasZeroWidth && borderStyle === 'none' ) {
+			newStyle.border.style = styleSelection;
+		}
+
+		// If width was reset, clean out undefined styles.
 		if ( newWidth === undefined || newWidth === '' ) {
 			newStyle = cleanEmptyObject( newStyle );
 		}
@@ -50,7 +80,7 @@ export const BorderWidthEdit = ( props ) => {
 
 	return (
 		<UnitControl
-			value={ style?.border?.width }
+			value={ width }
 			label={ __( 'Width' ) }
 			min={ MIN_BORDER_WIDTH }
 			onChange={ onChange }


### PR DESCRIPTION
~Depends on: https://github.com/WordPress/gutenberg/pull/31483~
Related issues: https://github.com/WordPress/gutenberg/issues/31333, https://github.com/WordPress/gutenberg/issues/31337
Related PRs: https://github.com/WordPress/gutenberg/pull/31585

## Description

As part of [refining the border support provided UI](https://github.com/WordPress/gutenberg/pull/31585), the border style dropdown is being replaced with a segmented control that does not include a `none` option. The idea is that setting a border width of `0` should apply the `border-style: none` property.

This PR updates the border width block support to update the border style attribute to `none` when the width is `0`. It then also re-applies the previous style selection if possible when the width is changed to a non-zero number, including being reset to undefined.

## How has this been tested?

#### Test Setup

Turn on custom borders within your theme.json file.
```json
			"border": {
				"customColor": true,
				"customRadius": true,
				"customStyle": true,
				"customWidth": true
			}
```

#### Test Instructions

1. Create a new post, add a group block to it and select the group block
2. Expand the border controls panel and select the solid border style option
3. Adjust the border width to a non-zero value, the solid border style button should remain on. 
4. Set the border width to `0`. The border style buttons should all be deselected.
5. Adjust the border width to a non-zero value again and the solid border style button should be reselected.
6. Update the border width to `0` again, switch to the code editor view and confirm that the border style attribute is now set to `none` and the appropriate style is applied within the markup.
2. Switch back to the visual editor, .
3. Change the border style selection to "Dashed" or "Dotted" and repeat the process adjusting the width value.
4. Confirm the block displays correctly on the frontend after saving.

## Screenshots 

https://user-images.githubusercontent.com/60436221/125031829-78d55b80-e0d0-11eb-9506-03f72a92a932.mp4


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
