### PR TITLE
Add Convert to Regular Blocks button to ellipsis Dropdown

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -4,13 +4,18 @@
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockSettingsMenuControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
 	const { isVisible } = useSelect(
@@ -33,6 +38,10 @@ function ReusableBlocksManageButton( { clientId } ) {
 		[ clientId ]
 	);
 
+	const {
+		__experimentalConvertBlockToStatic: convertBlockToStatic,
+	} = useDispatch( reusableBlocksStore );
+
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -43,6 +52,9 @@ function ReusableBlocksManageButton( { clientId } ) {
 				href={ addQueryArgs( 'edit.php', { post_type: 'wp_block' } ) }
 			>
 				{ __( 'Manage Reusable blocks' ) }
+			</MenuItem>
+			<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
+				{ __( 'Convert to Regular Blocks' ) }
 			</MenuItem>
 		</BlockSettingsMenuControls>
 	);

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -54,7 +54,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 				{ __( 'Manage Reusable blocks' ) }
 			</MenuItem>
 			<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-				{ __( 'Convert to Regular Blocks' ) }
+				{ __( 'Convert to regular blocks' ) }
 			</MenuItem>
 		</BlockSettingsMenuControls>
 	);


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/32217

#### Description

Added convert to regular blocks button to ellipsis dropdown for reusable blocks 

## How has this been tested?

1. Select a Reusable Block 
2. Select more options button (three vertical dots) in the Block Toolbar
3. Select Convert to Regular Blocks
4. This should convert the reusable block to independent regular blocks

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/69596988/119972342-b6be6a80-bfcf-11eb-94e0-9bddfedca26e.mov


## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

