### PR TITLE
Fix legacy widget previews

### DIFF
--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -7,12 +7,30 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Preview( { idBase, instance, isVisible } ) {
-	const [ iframeHeight, setIframeHeight ] = useState( null );
+	const [ iframeHeight, setIframeHeight ] = useState();
+	const [ iframeContentDocument, setIframeContentDocument ] = useState();
+
+	useEffect( () => {
+		const intervalId = setInterval( () => {
+			if (
+				iframeContentDocument &&
+				iframeContentDocument.body.scrollHeight > 0
+			) {
+				setIframeHeight( iframeContentDocument.body.scrollHeight );
+				clearInterval( intervalId );
+			}
+		}, 100 );
+
+		return () => {
+			clearInterval( intervalId );
+		};
+	}, [ iframeContentDocument ] );
+
 	return (
 		<>
 			{ /*
@@ -55,8 +73,8 @@ export default function Preview( { idBase, instance, isVisible } ) {
 						} ) }
 						height={ iframeHeight ?? 100 }
 						onLoad={ ( event ) => {
-							setIframeHeight(
-								event.target.contentDocument.body.scrollHeight
+							setIframeContentDocument(
+								event.target.contentDocument
 							);
 						} }
 					/>

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -85,7 +85,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 								instance,
 							},
 						} ) }
-						height={ iframeHeight ?? 100 }
+						height={ iframeHeight || 100 }
 					/>
 				</Disabled>
 			</div>


### PR DESCRIPTION
## Description
Closes #31935
Addresses half of #31960

The problem was that the code that dynamically resizes preview iframes didn't take into account that all but the first widget area is collapsed when loading the screen. The height was resolving to `0` in those collapsed widget areas and not being recalculated when the widget area expanded.

This PR does a couple of things:
- Use an IntersectionObserver to calculate height when an iframe becomes visible (yay! No IE11)
- Adjust the height calculation to solve another issue where previews were being cut-off at the bottom

## How has this been tested?
1. Use a theme with enough widget areas
2. Add a legacy widget to an area that's not the first and save
3. Reload
4. Expand the widget area with the legacy widget, the preview should be displayed

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
