### PR TITLE
Navigation Editor: Fix React warning

### DIFF
--- a/packages/edit-navigation/src/components/name-editor/index.js
+++ b/packages/edit-navigation/src/components/name-editor/index.js
@@ -28,18 +28,16 @@ export function NameEditor() {
 	}, [ isMenuNameEditFocused ] );
 
 	return (
-		<>
-			<TextControl
-				ref={ inputRef }
-				help={ __(
-					'A short, descriptive name used to refer to this menu elsewhere.'
-				) }
-				label={ __( 'Name' ) }
-				onBlur={ () => setIsMenuNameEditFocused( false ) }
-				className="edit-navigation-name-editor__text-control"
-				value={ name }
-				onChange={ setName }
-			/>
-		</>
+		<TextControl
+			ref={ inputRef }
+			help={ __(
+				'A short, descriptive name used to refer to this menu elsewhere.'
+			) }
+			label={ __( 'Name' ) }
+			onBlur={ () => setIsMenuNameEditFocused( false ) }
+			className="edit-navigation-name-editor__text-control"
+			value={ name || '' }
+			onChange={ setName }
+		/>
 	);
 }


### PR DESCRIPTION
## Description
The `name` prop returned by `useMenuEntityProp` can be `undefined`. This inadvertently causes warnings in React by changing between uncontrolled and controlled inputs.

## How has this been tested?
1. Go to the experimental navigation editor.
2. Following error shouldn't be displayed in DevTool's console:

```
Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
