### PR TITLE
[Mobile] - Slash inserter - Improve E2E

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
@@ -8,11 +8,21 @@ import { slashInserter, shortText } from './helpers/test-data';
 const ANIMATION_TIME = 200;
 
 // helper function for asserting slash inserter presence
-async function assertSlashInserterPresent() {
-	const slashInserterElement = await editorPage.driver.elementByAccessibilityId(
-		'Slash inserter results'
-	);
-	expect( slashInserterElement ).toBeTruthy();
+async function assertSlashInserterPresent( checkIsVisible ) {
+	let areResultsDisplayed;
+	try {
+		const foundElements = await editorPage.driver.elementsByAccessibilityId(
+			'Slash inserter results'
+		);
+		areResultsDisplayed = !! foundElements.length;
+	} catch ( e ) {
+		areResultsDisplayed = false;
+	}
+	if ( checkIsVisible ) {
+		expect( areResultsDisplayed ).toBeTruthy();
+	} else {
+		expect( areResultsDisplayed ).toBeFalsy();
+	}
 }
 
 describe( 'Gutenberg Editor Slash Inserter tests', () => {
@@ -31,7 +41,8 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		);
 		await editorPage.driver.sleep( ANIMATION_TIME );
 
-		assertSlashInserterPresent();
+		assertSlashInserterPresent( true );
+
 		await editorPage.removeBlockAtPosition( blockNames.paragraph );
 	} );
 
@@ -50,7 +61,7 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		);
 		await editorPage.driver.sleep( ANIMATION_TIME );
 
-		assertSlashInserterPresent();
+		assertSlashInserterPresent( true );
 
 		// Remove / character
 		if ( isAndroid() ) {
@@ -68,11 +79,8 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		}
 		await editorPage.driver.sleep( ANIMATION_TIME );
 
-		// Check if the slash inserter UI exists
-		const foundElements = await editorPage.driver.elementsByAccessibilityId(
-			'Slash inserter results'
-		);
-		expect( foundElements.length ).toBe( 0 );
+		// Check if the slash inserter UI no longer exists
+		assertSlashInserterPresent( false );
 
 		await editorPage.removeBlockAtPosition( blockNames.paragraph );
 	} );
@@ -92,7 +100,7 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		);
 		await editorPage.driver.sleep( ANIMATION_TIME );
 
-		assertSlashInserterPresent();
+		assertSlashInserterPresent( true );
 
 		// Find Image block button
 		const imageButtonElement = await editorPage.driver.elementByAccessibilityId(
@@ -109,10 +117,7 @@ describe( 'Gutenberg Editor Slash Inserter tests', () => {
 		).toBe( true );
 
 		// Slash inserter UI should not be present after adding a block
-		const foundElements = await editorPage.driver.elementsByAccessibilityId(
-			'Slash inserter results'
-		);
-		expect( foundElements.length ).toBe( 0 );
+		assertSlashInserterPresent( false );
 
 		// Remove image block
 		await editorPage.removeBlockAtPosition( blockNames.image );


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3549

## Description
Improve some flakiness of these E2E.

## How has this been tested?
Check that the `canary` and full tests pass on the [Gutenberg Mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3549).

## Screenshots <!-- if applicable -->
N/A 

## Types of changes
Fix E2E

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
