### PR TITLE
Remove query context leftovers

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -90,7 +90,7 @@ function gutenberg_inject_default_block_context( $args ) {
 	if ( is_callable( $args['render_callback'] ) ) {
 		$block_render_callback   = $args['render_callback'];
 		$args['render_callback'] = function( $attributes, $content, $block = null ) use ( $block_render_callback ) {
-			global $post, $wp_query;
+			global $post;
 
 			// Check for null for back compatibility with WP_Block_Type->render
 			// which is unused since the introduction of WP_Block class.
@@ -125,39 +125,6 @@ function gutenberg_inject_default_block_context( $args ) {
 				* it should be included to consistently fulfill the expectation.
 				*/
 				$block->context['postType'] = $post->post_type;
-			}
-
-			// Inject the query context if not done by Core.
-			$needs_query = ! empty( $block_type->uses_context ) && in_array( 'query', $block_type->uses_context, true );
-			if ( ! isset( $block->context['query'] ) && $needs_query ) {
-				if ( isset( $wp_query->tax_query->queried_terms['category'] ) ) {
-					$block->context['query'] = array( 'categoryIds' => array() );
-
-					foreach ( $wp_query->tax_query->queried_terms['category']['terms'] as $category_slug_or_id ) {
-						$block->context['query']['categoryIds'][] = 'slug' === $wp_query->tax_query->queried_terms['category']['field'] ? get_cat_ID( $category_slug_or_id ) : $category_slug_or_id;
-					}
-				}
-
-				if ( isset( $wp_query->tax_query->queried_terms['post_tag'] ) ) {
-					if ( isset( $block->context['query'] ) ) {
-						$block->context['query']['tagIds'] = array();
-					} else {
-						$block->context['query'] = array( 'tagIds' => array() );
-					}
-
-					foreach ( $wp_query->tax_query->queried_terms['post_tag']['terms'] as $tag_slug_or_id ) {
-						$tag_ID = $tag_slug_or_id;
-
-						if ( 'slug' === $wp_query->tax_query->queried_terms['post_tag']['field'] ) {
-							$tag = get_term_by( 'slug', $tag_slug_or_id, 'post_tag' );
-
-							if ( $tag ) {
-								$tag_ID = $tag->term_id;
-							}
-						}
-						$block->context['query']['tagIds'][] = $tag_ID;
-					}
-				}
 			}
 
 			return $block_render_callback( $attributes, $content, $block );

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -30,7 +30,7 @@ export default function QueryLoopEdit( {
 		query: {
 			perPage,
 			offset,
-			categoryIds,
+			categoryIds = [],
 			postType,
 			tagIds = [],
 			order,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Initially there were some exploration on different handling of Query and QueryLoop blocks that would aim to inherit the `global` query from the URL. This PR removes these leftovers.

## Testing instructions
1. Test Query block in post and site editors and verify everything works as before.
