### PR TITLE
Add min-height to media & text Block

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -83,6 +83,9 @@
 		},
 		"focalPoint": {
 			"type": "object"
+		},
+		"minHeight": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/media-text/constants.js
+++ b/packages/block-library/src/media-text/constants.js
@@ -1,1 +1,4 @@
+/**
+ * WordPress dependencies
+ */
 export const DEFAULT_MEDIA_SIZE_SLUG = 'full';

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -9,6 +9,7 @@ import { map, filter } from 'lodash';
  */
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
 import { useState, useRef } from '@wordpress/element';
 import {
 	BlockControls,
@@ -16,6 +17,7 @@ import {
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	useBlockProps,
+	useSetting,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	__experimentalImageSizeControl as ImageSizeControl,
 	store as blockEditorStore,
@@ -28,6 +30,9 @@ import {
 	ToolbarButton,
 	ExternalLink,
 	FocalPointPicker,
+	__experimentalUnitControl as UnitControl,
+	__experimentalUseCustomUnits as useCustomUnits,
+	BaseControl,
 } from '@wordpress/components';
 import { pullLeft, pullRight } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
@@ -137,8 +142,12 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		mediaWidth,
 		rel,
 		verticalAlignment,
+		minHeight,
 	} = attributes;
 	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
+
+	const instanceId = useInstanceId( UnitControl );
+	const inputId = `block-media-text-height-input-${ instanceId }`;
 
 	const image = useSelect(
 		( select ) =>
@@ -147,6 +156,24 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 				: null,
 		[ isSelected, mediaId ]
 	);
+
+	const CSS_UNITS = useCustomUnits( {
+		availableUnits: useSetting( 'spacing.units' ) || [
+			'px',
+			'em',
+			'rem',
+			'vw',
+			'vh',
+		],
+		defaultValues: {
+			px: '430',
+			'%': '50',
+			em: '20',
+			rem: '20',
+			vw: '20',
+			vh: '50',
+		},
+	} );
 
 	const refMediaContainer = useRef();
 	const imperativeFocalPointPreview = ( value ) => {
@@ -188,6 +215,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	const style = {
 		gridTemplateColumns,
 		msGridColumns: gridTemplateColumns,
+		minHeight,
 	};
 	const onMediaAltChange = ( newMediaAlt ) => {
 		setAttributes( { mediaAlt: newMediaAlt } );
@@ -290,6 +318,28 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		</PanelBody>
 	);
 
+	const dimensions = (
+		<PanelBody title={ __( 'Dimensions' ) }>
+			<BaseControl
+				id={ inputId }
+				label={ __( 'Minimum height of Media & Text' ) }
+			>
+				<UnitControl
+					id={ inputId }
+					style={ { maxWidth: 80, marginTop: 8 } }
+					units={ CSS_UNITS }
+					value={ minHeight }
+					step="1"
+					isResetValueOnUnitChange
+					min={ 0 }
+					onChange={ ( value ) => {
+						setAttributes( { minHeight: value } );
+					} }
+				></UnitControl>
+			</BaseControl>
+		</PanelBody>
+	);
+
 	const blockProps = useBlockProps( {
 		className: classNames,
 		style,
@@ -302,7 +352,10 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 
 	return (
 		<>
-			<InspectorControls>{ mediaTextGeneralSettings }</InspectorControls>
+			<InspectorControls>
+				{ mediaTextGeneralSettings }
+				{ dimensions }
+			</InspectorControls>
 			<BlockControls group="block">
 				<BlockVerticalAlignmentControl
 					onChange={ onVerticalAlignmentChange }

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -264,6 +264,7 @@ class MediaTextEdit extends Component {
 			mediaWidth,
 			mediaType,
 			verticalAlignment,
+			minHeight,
 		} = attributes;
 		const { containerWidth, isMediaSelected } = this.state;
 
@@ -365,7 +366,7 @@ class MediaTextEdit extends Component {
 					) }
 				</BlockControls>
 				<View
-					style={ containerStyles }
+					style={ ( containerStyles, minHeight ) }
 					onLayout={ this.onLayoutChange }
 				>
 					<View

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -33,6 +33,7 @@ export default function save( { attributes } ) {
 		href,
 		linkTarget,
 		rel,
+		minHeight,
 	} = attributes;
 	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 	const newRel = isEmpty( rel ) ? undefined : rel;
@@ -86,6 +87,7 @@ export default function save( { attributes } ) {
 	}
 	const style = {
 		gridTemplateColumns,
+		minHeight,
 	};
 	return (
 		<div { ...useBlockProps.save( { className, style } ) }>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes #31811
I have added the possibility to assign a min-height in the media and text block.
I have oriented myself here to the cover block. It is my first block customization, I hope I did everything right :)

## How has this been tested?
I tested the feature on my wp-env test environment with the latest version of Gutenberg.
I also tested the changes in the most popular browsers (Safari, Chrome, Firefox).

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/52854338/120009458-44a05280-bfdc-11eb-9cfe-aaee9361b381.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
