### PR TITLE
Avoid a PHP Notice when `render_block()` is called without attributes.

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -13,7 +13,10 @@
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content, $block ) {
-	$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );
+	$link_color = null;
+	if ( ! empty( $block['attrs'] ) ) {
+		$link_color = _wp_array_get( $block_attrs, array( 'style', 'elements', 'link', 'color', 'text' ), null );
+	}
 
 	/*
 	* For now we only care about link color.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -15,7 +15,7 @@
 function gutenberg_render_elements_support( $block_content, $block ) {
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
-		$link_color = _wp_array_get( $block_attrs, array( 'style', 'elements', 'link', 'color', 'text' ), null );
+		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );
 	}
 
 	/*


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When `render_block()` is called without block attributes set, `wp_render_elements_supports()` causes a PHP Notice.

Example:
```
<?php echo render_block( array( 'blockName' => 'wporg-learn/workshop-details' ) ); ?>

E_NOTICE: Undefined index: attrs in wp-includes/block-supports/elements.php:20
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
 - Visual testing

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
