### PR TITLE
Added onDismiss option in createInfoNotice

### DIFF
--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -107,6 +107,7 @@ The following props are used to control the behavior of the component.
     -   A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
     -   A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
 -   `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
+-   `onDismiss` : callback function which is executed when the notice is dismissed. It is distinct from onRemove, which _looks_ like a callback but is actually the function to call to remove the notice from the UI.
 -   `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. The default appearance of the button is inferred based on whether `url` or `onClick` are provided, rendering the button as a link if appropriate. A `noDefaultClasses` property value of `true` will remove all default styling. You can denote a primary button action for a notice by passing the `variant` property with a value of `primary`.
 
 ## Related components

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -88,12 +88,8 @@ function Notice( {
 		children = <RawHTML>{ children }</RawHTML>;
 	}
 
-	onDismiss = onDismiss || noop;
-
-	const dismissMe = ( event ) => {
-		if ( event && event.preventDefault ) {
-			event.preventDefault();
-		}
+	const onDismissNotice = ( event ) => {
+		event?.preventDefault?.();
 		onDismiss();
 		onRemove();
 	};
@@ -150,7 +146,7 @@ function Notice( {
 					className="components-notice__dismiss"
 					icon={ close }
 					label={ __( 'Dismiss this notice' ) }
-					onClick={ dismissMe }
+					onClick={ onDismissNotice }
 					showTooltip={ false }
 				/>
 			) }

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -68,6 +68,10 @@ function Notice( {
 	actions = [],
 	politeness = getDefaultPoliteness( status ),
 	__unstableHTML,
+	// onDismiss is a callback executed when the notice is dismissed.
+	// It is distinct from onRemove, which _looks_ like a callback but is
+	// actually the function to call to remove the notice from the UI.
+	onDismiss = noop,
 } ) {
 	useSpokenMessage( spokenMessage, politeness );
 
@@ -83,6 +87,16 @@ function Notice( {
 	if ( __unstableHTML ) {
 		children = <RawHTML>{ children }</RawHTML>;
 	}
+
+	onDismiss = onDismiss || noop;
+
+	const dismissMe = ( event ) => {
+		if ( event && event.preventDefault ) {
+			event.preventDefault();
+		}
+		onDismiss();
+		onRemove();
+	};
 
 	return (
 		<div className={ classes }>
@@ -136,7 +150,7 @@ function Notice( {
 					className="components-notice__dismiss"
 					icon={ close }
 					label={ __( 'Dismiss this notice' ) }
-					onClick={ onRemove }
+					onClick={ dismissMe }
 					showTooltip={ false }
 				/>
 			) }

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -20,12 +20,7 @@ import Notice from './';
  * @return {Object}                The rendered notices list.
  */
 function NoticeList( { notices, onRemove = noop, className, children } ) {
-	const removeNotice = ( notice ) => () => {
-		if ( notice.onDismiss ) {
-			notice.onDismiss( notice.id );
-		}
-		onRemove( notice.id );
-	};
+	const removeNotice = ( id ) => () => onRemove( id );
 
 	className = classnames( 'components-notice-list', className );
 
@@ -36,7 +31,7 @@ function NoticeList( { notices, onRemove = noop, className, children } ) {
 				<Notice
 					{ ...omit( notice, [ 'content' ] ) }
 					key={ notice.id }
-					onRemove={ removeNotice( notice ) }
+					onRemove={ removeNotice( notice.id ) }
 				>
 					{ notice.content }
 				</Notice>

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -20,7 +20,12 @@ import Notice from './';
  * @return {Object}                The rendered notices list.
  */
 function NoticeList( { notices, onRemove = noop, className, children } ) {
-	const removeNotice = ( id ) => () => onRemove( id );
+	const removeNotice = ( notice ) => () => {
+		if ( notice.onDismiss ) {
+			notice.onDismiss( notice.id );
+		}
+		onRemove( notice.id );
+	};
 
 	className = classnames( 'components-notice-list', className );
 
@@ -31,7 +36,7 @@ function NoticeList( { notices, onRemove = noop, className, children } ) {
 				<Notice
 					{ ...omit( notice, [ 'content' ] ) }
 					key={ notice.id }
-					onRemove={ removeNotice( notice.id ) }
+					onRemove={ removeNotice( notice ) }
 				>
 					{ notice.content }
 				</Notice>

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -60,7 +60,7 @@ export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 		__unstableHTML,
 		icon = null,
 		explicitDismiss = false,
-		onDismiss = null,
+		onDismiss,
 	} = options;
 
 	// The supported value shape of content is currently limited to plain text

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -76,7 +76,7 @@ describe( 'actions', () => {
 					type: 'default',
 					icon: '🌮',
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			} );
 		} );
@@ -107,7 +107,7 @@ describe( 'actions', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			} );
 		} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -35,7 +35,7 @@ describe( 'reducer', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			],
 		} );
@@ -60,7 +60,7 @@ describe( 'reducer', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			],
 		} );
@@ -86,7 +86,7 @@ describe( 'reducer', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 				{
 					id: expect.any( String ),
@@ -99,7 +99,7 @@ describe( 'reducer', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			],
 		} );
@@ -165,7 +165,7 @@ describe( 'reducer', () => {
 					type: 'default',
 					icon: null,
 					explicitDismiss: false,
-					onDismiss: null,
+					onDismiss: undefined,
 				},
 			],
 		} );


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/31571

## Description
Added onDismiss option in createInfoNotice method of Notices

## How has this been tested?
Create a Notice with onDismiss option
```
wp.data.dispatch( 'core/notices' ).createInfoNotice( 'hello world', { onDismiss: () => { console.log( 'hello world dismissed!' ) } } );
```

Create Multiple Notices with their onDismiss options
```
wp.data.dispatch( 'core/notices' ).createInfoNotice( 'hello 1', { onDismiss: () => { console.log( 'dismissed 1 !' ) } } );
wp.data.dispatch( 'core/notices' ).createInfoNotice( 'hello 2', { onDismiss: () => { console.log( 'dismissed 2 !' ) } } );
wp.data.dispatch( 'core/notices' ).createInfoNotice( 'hello 3', { onDismiss: () => { console.log( 'dismissed 3 !' ) } } );
```
## Screenshots

https://user-images.githubusercontent.com/69596988/120113804-d1443f80-c199-11eb-89d3-852c355ab2d0.mov


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

