### PR TITLE
[Mobile] - Refactor gallery - cherry pick Grid component

### DIFF
--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -125,10 +125,6 @@ export class BlockListItem extends Component {
 			contentResizeMode === 'stretch' && stretchStyle;
 		const { isContainerRelated } = alignmentHelpers;
 
-		if ( ! blockWidth ) {
-			return null;
-		}
-
 		return (
 			<ReadableContentView
 				align={ blockAlignment }
@@ -166,7 +162,18 @@ export class BlockListItem extends Component {
 	}
 
 	render() {
-		const { gridProperties, clientId, parentWidth, items } = this.props;
+		const {
+			gridProperties,
+			clientId,
+			parentWidth,
+			items,
+			blockWidth,
+		} = this.props;
+
+		if ( ! blockWidth ) {
+			return null;
+		}
+
 		if ( gridProperties ) {
 			return (
 				<Grid

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -16,6 +16,8 @@ import { ReadableContentView, alignmentHelpers } from '@wordpress/components';
  */
 import BlockListBlock from './block';
 import BlockInsertionPoint from './insertion-point';
+import Grid from './grid-item';
+
 import styles from './block-list-item.native.scss';
 import { store as blockEditorStore } from '../../store';
 
@@ -104,7 +106,7 @@ export class BlockListItem extends Component {
 		];
 	}
 
-	render() {
+	renderContent() {
 		const {
 			blockAlignment,
 			clientId,
@@ -161,6 +163,23 @@ export class BlockListItem extends Component {
 				</View>
 			</ReadableContentView>
 		);
+	}
+
+	render() {
+		const { gridProperties, clientId, parentWidth, items } = this.props;
+		if ( gridProperties ) {
+			return (
+				<Grid
+					numOfColumns={ gridProperties.numColumns }
+					tileCount={ items.length }
+					index={ items.indexOf( clientId ) }
+					maxWidth={ parentWidth }
+				>
+					{ this.renderContent() }
+				</Grid>
+			);
+		}
+		return this.renderContent();
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/block-list-item.native.scss
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.scss
@@ -10,3 +10,7 @@
 .fullAlignmentPadding {
 	padding: $block-edge-to-content;
 }
+
+.gridItem {
+	overflow: visible;
+}

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -48,7 +48,6 @@ function BlockForType( {
 	parentWidth,
 	wrapperProps,
 	blockWidth,
-	blockProps,
 } ) {
 	const defaultColors = useSetting( 'color.palette' ) || emptyArray;
 	const globalStyle = useGlobalStyles();
@@ -90,7 +89,6 @@ function BlockForType( {
 				contentStyle={ contentStyle }
 				onDeleteBlock={ onDeleteBlock }
 				blockWidth={ blockWidth }
-				{ ...( blockProps || {} ) }
 			/>
 			<View onLayout={ getBlockWidth } />
 		</GlobalStylesContext.Provider>

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -48,6 +48,7 @@ function BlockForType( {
 	parentWidth,
 	wrapperProps,
 	blockWidth,
+	blockProps,
 } ) {
 	const defaultColors = useSetting( 'color.palette' ) || emptyArray;
 	const globalStyle = useGlobalStyles();
@@ -89,6 +90,7 @@ function BlockForType( {
 				contentStyle={ contentStyle }
 				onDeleteBlock={ onDeleteBlock }
 				blockWidth={ blockWidth }
+				{ ...( blockProps || {} ) }
 			/>
 			<View onLayout={ getBlockWidth } />
 		</GlobalStylesContext.Provider>

--- a/packages/block-editor/src/components/block-list/grid-item.native.js
+++ b/packages/block-editor/src/components/block-list/grid-item.native.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import styles from './block-list-item.scss';
+
+function Grid( props ) {
+	/**
+	 * Since we don't have `calc()`, we must calculate our spacings here in
+	 * order to preserve even spacing between tiles and equal width for tiles
+	 * in a given row.
+	 *
+	 * In order to ensure equal sizing of tile contents, we distribute the
+	 * spacing such that each tile has an equal "share" of the fixed spacing. To
+	 * keep the tiles properly aligned within their rows, we calculate the left
+	 * and right paddings based on the tile's relative position within the row.
+	 *
+	 * Note: we use padding instead of margins so that the fixed spacing is
+	 * included within the relative spacing (i.e. width percentage), and
+	 * wrapping behavior is preserved.
+	 *
+	 * - The left most tile in a row must have left padding of zero.
+	 * - The right most tile in a row must have a right padding of zero.
+	 *
+	 * The values of these left and right paddings are interpolated for tiles in
+	 * between. The right padding is complementary with the left padding of the
+	 * next tile (i.e. the right padding of [tile n] + the left padding of
+	 * [tile n + 1] will be equal for all tiles except the last one in a given
+	 * row).
+	 *
+	 */
+	const { numOfColumns, children, tileCount, index, maxWidth } = props;
+	const lastTile = tileCount - 1;
+	const lastRow = Math.floor( lastTile / numOfColumns );
+
+	const row = Math.floor( index / numOfColumns );
+	const rowLength =
+		row === lastRow ? ( lastTile % numOfColumns ) + 1 : numOfColumns;
+
+	return (
+		<View
+			style={ [
+				{
+					width: maxWidth / rowLength,
+				},
+				styles.gridItem,
+			] }
+		>
+			{ children }
+		</View>
+	);
+}
+
+export default Grid;

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -48,6 +48,7 @@ const getStyles = (
 	const computedStyles = [
 		isStackedHorizontally && styles.horizontal,
 		horizontalAlignment && styles[ `is-aligned-${ horizontalAlignment }` ],
+		styles.overflowVisible,
 	];
 	stylesMemo[ styleName ] = computedStyles;
 	return computedStyles;
@@ -129,6 +130,8 @@ export class BlockList extends Component {
 			onDeleteBlock,
 			contentStyle,
 			renderAppender,
+			blockProps,
+			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
 		if (
@@ -137,7 +140,9 @@ export class BlockList extends Component {
 			this.extraData.onDeleteBlock !== onDeleteBlock ||
 			this.extraData.contentStyle !== contentStyle ||
 			this.extraData.renderAppender !== renderAppender ||
-			this.extraData.blockWidth !== blockWidth
+			this.extraData.blockWidth !== blockWidth ||
+			this.extraData.blockProps !== blockProps ||
+			this.extraData.gridProperties !== gridProperties
 		) {
 			this.extraData = {
 				parentWidth,
@@ -146,6 +151,8 @@ export class BlockList extends Component {
 				contentStyle,
 				renderAppender,
 				blockWidth,
+				blockProps,
+				gridProperties,
 			};
 		}
 		return this.extraData;
@@ -315,30 +322,34 @@ export class BlockList extends Component {
 			onDeleteBlock,
 			rootClientId,
 			isStackedHorizontally,
+			blockClientIds,
 			parentWidth,
 			marginVertical = styles.defaultBlock.marginTop,
 			marginHorizontal = styles.defaultBlock.marginLeft,
+			blockProps,
+			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
 		return (
-			<View style={ { flex: 1 } }>
-				<BlockListItem
-					isStackedHorizontally={ isStackedHorizontally }
-					rootClientId={ rootClientId }
-					clientId={ clientId }
-					parentWidth={ parentWidth }
-					contentResizeMode={ contentResizeMode }
-					contentStyle={ contentStyle }
-					onAddBlock={ onAddBlock }
-					marginVertical={ marginVertical }
-					marginHorizontal={ marginHorizontal }
-					onDeleteBlock={ onDeleteBlock }
-					shouldShowInnerBlockAppender={
-						this.shouldShowInnerBlockAppender
-					}
-					blockWidth={ blockWidth }
-				/>
-			</View>
+			<BlockListItem
+				isStackedHorizontally={ isStackedHorizontally }
+				rootClientId={ rootClientId }
+				clientId={ clientId }
+				parentWidth={ parentWidth }
+				contentResizeMode={ contentResizeMode }
+				contentStyle={ contentStyle }
+				onAddBlock={ onAddBlock }
+				marginVertical={ marginVertical }
+				marginHorizontal={ marginHorizontal }
+				onDeleteBlock={ onDeleteBlock }
+				shouldShowInnerBlockAppender={
+					this.shouldShowInnerBlockAppender
+				}
+				blockWidth={ blockWidth }
+				blockProps={ blockProps }
+				gridProperties={ gridProperties }
+				items={ blockClientIds }
+			/>
 		);
 	}
 

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -129,7 +129,6 @@ export class BlockList extends Component {
 			onDeleteBlock,
 			contentStyle,
 			renderAppender,
-			blockProps,
 			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
@@ -140,7 +139,6 @@ export class BlockList extends Component {
 			this.extraData.contentStyle !== contentStyle ||
 			this.extraData.renderAppender !== renderAppender ||
 			this.extraData.blockWidth !== blockWidth ||
-			this.extraData.blockProps !== blockProps ||
 			this.extraData.gridProperties !== gridProperties
 		) {
 			this.extraData = {
@@ -150,7 +148,6 @@ export class BlockList extends Component {
 				contentStyle,
 				renderAppender,
 				blockWidth,
-				blockProps,
 				gridProperties,
 			};
 		}
@@ -321,7 +318,6 @@ export class BlockList extends Component {
 			parentWidth,
 			marginVertical = styles.defaultBlock.marginTop,
 			marginHorizontal = styles.defaultBlock.marginLeft,
-			blockProps,
 			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
@@ -341,7 +337,6 @@ export class BlockList extends Component {
 					this.shouldShowInnerBlockAppender
 				}
 				blockWidth={ blockWidth }
-				blockProps={ blockProps }
 				gridProperties={ gridProperties }
 				items={ blockClientIds }
 			/>

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -35,10 +35,9 @@ const stylesMemo = {};
 const getStyles = (
 	isRootList,
 	isStackedHorizontally,
-	horizontalAlignment,
-	numColumns
+	horizontalAlignment
 ) => {
-	if ( isRootList || numColumns ) {
+	if ( isRootList ) {
 		return;
 	}
 	const styleName = `${ isStackedHorizontally }-${ horizontalAlignment }`;
@@ -216,7 +215,6 @@ export class BlockList extends Component {
 			contentResizeMode,
 			// eslint-disable-next-line no-unused-vars
 			blockWidth,
-			numColumns,
 		} = this.props;
 		const { parentScrollRef } = extraProps;
 
@@ -279,14 +277,11 @@ export class BlockList extends Component {
 					style={ getStyles(
 						isRootList,
 						isStackedHorizontally,
-						horizontalAlignment,
-						numColumns
+						horizontalAlignment
 					) }
 					data={ blockClientIds }
 					keyExtractor={ identity }
 					renderItem={ this.renderItem }
-					numColumns={ numColumns }
-					key={ numColumns }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll
 					}

--- a/packages/block-editor/src/components/block-styles/preview.native.js
+++ b/packages/block-editor/src/components/block-styles/preview.native.js
@@ -71,7 +71,7 @@ function StylePreview( { onPress, isActive, style, url } ) {
 			return (
 				<Animated.View
 					style={ [ outlineStyle, { opacity }, styles[ name ] ] }
-					key={ outlineStyle.borderColor }
+					key={ JSON.stringify( outlineStyle ) }
 				/>
 			);
 		} );

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -93,6 +93,8 @@ function UncontrolledInnerBlocks( props ) {
 		blockWidth,
 		__experimentalLayout: layout = defaultLayout,
 		numColumns,
+		gridProperties,
+		blockProps,
 	} = props;
 
 	const block = useSelect(
@@ -126,6 +128,8 @@ function UncontrolledInnerBlocks( props ) {
 			onAddBlock={ onAddBlock }
 			onDeleteBlock={ onDeleteBlock }
 			filterInnerBlocks={ filterInnerBlocks }
+			gridProperties={ gridProperties }
+			blockProps={ blockProps }
 			blockWidth={ blockWidth }
 			numColumns={ numColumns }
 		/>

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -92,7 +92,6 @@ function UncontrolledInnerBlocks( props ) {
 		filterInnerBlocks,
 		blockWidth,
 		__experimentalLayout: layout = defaultLayout,
-		numColumns,
 		gridProperties,
 		blockProps,
 	} = props;
@@ -131,7 +130,6 @@ function UncontrolledInnerBlocks( props ) {
 			gridProperties={ gridProperties }
 			blockProps={ blockProps }
 			blockWidth={ blockWidth }
-			numColumns={ numColumns }
 		/>
 	);
 

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -93,7 +93,6 @@ function UncontrolledInnerBlocks( props ) {
 		blockWidth,
 		__experimentalLayout: layout = defaultLayout,
 		gridProperties,
-		blockProps,
 	} = props;
 
 	const block = useSelect(
@@ -128,7 +127,6 @@ function UncontrolledInnerBlocks( props ) {
 			onDeleteBlock={ onDeleteBlock }
 			filterInnerBlocks={ filterInnerBlocks }
 			gridProperties={ gridProperties }
-			blockProps={ blockProps }
 			blockWidth={ blockWidth }
 		/>
 	);

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,5 +1,10 @@
 @import "./v1/gallery-styles.native.scss";
 
 .galleryAppender {
-	padding-top: 16px;
+	padding-top: $grid-unit-20;
+}
+
+.fullWidth {
+	margin-left: $block-edge-to-content;
+	margin-right: $block-edge-to-content;
 }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -74,10 +74,6 @@ export const Gallery = ( props ) => {
 			marginHorizontal: TILE_SPACING,
 			marginVertical: TILE_SPACING,
 			__experimentalLayout: { type: 'default', alignments: [] },
-			blockProps: {
-				imageCrop,
-				isGallery: true,
-			},
 			gridProperties: {
 				numColumns: displayedColumns,
 			},

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -21,6 +21,7 @@ import {
 import { useState, useEffect } from '@wordpress/element';
 import { mediaUploadSync } from '@wordpress/react-native-bridge';
 import { WIDE_ALIGNMENTS } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 
 const TILE_SPACING = 8;
 
@@ -30,6 +31,8 @@ const MAX_DISPLAYED_COLUMNS_NARROW = 2;
 
 export const Gallery = ( props ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
+	const [ resizeObserver, sizes ] = useResizeObserver();
+	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	useEffect( mediaUploadSync, [] );
 
 	const {
@@ -41,11 +44,17 @@ export const Gallery = ( props ) => {
 		clientId,
 	} = props;
 
+	useEffect( () => {
+		const { width } = sizes || {};
+		if ( width ) {
+			setMaxWidth( width );
+		}
+	}, [ sizes ] );
+
 	const {
 		imageCount,
 		align,
 		columns = defaultColumnsNumber( imageCount ),
-		// eslint-disable-next-line no-unused-vars
 		imageCrop,
 	} = attributes;
 
@@ -64,6 +73,15 @@ export const Gallery = ( props ) => {
 			numColumns: displayedColumns,
 			marginHorizontal: TILE_SPACING,
 			marginVertical: TILE_SPACING,
+			__experimentalLayout: { type: 'default', alignments: [] },
+			blockProps: {
+				imageCrop,
+				isGallery: true,
+			},
+			gridProperties: {
+				numColumns: displayedColumns,
+			},
+			parentWidth: maxWidth + 2 * TILE_SPACING,
 		}
 	);
 
@@ -77,6 +95,7 @@ export const Gallery = ( props ) => {
 
 	return (
 		<View style={ isFullWidth && styles.fullWidth }>
+			{ resizeObserver }
 			<View { ...innerBlocksProps } />
 			<View
 				style={ [


### PR DESCRIPTION
### Related PRs

* Main refactor PR: https://github.com/WordPress/gutenberg/pull/25940
* Mobile refactor PR: https://github.com/WordPress/gutenberg/pull/31306
  * This is the main mobile PR which is targeting the main refactor PR to bring the changes needed for the mobile implementations.
* Former mobile refactor PR: https://github.com/WordPress/gutenberg/pull/26823
  * Changes from this PR are being extracted and included in this and subsequent PRs

## Description
This PR brings the changes from the former PR which adds a `Grid` component to layout the gallery images, rather than relying on the `numColumns`. This seems to be a bit more performant, though still not as performant as former implementation ([noted here](https://github.com/WordPress/gutenberg/pull/26823#issuecomment-728186101)), which did not rely upon `InnerBlocks`.

### Screen recordings

Before | After
-|-
<video src="https://user-images.githubusercontent.com/8507675/119630517-8b385600-bdfe-11eb-820e-2f43dd716ebb.mp4"> | <video src="https://user-images.githubusercontent.com/8507675/119630505-88d5fc00-bdfe-11eb-949e-411cf73b279e.mp4">

## How has this been tested?
Create a gallery in the editor on the main app and add some images (at least 5). Change the columns setting in the gallery block to different values in portrait and landscape. The images should be displayed in 2 columns maximum on portrait, and 4 columns maximum on landscape, or the number of columns based on the setting, if it is less than those maximums.

Also, try moving the images around within the gallery. The performance should be improved compared to the previous state of the refactored implementation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
