### PR TITLE
Allow non-latin characters in slugs

### DIFF
--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -8,6 +8,10 @@ describe( 'cleanForSlug()', () => {
 		expect( cleanForSlug( '/Is th@t Déjà_vu? ' ) ).toBe( 'is-tht-deja_vu' );
 	} );
 
+	it( 'Should allow unicode characters', () => {
+		expect( cleanForSlug( 'Καλημέρα Κόσμε' ) ).toBe( 'καλημέρα-κόσμε' )
+	} );
+
 	it( 'Should return an empty string for missing argument', () => {
 		expect( cleanForSlug() ).toBe( '' );
 	} );

--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -8,7 +8,7 @@ describe( 'cleanForSlug()', () => {
 		expect( cleanForSlug( '/Is th@t Déjà_vu? ' ) ).toBe( 'is-tht-deja_vu' );
 	} );
 
-	it( 'Should allow unicode characters', () => {
+	it( 'Should allow non-latin characters', () => {
 		expect( cleanForSlug( 'Καλημέρα Κόσμε' ) ).toBe( 'καλημέρα-κόσμε' );
 	} );
 

--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -9,7 +9,7 @@ describe( 'cleanForSlug()', () => {
 	} );
 
 	it( 'Should allow unicode characters', () => {
-		expect( cleanForSlug( 'Καλημέρα Κόσμε' ) ).toBe( 'καλημέρα-κόσμε' )
+		expect( cleanForSlug( 'Καλημέρα Κόσμε' ) ).toBe( 'καλημέρα-κόσμε' );
 	} );
 
 	it( 'Should return an empty string for missing argument', () => {

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -45,7 +45,7 @@ export function cleanForSlug( string ) {
 	return trim(
 		deburr( string )
 			.replace( /[\s\./]+/g, '-' )
-			.replace( /[^\w-]+/g, '' )
+			.replace( /[^\w-]+/gu, '' )
 			.toLowerCase(),
 		'-'
 	);

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -45,7 +45,7 @@ export function cleanForSlug( string ) {
 	return trim(
 		deburr( string )
 			.replace( /[\s\./]+/g, '-' )
-			.replace( /[^\w-]+/gu, '' )
+			.replace( /[^\p{L}\p{N}_-]+/gu, '' )
 			.toLowerCase(),
 		'-'
 	);

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -28,11 +28,11 @@ export function getWPAdminURL( page, query ) {
  * This replicates some of what sanitize_title() does in WordPress core, but
  * is only designed to approximate what the slug will be.
  *
- * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
- * letters. Removes combining diacritical marks. Converts whitespace, periods,
+ * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin letters.
+ * Removes combining diacritical marks. Converts whitespace, periods,
  * and forward slashes to hyphens. Removes any remaining non-word characters
- * except hyphens. Converts remaining string to lowercase. It does not account
- * for octets, HTML entities, or other encoded characters.
+ * except hyphens and underscores. Converts remaining string to lowercase.
+ * It does not account for octets, HTML entities, or other encoded characters.
  *
  * @param {string} string Title or slug to be processed
  *


### PR DESCRIPTION
## Description
Allow non-latin characters in slugs. Fixes #24710 

## How has this been tested?
* Tested by creating posts with non-latin characters in multiple languages
* Added an extra test for unicode characters in URLs

## Types of changes
* Added the `u` (unicode) modifier in the regex inside `cleanForSlug`.
* Changed the regex, replacing `\w` with `\p{L}\p{N}_`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
