### PR TITLE
List Block: Add typography styles to theme.json

### DIFF
--- a/packages/block-library/src/list/deprecated.js
+++ b/packages/block-library/src/list/deprecated.js
@@ -8,7 +8,7 @@
   */
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
- const blockAttributes = {
+const blockAttributes = {
 	ordered: {
 		type: 'boolean',
 		default: false,

--- a/packages/block-library/src/list/deprecated.js
+++ b/packages/block-library/src/list/deprecated.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+
+
+ /**
+  * WordPress dependencies
+  */
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+ const blockAttributes = {
+	ordered: {
+		type: 'boolean',
+		default: false,
+		__experimentalRole: 'content'
+		},
+	values: {
+		type: 'string',
+		source: 'html',
+		selector: 'ol,ul',
+		multiline: 'li',
+		__unstableMultilineWrapperTags: [ 'ol', 'ul' ],
+		default: '',
+		__experimentalRole: 'content'
+	},
+	type: {
+		type: 'string'
+	},
+	start: {
+		type: 'number'
+	},
+	reversed: {
+		type: 'boolean'
+	},
+	placeholder: {
+		type: 'string'
+	}
+ };
+
+ const deprecated = [
+	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
+			const { ordered, values, type, reversed, start } = attributes;
+			const TagName = ordered ? 'ol' : 'ul';
+
+			return (
+				<TagName { ...useBlockProps.save( { type, reversed, start } ) }>
+					<RichText.Content value={ values } multiline="li" />
+				</TagName>
+			);
+		},
+	},
+ ];
+
+ export default deprecated;

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -137,6 +137,7 @@ export default function ListEdit( {
 	return (
 		<>
 			<RichText
+				className="wp-block-list"
 				identifier="values"
 				multiline="li"
 				tagName={ tagName }

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -6,7 +6,7 @@ import { list as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
- import deprecated from './deprecated';
+import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -6,6 +6,7 @@ import { list as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+ import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
@@ -38,4 +39,5 @@ export const settings = {
 	},
 	edit,
 	save,
+	deprecated,
 };


### PR DESCRIPTION
## Description
Following on from https://github.com/WordPress/gutenberg/pull/27510#event-4804558359, this makes it possible to style list blocks via theme.json. This will only work for new blocks that are created, not for previously created ones.

## How has this been tested?
- Using this PR: https://github.com/Automattic/themes/pull/3958
- Update the core/list portion of theme.json for blockbase to be a different font (e.g. Courier)
- Add a list block to the post
- The list block should have the same font family as the rest of the theme
- Checkout this PR
- The list block will still have the default font family
- Reload the editor
- Confirm that the blocks migrate to the new markup
- Conform that the list block now has the new font

## Screenshots <!-- if applicable -->
<img width="601" alt="Screenshot 2021-05-27 at 12 58 37" src="https://user-images.githubusercontent.com/275961/119822174-450cf080-beeb-11eb-8532-0262a1c1d99a.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
