### PR TITLE
Navigation Editor: Try fixing failing tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -520,34 +520,25 @@ describe( 'Navigation editor', () => {
 			] );
 
 			await visitNavigationEditor();
+
+			// Wait for the navigation setting sidebar.
+			await page.waitForSelector( '.edit-navigation-sidebar' );
 		} );
 
 		afterEach( async () => {
 			await setUpResponseMocking( [] );
 		} );
 
-		async function assertIsDirty( isDirty ) {
-			let hadDialog = false;
+		async function getIsDirty() {
+			const dirtyRecords = await page.evaluate( () =>
+				wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords()
+			);
 
-			function handleOnDialog() {
-				hadDialog = true;
-			}
-
-			try {
-				page.on( 'dialog', handleOnDialog );
-				await page.reload();
-
-				// Ensure whether it was expected that dialog was encountered.
-				expect( hadDialog ).toBe( isDirty );
-			} catch ( error ) {
-				throw error;
-			} finally {
-				page.removeListener( 'dialog', handleOnDialog );
-			}
+			return dirtyRecords.length > 0;
 		}
 
 		it( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
-			await assertIsDirty( false );
+			expect( await getIsDirty() ).toBe( false );
 		} );
 
 		it( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
@@ -556,7 +547,7 @@ describe( 'Navigation editor', () => {
 				' Menu'
 			);
 
-			await assertIsDirty( true );
+			expect( await getIsDirty() ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
PR is the second attempt to fix failing navigation editor e2e tests.

I've replaced how "dirty" records are asserted, and now it's checked via WP data instead of listening for a dialog.

I was only able to reproduce exact errors when disabled response mocking. Based on this, my best guess is that there's an issue with response mocking and `page.reload()`.

## How has this been tested?
1. Make sure the `wp-env` package is up to date.
2. Run `npm run test-e2e -- packages/e2e-tests/specs/experiments/navigation-editor.test.js` a few times.
3. Confirm that e2e tests for navigation aren't failing.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
