### PR TITLE
Rich text: contextual shortcuts

### DIFF
--- a/packages/block-editor/src/components/rich-text/shortcut.js
+++ b/packages/block-editor/src/components/rich-text/shortcut.js
@@ -1,17 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { useKeyboardShortcut } from '@wordpress/compose';
-import { rawShortcut } from '@wordpress/keycodes';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 
-export function RichTextShortcut( { character, type, onUse } ) {
-	const callback = () => {
-		onUse();
-		return false;
-	};
-	useKeyboardShortcut( rawShortcut[ type ]( character ), callback, {
-		bindGlobal: true,
-	} );
+/**
+ * Internal dependencies
+ */
+import { shortcuts } from './';
 
+export function RichTextShortcut( {
+	type: modifier,
+	character,
+	onUse: callback,
+} ) {
+	const set = useContext( shortcuts );
+	const callbackRef = useRef();
+	callbackRef.current = callback;
+	useEffect( () => {
+		const ref = { modifier, character, callbackRef };
+		set.current.add( ref );
+		return () => {
+			set.current.delete( ref );
+		};
+	}, [ modifier, character, callbackRef ] );
 	return null;
 }

--- a/packages/block-editor/src/components/rich-text/use-keyboard-shortcuts.js
+++ b/packages/block-editor/src/components/rich-text/use-keyboard-shortcuts.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { isKeyboardEvent } from '@wordpress/keycodes';
+
+export function useKeyboardShortcuts( shortcuts ) {
+	return useRefEffect(
+		( element ) => {
+			function onKeyDown( event ) {
+				for ( const {
+					modifier,
+					character,
+					callbackRef,
+				} of shortcuts.current ) {
+					if ( isKeyboardEvent[ modifier ]( event, character ) ) {
+						callbackRef.current();
+						event.preventDefault();
+						return false;
+					}
+				}
+			}
+			element.addEventListener( 'keydown', onKeyDown );
+			return () => {
+				element.removeEventListener( 'keydown', onKeyDown );
+			};
+		},
+		[ shortcuts ]
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
`useKeyboardShortcuts` adds shortcuts on the document, which we should avoid in favour of adding shortcuts locally.

This is important to eventually remove event bubbling of the iframe. Currently all shortcuts added by the format library are added to the main document, so it relies on event bubbling through the iframe.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
