### PR TITLE
[RNMobile] Updates Android Gradle Plugin to 4.0.2

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '4.0.1'
+        gradlePluginVersion = '4.0.2'
         kotlinVersion = '1.3.61'
         supportLibVersion = '29.0.2'
         tagSoupVersion = '1.2.1'

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '4.0.1'
+        gradlePluginVersion = '4.0.2'
         kotlinVersion = '1.3.61'
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3542

## Description
This PR updates Android Gradle Plugin to `4.0.2` to matches the [change introduced on `WordPress-Android`](https://github.com/wordpress-mobile/WordPress-Android/pull/14695), so it can be used for composite builds.

## How has this been tested?
* Check `gutenberg-mobile` PR: wordpress-mobile/gutenberg-mobile#3542

## Types of changes
Tooling change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
