### PR TITLE
Gallery refactor - Infer version from existing content

### DIFF
--- a/packages/block-library/src/gallery/edit-wrapper.js
+++ b/packages/block-library/src/gallery/edit-wrapper.js
@@ -23,10 +23,12 @@ export default function GalleryEditWrapper( props ) {
 		return settings.__experimentalGalleryRefactor;
 	}, [] );
 
+	const hasNewVersionContent = !! attributes?.imageCount;
+	const hasOldVersionContent =
+		0 < attributes?.ids?.length || 0 < attributes?.images?.length;
 	if (
-		! __experimentalGalleryRefactor ||
-		attributes?.ids?.length > 0 ||
-		attributes?.images?.length > 0
+		hasOldVersionContent ||
+		( ! hasNewVersionContent && ! __experimentalGalleryRefactor )
 	) {
 		return <GalleryEditV1 { ...props } />;
 	}

--- a/packages/block-library/src/gallery/edit-wrapper.js
+++ b/packages/block-library/src/gallery/edit-wrapper.js
@@ -23,6 +23,9 @@ export default function GalleryEditWrapper( props ) {
 		return settings.__experimentalGalleryRefactor;
 	}, [] );
 
+	// This logic is used to infer version information from content with higher
+	// precedence than the flag. New galleries (and existing empty galleries) will
+	// honor the flag.
 	const hasNewVersionContent = !! attributes?.imageCount;
 	const hasOldVersionContent =
 		0 < attributes?.ids?.length || 0 < attributes?.images?.length;


### PR DESCRIPTION
## Description
The current edit wrapper function gives precedence to the experimental flag over compatibility inferred from content when encountering content with the new format. This can result in hidden content within the editor, and potential loss if a user turns the feature off, and edits content that was created with it on. This PR adds additional logic to also infer when content is encountered with the _new_ format, similar to the fallback mechanism for older content when the flag is on.

## How has this been tested?
* Turn on the refactor gallery experiment
* Add a new gallery with some images to a post or page
* Observe that it is using the new implementation (with inner image blocks)
* Save the post or page
* Turn off the refactor gallery experiment
* Re-open the post or page with the refactored gallery content
  * The gallery content should still be present
* Add 1 more image to the gallery (which looks empty)
  * The images added earlier should remain in the gallery

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
