### PR TITLE
Blocks package: memoize getBlockVariations selector

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -84,16 +84,22 @@ export function getBlockStyles( state, name ) {
  *
  * @return {(WPBlockVariation[]|void)} Block variations.
  */
-export function getBlockVariations( state, blockName, scope ) {
-	const variations = state.blockVariations[ blockName ];
-	if ( ! variations || ! scope ) {
-		return variations;
-	}
-	return variations.filter( ( variation ) => {
-		// For backward compatibility reasons, variation's scope defaults to `block` and `inserter` when not set.
-		return ( variation.scope || [ 'block', 'inserter' ] ).includes( scope );
-	} );
-}
+export const getBlockVariations = createSelector(
+	( state, blockName, scope ) => {
+		const variations = state.blockVariations[ blockName ];
+		if ( ! variations || ! scope ) {
+			return variations;
+		}
+		return variations.filter( ( variation ) => {
+			// For backward compatibility reasons, variation's scope defaults to
+			// `block` and `inserter` when not set.
+			return ( variation.scope || [ 'block', 'inserter' ] ).includes(
+				scope
+			);
+		} );
+	},
+	( state, blockName ) => [ state.blockVariations[ blockName ] ]
+);
 
 /**
  * Returns the active block variation for a given block based on its attributes.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Must be memoized because Array.filter returns a new array.

Introduced in https://github.com/WordPress/gutenberg/commit/bc38a3d48178ba98adbcce2fd2f385bdf2270fc5#r51148490.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
