### PR TITLE
Reset the persisted selected menu ID if there are no longer any menus

### DIFF
--- a/packages/edit-navigation/src/hooks/use-navigation-editor.js
+++ b/packages/edit-navigation/src/hooks/use-navigation-editor.js
@@ -47,6 +47,10 @@ export default function useNavigationEditor() {
 	useEffect( () => {
 		if ( hasLoadedMenus ) {
 			setHasFinishedInitialLoad( true );
+
+			if ( ! menus?.length ) {
+				setSelectedMenuId( 0 );
+			}
 		}
 	}, [ hasLoadedMenus ] );
 

--- a/packages/edit-navigation/src/hooks/use-navigation-editor.js
+++ b/packages/edit-navigation/src/hooks/use-navigation-editor.js
@@ -47,12 +47,22 @@ export default function useNavigationEditor() {
 	useEffect( () => {
 		if ( hasLoadedMenus ) {
 			setHasFinishedInitialLoad( true );
-
-			if ( ! menus?.length ) {
-				setSelectedMenuId( 0 );
-			}
 		}
 	}, [ hasLoadedMenus ] );
+
+	useEffect( () => {
+		// Don't reset selected menu before we can check whether
+		// it is still available.
+		if ( ! hasLoadedMenus ) {
+			return;
+		}
+
+		const selectedMenu = menus?.find( ( { id } ) => id === selectedMenuId );
+
+		if ( ! menus?.length || ! selectedMenu ) {
+			setSelectedMenuId( 0 );
+		}
+	}, [ hasLoadedMenus, menus, selectedMenuId ] );
 
 	const navigationPost = useSelect(
 		( select ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/pull/31320 we started persisting the `selectedMenuId` to localStorage. Code was in place to reset this ID if the menu was deleted. However, there were no guards against the following conditions

1. There are no longer any menus.
2. The selected menu no longer exists.

This PR attempts to address this.

Fixes https://github.com/WordPress/gutenberg/issues/32256

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
