### PR TITLE
components: Add types to Disabled

### DIFF
--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -42,10 +42,26 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
 	'TEXTAREA',
 ];
 
+/**
+ * @typedef OwnProps
+ * @property {string} [className] Classname for the disabled element.
+ * @property {import('react').ReactNode} children Children to disable.
+ * @property {boolean} [isDisabled=true] Whether to disable the children.
+ */
+
+/**
+ * @param {OwnProps & import('react').HTMLAttributes<HTMLDivElement>} props
+ * @return {JSX.Element} Element wrapping the children to disable them when isDisabled is true.
+ */
 function Disabled( { className, children, isDisabled = true, ...props } ) {
-	const node = useRef();
+	/** @type {import('react').RefObject<HTMLDivElement>} */
+	const node = useRef( null );
 
 	const disable = () => {
+		if ( ! node.current ) {
+			return;
+		}
+
 		focus.focusable.find( node.current ).forEach( ( focusable ) => {
 			if (
 				includes( DISABLED_ELIGIBLE_NODE_NAMES, focusable.nodeName )
@@ -54,7 +70,7 @@ function Disabled( { className, children, isDisabled = true, ...props } ) {
 			}
 
 			if ( focusable.nodeName === 'A' ) {
-				focusable.setAttribute( 'tabindex', -1 );
+				focusable.setAttribute( 'tabindex', '-1' );
 			}
 
 			const tabIndex = focusable.getAttribute( 'tabindex' );
@@ -71,7 +87,7 @@ function Disabled( { className, children, isDisabled = true, ...props } ) {
 	// Debounce re-disable since disabling process itself will incur
 	// additional mutations which should be ignored.
 	const debouncedDisable = useCallback(
-		debounce( disable, { leading: true } ),
+		debounce( disable, undefined, { leading: true } ),
 		[]
 	);
 
@@ -82,15 +98,21 @@ function Disabled( { className, children, isDisabled = true, ...props } ) {
 
 		disable();
 
-		const observer = new window.MutationObserver( debouncedDisable );
-		observer.observe( node.current, {
-			childList: true,
-			attributes: true,
-			subtree: true,
-		} );
+		/** @type {MutationObserver | undefined} */
+		let observer;
+		if ( node.current ) {
+			observer = new window.MutationObserver( debouncedDisable );
+			observer.observe( node.current, {
+				childList: true,
+				attributes: true,
+				subtree: true,
+			} );
+		}
 
 		return () => {
-			observer.disconnect();
+			if ( observer ) {
+				observer.disconnect();
+			}
 			debouncedDisable.cancel();
 		};
 	}, [] );

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -7,6 +7,7 @@
 	},
 	"references": [
 		{ "path": "../deprecated" },
+		{ "path": "../dom" },
 		{ "path": "../element" },
 		{ "path": "../hooks" },
 		{ "path": "../icons" },
@@ -19,6 +20,7 @@
 		"src/animate/**/*",
 		"src/base-control/**/*",
 		"src/dashicon/**/*",
+		"src/disabled/**/*",
 		"src/draggable/**/*",
 		"src/flex/**/*",
 		"src/form-group/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to the `Disabled` component.

Part of #18838

## How has this been tested?
Types check pass. Storybook for `Disabled` continues to work as expected.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
