### PR TITLE
Writing flow: restore click redirect between blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { placeCaretAtVerticalEdge } from '@wordpress/dom';
+
+/**
+ * Internal dependencies
+ */
+import { getClosestTabbable } from '../../components/writing-flow/use-arrow-nav';
+
+export function useInBetweenClickRedirect() {
+	return useRefEffect( ( node ) => {
+		function onMouseMove( event ) {
+			const { clientX, clientY, target } = event;
+
+			if ( target !== node ) {
+				return;
+			}
+
+			const { children } = node;
+			const rect = node.getBoundingClientRect();
+			const offsetTop = clientY - rect.top;
+
+			let beforeChild;
+			let afterChild;
+
+			for ( const child of children ) {
+				if ( child.offsetTop > offsetTop ) {
+					afterChild = child;
+					break;
+				} else {
+					beforeChild = child;
+				}
+			}
+
+			let isReverse;
+
+			if ( ! beforeChild ) {
+				isReverse = false;
+			} else if ( ! afterChild ) {
+				isReverse = true;
+			} else {
+				const beforeY = beforeChild.getBoundingClientRect().bottom;
+				const afterY = afterChild.getBoundingClientRect().top;
+				isReverse = clientY - beforeY < afterY - clientY;
+			}
+
+			const container = isReverse ? node : afterChild;
+			const closest =
+				getClosestTabbable( afterChild, true, container ) || afterChild;
+
+			const carectRect = new window.DOMRect( clientX, clientY, 0, 16 );
+
+			placeCaretAtVerticalEdge( closest, isReverse, carectRect, false );
+		}
+
+		node.addEventListener( 'click', onMouseMove );
+
+		return () => {
+			node.removeEventListener( 'click', onMouseMove );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -46,6 +46,13 @@ export function useInBetweenClickRedirect() {
 				isReverse = clientY - beforeY < afterY - clientY;
 			}
 
+			const closestChild = isReverse ? beforeChild : afterChild;
+			const closestRect = closestChild.getBoundingClientRect();
+
+			if ( clientX < closestRect.left || clientX > closestRect.right ) {
+				return;
+			}
+
 			const container = isReverse ? node : afterChild;
 			const closest =
 				getClosestTabbable( afterChild, true, container ) || afterChild;

--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -82,6 +82,11 @@ export function useInBetweenClickRedirect() {
 	return useRefEffect( ( node ) => {
 		function onMouseMove( event ) {
 			const { clientX, clientY, target } = event;
+
+			if ( target !== node ) {
+				return;
+			}
+
 			const closestElement = getClosestChildElementFromPoint(
 				target,
 				clientX,

--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -83,22 +83,31 @@ function getClosestDescendentElementFromPointInDirection(
  * descendent if descendents are found in more than one direction (so that the
  * point falls in-between descendents).
  *
- * @param {HTMLElement} target Target element to check within.
- * @param {number}      x      X coordinate to check.
- * @param {number}      y      Y coordinate to check.
+ * @param {HTMLElement} target      Target element to check within.
+ * @param {number}      x           X coordinate to check.
+ * @param {number}      y           Y coordinate to check.
+ * @param {string}      orientation Orientation of the block list.
  *
  * @return {HTMLElement|undefined} The closest descendent element if the point
  *                                 is found to be in-between descendents.
  */
-function getClosestInBetweenDescendentElementFromPoint( target, x, y ) {
-	const directions = [
-		[ 1, 0 ],
-		[ 0, 1 ],
-		[ -1, 0 ],
-		[ 0, -1 ],
-	];
+function getClosestInBetweenDescendentElementFromPoint(
+	target,
+	x,
+	y,
+	orientation
+) {
+	const directions =
+		orientation === 'horizontal'
+			? [
+					[ 1, 0 ],
+					[ -1, 0 ],
+			  ]
+			: [
+					[ 0, 1 ],
+					[ 0, -1 ],
+			  ];
 
-	let count = 0;
 	let closestOffset;
 	let closestElement;
 
@@ -116,16 +125,10 @@ function getClosestInBetweenDescendentElementFromPoint( target, x, y ) {
 
 		const [ element, offset ] = result;
 
-		count++;
-
 		if ( ! closestOffset || offset < closestOffset ) {
 			closestOffset = offset;
 			closestElement = element;
 		}
-	}
-
-	if ( count < 2 ) {
-		return;
 	}
 
 	return closestElement;
@@ -137,9 +140,11 @@ function getClosestInBetweenDescendentElementFromPoint( target, x, y ) {
  * focusable elements are easier to focus. The redirect only happens if the
  * click happens in-between two child elements.
  *
+ * @param {string} orientation Orientation of the block list.
+ *
  * @return {Function} Ref callback.
  */
-export function useInBetweenClickRedirect() {
+export function useInBetweenClickRedirect( orientation ) {
 	return useRefEffect( ( node ) => {
 		function onMouseMove( event ) {
 			const { clientX, clientY, target } = event;
@@ -152,7 +157,8 @@ export function useInBetweenClickRedirect() {
 			const closestElement = getClosestInBetweenDescendentElementFromPoint(
 				target,
 				clientX,
-				clientY
+				clientY,
+				orientation
 			);
 
 			if ( ! closestElement ) {

--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -2,64 +2,110 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
-import { placeCaretAtVerticalEdge } from '@wordpress/dom';
+import { placeCaretAtVerticalEdge, focus } from '@wordpress/dom';
 
-/**
- * Internal dependencies
- */
-import { getClosestTabbable } from '../../components/writing-flow/use-arrow-nav';
+function isWithinRect( rect, x, y ) {
+	return x > rect.left && x < rect.right && y > rect.top && y < rect.bottom;
+}
+
+function isWithinViewport( doc, x, y ) {
+	const { defaultView } = doc;
+	return (
+		x > 0 &&
+		x < defaultView.innerWidth &&
+		y > 0 &&
+		y < defaultView.innerHeight
+	);
+}
+
+function getChildElementFromPoint( target, x, y, vector ) {
+	const rect = target.getBoundingClientRect();
+	let offset = 0;
+
+	while ( ++offset ) {
+		const _x = x + offset * vector[ 0 ];
+		const _y = y + offset * vector[ 1 ];
+		const { ownerDocument } = target;
+
+		if (
+			! isWithinRect( rect, _x, _y ) ||
+			! isWithinViewport( ownerDocument, _x, _y )
+		) {
+			return;
+		}
+
+		const element = ownerDocument.elementFromPoint( _x, _y );
+
+		if ( element !== target && target.contains( element ) ) {
+			return [ element, offset ];
+		}
+	}
+}
+
+function getClosestChildElementFromPoint( target, x, y ) {
+	const directions = [
+		[ 1, 0 ],
+		[ 0, 1 ],
+		[ -1, 0 ],
+		[ 0, -1 ],
+	];
+
+	let count = 0;
+	let closestOffset;
+	let closestElement;
+
+	for ( const direction of directions ) {
+		const result = getChildElementFromPoint( target, x, y, direction );
+
+		if ( ! result ) {
+			continue;
+		}
+
+		const [ element, offset ] = result;
+
+		count++;
+
+		if ( ! closestOffset || offset < closestOffset ) {
+			closestOffset = offset;
+			closestElement = element;
+		}
+	}
+
+	if ( count < 2 ) {
+		return;
+	}
+
+	return closestElement;
+}
 
 export function useInBetweenClickRedirect() {
 	return useRefEffect( ( node ) => {
 		function onMouseMove( event ) {
 			const { clientX, clientY, target } = event;
+			const closestElement = getClosestChildElementFromPoint(
+				target,
+				clientX,
+				clientY
+			);
 
-			if ( target !== node ) {
+			if ( ! closestElement ) {
 				return;
 			}
 
-			const { children } = node;
-			const rect = node.getBoundingClientRect();
-			const offsetTop = clientY - rect.top;
-
-			let beforeChild;
-			let afterChild;
-
-			for ( const child of children ) {
-				if ( child.offsetTop > offsetTop ) {
-					afterChild = child;
-					break;
-				} else {
-					beforeChild = child;
-				}
-			}
-
-			let isReverse;
-
-			if ( ! beforeChild ) {
-				isReverse = false;
-			} else if ( ! afterChild ) {
-				isReverse = true;
-			} else {
-				const beforeY = beforeChild.getBoundingClientRect().bottom;
-				const afterY = afterChild.getBoundingClientRect().top;
-				isReverse = clientY - beforeY < afterY - clientY;
-			}
-
-			const closestChild = isReverse ? beforeChild : afterChild;
-			const closestRect = closestChild.getBoundingClientRect();
-
-			if ( clientX < closestRect.left || clientX > closestRect.right ) {
-				return;
-			}
-
-			const container = isReverse ? node : afterChild;
-			const closest =
-				getClosestTabbable( afterChild, true, container ) || afterChild;
-
+			const closestFocusableElement = closestElement.closest(
+				focus.focusable.__unstableBuildSelector()
+			);
+			const isReverse =
+				closestFocusableElement.getBoundingClientRect().bottom <
+				clientY;
 			const carectRect = new window.DOMRect( clientX, clientY, 0, 16 );
 
-			placeCaretAtVerticalEdge( closest, isReverse, carectRect, false );
+			placeCaretAtVerticalEdge(
+				closestFocusableElement,
+				isReverse,
+				carectRect,
+				false
+			);
 		}
 
 		node.addEventListener( 'click', onMouseMove );

--- a/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-click-redirect.js
@@ -4,10 +4,28 @@
 import { useRefEffect } from '@wordpress/compose';
 import { placeCaretAtVerticalEdge, focus } from '@wordpress/dom';
 
+/**
+ * Checks if the coordinates are within a given DOM rectangle.
+ *
+ * @param {DOMRect} rect Rectangle to check.
+ * @param {number}  x    X coordinate to check.
+ * @param {number}  y    Y coordinate to check.
+ *
+ * @return {boolean} True if within rectangle, false if not.
+ */
 function isWithinRect( rect, x, y ) {
 	return x > rect.left && x < rect.right && y > rect.top && y < rect.bottom;
 }
 
+/**
+ * Checks if the coordinates are within the given document's viewport.
+ *
+ * @param {Document} doc Document to check the viewport.
+ * @param {number}   x   X coordinate to check.
+ * @param {number}   y   Y coordinate to check.
+ *
+ * @return {boolean} True if within the document's viewport, false if not.
+ */
 function isWithinViewport( doc, x, y ) {
 	const { defaultView } = doc;
 	return (
@@ -18,7 +36,25 @@ function isWithinViewport( doc, x, y ) {
 	);
 }
 
-function getChildElementFromPoint( target, x, y, vector ) {
+/**
+ * Gets the closest descendent element from a given point in a given direction.
+ * The given direction vector will be multiplied with an increasing offset until
+ * a descendent is found or until the target element or viewport boundary is
+ * reached.
+ *
+ * @param {HTMLElement} target Target element to check within.
+ * @param {number}      x      X coordinate to check.
+ * @param {number}      y      Y coordinate to check.
+ * @param {Array}       vector Direction vector.
+ *
+ * @return {HTMLElement|undefined} The closest descendent element if found.
+ */
+function getClosestDescendentElementFromPointInDirection(
+	target,
+	x,
+	y,
+	vector
+) {
 	const rect = target.getBoundingClientRect();
 	let offset = 0;
 
@@ -42,7 +78,19 @@ function getChildElementFromPoint( target, x, y, vector ) {
 	}
 }
 
-function getClosestChildElementFromPoint( target, x, y ) {
+/**
+ * Gets the closest descendent element from a given point. Only returns a
+ * descendent if descendents are found in more than one direction (so that the
+ * point falls in-between descendents).
+ *
+ * @param {HTMLElement} target Target element to check within.
+ * @param {number}      x      X coordinate to check.
+ * @param {number}      y      Y coordinate to check.
+ *
+ * @return {HTMLElement|undefined} The closest descendent element if the point
+ *                                 is found to be in-between descendents.
+ */
+function getClosestInBetweenDescendentElementFromPoint( target, x, y ) {
 	const directions = [
 		[ 1, 0 ],
 		[ 0, 1 ],
@@ -55,7 +103,12 @@ function getClosestChildElementFromPoint( target, x, y ) {
 	let closestElement;
 
 	for ( const direction of directions ) {
-		const result = getChildElementFromPoint( target, x, y, direction );
+		const result = getClosestDescendentElementFromPointInDirection(
+			target,
+			x,
+			y,
+			direction
+		);
 
 		if ( ! result ) {
 			continue;
@@ -78,16 +131,25 @@ function getClosestChildElementFromPoint( target, x, y ) {
 	return closestElement;
 }
 
+/**
+ * Behavioural hook that redirects clicks on the element to the closest
+ * focusable element so that there are no "dead zones" and so that small
+ * focusable elements are easier to focus. The redirect only happens if the
+ * click happens in-between two child elements.
+ *
+ * @return {Function} Ref callback.
+ */
 export function useInBetweenClickRedirect() {
 	return useRefEffect( ( node ) => {
 		function onMouseMove( event ) {
 			const { clientX, clientY, target } = event;
 
+			// Don't consider if the container element is not clicked directly.
 			if ( target !== node ) {
 				return;
 			}
 
-			const closestElement = getClosestChildElementFromPoint(
+			const closestElement = getClosestInBetweenDescendentElementFromPoint(
 				target,
 				clientX,
 				clientY
@@ -108,8 +170,7 @@ export function useInBetweenClickRedirect() {
 			placeCaretAtVerticalEdge(
 				closestFocusableElement,
 				isReverse,
-				carectRect,
-				false
+				carectRect
 			);
 		}
 

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import {
 	useCallback,
 	useRef,
@@ -32,7 +32,6 @@ function InsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { selectBlock } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
 	const ref = useRef();
 	const {
@@ -181,12 +180,6 @@ function InsertionPointPopover( {
 		'is-' + orientation
 	);
 
-	function onClick( event ) {
-		if ( event.target === ref.current && nextClientId ) {
-			selectBlock( nextClientId, -1 );
-		}
-	}
-
 	function onFocus( event ) {
 		// Only handle click on the wrapper specifically, and not an event
 		// bubbled from the inserter itself.
@@ -301,11 +294,8 @@ function InsertionPointPopover( {
 				exit="start"
 				ref={ ref }
 				tabIndex={ -1 }
-				onClick={ onClick }
 				onFocus={ onFocus }
-				className={ classnames( className, {
-					'is-with-inserter': showInsertionPointInserter,
-				} ) }
+				className={ className }
 				style={ style }
 			>
 				<motion.div
@@ -316,7 +306,10 @@ function InsertionPointPopover( {
 					<motion.div
 						variants={ inserterVariants }
 						className={ classnames(
-							'block-editor-block-list__insertion-point-inserter'
+							'block-editor-block-list__insertion-point-inserter',
+							{
+								'is-with-inserter': showInsertionPointInserter,
+							}
 						) }
 					>
 						<Inserter

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -180,10 +180,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 	const ref = useMergeRefs( [
 		props.ref,
-		useInBetweenClickRedirect(),
-		useBlockDropZone( {
-			rootClientId: clientId,
-		} ),
+		useInBetweenClickRedirect( props.orientation ),
+		useBlockDropZone( { rootClientId: clientId } ),
 	] );
 
 	const innerBlocksProps = {

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -29,6 +29,7 @@ import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
+import { useInBetweenClickRedirect } from '../block-list/use-in-between-click-redirect';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -179,6 +180,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 	const ref = useMergeRefs( [
 		props.ref,
+		useInBetweenClickRedirect(),
 		useBlockDropZone( {
 			rootClientId: clientId,
 		} ),

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -44,6 +44,8 @@ function buildSelector( sequential ) {
 	].join( ',' );
 }
 
+export { buildSelector as __unstableBuildSelector };
+
 /**
  * Returns true if the specified element is visible (i.e. neither display: none
  * nor visibility: hidden).

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -34,6 +34,12 @@ exports[`Writing Flow should allow selecting entire list with longer last item 1
 <!-- /wp:list -->"
 `;
 
+exports[`Writing Flow should be easy to select separator (tiny block with margin) 1`] = `
+"<!-- wp:separator -->
+<hr class=\\"wp-block-separator\\"/>
+<!-- /wp:separator -->"
+`;
+
 exports[`Writing Flow should create valid paragraph blocks when rapidly pressing Enter 1`] = `
 "<!-- wp:paragraph -->
 <p></p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -268,6 +268,16 @@ exports[`Writing Flow should not have a dead zone between blocks (lower) 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should not have a dead zone between blocks (upper) 1`] = `
+"<!-- wp:paragraph -->
+<p>13</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Writing Flow should not prematurely multi-select 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>
@@ -276,6 +286,12 @@ exports[`Writing Flow should not prematurely multi-select 1`] = `
 <!-- wp:paragraph -->
 <p>></p>
 <!-- /wp:paragraph -->"
+`;
+
+exports[`Writing Flow should only consider the content as one tab stop 1`] = `
+"<!-- wp:table -->
+<figure class=\\"wp-block-table\\"><table><tbody><tr><td></td><td>2</td></tr><tr><td></td><td></td></tr></tbody></table></figure>
+<!-- /wp:table -->"
 `;
 
 exports[`Writing Flow should preserve horizontal position when navigating vertically between blocks 1`] = `
@@ -296,10 +312,4 @@ exports[`Writing Flow should remember initial vertical position 1`] = `
 <!-- wp:paragraph -->
 <p><br>2</p>
 <!-- /wp:paragraph -->"
-`;
-
-exports[`Writing Flow should only consider the content as one tab stop 1`] = `
-"<!-- wp:table -->
-<figure class=\\"wp-block-table\\"><table><tbody><tr><td></td><td>2</td></tr><tr><td></td><td></td></tr></tbody></table></figure>
-<!-- /wp:table -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -526,23 +526,33 @@ describe( 'Writing Flow', () => {
 
 		// Find a point outside the paragraph between the blocks where it's
 		// expected that the sibling inserter would be placed.
+		const paragraph = await page.$(
+			'[data-type="core/paragraph"]:nth-child(2)'
+		);
+		const paragraphRect = await paragraph.boundingBox();
+		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
+		const y = paragraphRect.y - 1;
+
+		await page.mouse.click( x, y );
+		await page.keyboard.type( '3' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not have a dead zone between blocks (upper)', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+
+		// Find a point outside the paragraph between the blocks where it's
+		// expected that the sibling inserter would be placed.
 		const paragraph = await page.$( '[data-type="core/paragraph"]' );
 		const paragraphRect = await paragraph.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
 		const y = paragraphRect.y + paragraphRect.height + 1;
 
-		await page.mouse.move( x, y );
-		await page.waitForSelector(
-			'.block-editor-block-list__insertion-point'
-		);
-
-		const inserter = await page.$(
-			'.block-editor-block-list__insertion-point'
-		);
-		const inserterRect = await inserter.boundingBox();
-		const lowerInserterY = inserterRect.y + ( 2 * inserterRect.height ) / 3;
-
-		await page.mouse.click( x, lowerInserterY );
+		await page.mouse.click( x, y );
 		await page.keyboard.type( '3' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -636,4 +636,28 @@ describe( 'Writing Flow', () => {
 			)
 		).toBe( 'Table' );
 	} );
+
+	it( 'should be easy to select separator (tiny block with margin)', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '/separator' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+
+		// Confirm correct setup: Separator and Paragraph.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Click right under the separator.
+		const separator = await page.$( '[data-type="core/separator"]' );
+		const separatorRect = await separator.boundingBox();
+		const x = separatorRect.x + ( 2 * separatorRect.width ) / 3;
+		const y = separatorRect.y + separatorRect.height + 1;
+
+		await page.mouse.click( x, y );
+
+		const hasSelectedClass = await separator.evaluate( ( element ) =>
+			element.classList.contains( 'is-selected' )
+		);
+
+		expect( hasSelectedClass ).toBe( true );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -583,18 +583,7 @@ describe( 'Writing Flow', () => {
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
 		const y = paragraphRect.y + paragraphRect.height + 1;
 
-		await page.mouse.move( x, y );
-		await page.waitForSelector(
-			'.block-editor-block-list__insertion-point'
-		);
-
-		const inserter = await page.$(
-			'.block-editor-block-list__insertion-point'
-		);
-		const inserterRect = await inserter.boundingBox();
-		const lowerInserterY = inserterRect.y + ( 2 * inserterRect.height ) / 3;
-
-		await page.mouse.click( x, lowerInserterY );
+		await page.mouse.click( x, y );
 
 		const type = await page.evaluate( () =>
 			document.activeElement.getAttribute( 'data-type' )

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -578,10 +578,10 @@ describe( 'Writing Flow', () => {
 
 		// Find a point outside the paragraph between the blocks where it's
 		// expected that the sibling inserter would be placed.
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
-		const paragraphRect = await paragraph.boundingBox();
-		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
-		const y = paragraphRect.y + paragraphRect.height + 1;
+		const image = await page.$( '[data-type="core/image"]' );
+		const imageRect = await image.boundingBox();
+		const x = imageRect.x + ( 2 * imageRect.width ) / 3;
+		const y = imageRect.y - 1;
 
 		await page.mouse.click( x, y );
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -311,11 +311,8 @@ describe( 'Widgets screen', () => {
 
 		// Click outside the block to move the focus back to the widget area.
 		await page.mouse.click(
-			secondParagraphBlockBoundingBox.x +
-				firstWidgetAreaBoundingBox.width / 2,
-			secondParagraphBlockBoundingBox.y +
-				secondParagraphBlockBoundingBox.height +
-				10
+			secondParagraphBlockBoundingBox.x - 1,
+			secondParagraphBlockBoundingBox.y
 		);
 
 		// Hover above the last block to trigger the inline inserter between blocks.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #32129.
Fixes #28682.
Restored a feature removed in #27860 where a click between two block would set focus/caret to the closest point.

I rewrote the feature to be its own hook, independent of the insertion point.

## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
