### PR TITLE
edit-widgets: fix no-string-literal warnings

### DIFF
--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/keyboard-shortcuts';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { store as editWidgetsStore } from '../../store';
 
 function KeyboardShortcuts() {
-	const { redo, undo } = useDispatch( 'core' );
+	const { redo, undo } = useDispatch( coreStore );
 	const { saveEditedWidgetAreas } = useDispatch( editWidgetsStore );
 
 	useShortcut(

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -20,7 +20,7 @@ import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
  * Internal dependencies
  */
 import KeyboardShortcuts from '../keyboard-shortcuts';
-import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 import { store as editWidgetsStore } from '../../store';
@@ -38,12 +38,12 @@ export default function WidgetAreasBlockEditorProvider( {
 	} = useSelect(
 		( select ) => ( {
 			hasUploadPermissions: defaultTo(
-				select( 'core' ).canUser( 'create', 'media' ),
+				select( coreStore ).canUser( 'create', 'media' ),
 				true
 			),
 			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
 			widgets: select( editWidgetsStore ).getWidgets(),
-			reusableBlocks: select( 'core' ).getEntityRecords(
+			reusableBlocks: select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_block'
 			),

--- a/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -17,7 +19,7 @@ import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 const useLastSelectedWidgetArea = () =>
 	useSelect( ( select ) => {
 		const { getBlockSelectionEnd, getBlockParents, getBlockName } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const blockSelectionEndClientId = getBlockSelectionEnd();
 
@@ -41,7 +43,7 @@ const useLastSelectedWidgetArea = () =>
 
 		// If no widget area has been selected, return the clientId of the first
 		// area.
-		const { getEntityRecord } = select( 'core' );
+		const { getEntityRecord } = select( coreStore );
 		const widgetAreasPost = getEntityRecord(
 			KIND,
 			POST_TYPE,

--- a/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
+++ b/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 const useWidgetLibraryInsertionPoint = () => {
 	const firstRootId = useSelect( ( select ) => {
 		// Default to the first widget area
-		const { getEntityRecord } = select( 'core' );
+		const { getEntityRecord } = select( coreStore );
 		const widgetAreasPost = getEntityRecord(
 			KIND,
 			POST_TYPE,

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -8,6 +8,8 @@ import { get, keyBy } from 'lodash';
  */
 import { createRegistrySelector } from '@wordpress/data';
 import { getWidgetIdFromBlock } from '@wordpress/widgets';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,7 +25,7 @@ import {
 import { STORE_NAME as editWidgetsStoreName } from './constants';
 
 export const getWidgets = createRegistrySelector( ( select ) => () => {
-	const widgets = select( 'core' ).getEntityRecords(
+	const widgets = select( coreStore ).getEntityRecords(
 		'root',
 		'widget',
 		buildWidgetsQuery()
@@ -47,7 +49,7 @@ export const getWidget = createRegistrySelector(
 
 export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 	const query = buildWidgetAreasQuery();
-	return select( 'core' ).getEntityRecords(
+	return select( coreStore ).getEntityRecords(
 		KIND,
 		WIDGET_AREA_ENTITY_TYPE,
 		query
@@ -64,7 +66,7 @@ export const getWidgetAreaForWidgetId = createRegistrySelector(
 	( select ) => ( state, widgetId ) => {
 		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
 		return widgetAreas.find( ( widgetArea ) => {
-			const post = select( 'core' ).getEditedEntityRecord(
+			const post = select( coreStore ).getEditedEntityRecord(
 				KIND,
 				POST_TYPE,
 				buildWidgetAreaPostId( widgetArea.id )
@@ -90,14 +92,14 @@ export const getEditedWidgetAreas = createRegistrySelector(
 		}
 		return widgetAreas
 			.filter( ( { id } ) =>
-				select( 'core' ).hasEditsForEntityRecord(
+				select( coreStore ).hasEditsForEntityRecord(
 					KIND,
 					POST_TYPE,
 					buildWidgetAreaPostId( id )
 				)
 			)
 			.map( ( { id } ) =>
-				select( 'core' ).getEditedEntityRecord(
+				select( coreStore ).getEditedEntityRecord(
 					KIND,
 					WIDGET_AREA_ENTITY_TYPE,
 					id
@@ -117,7 +119,7 @@ export const getReferenceWidgetBlocks = createRegistrySelector(
 		const results = [];
 		const widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
 		for ( const _widgetArea of widgetAreas ) {
-			const post = select( 'core' ).getEditedEntityRecord(
+			const post = select( coreStore ).getEditedEntityRecord(
 				KIND,
 				POST_TYPE,
 				buildWidgetAreaPostId( _widgetArea.id )
@@ -146,7 +148,7 @@ export const isSavingWidgetAreas = createRegistrySelector( ( select ) => () => {
 	}
 
 	for ( const id of widgetAreasIds ) {
-		const isSaving = select( 'core' ).isSavingEntityRecord(
+		const isSaving = select( coreStore ).isSavingEntityRecord(
 			KIND,
 			WIDGET_AREA_ENTITY_TYPE,
 			id
@@ -161,7 +163,7 @@ export const isSavingWidgetAreas = createRegistrySelector( ( select ) => () => {
 		undefined, // account for new widgets without an ID
 	];
 	for ( const id of widgetIds ) {
-		const isSaving = select( 'core' ).isSavingEntityRecord(
+		const isSaving = select( coreStore ).isSavingEntityRecord(
 			'root',
 			'widget',
 			id
@@ -208,13 +210,13 @@ export function isInserterOpened( state ) {
 export const canInsertBlockInWidgetArea = createRegistrySelector(
 	( select ) => ( state, blockName ) => {
 		// Widget areas are always top-level blocks, which getBlocks will return.
-		const widgetAreas = select( 'core/block-editor' ).getBlocks();
+		const widgetAreas = select( blockEditorStore ).getBlocks();
 
 		// Makes an assumption that a block that can be inserted into one
 		// widget area can be inserted into any widget area. Uses the first
 		// widget area for testing whether the block can be inserted.
 		const [ firstWidgetArea ] = widgetAreas;
-		return select( 'core/block-editor' ).canInsertBlockType(
+		return select( blockEditorStore ).canInsertBlockType(
 			blockName,
 			firstWidgetArea.clientId
 		);


### PR DESCRIPTION
## Description
Fixes eslint warnings in the edit-widgets package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* Tested the widgets screen making sure nothing breaks
* `npm run lint-js packages/edit-widgets/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
