### PR TITLE
Fix widgets e2e tests

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Added `cleanupWidgets` - Delete all the widgets in the widgets screen.
+-   Added `deleteAllWidgets` - Delete all widgets in the widgets screen.
 
 ## 5.0.0 (2021-01-21)
 

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added `cleanupWidgets` - Delete all the widgets in the widgets screen.
+
 ## 5.0.0 (2021-01-21)
 
 ### Breaking Changes
@@ -12,7 +16,7 @@
 
 ## 4.16.0 (2020-12-17)
 
-### Nee Features
+### New Features
 
 -   Added `clickMenuItem` - clicks the item that matches the label in the opened menu.
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -58,6 +58,10 @@ _Returns_
 
 -   `string`: Value of the previous timezone.
 
+<a name="cleanupWidgets" href="#cleanupWidgets">#</a> **cleanupWidgets**
+
+Delete all the widgets in the widgets screen.
+
 <a name="clearLocalStorage" href="#clearLocalStorage">#</a> **clearLocalStorage**
 
 Clears the local storage.

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -58,10 +58,6 @@ _Returns_
 
 -   `string`: Value of the previous timezone.
 
-<a name="cleanupWidgets" href="#cleanupWidgets">#</a> **cleanupWidgets**
-
-Delete all the widgets in the widgets screen.
-
 <a name="clearLocalStorage" href="#clearLocalStorage">#</a> **clearLocalStorage**
 
 Clears the local storage.
@@ -184,6 +180,10 @@ Deactivates an active plugin.
 _Parameters_
 
 -   _slug_ `string`: Plugin slug.
+
+<a name="deleteAllWidgets" href="#deleteAllWidgets">#</a> **deleteAllWidgets**
+
+Delete all the widgets in the widgets screen.
 
 <a name="deleteTheme" href="#deleteTheme">#</a> **deleteTheme**
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -78,6 +78,6 @@ export { waitForWindowDimensions } from './wait-for-window-dimensions';
 export { showBlockToolbar } from './show-block-toolbar';
 export { openPreviewPage } from './preview';
 export { wpDataSelect } from './wp-data-select';
-export { cleanupWidgets } from './widgets';
+export { deleteAllWidgets } from './widgets';
 
 export * from './mocks';

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -78,5 +78,6 @@ export { waitForWindowDimensions } from './wait-for-window-dimensions';
 export { showBlockToolbar } from './show-block-toolbar';
 export { openPreviewPage } from './preview';
 export { wpDataSelect } from './wp-data-select';
+export { cleanupWidgets } from './widgets';
 
 export * from './mocks';

--- a/packages/e2e-test-utils/src/widgets.js
+++ b/packages/e2e-test-utils/src/widgets.js
@@ -8,7 +8,7 @@ import { visitAdminPage } from './visit-admin-page';
 /**
  * Delete all the widgets in the widgets screen.
  */
-export async function cleanupWidgets() {
+export async function deleteAllWidgets() {
 	// TODO: Deleting widgets in the new widgets screen is cumbersome and slow.
 	// To workaround this for now, we visit the old widgets screen to delete them.
 	await activatePlugin( 'gutenberg-test-classic-widgets' );

--- a/packages/e2e-test-utils/src/widgets.js
+++ b/packages/e2e-test-utils/src/widgets.js
@@ -1,18 +1,16 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import {
-	visitAdminPage,
-	activatePlugin,
-	deactivatePlugin,
-} from '@wordpress/e2e-test-utils';
+import { activatePlugin } from './activate-plugin';
+import { deactivatePlugin } from './deactivate-plugin';
+import { visitAdminPage } from './visit-admin-page';
 
 /**
- * TODO: Deleting widgets in the new widgets screen seems to be unreliable.
- * We visit the old widgets screen to delete them.
- * Refactor this to use real interactions in the new widgets screen once the bug is fixed.
+ * Delete all the widgets in the widgets screen.
  */
-async function cleanupWidgets() {
+export async function cleanupWidgets() {
+	// TODO: Deleting widgets in the new widgets screen is cumbersome and slow.
+	// To workaround this for now, we visit the old widgets screen to delete them.
 	await activatePlugin( 'gutenberg-test-classic-widgets' );
 
 	await visitAdminPage( 'widgets.php' );
@@ -32,5 +30,3 @@ async function cleanupWidgets() {
 
 	await deactivatePlugin( 'gutenberg-test-classic-widgets' );
 }
-
-export { cleanupWidgets };

--- a/packages/e2e-tests/plugins/classic-widgets.php
+++ b/packages/e2e-tests/plugins/classic-widgets.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Classic Widgets
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-classic-widgets
+ */
+
+add_filter( 'use_widgets_block_editor', '__return_false' );

--- a/packages/e2e-tests/plugins/classic-widgets.php
+++ b/packages/e2e-tests/plugins/classic-widgets.php
@@ -7,4 +7,5 @@
  * @package gutenberg-test-classic-widgets
  */
 
+// Disable the widgets block editor and enable the legacy widgets screen.
 add_filter( 'use_widgets_block_editor', '__return_false' );

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -8,7 +8,7 @@ import {
 	visitAdminPage,
 	showBlockToolbar,
 	clickBlockToolbarButton,
-	cleanupWidgets,
+	deleteAllWidgets,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -19,7 +19,7 @@ import { find } from 'puppeteer-testing-library';
 
 describe( 'Widgets Customizer', () => {
 	beforeEach( async () => {
-		await cleanupWidgets();
+		await deleteAllWidgets();
 		await visitAdminPage( 'customize.php' );
 
 		// Disable welcome guide if it is enabled.

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -16,6 +16,11 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { find } from 'puppeteer-testing-library';
 
+/**
+ * Internal dependencies
+ */
+import { cleanupWidgets } from './test-utils';
+
 describe( 'Widgets Customizer', () => {
 	beforeEach( async () => {
 		await cleanupWidgets();
@@ -511,28 +516,6 @@ describe( 'Widgets Customizer', () => {
 		);
 	} );
 } );
-
-/**
- * TODO: Deleting widgets in the new widgets screen seems to be unreliable.
- * We visit the old widgets screen to delete them.
- * Refactor this to use real interactions in the new widgets screen once the bug is fixed.
- */
-async function cleanupWidgets() {
-	await visitAdminPage( 'widgets.php' );
-
-	let widget = await page.$( '.widgets-sortables .widget' );
-
-	// We have to do this one-by-one since there might be race condition when deleting multiple widgets at once.
-	while ( widget ) {
-		const deleteButton = await widget.$( 'button.widget-control-remove' );
-		const id = await widget.evaluate( ( node ) => node.id );
-		await deleteButton.evaluate( ( node ) => node.click() );
-		// Wait for the widget to be removed from DOM.
-		await page.waitForSelector( `#${ id }`, { hidden: true } );
-
-		widget = await page.$( '.widgets-sortables .widget' );
-	}
-}
 
 /**
  * Wait when there's only one preview iframe.

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -8,6 +8,7 @@ import {
 	visitAdminPage,
 	showBlockToolbar,
 	clickBlockToolbarButton,
+	cleanupWidgets,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -15,11 +16,6 @@ import {
  */
 // eslint-disable-next-line no-restricted-imports
 import { find } from 'puppeteer-testing-library';
-
-/**
- * Internal dependencies
- */
-import { cleanupWidgets } from './test-utils';
 
 describe( 'Widgets Customizer', () => {
 	beforeEach( async () => {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -20,28 +20,7 @@ import { groupBy, mapValues } from 'lodash';
 
 describe( 'Widgets screen', () => {
 	beforeEach( async () => {
-		/**
-		 * Visit the widgets screen via link clicking. The widgets screen currently
-		 * has different URLs during the integration to core.
-		 * We should be able to refactor it once it's fully merged into core.
-		 */
-		// Visit the Appearance page.
-		await visitAdminPage( 'themes.php' );
-
-		// Go to the Widgets page.
-		const appearanceMenu = await page.$( '#menu-appearance' );
-		await appearanceMenu.hover();
-		const widgetsLink = await find(
-			{ role: 'link', name: 'Widgets' },
-			{ root: appearanceMenu }
-		);
-		await Promise.all( [
-			page.waitForNavigation(),
-			// Click on the link no matter if it's visible or not.
-			widgetsLink.evaluate( ( link ) => {
-				link.click();
-			} ),
-		] );
+		await visitWidgetsScreen();
 
 		// Disable welcome guide if it is enabled.
 		const isWelcomeGuideActive = await page.evaluate( () =>
@@ -537,7 +516,7 @@ describe( 'Widgets screen', () => {
 		// eslint-disable-next-line no-restricted-syntax
 		await page.waitForTimeout( 500 );
 
-		await visitAdminPage( 'themes.php', 'page=gutenberg-widgets' );
+		await visitWidgetsScreen();
 
 		// Wait for the Legacy Widget block's preview iframe to load.
 		const frame = await new Promise( ( resolve ) => {
@@ -690,6 +669,31 @@ describe( 'Widgets screen', () => {
 	` );
 	} );
 } );
+
+/**
+ * Visit the widgets screen via link clicking. The widgets screen currently
+ * has different URLs during the integration to core.
+ * We should be able to refactor it once it's fully merged into core.
+ */
+async function visitWidgetsScreen() {
+	// Visit the Appearance page.
+	await visitAdminPage( 'themes.php' );
+
+	// Go to the Widgets page.
+	const appearanceMenu = await page.$( '#menu-appearance' );
+	await appearanceMenu.hover();
+	const widgetsLink = await find(
+		{ role: 'link', name: 'Widgets' },
+		{ root: appearanceMenu }
+	);
+	await Promise.all( [
+		page.waitForNavigation(),
+		// Click on the link no matter if it's visible or not.
+		widgetsLink.evaluate( ( link ) => {
+			link.click();
+		} ),
+	] );
+}
 
 async function saveWidgets() {
 	const updateButton = await find( {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -8,6 +8,7 @@ import {
 	deactivatePlugin,
 	showBlockToolbar,
 	visitAdminPage,
+	cleanupWidgets,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -16,11 +17,6 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll } from 'puppeteer-testing-library';
 import { groupBy, mapValues } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { cleanupWidgets } from './test-utils';
 
 describe( 'Widgets screen', () => {
 	beforeEach( async () => {
@@ -33,12 +29,19 @@ describe( 'Widgets screen', () => {
 		await visitAdminPage( 'themes.php' );
 
 		// Go to the Widgets page.
-		const appearanceList = await page.$( '#menu-appearance' );
+		const appearanceMenu = await page.$( '#menu-appearance' );
+		await appearanceMenu.hover();
 		const widgetsLink = await find(
 			{ role: 'link', name: 'Widgets' },
-			{ root: appearanceList }
+			{ root: appearanceMenu }
 		);
-		await Promise.all( [ page.waitForNavigation(), widgetsLink.click() ] );
+		await Promise.all( [
+			page.waitForNavigation(),
+			// Click on the link no matter if it's visible or not.
+			widgetsLink.evaluate( ( link ) => {
+				link.click();
+			} ),
+		] );
 
 		// Disable welcome guide if it is enabled.
 		const isWelcomeGuideActive = await page.evaluate( () =>

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -8,7 +8,7 @@ import {
 	deactivatePlugin,
 	showBlockToolbar,
 	visitAdminPage,
-	cleanupWidgets,
+	deleteAllWidgets,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -44,7 +44,7 @@ describe( 'Widgets screen', () => {
 	} );
 
 	afterEach( async () => {
-		await cleanupWidgets();
+		await deleteAllWidgets();
 	} );
 
 	beforeAll( async () => {
@@ -53,7 +53,7 @@ describe( 'Widgets screen', () => {
 		await deactivatePlugin(
 			'gutenberg-test-plugin-disables-the-css-animations'
 		);
-		await cleanupWidgets();
+		await deleteAllWidgets();
 	} );
 
 	afterAll( async () => {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -479,6 +479,10 @@ describe( 'Widgets screen', () => {
 	} );
 
 	it( 'Should display legacy widgets', async () => {
+		/**
+		 * Using the classic widgets screen to simulate creating legacy widgets.
+		 */
+		await activatePlugin( 'gutenberg-test-classic-widgets' );
 		await visitAdminPage( 'widgets.php' );
 
 		const searchWidget = await find(
@@ -516,6 +520,7 @@ describe( 'Widgets screen', () => {
 		// eslint-disable-next-line no-restricted-syntax
 		await page.waitForTimeout( 500 );
 
+		await deactivatePlugin( 'gutenberg-test-classic-widgets' );
 		await visitWidgetsScreen();
 
 		// Wait for the Legacy Widget block's preview iframe to load.

--- a/packages/e2e-tests/specs/widgets/test-utils.js
+++ b/packages/e2e-tests/specs/widgets/test-utils.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	visitAdminPage,
+	activatePlugin,
+	deactivatePlugin,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * TODO: Deleting widgets in the new widgets screen seems to be unreliable.
+ * We visit the old widgets screen to delete them.
+ * Refactor this to use real interactions in the new widgets screen once the bug is fixed.
+ */
+async function cleanupWidgets() {
+	await activatePlugin( 'gutenberg-test-classic-widgets' );
+
+	await visitAdminPage( 'widgets.php' );
+
+	let widget = await page.$( '.widgets-sortables .widget' );
+
+	// We have to do this one-by-one since there might be race condition when deleting multiple widgets at once.
+	while ( widget ) {
+		const deleteButton = await widget.$( 'button.widget-control-remove' );
+		const id = await widget.evaluate( ( node ) => node.id );
+		await deleteButton.evaluate( ( node ) => node.click() );
+		// Wait for the widget to be removed from DOM.
+		await page.waitForSelector( `#${ id }`, { hidden: true } );
+
+		widget = await page.$( '.widgets-sortables .widget' );
+	}
+
+	await deactivatePlugin( 'gutenberg-test-classic-widgets' );
+}
+
+export { cleanupWidgets };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Part of the process of integrating widgets editor into core.

- We have to fix the e2e tests where it tries to clean up the widgets. Currently, the only reliable way of doing this is to visit the legacy widgets screen and remove the widgets one-by-one. I introduced a test plugin to enable the legacy widgets screen to do that.
- Remove the occurrences of `themes.php?page=gutenberg-widgets` as it will soon become just `widgets.php`.
- Move `cleanupWidgets` to `e2e-tests-utils`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
CI should pass. Or run:

```sh
npm run test-e2e -- packages/e2e-tests/specs/widgets/*
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
