### PR TITLE
Try: Remove opacity animation on canvas.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -220,8 +220,6 @@ export default function VisualEditor( { styles } ) {
 							<AnimatePresence>
 								<motion.div
 									key={ isTemplateMode ? 'template' : 'post' }
-									initial={ { opacity: 0 } }
-									animate={ { opacity: 1 } }
 								>
 									<WritingFlow>
 										{ ! isTemplateMode && (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 /**
  * WordPress dependencies
@@ -217,34 +217,28 @@ export default function VisualEditor( { styles } ) {
 									layout={ defaultLayout }
 								/>
 							) }
-							<AnimatePresence>
-								<motion.div
-									key={ isTemplateMode ? 'template' : 'post' }
-								>
-									<WritingFlow>
-										{ ! isTemplateMode && (
-											<div className="edit-post-visual-editor__post-title-wrapper">
-												<PostTitle />
-											</div>
-										) }
-										<RecursionProvider>
-											<BlockList
-												__experimentalLayout={
-													themeSupportsLayout
-														? {
-																type: 'default',
-																// Find a way to inject this in the support flag code (hooks).
-																alignments: themeSupportsLayout
-																	? alignments
-																	: undefined,
-														  }
-														: undefined
-												}
-											/>
-										</RecursionProvider>
-									</WritingFlow>
-								</motion.div>
-							</AnimatePresence>
+							<WritingFlow>
+								{ ! isTemplateMode && (
+									<div className="edit-post-visual-editor__post-title-wrapper">
+										<PostTitle />
+									</div>
+								) }
+								<RecursionProvider>
+									<BlockList
+										__experimentalLayout={
+											themeSupportsLayout
+												? {
+														type: 'default',
+														// Find a way to inject this in the support flag code (hooks).
+														alignments: themeSupportsLayout
+															? alignments
+															: undefined,
+												  }
+												: undefined
+										}
+									/>
+								</RecursionProvider>
+							</WritingFlow>
 						</MaybeIframe>
 					</motion.div>
 				</motion.div>


### PR DESCRIPTION
## Description

The animation that's added to the canvas when switching viewport size is great:

![hey](https://user-images.githubusercontent.com/1204802/119793993-64018780-bed7-11eb-9e4f-4317aa1c68f8.gif)

It's smooth, snappy, and just wonderful.

However there's also an opacity fade-in when the page initially loads; I'm less a fan of that:

- It makes it feel like you need to wait before you can get started. Even if it's just milliseconds.
- The fade is choppy on long documents.

Here's how it looks on a very long document for me:

https://user-images.githubusercontent.com/1204802/119794194-9b703400-bed7-11eb-837d-b49636ba0ef7.mov

This PR removes that opacity, and it immediately feels a bit snappier to me:

https://user-images.githubusercontent.com/1204802/119794278-ad51d700-bed7-11eb-92e8-46347fa19815.mov

## How has this been tested?

Check out the PR, then reload a long document in the post editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
