### PR TITLE
Improves PR 31763 for the URL Details Controller

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -328,8 +328,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Utility function to build cache key for a given URL.
 	 *
-	 * @param string $url the URL for which to build a cache key.
-	 * @return string the cache key.
+	 * @param string $url The URL for which to build a cache key.
+	 * @return string The cache key.
 	 */
 	private function build_cache_key_for_url( $url ) {
 		return 'g_url_details_response_' . md5( $url );
@@ -338,8 +338,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Utility function to retrieve a value from the cache at a given key.
 	 *
-	 * @param string $key the cache key.
-	 * @return string the value from the cache.
+	 * @param string $key The cache key.
+	 * @return mixed The value from the cache.
 	 */
 	private function get_cache( $key ) {
 		return get_transient( $key );
@@ -348,13 +348,13 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Utility function to cache a given data set at a given cache key.
 	 *
-	 * @param string $key the cache key under which to store the value.
-	 * @param string $data the data to be stored at the given cache key.
-	 * @return void
+	 * @param string $key  The cache key under which to store the value.
+	 * @param string $data The data to be stored at the given cache key.
+	 * @return bool True when transient set, or false.
 	 */
 	private function set_cache( $key, $data = '' ) {
 		if ( ! is_array( $data ) ) {
-			return;
+			return false;
 		}
 
 		$ttl = HOUR_IN_SECONDS;

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -57,7 +57,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return array the schema.
 	 */
 	public function get_item_schema() {
-
 		if ( $this->schema ) {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
@@ -86,10 +85,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * response.
 	 *
 	 * @param WP_REST_REQUEST $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error The parsed details as a response object or an error.
+	 * @return WP_REST_Response|WP_Error The parsed details as a response object, or an error.
 	 */
 	public function parse_url_details( $request ) {
-
 		$url = untrailingslashit( $request['url'] );
 
 		if ( empty( $url ) ) {
@@ -143,12 +141,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		return apply_filters( 'rest_prepare_url_details', $response, $url, $request, $remote_url_response );
 	}
 
-
-
 	/**
 	 * Checks whether a given request has permission to read remote urls.
 	 *
-	 * @return WP_Error|bool True if the request has access, WP_Error object otherwise.
+	 * @return WP_Error|bool True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
 		if ( current_user_can( 'edit_posts' ) ) {
@@ -168,16 +164,13 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		);
 	}
 
-
-
 	/**
 	 * Retrieves the document title from a remote URL.
 	 *
 	 * @param string $url The website url whose HTML we want to access.
-	 * @return array|WP_Error the HTTP response from the remote URL or error.
+	 * @return array|WP_Error the HTTP response from the remote URL, or an error.
 	 */
 	private function get_remote_url( $url ) {
-
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,
 			'user-agent'          => $this->get_random_user_agent(),
@@ -216,7 +209,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * Parses the <title> contents from the provided HTML
 	 *
 	 * @param string $html The HTML from the remote website at URL.
-	 * @return string The title tag contents on success; else empty string.
+	 * @return string The title tag contents on success, or an empty string.
 	 */
 	private function get_title( $html ) {
 		preg_match( '|<title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
@@ -231,7 +224,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 *
 	 * @param string $html The HTML from the remote website at URL.
 	 * @param string $url  The target website URL.
-	 * @return string The icon URI on success; else empty string.
+	 * @return string The icon URI on success, or an empty string.
 	 */
 	private function get_icon( $html, $url ) {
 		// Grab the icon's link element.
@@ -268,7 +261,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 *     @type string[] 1 Content attribute's opening quotation mark.
 	 *     @type string[] 2 Content attribute's value for each meta element.
 	 * }
-	 * @return string The meta description contents on success, else empty string.
+	 * @return string The meta description contents on success, or an empty string.
 	 */
 	private function get_description( $meta_elements ) {
 		// Bail out if there are no meta elements.
@@ -377,7 +370,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string the user agent string.
 	 */
 	private function get_random_user_agent() {
-
 		$agents = array(
 			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246', // Windows 10-based PC using Edge browser.
 			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9', // Mac OS X-based computer using a Safari browser.

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -212,11 +212,16 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string The title tag contents on success, or an empty string.
 	 */
 	private function get_title( $html ) {
-		preg_match( '|<title[^>]*>(.*?)<\s*/\s*title>|is', $html, $match_title );
+		$pattern = '#<title[^>]*>(.*?)<\s*/\s*title>#is';
+		preg_match( $pattern, $html, $match_title );
 
-		$title = isset( $match_title[1] ) && is_string( $match_title[1] ) ? trim( $match_title[1] ) : '';
+		$title = ! empty( $match_title[1] ) && is_string( $match_title[1] ) ? trim( $match_title[1] ) : '';
 
-		return $title;
+		if ( empty( $title ) ) {
+			return '';
+		}
+
+		return $this->convert_html_entities( $title );
 	}
 
 	/**
@@ -276,10 +281,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return '';
 		}
 
-		// Convert any entities to HTML for use downstream.
-		$description = html_entity_decode( $description, ENT_QUOTES, get_bloginfo( 'charset' ) );
-
-		return $description;
+		return $this->convert_html_entities( $description );
 	}
 
 	/**
@@ -311,6 +313,16 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$image      = WP_Http::make_absolute_url( $image, $root_url );
 
 		return $image;
+	}
+
+	/**
+	 * Convert HTML entities into HTML for use downstream.
+	 *
+	 * @param string $html The HTML to convert.
+	 * @return string The HTML with all entities converted.
+	 */
+	private function convert_html_entities( $html ) {
+		return html_entity_decode( $html, ENT_QUOTES, get_bloginfo( 'charset' ) );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -358,10 +358,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return bool True when transient set, or false.
 	 */
 	private function set_cache( $key, $data = '' ) {
-		if ( ! is_array( $data ) ) {
-			return false;
-		}
-
 		$ttl = HOUR_IN_SECONDS;
 
 		/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -221,7 +221,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return '';
 		}
 
-		return $this->convert_html_entities( $title );
+		return $this->prepare_metadata_for_output( $title );
 	}
 
 	/**
@@ -281,7 +281,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return '';
 		}
 
-		return $this->convert_html_entities( $description );
+		return $this->prepare_metadata_for_output( $description );
 	}
 
 	/**
@@ -316,13 +316,18 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Convert HTML entities into HTML for use downstream.
+	 * Prepare the metadata by:
 	 *
-	 * @param string $html The HTML to convert.
-	 * @return string The HTML with all entities converted.
+	 *    - stripping all HTML tags and tag entities
+	 *    - converting non-tag entities into characters.
+	 *
+	 * @param string $metadata The metadata content to prepare.
+	 * @return string The prepared metadata.
 	 */
-	private function convert_html_entities( $html ) {
-		return html_entity_decode( $html, ENT_QUOTES, get_bloginfo( 'charset' ) );
+	private function prepare_metadata_for_output( $metadata ) {
+		$metadata = html_entity_decode( $metadata, ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$metadata = wp_strip_all_tags( $metadata );
+		return $metadata;
 	}
 
 	/**

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -18,40 +18,13 @@
  */
 class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
-	/**
-	 * Admin user ID.
-	 *
-	 * @since x.x.0
-	 *
-	 * @var int $subscriber_id
-	 */
 	protected static $admin_id;
-
-	/**
-	 * Subscriber user ID.
-	 *
-	 * @since x.x.0
-	 *
-	 * @var int $subscriber_id
-	 */
 	protected static $subscriber_id;
-
-
-	protected static $route = '/__experimental/url-details';
-
-
+	protected static $route           = '/__experimental/url-details';
 	protected static $url_placeholder = 'https://placeholder-site.com';
+	protected static $request_args    = array();
 
-	protected static $request_args = array();
-
-	/**
-	 * Create fake data before our tests run.
-	 *
-	 * @since x.x.0
-	 *
-	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
-	 */
-	public static function wpSetUpBeforeClass( $factory ) {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id      = $factory->user->create(
 			array(
 				'role' => 'administrator',
@@ -69,11 +42,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		self::delete_user( self::$subscriber_id );
 	}
 
-
-
-	/**
-	 * Setup.
-	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -81,28 +49,17 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		// Disables usage of cache during major of tests.
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
-		add_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		add_filter( "pre_transient_{$transient_name}", '__return_null' );
 	}
 
-	/**
-	 * Tear down.
-	 */
 	public function tearDown() {
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_request_to_remote_url' ), 10 );
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		remove_filter( "pre_transient_{$transient_name}", '__return_null' );
 		static::$request_args = array();
 		parent::tearDown();
 	}
-
-
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -85,7 +85,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		// the filter `pre_http_request` (see this class's `setUp` method).
 		$this->assertArraySubset(
 			array(
-				'title'       => 'Example Website &mdash; - with encoded content.',
+				'title'       => 'Example Website — - with encoded content.',
 				'icon'        => 'https://placeholder-site.com/favicon.ico?querystringaddedfortesting',
 				'description' => 'Example description text here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
 				'image'       => 'https://placeholder-site.com/images/home/screen-themes.png?3',
@@ -362,7 +362,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		// data we provided via the filter.
 		$this->assertArraySubset(
 			array(
-				'title'    => 'Example Website &mdash; - with encoded content.',
+				'title'    => 'Example Website — - with encoded content.',
 				'og_title' => 'This was manually added to the data via filter',
 			),
 			$data
@@ -374,7 +374,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	public function test_allows_filtering_response() {
-
 		// Filter the response to known set of values changing only
 		// based on whether the response came from the cache or not.
 		add_filter(
@@ -477,36 +476,36 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 			// Happy path for default.
 			'default'                        => array(
-				'<title>Testing &lt;title&gt;:</title>',
-				'Testing &lt;title&gt;:',
+				'<title>Testing &lt;title&gt;</title>',
+				'Testing <title>',
 			),
 			'with attributes'                => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;:</title>',
-				'Testing &lt;title&gt;:',
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;</title>',
+				'Testing <title>',
 			),
 			'with text whitespace'           => array(
-				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;:	</title>',
-				'Testing &lt;title&gt;:',
+				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;	</title>',
+				'Testing <title>',
 			),
 			'with whitespace in opening tag' => array(
 				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
-				'Testing &lt;title&gt;: with whitespace in opening tag',
+				'Testing <title>: with whitespace in opening tag',
 			),
 			'when whitepace in closing tag'  => array(
 				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
-				'Testing &lt;title&gt;: with whitespace in closing tag',
+				'Testing <title>: with whitespace in closing tag',
 			),
 			'with other elements'            => array(
 				'<meta name="viewport" content="width=device-width">
-				<title>Testing &lt;title&gt;:</title>
+				<title>Testing &lt;title&gt;</title>
 				<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
-				'Testing &lt;title&gt;:',
+				'Testing <title>',
 			),
 			'multiline'                      => array(
 				'<title>
-					Testing &lt;title&gt;:
+					Testing &lt;title&gt;
 				</title>',
-				'Testing &lt;title&gt;:',
+				'Testing <title>',
 			),
 
 			// Unhappy paths.

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -1003,19 +1003,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-	public function provide_response_is_from_cache() {
-		return array(
-			'uncached_response' => array(
-				null,
-				false,
-			), // empty!
-			'cached_response'   => array(
-				null,
-				true,
-			),
-		);
-	}
-
 	/**
 	 * Mocks the HTTP response for the the `wp_safe_remote_get()` which
 	 * would otherwise make a call to a real website.

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -447,35 +447,35 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			// Happy path for default.
 			'default'                        => array(
 				'<title>Testing &lt;title&gt;</title>',
-				'Testing <title>',
+				'Testing',
 			),
 			'with attributes'                => array(
 				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">Testing &lt;title&gt;</title>',
-				'Testing <title>',
+				'Testing',
 			),
 			'with text whitespace'           => array(
 				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;	</title>',
-				'Testing <title>',
+				'Testing',
 			),
 			'with whitespace in opening tag' => array(
 				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
-				'Testing <title>: with whitespace in opening tag',
+				'Testing : with whitespace in opening tag',
 			),
 			'when whitepace in closing tag'  => array(
 				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
-				'Testing <title>: with whitespace in closing tag',
+				'Testing : with whitespace in closing tag',
 			),
 			'with other elements'            => array(
 				'<meta name="viewport" content="width=device-width">
 				<title>Testing &lt;title&gt;</title>
 				<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
-				'Testing <title>',
+				'Testing',
 			),
 			'multiline'                      => array(
 				'<title>
 					Testing &lt;title&gt;
 				</title>',
-				'Testing <title>',
+				'Testing',
 			),
 
 			// Unhappy paths.
@@ -739,19 +739,19 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			// Happy paths with HTML tags or entities in the description.
 			'with HTML tags'                             => array(
 				'<meta name="description" content="<strong>Description</strong>: has <em>HTML</em> tags">',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with content first and HTML tags'           => array(
 				'<meta content="<strong>Description</strong>: has <em>HTML</em> tags" name="description">',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with HTML tags and other attributes'        => array(
 				'<meta first="first" name="description" third="third" content="<strong>Description</strong>: has <em>HTML</em> tags" fifth="fifth>',
-				'<strong>Description</strong>: has <em>HTML</em> tags',
+				'Description: has HTML tags',
 			),
 			'with HTML entities'                         => array(
 				'<meta name="description" content="The &lt;strong&gt;description&lt;/strong&gt; meta &amp; its attribute value"',
-				'The <strong>description</strong> meta & its attribute value',
+				'The description meta & its attribute value',
 			),
 
 			// Unhappy paths.

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -81,9 +81,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Note the data in the subset comes from the fixture HTML returned by
-		// the filter `pre_http_request` (see this class's `setUp` method).
-		$this->assertArraySubset(
+		/*
+		 * Note the data in the subset comes from the fixture HTML returned by
+		 * the filter `pre_http_request` (see this class's `setUp` method).
+		 */
+		$this->assertSame(
 			array(
 				'title'       => 'Example Website — - with encoded content.',
 				'icon'        => 'https://placeholder-site.com/favicon.ico?querystringaddedfortesting',
@@ -93,7 +95,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			$data
 		);
 	}
-
 
 	public function test_get_items_fails_for_unauthenticated_user() {
 		wp_set_current_user( 0 );
@@ -107,12 +108,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::UNAUTHORIZED, $response->get_status() );
+		$this->assertSame( WP_Http::UNAUTHORIZED, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_cannot_view_url_details',
-			$data['code']
-		);
+		$this->assertSame( 'rest_cannot_view_url_details', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'you are not allowed to process remote urls' ),
@@ -132,12 +130,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::FORBIDDEN, $response->get_status() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_cannot_view_url_details',
-			$data['code']
-		);
+		$this->assertSame( 'rest_cannot_view_url_details', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'you are not allowed to process remote urls' ),
@@ -160,12 +155,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( WP_Http::BAD_REQUEST, $response->get_status() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_status() );
 
-		$this->assertEquals(
-			'rest_invalid_param',
-			$data['code']
-		);
+		$this->assertSame( 'rest_invalid_param', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Invalid parameter(s): url' ),
@@ -206,12 +198,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 
-		$this->assertEquals(
-			'no_response',
-			$data['code']
-		);
+		$this->assertSame( 'no_response', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Not found' ),
@@ -235,12 +224,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 
-		$this->assertEquals(
-			'no_content',
-			$data['code']
-		);
+		$this->assertSame( 'no_content', $data['code'] );
 
 		$this->assertContains(
 			strtolower( 'Unable to retrieve body from response at this URL' ),
@@ -276,7 +262,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		rest_get_server()->dispatch( $request );
 
 		// Check the args were filtered as expected.
-		$this->assertArraySubset(
+		$this->assertContains(
 			array(
 				'timeout'             => 27,
 				'limit_response_size' => 153600,
@@ -291,14 +277,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_will_return_from_cache_if_populated() {
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
+		remove_filter( "pre_transient_{$transient_name}", '__return_null' );
 
 		// Force cache to return a known value as the remote URL http response body.
 		add_filter(
-			"pre_transient_$transient_name",
+			"pre_transient_{$transient_name}",
 			function() {
 				return '<html><head><title>This value from cache.</title></head><body></body></html>';
 			}
@@ -316,14 +299,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$data     = $response->get_data();
 
 		// Data should be that from cache not from mocked network response.
-		$this->assertContains(
-			'This value from cache',
-			$data['title']
-		);
+		$this->assertContains( 'This value from cache', $data['title'] );
 
-		remove_all_filters(
-			"pre_transient_$transient_name"
-		);
+		remove_all_filters( "pre_transient_{$transient_name}" );
 	}
 
 	public function test_allows_filtering_data_retrieved_for_a_given_url() {
@@ -358,24 +336,21 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Instead of the default data retrieved we expect to see the modified
-		// data we provided via the filter.
-		$this->assertArraySubset(
-			array(
-				'title'    => 'Example Website — - with encoded content.',
-				'og_title' => 'This was manually added to the data via filter',
-			),
-			$data
-		);
+		/*
+		 * Instead of the default data retrieved we expect to see the modified
+		 * data we provided via the filter.
+		 */
+		$this->assertSame( 'Example Website — - with encoded content.', $data['title'] );
+		$this->assertSame( 'This was manually added to the data via filter', $data['og_title'] );
 
-		remove_all_filters(
-			'rest_prepare_url_details'
-		);
+		remove_all_filters( 'rest_prepare_url_details' );
 	}
 
 	public function test_allows_filtering_response() {
-		// Filter the response to known set of values changing only
-		// based on whether the response came from the cache or not.
+		/*
+		 * Filter the response to known set of values changing only
+		 * based on whether the response came from the cache or not.
+		 */
 		add_filter(
 			'rest_prepare_url_details',
 			function( $response, $url ) {
@@ -403,19 +378,14 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		$data = $response->get_data();
 
-		$this->assertEquals(
-			'418',
-			$data['status']
-		);
+		$this->assertSame( 418, $data['status'] );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Response for URL https://placeholder-site.com altered via rest_prepare_url_details filter',
 			$data['response']
 		);
 
-		remove_all_filters(
-			'rest_prepare_url_details'
-		);
+		remove_all_filters( 'rest_prepare_url_details' );
 	}
 
 	public function test_get_item() {
@@ -447,7 +417,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$endpoint = $data['endpoints'][0];
 
 		$this->assertArrayHasKey( 'url', $endpoint['args'] );
-		$this->assertArraySubset(
+		$this->assertContains(
 			array(
 				'type'     => 'string',
 				'required' => true,
@@ -978,7 +948,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	private function mock_request_to_remote_url( $result_type = 'success', $args ) {
-
 		static::$request_args = $args;
 
 		$types = array(

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -189,10 +189,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @dataProvider provide_invalid_url_data
+	 * @dataProvider data_invalid_url
 	 */
 	public function test_get_items_fails_for_invalid_url( $expected, $invalid_url ) {
-
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'GET', static::$route );
@@ -214,6 +213,23 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertContains(
 			strtolower( 'Invalid parameter(s): url' ),
 			strtolower( $data['message'] )
+		);
+	}
+
+	public function data_invalid_url() {
+		return array(
+			'empty_url'          => array(
+				null,
+				'',
+			), // empty!
+			'not_a_string'       => array(
+				null,
+				1234456,
+			),
+			'string_but_invalid' => array(
+				null,
+				'invalid.proto://wordpress.org',
+			),
 		);
 	}
 
@@ -354,7 +370,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	public function test_allows_filtering_data_retrieved_for_a_given_url() {
-
 		add_filter(
 			'rest_prepare_url_details',
 			function( $response ) {
@@ -400,9 +415,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'rest_prepare_url_details'
 		);
 	}
-
-
-
 
 	public function test_allows_filtering_response() {
 
@@ -450,8 +462,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-
-
 	public function test_get_item() {
 	}
 
@@ -492,7 +502,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
-	 * @dataProvider provide_get_title_data
+	 * @dataProvider data_get_title
 	 */
 	public function test_get_title( $html, $expected ) {
 		$controller = new WP_REST_URL_Details_Controller();
@@ -505,10 +515,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertSame( $expected, $actual );
 	}
 
-
-	public function provide_get_title_data() {
+	public function data_get_title() {
 		return array(
-			'no attributes'                  => array(
+
+			// Happy path for default.
+			'default'                        => array(
 				'<title>Testing &lt;title&gt;:</title>',
 				'Testing &lt;title&gt;:',
 			),
@@ -520,10 +531,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'<title data-test-title-attr-one="test" data-test-title-attr-two="test2">   Testing &lt;title&gt;:	</title>',
 				'Testing &lt;title&gt;:',
 			),
-			'when opening tag is malformed'  => array(
-				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
-				'',
-			),
 			'with whitespace in opening tag' => array(
 				'<title >Testing &lt;title&gt;: with whitespace in opening tag</title>',
 				'Testing &lt;title&gt;: with whitespace in opening tag',
@@ -531,6 +538,24 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'when whitepace in closing tag'  => array(
 				'<title>Testing &lt;title&gt;: with whitespace in closing tag</ title>',
 				'Testing &lt;title&gt;: with whitespace in closing tag',
+			),
+			'with other elements'            => array(
+				'<meta name="viewport" content="width=device-width">
+				<title>Testing &lt;title&gt;:</title>
+				<link rel="shortcut icon" href="https://wordpress.org/favicon.ico" />',
+				'Testing &lt;title&gt;:',
+			),
+			'multiline'                      => array(
+				'<title>
+					Testing &lt;title&gt;:
+				</title>',
+				'Testing &lt;title&gt;:',
+			),
+
+			// Unhappy paths.
+			'when opening tag is malformed'  => array(
+				'< title>Testing &lt;title&gt;: when opening tag is invalid</title>',
+				'',
 			),
 		);
 	}
@@ -978,27 +1003,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
-
-
-
-
-	public function provide_invalid_url_data() {
-		return array(
-			'empty_url'          => array(
-				null,
-				'',
-			), // empty!
-			'not_a_string'       => array(
-				null,
-				1234456,
-			),
-			'string_but_invalid' => array(
-				null,
-				'invalid.proto://wordpress.org',
-			),
-		);
-	}
-
 	public function provide_response_is_from_cache() {
 		return array(
 			'uncached_response' => array(
@@ -1011,8 +1015,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			),
 		);
 	}
-
-
 
 	/**
 	 * Mocks the HTTP response for the the `wp_safe_remote_get()` which


### PR DESCRIPTION
## Description
Improves PR #31763 

For metadata parsing:

- Design change: API exposes metadata with no HTML (strips out tags and tag entities) and non-HTML entities converted to characters
- Applies this design change to both the `<title>` and `<meta name="description"`
- Adds helper method to encapsulate how this is done

For the Controller (not really part of the parsing work, but needed to be done):
- Fixes controller method signatures
- Fixes formatting and comments per WordPress coding standards
- Replaces `assertArraySubset` which is deprecated in PHPUnit 9 (for future proofing)
- Replaces `assertEquals` with `assertSame`

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
