### PR TITLE
Navigation: Fix collapsing regression.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -330,17 +330,15 @@
 		display: none;
 	}
 
-	@include break-small() {
-		// Horizontal layout
-		display: flex;
-		flex-wrap: wrap;
+	// Horizontal layout
+	display: flex;
+	flex-wrap: wrap;
 
-		// Vertical layout
-		.is-vertical & {
-			display: block;
-			flex-direction: column;
-			align-items: flex-start;
-		}
+	// Vertical layout
+	.is-vertical & {
+		display: block;
+		flex-direction: column;
+		align-items: flex-start;
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #31942.

The horizontal navigation menu currently stacks vertically on mobile (<600px). It doesn't need to, and the fact that it does I think was an oversight. This PR fixes it:

<img width="373" alt="Screenshot 2021-05-21 at 09 10 44" src="https://user-images.githubusercontent.com/1204802/119097110-a6791f00-ba14-11eb-9b65-815cdc2210aa.png">

## How has this been tested?

Insert a horizontal navigation block with some custom menu items. (Page list doesn't wrap, so it won't work)

Verify that in the editor and on the frontend, it shows up as a horizontal list.

Bonus points for testing the navigation screen and veryfing everything is as before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
