### PR TITLE
Fix issue with customizer title overlapping block toolbar

### DIFF
--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -8,4 +8,17 @@
 	// Make the entire sidebar background white.
 	min-height: 100%;
 	background-color: $white;
+
+	// Override the inline styles added via JS that make the section title
+	// sticky feature work. The customize widget block-editor disables this
+	// sticky title.
+	padding-top: 10px !important;
+
+	.customize-section-title {
+		// Disable the sticky title. `!important` as this overrides inline
+		// styles added via JavaScript.
+		position: static !important;
+		top: 0 !important;
+		width: unset !important;
+	}
 }


### PR DESCRIPTION
## Description
Fixes #32060

Adds some CSS to override the 'sticky' title behavior in the widgets block editor part of the customizer.

I looked through the customizer codebase in WordPress core, and couldn't see an options to disable the sticky title. Its inline styles are set using a bunch of JavaScript. As we're now in the feature freeze period, it seems best to fix this in a low impact fashion, but in the long run there are some options:
- Make the sticky title feature configureable for each customizer section.
- Make the widget editor use `position: sticky` styling instead of the custom implementation it has now.

## How has this been tested?
1. Open the customize widgets editor
2. Add enough blocks until you get a decent sized scrollbar.
3. Select a block near the top so that the block toolbar shows
4. Scroll up and down a reasonable distance
5. The title of the customizer sizebar should never overlap the block toolbar (see the issue in the video for an example.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
