### PR TITLE
Add do_action hooks when rendering templates and template parts. ( #32309 )

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -58,6 +58,18 @@ function gutenberg_override_query_template( $template, $type, array $templates )
 
 	$block_template = gutenberg_resolve_template( $type, $templates );
 
+	/**
+	 * Fires before the template is rendered.
+	 *
+	 * Allows extensions to follow template processing.
+	 * Called before the template is rendered.
+	 *
+	 * @param object $current_template The current template object.
+	 * @param string $type      Sanitized filename without extension.
+	 * @param array  $templates A list of template candidates, in descending order of priority.
+	 */
+	do_action( 'rendering_template', $block_template, $type, $templates );
+
 	if ( $block_template ) {
 		if ( empty( $block_template->content ) && is_user_logged_in() ) {
 			$_wp_current_template_content =

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -96,6 +96,17 @@ function render_block_core_template_part( $attributes ) {
 
 	// Run through the actions that are typically taken on the_content.
 	$seen_ids[ $template_part_id ] = true;
+	/**
+	 * Fires before/after the template part is rendered.
+	 *
+	 * Allows extensions to follow template part processing.
+	 * Called before and after each template part is rendered.
+	 *
+	 * @param array|null $attributes The template part attributes. Null after rendering.
+	 * @param array $seen_ids The current template part nesting.
+	 */
+	do_action( 'rendering_template_part', $attributes, $seen_ids );
+
 	$content                       = do_blocks( $content );
 	unset( $seen_ids[ $template_part_id ] );
 	$content = wptexturize( $content );
@@ -121,6 +132,9 @@ function render_block_core_template_part( $attributes ) {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes();
+
+	/** This action is documented in template-part.php */
+	do_action( 'rendering_template_part', null, $seen_ids );
 
 	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
 }


### PR DESCRIPTION
## Description
I've added some calls to do_action() for two new action hooks: `rendering_template` and `rendering_template_part`. 
These allow plugins / themes to develop extensions that will enable problem determination and/or logic associated with invocation context.   
For example, I use these hooks to implement a debug block that will indicate which template has been used, the start and end of a template part and other information relevant during problem determination. See https://github.com/bobbingwide/sb-debug-block/issues/2

## How has this been tested?
I tested the changes by applying the `rendering_template` hook to Gutenberg v10.7.2 build, and the `rendering_template_part` hook to an override of `render_core_block_template_part` in my ThisIs theme.

Unfortunately I couldn't test using the latest extract from Gutenberg trunk since I could not get the build to work. Both `npm run dev` and `npm run build` fail. See https://github.com/bobbingwide/sb-debug-block/issues/3


## Screenshots <!-- if applicable -->

## Types of changes
Implements Feature Request #32309 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
