### PR TITLE
Plugin: Update block editor settings to work with context

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -75,8 +75,8 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'post-editor';
-		$settings = gutenberg_get_block_editor_settings( $context );
+		$editor_context  = new WP_Block_Editor_Context();
+		$settings = gutenberg_get_block_editor_settings( array(), $editor_context );
 
 		return rest_ensure_response( $settings );
 	}

--- a/lib/compat/wordpress-5.8/block-editor.php
+++ b/lib/compat/wordpress-5.8/block-editor.php
@@ -69,26 +69,30 @@ function gutenberg_get_default_block_categories() {
  *
  * @since 10.5.0
  *
- * @param string|WP_Post $editor_name_or_post The name of the editor (e.g. 'post-editor')
- *                                            or the post object.
- *
+ * @param WP_Post|WP_Block_Editor_Context $post_or_block_editor_context The current post object or
+ *                                                                      the block editor context.
  * @return array[] Array of categories for block types.
  */
-function gutenberg_get_block_categories( $editor_name_or_post ) {
-	// Assume the post editor when the WP_Post object passed.
-	$editor_name        = is_object( $editor_name_or_post ) ? 'post-editor' : $editor_name_or_post;
-	$default_categories = gutenberg_get_default_block_categories();
+function gutenberg_get_block_categories( $post_or_block_editor_context ) {
+	$block_categories     = gutenberg_get_default_block_categories();
+	$block_editor_context = $post_or_block_editor_context instanceof WP_Post ?
+		new WP_Block_Editor_Context(
+			array(
+				'post' => $post_or_block_editor_context,
+			)
+		) : $post_or_block_editor_context;
 
 	/**
 	 * Filters the default array of categories for block types.
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array[] $default_categories Array of categories for block types.
+	 * @param array[]                 $block_categories     Array of categories for block types.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$block_categories = apply_filters( 'block_categories_all', $default_categories );
-	if ( 'post-editor' === $editor_name ) {
-		$post = is_object( $editor_name_or_post ) ? $editor_name_or_post : get_post();
+	$block_categories = apply_filters( 'block_categories_all', $block_categories, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the default array of categories for block types.
@@ -115,25 +119,26 @@ function gutenberg_get_block_categories( $editor_name_or_post ) {
  *
  * @since 10.5.0
  *
- * @param string $editor_name The name of the editor (e.g. 'post-editor').
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
  *
  * @return bool|array Array of block type slugs, or boolean to enable/disable all.
  */
-function gutenberg_get_allowed_block_types( $editor_name ) {
+function gutenberg_get_allowed_block_types( $block_editor_context ) {
 	$allowed_block_types = true;
 
 	/**
-	 * Filters the allowed block types for the given editor, defaulting to true (all
-	 * registered block types supported).
+	 * Filters the allowed block types for all editor types, defaulting to `true`
+	 * (all registered block types supported).
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param bool|array $allowed_block_types Array of block type slugs, or
-	 *                                        boolean to enable/disable all.
+	 * @param bool|array              $allowed_block_types  Array of block type slugs, or
+	 *                                                      boolean to enable/disable all.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types );
-	if ( 'post-editor' === $editor_name ) {
-		$post = get_post();
+	$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the allowed block types for the editor, defaulting to true (all
@@ -251,31 +256,32 @@ function gutenberg_get_default_block_editor_settings() {
  *
  * @since 10.5.0
  *
- * @param string $editor_name     The name of the editor (e.g. 'post-editor').
- * @param array  $custom_settings Optional custom settings to use with the editor type.
+ * @param array                   $custom_settings      Optional custom settings to use with the editor type.
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
  *
  * @return array The contextualized block editor settings.
  */
-function gutenberg_get_block_editor_settings( $editor_name, $custom_settings = array() ) {
+function gutenberg_get_block_editor_settings( $custom_settings, $block_editor_context ) {
 	$editor_settings = array_merge(
-		gutenberg_get_default_block_editor_settings( $editor_name ),
+		gutenberg_get_default_block_editor_settings(),
 		array(
-			'allowedBlockTypes' => gutenberg_get_allowed_block_types( $editor_name ),
-			'blockCategories'   => gutenberg_get_block_categories( $editor_name ),
+			'allowedBlockTypes' => gutenberg_get_allowed_block_types( $block_editor_context ),
+			'blockCategories'   => gutenberg_get_block_categories( $block_editor_context ),
 		),
 		$custom_settings
 	);
 
 	/**
-	 * Filters the settings to pass to the block editor for all editor types.
+	 * Filters the settings to pass to the block editor for all editor type.
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array $editor_settings Default editor settings.
+	 * @param array                   $editor_settings      Default editor settings.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$editor_settings = apply_filters( 'block_editor_settings_all', $editor_settings );
-	if ( 'post-editor' === $editor_name ) {
-		$post = get_post();
+	$editor_settings = apply_filters( 'block_editor_settings_all', $editor_settings, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the settings to pass to the block editor.
@@ -290,4 +296,78 @@ function gutenberg_get_block_editor_settings( $editor_name, $custom_settings = a
 	}
 
 	return $editor_settings;
+}
+
+/**
+ * Preloads common data used with the block editor by specifying an array of
+ * REST API paths that will be preloaded for a given block editor context.
+ *
+ * @see https://core.trac.wordpress.org/ticket/52920
+ *
+ * @since 10.7.0
+ *
+ * @global WP_Post $post Global post object.
+ *
+ * @param array                   $preload_paths        List of paths to preload.
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
+ *
+ * @return void
+ */
+function gutenberg_block_editor_rest_api_preload( array $preload_paths, $block_editor_context ) {
+	global $post;
+
+	/**
+	 * Filters the array of REST API paths that will be used to preloaded common data
+	 * to use with the block editor.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param string[] $preload_paths Array of paths to preload.
+	 */
+	$preload_paths = apply_filters( 'block_editor_rest_api_preload_paths', $preload_paths, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$selected_post = $block_editor_context->post;
+
+		/**
+		 * Preload common data by specifying an array of REST API paths that will be preloaded.
+		 *
+		 * Filters the array of paths that will be preloaded.
+		 *
+		 * @since 5.0.0
+		 * @deprecated 5.8.0 The hook transitioned to support also screens that don't contain $post instance.
+		 *
+		 * @param string[] $preload_paths Array of paths to preload.
+		 * @param WP_Post  $selected_post Post being edited.
+		 */
+		$preload_paths = apply_filters_deprecated( 'block_editor_preload_paths', array( $preload_paths, $selected_post ), '5.8.0', 'block_editor_rest_api_preload_paths' );
+	}
+
+	if ( empty( $preload_paths ) ) {
+		return;
+	}
+
+	/*
+	 * Ensure the global $post remains the same after API data is preloaded.
+	 * Because API preloading can call the_content and other filters, plugins
+	 * can unexpectedly modify $post.
+	 */
+	$backup_global_post = ! empty( $post ) ? clone $post : $post;
+
+	$preload_data = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
+
+	// Restore the global $post as it was before API preloading.
+	$post = $backup_global_post;
+
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
+			wp_json_encode( $preload_data )
+		),
+		'after'
+	);
 }

--- a/lib/compat/wordpress-5.8/block-editor.php
+++ b/lib/compat/wordpress-5.8/block-editor.php
@@ -256,7 +256,7 @@ function gutenberg_get_default_block_editor_settings() {
  *
  * @since 10.5.0
  *
- * @param array                   $custom_settings      Optional custom settings to use with the editor type.
+ * @param array                   $custom_settings      Custom settings to use with the given editor type.
  * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
  *
  * @return array The contextualized block editor settings.

--- a/lib/compat/wordpress-5.8/class-wp-block-editor-context.php
+++ b/lib/compat/wordpress-5.8/class-wp-block-editor-context.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Blocks API: WP_Block_Editor_Context class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Class representing a current block editor context.
+ *
+ * The expectation is that block editor can have a different set
+ * of requirements on every screen where it is used. This class
+ * allows to define supporting settings that can be used with filters.
+ */
+final class WP_Block_Editor_Context {
+	/**
+	 * Post being edited. Optional.
+	 *
+	 * @var WP_Post|null
+	 */
+	public $post = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Populates optional properties for a given block editor context.
+	 *
+	 * @param array $settings The list of optional settings to expose in a given context.
+	 */
+	public function __construct( array $settings = array() ) {
+		if ( isset( $settings['post'] ) ) {
+			$this->post = $settings['post'];
+		}
+	}
+}

--- a/lib/compat/wordpress-5.8/index.php
+++ b/lib/compat/wordpress-5.8/index.php
@@ -7,6 +7,12 @@
  * @package gutenberg
  */
 
+if ( ! class_exists( 'WP_Block_Editor_Context' ) ) {
+	require_once __DIR__ . '/class-wp-block-editor-context.php';
+}
+
+require_once __DIR__ . '/block-editor.php';
+
 if ( ! function_exists( 'build_query_vars_from_query_block' ) ) {
 	/**
 	 * Helper function that constructs a WP_Query args array from

--- a/lib/load.php
+++ b/lib/load.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'WP_Widget_Block' ) ) {
 require_once __DIR__ . '/widgets-page.php';
 
 require __DIR__ . '/compat.php';
-require __DIR__ . '/compat/wordpress-5.8.php';
+require __DIR__ . '/compat/wordpress-5.8/index.php';
 require __DIR__ . '/utils.php';
 require __DIR__ . '/editor-settings.php';
 
@@ -110,7 +110,6 @@ require __DIR__ . '/full-site-editing/edit-site-page.php';
 require __DIR__ . '/full-site-editing/edit-site-export.php';
 
 require __DIR__ . '/blocks.php';
-require __DIR__ . '/block-editor.php';
 require __DIR__ . '/block-patterns.php';
 require __DIR__ . '/client-assets.php';
 require __DIR__ . '/demo.php';

--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -116,7 +116,8 @@ function gutenberg_customize_widgets_init() {
 		return;
 	}
 
-	$settings = array_merge(
+	$customizer_context = new WP_Block_Editor_Context();
+	$settings           = array_merge(
 		gutenberg_get_default_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
 	);
@@ -137,7 +138,7 @@ function gutenberg_customize_widgets_init() {
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( 'widgets_customizer' ) ) ),
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( $customizer_context ) ) ),
 		'after'
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -34,7 +34,8 @@ function gutenberg_widgets_init( $hook ) {
 
 	add_filter( 'admin_body_class', 'gutenberg_widgets_editor_add_admin_body_classes' );
 
-	$settings = array_merge(
+	$widgets_editor_context = new WP_Block_Editor_Context();
+	$settings               = array_merge(
 		gutenberg_get_default_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
 	);
@@ -60,7 +61,7 @@ function gutenberg_widgets_init( $hook ) {
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( 'widgets_editor' ) ) ),
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( $widgets_editor_context ) ) ),
 		'after'
 	);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to https://github.com/WordPress/wordpress-develop/pull/1118 where `WP_Block_Editor_Context` class was introduced to make customizations for the block editor settings simpler. With that change, the following filters expose this context replacing the editor name (at least in WP core, in the plugin there was no param so far):
- `allowed_block_types_all`
- `block_categories_all`
- `block_editor_rest_api_preload_paths`
- `block_editor_settings_all`

This PR also shims `block_editor_rest_api_preload` that is now part of WordPress core and can be used with new screens.