### PR TITLE
Alignment styles: Centre blocks using grid not margins

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -71,6 +71,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$style .= '}';
 
 		$style .= ".wp-container-$id > * {";
+		$style .= 'box-sizing: border-box;';
 		$style .= 'width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= '}';
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -64,9 +64,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$style = '';
 	if ( $content_size || $wide_size ) {
 
-		$style  = ".wp-container-$id {";
-		$style .= 'display: grid;';
-		$style .= '}';
+		$style  = ".wp-container-$id { display: grid; }";
 
 		$style .= ".wp-container-$id > * {";
 		$style .= 'box-sizing: border-box;';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -65,19 +65,19 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	if ( $content_size || $wide_size ) {
 
 		$style  = ".wp-container-$id {";
-		$style .= 'display: flex;';
-		$style .= 'flex-flow: column;';
-		$style .= 'align-items: center;';
+		$style .= 'display: grid;';
 		$style .= '}';
 
 		$style .= ".wp-container-$id > * {";
 		$style .= 'box-sizing: border-box;';
-		$style .= 'width: ' . esc_html( $all_max_width_value ) . ';';
+		$style .= 'justify-self: center;';
+		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
+		$style .= 'width: 100%;';
 		$style .= '}';
 
-		$style .= ".wp-container-$id > .alignwide { width: " . esc_html( $wide_max_width_value ) . ';}';
+		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
 
-		$style .= ".wp-container-$id .alignfull { width: 100%; }";
+		$style .= ".wp-container-$id .alignfull { max-width: none; }";
 	}
 
 	$style .= ".wp-container-$id .alignleft { float: left; margin-right: 2em; }";

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -63,15 +63,20 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$style = '';
 	if ( $content_size || $wide_size ) {
-		$style  = ".wp-container-$id > * {";
-		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-		$style .= 'margin-left: auto !important;';
-		$style .= 'margin-right: auto !important;';
+
+		$style  = ".wp-container-$id {";
+		$style .= 'display: flex;';
+		$style .= 'flex-flow: column;';
+		$style .= 'align-items: center;';
 		$style .= '}';
 
-		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
+		$style .= ".wp-container-$id > * {";
+		$style .= 'width: ' . esc_html( $all_max_width_value ) . ';';
+		$style .= '}';
 
-		$style .= ".wp-container-$id .alignfull { max-width: none; }";
+		$style .= ".wp-container-$id > .alignwide { width: " . esc_html( $wide_max_width_value ) . ';}';
+
+		$style .= ".wp-container-$id .alignfull { width: 100%; }";
 	}
 
 	$style .= ".wp-container-$id .alignleft { float: left; margin-right: 2em; }";

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -41,18 +41,22 @@ export function LayoutStyle( { selector, layout = {} } ) {
 	let style =
 		!! contentSize || !! wideSize
 			? `
+				${ selector } {
+					align-items: center;
+					display: flex;
+					flex-flow: column;
+				}
+
 				${ appendSelectors( selector, '> *' ) } {
-					max-width: ${ contentSize ?? wideSize };
-					margin-left: auto !important;
-					margin-right: auto !important;
+					width: ${ contentSize ?? wideSize };
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
-					max-width: ${ wideSize ?? contentSize };
+					width: ${ wideSize ?? contentSize };
 				}
 
 				${ appendSelectors( selector, '> [data-align="full"]' ) } {
-					max-width: none;
+					width: 100%;
 				}
 			`
 			: '';

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -42,22 +42,22 @@ export function LayoutStyle( { selector, layout = {} } ) {
 		!! contentSize || !! wideSize
 			? `
 				${ selector } {
-					align-items: center;
-					display: flex;
-					flex-flow: column;
+					display: grid;
 				}
 
 				${ appendSelectors( selector, '> *' ) } {
 					box-sizing: border-box;
-					width: ${ contentSize ?? wideSize };
+					justify-self: center;
+					width: 100%;
+					max-width: ${ contentSize ?? wideSize };
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
-					width: ${ wideSize ?? contentSize };
+					max-width: ${ wideSize ?? contentSize };
 				}
 
 				${ appendSelectors( selector, '> [data-align="full"]' ) } {
-					width: 100%;
+					max-width: none;
 				}
 			`
 			: '';

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -48,6 +48,7 @@ export function LayoutStyle( { selector, layout = {} } ) {
 				}
 
 				${ appendSelectors( selector, '> *' ) } {
+					box-sizing: border-box;
 					width: ${ contentSize ?? wideSize };
 				}
 


### PR DESCRIPTION
## Description
To centre the content inside blocks that use the "inherit layout" we are using "margin: auto" on every block. This will conflict with the new margin supports being added to blocks. To overcome this we added  !important declarations to the alignment styles for blocks that use the "inherit layout" setting (in https://github.com/WordPress/gutenberg/pull/30608). However this mean that left and right alignment settings in blocks won't work.

This PR takes a different approach to centering content inside blocks that use the "inherit layout" setting - instead of margins we use CSS grids. The container is given "display: gird". This means we can now set margins on these blocks without messing up the page alignments. Props to @MaggieCabrera for help with grid.

This requires declaring an explicit width to these blocks, rather than relying on the natural flow of the document. 

Adding margins to these blocks will make them wider than the page content, but I think that is the expected behaviour. I have also added "box-sizing: border-box" to these blocks, so that the padding settings don't make the blocks themselves wider.

## How has this been tested?
Switch to empty theme
Try adding normal content and ensure that its centered on the page
Try adding full width and wide width blocks and ensure they are centred and the correct width
Try adding left/right aligned blocks

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
