### PR TITLE
edit-navigation: no-string-literals fix

### DIFF
--- a/packages/edit-navigation/src/components/add-menu/index.js
+++ b/packages/edit-navigation/src/components/add-menu/index.js
@@ -12,6 +12,7 @@ import { TextControl, Button } from '@wordpress/components';
 import { useFocusOnMount } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 
 const menuNameMatches = ( menuName ) => ( menu ) =>
 	menu.name.toLowerCase() === menuName.toLowerCase();
@@ -29,7 +30,7 @@ export default function AddMenu( {
 		noticesStore
 	);
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
-	const { saveMenu } = useDispatch( 'core' );
+	const { saveMenu } = useDispatch( coreStore );
 
 	const inputRef = useFocusOnMount( focusInputOnMount );
 

--- a/packages/edit-navigation/src/components/layout/shortcuts.js
+++ b/packages/edit-navigation/src/components/layout/shortcuts.js
@@ -8,6 +8,7 @@ import {
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
 
 function NavigationEditorShortcuts( { saveBlocks } ) {
 	useShortcut(
@@ -21,7 +22,7 @@ function NavigationEditorShortcuts( { saveBlocks } ) {
 		}
 	);
 
-	const { redo, undo } = useDispatch( 'core' );
+	const { redo, undo } = useDispatch( coreStore );
 	useShortcut(
 		'core/edit-navigation/undo',
 		( event ) => {

--- a/packages/edit-navigation/src/hooks/use-menu-entity.js
+++ b/packages/edit-navigation/src/hooks/use-menu-entity.js
@@ -2,19 +2,20 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
 import { MENU_KIND, MENU_POST_TYPE } from '../constants';
 
 export default function useMenuEntity( menuId ) {
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord } = useDispatch( coreStore );
 
 	const menuEntityData = [ MENU_KIND, MENU_POST_TYPE, menuId ];
 	const editedMenu = useSelect(
 		( select ) =>
 			menuId &&
-			select( 'core' ).getEditedEntityRecord( ...menuEntityData ),
+			select( coreStore ).getEditedEntityRecord( ...menuEntityData ),
 		[ menuId ]
 	);
 

--- a/packages/edit-navigation/src/hooks/use-menu-notifications.js
+++ b/packages/edit-navigation/src/hooks/use-menu-notifications.js
@@ -4,6 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
@@ -12,11 +13,11 @@ import { MENU_POST_TYPE, MENU_KIND } from '../constants';
 export default function useMenuNotifications( menuId ) {
 	const { lastSaveError, lastDeleteError } = useSelect(
 		( select ) => ( {
-			lastSaveError: select( 'core' ).getLastEntitySaveError(
+			lastSaveError: select( coreStore ).getLastEntitySaveError(
 				MENU_KIND,
 				MENU_POST_TYPE
 			),
-			lastDeleteError: select( 'core' ).getLastEntityDeleteError(
+			lastDeleteError: select( coreStore ).getLastEntityDeleteError(
 				MENU_KIND,
 				MENU_POST_TYPE,
 				menuId

--- a/packages/edit-navigation/src/store/selectors.js
+++ b/packages/edit-navigation/src/store/selectors.js
@@ -7,6 +7,7 @@ import { invert } from 'lodash';
  * WordPress dependencies
  */
 import { createRegistrySelector } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -43,7 +44,7 @@ export const getNavigationPostForMenu = createRegistrySelector(
 		if ( ! hasResolvedNavigationPost( state, menuId ) ) {
 			return null;
 		}
-		return select( 'core' ).getEditedEntityRecord(
+		return select( coreStore ).getEditedEntityRecord(
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId )
@@ -59,7 +60,7 @@ export const getNavigationPostForMenu = createRegistrySelector(
  */
 export const hasResolvedNavigationPost = createRegistrySelector(
 	( select ) => ( state, menuId ) => {
-		return select( 'core' ).hasFinishedResolution( 'getEntityRecord', [
+		return select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId ),
@@ -77,6 +78,6 @@ export const hasResolvedNavigationPost = createRegistrySelector(
 export const getMenuItemForClientId = createRegistrySelector(
 	( select ) => ( state, postId, clientId ) => {
 		const mapping = invert( state.mapping[ postId ] );
-		return select( 'core' ).getMenuItem( mapping[ clientId ] );
+		return select( coreStore ).getMenuItem( mapping[ clientId ] );
 	}
 );

--- a/packages/edit-navigation/src/store/selectors.js
+++ b/packages/edit-navigation/src/store/selectors.js
@@ -44,7 +44,7 @@ export const getNavigationPostForMenu = createRegistrySelector(
 		if ( ! hasResolvedNavigationPost( state, menuId ) ) {
 			return null;
 		}
-		return select( coreStore ).getEditedEntityRecord(
+		return select( coreStore.name ).getEditedEntityRecord(
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId )
@@ -60,7 +60,9 @@ export const getNavigationPostForMenu = createRegistrySelector(
  */
 export const hasResolvedNavigationPost = createRegistrySelector(
 	( select ) => ( state, menuId ) => {
-		return select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
+		return select(
+			coreStore.name
+		).hasFinishedResolution( 'getEntityRecord', [
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId ),
@@ -78,6 +80,6 @@ export const hasResolvedNavigationPost = createRegistrySelector(
 export const getMenuItemForClientId = createRegistrySelector(
 	( select ) => ( state, postId, clientId ) => {
 		const mapping = invert( state.mapping[ postId ] );
-		return select( coreStore ).getMenuItem( mapping[ clientId ] );
+		return select( coreStore.name ).getMenuItem( mapping[ clientId ] );
 	}
 );


### PR DESCRIPTION
## Description
Fixes eslint warnings in the edit-navigation package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/edit-navigation/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
