### PR TITLE
SuggestionsList: Try to use a unique "key"

### DIFF
--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -110,7 +110,11 @@ class SuggestionsList extends Component {
 							id={ `components-form-token-suggestions-${ this.props.instanceId }-${ index }` }
 							role="option"
 							className={ classeName }
-							key={ this.props.displayTransform( suggestion ) }
+							key={
+								suggestion?.value
+									? suggestion.value
+									: this.props.displayTransform( suggestion )
+							}
 							onMouseDown={ this.handleMouseDown }
 							onClick={ this.handleClick( suggestion ) }
 							onMouseEnter={ this.handleHover( suggestion ) }


### PR DESCRIPTION
## Description
Updates the` SuggestionsList` component to use `value` as a key when available. Usually, when used with the `ComboboxControl` component.

Fixes #32127.

## How has this been tested?
1. Generate 100 authors to display Post Author Combobox - `wp user generate --count=3 --role=author`
2. Generate few users with same display name - `wp user generate --count=3 --role=author --format=ids | xargs -n1 -I % wp user update % --display_name=Mary`
3. Edit post/page and search for author Mary.
4. Console has no following error `Warning: Encountered two children with the same key [...].`

Cleanup: `wp user delete $(wp user list --role=author --field=ID)`

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
