### PR TITLE
Shortcuts: allow shortcuts to be attached through ref callback

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -7,9 +7,9 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { isEntirelySelected } from '@wordpress/dom';
-import { useRef, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { __unstableUseShortcutRef as useShortcutRef } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -17,7 +17,6 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { store as blockEditorStore } from '../../store';
 
 export default function useSelectAll() {
-	const ref = useRef();
 	const {
 		getBlockOrder,
 		getSelectedBlockClientIds,
@@ -62,9 +61,5 @@ export default function useSelectAll() {
 		event.preventDefault();
 	}, [] );
 
-	useShortcut( 'core/block-editor/select-all', callback, {
-		target: ref,
-	} );
-
-	return ref;
+	return useShortcutRef( 'core/block-editor/select-all', callback );
 }

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -23,7 +23,10 @@ export { default as __experimentalUseFocusOutside } from './hooks/use-focus-outs
 export { default as useFocusReturn } from './hooks/use-focus-return';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect';
-export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
+export {
+	default as useKeyboardShortcut,
+	useKeyboardShortcutRef as __unstableUseKeyboardShortcutRef,
+} from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as usePrevious } from './hooks/use-previous';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';

--- a/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
+++ b/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
@@ -2,22 +2,18 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useKeyboardShortcut } from '@wordpress/compose';
+import {
+	useKeyboardShortcut,
+	__unstableUseKeyboardShortcutRef as useKeyboardShortcutRef,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { store as keyboardShortcutsStore } from '../store';
 
-/**
- * Attach a keyboard shortcut handler.
- *
- * @param {string} name       Shortcut name.
- * @param {Function} callback Shortcut callback.
- * @param {Object} options    Shortcut options.
- */
-function useShortcut( name, callback, options ) {
-	const shortcuts = useSelect(
+function useShortcuts( name ) {
+	return useSelect(
 		( select ) => {
 			return select(
 				keyboardShortcutsStore
@@ -25,8 +21,27 @@ function useShortcut( name, callback, options ) {
 		},
 		[ name ]
 	);
+}
 
-	useKeyboardShortcut( shortcuts, callback, options );
+/**
+ * Attach a keyboard shortcut handler.
+ *
+ * @param {string}   name     Shortcut name.
+ * @param {Function} callback Shortcut callback.
+ */
+export function useShortcutRef( name, callback ) {
+	return useKeyboardShortcutRef( useShortcuts( name ), callback );
+}
+
+/**
+ * Attach a keyboard shortcut handler.
+ *
+ * @param {string}   name     Shortcut name.
+ * @param {Function} callback Shortcut callback.
+ * @param {Object}   options  Shortcut options.
+ */
+function useShortcut( name, callback, options ) {
+	useKeyboardShortcut( useShortcuts( name ), callback, options );
 }
 
 export default useShortcut;

--- a/packages/keyboard-shortcuts/src/index.js
+++ b/packages/keyboard-shortcuts/src/index.js
@@ -1,2 +1,5 @@
 export { store } from './store';
-export { default as useShortcut } from './hooks/use-shortcut';
+export {
+	default as useShortcut,
+	useShortcutRef as __unstableUseShortcutRef,
+} from './hooks/use-shortcut';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The problem with `useShortcut` is that a ref object is passed to it which wouldn't trigger it to reattach handlers if the ref ever changes. I created a new unstable API `useShortcutRef` which returns a ref callback that can be added to an element. If the target ever changes, the event handlers would be properly reattached. Like all other ref callback APIs, it's possible to add it conditionally (in other words, disable it).

In the bigger picture, this is needed to convert more shortcuts to ref callbacks to also be used in iframe context. Eventually we'll need to get rid of the event bubbling of key events on the iframe.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
