### PR TITLE
Fix broken template part converter modal styles.

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -140,7 +140,7 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 																icon={ icon }
 															/>
 														</FlexItem>
-														<FlexBlock>
+														<FlexBlock className="edit-site-template-part-converter__option-label">
 															{ label }
 															<div>
 																{ description }

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -56,12 +56,12 @@
 			color: $gray-900;
 			cursor: auto;
 
-			.components-flex-block div {
+			.edit-site-template-part-converter__option-label div {
 				color: $gray-600;
 			}
 		}
 
-		.components-flex-block {
+		.edit-site-template-part-converter__option-label {
 			padding-top: $grid-unit-05;
 			white-space: normal;
 

--- a/packages/edit-site/src/components/template-part-converter/style.scss
+++ b/packages/edit-site/src/components/template-part-converter/style.scss
@@ -56,12 +56,12 @@
 			color: $gray-900;
 			cursor: auto;
 
-			.components-flex__block div {
+			.components-flex-block div {
 				color: $gray-600;
 			}
 		}
 
-		.components-flex__block {
+		.components-flex-block {
 			padding-top: $grid-unit-05;
 			white-space: normal;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Recently styles for the template part converter modal have regressed.  The descriptions no longer wrap and no longer have their slightly lighter font color:

![Screen Shot 2021-05-21 at 9 30 30 AM](https://user-images.githubusercontent.com/28742426/119145472-aa5a7080-ba17-11eb-8062-f51027c14ac4.png)

It looks like the `FlexBlock` component's class name was updated from `components-flex__block` to `components-flex-block`.  Here, we add a custom className to our instance of the `FlexBlock` and avoid using the base selector from the component in css as this should be more robust:

![Screen Shot 2021-05-21 at 9 31 01 AM](https://user-images.githubusercontent.com/28742426/119146177-62881900-ba18-11eb-8809-5836124ba3da.png)

cc @sarayourfriend - in case this change to the format of component classNames is not expected / not a desired side effect of promoting the g2 version.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Select a block in the site editor.  
* Use the ellipsis menu in the block toolbar and select "Make template part"
* Verify the description does not overflow and is grey text color.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
