### PR TITLE
Fixed the description text of block movers for horizontal movement on multiple selection

### DIFF
--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -51,7 +51,8 @@ export function getBlockMoverDescription(
 			firstIndex,
 			isFirst,
 			isLast,
-			dir
+			dir,
+			getMovementDirection
 		);
 	}
 
@@ -217,12 +218,14 @@ export function getBlockMoverDescription(
 /**
  * Return a label for the block movement controls depending on block position.
  *
- * @param {number}  selectedCount Number of blocks selected.
- * @param {number}  firstIndex    The index (position - 1) of the first block selected.
- * @param {boolean} isFirst       This is the first block.
- * @param {boolean} isLast        This is the last block.
- * @param {number}  dir           Direction of movement (> 0 is considered to be going
- *                                 down, < 0 is up).
+ * @param {number}  selectedCount 				Number of blocks selected.
+ * @param {number}  firstIndex    				The index (position - 1) of the first block selected.
+ * @param {boolean} isFirst       				This is the first block.
+ * @param {boolean} isLast        				This is the last block.
+ * @param {number}  dir           				Direction of movement (> 0 is considered to be going
+ *                                				 down, < 0 is up).
+ * @param {Function} getMovementDirection  		Returns movement direction (string) based on the orientation
+ * 												 of the selected blocks
  *
  * @return {string} Label for the block movement controls.
  */
@@ -231,43 +234,104 @@ export function getMultiBlockMoverDescription(
 	firstIndex,
 	isFirst,
 	isLast,
-	dir
+	dir,
+	getMovementDirection
 ) {
 	const position = firstIndex + 1;
 
-	if ( dir < 0 && isFirst ) {
-		return __( 'Blocks cannot be moved up as they are already at the top' );
-	}
-
-	if ( dir > 0 && isLast ) {
-		return __(
-			'Blocks cannot be moved down as they are already at the bottom'
-		);
-	}
-
 	if ( dir < 0 && ! isFirst ) {
-		return sprintf(
-			// translators: 1: Number of selected blocks, 2: Position of selected blocks
-			_n(
-				'Move %1$d block from position %2$d up by one place',
-				'Move %1$d blocks from position %2$d up by one place',
-				selectedCount
-			),
-			selectedCount,
-			position
-		);
+		// moving up
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d up by one place',
+					'Move %1$d blocks from position %2$d up by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d left by one place',
+					'Move %1$d blocks from position %2$d left by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+	}
+
+	if ( dir < 0 && isFirst ) {
+		// moving up, and the selected blocks are the first item
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			return __(
+				'Blocks cannot be moved up as they are already at the top'
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return __(
+				'Blocks cannot be moved left as they are already are at the leftmost position'
+			);
+		}
 	}
 
 	if ( dir > 0 && ! isLast ) {
-		return sprintf(
-			// translators: 1: Number of selected blocks, 2: Position of selected blocks
-			_n(
-				'Move %1$d block from position %2$d down by one place',
-				'Move %1$d blocks from position %2$d down by one place',
-				selectedCount
-			),
-			selectedCount,
-			position
-		);
+		// moving down
+		const movementDirection = getMovementDirection( 'down' );
+
+		if ( movementDirection === 'down' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d down by one place',
+					'Move %1$d blocks from position %2$d down by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d right by one place',
+					'Move %1$d blocks from position %2$d right by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+	}
+
+	if ( dir > 0 && isLast ) {
+		// moving down, and the selected blocks are the last item
+		const movementDirection = getMovementDirection( 'down' );
+
+		if ( movementDirection === 'down' ) {
+			return __(
+				'Blocks cannot be moved down as they are already at the bottom'
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return __(
+				'Blocks cannot be moved right as they are already are at the rightmost position'
+			);
+		}
 	}
 }


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/25158

### Description
The description text of the blocks which can be moved horizontally was not correct on multiple selection.
Refer https://github.com/WordPress/gutenberg/issues/25158

## How has this been tested?
1. Select a block that can be moved horizontally (eg. Buttons Block)
2. Add 2 to 3 blocks to move them around
3. Select multiple blocks
4. Inspect the block mover buttons
5. The correct descriptive text should be displayed according to the orientation of the blocks

## Screenshots 
![Screenshot 2021-05-30 at 8 02 29 PM](https://user-images.githubusercontent.com/69596988/120108290-2d02ce80-c182-11eb-8ecb-17da8a54d313.png)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
