### PR TITLE
Fix oembeds not working in block template parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -108,6 +108,10 @@ function render_block_core_template_part( $attributes ) {
 	}
 	$content = do_shortcode( $content );
 
+	// Handle embeds for block template parts.
+	global $wp_embed;
+	$content = $wp_embed->autoembed( $content );
+
 	if ( empty( $attributes['tagName'] ) ) {
 		$defined_areas = gutenberg_get_allowed_template_part_areas();
 		$area_tag      = 'div';


### PR DESCRIPTION
## Description
This PR fixes https://github.com/WordPress/gutenberg/issues/32330, where oembeds (like YouTube videos) are not getting embedded if they are used inside a block template part.

## How has this been tested?
1. Added a YouTube video to a block template part.
2. Viewed the frontend, and only saw a youtube link.
3. On this branch, the video is embedded.

## Screenshots <!-- if applicable -->
Before:
<img width="1032" alt="Screen Shot 2021-05-28 at 3 24 35 PM" src="https://user-images.githubusercontent.com/7538525/120034709-76f58400-bfcb-11eb-82b7-75405909e74b.png">

After:
<img width="956" alt="Screen Shot 2021-05-28 at 3 42 47 PM" src="https://user-images.githubusercontent.com/7538525/120034735-7e1c9200-bfcb-11eb-8ac5-c6c10b141a77.png">


## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
