### PR TITLE
Page list block: add active page classes

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -99,19 +99,19 @@ function render_nested_page_list( $nested_pages, $active_page_ancestor_ids = arr
 	}
 	$markup = '';
 	foreach ( (array) $nested_pages as $page ) {
-		$css_class = 'wp-block-pages-list__item' . $page['is_active'] ? ' current-menu-item' : '';
+		$css_class = $page['is_active'] ? ' current-menu-item' : '';
 		$css_class .= in_array( $page['page_id'], $active_page_ancestor_ids, true ) ? ' current-menu-ancestor' : '';
 		if ( isset( $page['children'] ) ) {
 			$css_class .= ' has-child';
 		}
-		$markup .= '<li class="' . $css_class . '">';
+		$markup .= '<li class="wp-block-pages-list__item' . $css_class . '">';
 		$markup .= '<a class="wp-block-pages-list__item__link" href="' . esc_url( $page['link'] ) . '">' . wp_kses(
 			$page['title'],
 			wp_kses_allowed_html( 'post' )
 		) . '</a>';
 		if ( isset( $page['children'] ) ) {
 			$markup .= '<span class="wp-block-page-list__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
-			$markup .= '<ul class="submenu-container">' . render_nested_page_list( $page['children'] ) . '</ul>';
+			$markup .= '<ul class="submenu-container">' . render_nested_page_list( $page['children'], $active_page_ancestor_ids ) . '</ul>';
 		}
 		$markup .= '</li>';
 	}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -99,7 +99,7 @@ function render_nested_page_list( $nested_pages, $active_page_ancestor_ids = arr
 	}
 	$markup = '';
 	foreach ( (array) $nested_pages as $page ) {
-		$css_class = $page['is_active'] ? ' current-menu-item' : '';
+		$css_class  = $page['is_active'] ? ' current-menu-item' : '';
 		$css_class .= in_array( $page['page_id'], $active_page_ancestor_ids, true ) ? ' current-menu-ancestor' : '';
 		if ( isset( $page['children'] ) ) {
 			$css_class .= ' has-child';
@@ -170,24 +170,24 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$active_page_ancestor_ids = array();
 
 	foreach ( (array) $all_pages as $page ) {
-		$is_active   = ! empty( $page->ID ) && ( get_the_ID() === $page->ID );
-		
+		$is_active = ! empty( $page->ID ) && ( get_the_ID() === $page->ID );
+
 		if ( $is_active ) {
 			$active_page_ancestor_ids = get_post_ancestors( $page->ID );
 		}
 
 		if ( $page->post_parent ) {
 			$pages_with_children[ $page->post_parent ][ $page->ID ] = array(
-				'page_id' => $page->ID,
-				'title' => $page->post_title,
-				'link'  => get_permalink( $page->ID ),
+				'page_id'   => $page->ID,
+				'title'     => $page->post_title,
+				'link'      => get_permalink( $page->ID ),
 				'is_active' => $is_active,
 			);
 		} else {
 			$top_level_pages[ $page->ID ] = array(
-				'page_id' => $page->ID,
-				'title' => $page->post_title,
-				'link'  => get_permalink( $page->ID ),
+				'page_id'   => $page->ID,
+				'title'     => $page->post_title,
+				'link'      => get_permalink( $page->ID ),
 				'is_active' => $is_active,
 			);
 


### PR DESCRIPTION
## Description

Fixes #29422 by adding `current-menu-item` &  `current-menu-ancestor` class to active page menu tree

## Testing

- Check out this PR
- Make sure you have nested pages set up on your site
- Add a page list block to a nav menu block in the header of an FSE enabled theme
- Select a nested page menu item and make sure it has `current-menu-item` class added to its `li` wrapper and that all its parents have `current-menu-ancestor` added

## Screenshots

Before:
<img width="814" alt="Screen Shot 2021-05-24 at 2 08 40 PM" src="https://user-images.githubusercontent.com/3629020/119286944-92921f00-bc99-11eb-8e75-79c0ebd888e0.png">

After:
<img width="871" alt="Screen Shot 2021-05-24 at 2 07 58 PM" src="https://user-images.githubusercontent.com/3629020/119286957-9756d300-bc99-11eb-9752-6ee3332639b4.png">
