### PR TITLE
Fix: Allow themes to disable the color and gradients palette.

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -177,6 +177,22 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		unset( $settings['__experimentalFeatures']['spacing']['customPadding'] );
 	}
 
+	// On the site-editor for now we still need the core origin colors.
+	if ( 'site-editor' !== $context ) {
+		$settings_with_core_origin = array( 'colors', 'gradients' );
+		foreach ( $settings_with_core_origin as $setting_key ) {
+			if ( isset( $settings[ $setting_key ] ) ) {
+				$new_setting = array();
+				foreach ( $settings[ $setting_key ] as $node ) {
+					if ( ! ( isset( $node['origin'] ) && 'core' === $node['origin'] ) ) {
+						$new_setting[] = $node;
+					}
+				}
+				$settings[ $setting_key ] = $new_setting;
+			}
+		}
+	}
+
 	return $settings;
 }
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/32027

This PR fixes a regression and now themes can disable again the color and gradients palette.

## How has this been tested?
Using a thtme.json.
I did not configure any color palette and verified that the default core colors appear when the editor loads.
I set an empty color palette and verified the no color palette appears on the editor.
I repeated the test on theme without theme.json using the theme supports mechanism.
