### PR TITLE
Fix generation of presets classes per block

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -626,13 +626,13 @@ class WP_Theme_JSON_Gutenberg {
 	 * and the $to_append selector ".some-class" the result will be
 	 * "h1.some-class, h2.some-class, h3.some-class".
 	 *
-	 * @param string $selector
-	 * @param string $to_append
+	 * @param string $selector Original selector.
+	 * @param string $to_append Selector to append.
 	 *
 	 * @return string
 	 */
 	private static function append_to_selector( $selector, $to_append ) {
-		$new_selectors = [];
+		$new_selectors = array();
 		$selectors     = explode( ',', $selector );
 		foreach ( $selectors as $sel ) {
 			$new_selectors[] = $sel . $to_append;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -620,6 +620,28 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Function that appends a sub-selector to a existing one.
+	 *
+	 * Given the compounded $selector "h1, h2, h3"
+	 * and the $to_append selector ".some-class" the result will be
+	 * "h1.some-class, h2.some-class, h3.some-class".
+	 *
+	 * @param string $selector
+	 * @param string $to_append
+	 *
+	 * @return string
+	 */
+	private static function append_to_selector( $selector, $to_append ) {
+		$new_selectors = [];
+		$selectors     = explode( ',', $selector );
+		foreach ( $selectors as $sel ) {
+			$new_selectors[] = $sel . $to_append;
+		}
+
+		return implode( ',', $new_selectors );
+	}
+
+	/**
 	 * Given a settings array, it returns the generated rulesets
 	 * for the preset classes.
 	 *
@@ -641,7 +663,7 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $values as $value ) {
 				foreach ( $preset['classes'] as $class ) {
 					$stylesheet .= self::to_ruleset(
-						$selector . '.has-' . $value['slug'] . '-' . $class['class_suffix'],
+						self::append_to_selector( $selector, '.has-' . $value['slug'] . '-' . $class['class_suffix'] ),
 						array(
 							array(
 								'name'  => $class['property_name'],

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -174,6 +174,33 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_get_stylesheet_preset_classes_work_with_compounded_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/heading' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'white',
+										'color' => '#fff',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertEquals(
+			'h1.has-white-color, h2.has-white-color, h3.has-white-color, h4.has-white-color, h5.has-white-color, h6.has-white-color {color: #fff !important;}h1.has-white-background-color, h2.has-white-background-color, h3.has-white-background-color, h4.has-white-background-color, h5.has-white-background-color, h6.has-white-background-color {background-color: #fff !important;}h1.has-white-border-color, h2.has-white-border-color, h3.has-white-border-color, h4.has-white-border-color, h5.has-white-border-color, h6.has-white-border-color {border-color: #fff !important;}',
+			$theme_json->get_stylesheet( 'block_styles' )
+		);
+	}
+
 	function test_get_stylesheet_preset_rules_come_after_block_rules() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -196,7 +196,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'h1.has-white-color, h2.has-white-color, h3.has-white-color, h4.has-white-color, h5.has-white-color, h6.has-white-color {color: #fff !important;}h1.has-white-background-color, h2.has-white-background-color, h3.has-white-background-color, h4.has-white-background-color, h5.has-white-background-color, h6.has-white-background-color {background-color: #fff !important;}h1.has-white-border-color, h2.has-white-border-color, h3.has-white-border-color, h4.has-white-border-color, h5.has-white-border-color, h6.has-white-border-color {border-color: #fff !important;}',
+			'h1.has-white-color,h2.has-white-color,h3.has-white-color,h4.has-white-color,h5.has-white-color,h6.has-white-color{color: #fff !important;}h1.has-white-background-color,h2.has-white-background-color,h3.has-white-background-color,h4.has-white-background-color,h5.has-white-background-color,h6.has-white-background-color{background-color: #fff !important;}h1.has-white-border-color,h2.has-white-border-color,h3.has-white-border-color,h4.has-white-border-color,h5.has-white-border-color,h6.has-white-border-color{border-color: #fff !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -177,7 +177,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	function test_get_stylesheet_preset_classes_work_with_compounded_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'blocks' => array(
 						'core/heading' => array(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/31660

This needs to be backported to core.
