### PR TITLE
Add option for adding additional bundled packages in `DependencyExtractionWebpackPlugin`

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -219,3 +219,15 @@ wp_enqueue_script( 'script', $script_url, $script_asset['dependencies'], $script
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+
+##### `bundledPackages`
+
+-   Type: array
+
+A list of optional package names that will be bundled into the build.
+
+```js
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin( { bundledPackages: [ '@wordpress/components' ] } ) ],
+};
+```

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -25,7 +25,7 @@ class DependencyExtractionWebpackPlugin {
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
-				bundledPackages: []
+				bundledPackages: [],
 			},
 			options
 		);
@@ -59,7 +59,10 @@ class DependencyExtractionWebpackPlugin {
 			typeof externalRequest === 'undefined' &&
 			this.options.useDefaults
 		) {
-			externalRequest = defaultRequestToExternal( request, this.options.bundledPackages );
+			externalRequest = defaultRequestToExternal(
+				request,
+				this.options.bundledPackages
+			);
 		}
 
 		if ( externalRequest ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -25,6 +25,7 @@ class DependencyExtractionWebpackPlugin {
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
+				bundledPackages: []
 			},
 			options
 		);
@@ -58,7 +59,7 @@ class DependencyExtractionWebpackPlugin {
 			typeof externalRequest === 'undefined' &&
 			this.options.useDefaults
 		) {
-			externalRequest = defaultRequestToExternal( request );
+			externalRequest = defaultRequestToExternal( request, this.options.bundledPackages );
 		}
 
 		if ( externalRequest ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -1,5 +1,5 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
-const BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
+const DEFAULT_BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
 
 /**
  * Default request to global transformation
@@ -8,11 +8,12 @@ const BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
  * - request `@wordpress/api-fetch` becomes `[ 'wp', 'apiFetch' ]`
  * - request `@wordpress/i18n` becomes `[ 'wp', 'i18n' ]`
  *
- * @param {string} request Module request (the module name in `import from`) to be transformed
+ * @param {string}   request Module request (the module name in `import from`) to be transformed
+ * @param {string[]} additionalBundledPackages Optional bundled package list in addition to the default.
  * @return {string|string[]|undefined} The resulting external definition. Return `undefined`
  *   to ignore the request. Return `string|string[]` to map the request to an external.
  */
-function defaultRequestToExternal( request ) {
+function defaultRequestToExternal( request, additionalBundledPackages ) {
 	switch ( request ) {
 		case 'moment':
 			return request;
@@ -34,7 +35,8 @@ function defaultRequestToExternal( request ) {
 			return 'ReactDOM';
 	}
 
-	if ( BUNDLED_PACKAGES.includes( request ) ) {
+	const bundledPackages = [...DEFAULT_BUNDLED_PACKAGES, ...(additionalBundledPackages || [])]
+	if ( bundledPackages.includes( request ) ) {
 		return undefined;
 	}
 

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -35,7 +35,10 @@ function defaultRequestToExternal( request, additionalBundledPackages ) {
 			return 'ReactDOM';
 	}
 
-	const bundledPackages = [...DEFAULT_BUNDLED_PACKAGES, ...(additionalBundledPackages || [])]
+	const bundledPackages = [
+		...DEFAULT_BUNDLED_PACKAGES,
+		...( additionalBundledPackages || [] ),
+	];
 	if ( bundledPackages.includes( request ) ) {
 		return undefined;
 	}

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -47,6 +47,12 @@ describe( 'defaultRequestToExternal', () => {
 			defaultRequestToExternal( '@wordpress/some-future-package' )
 		).toEqual( [ 'wp', 'someFuturePackage' ] );
 	} );
+
+	test( 'Handles skipping over additional bundled packages', () => {
+		expect(
+			defaultRequestToExternal( '@wordpress/some-future-package', ['@wordpress/some-future-package'] )
+		).toBeUndefined();
+	});
 } );
 
 describe( 'defaultRequestToHandle', () => {

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -50,9 +50,11 @@ describe( 'defaultRequestToExternal', () => {
 
 	test( 'Handles skipping over additional bundled packages', () => {
 		expect(
-			defaultRequestToExternal( '@wordpress/some-future-package', ['@wordpress/some-future-package'] )
+			defaultRequestToExternal( '@wordpress/some-future-package', [
+				'@wordpress/some-future-package',
+			] )
 		).toBeUndefined();
-	});
+	} );
 } );
 
 describe( 'defaultRequestToHandle', () => {


### PR DESCRIPTION
<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Add option for adding additional bundled packages in `DependencyExtractionWebpackPlugin`, this will allow plugins to bundle a newer version of `@wordpress/*`, then what is available through `window.wp`. 

## How has this been tested?
- Checkout this branch run `npm install` and `cd packages/dependency-extraction-webpack-plugin`.
- `npm link` (so we can use it in another package)
- In a different directory pull a sample WP plugin, I [used one of mine](https://github.com/louwie17/woocommerce-admin-tasklist-helper) and ran `npm install`
- `npm install @wordpress/dependency-extraction-webpack-plugin --save-dev`
- Link the local version -> `npm link @wordpress/dependency-extraction-webpack-plugin`
- Add
  ```
  new DependencyExtractionWebpackPlugin({
    bundledPackages: ['@wordpress/components']
  }),
  ```
  Above `WooCommerceDependencyExtractionWebpackPlugin` in the webpack.config.js in `plugins`, and commenting out the `WooCommerceDependencyExtractionWebpackPlugin`.
- Run `npm run build`
- Check `./build/index.js`, `Button` should be included in the bundle (you can search for `function Button`).

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Adds a new option `bundledPackages` to `DependencyExtractionWebpackPlugin`, that takes an array of optional bundled dependencies, that will not be marked as external.

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
