### PR TITLE
Make sure `wp_get_attachment_image_src` filter gets removed in the site-logo even when no logo exists

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -22,8 +22,8 @@ function render_block_core_site_logo( $attributes ) {
 	};
 
 	add_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
-
 	$custom_logo = get_custom_logo();
+	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 
 	if ( empty( $custom_logo ) ) {
 		return ''; // Return early if no custom logo is set, avoiding extraneous wrapper div.
@@ -56,7 +56,6 @@ function render_block_core_site_logo( $attributes ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 	$html               = sprintf( '<div %s>%s</div>', $wrapper_attributes, $custom_logo );
-	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 	return $html;
 }
 


### PR DESCRIPTION
## Description

In the site-logo block we're adding a filter to `wp_get_attachment_image_src`. That filter is then removed at the end of the callback function, _but_ if there is no logo then the function returns early and never reaches the `remove_filter` call.
Came up in https://github.com/WordPress/wordpress-develop/pull/1275#discussion_r638665627, already committed to the core patch so this is a backport.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
