### PR TITLE
Prefix build with node command for Windows environments. (#32258)

### DIFF
--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -46,6 +46,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "./bin/index.js"
+		"build": "node ./bin/index.js"
 	}
 }


### PR DESCRIPTION

## Description
Prefixed the build command for `packages/babel-preset-default/package.json` with `node` so that it runs in a Windows development machine.
<!-- Please describe what you have changed or added -->

## How has this been tested?
`npm run dev` and `npm run build` ran without failing with 
```
'.' is not recognized as an internal or external command,
operable program or batch file.
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Fix for #32258, standard Windows command line. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
