### PR TITLE
Fix the visible widget area toolbar

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -14,7 +14,8 @@
 		"inserter": false,
 		"customClassName": false,
 		"reusable": false,
-		"__experimentalToolbar": false
+		"__experimentalToolbar": false,
+		"__experimentalParentSelector": false
 	},
 	"editorStyle": "wp-block-widget-area-editor",
 	"style": "wp-block-widget-area"

--- a/packages/edit-widgets/src/blocks/widget-area/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/index.js
@@ -16,9 +16,5 @@ export const settings = {
 	title: __( 'Widget Area' ),
 	description: __( 'A widget area container.' ),
 	__experimentalLabel: ( { name: label } ) => label,
-	supports: {
-		// Should show the parent selector for its children or not. Defaults to true.
-		__experimentalParentSelector: false,
-	},
 	edit,
 };


### PR DESCRIPTION
## Description
Fixes #26261
Fixes #31889
Fixes #31959

Widget area toolbars are not supposed to be visible as per the `__experimentalToolbar` support setting.

The problem was the block `supports` property was defined differently in two places, both the block.json and index.js, the index.js was overwriting the block.json.

So the fix was pretty simple, just consolidate the two in the block.json.

## How has this been tested?
1. Select a widget area.
2. The block toolbar shouldn't be displayed

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
