### PR TITLE
Workflows: Performance: Run suite atop latest stable major WordPress version

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -55,5 +55,5 @@ jobs:
                   PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
                   WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
-                  WP_BRANCH="wp/${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf --ci "$WP_BRANCH" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_BRANCH"
+                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
+                  ./bin/plugin/cli.js perf --ci "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_MAJOR"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -56,4 +56,4 @@ jobs:
                   WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_BRANCH="wp/${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf --ci "$WP_BRANCH" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch "$WP_BRANCH"
+                  ./bin/plugin/cli.js perf --ci "$WP_BRANCH" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_BRANCH"

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -62,6 +62,10 @@ program
 		'--tests-branch <branch>',
 		"Use this branch's performance test files"
 	)
+	.option(
+		'--wp-version <version>',
+		'Specify a WordPress version on which to test all branches'
+	)
 	.description(
 		'Runs performance tests on two separate branches and outputs the result'
 	)

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+const fs = require( 'fs' );
 const path = require( 'path' );
 const { pickBy, mapValues } = require( 'lodash' );
 
@@ -269,7 +270,7 @@ async function runPerformanceTests( branches, options ) {
 		//     5.7.0 -> 5.7   (changed)
 		//     5.7.2 -> 5.7.2 (unchanged)
 		const zipVersion = options.wpVersion.replace( /^(\d+\.\d+).0/, '$1' );
-		const zipUrl = `https:\\/\\/wordpress.org\\/wordpress-${ zipVersion }.zip`;
+		const zipUrl = `https://wordpress.org/wordpress-${ zipVersion }.zip`;
 
 		log( `Using WordPress version ${ zipVersion }` );
 
@@ -280,8 +281,12 @@ async function runPerformanceTests( branches, options ) {
 		//         "core": "https://wordpress.org/wordpress-$VERSION.zip",
 		//         ...
 		//     }
-		await runShellScript(
-			`sed -I '' -e '/"core":/s/WordPress\\/WordPress/${ zipUrl }/' "${ environmentDirectory }/.wp-env.json"`
+		const confPath = `${ environmentDirectory }/.wp-env.json`;
+		const conf = { ...readJSONFile( confPath ), core: zipUrl };
+		await fs.writeFileSync(
+			confPath,
+			JSON.stringify( conf, null, 2 ),
+			'utf8'
 		);
 	}
 	await runShellScript( 'npm run wp-env start', environmentDirectory );

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -262,17 +262,24 @@ async function runPerformanceTests( branches, options ) {
 
 	log( '>> Starting the WordPress environment' );
 	if ( options.wpVersion ) {
-		// Patch the environment's .wp-env.json config to use the specified WP version:
+		// In order to match the topology of ZIP files at wp.org, remap .0
+		// patch versions to major versions:
+		//
+		//     5.7   -> 5.7   (unchanged)
+		//     5.7.0 -> 5.7   (changed)
+		//     5.7.2 -> 5.7.2 (unchanged)
+		const zipVersion = options.wpVersion.replace( /^(\d+\.\d+).0/, '$1' );
+		const zipUrl = `https:\\/\\/wordpress.org\\/wordpress-${ zipVersion }.zip`;
+
+		log( `Using WordPress version ${ zipVersion }` );
+
+		// Patch the environment's .wp-env.json config to use the specified WP
+		// version:
 		//
 		//     {
-		//         "core": "https://wordpress.org/wordpress-$VERSION",
+		//         "core": "https://wordpress.org/wordpress-$VERSION.zip",
 		//         ...
 		//     }
-		//
-		// Only use the major version, i.e. 5.7.2 becomes 5.7.
-		const major = options.wpVersion.split( '.' ).slice( 0, 2 ).join( '.' );
-		const zipUrl = `https:\\/\\/wordpress.org\\/wordpress-${ major }.zip`;
-		log( `Using WordPress version ${ major }` );
 		await runShellScript(
 			`sed -I '' -e '/"core":/s/WordPress\\/WordPress/${ zipUrl }/' "${ environmentDirectory }/.wp-env.json"`
 		);


### PR DESCRIPTION
Potential alternative to #32277 

## Description

Right now [our _Run performance test_ GitHub Action is failing](https://github.com/WordPress/gutenberg/runs/2676154517?check_suite_focus=true), presumably because it is trying to run Gutenberg's performance test suite on top of WordPress trunk. Since we have just ported all WP5.8-related pieces to WordPress trunk (#31322), the Gutenberg plugin is temporarily in a state of conflict with WordPress trunk.

~This PR simply changes the default setting in our `.wp-env.json` configuration so that it will prefer to run on whichever is the latest stable release of WordPress (as of today, `5.7.x`). I thought this might be a saner and more stable configuration anyway, regardless of performance testing.~

This PR:
* adds a `--wp-version` option to the `performance-tests` CLI command
* updates the performance tests workflow to explicitly use the latest stable major version of WordPress as `--wp-version`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
