### PR TITLE
Docs: Fix broken contributors readme files

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -39,7 +39,7 @@ function gutenberg_wordpress_version_notice() {
  */
 function gutenberg_build_files_notice() {
 	echo '<div class="error"><p>';
-	_e( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/getting-started.md">contributing</a> file for more information.', 'gutenberg' );
+	_e( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/getting-started-with-code-contribution.md">contributing</a> file for more information.', 'gutenberg' );
 	echo '</p></div>';
 }
 

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -1,6 +1,6 @@
 # Enforce dependencies docblocks formatting (dependency-group)
 
-Ensures that all top-level package imports adhere to the dependencies grouping conventions as outlined in the [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/coding-guidelines.md#imports).
+Ensures that all top-level package imports adhere to the dependencies grouping conventions as outlined in the [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/coding-guidelines.md#imports).
 
 Specifically, this ensures that:
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-wp-apis.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-wp-apis.md
@@ -3,7 +3,7 @@
 Prevent unsafe APIs from `@wordpress/*` packages from being imported.
 
 This includes experimental and unstable APIs which are expected to change and likely to cause issues in application code.
-See the [documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/coding-guidelines.md#experimental-and-unstable-apis).
+See the [documentation](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/coding-guidelines.md#experimental-and-unstable-apis).
 
 > **There is no support commitment for experimental and unstable APIs.** They can and will be removed or changed without advance warning, including as part of a minor or patch release. As an external consumer, you should avoid these APIs.
 > …

--- a/packages/project-management-automation/lib/tasks/add-milestone/README.md
+++ b/packages/project-management-automation/lib/tasks/add-milestone/README.md
@@ -8,4 +8,4 @@ Creates the milestone if it does not yet exist.
 
 If a pull request is merged, it can be difficult to know which upcoming or past plugin version that change would be included within. This is useful for debugging if a change should be expected to be available for testing, and to know if a change should be anticipated to be released within an upcoming release of the plugin.
 
-It is also used in automation associated with [release changelogs](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/release.md#writing-the-release-post-and-changelog), which aggregate pull requests based on the assigned milestone.
+It is also used in automation associated with [release changelogs](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/release.md#writing-the-release-notes-and-post), which aggregate pull requests based on the assigned milestone.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
This PR fixes the broken links to code contributors related readme files.
<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The `contributing` link in the Gutenberg build files notice is broken leading to a 404 page on Github. 
This PR updates this link and also other documentation files linking to contributor related md files:
- [eslint-plugin/docs/rules/dependency-group.md](https://github.com/WordPress/gutenberg/blob/fb7cb485b48bd021c8010785ca838837edfc520c/packages/eslint-plugin/docs/rules/dependency-group.md): `Coding Guidelines` link
- [packages/eslint-plugin/docs/rules/no-unsafe-wp-apis.md](https://github.com/WordPress/gutenberg/blob/fb7cb485b48bd021c8010785ca838837edfc520c/packages/eslint-plugin/docs/rules/no-unsafe-wp-apis.md): `See the documentation.` link
- [packages/project-management-automation/lib/tasks/add-milestone/README.md](https://github.com/WordPress/gutenberg/blob/fb7cb485b48bd021c8010785ca838837edfc520c/packages/project-management-automation/lib/tasks/add-milestone/README.md): `release changelogs` link

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- clone the Gutenberg fork to '/plugins'
- got to `SITE_URL/wp-admin/plugins.php` and see the Gutenberg build files notice
- click the `contributing` link and see the Getting Started With Code Contribution page on Github

## Screenshots <!-- if applicable -->
The build file notice is the first place where the broken link was noticed
<img width="1727" alt="Screenshot 2021-05-27 at 11 47 45" src="https://user-images.githubusercontent.com/1628454/119811511-797ead80-bee7-11eb-9f79-feec0fd7fbcd.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
