### PR TITLE
compose: Add types to `useDragging`

### DIFF
--- a/packages/compose/src/hooks/use-dragging/index.js
+++ b/packages/compose/src/hooks/use-dragging/index.js
@@ -8,6 +8,12 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  */
 import useIsomorphicLayoutEffect from '../use-isomorphic-layout-effect';
 
+/**
+ * @param {Object} props
+ * @param {(e: MouseEvent) => void} props.onDragStart
+ * @param {(e: MouseEvent) => void} props.onDragMove
+ * @param {(e: MouseEvent) => void} props.onDragEnd
+ */
 export default function useDragging( { onDragStart, onDragMove, onDragEnd } ) {
 	const [ isDragging, setIsDragging ] = useState( false );
 
@@ -23,22 +29,22 @@ export default function useDragging( { onDragStart, onDragMove, onDragEnd } ) {
 	}, [ onDragStart, onDragMove, onDragEnd ] );
 
 	const onMouseMove = useCallback(
-		( ...args ) =>
+		( /** @type {MouseEvent} */ event ) =>
 			eventsRef.current.onDragMove &&
-			eventsRef.current.onDragMove( ...args ),
+			eventsRef.current.onDragMove( event ),
 		[]
 	);
-	const endDrag = useCallback( ( ...args ) => {
+	const endDrag = useCallback( ( /** @type {MouseEvent} */ event ) => {
 		if ( eventsRef.current.onDragEnd ) {
-			eventsRef.current.onDragEnd( ...args );
+			eventsRef.current.onDragEnd( event );
 		}
 		document.removeEventListener( 'mousemove', onMouseMove );
 		document.removeEventListener( 'mouseup', endDrag );
 		setIsDragging( false );
 	}, [] );
-	const startDrag = useCallback( ( ...args ) => {
+	const startDrag = useCallback( ( /** @type {MouseEvent} */ event ) => {
 		if ( eventsRef.current.onDragStart ) {
-			eventsRef.current.onDragStart( ...args );
+			eventsRef.current.onDragStart( event );
 		}
 		document.addEventListener( 'mousemove', onMouseMove );
 		document.addEventListener( 'mouseup', endDrag );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -18,6 +18,7 @@
 		"src/hooks/use-async-list/**/*",
 		"src/hooks/use-constrained-tabbing/**/*",
 		"src/hooks/use-debounce/**/*",
+		"src/hooks/use-dragging/**/*",
 		"src/hooks/use-copy-on-click/**/*",
 		"src/hooks/use-copy-to-clipboard/**/*",
 		"src/hooks/use-focus-return/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useDragging`. There are no real runtime changes except to explicitly pass through the event parameter instead of using `...args`. Using varargs was not necessary in this case (there's only ever one parameter, the event).

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
