### PR TITLE
Link to widgets.php instead of themes.php?page=gutenberg-widgets

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -30,7 +30,10 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	if ( gutenberg_use_widgets_block_editor() ) {
+	if (
+		gutenberg_use_widgets_block_editor() &&
+		! function_exists( 'wp_use_widgets_block_editor' )
+	) {
 		add_theme_page(
 			__( 'Widgets', 'gutenberg' ),
 			__( 'Widgets', 'gutenberg' ),
@@ -113,7 +116,11 @@ add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
  * @param WP_Admin_Bar $wp_admin_bar Core class used to implement the Toolbar API.
  */
 function modify_admin_bar( $wp_admin_bar ) {
-	if ( gutenberg_use_widgets_block_editor() && $wp_admin_bar->get_node( 'widgets' ) !== null ) {
+	if (
+		gutenberg_use_widgets_block_editor() &&
+		! function_exists( 'wp_use_widgets_block_editor' ) &&
+		$wp_admin_bar->get_node( 'widgets' ) !== null
+	) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id'   => 'widgets',
@@ -137,7 +144,10 @@ function modify_welcome_panel() {
 	ob_start();
 	wp_welcome_panel();
 	$welcome_panel = ob_get_clean();
-	if ( gutenberg_use_widgets_block_editor() ) {
+	if (
+		gutenberg_use_widgets_block_editor() &&
+		! function_exists( 'wp_use_widgets_block_editor' )
+	) {
 		echo str_replace(
 			admin_url( 'widgets.php' ),
 			admin_url( 'themes.php?page=gutenberg-widgets' ),
@@ -177,5 +187,4 @@ function register_site_icon_url( $response ) {
 
 add_filter( 'rest_index', 'register_site_icon_url' );
 
-add_theme_support( 'widgets-block-editor' );
 add_theme_support( 'block-templates' );

--- a/lib/init.php
+++ b/lib/init.php
@@ -187,4 +187,5 @@ function register_site_icon_url( $response ) {
 
 add_filter( 'rest_index', 'register_site_icon_url' );
 
+add_theme_support( 'widgets-block-editor' );
 add_theme_support( 'block-templates' );

--- a/packages/block-library/src/legacy-widget/edit/preview.js
+++ b/packages/block-library/src/legacy-widget/edit/preview.js
@@ -78,8 +78,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 						// TODO: This chokes when the query param is too big.
 						// Ideally, we'd render a <ServerSideRender>. Maybe by
 						// rendering one in an iframe via a portal.
-						src={ addQueryArgs( 'themes.php', {
-							page: 'gutenberg-widgets',
+						src={ addQueryArgs( 'widgets.php', {
 							'legacy-widget-preview': {
 								idBase,
 								instance,

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -59,7 +59,7 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 						<Button
 							href={ addQueryArgs( 'customize.php', {
 								'autofocus[panel]': 'widgets',
-								return: 'widgets.php',
+								return: window.location.pathname,
 							} ) }
 							variant="tertiary"
 						>

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -59,7 +59,7 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 						<Button
 							href={ addQueryArgs( 'customize.php', {
 								'autofocus[panel]': 'widgets',
-								return: 'themes.php?page=gutenberg-widgets',
+								return: 'widgets.php',
 							} ) }
 							variant="tertiary"
 						>


### PR DESCRIPTION
Makes Appearance → Widgets and other similar links go to `wp-admin/widgets.php` if the version of WordPress that the plugin is running on supports the widgets block editor.

We can tell if the widgets block editor is supported or not by checking for the existence of `wp_use_widgets_block_editor`.

This sets us up for a future where the Gutenberg plugin uses core's `widgets.php` and will just replace the `@wordpress` packages (e.g. `@wordpress/edit-widgets`) with updated versions.

### Testing instructions

With an environment that has both `wordpress-develop-git` and `gutenberg` cloned and running together:

1. Check out the `5.7` branch in `wordpress-develop-git`.
1. Disable the gutenberg plugin. 
1. Go to Appearance → Widgets. The URL should be `widgets.php` and the old editor should appear.
1. Enable the gutenberg plugin.
1. Go to Appearance → Widgets. The URL should be `themes.php?page=gutenberg-widgets` and the new editor should appear.
1. Check out the `master` branch in `wordpress-develop-git`.
1. Disable the gutenberg plugin. 
1. Go to Appearance → Widgets. The URL should be `widgets.php` and the new editor should appear.
1. Enable the gutenberg plugin.
1. Go to Appearance → Widgets. The URL should be `widgets.php` and the new editor should appear.