### PR TITLE
Avoid duplicate skip-links in WP 5.8+

### DIFF
--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -177,9 +177,16 @@ add_action( 'save_post_wp_template', 'set_unique_slug_on_create_template' );
 /**
  * Print the skip-link script & styles.
  *
+ * @todo Remove this when WP 5.8 is the minimum required version.
+ *
  * @return void
  */
 function gutenberg_the_skip_link() {
+
+	// Early exit if on WP 5.8+.
+	if ( function_exists( 'the_block_template_skip_link' ) ) {
+		return;
+	}
 
 	// Early exit if not an FSE theme.
 	if ( ! gutenberg_supports_block_templates() ) {


### PR DESCRIPTION
## Description

The `gutenberg_the_skip_link` function was backported to WP5.8. As a result, in WP5.8 + Gutenberg, the script and styles for skip-links get added twice.

This PR adds a check, and early exits if the `the_block_template_skip_link` function exists.

## How has this been tested?
Tested with an FSE theme, using WP-trunk + Gutenberg, and confirmed that the skip-link scripts & styles only get added once.

## Types of changes
* Added a check and early-exit in the function
* Added a `@todo` note in the function, noting it should be removed when WP5.8 is the minimum required version.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
