### PR TITLE
Editor package: no-string-literals fix

### DIFF
--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -4,6 +4,12 @@
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 /**
  * AutosaveMonitor invokes `props.autosave()` within at most `interval` seconds after an unsaved change is detected.
@@ -82,14 +88,14 @@ export class AutosaveMonitor extends Component {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getReferenceByDistinctEdits } = select( 'core' );
+		const { getReferenceByDistinctEdits } = select( coreStore );
 
 		const {
 			isEditedPostDirty,
 			isEditedPostAutosaveable,
 			isAutosavingPost,
 			getEditorSettings,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 
 		const { interval = getEditorSettings().autosaveInterval } = ownProps;
 
@@ -103,7 +109,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		autosave() {
-			const { autosave = dispatch( 'core/editor' ).autosave } = ownProps;
+			const { autosave = dispatch( editorStore ).autosave } = ownProps;
 			autosave();
 		},
 	} ) ),

--- a/packages/editor/src/components/character-count/index.js
+++ b/packages/editor/src/components/character-count/index.js
@@ -4,9 +4,14 @@
 import { useSelect } from '@wordpress/data';
 import { count as characterCount } from '@wordpress/wordcount';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export default function CharacterCount() {
 	const content = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( 'content' )
+		select( editorStore ).getEditedPostAttribute( 'content' )
 	);
 
 	return characterCount( content, 'characters_including_spaces' );

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -11,11 +11,13 @@ import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { create, getTextContent } from '@wordpress/rich-text';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import DocumentOutlineItem from './item';
+import { store as editorStore } from '../../store';
 
 /**
  * Module constants
@@ -146,8 +148,8 @@ export const DocumentOutline = ( {
 export default compose(
 	withSelect( ( select ) => {
 		const { getBlocks } = select( blockEditorStore );
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const { getPostType } = select( 'core' );
+		const { getEditedPostAttribute } = select( editorStore );
+		const { getPostType } = select( coreStore );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -6,6 +6,12 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 export default function EntityRecordItem( {
 	record,
@@ -16,7 +22,7 @@ export default function EntityRecordItem( {
 	const { name, kind, title, key } = record;
 	const parentBlockId = useSelect( ( select ) => {
 		// Get entity's blocks.
-		const { blocks = [] } = select( 'core' ).getEditedEntityRecord(
+		const { blocks = [] } = select( coreStore ).getEditedEntityRecord(
 			kind,
 			name,
 			key
@@ -36,12 +42,12 @@ export default function EntityRecordItem( {
 				return title;
 			}
 
-			const template = select( 'core' ).getEditedEntityRecord(
+			const template = select( coreStore ).getEditedEntityRecord(
 				kind,
 				name,
 				key
 			);
-			return select( 'core/editor' ).__experimentalGetTemplateInfo(
+			return select( editorStore ).__experimentalGetTemplateInfo(
 				template
 			).title;
 		},

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -8,6 +8,11 @@ import { select } from '@wordpress/data';
 import { Warning } from '@wordpress/block-editor';
 import { useCopyToClipboard } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function CopyButton( { text, children } ) {
 	const ref = useCopyToClipboard( text );
 	return (
@@ -45,7 +50,7 @@ class ErrorBoundary extends Component {
 			// (b) avoids the performance cost associated with unnecessary
 			// content serialization throughout the lifetime of a non-erroring
 			// application.
-			return select( 'core/editor' ).getEditedPostContent();
+			return select( editorStore ).getEditedPostContent();
 		} catch ( error ) {}
 	}
 

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -5,13 +5,18 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function SaveShortcut( { resetBlocksOnSave } ) {
-	const { resetEditorBlocks, savePost } = useDispatch( 'core/editor' );
+	const { resetEditorBlocks, savePost } = useDispatch( editorStore );
 	const { isEditedPostDirty, getPostEdits } = useSelect( ( select ) => {
 		const {
 			isEditedPostDirty: _isEditedPostDirty,
 			getPostEdits: _getPostEdits,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 
 		return {
 			isEditedPostDirty: _isEditedPostDirty,

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -9,9 +9,10 @@ import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import SaveShortcut from './save-shortcut';
+import { store as editorStore } from '../../store';
 
 function VisualEditorGlobalKeyboardShortcuts() {
-	const { redo, undo } = useDispatch( 'core/editor' );
+	const { redo, undo } = useDispatch( editorStore );
 
 	useShortcut(
 		'core/editor/undo',

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -18,6 +18,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import AutosaveMonitor from '../autosave-monitor';
 import { localAutosaveGet, localAutosaveClear } from '../../store/controls';
+import { store as editorStore } from '../../store';
 
 const requestIdleCallback = window.requestIdleCallback
 	? window.requestIdleCallback
@@ -48,11 +49,11 @@ const hasSessionStorageSupport = once( () => {
 function useAutosaveNotice() {
 	const { postId, isEditedPostNew, hasRemoteAutosave } = useSelect(
 		( select ) => ( {
-			postId: select( 'core/editor' ).getCurrentPostId(),
-			isEditedPostNew: select( 'core/editor' ).isEditedPostNew(),
-			getEditedPostAttribute: select( 'core/editor' )
+			postId: select( editorStore ).getCurrentPostId(),
+			isEditedPostNew: select( editorStore ).isEditedPostNew(),
+			getEditedPostAttribute: select( editorStore )
 				.getEditedPostAttribute,
-			hasRemoteAutosave: !! select( 'core/editor' ).getEditorSettings()
+			hasRemoteAutosave: !! select( editorStore ).getEditorSettings()
 				.autosave,
 		} ),
 		[]
@@ -60,7 +61,7 @@ function useAutosaveNotice() {
 	const { getEditedPostAttribute } = useSelect( 'core/editor' );
 
 	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
-	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+	const { editPost, resetEditorBlocks } = useDispatch( editorStore );
 
 	useEffect( () => {
 		let localAutosave = localAutosaveGet( postId, isEditedPostNew );
@@ -130,11 +131,11 @@ function useAutosavePurge() {
 		didError,
 	} = useSelect(
 		( select ) => ( {
-			postId: select( 'core/editor' ).getCurrentPostId(),
-			isEditedPostNew: select( 'core/editor' ).isEditedPostNew(),
-			isDirty: select( 'core/editor' ).isEditedPostDirty(),
-			isAutosaving: select( 'core/editor' ).isAutosavingPost(),
-			didError: select( 'core/editor' ).didPostSaveRequestFail(),
+			postId: select( editorStore ).getCurrentPostId(),
+			isEditedPostNew: select( editorStore ).isEditedPostNew(),
+			isDirty: select( editorStore ).isEditedPostDirty(),
+			isAutosaving: select( editorStore ).isAutosavingPost(),
+			didError: select( editorStore ).didPostSaveRequestFail(),
 		} ),
 		[]
 	);
@@ -166,7 +167,7 @@ function useAutosavePurge() {
 }
 
 function LocalAutosaveMonitor() {
-	const { autosave } = useDispatch( 'core/editor' );
+	const { autosave } = useDispatch( editorStore );
 	const deferedAutosave = useCallback( () => {
 		requestIdleCallback( () => autosave( { local: true } ) );
 	}, [] );
@@ -175,7 +176,7 @@ function LocalAutosaveMonitor() {
 
 	const { localAutosaveInterval } = useSelect(
 		( select ) => ( {
-			localAutosaveInterval: select( 'core/editor' ).getEditorSettings()
+			localAutosaveInterval: select( editorStore ).getEditorSettings()
 				.__experimentalLocalAutosaveInterval,
 		} ),
 		[]

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -15,6 +15,7 @@ import { compose, withState } from '@wordpress/compose';
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 
 export const PageAttributesOrder = withState( {
 	orderInput: null,
@@ -60,14 +61,12 @@ function PageAttributesOrderWithChecks( props ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			order: select( 'core/editor' ).getEditedPostAttribute(
-				'menu_order'
-			),
+			order: select( editorStore ).getEditedPostAttribute( 'menu_order' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
 		onUpdateOrder( order ) {
-			dispatch( 'core/editor' ).editPost( {
+			dispatch( editorStore ).editPost( {
 				menu_order: order,
 			} );
 		},

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -19,11 +19,13 @@ import { ComboboxControl } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { buildTermsTree } from '../../utils/terms';
+import { store as editorStore } from '../../store';
 
 function getTitle( post ) {
 	return post?.title?.rendered
@@ -46,15 +48,15 @@ export const getItemPriority = ( name, searchValue ) => {
 };
 
 export function PageAttributesParent() {
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 	const [ fieldValue, setFieldValue ] = useState( false );
 	const { parentPost, parentPostId, items, postType } = useSelect(
 		( select ) => {
 			const { getPostType, getEntityRecords, getEntityRecord } = select(
-				'core'
+				coreStore
 			);
 			const { getCurrentPostId, getEditedPostAttribute } = select(
-				'core/editor'
+				editorStore
 			);
 			const postTypeSlug = getEditedPostAttribute( 'type' );
 			const pageId = getEditedPostAttribute( 'parent' );

--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -8,11 +8,13 @@ import { get } from 'lodash';
  */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 
 export function PostAuthorCheck( {
 	hasAssignAuthorAction,
@@ -32,15 +34,15 @@ export function PostAuthorCheck( {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const post = select( 'core/editor' ).getCurrentPost();
+		const post = select( editorStore ).getCurrentPost();
 		return {
 			hasAssignAuthorAction: get(
 				post,
 				[ '_links', 'wp:action-assign-author' ],
 				false
 			),
-			postType: select( 'core/editor' ).getCurrentPostType(),
-			authors: select( 'core' ).getAuthors(),
+			postType: select( editorStore ).getCurrentPostType(),
+			authors: select( coreStore ).getAuthors(),
 		};
 	} ),
 	withInstanceId,

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -10,6 +10,12 @@ import { useState, useMemo, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ComboboxControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function PostAuthorCombobox() {
 	const [ fieldValue, setFieldValue ] = useState();
@@ -17,9 +23,9 @@ function PostAuthorCombobox() {
 	const { authorId, isLoading, authors, postAuthor } = useSelect(
 		( select ) => {
 			const { __unstableGetAuthor, getAuthors, isResolving } = select(
-				'core'
+				coreStore
 			);
-			const { getEditedPostAttribute } = select( 'core/editor' );
+			const { getEditedPostAttribute } = select( editorStore );
 			const author = __unstableGetAuthor(
 				getEditedPostAttribute( 'author' )
 			);
@@ -34,7 +40,7 @@ function PostAuthorCombobox() {
 		},
 		[ fieldValue ]
 	);
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 
 	const authorOptions = useMemo( () => {
 		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -5,13 +5,19 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { SelectControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function PostAuthorSelect() {
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 	const { postAuthor, authors } = useSelect( ( select ) => {
-		const authorsFromAPI = select( 'core' ).getAuthors();
+		const authorsFromAPI = select( coreStore ).getAuthors();
 		return {
-			postAuthor: select( 'core/editor' ).getEditedPostAttribute(
+			postAuthor: select( editorStore ).getEditedPostAttribute(
 				'author'
 			),
 			authors: authorsFromAPI.map( ( author ) => ( {

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -6,6 +6,11 @@ import { CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function PostComments( { commentStatus = 'open', ...props } ) {
 	const onToggleComments = () =>
 		props.editPost( {
@@ -24,12 +29,12 @@ function PostComments( { commentStatus = 'open', ...props } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			commentStatus: select( 'core/editor' ).getEditedPostAttribute(
+			commentStatus: select( editorStore ).getEditedPostAttribute(
 				'comment_status'
 			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		editPost: dispatch( 'core/editor' ).editPost,
+		editPost: dispatch( editorStore ).editPost,
 	} ) ),
 ] )( PostComments );

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -6,6 +6,11 @@ import { ExternalLink, TextareaControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	return (
 		<div className="editor-post-excerpt">
@@ -27,14 +32,12 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			excerpt: select( 'core/editor' ).getEditedPostAttribute(
-				'excerpt'
-			),
+			excerpt: select( editorStore ).getEditedPostAttribute( 'excerpt' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
 		onUpdateExcerpt( excerpt ) {
-			dispatch( 'core/editor' ).editPost( { excerpt } );
+			dispatch( editorStore ).editPost( { excerpt } );
 		},
 	} ) ),
 ] )( PostExcerpt );

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -23,11 +23,13 @@ import {
 	MediaUploadCheck,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import PostFeaturedImageCheck from './check';
+import { store as editorStore } from '../../store';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -209,10 +211,8 @@ function PostFeaturedImage( {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getMedia, getPostType } = select( 'core' );
-	const { getCurrentPostId, getEditedPostAttribute } = select(
-		'core/editor'
-	);
+	const { getMedia, getPostType } = select( coreStore );
+	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
@@ -225,7 +225,7 @@ const applyWithSelect = withSelect( ( select ) => {
 
 const applyWithDispatch = withDispatch(
 	( dispatch, { noticeOperations }, { select } ) => {
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( editorStore );
 		return {
 			onUpdateImage( image ) {
 				editPost( { featured_media: image.id } );

--- a/packages/editor/src/components/post-format/check.js
+++ b/packages/editor/src/components/post-format/check.js
@@ -7,6 +7,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 
 function PostFormatCheck( { disablePostFormats, ...props } ) {
 	return (
@@ -17,7 +18,7 @@ function PostFormatCheck( { disablePostFormats, ...props } ) {
 }
 
 export default withSelect( ( select ) => {
-	const editorSettings = select( 'core/editor' ).getEditorSettings();
+	const editorSettings = select( editorStore ).getEditorSettings();
 	return {
 		disablePostFormats: editorSettings.disablePostFormats,
 	};

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -10,11 +10,13 @@ import { __ } from '@wordpress/i18n';
 import { Button, SelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import PostFormatCheck from './check';
+import { store as editorStore } from '../../store';
 
 // All WP post formats, sorted alphabetically by translated name.
 export const POST_FORMATS = [
@@ -48,10 +50,10 @@ export default function PostFormat() {
 	const { postFormat, suggestedFormat, supportedFormats } = useSelect(
 		( select ) => {
 			const { getEditedPostAttribute, getSuggestedPostFormat } = select(
-				'core/editor'
+				editorStore
 			);
 			const _postFormat = getEditedPostAttribute( 'format' );
-			const themeSupports = select( 'core' ).getThemeSupports();
+			const themeSupports = select( coreStore ).getThemeSupports();
 			return {
 				postFormat: _postFormat ?? 'standard',
 				suggestedFormat: getSuggestedPostFormat(),
@@ -74,7 +76,7 @@ export default function PostFormat() {
 		( format ) => format.id === suggestedFormat
 	);
 
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 
 	const onUpdatePostFormat = ( format ) => editPost( { format } );
 

--- a/packages/editor/src/components/post-last-revision/check.js
+++ b/packages/editor/src/components/post-last-revision/check.js
@@ -7,6 +7,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 
 export function PostLastRevisionCheck( {
 	lastRevisionId,
@@ -28,7 +29,7 @@ export default withSelect( ( select ) => {
 	const {
 		getCurrentPostLastRevisionId,
 		getCurrentPostRevisionsCount,
-	} = select( 'core/editor' );
+	} = select( editorStore );
 	return {
 		lastRevisionId: getCurrentPostLastRevisionId(),
 		revisionsCount: getCurrentPostRevisionsCount(),

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -11,6 +11,7 @@ import { backup } from '@wordpress/icons';
  */
 import PostLastRevisionCheck from './check';
 import { getWPAdminURL } from '../../utils/url';
+import { store as editorStore } from '../../store';
 
 function LastRevision( { lastRevisionId, revisionsCount } ) {
 	return (
@@ -37,7 +38,7 @@ export default withSelect( ( select ) => {
 	const {
 		getCurrentPostLastRevisionId,
 		getCurrentPostRevisionsCount,
-	} = select( 'core/editor' );
+	} = select( editorStore );
 	return {
 		lastRevisionId: getCurrentPostLastRevisionId(),
 		revisionsCount: getCurrentPostRevisionsCount(),

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -13,17 +13,19 @@ import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
 import { useInstanceId } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { getWPAdminURL } from '../../utils/url';
 import PostPreviewButton from '../post-preview-button';
+import { store as editorStore } from '../../store';
 
 export default function PostLockedModal() {
 	const instanceId = useInstanceId( PostLockedModal );
 	const hookName = 'core/editor/post-locked-modal-' + instanceId;
-	const { autosave, updatePostLock } = useDispatch( 'core/editor' );
+	const { autosave, updatePostLock } = useDispatch( editorStore );
 	const {
 		isLocked,
 		isTakeover,
@@ -41,8 +43,8 @@ export default function PostLockedModal() {
 			getActivePostLock,
 			getEditedPostAttribute,
 			getEditorSettings,
-		} = select( 'core/editor' );
-		const { getPostType } = select( 'core' );
+		} = select( editorStore );
+		const { getPostType } = select( coreStore );
 		return {
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),

--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -9,6 +9,11 @@ import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PostPendingStatusCheck( {
 	hasPublishAction,
 	isPublished,
@@ -27,7 +32,7 @@ export default compose(
 			isCurrentPostPublished,
 			getCurrentPostType,
 			getCurrentPost,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		return {
 			hasPublishAction: get(
 				getCurrentPost(),

--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -10,6 +10,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import PostPendingStatusCheck from './check';
+import { store as editorStore } from '../../store';
 
 export function PostPendingStatus( { status, onUpdateStatus } ) {
 	const togglePendingStatus = () => {
@@ -30,11 +31,11 @@ export function PostPendingStatus( { status, onUpdateStatus } ) {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		status: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+		status: select( editorStore ).getEditedPostAttribute( 'status' ),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
 		onUpdateStatus( status ) {
-			dispatch( 'core/editor' ).editPost( { status } );
+			dispatch( editorStore ).editPost( { status } );
 		},
 	} ) )
 )( PostPendingStatus );

--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -6,6 +6,11 @@ import { CheckboxControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function PostPingbacks( { pingStatus = 'open', ...props } ) {
 	const onTogglePingback = () =>
 		props.editPost( {
@@ -24,12 +29,12 @@ function PostPingbacks( { pingStatus = 'open', ...props } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			pingStatus: select( 'core/editor' ).getEditedPostAttribute(
+			pingStatus: select( editorStore ).getEditedPostAttribute(
 				'ping_status'
 			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		editPost: dispatch( 'core/editor' ).editPost,
+		editPost: dispatch( editorStore ).editPost,
 	} ) ),
 ] )( PostPingbacks );

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -13,6 +13,12 @@ import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { ifCondition, compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function writeInterstitialMessage( targetDocument ) {
 	let markup = renderToString(
@@ -232,8 +238,8 @@ export default compose( [
 			isEditedPostSaveable,
 			isEditedPostAutosaveable,
 			getEditedPostPreviewLink,
-		} = select( 'core/editor' );
-		const { getPostType } = select( 'core' );
+		} = select( editorStore );
+		const { getPostType } = select( coreStore );
 
 		const previewLink = getEditedPostPreviewLink();
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
@@ -253,8 +259,8 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		autosave: dispatch( 'core/editor' ).autosave,
-		savePost: dispatch( 'core/editor' ).savePost,
+		autosave: dispatch( editorStore ).autosave,
+		savePost: dispatch( editorStore ).savePost,
 	} ) ),
 	ifCondition( ( { isViewable } ) => isViewable ),
 ] )( PostPreviewButton );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import PublishButtonLabel from './label';
+import { store as editorStore } from '../../store';
 
 export class PostPublishButton extends Component {
 	constructor( props ) {
@@ -209,7 +210,7 @@ export default compose( [
 			getCurrentPostType,
 			getCurrentPostId,
 			hasNonPostEntityChanges,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		const _isAutoSaving = isAutosavingPost();
 		return {
 			isSaving: isSavingPost() || _isAutoSaving,
@@ -231,7 +232,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost, savePost } = dispatch( 'core/editor' );
+		const { editPost, savePost } = dispatch( editorStore );
 		return {
 			onStatusChange: ( status ) =>
 				editPost( { status }, { undoIgnore: true } ),

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -10,6 +10,11 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PublishButtonLabel( {
 	isPublished,
 	isBeingScheduled,
@@ -53,7 +58,7 @@ export default compose( [
 			getCurrentPost,
 			getCurrentPostType,
 			isAutosavingPost,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		return {
 			isPublished: isCurrentPostPublished(),
 			isBeingScheduled: isEditedPostBeingScheduled(),

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -18,6 +18,7 @@ import {
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { closeSmall } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import { closeSmall } from '@wordpress/icons';
 import PostPublishButton from '../post-publish-button';
 import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
+import { store as editorStore } from '../../store';
 
 export class PostPublishPanel extends Component {
 	constructor() {
@@ -129,7 +131,7 @@ export class PostPublishPanel extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getPostType } = select( 'core' );
+		const { getPostType } = select( coreStore );
 		const {
 			getCurrentPost,
 			getEditedPostAttribute,
@@ -138,8 +140,8 @@ export default compose( [
 			isEditedPostBeingScheduled,
 			isEditedPostDirty,
 			isSavingPost,
-		} = select( 'core/editor' );
-		const { isPublishSidebarEnabled } = select( 'core/editor' );
+		} = select( editorStore );
+		const { isPublishSidebarEnabled } = select( editorStore );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
@@ -159,7 +161,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, { isPublishSidebarEnabled } ) => {
 		const { disablePublishSidebar, enablePublishSidebar } = dispatch(
-			'core/editor'
+			editorStore
 		);
 		return {
 			onTogglePublishSidebar: () => {

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -9,11 +9,13 @@ import { find, get, includes } from 'lodash';
 import { Button, PanelBody } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { POST_FORMATS } from '../post-format';
+import { store as editorStore } from '../../store';
 
 const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
 	const formats = POST_FORMATS.filter( ( format ) =>
@@ -35,10 +37,10 @@ const PostFormatSuggestion = ( {
 export default function PostFormatPanel() {
 	const { currentPostFormat, suggestion } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
-			'core/editor'
+			editorStore
 		);
 		const supportedFormats = get(
-			select( 'core' ).getThemeSupports(),
+			select( coreStore ).getThemeSupports(),
 			[ 'formats' ],
 			[]
 		);
@@ -51,7 +53,7 @@ export default function PostFormatPanel() {
 		};
 	}, [] );
 
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 
 	const onUpdatePostFormat = ( format ) => editPost( { format } );
 

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -11,11 +11,13 @@ import { Component } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
+import { store as editorStore } from '../../store';
 
 const TagsPanel = () => {
 	const panelBodyTitle = [
@@ -66,11 +68,11 @@ class MaybeTagsPanel extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const postType = select( 'core/editor' ).getCurrentPostType();
-		const tagsTaxonomy = select( 'core' ).getTaxonomy( 'post_tag' );
+		const postType = select( editorStore ).getCurrentPostType();
+		const tagsTaxonomy = select( coreStore ).getTaxonomy( 'post_tag' );
 		const tags =
 			tagsTaxonomy &&
-			select( 'core/editor' ).getEditedPostAttribute(
+			select( editorStore ).getEditedPostAttribute(
 				tagsTaxonomy.rest_base
 			);
 		return {

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -13,11 +13,13 @@ import { withSelect } from '@wordpress/data';
 import { safeDecodeURIComponent } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCopyToClipboard } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import PostScheduleLabel from '../post-schedule/label';
+import { store as editorStore } from '../../store';
 
 const POSTNAME = '%postname%';
 
@@ -149,8 +151,8 @@ export default withSelect( ( select ) => {
 		getEditedPostAttribute,
 		getCurrentPost,
 		isCurrentPostScheduled,
-	} = select( 'core/editor' );
-	const { getPostType } = select( 'core' );
+	} = select( editorStore );
+	const { getPostType } = select( coreStore );
 
 	return {
 		post: getCurrentPost(),

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -11,6 +11,7 @@ import { Icon, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { wordpress } from '@wordpress/icons';
 import { filterURLForDisplay } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
 import MaybeTagsPanel from './maybe-tags-panel';
 import MaybePostFormatPanel from './maybe-post-format-panel';
+import { store as editorStore } from '../../store';
 
 function PostPublishPanelPrepublish( { children } ) {
 	const {
@@ -33,9 +35,9 @@ function PostPublishPanelPrepublish( { children } ) {
 	} = useSelect( ( select ) => {
 		const { isResolving } = select( 'core/data' );
 		const { getCurrentPost, isEditedPostBeingScheduled } = select(
-			'core/editor'
+			editorStore
 		);
-		const { getEntityRecord } = select( 'core' );
+		const { getEntityRecord } = select( coreStore );
 		const siteData =
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -21,6 +21,7 @@ import { displayShortcut } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import PostSwitchToDraftButton from '../post-switch-to-draft-button';
+import { store as editorStore } from '../../store';
 
 /**
  * Component showing whether the post is saved or not and providing save
@@ -64,7 +65,7 @@ export default function PostSavedState( {
 				getCurrentPost,
 				isAutosavingPost,
 				getEditedPostAttribute,
-			} = select( 'core/editor' );
+			} = select( editorStore );
 
 			return {
 				isAutosaving: isAutosavingPost(),
@@ -82,7 +83,7 @@ export default function PostSavedState( {
 		[ forceIsDirty, forceIsSaving ]
 	);
 
-	const { savePost } = useDispatch( 'core/editor' );
+	const { savePost } = useDispatch( editorStore );
 
 	const wasSaving = usePrevious( isSaving );
 

--- a/packages/editor/src/components/post-schedule/check.js
+++ b/packages/editor/src/components/post-schedule/check.js
@@ -9,6 +9,11 @@ import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PostScheduleCheck( { hasPublishAction, children } ) {
 	if ( ! hasPublishAction ) {
 		return null;
@@ -19,7 +24,7 @@ export function PostScheduleCheck( { hasPublishAction, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
+		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
 			hasPublishAction: get(
 				getCurrentPost(),

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { format, __experimentalGetSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PostScheduleLabel( { date, isFloating } ) {
 	const settings = __experimentalGetSettings();
 	return date && ! isFloating
@@ -17,7 +22,7 @@ export function PostScheduleLabel( { date, isFloating } ) {
 
 export default withSelect( ( select ) => {
 	return {
-		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		isFloating: select( 'core/editor' ).isEditedPostDateFloating(),
+		date: select( editorStore ).getEditedPostAttribute( 'date' ),
+		isFloating: select( editorStore ).isEditedPostDateFloating(),
 	};
 } )( PostScheduleLabel );

--- a/packages/editor/src/components/post-slug/index.js
+++ b/packages/editor/src/components/post-slug/index.js
@@ -12,6 +12,7 @@ import { safeDecodeURIComponent } from '@wordpress/url';
  */
 import PostSlugCheck from './check';
 import { cleanForSlug } from '../../utils/url';
+import { store as editorStore } from '../../store';
 
 export class PostSlug extends Component {
 	constructor( { postSlug, postTitle, postID } ) {
@@ -67,7 +68,7 @@ export class PostSlug extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getCurrentPost, getEditedPostAttribute } = select(
-			'core/editor'
+			editorStore
 		);
 
 		const { id } = getCurrentPost();
@@ -78,7 +79,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( editorStore );
 		return {
 			onUpdateSlug( slug ) {
 				editPost( { slug } );

--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -9,6 +9,11 @@ import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PostStickyCheck( { hasStickyAction, postType, children } ) {
 	if ( postType !== 'post' || ! hasStickyAction ) {
 		return null;
@@ -19,14 +24,14 @@ export function PostStickyCheck( { hasStickyAction, postType, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const post = select( 'core/editor' ).getCurrentPost();
+		const post = select( editorStore ).getCurrentPost();
 		return {
 			hasStickyAction: get(
 				post,
 				[ '_links', 'wp:action-sticky' ],
 				false
 			),
-			postType: select( 'core/editor' ).getCurrentPostType(),
+			postType: select( editorStore ).getCurrentPostType(),
 		};
 	} ),
 ] )( PostStickyCheck );

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -10,6 +10,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import PostStickyCheck from './check';
+import { store as editorStore } from '../../store';
 
 export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
@@ -26,7 +27,7 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			postSticky: select( 'core/editor' ).getEditedPostAttribute(
+			postSticky: select( editorStore ).getEditedPostAttribute(
 				'sticky'
 			),
 		};
@@ -34,7 +35,7 @@ export default compose( [
 	withDispatch( ( dispatch ) => {
 		return {
 			onUpdateSticky( postSticky ) {
-				dispatch( 'core/editor' ).editPost( { sticky: postSticky } );
+				dispatch( editorStore ).editPost( { sticky: postSticky } );
 			},
 		};
 	} ),

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -6,6 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, useViewportMatch } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function PostSwitchToDraftButton( {
 	isSaving,
 	isPublished,
@@ -53,7 +58,7 @@ export default compose( [
 			isSavingPost,
 			isCurrentPostPublished,
 			isCurrentPostScheduled,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		return {
 			isSaving: isSavingPost(),
 			isPublished: isCurrentPostPublished(),
@@ -61,7 +66,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { editPost, savePost } = dispatch( 'core/editor' );
+		const { editPost, savePost } = dispatch( editorStore );
 		return {
 			onClick: () => {
 				editPost( { status: 'draft' } );

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -8,6 +8,12 @@ import { some, includes } from 'lodash';
  */
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
 	const hasTaxonomies = some( taxonomies, ( taxonomy ) =>
@@ -23,8 +29,8 @@ export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			postType: select( 'core/editor' ).getCurrentPostType(),
-			taxonomies: select( 'core' ).getTaxonomies( { per_page: -1 } ),
+			postType: select( editorStore ).getCurrentPostType(),
+			taxonomies: select( coreStore ).getTaxonomies( { per_page: -1 } ),
 		};
 	} ),
 ] )( PostTaxonomiesCheck );

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -26,11 +26,13 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { buildTermsTree } from '../../utils/terms';
+import { store as editorStore } from '../../store';
 
 /**
  * Module Constants
@@ -532,8 +534,8 @@ class HierarchicalTermSelector extends Component {
 
 export default compose( [
 	withSelect( ( select, { slug } ) => {
-		const { getCurrentPost } = select( 'core/editor' );
-		const { getTaxonomy } = select( 'core' );
+		const { getCurrentPost } = select( editorStore );
+		const { getTaxonomy } = select( coreStore );
 		const taxonomy = getTaxonomy( slug );
 		return {
 			hasCreateAction: taxonomy
@@ -551,7 +553,7 @@ export default compose( [
 				  )
 				: false,
 			terms: taxonomy
-				? select( 'core/editor' ).getEditedPostAttribute(
+				? select( editorStore ).getEditedPostAttribute(
 						taxonomy.rest_base
 				  )
 				: [],
@@ -560,7 +562,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => ( {
 		onUpdateTerms( terms, restBase ) {
-			dispatch( 'core/editor' ).editPost( { [ restBase ]: terms } );
+			dispatch( editorStore ).editPost( { [ restBase ]: terms } );
 		},
 	} ) ),
 	withSpokenMessages,

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -9,12 +9,14 @@ import { filter, identity, includes } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
+import { store as editorStore } from '../../store';
 
 export function PostTaxonomies( {
 	postType,
@@ -46,8 +48,8 @@ export function PostTaxonomies( {
 export default compose( [
 	withSelect( ( select ) => {
 		return {
-			postType: select( 'core/editor' ).getCurrentPostType(),
-			taxonomies: select( 'core' ).getTaxonomies( { per_page: -1 } ),
+			postType: select( editorStore ).getCurrentPostType(),
+			taxonomies: select( coreStore ).getTaxonomies( { per_page: -1 } ),
 		};
 	} ),
 ] )( PostTaxonomies );

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -13,13 +13,18 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export default function PostTextEditor() {
 	const postContent = useSelect(
-		( select ) => select( 'core/editor' ).getEditedPostContent(),
+		( select ) => select( editorStore ).getEditedPostContent(),
 		[]
 	);
 
-	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+	const { editPost, resetEditorBlocks } = useDispatch( editorStore );
 
 	const [ value, setValue ] = useState( postContent );
 	const [ isDirty, setIsDirty ] = useState( false );

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -21,6 +21,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 
 /**
  * Constants
@@ -31,7 +32,7 @@ export default function PostTitle() {
 	const instanceId = useInstanceId( PostTitle );
 	const ref = useRef();
 	const [ isSelected, setIsSelected ] = useState( false );
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost } = useDispatch( editorStore );
 	const {
 		insertDefaultBlock,
 		clearSelectedBlock,
@@ -47,7 +48,7 @@ export default function PostTitle() {
 		const {
 			getEditedPostAttribute,
 			isCleanNewPost: _isCleanNewPost,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		const { getSettings } = select( blockEditorStore );
 		const {
 			titlePlaceholder,

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 function PostTrashCheck( { isNew, postId, canUserDelete, children } ) {
 	if ( isNew || ! postId || ! canUserDelete ) {
@@ -13,9 +19,9 @@ function PostTrashCheck( { isNew, postId, canUserDelete, children } ) {
 
 export default withSelect( ( select ) => {
 	const { isEditedPostNew, getCurrentPostId, getCurrentPostType } = select(
-		'core/editor'
+		editorStore
 	);
-	const { getPostType, canUser } = select( 'core' );
+	const { getPostType, canUser } = select( coreStore );
 	const postId = getCurrentPostId();
 	const postType = getPostType( getCurrentPostType() );
 	const resource = postType?.rest_base || ''; // eslint-disable-line camelcase

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -6,6 +6,11 @@ import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 function PostTrash( { isNew, postId, postType, ...props } ) {
 	if ( isNew || ! postId ) {
 		return null;
@@ -31,7 +36,7 @@ export default compose( [
 			isEditedPostNew,
 			getCurrentPostId,
 			getCurrentPostType,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		return {
 			isNew: isEditedPostNew(),
 			postId: getCurrentPostId(),
@@ -39,6 +44,6 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		trashPost: dispatch( 'core/editor' ).trashPost,
+		trashPost: dispatch( editorStore ).trashPost,
 	} ) ),
 ] )( PostTrash );

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -7,6 +7,12 @@ import { some, castArray } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 /**
  * A component which renders its own children only if the current editor post
@@ -38,8 +44,8 @@ export function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 }
 
 export default withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const { getPostType } = select( 'core' );
+	const { getEditedPostAttribute } = select( editorStore );
+	const { getPostType } = select( coreStore );
 	return {
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 	};

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -9,6 +9,11 @@ import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export function PostVisibilityCheck( { hasPublishAction, render } ) {
 	const canEdit = hasPublishAction;
 	return render( { canEdit } );
@@ -16,7 +21,7 @@ export function PostVisibilityCheck( { hasPublishAction, render } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
+		const { getCurrentPost, getCurrentPostType } = select( editorStore );
 		return {
 			hasPublishAction: get(
 				getCurrentPost(),

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -11,6 +11,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { visibilityOptions } from './utils';
+import { store as editorStore } from '../../store';
 
 export class PostVisibility extends Component {
 	constructor( props ) {
@@ -151,7 +152,7 @@ export class PostVisibility extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getEditedPostAttribute, getEditedPostVisibility } = select(
-			'core/editor'
+			editorStore
 		);
 		return {
 			status: getEditedPostAttribute( 'status' ),
@@ -160,7 +161,7 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { savePost, editPost } = dispatch( 'core/editor' );
+		const { savePost, editPost } = dispatch( editorStore );
 		return {
 			onSave: savePost,
 			onUpdateVisibility( status, password = '' ) {

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -12,6 +12,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { visibilityOptions } from './utils';
+import { store as editorStore } from '../../store';
 
 function PostVisibilityLabel( { visibility } ) {
 	const getVisibilityLabel = () =>
@@ -21,5 +22,5 @@ function PostVisibilityLabel( { visibility } ) {
 }
 
 export default withSelect( ( select ) => ( {
-	visibility: select( 'core/editor' ).getEditedPostVisibility(),
+	visibility: select( editorStore ).getEditedPostVisibility(),
 } ) )( PostVisibilityLabel );

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -7,6 +7,12 @@ import { castArray, includes, isArray, get, some } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 export function ThemeSupportCheck( {
 	themeSupports,
@@ -34,8 +40,8 @@ export function ThemeSupportCheck( {
 }
 
 export default withSelect( ( select ) => {
-	const { getThemeSupports } = select( 'core' );
-	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getThemeSupports } = select( coreStore );
+	const { getEditedPostAttribute } = select( editorStore );
 	return {
 		postType: getEditedPostAttribute( 'type' ),
 		themeSupports: getThemeSupports(),

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Warns the user if there are unsaved changes before leaving the editor.
@@ -14,7 +15,7 @@ import { useSelect } from '@wordpress/data';
 export default function UnsavedChangesWarning() {
 	const isDirty = useSelect( ( select ) => {
 		return () => {
-			const { __experimentalGetDirtyEntityRecords } = select( 'core' );
+			const { __experimentalGetDirtyEntityRecords } = select( coreStore );
 			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 			return dirtyEntityRecords.length > 0;
 		};

--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -5,9 +5,14 @@ import { useSelect } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 import { count as wordCount } from '@wordpress/wordcount';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
 export default function WordCount() {
 	const content = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( 'content' )
+		select( editorStore ).getEditedPostAttribute( 'content' )
 	);
 
 	/*

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -13,6 +13,11 @@ import { useMemo } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../store';
+
 /** @typedef {import('@wordpress/compose').WPHigherOrderComponent} WPHigherOrderComponent */
 /** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
 
@@ -39,7 +44,7 @@ const createWithMetaAttributeSource = ( metaAttributes ) =>
 	createHigherOrderComponent(
 		( BlockEdit ) => ( { attributes, setAttributes, ...props } ) => {
 			const postType = useSelect(
-				( select ) => select( 'core/editor' ).getCurrentPostType(),
+				( select ) => select( editorStore ).getCurrentPostType(),
 				[]
 			);
 			const [ meta, setMeta ] = useEntityProp(

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -15,6 +15,8 @@ import {
 	__unstableSerializeAndClean,
 } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -119,7 +121,12 @@ export function* resetAutosave( newAutosave ) {
 	} );
 
 	const postId = yield controls.select( STORE_NAME, 'getCurrentPostId' );
-	yield controls.dispatch( 'core', 'receiveAutosaves', postId, newAutosave );
+	yield controls.dispatch(
+		coreStore,
+		'receiveAutosaves',
+		postId,
+		newAutosave
+	);
 
 	return { type: '__INERT__' };
 }
@@ -196,7 +203,7 @@ export function setupEditorState( post ) {
 export function* editPost( edits, options ) {
 	const { id, type } = yield controls.select( STORE_NAME, 'getCurrentPost' );
 	yield controls.dispatch(
-		'core',
+		coreStore,
 		'editEntityRecord',
 		'postType',
 		type,
@@ -232,7 +239,7 @@ export function* savePost( options = {} ) {
 	edits = {
 		id: previousRecord.id,
 		...( yield controls.select(
-			'core',
+			coreStore,
 			'getEntityRecordNonTransientEdits',
 			'postType',
 			previousRecord.type,
@@ -241,7 +248,7 @@ export function* savePost( options = {} ) {
 		...edits,
 	};
 	yield controls.dispatch(
-		'core',
+		coreStore,
 		'saveEntityRecord',
 		'postType',
 		previousRecord.type,
@@ -251,7 +258,7 @@ export function* savePost( options = {} ) {
 	yield __experimentalRequestPostUpdateFinish( options );
 
 	const error = yield controls.select(
-		'core',
+		coreStore,
 		'getLastEntitySaveError',
 		'postType',
 		previousRecord.type,
@@ -279,7 +286,7 @@ export function* savePost( options = {} ) {
 			previousPost: previousRecord,
 			post: updatedRecord,
 			postType: yield controls.resolveSelect(
-				'core',
+				coreStore,
 				'getPostType',
 				updatedRecord.type
 			),
@@ -296,7 +303,7 @@ export function* savePost( options = {} ) {
 		// considered for change detection.
 		if ( ! options.isAutosave ) {
 			yield controls.dispatch(
-				'core/block-editor',
+				blockEditorStore,
 				'__unstableMarkLastChangeAsPersistent'
 			);
 		}
@@ -313,7 +320,7 @@ export function* refreshPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		'core',
+		coreStore,
 		'getPostType',
 		postTypeSlug
 	);
@@ -336,7 +343,7 @@ export function* trashPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		'core',
+		coreStore,
 		'getPostType',
 		postTypeSlug
 	);
@@ -415,7 +422,7 @@ export function* autosave( { local = false, ...options } = {} ) {
  * @yield {Object} Action object.
  */
 export function* redo() {
-	yield controls.dispatch( 'core', 'redo' );
+	yield controls.dispatch( coreStore, 'redo' );
 }
 
 /**
@@ -424,7 +431,7 @@ export function* redo() {
  * @yield {Object} Action object.
  */
 export function* undo() {
-	yield controls.dispatch( 'core', 'undo' );
+	yield controls.dispatch( coreStore, 'undo' );
 }
 
 /**
@@ -604,7 +611,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 		);
 		const noChange =
 			( yield controls.select(
-				'core',
+				coreStore,
 				'getEditedEntityRecord',
 				'postType',
 				type,
@@ -612,7 +619,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 			) ).blocks === edits.blocks;
 		if ( noChange ) {
 			return yield controls.dispatch(
-				'core',
+				coreStore,
 				'__unstableCreateUndoLevel',
 				'postType',
 				type,
@@ -654,7 +661,7 @@ const getBlockEditorAction = ( name ) =>
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
 		} );
-		yield controls.dispatch( 'core/block-editor', name, ...args );
+		yield controls.dispatch( blockEditorStore, name, ...args );
 	};
 
 /**

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -122,7 +122,7 @@ export function* resetAutosave( newAutosave ) {
 
 	const postId = yield controls.select( STORE_NAME, 'getCurrentPostId' );
 	yield controls.dispatch(
-		coreStore,
+		coreStore.name,
 		'receiveAutosaves',
 		postId,
 		newAutosave
@@ -203,7 +203,7 @@ export function setupEditorState( post ) {
 export function* editPost( edits, options ) {
 	const { id, type } = yield controls.select( STORE_NAME, 'getCurrentPost' );
 	yield controls.dispatch(
-		coreStore,
+		coreStore.name,
 		'editEntityRecord',
 		'postType',
 		type,
@@ -239,7 +239,7 @@ export function* savePost( options = {} ) {
 	edits = {
 		id: previousRecord.id,
 		...( yield controls.select(
-			coreStore,
+			coreStore.name,
 			'getEntityRecordNonTransientEdits',
 			'postType',
 			previousRecord.type,
@@ -248,7 +248,7 @@ export function* savePost( options = {} ) {
 		...edits,
 	};
 	yield controls.dispatch(
-		coreStore,
+		coreStore.name,
 		'saveEntityRecord',
 		'postType',
 		previousRecord.type,
@@ -258,7 +258,7 @@ export function* savePost( options = {} ) {
 	yield __experimentalRequestPostUpdateFinish( options );
 
 	const error = yield controls.select(
-		coreStore,
+		coreStore.name,
 		'getLastEntitySaveError',
 		'postType',
 		previousRecord.type,
@@ -286,7 +286,7 @@ export function* savePost( options = {} ) {
 			previousPost: previousRecord,
 			post: updatedRecord,
 			postType: yield controls.resolveSelect(
-				coreStore,
+				coreStore.name,
 				'getPostType',
 				updatedRecord.type
 			),
@@ -303,7 +303,7 @@ export function* savePost( options = {} ) {
 		// considered for change detection.
 		if ( ! options.isAutosave ) {
 			yield controls.dispatch(
-				blockEditorStore,
+				blockEditorStore.name,
 				'__unstableMarkLastChangeAsPersistent'
 			);
 		}
@@ -320,7 +320,7 @@ export function* refreshPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		coreStore,
+		coreStore.name,
 		'getPostType',
 		postTypeSlug
 	);
@@ -343,7 +343,7 @@ export function* trashPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		coreStore,
+		coreStore.name,
 		'getPostType',
 		postTypeSlug
 	);
@@ -422,7 +422,7 @@ export function* autosave( { local = false, ...options } = {} ) {
  * @yield {Object} Action object.
  */
 export function* redo() {
-	yield controls.dispatch( coreStore, 'redo' );
+	yield controls.dispatch( coreStore.name, 'redo' );
 }
 
 /**
@@ -431,7 +431,7 @@ export function* redo() {
  * @yield {Object} Action object.
  */
 export function* undo() {
-	yield controls.dispatch( coreStore, 'undo' );
+	yield controls.dispatch( coreStore.name, 'undo' );
 }
 
 /**
@@ -611,7 +611,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 		);
 		const noChange =
 			( yield controls.select(
-				coreStore,
+				coreStore.name,
 				'getEditedEntityRecord',
 				'postType',
 				type,
@@ -619,7 +619,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 			) ).blocks === edits.blocks;
 		if ( noChange ) {
 			return yield controls.dispatch(
-				coreStore,
+				coreStore.name,
 				'__unstableCreateUndoLevel',
 				'postType',
 				type,
@@ -661,7 +661,7 @@ const getBlockEditorAction = ( name ) =>
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
 		} );
-		yield controls.dispatch( blockEditorStore, name, ...args );
+		yield controls.dispatch( blockEditorStore.name, name, ...args );
 	};
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -28,6 +28,8 @@ import { createRegistrySelector } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { Platform } from '@wordpress/element';
 import { layout } from '@wordpress/icons';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -69,7 +71,7 @@ const EMPTY_ARRAY = [];
  * @return {boolean} Whether undo history exists.
  */
 export const hasEditorUndo = createRegistrySelector( ( select ) => () => {
-	return select( 'core' ).hasUndo();
+	return select( coreStore ).hasUndo();
 } );
 
 /**
@@ -81,7 +83,7 @@ export const hasEditorUndo = createRegistrySelector( ( select ) => () => {
  * @return {boolean} Whether redo history exists.
  */
 export const hasEditorRedo = createRegistrySelector( ( select ) => () => {
-	return select( 'core' ).hasRedo();
+	return select( coreStore ).hasRedo();
 } );
 
 /**
@@ -133,7 +135,7 @@ export const isEditedPostDirty = createRegistrySelector(
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
 		if (
-			select( 'core' ).hasEditsForEntityRecord(
+			select( coreStore ).hasEditsForEntityRecord(
 				'postType',
 				postType,
 				postId
@@ -156,7 +158,7 @@ export const isEditedPostDirty = createRegistrySelector(
 export const hasNonPostEntityChanges = createRegistrySelector(
 	( select ) => ( state ) => {
 		const dirtyEntityRecords = select(
-			'core'
+			coreStore
 		).__experimentalGetDirtyEntityRecords();
 		const { type, id } = getCurrentPost( state );
 		return some(
@@ -195,7 +197,7 @@ export const getCurrentPost = createRegistrySelector(
 		const postId = getCurrentPostId( state );
 		const postType = getCurrentPostType( state );
 
-		const post = select( 'core' ).getRawEntityRecord(
+		const post = select( coreStore ).getRawEntityRecord(
 			'postType',
 			postType,
 			postId
@@ -277,8 +279,11 @@ export const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
 	return (
-		select( 'core' ).getEntityRecordEdits( 'postType', postType, postId ) ||
-		EMPTY_OBJECT
+		select( coreStore ).getEntityRecordEdits(
+			'postType',
+			postType,
+			postId
+		) || EMPTY_OBJECT
 	);
 } );
 
@@ -313,7 +318,7 @@ export const getReferenceByDistinctEdits = createRegistrySelector(
 			}
 		);
 
-		return select( 'core' ).getReferenceByDistinctEdits();
+		return select( coreStore ).getReferenceByDistinctEdits();
 	}
 );
 
@@ -421,10 +426,10 @@ export const getAutosaveAttribute = createRegistrySelector(
 
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
-		const currentUserId = get( select( 'core' ).getCurrentUser(), [
+		const currentUserId = get( select( coreStore ).getCurrentUser(), [
 			'id',
 		] );
-		const autosave = select( 'core' ).getAutosave(
+		const autosave = select( coreStore ).getAutosave(
 			postType,
 			postId,
 			currentUserId
@@ -627,11 +632,11 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
-		const hasFetchedAutosave = select( 'core' ).hasFetchedAutosaves(
+		const hasFetchedAutosave = select( coreStore ).hasFetchedAutosaves(
 			postType,
 			postId
 		);
-		const currentUserId = get( select( 'core' ).getCurrentUser(), [
+		const currentUserId = get( select( coreStore ).getCurrentUser(), [
 			'id',
 		] );
 
@@ -639,7 +644,7 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		// via a resolver, moving below the return would result in the autosave never
 		// being fetched.
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const autosave = select( 'core' ).getAutosave(
+		const autosave = select( coreStore ).getAutosave(
 			postType,
 			postId,
 			currentUserId
@@ -694,8 +699,8 @@ export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
-	const autosave = select( 'core' ).getAutosave(
+	const currentUserId = get( select( coreStore ).getCurrentUser(), [ 'id' ] );
+	const autosave = select( coreStore ).getAutosave(
 		postType,
 		postId,
 		currentUserId
@@ -722,8 +727,12 @@ export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
 
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	const currentUserId = get( select( 'core' ).getCurrentUser(), [ 'id' ] );
-	return !! select( 'core' ).getAutosave( postType, postId, currentUserId );
+	const currentUserId = get( select( coreStore ).getCurrentUser(), [ 'id' ] );
+	return !! select( coreStore ).getAutosave(
+		postType,
+		postId,
+		currentUserId
+	);
 } );
 
 /**
@@ -786,7 +795,7 @@ export function isEditedPostDateFloating( state ) {
 export const isSavingPost = createRegistrySelector( ( select ) => ( state ) => {
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	return select( 'core' ).isSavingEntityRecord(
+	return select( coreStore ).isSavingEntityRecord(
 		'postType',
 		postType,
 		postId
@@ -805,7 +814,7 @@ export const didPostSaveRequestSucceed = createRegistrySelector(
 	( select ) => ( state ) => {
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
-		return ! select( 'core' ).getLastEntitySaveError(
+		return ! select( coreStore ).getLastEntitySaveError(
 			'postType',
 			postType,
 			postId
@@ -825,7 +834,7 @@ export const didPostSaveRequestFail = createRegistrySelector(
 	( select ) => ( state ) => {
 		const postType = getCurrentPostType( state );
 		const postId = getCurrentPostId( state );
-		return !! select( 'core' ).getLastEntitySaveError(
+		return !! select( coreStore ).getLastEntitySaveError(
 			'postType',
 			postType,
 			postId
@@ -990,7 +999,7 @@ export const getEditedPostContent = createRegistrySelector(
 	( select ) => ( state ) => {
 		const postId = getCurrentPostId( state );
 		const postType = getCurrentPostType( state );
-		const record = select( 'core' ).getEditedEntityRecord(
+		const record = select( coreStore ).getEditedEntityRecord(
 			'postType',
 			postType,
 			postId
@@ -1331,7 +1340,7 @@ function getBlockEditorSelector( name ) {
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
 		} );
 
-		return select( 'core/block-editor' )[ name ]( ...args );
+		return select( blockEditorStore )[ name ]( ...args );
 	} );
 }
 

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -10,6 +10,11 @@ import { select } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 
 /**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+/**
  * Upload a media file when the file upload button is activated.
  * Wrapper around mediaUpload() that injects the current post ID.
  *
@@ -29,7 +34,7 @@ export default function mediaUpload( {
 	onError = noop,
 	onFileChange,
 } ) {
-	const { getCurrentPostId, getEditorSettings } = select( 'core/editor' );
+	const { getCurrentPostId, getEditorSettings } = select( editorStore );
 	const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes;
 	maxUploadFileSize =
 		maxUploadFileSize || getEditorSettings().maxUploadFileSize;


### PR DESCRIPTION
## Description
Fixes eslint warnings in the editor package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/editor/` no longer throws warnings for string literals
* tests should be green

Note: There is 1 warning remaining for `'core/data'` but I couldn't replace it in this PR because the `data` package doesn't have a `store`. We'll need to dig a bit deeper for that one.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
