### PR TITLE
Performance Tests Workflow: Use latest WP branch for release tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -56,4 +56,4 @@ jobs:
                   WP_VERSION=$(grep -oP "$TESTED_UP_TO_REGEX" ./readme.txt)
                   IFS='.' read -r -a WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_BRANCH="wp/${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf --ci $WP_BRANCH $PREVIOUS_RELEASE_BRANCH $CURRENT_RELEASE_BRANCH
+                  ./bin/plugin/cli.js perf --ci $WP_BRANCH $PREVIOUS_RELEASE_BRANCH $CURRENT_RELEASE_BRANCH --tests-branch $WP_BRANCH


### PR DESCRIPTION
## Description

Supersedes #32244.

As @youknowriad mentioned in Slack:

> [R]elease perf jobs are breaking https://github.com/WordPress/gutenberg/runs/2676154517?check_suite_focus=true. If I have to guess, I think it's because the base WP install used comes from trunk and the fixes for the conflicts introduced so solve the conflicts are not included in both the previous release's branch and `wp/5.7` branch. Ideal fix would be to rely on the `5.7` (previous wp release) as base branch instead of latest trunk like all the e2e tests jobs.

Turns out the performance script has a `--tests-branch` arg that is already used to set the branch from which we run the WP env for those tests:

https://github.com/WordPress/gutenberg/blob/45e19974643857aea8273888cabf9e428451db0d/.github/workflows/performance.yml#L44

It's used at https://github.com/WordPress/gutenberg/blob/45e19974643857aea8273888cabf9e428451db0d/bin/plugin/commands/performance.js#L231-L241 (and below).

## How has this been tested?
We'll only really know once we release the next GB version.