### PR TITLE
Update: Make getBlockSupport support any lodash path. 

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -255,7 +255,7 @@ export const getChildBlockNames = createSelector(
  *
  * @param  {Object}          state           Data state.
  * @param  {(string|Object)} nameOrType      Block name or type object
- * @param  {string}          feature         Feature to retrieve
+ * @param  {Array|string}    feature         Feature to retrieve
  * @param  {*}               defaultSupports Default value to return if not
  *                                           explicitly defined
  *
@@ -268,12 +268,11 @@ export const getBlockSupport = (
 	defaultSupports
 ) => {
 	const blockType = getNormalizedBlockType( state, nameOrType );
+	if ( ! blockType?.supports ) {
+		return defaultSupports;
+	}
 
-	return get(
-		blockType,
-		[ 'supports', ...feature.split( '.' ) ],
-		defaultSupports
-	);
+	return get( blockType.supports, feature, defaultSupports );
 };
 
 /**


### PR DESCRIPTION
This PR updates getBlockSupport to rely on lodash path processing instead of using a split operation.  Relying on lodash makes us take advantage of any lodash performance optimization.


## How has this been tested?
I verified the correct block supports are still enabled.
