### PR TITLE
fixes issue with site-logo when option is unset

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -197,7 +197,9 @@ register_setting(
 			'schema' => array(
 				'type'       => 'object',
 				'properties' => array(
-					'custom_logo' => array( 'type' => 'integer' ),
+					'custom_logo' => array(
+						'type' => array( 'integer', 'boolean' ),
+					),
 				),
 			),
 		),
@@ -234,6 +236,7 @@ function gutenberg_rest_pre_get_setting_filter_custom_logo( $result, $name ) {
 			'custom_logo' => get_theme_mod( 'custom_logo' ),
 		);
 	}
+	return $result;
 }
 add_filter( 'rest_pre_get_setting', 'gutenberg_rest_pre_get_setting_filter_custom_logo', 10, 2 );
 
@@ -258,6 +261,7 @@ function gutenberg_rest_pre_set_setting_filter_theme_mods( $result, $name, $valu
 		update_option( $theme_mods_setting_name, $value );
 		return true;
 	}
+	return $result;
 }
 
 add_filter( 'rest_pre_update_setting', 'gutenberg_rest_pre_set_setting_filter_theme_mods', 10, 3 );


### PR DESCRIPTION
## Description
The schema for the option had `integer` defined as `type`. However, when the option is not set, it returns `false` which meant that the REST API validation was failing. This PR allows `boolean` and `integer` values in the response.

## How has this been tested?
Tested by switching to a theme I haven't used before to make sure the `custom_logo` theme-mod is not set, then added a site-logo block in a post.

## Types of changes
* Allow both `boolean` and `integer` values in the API respose
* Add `return` to the 2 extra filters we have to avoid breaking other filters that use the same hook.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
