### PR TITLE
Remove metaboxes from template mode

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -85,9 +85,11 @@ function Layout( { styles } ) {
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
+		isTemplateMode,
 	} = useSelect( ( select ) => {
 		const editorSettings = select( editorStore ).getEditorSettings();
 		return {
+			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
 				'fixedToolbar'
 			),
@@ -227,10 +229,12 @@ function Layout( { styles } ) {
 						{ isRichEditingEnabled && mode === 'visual' && (
 							<VisualEditor styles={ styles } />
 						) }
-						<div className="edit-post-layout__metaboxes">
-							<MetaBoxes location="normal" />
-							<MetaBoxes location="advanced" />
-						</div>
+						{ ! isTemplateMode && (
+							<div className="edit-post-layout__metaboxes">
+								<MetaBoxes location="normal" />
+								<MetaBoxes location="advanced" />
+							</div>
+						) }
 						{ isMobileViewport && sidebarIsOpened && (
 							<ScrollLock />
 						) }


### PR DESCRIPTION
closes #31789 

This removes the meta boxes from templates mode for several reasons:

 - The sidebar meta boxes are not shown, we should be consistent
 - The template mode might change the expectations of the metaboxes : their code might expect elements like post content, post title to be present in the page which is not always the case in template mode.
 - MetaBoxes have always been considered an API that is only there for backward compatibility and not something that third-party plugins should be encouraged to use, in that sense, adding it to a new screen like the template mode doesn't make sense.