### PR TITLE
Alternative fix: set persisted menu id when no menus or missing menu

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -83,6 +83,11 @@ const REST_SEARCH_ROUTES = [
 	`rest_route=${ encodeURIComponent( '/wp/v2/search' ) }`,
 ];
 
+const REST_PAGES_ROUTES = [
+	'/wp/v2/pages',
+	`rest_route=${ encodeURIComponent( '/wp/v2/pages' ) }`,
+];
+
 /**
  * Determines if a given URL matches any of a given collection of
  * routes (expressed as substrings).
@@ -135,6 +140,10 @@ function getSearchMocks( responsesByMethod ) {
 	return getEndpointMocks( REST_SEARCH_ROUTES, responsesByMethod );
 }
 
+function getPagesMocks( responsesByMethod ) {
+	return getEndpointMocks( REST_PAGES_ROUTES, responsesByMethod );
+}
+
 async function visitNavigationEditor() {
 	const query = addQueryArgs( '', {
 		page: 'gutenberg-navigation',
@@ -184,6 +193,7 @@ describe( 'Navigation editor', () => {
 				POST: menuPostResponse,
 			} ),
 			...getMenuItemMocks( { GET: [] } ),
+			...getPagesMocks( { GET: [ {} ] } ), // mock a single page
 		] );
 
 		await page.keyboard.type( 'Main Menu' );

--- a/packages/edit-navigation/src/hooks/use-menu-entity.js
+++ b/packages/edit-navigation/src/hooks/use-menu-entity.js
@@ -12,10 +12,21 @@ export default function useMenuEntity( menuId ) {
 	const { editEntityRecord } = useDispatch( coreStore );
 
 	const menuEntityData = [ MENU_KIND, MENU_POST_TYPE, menuId ];
-	const editedMenu = useSelect(
-		( select ) =>
-			menuId &&
-			select( coreStore ).getEditedEntityRecord( ...menuEntityData ),
+	const { editedMenu, hasLoadedEditedMenu } = useSelect(
+		( select ) => {
+			return {
+				editedMenu:
+					menuId &&
+					select( coreStore ).getEditedEntityRecord(
+						...menuEntityData
+					),
+				hasLoadedEditedMenu: select(
+					coreStore
+				).hasFinishedResolution( 'getEditedEntityRecord', [
+					...menuEntityData,
+				] ),
+			};
+		},
 		[ menuId ]
 	);
 
@@ -23,5 +34,6 @@ export default function useMenuEntity( menuId ) {
 		editedMenu,
 		menuEntityData,
 		editMenuEntityRecord: editEntityRecord,
+		hasLoadedEditedMenu,
 	};
 }

--- a/packages/edit-navigation/src/hooks/use-navigation-editor.js
+++ b/packages/edit-navigation/src/hooks/use-navigation-editor.js
@@ -12,6 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editNavigationStore } from '../store';
 import { useSelectedMenuId } from './index';
+import useMenuEntity from './use-menu-entity';
 
 const getMenusData = ( select ) => {
 	const selectors = select( 'core' );
@@ -29,7 +30,18 @@ export default function useNavigationEditor() {
 	const [ hasFinishedInitialLoad, setHasFinishedInitialLoad ] = useState(
 		false
 	);
+	const { editedMenu, hasLoadedEditedMenu } = useMenuEntity( selectedMenuId );
 	const { menus, hasLoadedMenus } = useSelect( getMenusData, [] );
+
+	/**
+	 * If the Menu being edited has been requested from API and it has
+	 * no values then it has been deleted so reset the selected menu ID.
+	 */
+	useEffect( () => {
+		if ( hasLoadedEditedMenu && ! Object.keys( editedMenu )?.length ) {
+			setSelectedMenuId( null );
+		}
+	}, [ hasLoadedEditedMenu, editedMenu ] );
 
 	const { createErrorNotice, createInfoNotice } = useDispatch( noticesStore );
 	const isMenuBeingDeleted = useSelect(
@@ -67,7 +79,7 @@ export default function useNavigationEditor() {
 			force: true,
 		} );
 		if ( didDeleteMenu ) {
-			setSelectedMenuId( 0 );
+			setSelectedMenuId( null );
 			createInfoNotice(
 				sprintf(
 					// translators: %s: the name of a menu.

--- a/packages/edit-navigation/src/store/reducer.js
+++ b/packages/edit-navigation/src/store/reducer.js
@@ -89,7 +89,7 @@ export function processingQueue( state, action ) {
  *
  * @return {Object} Updated state.
  */
-export function selectedMenuId( state = 0, action ) {
+export function selectedMenuId( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_SELECTED_MENU_ID':
 			return action.menuId;

--- a/packages/edit-navigation/src/store/selectors.js
+++ b/packages/edit-navigation/src/store/selectors.js
@@ -23,7 +23,7 @@ import { buildNavigationPostId } from './utils';
  * @return {number} The selected menu ID.
  */
 export function getSelectedMenuId( state ) {
-	return state.selectedMenuId ?? 0;
+	return state.selectedMenuId ?? null;
 }
 
 /**

--- a/packages/edit-navigation/src/store/test/reducer.js
+++ b/packages/edit-navigation/src/store/test/reducer.js
@@ -179,7 +179,7 @@ describe( 'processingQueue', () => {
 
 describe( 'selectedMenuId', () => {
 	it( 'should apply default state', () => {
-		expect( selectedMenuId( undefined, {} ) ).toEqual( 0 );
+		expect( selectedMenuId( undefined, {} ) ).toEqual( null );
 	} );
 
 	it( 'should update when a new menu is selected', () => {

--- a/packages/edit-navigation/src/store/test/selectors.js
+++ b/packages/edit-navigation/src/store/test/selectors.js
@@ -135,7 +135,7 @@ describe( 'getMenuItemForClientId', () => {
 describe( 'getSelectedMenuId', () => {
 	it( 'returns default selected menu ID (zero)', () => {
 		const state = {};
-		expect( getSelectedMenuId( state ) ).toBe( 0 );
+		expect( getSelectedMenuId( state ) ).toBe( null );
 	} );
 
 	it( 'returns selected menu ID', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
**Alternative** to https://github.com/WordPress/gutenberg/pull/32306.

In https://github.com/WordPress/gutenberg/pull/31320 we started persisting the `selectedMenuId` to localStorage. Code was in place to reset this ID if the menu was deleted. However, there were no guards against the following conditions

1. There are no longer any menus.
2. The selected menu no longer exists.

This PR attempts to address this.

Moreover, it resolves the edge case whereby due to a default of `0` for selectedMenuId, requests were being made to `/menus/0` for a menu that could _never_ exist. Using `null` as the default prevents this.

Fixes https://github.com/WordPress/gutenberg/issues/32256

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually only - needs e2e and unit tests.

### Manual Instructions

1. Create x2 Menus using the new Navigation Editor or the classic Menus screen - call them `Menu 1` and `Menu 2`.
2. In the Navigation Editor open `Menu 2`. Make a note of it's menu ID by checking the state or network requests.
3. In a _new tab_ go to the _classic_ Menus screen, delete `Menu 2`.
4. Go back to the Navigation Editor and reload.
5. You should see:
    - `Menu 1` becomes selected in the Navigation Editor.
    - a 404 request to `/menus/{{MENU_ID_OF_MENU_2}}` in the Network tab.
    - **_no_** 404 requests to `/menus/0` in the Network tab.
6. Go back to the classic Menus screen and delete `Menu 1`.
7. Go back to the Navigation Editor and reload.
8. You should see:
    - The "Create new Menu" screen.
    - a 404 request to `/menus/{{MENU_ID_OF_MENU_1}}` in the Network tab.
    - **_no_** 404 requests to `/menus/0` in the Network tab.

It should be impossible to arrive at the state observed in https://github.com/WordPress/gutenberg/issues/32256.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/119980226-e52e4c80-bfb3-11eb-905e-77c956eb2d01.mov

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
