### PR TITLE
Adapt the Gutenberg plugin's code to work with FSE infrastructure in Core.

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -145,7 +145,7 @@ function _gutenberg_add_template_part_area_info( $template_info ) {
  *
  * @return array block references to the passed blocks and their inner blocks.
  */
-function _flatten_blocks( &$blocks ) {
+function _gutenberg_flatten_blocks( &$blocks ) {
 	$all_blocks = array();
 	$queue      = array();
 	foreach ( $blocks as &$block ) {
@@ -175,12 +175,12 @@ function _flatten_blocks( &$blocks ) {
  *
  * @return string Updated wp_template content.
  */
-function _inject_theme_attribute_in_content( $template_content ) {
+function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
 
-	$blocks = _flatten_blocks( $template_blocks );
+	$blocks = _gutenberg_flatten_blocks( $template_blocks );
 	foreach ( $blocks as &$block ) {
 		if (
 			'core/template-part' === $block['blockName'] &&
@@ -218,7 +218,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _inject_theme_attribute_in_content( $template_content );
+	$template->content        = _gutenberg_inject_theme_attribute_in_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -335,22 +335,23 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 * @return stdClass Changes to pass to wp_update_post.
 	 */
 	protected function prepare_item_for_database( $request ) {
-		$template           = $request['id'] ? gutenberg_get_block_template( $request['id'], $this->post_type ) : null;
-		$changes            = new stdClass();
-		$changes->post_name = $template->slug;
+		$template = $request['id'] ? gutenberg_get_block_template( $request['id'], $this->post_type ) : null;
+		$changes  = new stdClass();
 		if ( null === $template ) {
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
-				'wp_theme' => isset( $request['theme'] ) ? $request['content'] : wp_get_theme()->get_stylesheet(),
+				'wp_theme' => isset( $request['theme'] ) ? $request['theme'] : wp_get_theme()->get_stylesheet(),
 			);
 		} elseif ( 'custom' !== $template->source ) {
+			$changes->post_name   = $template->slug;
 			$changes->post_type   = $this->post_type;
 			$changes->post_status = 'publish';
 			$changes->tax_input   = array(
 				'wp_theme' => $template->theme,
 			);
 		} else {
+			$changes->post_name   = $template->slug;
 			$changes->ID          = $template->wp_id;
 			$changes->post_status = 'publish';
 		}

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: WP_REST_Templates_Controller class
+ * REST API: Gutenberg_REST_Templates_Controller class
  *
  * @package    Gutenberg
  * @subpackage REST_API
@@ -9,7 +9,7 @@
 /**
  * Base Templates REST API Controller.
  */
-class WP_REST_Templates_Controller extends WP_REST_Controller {
+class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Post type.
 	 *
@@ -406,7 +406,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			),
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
-			'has_theme_file' => $template->has_theme_file,
+			'has_theme_file' => $template->has_theme_file
 		);
 
 		if ( 'wp_template_part' === $template->type ) {

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -45,7 +45,7 @@ function gutenberg_register_template_part_post_type() {
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,
 		'rest_base'             => 'template-parts',
-		'rest_controller_class' => 'WP_REST_Templates_Controller',
+		'rest_controller_class' => 'Gutenberg_REST_Templates_Controller',
 		'map_meta_cap'          => true,
 		'supports'              => array(
 			'title',

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -45,7 +45,7 @@ function gutenberg_register_template_post_type() {
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,
 		'rest_base'             => 'templates',
-		'rest_controller_class' => 'WP_REST_Templates_Controller',
+		'rest_controller_class' => 'Gutenberg_REST_Templates_Controller',
 		'capability_type'       => array( 'template', 'templates' ),
 		'map_meta_cap'          => true,
 		'supports'              => array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -56,9 +56,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 		require_once __DIR__ . '/class-wp-rest-customizer-nonces.php';
 	}
-	if ( ! class_exists( 'WP_REST_Templates_Controller' ) ) {
-		require_once __DIR__ . '/full-site-editing/class-wp-rest-templates-controller.php';
-	}
+	require_once __DIR__ . '/full-site-editing/class-gutenberg-rest-templates-controller.php';
 	if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 		require_once dirname( __FILE__ ) . '/class-wp-rest-block-editor-settings-controller.php';
 	}
@@ -74,7 +72,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 if ( ! class_exists( 'WP_Widget_Block' ) ) {
-	require_once __DIR__ . '/class-wp-widget-block.php';
+//	require_once __DIR__ . '/class-wp-widget-block.php';
 }
 
 require_once __DIR__ . '/widgets-page.php';
@@ -84,7 +82,7 @@ require __DIR__ . '/compat/wordpress-5.8/index.php';
 require __DIR__ . '/utils.php';
 require __DIR__ . '/editor-settings.php';
 
-if ( ! class_exists( 'WP_Block_Template ' ) ) {
+if ( ! class_exists( 'WP_Block_Template' ) ) {
 	require __DIR__ . '/full-site-editing/class-wp-block-template.php';
 }
 

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -1,6 +1,6 @@
 <?php
 
-class WP_REST_Template_Controller_Test extends WP_Test_REST_Controller_Testcase {
+class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @var int
 	 */


### PR DESCRIPTION
FSE infrastructure is going to be committed to Core soon and the Gutenberg plugin needs to be adapted in consequence to work for 5.8 and avoid breaking tests. (https://github.com/WordPress/wordpress-develop/pull/1267)