### PR TITLE
Revert "Alignment styles: Centre blocks using grid not margins"

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -63,14 +63,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$style = '';
 	if ( $content_size || $wide_size ) {
-
-		$style  = ".wp-container-$id { display: grid; }";
-
-		$style .= ".wp-container-$id > * {";
-		$style .= 'box-sizing: border-box;';
-		$style .= 'justify-self: center;';
+		$style  = ".wp-container-$id > * {";
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-		$style .= 'width: 100%;';
+		$style .= 'margin-left: auto !important;';
+		$style .= 'margin-right: auto !important;';
 		$style .= '}';
 
 		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -41,15 +41,10 @@ export function LayoutStyle( { selector, layout = {} } ) {
 	let style =
 		!! contentSize || !! wideSize
 			? `
-				${ selector } {
-					display: grid;
-				}
-
 				${ appendSelectors( selector, '> *' ) } {
-					box-sizing: border-box;
-					justify-self: center;
-					width: 100%;
 					max-width: ${ contentSize ?? wideSize };
+					margin-left: auto !important;
+					margin-right: auto !important;
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {


### PR DESCRIPTION
Reverts WordPress/gutenberg#32231


See discussion on https://github.com/WordPress/gutenberg/pull/32231#issuecomment-850260299