### PR TITLE
Prepare for adding the Widgets block editor to Core

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Marks the `core/legacy-widget` block as stable.
+
 ## 3.1.0 (2021-05-20)
 
 ## 3.0.0 (2021-05-14)

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -148,6 +148,7 @@ export const __experimentalGetCoreBlocks = () => [
 	mediaText,
 	latestComments,
 	latestPosts,
+	legacyWidget,
 	missing,
 	more,
 	nextpage,
@@ -229,14 +230,11 @@ export const registerCoreBlocks = (
  */
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
-		? ( { enableLegacyWidgetBlock, enableFSEBlocks } = {} ) => {
+		? ( { enableFSEBlocks } = {} ) => {
 				[
 					navigation,
 					navigationLink,
 					homeLink,
-
-					// Register Legacy Widget block.
-					...( enableLegacyWidgetBlock ? [ legacyWidget ] : [] ),
 
 					// Register Full Site Editing Blocks.
 					...( enableFSEBlocks

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"private": true,
 	"version": "1.0.0-prerelease",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -5,7 +5,6 @@ import { render } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { registerLegacyWidgetVariations } from '@wordpress/widgets';
 
@@ -30,12 +29,6 @@ export function initialize( editorName, blockEditorSettings ) {
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
 	registerCoreBlocks( coreBlocks );
-
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( {
-			enableLegacyWidgetBlock: true,
-		} );
-	}
 
 	registerLegacyWidgetVariations( blockEditorSettings );
 

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -5,6 +5,7 @@ import { render } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
+	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { registerLegacyWidgetVariations } from '@wordpress/widgets';
 
@@ -29,6 +30,8 @@ export function initialize( editorName, blockEditorSettings ) {
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
 	registerCoreBlocks( coreBlocks );
+
+	__experimentalRegisterExperimentalCoreBlocks();
 
 	registerLegacyWidgetVariations( blockEditorSettings );
 

--- a/packages/e2e-tests/fixtures/blocks/core__legacy-widget.html
+++ b/packages/e2e-tests/fixtures/blocks/core__legacy-widget.html
@@ -1,0 +1,1 @@
+<!-- wp:legacy-widget {"idBase":"search","instance":{"encoded":"YTowOnt9","hash":"b9b82f721929717273108125217fbcd9","raw":{}}} /-->

--- a/packages/e2e-tests/fixtures/blocks/core__legacy-widget.json
+++ b/packages/e2e-tests/fixtures/blocks/core__legacy-widget.json
@@ -1,0 +1,18 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "core/legacy-widget",
+		"isValid": true,
+		"attributes": {
+			"id": null,
+			"idBase": "search",
+			"instance": {
+				"encoded": "YTowOnt9",
+				"hash": "b9b82f721929717273108125217fbcd9",
+				"raw": {}
+			}
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__legacy-widget.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__legacy-widget.parsed.json
@@ -1,0 +1,16 @@
+[
+	{
+		"blockName": "core/legacy-widget",
+		"attrs": {
+			"idBase": "search",
+			"instance": {
+				"encoded": "YTowOnt9",
+				"hash": "b9b82f721929717273108125217fbcd9",
+				"raw": {}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__legacy-widget.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__legacy-widget.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:legacy-widget {"idBase":"search","instance":{"encoded":"YTowOnt9","hash":"b9b82f721929717273108125217fbcd9","raw":{}}} /-->

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -9,6 +9,7 @@ import { render } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
+	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import { registerLegacyWidgetVariations } from '@wordpress/widgets';
@@ -32,6 +33,7 @@ export function initialize( id, settings ) {
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
 	registerCoreBlocks( coreBlocks );
+	__experimentalRegisterExperimentalCoreBlocks();
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -9,7 +9,6 @@ import { render } from '@wordpress/element';
 import {
 	registerCoreBlocks,
 	__experimentalGetCoreBlocks,
-	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import { registerLegacyWidgetVariations } from '@wordpress/widgets';
@@ -33,11 +32,6 @@ export function initialize( id, settings ) {
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
 	registerCoreBlocks( coreBlocks );
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( {
-			enableLegacyWidgetBlock: true,
-		} );
-	}
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>


### PR DESCRIPTION
Makes two changes required to add the Widgets block editor to Core (https://core.trac.wordpress.org/ticket/51506):

- Marks the `@wordpress/customize-widgets` package as non-private so that it can be required by Core's package.json.
- Marks the Legacy Widget block as stable so that `registerCoreBlocks()` will register it.

I decided to enable Legacy Widget everywhere because:

- It works fine.
- We generally don't put restrictions on blocks, e.g. Site Logo can be used anywhere.
- There are good use-cases for having the block everywhere e.g. inserting a SiteOrigin Button into a block template.

To test:

1. Check that Appearance → Widgets still loads and supports Legacy Widget.
2. Check that Appearance → Customize → Widgets still loads and supports Legacy Widget.
4. Go to Posts → Add New and verify that you can add a Legacy Widget block. (Install the SiteOrigin Widgets plugin to get some widgets to test with.)