### PR TITLE
compose: Add types to `useViewportMatch`

### DIFF
--- a/packages/compose/src/hooks/use-viewport-match/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/index.js
@@ -9,7 +9,7 @@ import { createContext, useContext } from '@wordpress/element';
 import useMediaQuery from '../use-media-query';
 
 /**
- * @typedef {"huge"|"wide"|"large"|"medium"|"small"|"mobile"} WPBreakpoint
+ * @typedef {"huge" | "wide" | "large" | "medium" | "small" | "mobile"} WPBreakpoint
  */
 
 /**
@@ -17,7 +17,7 @@ import useMediaQuery from '../use-media-query';
  *
  * @see _breakpoints.scss
  *
- * @type {Object<WPBreakpoint,number>}
+ * @type {Record<WPBreakpoint, number>}
  */
 const BREAKPOINTS = {
 	huge: 1440,
@@ -29,13 +29,13 @@ const BREAKPOINTS = {
 };
 
 /**
- * @typedef {">="|"<"} WPViewportOperator
+ * @typedef {">=" | "<"} WPViewportOperator
  */
 
 /**
  * Object mapping media query operators to the condition to be used.
  *
- * @type {Object<WPViewportOperator,string>}
+ * @type {Record<WPViewportOperator, string>}
  */
 const CONDITIONS = {
 	'>=': 'min-width',
@@ -45,14 +45,16 @@ const CONDITIONS = {
 /**
  * Object mapping media query operators to a function that given a breakpointValue and a width evaluates if the operator matches the values.
  *
- * @type {Object<WPViewportOperator,Function>}
+ * @type {Record<WPViewportOperator, (breakpointValue: number, width: number) => boolean>}
  */
 const OPERATOR_EVALUATORS = {
 	'>=': ( breakpointValue, width ) => width >= breakpointValue,
 	'<': ( breakpointValue, width ) => width < breakpointValue,
 };
 
-const ViewportMatchWidthContext = createContext( null );
+const ViewportMatchWidthContext = createContext(
+	/** @type {null | number} */ ( null )
+);
 
 /**
  * Returns true if the viewport matches the given query, or false otherwise.
@@ -74,7 +76,7 @@ const useViewportMatch = ( breakpoint, operator = '>=' ) => {
 	const mediaQuery =
 		! simulatedWidth &&
 		`(${ CONDITIONS[ operator ] }: ${ BREAKPOINTS[ breakpoint ] }px)`;
-	const mediaQueryResult = useMediaQuery( mediaQuery );
+	const mediaQueryResult = useMediaQuery( mediaQuery || undefined );
 	if ( simulatedWidth ) {
 		return OPERATOR_EVALUATORS[ operator ](
 			BREAKPOINTS[ breakpoint ],

--- a/packages/compose/src/hooks/use-viewport-match/test/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/test/index.js
@@ -118,10 +118,10 @@ describe( 'useViewportMatch', () => {
 		expect( root.toJSON() ).toBe( 'useViewportMatch: false' );
 
 		expect( useMediaQueryMock.mock.calls ).toEqual( [
-			[ false ],
-			[ false ],
-			[ false ],
-			[ false ],
+			[ undefined ],
+			[ undefined ],
+			[ undefined ],
+			[ undefined ],
 		] );
 
 		root.unmount();

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -30,6 +30,7 @@
 		"src/hooks/use-reduced-motion/**/*",
 		"src/hooks/use-merge-refs/**/*",
 		"src/hooks/use-resize-observer/**/*",
+		"src/hooks/use-viewport-match/**/*",
 		"src/utils/**/*"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useViewportMatch`. Required one small runtime change because `useMediaQuery` only accepts `string | undefined` and not `false` as was the non-value that was being passed in. So we just default it to `undefined` instead using `||`.

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
