### PR TITLE
Fix widget editor block toolbar scrolling behavior

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -21,20 +21,22 @@ export default function WidgetAreasBlockEditorContent( {
 	blockEditorSettings,
 } ) {
 	return (
-		<BlockTools>
+		<>
 			<KeyboardShortcuts />
 			<BlockEditorKeyboardShortcuts />
-			<Notices />
 			<div className="edit-widgets-block-editor editor-styles-wrapper">
-				<EditorStyles styles={ blockEditorSettings.styles } />
-				<BlockSelectionClearer>
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList className="edit-widgets-main-block-list" />
-						</ObserveTyping>
-					</WritingFlow>
-				</BlockSelectionClearer>
+				<BlockTools>
+					<Notices />
+					<EditorStyles styles={ blockEditorSettings.styles } />
+					<BlockSelectionClearer>
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList className="edit-widgets-main-block-list" />
+							</ObserveTyping>
+						</WritingFlow>
+					</BlockSelectionClearer>
+				</BlockTools>
 			</div>
-		</BlockTools>
+		</>
 	);
 }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,6 +1,7 @@
 .edit-widgets-block-editor {
 	position: relative;
 	background: $gray-100;
+	padding: 0;
 
 	// This is the default font that is going to be used in the content of the areas (blocks).
 	font-family: $default-font;


### PR DESCRIPTION
## Description
Related https://github.com/WordPress/gutenberg/issues/32178

Fixes an issue where the block toolbar doesn't stay anchored to the block in the customize widget editor. For some reason, `BlockTools` is very particular about where it should be rendered, it seems to need to be in the editor styles wrapper.

This seems to be an issue with `BlockTools` across multiple editors (Widget, Navigation, Storybook Playground), but is most obvious in the standalone widget editor (also the most important place to fix).

## How has this been tested?
1. Add enough blocks for a scrollbar to appear
2. Select a block
3. Scroll
4. The block toolbar should stay anchored to the block
5. Switch to top toolbar mode, the toolbar should look visually correct
6. Create a notice by executing the following JavaScript - `wp.data.dispatch( 'core/notices' ).createInfoNotice( 'hello' );`
7. The notice should appear below the top toolbar

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
