### PR TITLE
Limit latest posts featured image width to 100%

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -57,6 +57,7 @@
 	img {
 		height: auto;
 		width: auto;
+		max-width: 100%;
 	}
 	&.alignleft {
 		/*rtl:ignore*/


### PR DESCRIPTION
Currently, Gutenberg doesn't limit the width of featured images within the Latest Posts block. This causes overflow in the site editor, and in the front end (if a theme doesn't include a `img { max-width: 100% }` style rule:

<img width="751" alt="Screen Shot 2021-05-26 at 2 02 37 PM" src="https://user-images.githubusercontent.com/1202812/119710126-02381380-be2c-11eb-972c-4758e1357aab.png">

This PR limits the max-width of those images to `100%`. 

Before|After
---|---
<img width="896" alt="Screen Shot 2021-05-26 at 2 06 30 PM" src="https://user-images.githubusercontent.com/1202812/119710175-0fed9900-be2c-11eb-9c4c-eab5dca28eeb.png">|<img width="896" alt="Screen Shot 2021-05-26 at 2 08 36 PM" src="https://user-images.githubusercontent.com/1202812/119710177-10862f80-be2c-11eb-8b73-8c23f07c9718.png">

---

Testing: 

1. In the site editor, add a Latest Posts block
2. Set it to Grid view. 
3. Choose "Display featured image"
4. Set the image size to "Large"
5. Ensure that the image doesn't expand beyond the column.