### PR TITLE
nux: no-string-literals fix

### DIFF
--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -8,6 +8,11 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { store as nuxStore } from '../../store';
+
 function onClick( event ) {
 	// Tips are often nested within buttons. We stop propagation so that clicking
 	// on a tip doesn't result in the button being clicked.
@@ -69,7 +74,7 @@ export function DotTip( {
 
 export default compose(
 	withSelect( ( select, { tipId } ) => {
-		const { isTipVisible, getAssociatedGuide } = select( 'core/nux' );
+		const { isTipVisible, getAssociatedGuide } = select( nuxStore );
 		const associatedGuide = getAssociatedGuide( tipId );
 		return {
 			isVisible: isTipVisible( tipId ),
@@ -77,7 +82,7 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { tipId } ) => {
-		const { dismissTip, disableTips } = dispatch( 'core/nux' );
+		const { dismissTip, disableTips } = dispatch( nuxStore );
 		return {
 			onDismiss() {
 				dismissTip( tipId );


### PR DESCRIPTION
## Description
Fixes eslint warnings in the nux package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/nux/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
