### PR TITLE
Performance tests: add more detailed loading metrics

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -329,16 +329,22 @@ async function runPerformanceTests( branches, options ) {
 		for ( const branch of branches ) {
 			const medians = mapValues(
 				{
-					serverResponse: rawResults.map( ( r ) => r.serverResponse ),
-					firstPaint: rawResults.map( ( r ) => r.firstPaint ),
+					serverResponse: rawResults.map(
+						( r ) => r[ branch ].serverResponse
+					),
+					firstPaint: rawResults.map(
+						( r ) => r[ branch ].firstPaint
+					),
 					domContentLoaded: rawResults.map(
-						( r ) => r.domContentLoaded
+						( r ) => r[ branch ].domContentLoaded
 					),
-					loaded: rawResults.map( ( r ) => r.loaded ),
+					loaded: rawResults.map( ( r ) => r[ branch ].loaded ),
 					firstContentfulPaint: rawResults.map(
-						( r ) => r.firstContentfulPaint
+						( r ) => r[ branch ].firstContentfulPaint
 					),
-					firstBlock: rawResults.map( ( r ) => r.firstBlock ),
+					firstBlock: rawResults.map(
+						( r ) => r[ branch ].firstBlock
+					),
 					type: rawResults.map( ( r ) => r[ branch ].type ),
 					minType: rawResults.map( ( r ) => r[ branch ].minType ),
 					maxType: rawResults.map( ( r ) => r[ branch ].maxType ),

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -29,33 +29,43 @@ const config = require( '../config' );
 /**
  * @typedef WPRawPerformanceResults
  *
- * @property {number[]} load           Load Time.
- * @property {number[]} type           Average type time.
- * @property {number[]} focus          Average block selection time.
- * @property {number[]} inserterOpen   Average time to open global inserter.
- * @property {number[]} inserterSearch Average time to search the inserter.
- * @property {number[]} inserterHover  Average time to move mouse between two block item in the inserter.
+ * @property {number[]} serverResponse       Represents the time the server takes to respond.
+ * @property {number[]} firstPaint           Represents the time when the user agent first rendered after navigation.
+ * @property {number[]} domContentLoaded     Represents the time immediately after the document's DOMContentLoaded event completes.
+ * @property {number[]} loaded               Represents the time when the load event of the current document is completed.
+ * @property {number[]} firstContentfulPaint Represents the time when the browser first renders any text or media.
+ * @property {number[]} firstBlock           Represents the time when Puppeteer first sees a block selector in the DOM.
+ * @property {number[]} type                 Average type time.
+ * @property {number[]} focus                Average block selection time.
+ * @property {number[]} inserterOpen         Average time to open global inserter.
+ * @property {number[]} inserterSearch       Average time to search the inserter.
+ * @property {number[]} inserterHover        Average time to move mouse between two block item in the inserter.
  */
 
 /**
  * @typedef WPPerformanceResults
  *
- * @property {number=} load              Load Time.
- * @property {number=} type              Average type time.
- * @property {number=} minType           Minium type time.
- * @property {number=} maxType           Maximum type time.
- * @property {number=} focus             Average block selection time.
- * @property {number=} minFocus          Min block selection time.
- * @property {number=} maxFocus          Max block selection time.
- * @property {number=} inserterOpen      Average time to open global inserter.
- * @property {number=} minInserterOpen   Min time to open global inserter.
- * @property {number=} maxInserterOpen   Max time to open global inserter.
- * @property {number=} inserterSearch    Average time to open global inserter.
- * @property {number=} minInserterSearch Min time to open global inserter.
- * @property {number=} maxInserterSearch Max time to open global inserter.
- * @property {number=} inserterHover     Average time to move mouse between two block item in the inserter.
- * @property {number=} minInserterHover  Min time to move mouse between two block item in the inserter.
- * @property {number=} maxInserterHover  Max time to move mouse between two block item in the inserter.
+ * @property {number=} serverResponse       Represents the time the server takes to respond.
+ * @property {number=} firstPaint           Represents the time when the user agent first rendered after navigation.
+ * @property {number=} domContentLoaded     Represents the time immediately after the document's DOMContentLoaded event completes.
+ * @property {number=} loaded               Represents the time when the load event of the current document is completed.
+ * @property {number=} firstContentfulPaint Represents the time when the browser first renders any text or media.
+ * @property {number=} firstBlock           Represents the time when Puppeteer first sees a block selector in the DOM.
+ * @property {number=} type                 Average type time.
+ * @property {number=} minType              Minium type time.
+ * @property {number=} maxType              Maximum type time.
+ * @property {number=} focus                Average block selection time.
+ * @property {number=} minFocus             Min block selection time.
+ * @property {number=} maxFocus             Max block selection time.
+ * @property {number=} inserterOpen         Average time to open global inserter.
+ * @property {number=} minInserterOpen      Min time to open global inserter.
+ * @property {number=} maxInserterOpen      Max time to open global inserter.
+ * @property {number=} inserterSearch       Average time to open global inserter.
+ * @property {number=} minInserterSearch    Min time to open global inserter.
+ * @property {number=} maxInserterSearch    Max time to open global inserter.
+ * @property {number=} inserterHover        Average time to move mouse between two block item in the inserter.
+ * @property {number=} minInserterHover     Min time to move mouse between two block item in the inserter.
+ * @property {number=} maxInserterHover     Max time to move mouse between two block item in the inserter.
  */
 
 /**
@@ -105,7 +115,12 @@ function formatTime( number ) {
  */
 function curateResults( results ) {
 	return {
-		load: average( results.load ),
+		serverResponse: average( results.serverResponse ),
+		firstPaint: average( results.firstPaint ),
+		domContentLoaded: average( results.domContentLoaded ),
+		loaded: average( results.loaded ),
+		firstContentfulPaint: average( results.firstContentfulPaint ),
+		firstBlock: average( results.firstBlock ),
 		type: average( results.type ),
 		minType: Math.min( ...results.type ),
 		maxType: Math.max( ...results.type ),
@@ -314,7 +329,16 @@ async function runPerformanceTests( branches, options ) {
 		for ( const branch of branches ) {
 			const medians = mapValues(
 				{
-					load: rawResults.map( ( r ) => r[ branch ].load ),
+					serverResponse: rawResults.map( ( r ) => r.serverResponse ),
+					firstPaint: rawResults.map( ( r ) => r.firstPaint ),
+					domContentLoaded: rawResults.map(
+						( r ) => r.domContentLoaded
+					),
+					loaded: rawResults.map( ( r ) => r.loaded ),
+					firstContentfulPaint: rawResults.map(
+						( r ) => r.firstContentfulPaint
+					),
+					firstBlock: rawResults.map( ( r ) => r.firstBlock ),
 					type: rawResults.map( ( r ) => r[ branch ].type ),
 					minType: rawResults.map( ( r ) => r[ branch ].minType ),
 					maxType: rawResults.map( ( r ) => r[ branch ].maxType ),
@@ -359,6 +383,11 @@ async function runPerformanceTests( branches, options ) {
 
 	// 5- Formatting the results.
 	log( '\n>> 🎉 Results.\n' );
+
+	log(
+		'\nPlease note that client side metrics EXCLUDE the server response time.\n'
+	);
+
 	for ( const testSuite of testSuites ) {
 		log( `\n>> ${ testSuite }\n` );
 

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -6,7 +6,7 @@ Performance is a key feature for editor applications and the Block editor is not
 
 To ensure the block editor stays performant across releases and development, we monitor some key metrics using [performance testing](/docs/contributors/code/testing-overview.md#performance-testing).
 
-**Loading Time:** The time it takes to load an editor page.
+**Loading Time:** The time it takes to load an editor page. This includes time the server takes to respond, times to first paint, first contentful paint, DOM content load complete, load complete and first block render.
 **Typing Time:** The time it takes for the browser to respond while typing on the editor.
 **Block Selection Time:** The time it takes for the browser to respond after a user selects block. (Inserting a block is also equivalent to selecting a block. Monitoring the selection is sufficient to cover both metrics).
 

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -29,7 +29,12 @@ class PerformanceReporter {
 
 		const results = readFileSync( filepath, 'utf8' );
 		const {
-			load,
+			serverResponse,
+			firstPaint,
+			domContentLoaded,
+			loaded,
+			firstContentfulPaint,
+			firstBlock,
 			type,
 			focus,
 			inserterOpen,
@@ -37,11 +42,26 @@ class PerformanceReporter {
 			inserterSearch,
 		} = JSON.parse( results );
 
-		if ( load && load.length ) {
+		if ( serverResponse && serverResponse.length ) {
 			// eslint-disable-next-line no-console
 			console.log( `
 ${ title( 'Loading Time:' ) }
-Average time to load: ${ success( round( average( load ) ) + 'ms' ) }` );
+Average time to server response (subtracted from client side metrics): ${ success(
+				round( average( serverResponse ) ) + 'ms'
+			) }
+Average time to first paint: ${ success(
+				round( average( firstPaint ) ) + 'ms'
+			) }
+Average time to DOM content load: ${ success(
+				round( average( domContentLoaded ) ) + 'ms'
+			) }
+Average time to load: ${ success( round( average( loaded ) ) + 'ms' ) }
+Average time to first contentful paint: ${ success(
+				round( average( firstContentfulPaint ) ) + 'ms'
+			) }
+Average time to first block: ${ success(
+				round( average( firstBlock ) ) + 'ms'
+			) }` );
 		}
 
 		if ( type && type.length ) {

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -26,13 +26,19 @@ import {
 	getClickEventDurations,
 	getHoverEventDurations,
 	getSelectionEventDurations,
+	getLoadingDurations,
 } from './utils';
 
 jest.setTimeout( 1000000 );
 
 describe( 'Post Editor Performance', () => {
 	const results = {
-		load: [],
+		serverResponse: [],
+		firstPaint: [],
+		domContentLoaded: [],
+		loaded: [],
+		firstContentfulPaint: [],
+		firstBlock: [],
 		type: [],
 		focus: [],
 		inserterOpen: [],
@@ -90,10 +96,23 @@ describe( 'Post Editor Performance', () => {
 		// Measuring loading time
 		let i = 5;
 		while ( i-- ) {
-			const startTime = new Date();
 			await page.reload();
 			await page.waitForSelector( '.wp-block' );
-			results.load.push( new Date() - startTime );
+			const {
+				serverResponse,
+				firstPaint,
+				domContentLoaded,
+				loaded,
+				firstContentfulPaint,
+				firstBlock,
+			} = await getLoadingDurations();
+
+			results.serverResponse.push( serverResponse );
+			results.firstPaint.push( firstPaint );
+			results.domContentLoaded.push( domContentLoaded );
+			results.loaded.push( loaded );
+			results.firstContentfulPaint.push( firstContentfulPaint );
+			results.firstBlock.push( firstBlock );
 		}
 	} );
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -20,7 +20,12 @@ import {
  * Internal dependencies
  */
 import { siteEditor } from '../../experimental-features';
-import { readFile, deleteFile, getTypingEventDurations } from './utils';
+import {
+	readFile,
+	deleteFile,
+	getTypingEventDurations,
+	getLoadingDurations,
+} from './utils';
 
 jest.setTimeout( 1000000 );
 
@@ -39,7 +44,12 @@ describe( 'Site Editor Performance', () => {
 
 	it( 'Loading', async () => {
 		const results = {
-			load: [],
+			serverResponse: [],
+			firstPaint: [],
+			domContentLoaded: [],
+			loaded: [],
+			firstContentfulPaint: [],
+			firstBlock: [],
 			type: [],
 			focus: [],
 			inserterOpen: [],
@@ -78,14 +88,26 @@ describe( 'Site Editor Performance', () => {
 
 		// Measuring loading time
 		while ( i-- ) {
-			const startTime = new Date();
 			await page.reload();
 			await page.waitForSelector( '.edit-site-visual-editor', {
 				timeout: 120000,
 			} );
 			await canvas().waitForSelector( '.wp-block', { timeout: 120000 } );
+			const {
+				serverResponse,
+				firstPaint,
+				domContentLoaded,
+				loaded,
+				firstContentfulPaint,
+				firstBlock,
+			} = await getLoadingDurations();
 
-			results.load.push( new Date() - startTime );
+			results.serverResponse.push( serverResponse );
+			results.firstPaint.push( firstPaint );
+			results.domContentLoaded.push( domContentLoaded );
+			results.loaded.push( loaded );
+			results.firstContentfulPaint.push( firstContentfulPaint );
+			results.firstBlock.push( firstBlock );
 		}
 
 		// Measuring typing performance inside the post content.

--- a/packages/e2e-tests/specs/performance/utils.js
+++ b/packages/e2e-tests/specs/performance/utils.js
@@ -81,3 +81,35 @@ export function getHoverEventDurations( trace ) {
 		getEventDurationsForType( trace, isMouseOutEvent ),
 	];
 }
+
+export async function getLoadingDurations() {
+	return await page.evaluate( () => {
+		const [
+			{
+				requestStart,
+				responseStart,
+				responseEnd,
+				domContentLoadedEventEnd,
+				loadEventEnd,
+			},
+		] = performance.getEntriesByType( 'navigation' );
+		const paintTimings = performance.getEntriesByType( 'paint' );
+		return {
+			// Server side metric.
+			serverResponse: responseStart - requestStart,
+			// For client side metrics, consider the end of the response (the
+			// browser receives the HTML) as the start time (0).
+			firstPaint:
+				paintTimings.find( ( { name } ) => name === 'first-paint' )
+					.startTime - responseEnd,
+			domContentLoaded: domContentLoadedEventEnd - responseEnd,
+			loaded: loadEventEnd - responseEnd,
+			firstContentfulPaint:
+				paintTimings.find(
+					( { name } ) => name === 'first-contentful-paint'
+				).startTime - responseEnd,
+			// This is evaluated right after Puppeteer found the block selector.
+			firstBlock: performance.now() - responseEnd,
+		};
+	} );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Adds more detailed loading metrics. Currently it's hard to measure any improvements made without seeing more fine grained results.

|Metric|Description|
|-|-|
|**Server response**|Represents the time the server takes to respond: from the moment the browser requests the page from the server until the first byte is received. See [`requestStart`](https://w3c.github.io/navigation-timing/#dom-performancetiming-requeststart) and [`responseStart`](https://w3c.github.io/navigation-timing/#dom-performancetiming-responsestart).|
||Client side metrics start from the moment the last byte is received. See [`responseEnd`](https://w3c.github.io/navigation-timing/#dom-performancetiming-responseend).|
|**First paint**| Represents the time when the user agent first rendered after navigation. This excludes the default background paint, but includes non-default background paint and the enclosing box of an iframe. This is the first key moment developers care about in page load – when the user agent has started to render the page. See ["first paint".](https://w3c.github.io/paint-timing/#first-paint)|
|**DOM content loaded**|Represents the time immediately after the document's `DOMContentLoaded` event completes. See [`domContentLoadedEventEnd`](https://w3c.github.io/navigation-timing/#dom-performancetiming-domcontentloadedeventend). ([The `DOMContentLoaded` event fires when the initial HTML document has been completely loaded and parsed, without waiting for stylesheets, images, and subframes to finish loading.](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event))|
|**Loaded**|Represents the time when the load event of the current document is completed. See [`loadEventEnd`](https://w3c.github.io/navigation-timing/#dom-performancetiming-loadeventend). ([The `load` event is fired when the whole page has loaded, including all dependent resources such as stylesheets and images.](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event))|
|**First Contentful Paint**|Represents the time when the browser first renders any text or media. See ["contentful"](https://w3c.github.io/paint-timing/#contentful).|
|**First block**|Represents the time when Puppeteer first sees a block selector in the DOM. This was our previous "load" metric.|

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Check the performance job.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
