### PR TITLE
Search block : Fix vertical alignment of search button text

### DIFF
--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -23,6 +23,8 @@
 		// stylelint-disable-line no-duplicate-selectors
 		&.wp-block-search__button.wp-block-search__button {
 			padding: 6px 10px;
+			display: flex;
+			align-items: center;
 		}
 	}
 


### PR DESCRIPTION
## Description
Depending on the height of the surround container the search button text can end up aligned to the top of the button which doesn't match the alignment of the input box text.

Fixes #29952

## How to test
Check out PR and add a search block with outside button with blank canvas theme
Check that the text alignment on button matches the input box placeholder alignment

## Screenshots 
Before:

<img width="651" alt="Screen Shot 2021-05-31 at 3 30 25 PM" src="https://user-images.githubusercontent.com/3629020/120136305-2168e380-c226-11eb-9208-69e0bb2edd19.png">

After:

<img width="637" alt="Screen Shot 2021-05-31 at 3 27 43 PM" src="https://user-images.githubusercontent.com/3629020/120136255-05fdd880-c226-11eb-8e3b-c122db1b860c.png">

