### PR TITLE
Reusable-block: no-string-literals fix

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { hasBlockSupport, isReusableBlock } from '@wordpress/blocks';
-import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import {
+	BlockSettingsMenuControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useCallback, useState } from '@wordpress/element';
 import {
 	MenuItem,
@@ -16,6 +19,7 @@ import { reusableBlock } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -38,9 +42,9 @@ export default function ReusableBlockConvertButton( {
 	const [ title, setTitle ] = useState( '' );
 	const canConvert = useSelect(
 		( select ) => {
-			const { canUser } = select( 'core' );
+			const { canUser } = select( coreStore );
 			const { getBlocksByClientId, canInsertBlockType } = select(
-				'core/block-editor'
+				blockEditorStore
 			);
 
 			const blocks = getBlocksByClientId( clientIds ) ?? [];
@@ -49,7 +53,7 @@ export default function ReusableBlockConvertButton( {
 				blocks.length === 1 &&
 				blocks[ 0 ] &&
 				isReusableBlock( blocks[ 0 ] ) &&
-				!! select( 'core' ).getEntityRecord(
+				!! select( coreStore ).getEntityRecord(
 					'postType',
 					'wp_block',
 					blocks[ 0 ].attributes.ref

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -10,12 +10,13 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 function ReusableBlocksManageButton( { clientId } ) {
 	const { isVisible } = useSelect(
 		( select ) => {
 			const { getBlock } = select( blockEditorStore );
-			const { canUser } = select( 'core' );
+			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
 
 			return {


### PR DESCRIPTION
## Description
Fixes eslint warnings in the reusable-blocks package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/reusable-blocks/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
