### PR TITLE
edit-site: Fix no-string-literals warnings

### DIFF
--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { edit } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 export default function NavigateToLink( {
 	type,
@@ -19,7 +20,7 @@ export default function NavigateToLink( {
 			type &&
 			id &&
 			type !== 'URL' &&
-			select( 'core' ).getEntityRecord( 'postType', type, id ),
+			select( coreStore ).getEntityRecord( 'postType', type, id ),
 		[ type, id ]
 	);
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-categories.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-categories.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ export default function ContentCategoriesMenu() {
 	const { categories, isResolved } = useSelect(
 		( select ) => {
 			const { getEntityRecords, hasFinishedResolution } = select(
-				'core'
+				coreStore
 			);
 			const getEntityRecordsArgs = [
 				'taxonomy',

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-pages.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-pages.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ export default function ContentPagesMenu() {
 	const { pages, isResolved } = useSelect(
 		( select ) => {
 			const { getEntityRecords, hasFinishedResolution } = select(
-				'core'
+				coreStore
 			);
 			const getEntityRecordsArgs = [
 				'postType',

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
@@ -8,6 +8,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function ContentPostsMenu() {
 				getEntityRecords,
 				getEditedEntityRecord,
 				hasFinishedResolution,
-			} = select( 'core' );
+			} = select( coreStore );
 			const getEntityRecodsArgs = [
 				'postType',
 				'post',

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-entity-items.js
@@ -4,6 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalNavigationItem as NavigationItem } from '@wordpress/components';
 import { getPathAndQueryString } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ const getEntityTitle = ( kind, entity ) =>
 
 export default function NavigationEntityItems( { kind, name, query = {} } ) {
 	const entities = useSelect(
-		( select ) => select( 'core' ).getEntityRecords( kind, name, query ),
+		( select ) => select( coreStore ).getEntityRecords( kind, name, query ),
 		[ kind, name, query ]
 	);
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -15,6 +15,8 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -27,8 +29,8 @@ export default function NewTemplateDropdown() {
 	const { defaultTemplateTypes, templates } = useSelect( ( select ) => {
 		const {
 			__experimentalGetDefaultTemplateTypes: getDefaultTemplateTypes,
-		} = select( 'core/editor' );
-		const templateEntities = select( 'core' ).getEntityRecords(
+		} = select( editorStore );
+		const templateEntities = select( coreStore ).getEntityRecords(
 			'postType',
 			'wp_template'
 		);

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/search-results.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/search-results.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { normalizedSearch } from './utils';
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import TemplateNavigationItem from './template-navigation-item';
 import ContentNavigationItem from './content-navigation-item';
 
@@ -37,7 +38,7 @@ export default function SearchResults( { items, search, disableFilter } ) {
 			if ( itemType === 'wp_template' ) {
 				const {
 					__experimentalGetTemplateInfo: getTemplateInfo,
-				} = select( 'core/editor' );
+				} = select( editorStore );
 
 				return items.map( ( item ) => ( {
 					slug: item.slug,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -8,6 +8,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ export default function TemplateNavigationItem( { item } ) {
 	const { title, description } = useSelect(
 		( select ) =>
 			'wp_template' === item.type
-				? select( 'core/editor' ).__experimentalGetTemplateInfo( item )
+				? select( editorStore ).__experimentalGetTemplateInfo( item )
 				: {
 						title: item?.title?.rendered || item?.slug,
 						description: '',

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -8,6 +8,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ import { store as editSiteStore } from '../../store';
 export default function TemplateDetails( { template, onClose } ) {
 	const { title, description } = useSelect(
 		( select ) =>
-			select( 'core/editor' ).__experimentalGetTemplateInfo( template ),
+			select( editorStore ).__experimentalGetTemplateInfo( template ),
 		[]
 	);
 	const { openNavigationPanelToMenu, revertTemplate } = useDispatch(

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import ConvertToTemplatePart from './convert-to-template-part';
 export default function TemplatePartConverter() {
 	const { clientIds, blocks } = useSelect( ( select ) => {
 		const { getSelectedBlockClientIds, getBlocksByClientId } = select(
-			'core/block-editor'
+			blockEditorStore
 		);
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		return {

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -54,7 +54,7 @@ export function* setTemplate( templateId, templateSlug ) {
 	const pageContext = { templateSlug };
 	if ( ! templateSlug ) {
 		const template = yield controls.resolveSelect(
-			'core',
+			coreStore,
 			'getEntityRecord',
 			'postType',
 			'wp_template',
@@ -78,7 +78,7 @@ export function* setTemplate( templateId, templateSlug ) {
  */
 export function* addTemplate( template ) {
 	const newTemplate = yield controls.dispatch(
-		'core',
+		coreStore,
 		'saveEntityRecord',
 		'postType',
 		'wp_template',
@@ -87,7 +87,7 @@ export function* addTemplate( template ) {
 
 	if ( template.content ) {
 		yield controls.dispatch(
-			'core',
+			coreStore,
 			'editEntityRecord',
 			'postType',
 			'wp_template',
@@ -160,7 +160,7 @@ export function setHomeTemplateId( homeTemplateId ) {
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
 		const entity = yield controls.resolveSelect(
-			'core',
+			coreStore,
 			'getEntityRecord',
 			'postType',
 			page.context.postType || 'post',
@@ -170,7 +170,7 @@ export function* setPage( page ) {
 		page.path = getPathAndQueryString( entity.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
-		'core',
+		coreStore,
 		'__experimentalGetTemplateForLink',
 		page.path
 	);
@@ -198,7 +198,7 @@ export function* showHomepage() {
 		show_on_front: showOnFront,
 		page_on_front: frontpageId,
 	} = yield controls.resolveSelect(
-		'core',
+		coreStore,
 		'getEntityRecord',
 		'root',
 		'site'

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -12,10 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import {
-	STORE_NAME as editSiteStoreName,
-	CORE_STORE_NAME as coreStoreName,
-} from './constants';
+import { STORE_NAME as editSiteStoreName } from './constants';
 import isTemplateRevertable from '../utils/is-template-revertable';
 
 /**
@@ -57,7 +54,7 @@ export function* setTemplate( templateId, templateSlug ) {
 	const pageContext = { templateSlug };
 	if ( ! templateSlug ) {
 		const template = yield controls.resolveSelect(
-			coreStoreName,
+			coreStore.name,
 			'getEntityRecord',
 			'postType',
 			'wp_template',
@@ -81,7 +78,7 @@ export function* setTemplate( templateId, templateSlug ) {
  */
 export function* addTemplate( template ) {
 	const newTemplate = yield controls.dispatch(
-		coreStoreName,
+		coreStore.name,
 		'saveEntityRecord',
 		'postType',
 		'wp_template',
@@ -90,7 +87,7 @@ export function* addTemplate( template ) {
 
 	if ( template.content ) {
 		yield controls.dispatch(
-			coreStoreName,
+			coreStore.name,
 			'editEntityRecord',
 			'postType',
 			'wp_template',
@@ -163,7 +160,7 @@ export function setHomeTemplateId( homeTemplateId ) {
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
 		const entity = yield controls.resolveSelect(
-			coreStoreName,
+			coreStore.name,
 			'getEntityRecord',
 			'postType',
 			page.context.postType || 'post',
@@ -173,7 +170,7 @@ export function* setPage( page ) {
 		page.path = getPathAndQueryString( entity.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
-		coreStoreName,
+		coreStore.name,
 		'__experimentalGetTemplateForLink',
 		page.path
 	);
@@ -201,7 +198,7 @@ export function* showHomepage() {
 		show_on_front: showOnFront,
 		page_on_front: frontpageId,
 	} = yield controls.resolveSelect(
-		coreStoreName,
+		coreStore.name,
 		'getEntityRecord',
 		'root',
 		'site'

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -12,7 +12,10 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { STORE_NAME as editSiteStoreName } from './constants';
+import {
+	STORE_NAME as editSiteStoreName,
+	CORE_STORE_NAME as coreStoreName,
+} from './constants';
 import isTemplateRevertable from '../utils/is-template-revertable';
 
 /**
@@ -54,7 +57,7 @@ export function* setTemplate( templateId, templateSlug ) {
 	const pageContext = { templateSlug };
 	if ( ! templateSlug ) {
 		const template = yield controls.resolveSelect(
-			coreStore,
+			coreStoreName,
 			'getEntityRecord',
 			'postType',
 			'wp_template',
@@ -78,7 +81,7 @@ export function* setTemplate( templateId, templateSlug ) {
  */
 export function* addTemplate( template ) {
 	const newTemplate = yield controls.dispatch(
-		coreStore,
+		coreStoreName,
 		'saveEntityRecord',
 		'postType',
 		'wp_template',
@@ -87,7 +90,7 @@ export function* addTemplate( template ) {
 
 	if ( template.content ) {
 		yield controls.dispatch(
-			coreStore,
+			coreStoreName,
 			'editEntityRecord',
 			'postType',
 			'wp_template',
@@ -160,7 +163,7 @@ export function setHomeTemplateId( homeTemplateId ) {
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
 		const entity = yield controls.resolveSelect(
-			coreStore,
+			coreStoreName,
 			'getEntityRecord',
 			'postType',
 			page.context.postType || 'post',
@@ -170,7 +173,7 @@ export function* setPage( page ) {
 		page.path = getPathAndQueryString( entity.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
-		coreStore,
+		coreStoreName,
 		'__experimentalGetTemplateForLink',
 		page.path
 	);
@@ -198,7 +201,7 @@ export function* showHomepage() {
 		show_on_front: showOnFront,
 		page_on_front: frontpageId,
 	} = yield controls.resolveSelect(
-		coreStore,
+		coreStoreName,
 		'getEntityRecord',
 		'root',
 		'site'

--- a/packages/edit-site/src/store/constants.js
+++ b/packages/edit-site/src/store/constants.js
@@ -4,10 +4,3 @@
  * @type {string}
  */
 export const STORE_NAME = 'core/edit-site';
-
-/**
- * The identifier for the core data store.
- *
- * @type {string}
- */
-export const CORE_STORE_NAME = 'core';

--- a/packages/edit-site/src/store/constants.js
+++ b/packages/edit-site/src/store/constants.js
@@ -4,3 +4,10 @@
  * @type {string}
  */
 export const STORE_NAME = 'core/edit-site';
+
+/**
+ * The identifier for the core data store.
+ *
+ * @type {string}
+ */
+export const CORE_STORE_NAME = 'core';


### PR DESCRIPTION
## Description
Fixes eslint warnings in the edit-site package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* Tested the site editor making sure nothing breaks
* `npm run lint-js packages/edit-site/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
