### PR TITLE
Fix legacy widget block preview iframe

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -5,6 +5,24 @@
  * @package gutenberg
  */
 
+/*
+ * Fixes the priority of register_block_core_legacy_widget().
+ *
+ * This hook was incorrectly added to Core with priority 20. #32300 fixes this
+ * but causes block registration warnings in the Gutenberg plugin until the
+ * changes are made in Core.
+ *
+ * This temporary fix can be removed after the changes to
+ * @wordpress/block-library in #32300 have been published to npm and updated in
+ * Core.
+ *
+ * See https://github.com/WordPress/gutenberg/pull/32300.
+ */
+if ( 20 === has_action( 'init', 'register_block_core_legacy_widget' ) ) {
+	remove_action( 'init', 'register_block_core_legacy_widget', 20 );
+	add_action( 'init', 'register_block_core_legacy_widget', 10 );
+}
+
 /**
  * Substitutes the implementation of a core-registered block type, if exists,
  * with the built result from the plugin.

--- a/packages/block-library/src/legacy-widget/index.php
+++ b/packages/block-library/src/legacy-widget/index.php
@@ -50,21 +50,25 @@ function render_block_core_legacy_widget( $attributes ) {
 }
 
 /**
- * On application init this does two things:
- *
- * - Registers the 'core/legacy-widget' block.
- * - Intercepts any request with legacy-widget-preview in the query param and,
- *   if set, renders a page containing a preview of the requested Legacy Widget
- *   block.
+ * Registers the 'core/legacy-widget' block.
  */
-function init_legacy_widget_block() {
+function register_block_core_legacy_widget() {
 	register_block_type_from_metadata(
 		__DIR__ . '/legacy-widget',
 		array(
 			'render_callback' => 'render_block_core_legacy_widget',
 		)
 	);
+}
 
+add_action( 'init', 'register_block_core_legacy_widget' );
+
+/**
+ * Intercepts any request with legacy-widget-preview in the query param and, if
+ * set, renders a page containing a preview of the requested Legacy Widget
+ * block.
+ */
+function handle_legacy_widget_preview_iframe() {
 	if ( empty( $_GET['legacy-widget-preview'] ) ) {
 		return;
 	}
@@ -110,4 +114,7 @@ function init_legacy_widget_block() {
 	exit;
 }
 
-add_action( 'init', 'init_legacy_widget_block' );
+// Ensure handle_legacy_widget_preview_iframe() is called after Core's
+// register_block_core_legacy_widget() (priority = 10) and after Gutenberg's
+// register_block_core_legacy_widget() (priority = 20).
+add_action( 'init', 'handle_legacy_widget_preview_iframe', 21 );


### PR DESCRIPTION
### Description 

Fixes #32281.

The PHP code in `legacy-widget/index.php` registers the Legacy Widget block and intercepts any request with the `legacy-widget-preview` query param. This is how the block's preview iframe is implemented.

The iframe intercept code will not work if the Legacy Widget block has not been registered. This is because we render the iframe using `$block->render()`.

Block registration must be done in an `init` action beginning with `register_`. This is so that the Gutenberg plugin's webpack config can set the priority of this action to be 20 instead of 10. This lets the plugin redeclare blocks that are registered in core.

https://github.com/WordPress/gutenberg/blob/e4a2ea51c9bd5aa18e29918a963a1f80fe0be7d7/webpack.config.js#L275-L286

So, we have two requirements:

- The iframe intercept must happen after block registration; and
- Block registration must happen in an `init` action beginning with `register_`.

We could meet these two requirements by performing the iframe intercept in the `register_block_core_legacy_widget` function, but I don't like this because it means one cannot unhook registration without also unhooking the iframe intercept. It also means the function name doesn't describe what it does 😇

Instead, this PR performs the intercept in a second `init` action which uses the same priority as the first `init` action. This priority will be 20 in the plugin and 10 in core. We can determine an action's priority by using `has_action`.

https://developer.wordpress.org/reference/functions/has_action

### How to test

1. Go to Appearance → Widgets with the Gutenberg plugin installed and running latest WordPress `trunk`.
2. Insert or select a Legacy Widget block.
3. The preview functionality should work without displaying a WP Admin menu bar in the iframe.

**Note:** There is a PHP warning caused by registering `core/legacy-widget` twice. It's because core is incorrectly adding the registration action with priority 20. This will be fixed once `@wordpress/block-library` is published to npm and the changes in this PR are included in core. You can verify this by copying `packages/block-library/src/legacy-widget/index.php` in Gutenberg to `blocks/legacy-widget.php` in core.