### PR TITLE
edit-post: no-string-literals fix

### DIFF
--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Returns the Post's Edit URL.
@@ -98,7 +99,7 @@ export class BrowserURL extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost, isSavingPost } = select( 'core/editor' );
+	const { getCurrentPost, isSavingPost } = select( editorStore );
 	const post = getCurrentPost();
 	let { id, status, type } = post;
 	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( type );

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Icon, MenuGroup } from '@wordpress/components';
-import { PostPreviewButton } from '@wordpress/editor';
+import { PostPreviewButton, store as editorStore } from '@wordpress/editor';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
@@ -23,7 +23,7 @@ export default function DevicePreview() {
 		( select ) => ( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
-			isPostSaveable: select( 'core/editor' ).isEditedPostSaveable(),
+			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
 			deviceType: select(
 				editPostStore
 			).__experimentalGetPreviewDeviceType(),

--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -3,6 +3,8 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -23,7 +25,7 @@ export const useBlockSelectionListener = ( postId ) => {
 	const { hasBlockSelection, isEditorSidebarOpened } = useSelect(
 		( select ) => ( {
 			hasBlockSelection: !! select(
-				'core/block-editor'
+				blockEditorStore
 			).getBlockSelectionStart(),
 			isEditorSidebarOpened: select( STORE_NAME ).isEditorSidebarOpened(),
 		} ),
@@ -53,7 +55,7 @@ export const useBlockSelectionListener = ( postId ) => {
 export const useUpdatePostLinkListener = ( postId ) => {
 	const { newPermalink } = useSelect(
 		( select ) => ( {
-			newPermalink: select( 'core/editor' ).getCurrentPost().link,
+			newPermalink: select( editorStore ).getCurrentPost().link,
 		} ),
 		[ postId ]
 	);

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -11,6 +11,8 @@ import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { wordpress } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,10 +22,10 @@ import { store as editPostStore } from '../../../store';
 function FullscreenModeClose( { showTooltip, icon, href } ) {
 	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
 		( select ) => {
-			const { getCurrentPostType } = select( 'core/editor' );
+			const { getCurrentPostType } = select( editorStore );
 			const { isFeatureActive } = select( editPostStore );
 			const { isResolving } = select( 'core/data' );
-			const { getEntityRecord, getPostType } = select( 'core' );
+			const { getEntityRecord, getPostType } = select( coreStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { MenuItemsChoice, MenuGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -38,9 +39,9 @@ function ModeSwitcher() {
 			shortcut: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation( 'core/edit-post/toggle-mode' ),
-			isRichEditingEnabled: select( 'core/editor' ).getEditorSettings()
+			isRichEditingEnabled: select( editorStore ).getEditorSettings()
 				.richEditingEnabled,
-			isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings()
+			isCodeEditingEnabled: select( editorStore ).getEditorSettings()
 				.codeEditingEnabled,
 			mode: select( editPostStore ).getEditorMode(),
 		} ),

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { useViewportMatch, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { PostPublishButton } from '@wordpress/editor';
+import { PostPublishButton, store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -84,20 +84,20 @@ export function PostPublishButtonOrToggle( {
 export default compose(
 	withSelect( ( select ) => ( {
 		hasPublishAction: get(
-			select( 'core/editor' ).getCurrentPost(),
+			select( editorStore ).getCurrentPost(),
 			[ '_links', 'wp:action-publish' ],
 			false
 		),
-		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
-		isPending: select( 'core/editor' ).isCurrentPostPending(),
-		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
+		isBeingScheduled: select( editorStore ).isEditedPostBeingScheduled(),
+		isPending: select( editorStore ).isCurrentPostPending(),
+		isPublished: select( editorStore ).isCurrentPostPublished(),
 		isPublishSidebarEnabled: select(
-			'core/editor'
+			editorStore
 		).isPublishSidebarEnabled(),
 		isPublishSidebarOpened: select(
 			editPostStore
 		).isPublishSidebarOpened(),
-		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
+		isScheduled: select( editorStore ).isCurrentPostScheduled(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { togglePublishSidebar } = dispatch( editPostStore );

--- a/packages/edit-post/src/components/layout/actions-panel.js
+++ b/packages/edit-post/src/components/layout/actions-panel.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { EntitiesSavedStates, PostPublishPanel } from '@wordpress/editor';
+import {
+	EntitiesSavedStates,
+	PostPublishPanel,
+	store as editorStore,
+} from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -38,7 +42,7 @@ export default function ActionsPanel( {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSavingMetaBoxes: select( editPostStore ).isSavingMetaBoxes(),
 			hasNonPostEntityChanges: select(
-				'core/editor'
+				editorStore
 			).hasNonPostEntityChanges(),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -8,6 +8,7 @@ import { filter, map } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -48,7 +49,7 @@ export function MetaBoxesSection( {
 }
 
 export default withSelect( ( select ) => {
-	const { getEditorSettings } = select( 'core/editor' );
+	const { getEditorSettings } = select( editorStore );
 	const { getAllMetaBoxes } = select( editPostStore );
 
 	return {

--- a/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-custom-fields.js
@@ -5,6 +5,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -58,6 +59,6 @@ export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
 }
 
 export default withSelect( ( select ) => ( {
-	areCustomFieldsEnabled: !! select( 'core/editor' ).getEditorSettings()
+	areCustomFieldsEnabled: !! select( editorStore ).getEditorSettings()
 		.enableCustomFields,
 } ) )( EnableCustomFieldsOption );

--- a/packages/edit-post/src/components/preferences-modal/options/enable-publish-sidebar.js
+++ b/packages/edit-post/src/components/preferences-modal/options/enable-publish-sidebar.js
@@ -4,6 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { ifViewportMatches } from '@wordpress/viewport';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -12,11 +13,11 @@ import BaseOption from './base';
 
 export default compose(
 	withSelect( ( select ) => ( {
-		isChecked: select( 'core/editor' ).isPublishSidebarEnabled(),
+		isChecked: select( editorStore ).isPublishSidebarEnabled(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { enablePublishSidebar, disablePublishSidebar } = dispatch(
-			'core/editor'
+			editorStore
 		);
 		return {
 			onChange: ( isEnabled ) =>

--- a/packages/edit-post/src/components/sidebar/featured-image/index.js
+++ b/packages/edit-post/src/components/sidebar/featured-image/index.js
@@ -8,9 +8,14 @@ import { get, partial } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
+import {
+	PostFeaturedImage,
+	PostFeaturedImageCheck,
+	store as editorStore,
+} from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -45,8 +50,8 @@ function FeaturedImage( { isEnabled, isOpened, postType, onTogglePanel } ) {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const { getPostType } = select( 'core' );
+	const { getEditedPostAttribute } = select( editorStore );
+	const { getPostType } = select( coreStore );
 	const { isEditorPanelEnabled, isEditorPanelOpened } = select(
 		editPostStore
 	);

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -5,6 +5,7 @@ import { ComplementaryArea } from '@wordpress/interface';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -79,9 +80,7 @@ import { store as editPostStore } from '../../../store';
 export default function PluginSidebarEditPost( { className, ...props } ) {
 	const { postTitle, shortcut, showIconLabels } = useSelect( ( select ) => {
 		return {
-			postTitle: select( 'core/editor' ).getEditedPostAttribute(
-				'title'
-			),
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
 			shortcut: select(
 				keyboardShortcutsStore
 			).getShortcutRepresentation( 'core/edit-post/toggle-sidebar' ),

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -10,8 +10,9 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
-import { cleanForSlug } from '@wordpress/editor';
+import { cleanForSlug, store as editorStore } from '@wordpress/editor';
 import { safeDecodeURIComponent } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -136,11 +137,11 @@ export default compose( [
 			getPermalinkParts,
 			getEditedPostAttribute,
 			getEditedPostSlug,
-		} = select( 'core/editor' );
+		} = select( editorStore );
 		const { isEditorPanelEnabled, isEditorPanelOpened } = select(
 			editPostStore
 		);
-		const { getPostType } = select( 'core' );
+		const { getPostType } = select( coreStore );
 
 		const { link } = getCurrentPost();
 
@@ -167,7 +168,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { toggleEditorPanelOpened } = dispatch( editPostStore );
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( editorStore );
 		return {
 			onTogglePanel: () => toggleEditorPanelOpened( PANEL_NAME ),
 			editPermalink: ( newSlug ) => {

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -4,6 +4,8 @@
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -17,8 +19,8 @@ const SettingsHeader = ( { sidebarName } ) => {
 	const openBlockSettings = () => openGeneralSidebar( 'edit-post/block' );
 
 	const { documentLabel, isTemplateMode } = useSelect( ( select ) => {
-		const currentPostType = select( 'core/editor' ).getCurrentPostType();
-		const postType = select( 'core' ).getPostType( currentPostType );
+		const currentPostType = select( editorStore ).getCurrentPostType();
+		const postType = select( coreStore ).getPostType( currentPostType );
 
 		return {
 			documentLabel:

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -5,6 +5,7 @@ import {
 	PostTextEditor,
 	PostTitle,
 	TextEditorGlobalKeyboardShortcuts,
+	store as editorStore,
 } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -43,7 +44,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings()
+		isRichEditingEnabled: select( editorStore ).getEditorSettings()
 			.richEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -12,9 +12,11 @@ import {
 	EditorProvider,
 	ErrorBoundary,
 	PostLockedModal,
+	store as editorStore,
 } from '@wordpress/editor';
 import { StrictMode, useMemo } from '@wordpress/element';
 import { KeyboardShortcuts, SlotFillProvider } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -55,9 +57,9 @@ function Editor( {
 			getEditedPostTemplate,
 		} = select( editPostStore );
 		const { getEntityRecord, getPostType, getEntityRecords } = select(
-			'core'
+			coreStore
 		);
-		const { getEditorSettings } = select( 'core/editor' );
+		const { getEditorSettings } = select( editorStore );
 		const { getBlockTypes } = select( blocksStore );
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			postType

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -307,8 +307,8 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 
 	// Save metaboxes when performing a full save on the post.
 	saveMetaboxUnsubscribe = subscribe( () => {
-		const isSavingPost = select( editorStore ).isSavingPost();
-		const isAutosavingPost = select( editorStore ).isAutosavingPost();
+		const isSavingPost = select( editorStore.name ).isSavingPost();
+		const isAutosavingPost = select( editorStore.name ).isAutosavingPost();
 
 		// Save metaboxes on save completion, except for autosaves that are not a post preview.
 		const shouldTriggerMetaboxesSave =

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -13,6 +13,8 @@ import { controls, dispatch, select, subscribe } from '@wordpress/data';
 import { speak } from '@wordpress/a11y';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -172,7 +174,7 @@ export function* switchEditorMode( mode ) {
 
 	// Unselect blocks when we switch to the code editor.
 	if ( mode !== 'visual' ) {
-		yield controls.dispatch( 'core/block-editor', 'clearSelectedBlock' );
+		yield controls.dispatch( blockEditorStore.name, 'clearSelectedBlock' );
 	}
 
 	const message =
@@ -273,16 +275,19 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 	};
 
 	const postType = yield controls.select(
-		'core/editor',
+		editorStore.name,
 		'getCurrentPostType'
 	);
 	if ( window.postboxes.page !== postType ) {
 		window.postboxes.add_postbox_toggles( postType );
 	}
 
-	let wasSavingPost = yield controls.select( 'core/editor', 'isSavingPost' );
+	let wasSavingPost = yield controls.select(
+		editorStore.name,
+		'isSavingPost'
+	);
 	let wasAutosavingPost = yield controls.select(
-		'core/editor',
+		editorStore.name,
 		'isAutosavingPost'
 	);
 
@@ -302,8 +307,8 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 
 	// Save metaboxes when performing a full save on the post.
 	saveMetaboxUnsubscribe = subscribe( () => {
-		const isSavingPost = select( 'core/editor' ).isSavingPost();
-		const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
+		const isSavingPost = select( editorStore ).isSavingPost();
+		const isAutosavingPost = select( editorStore ).isAutosavingPost();
 
 		// Save metaboxes on save completion, except for autosaves that are not a post preview.
 		const shouldTriggerMetaboxesSave =
@@ -339,7 +344,7 @@ export function* requestMetaBoxUpdates() {
 
 	// Additional data needed for backward compatibility.
 	// If we do not provide this data, the post will be overridden with the default values.
-	const post = yield controls.select( 'core/editor', 'getCurrentPost' );
+	const post = yield controls.select( editorStore.name, 'getCurrentPost' );
 	const additionalData = [
 		post.comment_status ? [ 'comment_status', post.comment_status ] : false,
 		post.ping_status ? [ 'ping_status', post.ping_status ] : false,
@@ -472,7 +477,10 @@ export function* __unstableSwitchToTemplateMode( template ) {
 			'wp_template',
 			template
 		);
-		const post = yield controls.select( 'core/editor', 'getCurrentPost' );
+		const post = yield controls.select(
+			editorStore.name,
+			'getCurrentPost'
+		);
 
 		yield controls.dispatch(
 			coreStore,


### PR DESCRIPTION
## Description
Fixes eslint warnings in the edit-post package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/edit-post/` no longer throws warnings for string literals
* tests should be green

Note: There is 1 warning remaining for `'core/data'` but I couldn't replace it in this PR because the `data` package doesn't have a `store`. We'll need to dig a bit deeper for that one.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
