### PR TITLE
[RNMobile] Audio block local url parsing fix

### DIFF
--- a/packages/components/src/mobile/audio-player/audio-url-parser.native.js
+++ b/packages/components/src/mobile/audio-player/audio-url-parser.native.js
@@ -1,10 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { safeDecodeURI, getPath } from '@wordpress/url';
+import { safeDecodeURI } from '@wordpress/url';
 
 export const parseAudioUrl = ( src ) => {
-	const fileName = getPath( safeDecodeURI( src ) ).split( '/' ).pop();
+	const decodedURI = safeDecodeURI( src );
+	const fileName = decodedURI
+		.split( '#' )
+		.shift()
+		.split( '?' )
+		.shift()
+		.split( '/' )
+		.pop();
+
 	const parts = fileName.split( '.' );
 	const extension = parts.length === 2 ? parts.pop().toUpperCase() + ' ' : '';
 	const title = parts.join( '.' );

--- a/packages/components/src/mobile/audio-player/test/audio-url-parser.native.js
+++ b/packages/components/src/mobile/audio-player/test/audio-url-parser.native.js
@@ -17,6 +17,11 @@ const supportedAudioUrlsWithoutExtensions = [
 	'https://www.mp3.com/folder/file',
 ];
 
+const supportedLocalAudioUrls = [
+	'file.mp3',
+	'file:///storage/emulated/0/Download/file.mp3',
+];
+
 describe( 'supportedAudioUrlsWithExtensions', () => {
 	supportedAudioUrlsWithExtensions.forEach( ( url ) => {
 		it( `supports ${ url }`, () => {
@@ -33,6 +38,16 @@ describe( 'supportedAudioUrlsWithoutExtensions', () => {
 			const { title, extension } = parseAudioUrl( url );
 			expect( title ).toBe( 'file' );
 			expect( extension ).toBe( '' );
+		} );
+	} );
+} );
+
+describe( 'supportedLocalAudioUrls', () => {
+	supportedLocalAudioUrls.forEach( ( url ) => {
+		it( `supports ${ url }`, () => {
+			const { title, extension } = parseAudioUrl( url );
+			expect( title ).toBe( 'file' );
+			expect( extension ).toBe( 'MP3 ' );
 		} );
 	} );
 } );


### PR DESCRIPTION
`Gutenberg-Mobile` PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/3558
`WP Android` PR https://github.com/wordpress-mobile/WordPress-Android/pull/14738
`WP iOS` PR https://github.com/wordpress-mobile/WordPress-iOS/pull/16589

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
[Reverted the changes](https://github.com/WordPress/gutenberg/pull/31920#discussion_r635115054) done to the URL parsing logic within the `audio-player` since it doesn't cover all URL types that are supported by the Audio block, in particular local files. 

## How has this been tested?
1. This was tested with the main Apps PRs. I ensured that all the flows in the audio block's media upload selection work with the refactored parsing component. 
2. The unit tests were run via `npm run test-unit:native` and they all passed. 

<img width="930" alt="Screenshot 2021-05-27 at 2 33 15 PM" src="https://user-images.githubusercontent.com/1509205/119886548-b4d5a800-bef8-11eb-8f4c-90717badcb87.png">

## Types of changes

- The main change here is I reverted to the previous implementation of parsing audio based URLs. 
- Tests were added for the local URIs that are utilized on iOS and Android.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
