### PR TITLE
compose: Add types to `useDropZone`

### DIFF
--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -8,27 +8,34 @@ import { useRef } from '@wordpress/element';
  */
 import useRefEffect from '../use-ref-effect';
 
-/** @typedef {import('@wordpress/element').RefCallback} RefCallback */
-
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @template T
+ * @param {T} value
+ * @return {import('react').MutableRefObject<T>} A ref with the value.
+ */
 function useFreshRef( value ) {
-	const ref = useRef();
-	ref.current = value;
+	/* eslint-enable jsdoc/valid-types */
+	/* eslint-disable jsdoc/no-undefined-types */
+	/** @type {import('react').MutableRefObject<T>} */
+	/* eslint-enable jsdoc/no-undefined-types */
+	const ref = useRef( value );
 	return ref;
 }
 
 /**
  * A hook to facilitate drag and drop handling.
  *
- * @param {Object}     $1             Named parameters.
- * @param {boolean}    $1.isDisabled  Whether or not to disable the drop zone.
- * @param {DragEvent}  $1.onDragStart Called when dragging has started.
- * @param {DragEvent}  $1.onDragEnter Called when the zone is entered.
- * @param {DragEvent}  $1.onDragOver  Called when the zone is moved within.
- * @param {DragEvent}  $1.onDragLeave Called when the zone is left.
- * @param {MouseEvent} $1.onDragEnd   Called when dragging has ended.
- * @param {DragEvent}  $1.onDrop      Called when dropping in the zone.
+ * @param {Object}     props             Named parameters.
+ * @param {boolean}    props.isDisabled  Whether or not to disable the drop zone.
+ * @param {(e: DragEvent) => void}  props.onDragStart Called when dragging has started.
+ * @param {(e: DragEvent) => void}  props.onDragEnter Called when the zone is entered.
+ * @param {(e: DragEvent) => void}  props.onDragOver  Called when the zone is moved within.
+ * @param {(e: DragEvent) => void}  props.onDragLeave Called when the zone is left.
+ * @param {(e: MouseEvent) => void} props.onDragEnd   Called when dragging has ended.
+ * @param {(e: DragEvent) => void}  props.onDrop      Called when dropping in the zone.
  *
- * @return {RefCallback} Ref callback to be passed to the drop zone element.
+ * @return {import('react').RefCallback<HTMLElement>} Ref callback to be passed to the drop zone element.
  */
 export default function useDropZone( {
 	isDisabled,
@@ -56,7 +63,7 @@ export default function useDropZone( {
 
 			const { ownerDocument } = element;
 
-			function maybeDragStart( event ) {
+			function maybeDragStart( /** @type {DragEvent} */ event ) {
 				if ( isDragging ) {
 					return;
 				}
@@ -73,14 +80,18 @@ export default function useDropZone( {
 				}
 			}
 
-			function onDragEnter( event ) {
+			function onDragEnter( /** @type {DragEvent} */ event ) {
 				event.preventDefault();
 
 				// The `dragenter` event will also fire when entering child
 				// elements, but we only want to call `onDragEnter` when
 				// entering the drop zone, which means the `relatedTarget`
 				// (element that has been left) should be outside the drop zone.
-				if ( element.contains( event.relatedTarget ) ) {
+				if (
+					element.contains(
+						/** @type {Node} */ ( event.relatedTarget )
+					)
+				) {
 					return;
 				}
 
@@ -89,7 +100,7 @@ export default function useDropZone( {
 				}
 			}
 
-			function onDragOver( event ) {
+			function onDragOver( /** @type {DragEvent} */ event ) {
 				// Only call onDragOver for the innermost hovered drop zones.
 				if ( ! event.defaultPrevented && onDragOverRef.current ) {
 					onDragOverRef.current( event );
@@ -100,13 +111,17 @@ export default function useDropZone( {
 				event.preventDefault();
 			}
 
-			function onDragLeave( event ) {
+			function onDragLeave( /** @type {DragEvent} */ event ) {
 				// The `dragleave` event will also fire when leaving child
 				// elements, but we only want to call `onDragLeave` when
 				// leaving the drop zone, which means the `relatedTarget`
 				// (element that has been entered) should be outside the drop
 				// zone.
-				if ( element.contains( event.relatedTarget ) ) {
+				if (
+					element.contains(
+						/** @type {Node} */ ( event.relatedTarget )
+					)
+				) {
 					return;
 				}
 
@@ -115,7 +130,7 @@ export default function useDropZone( {
 				}
 			}
 
-			function onDrop( event ) {
+			function onDrop( /** @type {DragEvent} */ event ) {
 				// Don't handle drop if an inner drop zone already handled it.
 				if ( event.defaultPrevented ) {
 					return;
@@ -138,7 +153,7 @@ export default function useDropZone( {
 				maybeDragEnd( event );
 			}
 
-			function maybeDragEnd( event ) {
+			function maybeDragEnd( /** @type {MouseEvent} */ event ) {
 				if ( ! isDragging ) {
 					return;
 				}
@@ -157,7 +172,7 @@ export default function useDropZone( {
 			element.addEventListener( 'dragover', onDragOver );
 			element.addEventListener( 'dragleave', onDragLeave );
 			// Note that `dragend` doesn't fire consistently for file and HTML
-			// drag  events where the drag origin is outside the browser window.
+			// drag events where the drag origin is outside the browser window.
 			// In Firefox it may also not fire if the originating node is
 			// removed.
 			ownerDocument.addEventListener( 'dragend', maybeDragEnd );

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -26,14 +26,14 @@ function useFreshRef( value ) {
 /**
  * A hook to facilitate drag and drop handling.
  *
- * @param {Object}     props             Named parameters.
- * @param {boolean}    props.isDisabled  Whether or not to disable the drop zone.
- * @param {(e: DragEvent) => void}  props.onDragStart Called when dragging has started.
- * @param {(e: DragEvent) => void}  props.onDragEnter Called when the zone is entered.
- * @param {(e: DragEvent) => void}  props.onDragOver  Called when the zone is moved within.
- * @param {(e: DragEvent) => void}  props.onDragLeave Called when the zone is left.
- * @param {(e: MouseEvent) => void} props.onDragEnd   Called when dragging has ended.
- * @param {(e: DragEvent) => void}  props.onDrop      Called when dropping in the zone.
+ * @param {Object} props Named parameters.
+ * @param {boolean} props.isDisabled Whether or not to disable the drop zone.
+ * @param {(e: DragEvent) => void} props.onDragStart Called when dragging has started.
+ * @param {(e: DragEvent) => void} props.onDragEnter Called when the zone is entered.
+ * @param {(e: DragEvent) => void} props.onDragOver Called when the zone is moved within.
+ * @param {(e: DragEvent) => void} props.onDragLeave Called when the zone is left.
+ * @param {(e: MouseEvent) => void} props.onDragEnd Called when dragging has ended.
+ * @param {(e: DragEvent) => void} props.onDrop Called when dropping in the zone.
  *
  * @return {import('react').RefCallback<HTMLElement>} Ref callback to be passed to the drop zone element.
  */

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -19,7 +19,14 @@ function useFreshRef( value ) {
 	/* eslint-disable jsdoc/no-undefined-types */
 	/** @type {import('react').MutableRefObject<T>} */
 	/* eslint-enable jsdoc/no-undefined-types */
-	const ref = useRef( value );
+	// Disable reason: We're doing something pretty JavaScript-y here where the
+	// ref will always have a current value that is not null or undefined but it
+	// needs to start as undefined. We don't want to change the return type so
+	// it's easier to just ts-ignore this specific line that's complaining about
+	// undefined not being part of T.
+	// @ts-ignore
+	const ref = useRef();
+	ref.current = value;
 	return ref;
 }
 

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -20,6 +20,7 @@
 		"src/hooks/use-constrained-tabbing/**/*",
 		"src/hooks/use-debounce/**/*",
 		"src/hooks/use-dragging/**/*",
+		"src/hooks/use-drop-zone/**/*",
 		"src/hooks/use-copy-on-click/**/*",
 		"src/hooks/use-copy-to-clipboard/**/*",
 		"src/hooks/use-focus-return/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useDropZone`. No runtime changes were necessary.

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
