### PR TITLE
Try: Fix notices below block toolbars.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -114,10 +114,6 @@ $z-layers: (
 	// Show the FSE template previews above the editor and any open block toolbars
 	".edit-site-navigation-panel__preview": 32,
 
-	// Show notices below expanded editor bar
-	// .edit-post-header { z-index: 30 }
-	".components-notice-list": 29,
-
 	// Above the block list and the header.
 	".block-editor-block-list__block-popover": 31,
 

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -76,7 +76,6 @@
 	// The notice should never be wider than the viewport, or the close button might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 	box-sizing: border-box;
-	z-index: z-index(".components-notice-list");
 
 	.components-notice__content {
 		margin-top: $grid-unit-15;

--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -1,22 +1,12 @@
-// Dismissible notices.
-.components-editor-notices__dismissible {
-	position: sticky;
-	top: 0;
-	right: 0;
-	color: $gray-900;
-}
-
-// Non-dismissible notices.
+// Dismissible & non-dismissible notices.
+.components-editor-notices__dismissible,
 .components-editor-notices__pinned {
 	position: relative;
 	left: 0;
 	top: 0;
 	right: 0;
 	color: $gray-900;
-}
 
-.components-editor-notices__dismissible,
-.components-editor-notices__pinned {
 	.components-notice {
 		box-sizing: border-box;
 		margin: 0;


### PR DESCRIPTION
## Description
Fixes #32000.

Notices overlap block toolbars, both classic and others.

I went in thinking this would be an easy z-index fix. However it is not, because the z-index for the top toolbar is 30, the z-index for popovers is intentionally 31 (so you can have menus extending from the top toolbar), and block toolbars are in the popover container. So just make the notice z-index 32 right? Cool but then it would cover the and cause other weird issues:

<img width="1249" alt="Screenshot 2021-05-26 at 16 11 55" src="https://user-images.githubusercontent.com/1204802/119677398-face3580-be3e-11eb-914a-9d8bba68b4da.png">

So this PR removes the need for a z-index in the first place, and leverages the fact that the notices push the content down:

![nonsticky](https://user-images.githubusercontent.com/1204802/119677646-2fda8800-be3f-11eb-896e-59db56094e7e.gif)

The casualty is that dismissible notices are no longer sticky (i.e. they no longer scroll with you down the page). But honestly I think that's an upgrade.

## How has this been tested?

Open the post editor, add some content. Then force reload the page, hopefully you should get a notice. 

Now add some content and select a block, then scroll. No toolbars should overlap the notice.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
