### PR TITLE
Fix `theme.json` styles for the `core/list` block

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -42,7 +42,8 @@
 			"gradients": true
 		},
 		"__experimentalFontFamily": true,
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"__experimentalSelector": "ol,ul"
 	},
 	"editorStyle": "wp-block-list-editor",
 	"style": "wp-block-list"


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/32273

I was trying to add some styles for the `core/list` block via `theme.json`, using something like:

```json
{
  "version": 1,
  "styles": {
    "blocks": {
      "core/list": {
        "color": {
          "text": "hotpink"
        }
      }
    }
  }
}
```

I expected the `core/list` block to have those styles applied in both the editor and the front end. What happened instead was that it worked in the editor but not in the front end.

## Why it fails

In the editor, the block gets a few extra classes attached, including the `wp-block-list`. However, in the front, it doesn't get any class attached.

The stylesheet generated from `theme.json` taking into account the `block.json` of a block to know what selector should use for a particular block. If the `block.json` contains a `__experimentalSelector` key, that's what it uses. Otherwise, it uses the block class selector. Because the `core/list` block doesn't declare any `__experimentalSelector, the `wp-block-list` is used, resulting in the styles not being applied because the block markup doesn't have that class.

## How this fixes it

This PR fixes it by declaring the block selector for the `core/list` block that "global styles" can use to output the stylesheet.

Other alternatives considered:

- Add the `.wp-block-list` class to the block. Discarded because this is not backward compatible: existing blocks won't work because they don't have the class applied. This is what is done at https://github.com/WordPress/gutenberg/pull/32273
