### PR TITLE
ignore some eslint rules in react-native folders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -164,7 +164,11 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/*.@(android|ios|native).js', ...developmentFiles ],
+			files: [
+				'**/*.@(android|ios|native).js',
+				'packages/react-native-*/**/*.js',
+				...developmentFiles,
+			],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 				'import/no-unresolved': 'off',


### PR DESCRIPTION
## Description
We're currently bypassing some eslint rules for `*native.js` files. The `react-native-*` packages should also be excluded from these checks.

## Types of changes
`.eslintrc` edit

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
