### PR TITLE
Multi select: select all: restore ref callback

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -7,9 +7,9 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { isEntirelySelected } from '@wordpress/dom';
-import { useRef, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -17,54 +17,60 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { store as blockEditorStore } from '../../store';
 
 export default function useSelectAll() {
-	const ref = useRef();
 	const {
 		getBlockOrder,
 		getSelectedBlockClientIds,
 		getBlockRootClientId,
 	} = useSelect( blockEditorStore );
 	const { multiSelect } = useDispatch( blockEditorStore );
+	const isMatch = useShortcutEventMatch();
 
-	const callback = useCallback( ( event ) => {
-		const selectedClientIds = getSelectedBlockClientIds();
+	return useRefEffect( ( node ) => {
+		function onKeyDown( event ) {
+			const selectedClientIds = getSelectedBlockClientIds();
 
-		if ( ! selectedClientIds.length ) {
-			return;
+			if ( ! selectedClientIds.length ) {
+				return;
+			}
+
+			if ( ! isMatch( 'core/block-editor/select-all', event ) ) {
+				return;
+			}
+
+			if (
+				selectedClientIds.length === 1 &&
+				! isEntirelySelected( event.target )
+			) {
+				return;
+			}
+
+			const [ firstSelectedClientId ] = selectedClientIds;
+			const rootClientId = getBlockRootClientId( firstSelectedClientId );
+			let blockClientIds = getBlockOrder( rootClientId );
+
+			// If we have selected all sibling nested blocks, try selecting up a
+			// level. See: https://github.com/WordPress/gutenberg/pull/31859/
+			if ( selectedClientIds.length === blockClientIds.length ) {
+				blockClientIds = getBlockOrder(
+					getBlockRootClientId( rootClientId )
+				);
+			}
+
+			const firstClientId = first( blockClientIds );
+			const lastClientId = last( blockClientIds );
+
+			if ( firstClientId === lastClientId ) {
+				return;
+			}
+
+			multiSelect( firstClientId, lastClientId );
+			event.preventDefault();
 		}
 
-		if (
-			selectedClientIds.length === 1 &&
-			! isEntirelySelected( event.target )
-		) {
-			return;
-		}
+		node.addEventListener( 'keydown', onKeyDown );
 
-		const [ firstSelectedClientId ] = selectedClientIds;
-		const rootClientId = getBlockRootClientId( firstSelectedClientId );
-		let blockClientIds = getBlockOrder( rootClientId );
-
-		// If we have selected all sibling nested blocks, try selecting up a
-		// level. See: https://github.com/WordPress/gutenberg/pull/31859/
-		if ( selectedClientIds.length === blockClientIds.length ) {
-			blockClientIds = getBlockOrder(
-				getBlockRootClientId( rootClientId )
-			);
-		}
-
-		const firstClientId = first( blockClientIds );
-		const lastClientId = last( blockClientIds );
-
-		if ( firstClientId === lastClientId ) {
-			return;
-		}
-
-		multiSelect( firstClientId, lastClientId );
-		event.preventDefault();
-	}, [] );
-
-	useShortcut( 'core/block-editor/select-all', callback, {
-		target: ref,
+		return () => {
+			node.removeEventListener( 'keydown', onKeyDown );
+		};
 	} );
-
-	return ref;
 }

--- a/packages/keyboard-shortcuts/src/hooks/use-shortcut-event-match.js
+++ b/packages/keyboard-shortcuts/src/hooks/use-shortcut-event-match.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { isKeyboardEvent } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { store as keyboardShortcutsStore } from '../store';
+
+/**
+ * Returns a function to check if a keyboard event matches a shortcut name.
+ *
+ * @return {Function} A function to to check if a keyboard event matches a
+ *                    predefined shortcut combination.
+ */
+export default function useShortcutEventMatch() {
+	const { getAllShortcutKeyCombinations } = useSelect(
+		keyboardShortcutsStore
+	);
+
+	/**
+	 * A function to check if a keyboard event matches a predefined shortcut
+	 * combination.
+	 *
+	 * @param {string}        name  Shortcut name.
+	 * @param {KeyboardEvent} event Event to check.
+	 *
+	 * @return {boolean} True if the event matches any shortcuts, false if not.
+	 */
+	function isMatch( name, event ) {
+		return getAllShortcutKeyCombinations( name ).some(
+			( { modifier, character } ) => {
+				return isKeyboardEvent[ modifier ]( event, character );
+			}
+		);
+	}
+
+	return isMatch;
+}

--- a/packages/keyboard-shortcuts/src/index.js
+++ b/packages/keyboard-shortcuts/src/index.js
@@ -1,2 +1,3 @@
 export { store } from './store';
 export { default as useShortcut } from './hooks/use-shortcut';
+export { default as __unstableUseShortcutEventMatch } from './hooks/use-shortcut-event-match';

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -116,6 +116,16 @@ export function getShortcutAliases( state, name ) {
 		: EMPTY_ARRAY;
 }
 
+export const getAllShortcutKeyCombinations = createSelector(
+	( state, name ) => {
+		return compact( [
+			getShortcutKeyCombination( state, name ),
+			...getShortcutAliases( state, name ),
+		] );
+	},
+	( state, name ) => [ state[ name ] ]
+);
+
 /**
  * Returns the raw representation of all the keyboard combinations of a given shortcut name.
  *
@@ -126,15 +136,12 @@ export function getShortcutAliases( state, name ) {
  */
 export const getAllShortcutRawKeyCombinations = createSelector(
 	( state, name ) => {
-		return compact( [
-			getKeyCombinationRepresentation(
-				getShortcutKeyCombination( state, name ),
-				'raw'
-			),
-			...getShortcutAliases( state, name ).map( ( combination ) =>
-				getKeyCombinationRepresentation( combination, 'raw' )
-			),
-		] );
+		return getAllShortcutKeyCombinations(
+			state,
+			name
+		).map( ( combination ) =>
+			getKeyCombinationRepresentation( combination, 'raw' )
+		);
 	},
 	( state, name ) => [ state[ name ] ]
 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

See #31859.

This PR restores the ref callback we previously had to attach event handlers. Currently `useShortcut` is used, which won't reattach handlers if the ref value changes. This stands in the way rewriting writing flow as a ref callback, which should not break if the ref changes.

Introduces `__unstableUseShortcutEventMatch`, which works regardless of whether an event is synthetic or not. If the future, this could enable us to attach shortcut event handlers to _React_ events, which bubble through portals, so there would be no need to bubble _native_ events through the iframe.

Not only is this an important thing to have for the iframe, it will also prove to be an important in contextualising (or localising) all editor shortcuts, which are now all global as they are bound to the `document`. This is important because you may have other things on the page beside the block editor, or multiple block editors. Shortcuts should only work if focus is within a certain context.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
