### PR TITLE
Template Controller: Make test use test theme

### DIFF
--- a/phpunit/fixtures/themes/test-theme/block-template-parts/header.html
+++ b/phpunit/fixtures/themes/test-theme/block-template-parts/header.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Header Template Part</p>
+<!-- /wp:paragraph -->

--- a/phpunit/fixtures/themes/test-theme/experimental-theme.json
+++ b/phpunit/fixtures/themes/test-theme/experimental-theme.json
@@ -1,0 +1,8 @@
+{
+	"templateParts": [
+		{
+			"name": "header",
+			"area": "header"
+		}
+	]
+}


### PR DESCRIPTION
## Description
Follow-up to https://github.com/WordPress/wordpress-develop/pull/1267#issuecomment-847217976. The relevant controller fix (https://github.com/ockham/wordpress-develop/commit/2fc65d07685c86748f4cec97307829a14113a27d) was carried over to Gutenberg [here](https://github.com/WordPress/gutenberg/pull/32176/files#diff-c8f55bd6935940e0c1da0ed126bb7642883fc57d1cd5e5b002548c45ce08c789). This PR makes sure that tests would break without the fix.

## How has this been tested?
Verify that unit tests are green in CI.

To test locally:

```
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/class-gutenberg-rest-template-controller-test.php
```
