### PR TITLE
Removed !important from alignment margins.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -65,8 +65,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	if ( $content_size || $wide_size ) {
 		$style  = ".wp-container-$id > * {";
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-		$style .= 'margin-left: auto !important;';
-		$style .= 'margin-right: auto !important;';
+		$style .= 'margin-left: auto;';
+		$style .= 'margin-right: auto;';
 		$style .= '}';
 
 		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -43,8 +43,8 @@ export function LayoutStyle( { selector, layout = {} } ) {
 			? `
 				${ appendSelectors( selector, '> *' ) } {
 					max-width: ${ contentSize ?? wideSize };
-					margin-left: auto !important;
-					margin-right: auto !important;
+					margin-left: auto;
+					margin-right: auto;
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {


### PR DESCRIPTION
## Description
So that exceptions can be coded for blocks and elements inside of a container controlling layout !important was removed from the margin styles being applied.

These `!important` attributes were introduced in [this change](https://github.com/WordPress/gutenberg/pull/30608) and described [here](https://github.com/WordPress/gutenberg/pull/30371).

> ...if you apply a margin to a block, it overrides the "margin: auto" applied by the alignment (layout), the only way to solve that is to use !important for these. ...

However this appears to not (or no longer) be the case and !important can be removed.

## How has this been tested?
Leveraging emptytheme apply theme.json similar to the below where a block defines both TOP and LEFT margin styles:
```
{
	"version": 1,
	"settings": {
		"spacing": {
			"customPadding": true,
			"customMargins": true
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/paragraph": {
				"spacing": {
					"margin": {
						"left": "100px",
						"top": "100px"
					}
				}
			}
		}
	}
}
```

I used a simple test page with the following block markup:
```
<!-- wp:group {"align":"full","backgroundColor":"blue","layout":{"inherit":true}} -->
<div class="wp-block-group alignfull has-blue-background-color has-background"><!-- wp:paragraph -->
<p>This is a group with a paragraph in it.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Note that both BEFORE and AFTER the change the paragraph adopted the TOP margin style expressed in theme.json (100px)  and the LEFT margin style from the alignment class (auto).

This was also tested in the same manner with various other blocks (group, columns, image)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
