### PR TITLE
Memoize core-data selectors

### DIFF
--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -221,7 +221,22 @@ export const getRawEntityRecord = createSelector(
 			}, {} )
 		);
 	},
-	( state ) => [ state.entities.data ]
+	( state, kind, name, recordId ) => [
+		get( state.entities.data, [
+			kind,
+			name,
+			'queriedData',
+			'items',
+			recordId,
+		] ),
+		get( state.entities.data, [
+			kind,
+			name,
+			'queriedData',
+			'itemIsComplete',
+			recordId,
+		] ),
+	]
 );
 
 /**
@@ -408,7 +423,10 @@ export const getEntityRecordNonTransientEdits = createSelector(
 			return acc;
 		}, {} );
 	},
-	( state ) => [ state.entities.config, state.entities.data ]
+	( state, kind, name, recordId ) => [
+		state.entities.config,
+		get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+	]
 );
 
 /**
@@ -446,7 +464,23 @@ export const getEditedEntityRecord = createSelector(
 		...getRawEntityRecord( state, kind, name, recordId ),
 		...getEntityRecordEdits( state, kind, name, recordId ),
 	} ),
-	( state ) => [ state.entities.data ]
+	( state, kind, name, recordId ) => [
+		get( state.entities.data, [
+			kind,
+			name,
+			'queriedData',
+			'items',
+			recordId,
+		] ),
+		get( state.entities.data, [
+			kind,
+			name,
+			'queriedData',
+			'itemIsComplete',
+			recordId,
+		] ),
+		get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+	]
 );
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Currently, the whole editor re-renders on every keystroke become a new reference is returned for the template entity record (which is also retrieved in the normal post editor).

I'm not sure IF we need to get the _edited_ template record. If not, it's a pretty easy fix. If we do, we'll need to fix the `getEditedEntityRecord` cached selector, because it currently invalidates on any entity change.

|Before|After|
|-|-|
|![large-before](https://user-images.githubusercontent.com/4710635/119173390-e15c7080-ba6f-11eb-8417-8b1054375166.gif)|![large-after](https://user-images.githubusercontent.com/4710635/119173401-e6212480-ba6f-11eb-909f-8d3653cede73.gif)|

<img width="596" alt="Screenshot 2021-05-22 at 02 05 55" src="https://user-images.githubusercontent.com/4710635/119205992-90b23b00-baa2-11eb-8088-3055f6f3e6b9.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
