### PR TITLE
Latest Posts: Declare 'hasPosts' before 'inspectorControls'

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -229,6 +229,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		};
 	}, [] );
 
+	const hasPosts = !! latestPosts?.length;
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Post content settings' ) }>
@@ -412,7 +413,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		} ),
 	} );
 
-	const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 	if ( ! hasPosts ) {
 		return (
 			<div { ...blockProps }>


### PR DESCRIPTION
## Description
Fixes #31847

## How has this been tested?
1. Create a post.
2. Add "Latest Posts" blocks.
3. Switch to "Grid view."
4. Posts are displayed in grid view, and there's no error.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
