### PR TITLE
Try: Make focus style valid CSS.

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -20,7 +20,7 @@
 
 		&:focus:not(:disabled) {
 			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 calc(var(--wp-admin-border-width-focus) - $border-width) var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 calc(var(--wp-admin-border-width-focus) - #{ $border-width }) var(--wp-admin-theme-color);
 		}
 
 		svg {

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -20,7 +20,7 @@
 
 		&:focus:not(:disabled) {
 			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 (var(--wp-admin-border-width-focus) - $border-width) var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 calc(var(--wp-admin-border-width-focus) - $border-width) var(--wp-admin-theme-color);
 		}
 
 		svg {


### PR DESCRIPTION
## Description

Hopefully fixes #32181.

There's some CSS math to set the right focus style on block variation transforms, but I wasn't entirely sure where in the interface to test this. But just looking at the code, this PR _should_ address it.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
