### PR TITLE
Fix escape key events in customizer closing the editor

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -91,6 +91,7 @@ export default function useTabNav() {
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
 			if ( event.keyCode === ESCAPE && ! hasMultiSelection() ) {
+				event.stopPropagation();
 				setNavigationMode( true );
 				return;
 			}

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -233,7 +233,6 @@ const Popover = (
 	{
 		headerTitle,
 		onClose,
-		onKeyDown,
 		children,
 		className,
 		noArrow = true,
@@ -505,7 +504,8 @@ const Popover = (
 	const mergedRefs = useMergeRefs( [
 		ref,
 		containerRef,
-		closeEventRef,
+		// Don't register the event at all if there's no onClose callback.
+		onClose ? closeEventRef : null,
 		focusOnMount ? constrainedTabbingRef : null,
 		focusOnMount ? focusReturnRef : null,
 		focusOnMount ? focusOnMountRef : null,
@@ -595,7 +595,6 @@ const Popover = (
 				}
 			) }
 			{ ...contentProps }
-			onKeyDown={ onKeyDown }
 			{ ...focusOutsideProps }
 			ref={ mergedRefs }
 			tabIndex="-1"

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -10,6 +10,7 @@ import {
 	useRef,
 	useState,
 	useLayoutEffect,
+	useEffect,
 	forwardRef,
 } from '@wordpress/element';
 import { getRectangleFromRange } from '@wordpress/dom';
@@ -490,18 +491,25 @@ const Popover = (
 	] );
 
 	// Event handlers
-	const maybeClose = ( event ) => {
-		// Close on escape
-		if ( event.keyCode === ESCAPE && onClose ) {
-			event.stopPropagation();
-			onClose();
-		}
+	useEffect( () => {
+		const container = containerRef.current;
 
-		// Preserve original content prop behavior
-		if ( onKeyDown ) {
-			onKeyDown( event );
+		if ( container ) {
+			function maybeClose( event ) {
+				// Close on escape
+				if ( event.keyCode === ESCAPE && onClose ) {
+					event.stopPropagation();
+					onClose();
+				}
+			}
+
+			container.addEventListener( 'keydown', maybeClose );
+
+			return () => {
+				container.removeEventListener( 'keydown', maybeClose );
+			};
 		}
-	};
+	}, [ onClose ] );
 
 	/**
 	 * Shims an onFocusOutside callback to be compatible with a deprecated
@@ -587,7 +595,7 @@ const Popover = (
 				}
 			) }
 			{ ...contentProps }
-			onKeyDown={ maybeClose }
+			onKeyDown={ onKeyDown }
 			{ ...focusOutsideProps }
 			ref={ mergedRefs }
 			tabIndex="-1"

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -511,6 +511,57 @@ describe( 'Widgets Customizer', () => {
 			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
 		);
 	} );
+
+	it( 'should handle esc key events', async () => {
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /^Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		const paragraphBlock = await addBlock( 'Paragraph' );
+		await page.keyboard.type( 'First Paragraph' );
+		await showBlockToolbar();
+
+		// Open the more menu dropdown in block toolbar.
+		await clickBlockToolbarButton( 'Options' );
+		await expect( {
+			role: 'menu',
+			name: 'Options',
+		} ).toBeFound();
+
+		// Expect pressing the Escape key to close the dropdown,
+		// but not close the editor.
+		await page.keyboard.press( 'Escape' );
+		await expect( {
+			role: 'menu',
+			name: 'Options',
+		} ).not.toBeFound();
+		await expect( paragraphBlock ).toBeVisible();
+
+		await paragraphBlock.focus();
+
+		// Expect pressing the Escape key to enter navigation mode,
+		// but not close the editor.
+		await page.keyboard.press( 'Escape' );
+		await expect( {
+			text: /^You are currently in navigation mode\./,
+			selector: '*[aria-live="polite"][aria-relevant="additions text"]',
+		} ).toBeFound();
+		await expect( paragraphBlock ).toBeVisible();
+
+		expect( console ).toHaveWarned(
+			"The page delivered both an 'X-Frame-Options' header and a 'Content-Security-Policy' header with a 'frame-ancestors' directive. Although the 'X-Frame-Options' header alone would have blocked embedding, it has been ignored."
+		);
+	} );
 } );
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #31730.

The issue is that there are 2 different ways to bind <kbd>esc</kbd> key events in Widgets Customizer. One is binding it to close the section/control/panel in the customizer, which is registered in core. The other one is binding it to close the popup or entering the navigation mode in the block editor, which is registered in Gutenberg. Ideally, we should favor the events in Gutenberg first and stop the propagation there, so that the customizer won't trigger the handler and close the current section. However, since that the events in Gutenberg are registered via React's (v16) [event delegation](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation), they are bound to the `document` element. On the other hand, events in core are bound to [`$(body)`](https://github.com/WordPress/WordPress/blob/270f2011f8ec7265c3f4ddce39c77ef5b496ed1c/wp-admin/js/customize-controls.js#L8440-L8495) instead. Which means that when the handlers in React are getting the events, it's already too late to stop the propagation, events in core will always fire first.

The solution I take in this PR is to rewrite those events to bind to the nearest elements which make sense. Instead of implicitly binding to `document` via `onKeyDown`, I'm binding the events to the container element using `addEventListener` directly in `<Popover>`. This might have some undesired side effects though, the <kbd>esc</kbd> won't work now if the focus is not within the container element anymore. We can solve that by binding the events to the React root element instead (the same as in React 17 #26847), but let's see if we actually need to do this.

For navigation mode events, they're already binding themself via `useRefEffect`, we only need to add the missing `event.stopPropagation` to make it work.

These two are the events mentioned in the issue, I'm not sure if there're other ones I'm missing?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**Navigation mode**
1. Go to Appearance -> Customizer -> Widgets
2. Select any block in the editor
3. Press <kbd>esc</kbd>
4. It should enter navigation mode without closing the editor.

**Popover**
1. Go to Appearance -> Customizer -> Widgets
2. Open any popover (block settings dropdown, editor settings dropdown, etc)
3. Press <kbd>esc</kbd>
4. It should close the popover without closing the editor.

Also added e2e tests.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
