### PR TITLE
Fix call to undefined __experimentalRegisterExperimentalCoreBlocks

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -31,7 +31,9 @@ export function initialize( editorName, blockEditorSettings ) {
 	);
 	registerCoreBlocks( coreBlocks );
 
-	__experimentalRegisterExperimentalCoreBlocks();
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		__experimentalRegisterExperimentalCoreBlocks();
+	}
 
 	registerLegacyWidgetVariations( blockEditorSettings );
 

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -33,7 +33,9 @@ export function initialize( id, settings ) {
 		( block ) => ! [ 'core/more' ].includes( block.name )
 	);
 	registerCoreBlocks( coreBlocks );
-	__experimentalRegisterExperimentalCoreBlocks();
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		__experimentalRegisterExperimentalCoreBlocks();
+	}
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/32136 contained a mistake: If we're not in the Gutenberg plugin and `GUTENBERG_PHASE` is 1 then `__experimentalRegisterExperimentalCoreBlocks` will be `undefined`. We need to wrap the calls with a phase `if()`.

To test:

1. Set `GUTENBERG_PHASE` in `package.json` to `1` and re-run `npm run dev`.
2. Go to Appearance → Widgets or Appearance → Customize → Widgets.
3. There should be no error in the console.