### PR TITLE
compose: Add types to `useWarnOnChange`

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -485,7 +485,7 @@ function MyComponent(props) {
 
 _Parameters_
 
--   _object_ `Object`: Object which changes to compare.
+-   _object_ `object`: Object which changes to compare.
 -   _prefix_ `string`: Just a prefix to show when console logging.
 
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -3,6 +3,9 @@
  */
 import usePrevious from '../use-previous';
 
+// Disable reason: Object and object are distinctly different types in TypeScript and we mean the lowercase object in thise case
+// but eslint wants to force us to use `Object`. See https://stackoverflow.com/questions/49464634/difference-between-object-and-object-in-typescript
+/* eslint-disable jsdoc/check-types */
 /**
  * Hook that performs a shallow comparison between the preview value of an object
  * and the new one, if there's a difference, it prints it to the console.
@@ -18,19 +21,20 @@ import usePrevious from '../use-previous';
  * }
  * ```
  *
- * @param {Object} object Object which changes to compare.
+ * @param {object} object Object which changes to compare.
  * @param {string} prefix Just a prefix to show when console logging.
  */
 function useWarnOnChange( object, prefix = 'Change detection' ) {
 	const previousValues = usePrevious( object );
 
 	Object.entries( previousValues ?? [] ).forEach( ( [ key, value ] ) => {
-		if ( value !== object[ key ] ) {
+		if ( value !== object[ /** @type {keyof typeof object} */ ( key ) ] ) {
 			// eslint-disable-next-line no-console
 			console.warn(
 				`${ prefix }: ${ key } key changed:`,
 				value,
-				object[ key ]
+				object[ /** @type {keyof typeof object} */ ( key ) ]
+				/* eslint-enable jsdoc/check-types */
 			);
 		}
 	} );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -33,6 +33,7 @@
 		"src/hooks/use-merge-refs/**/*",
 		"src/hooks/use-resize-observer/**/*",
 		"src/hooks/use-viewport-match/**/*",
+		"src/hooks/use-warn-on-change/**/*",
 		"src/utils/**/*"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `useWarnOnChange`. No runtime changes were necessary for this.

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
