### PR TITLE
Navigation Screen: Hide sidebar when a menu isn't selected

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -94,7 +94,7 @@ export default function Layout( { blockEditorSettings } ) {
 	useMenuNotifications( selectedMenuId );
 
 	const hasMenus = !! menus?.length;
-	const hasPermanentSidebar = isLargeViewport && hasMenus;
+	const hasPermanentSidebar = isLargeViewport && isMenuSelected;
 
 	const isBlockEditorReady = !! (
 		hasMenus &&

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -183,14 +183,16 @@ export default function Layout( { blockEditorSettings } ) {
 								)
 							}
 						/>
-						<Sidebar
-							onSelectMenu={ selectMenu }
-							menus={ menus }
-							menuId={ selectedMenuId }
-							onDeleteMenu={ deleteMenu }
-							isMenuBeingDeleted={ isMenuBeingDeleted }
-							hasPermanentSidebar={ hasPermanentSidebar }
-						/>
+						{ isMenuSelected && (
+							<Sidebar
+								menus={ menus }
+								menuId={ selectedMenuId }
+								onSelectMenu={ selectMenu }
+								onDeleteMenu={ deleteMenu }
+								isMenuBeingDeleted={ isMenuBeingDeleted }
+								hasPermanentSidebar={ hasPermanentSidebar }
+							/>
+						) }
 					</IsMenuNameControlFocusedContext.Provider>
 					<UnsavedChangesWarning />
 				</BlockEditorProvider>


### PR DESCRIPTION
## Description
The setting sidebar shouldn't be displayed when a menu isn't selected.

Fixes regression introduced in #31821.

## How has this been tested?
1. Go to the new experimental navigation screen.
2. Delete all menus.
3. The "Create your first menu" component should be visible.
4. Sidebar is hidden.
5. Create a new menu.
6. Sidebar should be visible.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
