### PR TITLE
Alignment styles: Centering layout without using margins

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -63,7 +63,15 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$style = '';
 	if ( $content_size || $wide_size ) {
-		$style  = ".wp-container-$id > * {";
+
+		$style  = ".wp-container-$id {";
+		$style .= 'display: flex;';
+		$style .= 'flex-flow: column;';
+		$style .= 'align-items: center;';
+		$style .= '}';
+
+		$style .= ".wp-container-$id > * {";
+		$style .= 'box-sizing: border-box;';
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= 'margin-left: auto !important;';
 		$style .= 'margin-right: auto !important;';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -72,7 +72,6 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		$style .= ".wp-container-$id > * {";
 		$style .= 'box-sizing: border-box;';
-		$style .= 'box-sizing: border-box;';
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= 'width: 100%;';
 		$style .= '}';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -72,9 +72,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		$style .= ".wp-container-$id > * {";
 		$style .= 'box-sizing: border-box;';
+		$style .= 'box-sizing: border-box;';
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-		$style .= 'margin-left: auto !important;';
-		$style .= 'margin-right: auto !important;';
+		$style .= 'width: 100%;';
 		$style .= '}';
 
 		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -51,8 +51,6 @@ export function LayoutStyle( { selector, layout = {} } ) {
 					box-sizing: border-box;
 					width: 100%;
 					max-width: ${ contentSize ?? wideSize };
-					margin-left: auto !important;
-					margin-right: auto !important;
 				}
 
 				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -41,7 +41,15 @@ export function LayoutStyle( { selector, layout = {} } ) {
 	let style =
 		!! contentSize || !! wideSize
 			? `
+				${ selector } {
+					display: flex;
+					flex-flow: column;
+					align-items: center;
+				}
+
 				${ appendSelectors( selector, '> *' ) } {
+					box-sizing: border-box;
+					width: 100%;
 					max-width: ${ contentSize ?? wideSize };
 					margin-left: auto !important;
 					margin-right: auto !important;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This is an alternative to https://github.com/WordPress/gutenberg/pull/32231 since that's going to get reverted. 

Copying from that PR's description:

> To centre the content inside blocks that use the "inherit layout" we are using "margin: auto" on every block. This will conflict with the new margin supports being added to blocks. To overcome this we added !important declarations to the alignment styles for blocks that use the "inherit layout" setting (in #30608). However this mean that left and right alignment settings in blocks won't work.

When @scruffian was trying this approach, he said that 

> small paragraph blocks don't align to the left of the content area

but I haven't been able to reproduce. I've tried to break this as much as I couldn't and didn't find a way to do so. Any other combinations of blocks to test this are more than welcome.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I tested this mainly using emptytheme

## Screenshots <!-- if applicable -->

Desktop:

Emptytheme | TT1
--- | ---
![Screenshot_2021-05-28 Test alignments – test sitesdpfdsfs](https://user-images.githubusercontent.com/3593343/119979132-d1d2af80-bfba-11eb-846b-230d391479d0.png) | ![Screenshot_2021-05-28 Test alignments – test sitesdpfdsfs(2)](https://user-images.githubusercontent.com/3593343/119979151-d5fecd00-bfba-11eb-90d0-933d7b505410.png)

Mobile

Emptytheme | TT1
--- | ---
![Screenshot_2021-05-28 Test alignments – test sitesdpfdsfs(1)](https://user-images.githubusercontent.com/3593343/119979183-e151f880-bfba-11eb-9deb-9e06eefecf9b.png) | ![FireShot Capture 016 - Test alignments – test sitesdpfdsfs - freethemes local](https://user-images.githubusercontent.com/3593343/119979197-e4e57f80-bfba-11eb-9fa8-3db0af31cb40.png)




## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
