### PR TITLE
Remove `gutenberg` domain from core blocks

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -31,7 +31,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 	// Set default values.
 	$format = '%link';
-	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link', 'gutenberg' ) : _x( 'Previous', 'label for previous post link', 'gutenberg' );
+	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
 	$label  = '';
 	// If a custom label is provided, make this a link.
 	// `$label` is used to prepend the provided label, if we want to show the page title as well.

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -20,7 +20,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$default_label      = __( 'Next Page &raquo;', 'gutenberg' );
+	$default_label      = __( 'Next Page &raquo;' );
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$content            = '';
 

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -19,7 +19,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$default_label      = __( '&laquo; Previous Page', 'gutenberg' );
+	$default_label      = __( '&laquo; Previous Page' );
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$content            = '';
 	// Check if the pagination is for Query that inherits the global context

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -21,7 +21,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label   = ( isset( $attributes['label'] ) ) ? $attributes['label'] : sprintf(
 		/* translators: %1$s: Social-network name. %2$s: URL. */
-		__( '%1$s: %2$s', 'gutenberg' ),
+		__( '%1$s: %2$s' ),
 		block_core_social_link_get_name( $service ),
 		$url
 	);


### PR DESCRIPTION
This PR just removes `gutenberg` domain left from some core blocks.