### PR TITLE
compose: Type `withGlobalEvents` as any

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -501,11 +501,11 @@ event handler for the entire application.
 
 _Parameters_
 
--   _eventTypesToHandlers_ `Object<string,string>`: Object with keys of DOM event type, the value a name of the function on the original component's instance which handles the event.
+-   _eventTypesToHandlers_ `Record<keyof GlobalEventHandlersEventMap, string>`: Object with keys of DOM event type, the value a name of the function on the original component's instance which handles the event.
 
 _Returns_
 
--   `Function`: Higher-order component.
+-   `any`: Higher-order component.
 
 <a name="withInstanceId" href="#withInstanceId">#</a> **withInstanceId**
 

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -17,11 +17,10 @@ import Listener from './listener';
 
 /**
  * Listener instance responsible for managing document event handling.
- *
- * @type {Listener}
  */
 const listener = new Listener();
 
+/* eslint-disable jsdoc/no-undefined-types */
 /**
  * Higher-order component creator which, given an object of DOM event types and
  * values corresponding to a callback function name on the component, will
@@ -32,14 +31,14 @@ const listener = new Listener();
  *
  * @deprecated
  *
- * @param {Object<string,string>} eventTypesToHandlers Object with keys of DOM
+ * @param {Record<keyof GlobalEventHandlersEventMap, string>} eventTypesToHandlers Object with keys of DOM
  *                                                     event type, the value a
  *                                                     name of the function on
  *                                                     the original component's
  *                                                     instance which handles
  *                                                     the event.
  *
- * @return {Function} Higher-order component.
+ * @return {any} Higher-order component.
  */
 export default function withGlobalEvents( eventTypesToHandlers ) {
 	deprecated( 'wp.compose.withGlobalEvents', {
@@ -49,33 +48,37 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
-			constructor() {
-				super( ...arguments );
+			constructor( /** @type {any} */ props ) {
+				super( props );
 
 				this.handleEvent = this.handleEvent.bind( this );
 				this.handleRef = this.handleRef.bind( this );
 			}
 
 			componentDidMount() {
-				forEach( eventTypesToHandlers, ( handler, eventType ) => {
+				forEach( eventTypesToHandlers, ( _, eventType ) => {
 					listener.add( eventType, this );
 				} );
 			}
 
 			componentWillUnmount() {
-				forEach( eventTypesToHandlers, ( handler, eventType ) => {
+				forEach( eventTypesToHandlers, ( _, eventType ) => {
 					listener.remove( eventType, this );
 				} );
 			}
 
-			handleEvent( event ) {
-				const handler = eventTypesToHandlers[ event.type ];
+			handleEvent( /** @type {any} */ event ) {
+				const handler =
+					eventTypesToHandlers[
+						/** @type {keyof GlobalEventHandlersEventMap} */ ( event.type )
+						/* eslint-enable jsdoc/no-undefined-types */
+					];
 				if ( typeof this.wrappedRef[ handler ] === 'function' ) {
 					this.wrappedRef[ handler ]( event );
 				}
 			}
 
-			handleRef( el ) {
+			handleRef( /** @type {any} */ el ) {
 				this.wrappedRef = el;
 				// Any component using `withGlobalEvents` that is not setting a `ref`
 				// will cause `this.props.forwardedRef` to be `null`, so we need this

--- a/packages/compose/src/higher-order/with-global-events/listener.js
+++ b/packages/compose/src/higher-order/with-global-events/listener.js
@@ -10,12 +10,13 @@ import { forEach, without } from 'lodash';
  */
 class Listener {
 	constructor() {
+		/** @type {any} */
 		this.listeners = {};
 
 		this.handleEvent = this.handleEvent.bind( this );
 	}
 
-	add( eventType, instance ) {
+	add( /** @type {any} */ eventType, /** @type {any} */ instance ) {
 		if ( ! this.listeners[ eventType ] ) {
 			// Adding first listener for this type, so bind event.
 			window.addEventListener( eventType, this.handleEvent );
@@ -25,7 +26,7 @@ class Listener {
 		this.listeners[ eventType ].push( instance );
 	}
 
-	remove( eventType, instance ) {
+	remove( /** @type {any} */ eventType, /** @type {any} */ instance ) {
 		this.listeners[ eventType ] = without(
 			this.listeners[ eventType ],
 			instance
@@ -38,7 +39,7 @@ class Listener {
 		}
 	}
 
-	handleEvent( event ) {
+	handleEvent( /** @type {any} */ event ) {
 		forEach( this.listeners[ event.type ], ( instance ) => {
 			instance.handleEvent( event );
 		} );

--- a/packages/compose/tsconfig.json
+++ b/packages/compose/tsconfig.json
@@ -15,6 +15,7 @@
 		"src/higher-order/if-condition/**/*",
 		"src/higher-order/pure/**/*",
 		"src/higher-order/with-instance-id/**/*",
+		"src/higher-order/with-global-events/**/*",
 		"src/hooks/use-async-list/**/*",
 		"src/hooks/use-constrained-tabbing/**/*",
 		"src/hooks/use-debounce/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Add types to `withGlobalEvents` but really in the weakest sense possible. Most things are explicitly just typed as any. `withGlobalEvents` is deprecated, there's no reason to spend time making super complex types to handle all the cases it covers. The types I've added should be "good enough" for most cases and are about as good as the DT definitions.

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
