### PR TITLE
Components: Fix the list of package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1611,6 +1611,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
 			"integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+			"dev": true,
 			"requires": {
 				"@emotion/primitives-core": "10.0.27"
 			}
@@ -1619,6 +1620,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
 			"integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+			"dev": true,
 			"requires": {
 				"css-to-react-native": "^2.2.1"
 			}
@@ -13186,7 +13188,6 @@
 				"@emotion/cache": "^10.0.27",
 				"@emotion/core": "^10.1.1",
 				"@emotion/css": "^10.0.22",
-				"@emotion/native": "^10.0.22",
 				"@emotion/styled": "^10.0.23",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"@babel/plugin-syntax-jsx": "7.12.13",
 		"@babel/runtime-corejs3": "7.13.10",
 		"@babel/traverse": "7.13.0",
+		"@emotion/native": "10.0.27",
 		"@octokit/rest": "16.26.0",
 		"@octokit/webhooks": "7.1.0",
 		"@storybook/addon-a11y": "6.2.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,6 @@
 		"@emotion/cache": "^10.0.27",
 		"@emotion/core": "^10.1.1",
 		"@emotion/css": "^10.0.22",
-		"@emotion/native": "^10.0.22",
 		"@emotion/styled": "^10.0.23",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION
Fixes #31868.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

> `npm install @wordpress/components@~14.0.0 --save` currently fails without `--force`
> 
> `npm install @wordpress/components@~13.0.0 --save` works fine.
> 
> ## Step-by-step reproduction instructions
> 1. On a fresh project run `npm init` and use defaults. Or run it on an existing project as I found initially.
> 2. Run `npm install @wordpress/components@~14.0.0`

It looks like the issue exists only with npm 7. The approach proposed is to remove `@emotion/native` from the list of dependencies that causes issues. It's only used in unit tests and by code consumed by React Native that handles all code dependencies differently.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

We can test after publishing to npm.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
