### PR TITLE
core-data: no-string-literals fix

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { addEntities } from './actions';
+import { CORE_STORE_NAME as coreStoreName } from './utils/constants';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 
@@ -247,7 +248,11 @@ export const getMethodName = (
  * @return {Array} Entities
  */
 export function* getKindEntities( kind ) {
-	let entities = yield controls.select( 'core', 'getEntitiesByKind', kind );
+	let entities = yield controls.select(
+		coreStoreName,
+		'getEntitiesByKind',
+		kind
+	);
 	if ( entities && entities.length !== 0 ) {
 		return entities;
 	}

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -10,6 +10,11 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { CORE_STORE_NAME as coreStoreName } from './utils/constants';
+
 const EMPTY_ARRAY = [];
 
 /**
@@ -91,7 +96,9 @@ export function useEntityProp( kind, type, prop, _id ) {
 
 	const { value, fullValue } = useSelect(
 		( select ) => {
-			const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
+			const { getEntityRecord, getEditedEntityRecord } = select(
+				coreStoreName
+			);
 			const entity = getEntityRecord( kind, type, id ); // Trigger resolver.
 			const editedEntity = getEditedEntityRecord( kind, type, id );
 			return entity && editedEntity
@@ -103,7 +110,7 @@ export function useEntityProp( kind, type, prop, _id ) {
 		},
 		[ kind, type, id, prop ]
 	);
-	const { editEntityRecord } = useDispatch( 'core' );
+	const { editEntityRecord } = useDispatch( coreStoreName );
 	const setValue = useCallback(
 		( newValue ) => {
 			editEntityRecord( kind, type, id, {
@@ -139,7 +146,7 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 	const id = _id ?? providerId;
 	const { content, blocks } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord } = select( 'core' );
+			const { getEditedEntityRecord } = select( coreStoreName );
 			const editedEntity = getEditedEntityRecord( kind, type, id );
 			return {
 				blocks: editedEntity.blocks,
@@ -149,7 +156,7 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 		[ kind, type, id ]
 	);
 	const { __unstableCreateUndoLevel, editEntityRecord } = useDispatch(
-		'core'
+		coreStoreName
 	);
 
 	useEffect( () => {

--- a/packages/core-data/src/locks/actions.js
+++ b/packages/core-data/src/locks/actions.js
@@ -4,6 +4,11 @@
 import { __unstableAwaitPromise } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { CORE_STORE_NAME as coreStoreName } from '../utils/constants';
+
 export function* __unstableAcquireStoreLock( store, path, { exclusive } ) {
 	const promise = yield* __unstableEnqueueLockRequest( store, path, {
 		exclusive,
@@ -37,13 +42,13 @@ export function* __unstableProcessPendingLockRequests() {
 		type: 'PROCESS_PENDING_LOCK_REQUESTS',
 	};
 	const lockRequests = yield controls.select(
-		'core',
+		coreStoreName,
 		'__unstableGetPendingLockRequests'
 	);
 	for ( const request of lockRequests ) {
 		const { store, path, exclusive, notifyAcquired } = request;
 		const isAvailable = yield controls.select(
-			'core',
+			coreStoreName,
 			'__unstableIsLockAvailable',
 			store,
 			path,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -13,6 +13,7 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import { regularFetch } from './controls';
+import { CORE_STORE_NAME as coreStoreName } from './utils/constants';
 
 /**
  * Internal dependencies
@@ -85,7 +86,7 @@ export function* getEntityRecord( kind, name, key = '', query ) {
 	}
 
 	const lock = yield* __unstableAcquireStoreLock(
-		'core',
+		coreStoreName,
 		[ 'entities', 'data', kind, name, key ],
 		{ exclusive: false }
 	);
@@ -122,7 +123,7 @@ export function* getEntityRecord( kind, name, key = '', query ) {
 			// fields, so it's tested here, prior to initiating the REST request,
 			// and without causing `getEntityRecords` resolution to occur.
 			const hasRecords = yield controls.select(
-				'core',
+				coreStoreName,
 				'hasEntityRecords',
 				kind,
 				name,
@@ -174,7 +175,7 @@ export function* getEntityRecords( kind, name, query = {} ) {
 	}
 
 	const lock = yield* __unstableAcquireStoreLock(
-		'core',
+		coreStoreName,
 		[ 'entities', 'data', kind, name ],
 		{ exclusive: false }
 	);
@@ -350,7 +351,7 @@ export function* canUser( action, resource, id ) {
  */
 export function* getAutosaves( postType, postId ) {
 	const { rest_base: restBase } = yield controls.resolveSelect(
-		'core',
+		coreStoreName,
 		'getPostType',
 		postType
 	);
@@ -373,7 +374,12 @@ export function* getAutosaves( postType, postId ) {
  * @param {number} postId   The id of the parent post.
  */
 export function* getAutosave( postType, postId ) {
-	yield controls.resolveSelect( 'core', 'getAutosaves', postType, postId );
+	yield controls.resolveSelect(
+		coreStoreName,
+		'getAutosaves',
+		postType,
+		postId
+	);
 }
 
 /**
@@ -402,7 +408,7 @@ export function* __experimentalGetTemplateForLink( link ) {
 
 	yield getEntityRecord( 'postType', 'wp_template', template.id );
 	const record = yield controls.select(
-		'core',
+		coreStoreName,
 		'getEntityRecord',
 		'postType',
 		'wp_template',

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -17,6 +17,7 @@ import { STORE_NAME } from './name';
 import { getQueriedItems } from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
 import { getNormalizedCommaSeparable } from './utils';
+import { CORE_DATA_STORE_NAME as coreDataStoreName } from './utils/constants';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -40,7 +41,7 @@ const EMPTY_ARRAY = [];
  */
 export const isRequestingEmbedPreview = createRegistrySelector(
 	( select ) => ( state, url ) => {
-		return select( 'core/data' ).isResolving(
+		return select( coreDataStoreName ).isResolving(
 			STORE_NAME,
 			'getEmbedPreview',
 			[ url ]

--- a/packages/core-data/src/utils/constants.js
+++ b/packages/core-data/src/utils/constants.js
@@ -10,4 +10,4 @@ export const CORE_STORE_NAME = 'core';
  *
  * @type {string}
  */
-export const CORE_DATA_STORE_NAME = 'core';
+export const CORE_DATA_STORE_NAME = 'core/data';

--- a/packages/core-data/src/utils/constants.js
+++ b/packages/core-data/src/utils/constants.js
@@ -1,0 +1,13 @@
+/**
+ * The identifier for the core store.
+ *
+ * @type {string}
+ */
+export const CORE_STORE_NAME = 'core';
+
+/**
+ * The identifier for the core/data store.
+ *
+ * @type {string}
+ */
+export const CORE_DATA_STORE_NAME = 'core';

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -4,6 +4,11 @@
 import { controls } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import { CORE_STORE_NAME as coreStoreName } from './constants';
+
+/**
  * Higher-order function which invokes the given resolver only if it has not
  * already been resolved with the arguments passed to the enhanced function.
  *
@@ -21,7 +26,7 @@ const ifNotResolved = ( resolver, selectorName ) =>
 	 */
 	function* resolveIfNotResolved( ...args ) {
 		const hasStartedResolution = yield controls.select(
-			'core',
+			coreStoreName,
 			'hasStartedResolution',
 			selectorName,
 			args


### PR DESCRIPTION
## Description
Fixes eslint warnings in the core-data package, replaces string literals with store definitions.
Part of #27088.

## How has this been tested?
* Tested the editor making sure nothing breaks.
* `npm run lint-js packages/core-data/` no longer throws warnings for string literals
* tests should be green

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
