### PR TITLE
Mobile - Gallery block - Fix gallery images caption text formatting

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -283,7 +283,7 @@ class GalleryImage extends Component {
 							>
 								<Caption
 									inlineToolbar
-									isSelected={ captionSelected }
+									isSelected={ isSelected && captionSelected }
 									onChange={ this.onCaptionChange }
 									onFocus={ this.onSelectCaption }
 									placeholder={

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Audio block: Add Insert from URL functionality. [#27817]
 -   [*] The BottomSheet Cell component now supports the help prop so that a hint can be supplied to all Cell based components. [#30885]
 -   [***] Enable reusable block only in WP.com sites [#31744]
+-   [*] Gallery block - Fix gallery images caption text formatting [#32351]
 
 ## 1.53.1
 


### PR DESCRIPTION
## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3511

`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3568

This PR fixes the current issue with images within a Gallery block, focusing between different captions would cause the formatting toolbar to disappear. This change adds the `isSelected` state of the image as well as the `isCaptionSelected`.

## How has this been tested? 
1. Add a Gallery block
2. Add some images to your gallery
3. Set some captions to the images
4. Move the focus between image gallery captions
5. **Expect** that the formatting toolbar to be consistent and to be visible
6. Add a paragraph block
7. Move the focus between image gallery captions
8. Move the focus to the paragraph
9. **Expect** that the formatting toolbar is still visible

## Screenshots <!-- if applicable -->
iOS|Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/120290976-2039c400-c2c3-11eb-8c08-42852cd6b293.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/120291047-334c9400-c2c3-11eb-85ca-257cc1de878b.gif" width="250" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
