### PR TITLE
Add ability to filter the settings options for `<LinkControl>`

### DIFF
--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -7,6 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
 const defaultSettings = [
@@ -21,7 +22,13 @@ const LinkControlSettingsDrawer = ( {
 	onChange = noop,
 	settings = defaultSettings,
 } ) => {
-	if ( ! settings || ! settings.length ) {
+	settings = applyFilters(
+		'core.block-editor.link-control.settings',
+		settings,
+		value
+	);
+
+	if ( ! settings || ! Array.isArray( settings ) || ! settings.length ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -35,7 +35,10 @@ const LinkControlSettingsDrawer = ( {
 	const handleSettingChange = ( setting ) => ( newValue ) => {
 		onChange( {
 			...value,
-			[ setting.id ]: newValue,
+			settings: {
+				...value.settings,
+				[ setting.id ]: newValue,
+			},
 		} );
 	};
 
@@ -45,7 +48,9 @@ const LinkControlSettingsDrawer = ( {
 			key={ setting.id }
 			label={ setting.title }
 			onChange={ handleSettingChange( setting ) }
-			checked={ value ? !! value[ setting.id ] : false }
+			checked={
+				value?.settings ? !! value?.settings[ setting.id ] : false
+			}
 		/>
 	) );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1752,6 +1752,52 @@ describe( 'Additional Settings UI', () => {
 			'myplugin/block-editor/link-control-settings'
 		);
 	} );
+
+	it.each( [ [], false, undefined, 'foo' ] )(
+		'should not render a UI for invalid/empty settings value of: %s',
+		( filteredSettings ) => {
+			const selectedLink = first( fauxEntitySuggestions );
+
+			const LinkControlConsumer = () => {
+				const [ link ] = useState( selectedLink );
+
+				return <LinkControl value={ { ...link } } />;
+			};
+
+			// Filter the settings.
+			addFilter(
+				'core.block-editor.link-control.settings',
+				'myplugin/block-editor/link-control-settings',
+				() => {
+					return filteredSettings;
+				}
+			);
+
+			act( () => {
+				render( <LinkControlConsumer />, container );
+			} );
+
+			// Grab the elements using user perceivable DOM queries
+			const settingsLegend = Array.from(
+				container.querySelectorAll( 'legend' )
+			).find(
+				( legend ) =>
+					legend.innerHTML &&
+					legend.innerHTML.includes(
+						'Currently selected link settings'
+					)
+			);
+
+			// Should not exist because component will have returned null due
+			// no settings being passed.
+			expect( settingsLegend ).toBeUndefined();
+
+			removeFilter(
+				'core.block-editor.link-control.settings',
+				'myplugin/block-editor/link-control-settings'
+			);
+		}
+	);
 } );
 
 describe( 'Post types', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<img width="573" alt="Screen Shot 2021-05-24 at 12 29 36" src="https://user-images.githubusercontent.com/444434/119341485-b9e1ef80-bc8b-11eb-88e4-e7a731764a66.png">

[As suggested by Tammie](https://github.com/WordPress/gutenberg/issues/23011#issuecomment-725638745), this PR adds a filter to the `<LinkControlSettingsDrawer>` component to allow Plugin developers to customise the options displayed there.

There is some concern regarding adding too much visual "clutter" to such an important piece of UI. Therefore, this implementation _intentionally_ does not use Slot/Fill and prefers the hooks API (yes I am aware that we prefer not to use filters in Gutenberg) in order to limit the scope of what can be added. Currently, this is limited to boolean-type options only.



It was suggested to add a toggle to show/hide the additional options based on the number of options shown. THis was to avoid undue visual clutter. This PR does not attempt to address this aspect.

**Note**: I am suggesting this filter is marked as `__experimental` in order that it can be revoked if the community feel it is becoming a problem. I haven't yet implemented it as such but that can't be changed very easily by updating the hook name from:

```
'core.block-editor.link-control.settings',
```

...to something like: 

```
'__experimental.block-editor.link-control.settings',
```

cc'ing @mtias as I have a feeling he had some opinions on whether this is a good idea.

## How has this been tested?

I've added automated unit tests to validate the filter.

You can also test the UI directly using browser dev tools. 

* Open the `Console` tab of dev tools.
* Paste in 
```js
wp.hooks.addFilter(
  "core.block-editor.link-control.settings",
  "myplugin/block-editor/link-control-settings",
  (settings) => {
    console.log(settings);
    return [
      ...settings,
      {
        id: "noFollow",
        title: "No follow",
      },
      {
        id: "myCustomOption",
        title: "Is this filter good?",
      },
    ];
  }
);
```
* Add a link to a piece of text.
* See new options added.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/119341313-8606ca00-bc8b-11eb-85d1-46511c8b8764.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
