### PR TITLE
[Patterns]: Prepare GB bundled patterns for core back port

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -10,12 +10,12 @@
  */
 function register_gutenberg_patterns() {
 	// Register categories used for block patterns.
-	register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
+	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'query' ) ) {
+		register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
+	}
 
-	// Initial Query block patterns.
-	register_block_pattern(
-		'query/standard-posts',
-		array(
+	$patterns = array(
+		'query/standard-posts'                 => array(
 			'title'      => __( 'Standard', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -32,12 +32,8 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query-loop -->
 							</div>
 							<!-- /wp:query -->',
-		)
-	);
-
-	register_block_pattern(
-		'query/medium-posts',
-		array(
+		),
+		'query/medium-posts'                   => array(
 			'title'      => __( 'Image at left', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -56,12 +52,8 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query-loop -->
 							</div>
 							<!-- /wp:query -->',
-		)
-	);
-
-	register_block_pattern(
-		'query/small-posts',
-		array(
+		),
+		'query/small-posts'                    => array(
 			'title'      => __( 'Small image and title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -79,12 +71,8 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query-loop -->
 							</div>
 							<!-- /wp:query -->',
-		)
-	);
-
-	register_block_pattern(
-		'query/grid-posts',
-		array(
+		),
+		'query/grid-posts'                     => array(
 			'title'      => __( 'Grid', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -99,12 +87,8 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query-loop -->
 							</div>
 							<!-- /wp:query -->',
-		)
-	);
-
-	register_block_pattern(
-		'query/large-title-posts',
-		array(
+		),
+		'query/large-title-posts'              => array(
 			'title'      => __( 'Large title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -127,13 +111,9 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query-loop --></div>
 							<!-- /wp:query --></div>
 							<!-- /wp:group -->',
-		)
-	);
-
-	register_block_pattern(
-		'query/offset-posts',
-		array(
-			'title'      => __( 'Offset', 'gutenberg' ),
+		),
+		'query/offset-posts'                   => array(
+			'title'      => __( 'Offsetss', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
@@ -164,13 +144,9 @@ function register_gutenberg_patterns() {
 							<!-- /wp:column --></div>
 							<!-- /wp:columns --></main>
 							<!-- /wp:group -->',
-		)
-	);
-
-	// Initial block pattern to be used with block transformations with patterns.
-	register_block_pattern(
-		'social-links/shared-background-color',
-		array(
+		),
+		// Initial block pattern to be used with block transformations with patterns.
+		'social-links/shared-background-color' => array(
 			'title'         => __( 'Social links with a shared background color', 'gutenberg' ),
 			'categories'    => array( 'buttons' ),
 			'blockTypes'    => array( 'core/social-links' ),
@@ -180,8 +156,15 @@ function register_gutenberg_patterns() {
 								<!-- wp:social-link {"url":"#","service":"chain"} /-->
 								<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>
 								<!-- /wp:social-links -->',
-		)
+		),
 	);
+
+	foreach ( $patterns as $name => $pattern ) {
+		$pattern_name = 'core/' . $name;
+		if ( ! WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_name ) ) {
+			register_block_pattern( $pattern_name, $pattern );
+		}
+	}
 }
 
 /**

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -113,7 +113,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:group -->',
 		),
 		'query-offset-posts'                   => array(
-			'title'      => __( 'Offsetss', 'gutenberg' ),
+			'title'      => __( 'Offset', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -182,6 +182,13 @@ function remove_core_patterns() {
 		'three-buttons',
 		'heading-paragraph',
 		'quote',
+		'query-standard-posts',
+		'query-medium-posts',
+		'query-small-posts',
+		'query-grid-posts',
+		'query-large-title-posts',
+		'query-offset-posts',
+		'social-links-shared-background-color',
 	);
 
 	foreach ( $core_block_patterns as $core_block_pattern ) {

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -15,7 +15,7 @@ function register_gutenberg_patterns() {
 	}
 
 	$patterns = array(
-		'query/standard-posts'                 => array(
+		'query_standard-posts'                 => array(
 			'title'      => __( 'Standard', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -33,7 +33,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query/medium-posts'                   => array(
+		'query_medium-posts'                   => array(
 			'title'      => __( 'Image at left', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -53,7 +53,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query/small-posts'                    => array(
+		'query_small-posts'                    => array(
 			'title'      => __( 'Small image and title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -72,7 +72,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query/grid-posts'                     => array(
+		'query_grid-posts'                     => array(
 			'title'      => __( 'Grid', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -88,7 +88,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query/large-title-posts'              => array(
+		'query_large-title-posts'              => array(
 			'title'      => __( 'Large title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -112,7 +112,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query --></div>
 							<!-- /wp:group -->',
 		),
-		'query/offset-posts'                   => array(
+		'query_offset-posts'                   => array(
 			'title'      => __( 'Offsetss', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -146,7 +146,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:group -->',
 		),
 		// Initial block pattern to be used with block transformations with patterns.
-		'social-links/shared-background-color' => array(
+		'social-links_shared-background-color' => array(
 			'title'         => __( 'Social links with a shared background color', 'gutenberg' ),
 			'categories'    => array( 'buttons' ),
 			'blockTypes'    => array( 'core/social-links' ),

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -15,7 +15,7 @@ function register_gutenberg_patterns() {
 	}
 
 	$patterns = array(
-		'query_standard-posts'                 => array(
+		'query-standard-posts'                 => array(
 			'title'      => __( 'Standard', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -33,7 +33,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query_medium-posts'                   => array(
+		'query-medium-posts'                   => array(
 			'title'      => __( 'Image at left', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -53,7 +53,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query_small-posts'                    => array(
+		'query-small-posts'                    => array(
 			'title'      => __( 'Small image and title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -72,7 +72,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query_grid-posts'                     => array(
+		'query-grid-posts'                     => array(
 			'title'      => __( 'Grid', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -88,7 +88,7 @@ function register_gutenberg_patterns() {
 							</div>
 							<!-- /wp:query -->',
 		),
-		'query_large-title-posts'              => array(
+		'query-large-title-posts'              => array(
 			'title'      => __( 'Large title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -112,7 +112,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:query --></div>
 							<!-- /wp:group -->',
 		),
-		'query_offset-posts'                   => array(
+		'query-offset-posts'                   => array(
 			'title'      => __( 'Offsetss', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
@@ -146,7 +146,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:group -->',
 		),
 		// Initial block pattern to be used with block transformations with patterns.
-		'social-links_shared-background-color' => array(
+		'social-links-shared-background-color' => array(
 			'title'         => __( 'Social links with a shared background color', 'gutenberg' ),
 			'categories'    => array( 'buttons' ),
 			'blockTypes'    => array( 'core/social-links' ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR updates the GB pattern registration, as they are going to be included in `core`.
