### PR TITLE
[Block Library - Query]: Set inherit value according to detected context

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -43,6 +43,7 @@
 		"query": "query",
 		"displayLayout": "displayLayout"
 	},
+	"usesContext": [ "templateSlug" ],
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -25,7 +25,11 @@ import QueryPlaceholder from './query-placeholder';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 
 const TEMPLATE = [ [ 'core/query-loop' ] ];
-export function QueryContent( { attributes, setAttributes } ) {
+export function QueryContent( {
+	attributes,
+	setAttributes,
+	context: { templateSlug } = {},
+} ) {
 	const {
 		queryId,
 		query,
@@ -83,12 +87,20 @@ export function QueryContent( { attributes, setAttributes } ) {
 			updateQuery( newQuery );
 		}
 	}, [ query.perPage ] );
-	// We need this for multi-query block pagination.
-	// Query parameters for each block are scoped to their ID.
+	/**
+	 * We need to perform some actions during insertion of a Query block.
+	 * 1. Set a unique `queryId` which is needed for multi-query block pagination.
+	 * Query parameters for each block are scoped to their ID.
+	 * 2. Detect the context in which the block is inserted and set the proper
+	 * value to `inherit` property.
+	 */
 	useEffect( () => {
 		if ( ! queryId ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { queryId: instanceId } );
+			setAttributes( {
+				queryId: instanceId,
+				query: { ...query, inherit: !! templateSlug },
+			} );
 		}
 	}, [ queryId, instanceId ] );
 	const updateQuery = ( newQuery ) =>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of: https://github.com/WordPress/gutenberg/issues/30369

We need to find a way to detect the context a Query block 'lives' and handle any settings needed appropriately. By context I mean FSE context (site-editor) or a page/post (post-editor). Moreover is valuable to even know the kind of template we are on FSE context (related: #29438).

This PR checks during the insertion of a Query block if we are in FSE context or not and sets the `inherit` value accordingly.
In a single page there is no much use in having an inherit Query, but instead a custom one. Since `Query` block is now in `core` and the site editor is not, we should at least set this value to false when is inserted in post editor.

## Testing instructions
1. In a page add the `Query` block and click `Start blank`
2. Select one of the provided variations
3. Observe that the `inherit` option is set to `false`
4. Do the same at the `site editor` and observe that the `inherit` option is set to `true`

## Notes
This change overrides the `Query patterns inherit` value which is not bad as this is something that should be handled under the hood mostly. It will be revisited in the next iteration for the context detection which should make more changes to `QueryLoop` depending on the current template editing etc..


Related: https://github.com/WordPress/gutenberg/issues/30910
