### PR TITLE
rich-text: no-string-literals fix

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -6,7 +6,7 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-
+import { store as richTextStore } from './store';
 import { isFormatEqual } from './is-format-equal';
 import { createElement } from './create-element';
 import { mergePair } from './concat';
@@ -56,7 +56,7 @@ function toFormat( { type, attributes } ) {
 	let formatType;
 
 	if ( attributes && attributes.class ) {
-		formatType = select( 'core/rich-text' ).getFormatTypeForClassName(
+		formatType = select( richTextStore ).getFormatTypeForClassName(
 			attributes.class
 		);
 
@@ -73,7 +73,7 @@ function toFormat( { type, attributes } ) {
 	}
 
 	if ( ! formatType ) {
-		formatType = select( 'core/rich-text' ).getFormatTypeForBareElement(
+		formatType = select( richTextStore ).getFormatTypeForBareElement(
 			type
 		);
 	}


### PR DESCRIPTION
## Description
Fixes eslint warnings in the rich-text package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/rich-text/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
