### PR TITLE
Try: Safari flickering fix, take two

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -169,6 +169,9 @@
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
 
+			// This renders the border on the GPU which fixes a Safari flicker issue.
+			will-change: transform;
+
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -160,14 +160,14 @@
 			z-index: 1;
 			pointer-events: none;
 			content: "";
-			top: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			right: $border-width;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
 
-			// 2px outside.
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+			// 2px inside.
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui;
 
 			// This renders the border on the GPU which fixes a Safari flicker issue.
 			will-change: transform;

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -61,6 +61,9 @@
 		right: 0;
 		z-index: z-index(".wp-block-cover.has-background-dim::before");
 		opacity: 0.5;
+
+		// This renders the border on the GPU which fixes a Safari flicker issue.
+		will-change: transform;
 	}
 
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -51,6 +51,9 @@ figure.wp-block-gallery {
 			left: 0;
 			z-index: 1;
 			pointer-events: none;
+
+			// This renders the border on the GPU which fixes a Safari flicker issue.
+			will-change: transform;
 		}
 		figcaption {
 			z-index: 2;


### PR DESCRIPTION
## Description

Better alternative to #31412 which in my testing appears to accomplish the same.

The block toolbar is absolutely positioned. When it "unsticks" and scrolls with a block down the page, a la how `position: sticky;` works, due to a refactor, in actuality `top` values are updated on the block toolbar to emulate this behavior.

This specific behavior appears to interfere with some other abs positioned layers, causing them to flicker.

Before:

![before](https://user-images.githubusercontent.com/1204802/119490465-28db4900-bd5d-11eb-816a-675b710772f0.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/119490438-22e56800-bd5d-11eb-8efd-59093547094c.gif)


## How has this been tested?

Please test blocks in Safari. Notably Media & Text and the Gallery appear to be affected. You can use this test content:

```
<!-- wp:media-text {"mediaId":1834,"mediaLink":"http://localhost:8888/?attachment_id=1834","mediaType":"image"} -->
<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-2-1024x1008.jpg" alt="" class="wp-image-1834 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size">Hello</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:gallery {"ids":[null,null,null],"columns":2,"linkTo":"none"} -->
<figure class="wp-block-gallery columns-2 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/n0g6ME5VKC.jpg" alt=""/></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/ZjESfxPI3R.jpg" alt=""/></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/EKNF8xD2UM.jpg" alt=""/></figure></li></ul></figure>
<!-- /wp:gallery -->
```

Add that, then select either block, and scroll down the page so the block toolbar of the selected block "unsticks" and starts scrolling with you down the page. You should not see any flicker.

## Note

I think this is a good fix. `will-change: transform` is a way to tell the GPU to render the element. In this case it fixes the issue, and in all cases it has a theoretical performance benefit (which in this case would be mostly negligible).

But the rule would apply to all browsers, so it would be good to verify it doesn't regress anything in any browser. So please test also Chrome and Firefox. Specifically, the rule change affects the blue focus style that appears when you select a block. Things to look for is width changes, radius changes, z index changes, other cropping. **Nothing should be affected**, but I have seen some of these behaviors in rare instances. Testing nested blocks would be good.

Remember, you can also test on Gutenberg run, here: http://gutenberg.run/32188


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
