### PR TITLE
Update Dropdown’s close-on-blur logic to work inside dialogs

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -56,17 +56,17 @@ export default function Dropdown( {
 	}
 
 	/**
-	 * Closes the dropdown if a focus leaves the dropdown wrapper. This is
-	 * intentionally distinct from `onClose` since focus loss from the popover
-	 * is expected to occur when using the Dropdown's toggle button, in which
-	 * case the correct behavior is to keep the dropdown closed. The same applies
-	 * in case when focus is moved to the modal dialog.
+	 * Closes the popover when focus leaves it unless the toggle was pressed or
+	 * focus has moved to a separate dialog. The former is to let the toggle
+	 * handle closing the popover and the latter is to preserve presence in
+	 * case a dialog has opened, allowing focus to return when it's dismissed.
 	 */
 	function closeIfFocusOutside() {
 		const { ownerDocument } = containerRef.current;
+		const dialog = ownerDocument.activeElement.closest( '[role="dialog"]' );
 		if (
 			! containerRef.current.contains( ownerDocument.activeElement ) &&
-			! ownerDocument.activeElement.closest( '[role="dialog"]' )
+			( ! dialog || dialog.contains( containerRef.current ) )
 		) {
 			close();
 		}


### PR DESCRIPTION
To fix: #32128

## How has this been tested?
Manually in the post editor. 
<details>
<summary>Snippet to run in the console for testable Modal with DropdownMenu as seen in the videos</summary>

```javascript
( function ( wp ) {
    const registerPlugin = wp.plugins.registerPlugin;
    const PluginSidebar = wp.editPost.PluginSidebar;
    const { createElement:el, Fragment } = wp.element;
    const { Button, DropdownMenu, Modal } = wp.components;

    const NModal = () => {
        const [ isOpen, setOpen ] = wp.element.useState( false );
        const openModal = () => setOpen( true );
        const closeModal = () => setOpen( false );

        return el( Fragment,{},
            el( Button, {isSecondary: true, onClick: openModal }, 'DropdownMenu in Modal' ),
            ( isOpen &&
                el( Modal, {
                    title: "Not dismissible",
                    isDismissible: false
                },
                    el( 'p', {}, 'Someone set up us the bomb' ),
                    el( DropdownMenu, {
                        icon: 'ellipsis',
                        label: 'Actions',
                        controls: [
                            {
                                title: 'Foo',
                                label: 'Foo',
                                icon: 'table-col-delete',
                            },
                        ],
                    } ),
                    el( 'hr', {} ),
                    el( Button, {
                        isSecondary:true,
                        onClick: closeModal
                    },
                        'Okay'
                    )
                )
            )
        );
    };

    registerPlugin( 'sidebarino', {
        render: function () {
            return el(
                PluginSidebar,
                {
                    name: 'sidebarino',
                    icon: 'admin-post',
                    title: 'Sidebarino',
                },
                el( NModal )
            );
        },
    } );

} )( window.wp );
```

</details>

## Screenshots
### Before

https://user-images.githubusercontent.com/9000376/119283566-53f55980-bbf2-11eb-8428-d04e04441a00.mp4

### After
Now the dropdown closes when focus goes back to its containing dialog. The end of the video shows that the dropdown does still remain open in cases where the focus goes to a modal launched from the dropdown (more menu).

https://user-images.githubusercontent.com/9000376/119283598-61aadf00-bbf2-11eb-8945-312a76977652.mp4

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
