### PR TITLE
Lock the document from scrolling when the modal is open.

### DIFF
--- a/packages/block-library/src/navigation/frontend.js
+++ b/packages/block-library/src/navigation/frontend.js
@@ -14,6 +14,10 @@ function navigationToggleModal( modal ) {
 	triggerButton.setAttribute( 'aria-expanded', ! isHidden );
 	closeButton.setAttribute( 'aria-expanded', ! isHidden );
 	modal.classList.toggle( 'has-modal-open', ! isHidden );
+
+	// Add a class to indicate the modal is open.
+	const toggleClass = ( el, className ) => el.classList.toggle( className );
+	toggleClass( document.querySelector( 'html' ), 'has-modal-open' );
 }
 
 MicroModal.init( {

--- a/packages/block-library/src/navigation/frontend.js
+++ b/packages/block-library/src/navigation/frontend.js
@@ -16,8 +16,8 @@ function navigationToggleModal( modal ) {
 	modal.classList.toggle( 'has-modal-open', ! isHidden );
 
 	// Add a class to indicate the modal is open.
-	const toggleClass = ( el, className ) => el.classList.toggle( className );
-	toggleClass( document.querySelector( 'html' ), 'has-modal-open' );
+	const htmlElement = document.querySelector( 'html' );
+	htmlElement.classList.toggle( 'has-modal-open' );
 }
 
 MicroModal.init( {


### PR DESCRIPTION
## Description

Fixes #32206.

This PR applies a classname to the HTML element when the navigation burger menu is open.

This code was actually in the responsive navigation branch, [here](https://github.com/WordPress/gutenberg/commit/3b9126e843276ee4b47dad6a1be3be91d65fd7d3), but appears to have gotten lost along the way. The CSS to lock it from scrolling is [still present](https://github.com/WordPress/gutenberg/commit/2d473e19b731a214c9158efd19088b10abe6fece).

I could use a sanity check on the JS, but I think it should be good.

![scrollock](https://user-images.githubusercontent.com/1204802/119803111-71bb0b00-bedf-11eb-864a-c0e4ef44c325.gif)

## How has this been tested?

Insert a navigation menu and toggle responsive. Also insert enough content so that there's a scrollbar. Then preview or publish and view the frontend, resize the viewport below 600px, then open the menu. When the menu is open, the content underneath should not scroll.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
