### PR TITLE
List View: allow expanding and collapsing of nested blocks

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -22,6 +22,7 @@ const BlockNavigationBlockContents = forwardRef(
 	(
 		{
 			onClick,
+			onToggleExpanded,
 			block,
 			isSelected,
 			position,
@@ -98,7 +99,7 @@ const BlockNavigationBlockContents = forwardRef(
 							ref={ ref }
 							className={ className }
 							block={ block }
-							onClick={ onClick }
+							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }
@@ -114,6 +115,7 @@ const BlockNavigationBlockContents = forwardRef(
 							className={ className }
 							block={ block }
 							onClick={ onClick }
+							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -18,6 +18,7 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { getBlockPositionDescription } from './utils';
 import BlockTitle from '../block-title';
+import BlockNavigationExpander from './expander';
 
 function BlockNavigationBlockSelectButton(
 	{
@@ -61,6 +62,7 @@ function BlockNavigationBlockSelectButton(
 				onDragEnd={ onDragEnd }
 				draggable={ draggable }
 			>
+				<BlockNavigationExpander onClick={ onClick } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<BlockTitle clientId={ clientId } />
 				{ blockInformation?.anchor && (

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -26,6 +26,7 @@ function BlockNavigationBlockSelectButton(
 		block: { clientId },
 		isSelected,
 		onClick,
+		onToggleExpanded,
 		position,
 		siblingBlockCount,
 		level,
@@ -62,7 +63,7 @@ function BlockNavigationBlockSelectButton(
 				onDragEnd={ onDragEnd }
 				draggable={ draggable }
 			>
-				<BlockNavigationExpander onClick={ onClick } />
+				<BlockNavigationExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<BlockTitle clientId={ clientId } />
 				{ blockInformation?.anchor && (

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -26,6 +26,7 @@ import { BlockListBlockContext } from '../block-list/block';
 import BlockNavigationBlockSelectButton from './block-select-button';
 import { getBlockPositionDescription } from './utils';
 import { store as blockEditorStore } from '../../store';
+import BlockNavigationExpander from './expander';
 
 const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
@@ -57,6 +58,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 					level,
 					tabIndex,
 					onFocus,
+					onClick,
 				} = props;
 
 				const blockType = getBlockType( name );
@@ -86,6 +88,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 								className
 							) }
 						>
+							<BlockNavigationExpander onClick={ onClick } />
 							<BlockIcon icon={ blockType.icon } showColors />
 							{ Children.map( fills, ( fill ) =>
 								cloneElement( fill, {

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -58,7 +58,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 					level,
 					tabIndex,
 					onFocus,
-					onClick,
+					onToggleExpanded,
 				} = props;
 
 				const blockType = getBlockType( name );
@@ -88,7 +88,9 @@ function BlockNavigationBlockSlot( props, ref ) {
 								className
 							) }
 						>
-							<BlockNavigationExpander onClick={ onClick } />
+							<BlockNavigationExpander
+								onClick={ onToggleExpanded }
+							/>
 							<BlockIcon icon={ blockType.icon } showColors />
 							{ Children.map( fills, ( fill ) =>
 								cloneElement( fill, {

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -36,6 +36,7 @@ export default function BlockNavigationBlock( {
 	isBranchSelected,
 	isLastOfSelectedBranch,
 	onClick,
+	onToggleExpanded,
 	position,
 	level,
 	rowCount,
@@ -155,6 +156,7 @@ export default function BlockNavigationBlock( {
 						<BlockNavigationBlockContents
 							block={ block }
 							onClick={ onClick }
+							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -42,6 +42,7 @@ export default function BlockNavigationBlock( {
 	siblingBlockCount,
 	showBlockMovers,
 	path,
+	isExpanded,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -142,6 +143,7 @@ export default function BlockNavigationBlock( {
 			path={ path }
 			id={ `block-navigation-block-${ clientId }` }
 			data-block={ clientId }
+			isExpanded={ isExpanded }
 		>
 			<TreeGridCell
 				className="block-editor-block-navigation-block__contents-cell"
@@ -152,7 +154,7 @@ export default function BlockNavigationBlock( {
 					<div className="block-editor-block-navigation-block__contents-container">
 						<BlockNavigationBlockContents
 							block={ block }
-							onClick={ () => onClick( block.clientId ) }
+							onClick={ onClick }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -79,29 +79,26 @@ export default function BlockNavigationBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				const toggleExpandOrSelectBlock = (
-					event,
-					{ forceToggle } = { forceToggle: false }
-				) => {
+				const selectBlockWithClientId = ( event ) => {
 					event.stopPropagation();
-					const toggle = () => {
-						if ( isExpanded === true ) {
-							collapse( clientId );
-						} else if ( isExpanded === false ) {
-							expand( clientId );
-						}
-					};
-					if ( forceToggle ) {
-						return toggle();
-					}
 					selectBlock( clientId );
+				};
+
+				const toggleExpanded = ( event ) => {
+					event.stopPropagation();
+					if ( isExpanded === true ) {
+						collapse( clientId );
+					} else if ( isExpanded === false ) {
+						expand( clientId );
+					}
 				};
 
 				return (
 					<Fragment key={ clientId }>
 						<BlockNavigationBlock
 							block={ block }
-							onClick={ toggleExpandOrSelectBlock }
+							onClick={ selectBlockWithClientId }
+							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							isBranchSelected={ isSelectedBranch }
 							isLastOfSelectedBranch={ isLastOfSelectedBranch }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -44,7 +44,7 @@ export default function BlockNavigationBranch( props ) {
 	const rowCount = hasAppender ? blockCount + 1 : blockCount;
 	const appenderPosition = rowCount;
 
-	const { expandedState, setExpandedState } = useBlockNavigationContext();
+	const { expandedState, expand, collapse } = useBlockNavigationContext();
 
 	return (
 		<>
@@ -84,13 +84,13 @@ export default function BlockNavigationBranch( props ) {
 					{ forceToggle } = { forceToggle: false }
 				) => {
 					event.stopPropagation();
-					const toggle = () =>
-						setExpandedState( {
-							...expandedState,
-							...{
-								[ clientId ]: ! isExpanded,
-							},
-						} );
+					const toggle = () => {
+						if ( isExpanded === true ) {
+							collapse( clientId );
+						} else if ( isExpanded === false ) {
+							expand( clientId );
+						}
+					};
 					if ( forceToggle ) {
 						return toggle();
 					}

--- a/packages/block-editor/src/components/block-navigation/expander.js
+++ b/packages/block-editor/src/components/block-navigation/expander.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { chevronRight, Icon } from '@wordpress/icons';
+export default function BlockNavigationExpander( { onClick } ) {
+	return (
+		//TODO: add keyboard events as noted in https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html
+		// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+		<span
+			className="block-editor-block-navigation__expander"
+			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }
+		>
+			<Icon icon={ chevronRight } />
+		</span>
+	);
+}

--- a/packages/block-editor/src/components/block-navigation/expander.js
+++ b/packages/block-editor/src/components/block-navigation/expander.js
@@ -5,10 +5,18 @@ import { chevronRightSmall, Icon } from '@wordpress/icons';
 export default function BlockNavigationExpander( { onClick } ) {
 	return (
 		// Keyboard events are handled by TreeGrid see: components/src/tree-grid/index.js
+		//
+		// The expander component is implemented as a pseudo element in the w3 example
+		// https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html
+		//
+		// We've mimicked this by adding an icon with aria-hidden set to true to hide this from the accessibility tree.
+		// For the current tree grid implementation, please do not try to make this a button.
+		//
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
 		<span
 			className="block-editor-block-navigation__expander"
 			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }
+			aria-hidden="true"
 		>
 			<Icon icon={ chevronRightSmall } />
 		</span>

--- a/packages/block-editor/src/components/block-navigation/expander.js
+++ b/packages/block-editor/src/components/block-navigation/expander.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { chevronRight, Icon } from '@wordpress/icons';
+import { chevronRightSmall, Icon } from '@wordpress/icons';
 export default function BlockNavigationExpander( { onClick } ) {
 	return (
 		// Keyboard events are handled by TreeGrid see: components/src/tree-grid/index.js
@@ -10,7 +10,7 @@ export default function BlockNavigationExpander( { onClick } ) {
 			className="block-editor-block-navigation__expander"
 			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }
 		>
-			<Icon icon={ chevronRight } />
+			<Icon icon={ chevronRightSmall } />
 		</span>
 	);
 }

--- a/packages/block-editor/src/components/block-navigation/expander.js
+++ b/packages/block-editor/src/components/block-navigation/expander.js
@@ -4,7 +4,7 @@
 import { chevronRight, Icon } from '@wordpress/icons';
 export default function BlockNavigationExpander( { onClick } ) {
 	return (
-		//TODO: add keyboard events as noted in https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html
+		// Keyboard events are handled by TreeGrid see: components/src/tree-grid/index.js
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
 		<span
 			className="block-editor-block-navigation__expander"

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -40,6 +40,12 @@
 	&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
 		border-radius: 2px 2px 0 0;
 	}
+
+	&[aria-expanded="false"] {
+		&.is-branch-selected.is-selected .block-editor-block-navigation-block-contents {
+			border-radius: 2px;
+		}
+	}
 	&.is-branch-selected:not(.is-selected) .block-editor-block-navigation-block-contents {
 		// Lighten a CSS variable without introducing a new SASS variable
 		background:

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -60,7 +60,7 @@
 		align-items: center;
 		width: 100%;
 		height: auto;
-		padding: ($grid-unit-15 / 2) $grid-unit-15;
+		padding: ($grid-unit-15 / 2) $grid-unit-15 ($grid-unit-15 / 2) 0;
 		text-align: left;
 		color: $gray-900;
 		border-radius: 2px;
@@ -121,8 +121,8 @@
 
 	.block-editor-block-icon {
 		align-self: flex-start;
-		margin-right: ( $grid-unit-05 * 2.5 ); // 10px is off the 4px grid, but required for visual alignment between block name and subsequent nested icon
-		width: 20px;
+		margin-right: $grid-unit-10;
+		width: $icon-size;
 	}
 
 	.block-editor-block-navigation-block__menu-cell,
@@ -272,6 +272,13 @@
 	.block-editor-block-navigation-appender__container {
 		display: flex;
 	}
+}
+
+// Chevron container metrics.
+.block-editor-block-navigation__expander {
+	height: $icon-size;
+	margin-left: $grid-unit-05;
+	width: $icon-size - $grid-unit-05;
 }
 
 // First level of indentation is aria-level 2, max indent is 8.

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -284,19 +284,48 @@
 .block-editor-block-navigation__expander {
 	height: $icon-size;
 	margin-left: $grid-unit-05;
-	width: $icon-size - $grid-unit-05;
+	width: $icon-size;
 }
 
 // First level of indentation is aria-level 2, max indent is 8.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
 $block-navigation-max-indent: 8;
 .block-editor-block-navigation-leaf[aria-level] .block-editor-block-navigation__expander {
-	margin-left: ( $grid-unit-30 + $grid-unit-05 ) * $block-navigation-max-indent;
+	margin-left: ( $grid-unit-30 ) * $block-navigation-max-indent;
 }
-@for $i from 0 through $block-navigation-max-indent {
-	.block-editor-block-navigation-leaf[aria-level="#{ $i + 1 }"] .block-editor-block-navigation__expander {
-		margin-left: ( $grid-unit-30 + $grid-unit-05 ) * $i;
+
+.block-editor-block-navigation-leaf:not([aria-level="1"]) {
+	.block-editor-block-navigation__expander {
+		margin-right: 4px;
 	}
+}
+
+.block-editor-block-navigation-leaf[aria-level="1"] .block-editor-block-navigation__expander {
+	margin-left: 0;
+}
+
+.block-editor-block-navigation-leaf[aria-level="2"] .block-editor-block-navigation__expander {
+	margin-left: 24px;
+}
+
+.block-editor-block-navigation-leaf[aria-level="3"] .block-editor-block-navigation__expander {
+	margin-left: 52px;
+}
+
+.block-editor-block-navigation-leaf[aria-level="4"] .block-editor-block-navigation__expander {
+	margin-left: 80px;
+}
+
+.block-editor-block-navigation-leaf[aria-level="5"] .block-editor-block-navigation__expander {
+	margin-left: 108px;
+}
+
+.block-editor-block-navigation-leaf[aria-level="6"] .block-editor-block-navigation__expander {
+	margin-left: 136px;
+}
+
+.block-editor-block-navigation-leaf[aria-level="7"] .block-editor-block-navigation__expander {
+	margin-left: 164px;
 }
 
 .block-editor-block-navigation-leaf .block-editor-block-navigation__expander {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -291,7 +291,7 @@
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
 $block-navigation-max-indent: 8;
 .block-editor-block-navigation-leaf[aria-level] .block-editor-block-navigation__expander {
-	margin-left: ( $grid-unit-30 ) * $block-navigation-max-indent;
+	margin-left: ( $icon-size ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
 }
 
 .block-editor-block-navigation-leaf:not([aria-level="1"]) {
@@ -300,32 +300,15 @@ $block-navigation-max-indent: 8;
 	}
 }
 
-.block-editor-block-navigation-leaf[aria-level="1"] .block-editor-block-navigation__expander {
-	margin-left: 0;
-}
-
-.block-editor-block-navigation-leaf[aria-level="2"] .block-editor-block-navigation__expander {
-	margin-left: 24px;
-}
-
-.block-editor-block-navigation-leaf[aria-level="3"] .block-editor-block-navigation__expander {
-	margin-left: 52px;
-}
-
-.block-editor-block-navigation-leaf[aria-level="4"] .block-editor-block-navigation__expander {
-	margin-left: 80px;
-}
-
-.block-editor-block-navigation-leaf[aria-level="5"] .block-editor-block-navigation__expander {
-	margin-left: 108px;
-}
-
-.block-editor-block-navigation-leaf[aria-level="6"] .block-editor-block-navigation__expander {
-	margin-left: 136px;
-}
-
-.block-editor-block-navigation-leaf[aria-level="7"] .block-editor-block-navigation__expander {
-	margin-left: 164px;
+@for $i from 0 to $block-navigation-max-indent {
+	.block-editor-block-navigation-leaf[aria-level="#{ $i + 1 }"] .block-editor-block-navigation__expander {
+		@if $i - 1 >= 0 {
+			margin-left: ( $icon-size * $i ) + 4 * ($i - 1);
+		}
+		@else {
+			margin-left: ( $icon-size * $i );
+		}
+	}
 }
 
 .block-editor-block-navigation-leaf .block-editor-block-navigation__expander {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -277,12 +277,31 @@
 // First level of indentation is aria-level 2, max indent is 8.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
 $block-navigation-max-indent: 8;
-.block-editor-block-navigation-leaf[aria-level] .block-editor-block-icon {
+.block-editor-block-navigation-leaf[aria-level] .block-editor-block-navigation__expander {
 	margin-left: ( $grid-unit-30 + $grid-unit-05 ) * $block-navigation-max-indent;
 }
 @for $i from 0 through $block-navigation-max-indent {
-	.block-editor-block-navigation-leaf[aria-level="#{ $i + 1 }"] .block-editor-block-icon {
+	.block-editor-block-navigation-leaf[aria-level="#{ $i + 1 }"] .block-editor-block-navigation__expander {
 		margin-left: ( $grid-unit-30 + $grid-unit-05 ) * $i;
 	}
 }
 
+.block-editor-block-navigation-leaf .block-editor-block-navigation__expander {
+	visibility: hidden;
+}
+
+// Point downwards when open.
+.block-editor-block-navigation-leaf[aria-expanded="true"] .block-editor-block-navigation__expander svg {
+	visibility: visible;
+	transition: transform 0.2s ease;
+	transform: rotate(90deg);
+	@include reduce-motion("transition");
+}
+
+// Point rightwards when closed
+.block-editor-block-navigation-leaf[aria-expanded="false"] .block-editor-block-navigation__expander svg {
+	visibility: visible;
+	transform: rotate(0deg);
+	transition: transform 0.2s ease;
+	@include reduce-motion("transition");
+}

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -93,11 +93,23 @@ export default function BlockNavigationTree( {
 		]
 	);
 
+	const toggleExpandCollapse = ( clientId ) => {
+		//TODO: this isn't quite right, see if we need to move toggle state to treegrid
+		setExpandedState( {
+			...expandedState,
+			...{
+				[ clientId ]: ! ( expandedState[ clientId ] ?? true ),
+			},
+		} );
+	};
+
 	return (
 		<TreeGrid
 			className="block-editor-block-navigation-tree"
 			aria-label={ __( 'Block navigation structure' ) }
 			ref={ treeGridRef }
+			onExpandRow={ toggleExpandCollapse }
+			onCollapseRow={ toggleExpandCollapse }
 		>
 			<BlockNavigationContext.Provider value={ contextValue }>
 				<BlockNavigationBranch

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -4,7 +4,13 @@
 
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -52,6 +58,7 @@ export default function BlockNavigationTree( {
 		},
 		[ selectBlock, onSelect ]
 	);
+	const [ expandedState, setExpandedState ] = useState( {} );
 
 	let {
 		ref: treeGridRef,
@@ -73,12 +80,16 @@ export default function BlockNavigationTree( {
 			__experimentalPersistentListViewFeatures,
 			blockDropTarget,
 			isTreeGridMounted: isMounted.current,
+			expandedState,
+			setExpandedState,
 		} ),
 		[
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			blockDropTarget,
 			isMounted.current,
+			expandedState,
+			setExpandedState,
 		]
 	);
 

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -93,14 +93,11 @@ export default function BlockNavigationTree( {
 		]
 	);
 
-	const toggleExpandCollapse = ( clientId ) => {
-		//TODO: this isn't quite right, see if we need to move toggle state to treegrid
-		setExpandedState( {
-			...expandedState,
-			...{
-				[ clientId ]: ! ( expandedState[ clientId ] ?? true ),
-			},
-		} );
+	const toggleExpandCollapse = ( clientId, activeRow ) => {
+		// TODO: expandedState is stale in the callback, we could alternatively use a data store here instead of context.
+		activeRow
+			.querySelector( '.block-editor-block-navigation__expander' )
+			.click();
 	};
 
 	return (
@@ -108,8 +105,8 @@ export default function BlockNavigationTree( {
 			className="block-editor-block-navigation-tree"
 			aria-label={ __( 'Block navigation structure' ) }
 			ref={ treeGridRef }
-			onExpandRow={ toggleExpandCollapse }
 			onCollapseRow={ toggleExpandCollapse }
+			onExpandRow={ toggleExpandCollapse }
 		>
 			<BlockNavigationContext.Provider value={ contextValue }>
 				<BlockNavigationBranch

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -84,10 +84,24 @@ export default function BlockNavigationTree( {
 		blockDropTarget = undefined;
 	}
 
-	const expand = ( clientId ) =>
+	const expand = ( clientId ) => {
+		if ( ! clientId ) {
+			return;
+		}
 		setExpandedState( { type: 'expand', clientId } );
-	const collapse = ( clientId ) =>
+	};
+	const collapse = ( clientId ) => {
+		if ( ! clientId ) {
+			return;
+		}
 		setExpandedState( { type: 'collapse', clientId } );
+	};
+	const expandRow = ( row ) => {
+		expand( row?.dataset?.block );
+	};
+	const collapseRow = ( row ) => {
+		collapse( row?.dataset?.block );
+	};
 
 	const contextValue = useMemo(
 		() => ( {
@@ -115,8 +129,8 @@ export default function BlockNavigationTree( {
 			className="block-editor-block-navigation-tree"
 			aria-label={ __( 'Block navigation structure' ) }
 			ref={ treeGridRef }
-			onCollapseRow={ collapse }
-			onExpandRow={ expand }
+			onCollapseRow={ collapseRow }
+			onExpandRow={ expandRow }
 		>
 			<BlockNavigationContext.Provider value={ contextValue }>
 				<BlockNavigationBranch

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -93,7 +93,7 @@ function TreeGrid(
 					// Left:
 					// If a row is focused, and it is expanded, collapses the current row.
 					if ( activeRow?.ariaExpanded === 'true' ) {
-						onCollapseRow( activeRow?.dataset?.block );
+						onCollapseRow( activeRow );
 						event.preventDefault();
 						return;
 					}
@@ -118,7 +118,7 @@ function TreeGrid(
 					// Right:
 					// If a row is focused, and it is collapsed, expands the current row.
 					if ( activeRow?.ariaExpanded === 'false' ) {
-						onExpandRow( activeRow?.dataset?.block );
+						onExpandRow( activeRow );
 						event.preventDefault();
 						return;
 					}

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -92,25 +92,33 @@ function TreeGrid(
 				if ( keyCode === LEFT ) {
 					// Left:
 					// If a row is focused, and it is expanded, collapses the current row.
-					if ( activeRow?.ariaExpanded ) {
-						onCollapseRow( activeRow?.dataset?.block );
+					if ( activeRow?.ariaExpanded === 'true' ) {
+						onCollapseRow( activeRow?.dataset?.block, activeRow );
 						event.preventDefault();
 						return;
 					}
 					// If a row is focused, and it is collapsed, moves to the parent row (if there is one).
 					const level = Math.max(
-						( activeRow?.ariaLevel ?? 1 ) - 1,
+						( parseInt( activeRow?.ariaLevel ?? 1, 10 ) ) - 1,
 						1
 					);
-					const parentRow = treeGridElement.querySelector(
-						`[aria-posinset="1"][aria-level="${ level }"]`
+					const rows = Array.from(
+						treeGridElement.querySelectorAll( '[role="row"]' )
 					);
+					let parentRow = activeRow;
+					const currentRowIndex = rows.indexOf( activeRow );
+					for ( let i = currentRowIndex; i >= 0; i-- ) {
+						if ( parseInt( rows[ i ].ariaLevel, 10 ) === level ) {
+							parentRow = rows[ i ];
+							break;
+						}
+					}
 					getRowFocusables( parentRow )?.[ 0 ]?.focus();
 				} else {
 					// Right:
 					// If a row is focused, and it is collapsed, expands the current row.
-					if ( activeRow?.ariaExpanded === false ) {
-						onExpandRow( activeRow?.dataset?.block );
+					if ( activeRow?.ariaExpanded === 'false' ) {
+						onExpandRow( activeRow?.dataset?.block, activeRow );
 						event.preventDefault();
 						return;
 					}

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -99,7 +99,7 @@ function TreeGrid(
 					}
 					// If a row is focused, and it is collapsed, moves to the parent row (if there is one).
 					const level = Math.max(
-						( parseInt( activeRow?.ariaLevel ?? 1, 10 ) ) - 1,
+						parseInt( activeRow?.ariaLevel ?? 1, 10 ) - 1,
 						1
 					);
 					const rows = Array.from(

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -46,12 +46,7 @@ function getRowFocusables( rowElement ) {
  * @param {Object}    ref                 A ref to the underlying DOM table element.
  */
 function TreeGrid(
-	{
-		children,
-		onExpandRow = () => {},
-		onCollapseRow = () => {},
-		...props
-	},
+	{ children, onExpandRow = () => {}, onCollapseRow = () => {}, ...props },
 	ref
 ) {
 	const onKeyDown = useCallback( ( event ) => {

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -122,8 +122,11 @@ function TreeGrid(
 						event.preventDefault();
 						return;
 					}
-					// If a row is focused, and it is expanded, focuses the first cell in the row.
-					getRowFocusables( activeRow )?.[ 0 ]?.focus();
+					// If a row is focused, and it is expanded, focuses the rightmost cell in the row.
+					const focusableItems = getRowFocusables( activeRow );
+					if ( focusableItems.length > 0 ) {
+						focusableItems[ focusableItems.length - 1 ]?.focus();
+					}
 				}
 				// Prevent key use for anything else. For example, Voiceover
 				// will start reading text on continued use of left/right arrow

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -93,7 +93,7 @@ function TreeGrid(
 					// Left:
 					// If a row is focused, and it is expanded, collapses the current row.
 					if ( activeRow?.ariaExpanded === 'true' ) {
-						onCollapseRow( activeRow?.dataset?.block, activeRow );
+						onCollapseRow( activeRow?.dataset?.block );
 						event.preventDefault();
 						return;
 					}
@@ -118,7 +118,7 @@ function TreeGrid(
 					// Right:
 					// If a row is focused, and it is collapsed, expands the current row.
 					if ( activeRow?.ariaExpanded === 'false' ) {
-						onExpandRow( activeRow?.dataset?.block, activeRow );
+						onExpandRow( activeRow?.dataset?.block );
 						event.preventDefault();
 						return;
 					}

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -46,5 +46,6 @@
 
 .edit-post-editor__list-view-panel-content {
 	overflow-y: auto;
-	padding: $grid-unit-10;
+	// The table cells use an extra pixels of space left and right. We compensate for that here.
+	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
 }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -33,6 +33,7 @@ export { default as check } from './library/check';
 export { default as chevronDown } from './library/chevron-down';
 export { default as chevronLeft } from './library/chevron-left';
 export { default as chevronRight } from './library/chevron-right';
+export { default as chevronRightSmall } from './library/chevron-right-small';
 export { default as chevronUp } from './library/chevron-up';
 export { default as classic } from './library/classic';
 export { default as close } from './library/close';

--- a/packages/icons/src/library/chevron-right-small.js
+++ b/packages/icons/src/library/chevron-right-small.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const chevronRightSmall = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M10.6 7L9.4 8l3.7 4-3.7 4 1.2 1 4.5-5z" />
+		<Path d="M10.8622 8.04053L14.2805 12.0286L10.8622 16.0167L9.72327 15.0405L12.3049 12.0286L9.72327 9.01672L10.8622 8.04053Z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/chevron-right-small.js
+++ b/packages/icons/src/library/chevron-right-small.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const chevronRightSmall = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M10.6 7L9.4 8l3.7 4-3.7 4 1.2 1 4.5-5z" />
+	</SVG>
+);
+
+export default chevronRightSmall;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/26141 to add the ability to expand and collapse parts of list view.

Updates in this PR include click support for expand/collapse and left and right keyboard events, as noted in https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html. A left keypress on a expanded item should collapse it, and a second keypress should navigate to its parent. Similarly a right keypress on a collapsed item should expand it.

I plan on splitting up work for List View expand/collapse in two parts:

- **This PR** will focus on basic UI + click/keyboard events.
- **A follow up PR** will add animations for slide in and out for the tree grid rows. Work here is somewhat non-trivial due to the nature of the markup (nested items aren't children but siblings) and no native support for transitions on [auto dimensions](https://css-tricks.com/using-css-transitions-auto-dimensions/). We'll need JS to animate this. Ideally react spring should be updated before we add another animation here. See https://github.com/WordPress/gutenberg/pull/30979

Due to related interest, I also wrote up a quick issue around if Tree Grid still makes sense for this component https://github.com/WordPress/gutenberg/issues/32294

https://user-images.githubusercontent.com/1270189/119903244-4a733680-befd-11eb-9704-d819408f648f.mp4

### Requested Feedback 👀 

~~The main thing that sticks out is **state management** and **keyboard/focus handling**. Right now keyboard handling is implemented at the Tree Grid level, which makes triggering callbacks at the branch level very difficult. I couldn't think of a good way of preserving nested collapsed state without resorting to a heavier data solution like a data store, or something a bit hacky like the click() call I made. Let me know if folks had thoughts around that.~~ I think I have this mostly sorted with useReducer, but I can also make a data store here if folks would prefer that instead.

### Testing Instructions

- Navigate to the Post or Site Editor, and click to display the list view.
- Verify that clicking on the chevron toggles display of nested items
- Hidden items should not be rendered in the DOM
- Toggle state of child items should be preserved.
- Other list views like in the Navigation block should still work/make sense


https://user-images.githubusercontent.com/1270189/119904700-97f0a300-beff-11eb-8f78-3e4fa7b837cd.mp4





