### PR TITLE
Handle large padding values in Spacing Block Support

### DIFF
--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -14,6 +14,16 @@ export default function SpacingPanelControl( { children, ...props } ) {
 	const isSpacingEnabled = useEditorFeature( 'spacing.customPadding' );
 
 	if ( ! isSpacingEnabled ) return null;
+	const styles = children?.props?.attributes?.style?.spacing?.padding;
+	const topPX = parseInt( styles?.top );
+	const clientWidth = window.screen.width / 2;
+	if ( styles && topPX > clientWidth ) {
+		alert( 'Very big padding , script will refresh padding' );
+		styles.top = '20px';
+		styles.left = '20px';
+		styles.bottom = '20px';
+		styles.right = '20px';
+	}
 
 	return (
 		<InspectorControls { ...props }>


### PR DESCRIPTION
Hello everyone ) this is a fix to " Spacing Block Support allows extremely large padding values causing overflow #31773 " issue . I was trying to change styles in CoverEdit function but it is not change styles when padding is big. So I added check for padding in SpacingPanelControl