### PR TITLE
BoxControl: Add allowReset option

### DIFF
--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -103,6 +103,7 @@ If this property is true, a button to reset the box control is rendered.
 
 - Type: `Boolean`
 - Required: No
+- Default: `true`
 
 ### inputProps
 

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -97,6 +97,12 @@ const Example = () => {
 ```
 
 ## Props
+### allowReset
+
+If this property is true, a button to reset the box control is rendered.
+
+- Type: `Boolean`
+- Required: No
 
 ### inputProps
 
@@ -126,6 +132,13 @@ A callback function for visualizer changes, based on input hover interactions.
 
 -   Type: `Function`
 -   Required: Yes
+
+### resetValues
+
+The `top`, `right`, `bottom`, and `left` box dimension values to use when the control is reset.
+
+-   Type: `Object`
+-   Required: No
 
 ### sides
 

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -52,6 +52,7 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
+	allowReset = true,
 	resetValues = DEFAULT_VALUES,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
@@ -123,17 +124,19 @@ export default function BoxControl( {
 						{ label }
 					</Text>
 				</FlexItem>
-				<FlexItem>
-					<Button
-						className="component-box-control__reset-button"
-						variant="secondary"
-						isSmall
-						onClick={ handleOnReset }
-						disabled={ ! isDirty }
-					>
-						{ __( 'Reset' ) }
-					</Button>
-				</FlexItem>
+				{ allowReset && (
+					<FlexItem>
+						<Button
+							className="component-box-control__reset-button"
+							isSecondary
+							isSmall
+							onClick={ handleOnReset }
+							disabled={ ! isDirty }
+						>
+							{ __( 'Reset' ) }
+						</Button>
+					</FlexItem>
+				) }
 			</Header>
 			<HeaderControlWrapper className="component-box-control__header-control-wrapper">
 				<FlexItem>


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/28356

## Description

As part of moving towards the new "Dimensions" panel where block support controls when toggled off are reset, the BoxControl reset button is superfluous. To reduce clutter in the controls it would be nice to have a means of not rendering it.

This PR:
- Adds an `allowReset` option on the `BoxControl` that defaults to `true`
- Only renders the reset button if `allowReset` is `true`.
- Updates the `BoxControl` docs for the new option as well as the missing `resetValues` prop

## How has this been tested?
Manually.

#### Testing instructions

1. Checkout this PR, build, and load the block editor
2. Create a new post, add a group block, save the post, then select the group block
3. Confirm the padding control in the sidebar's spacing panel has a reset button
4. Edit `packages/block-editor/src/hooks/padding.js` and add an `allowReset={ false }` prop to the `BoxControl` - [gist](https://gist.github.com/aaronrobertshaw/34c22ee6062b8737ec6e3a5da71f5035)
5. Reload the editor, reselect the group block.
6. Confirm the padding control no longer renders the reset button.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="281" alt="Screen Shot 2021-05-31 at 7 35 01 pm" src="https://user-images.githubusercontent.com/60436221/120174559-90efca80-c248-11eb-83e8-e492c2a83975.png"> | <img width="282" alt="Screen Shot 2021-05-31 at 7 34 06 pm" src="https://user-images.githubusercontent.com/60436221/120174580-977e4200-c248-11eb-9bcf-7aef3a2ca3a7.png"> |

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
