### PR TITLE
Pattern Directory API: Pass through the pattern's blockTypes to support pattern transforms

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -332,7 +332,7 @@ add_action(
  * @param object           $raw_pattern The unprepared pattern.
  */
 function filter_block_pattern_response( $response, $raw_pattern ) {
-	$data = $response->get_data();
+	$data                = $response->get_data();
 	$data['block_types'] = array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types );
 	$response->set_data( $data );
 	return $response;

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -231,6 +231,10 @@ function gutenberg_load_remote_core_patterns() {
 
 		foreach ( $patterns as $settings ) {
 			$pattern_name = 'core/' . sanitize_title( $settings['title'] );
+			if ( isset( $settings['block_types'] ) ) {
+				$settings['blockTypes'] = $settings['block_types'];
+				unset( $settings['block_types'] );
+			}
 			register_block_pattern( $pattern_name, (array) $settings );
 		}
 	}

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -302,3 +302,38 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Inject the block_types value into the API response.
+ *
+ * @param WP_REST_Response $response    The response object.
+ * @param object           $raw_pattern The unprepared pattern.
+ */
+function filter_block_pattern_response( $response, $raw_pattern ) {
+	$data = $response->get_data();
+	$data['block_types'] = array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types );
+	$response->set_data( $data );
+	return $response;
+}
+add_filter( 'rest_prepare_block_pattern', 'filter_block_pattern_response', 10, 2 );
+
+/**
+ * Add the schema to the block_types value. The value itself is injected in the
+ * `rest_prepare_*` filter, so that the raw pattern response is available.
+ */
+function add_block_pattern_block_types_schema() {
+	register_rest_field(
+		'pattern-directory-item',
+		'block_types',
+		array(
+			'schema' => array(
+				'description' => __( 'The block types which can use this pattern.', 'gutenberg' ),
+				'type'        => 'array',
+				'uniqueItems' => true,
+				'items'       => array( 'type' => 'string' ),
+				'context'     => array( 'view', 'embed' ),
+			),
+		)
+	);
+}
+add_filter( 'rest_api_init', 'add_block_pattern_block_types_schema' );

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -235,6 +235,10 @@ function gutenberg_load_remote_core_patterns() {
 				$settings['blockTypes'] = $settings['block_types'];
 				unset( $settings['block_types'] );
 			}
+			if ( isset( $settings['viewport_width'] ) ) {
+				$settings['viewportWidth'] = $settings['viewport_width'];
+				unset( $settings['viewport_width'] );
+			}
 			register_block_pattern( $pattern_name, (array) $settings );
 		}
 	}

--- a/phpunit/fixtures/rest-api/pattern-directory/browse-all.json
+++ b/phpunit/fixtures/rest-api/pattern-directory/browse-all.json
@@ -9,7 +9,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": [ "core/heading" ]
 		},
 		"category_slugs": [ "text" ],
 		"keyword_slugs": [ "core" ],
@@ -25,7 +26,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -41,7 +43,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],

--- a/phpunit/fixtures/rest-api/pattern-directory/browse-category-2.json
+++ b/phpunit/fixtures/rest-api/pattern-directory/browse-category-2.json
@@ -9,7 +9,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
-			"wpop_viewport_width": 600
+			"wpop_viewport_width": 600,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],
@@ -25,7 +26,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
-			"wpop_viewport_width": 500
+			"wpop_viewport_width": 500,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],

--- a/phpunit/fixtures/rest-api/pattern-directory/browse-keyword-11.json
+++ b/phpunit/fixtures/rest-api/pattern-directory/browse-keyword-11.json
@@ -9,7 +9,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "text" ],
 		"keyword_slugs": [ "core" ],
@@ -25,7 +26,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -41,7 +43,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],

--- a/phpunit/fixtures/rest-api/pattern-directory/search-button.json
+++ b/phpunit/fixtures/rest-api/pattern-directory/search-button.json
@@ -9,7 +9,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -25,7 +26,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three small columns of text, each with an outlined button with rounded corners at the bottom.",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "columns" ],
 		"keyword_slugs": [ "core" ],
@@ -41,7 +43,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
-			"wpop_viewport_width": 600
+			"wpop_viewport_width": 600,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],
@@ -57,7 +60,8 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
-			"wpop_viewport_width": 500
+			"wpop_viewport_width": 500,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],


### PR DESCRIPTION
## Description
In https://github.com/WordPress/pattern-directory/pull/111, we added a `blockTypes` property to patterns in the Pattern Directory. This is returned in the API endpoint `http://api.wordpress.org/patterns/1.0/` as an array in `meta.wpop_block_types` for each pattern.

This PR updates the local endpoint to pass through that `blockTypes` property and use it when registering remote blocks.

See #28800

## How has this been tested?

- Make a request to `/wp-json/wp/v2/pattern-directory/patterns`
- In the returned patterns, you should see `block_types` property
- Load the editor, and insert a heading
- View the transforms by clicking the block icon, you should see the Heading pattern available

The quote block also has a pattern transform if you want to test that too :)
