### PR TITLE
[Block Conversion - Embed]: Fix embed to paragraph transform when caption has rich text formats

### DIFF
--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -34,15 +34,13 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			isMatch: ( { url } ) => !! url,
 			transform: ( { url, caption } ) => {
-				const values = [ `<a href="${ url }">${ url }</a>` ];
+				let value = `<a href="${ url }">${ url }</a>`;
 				if ( caption?.trim() ) {
-					values.push( caption );
+					value += `<br />${ caption }`;
 				}
-				return values.map( ( value ) =>
-					createBlock( 'core/paragraph', {
-						content: value,
-					} )
-				);
+				return createBlock( 'core/paragraph', {
+					content: value,
+				} );
 			},
 		},
 	],

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { renderToString } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
+import { toHTMLString, removeFormat, create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -33,10 +33,25 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
+			isMatch: ( { url } ) => !! url,
 			transform: ( { url, caption } ) => {
-				const link = <a href={ url }>{ caption || url }</a>;
+				let linkText = url;
+				if ( caption?.trim() ) {
+					const captionEl = create( { html: caption } );
+					linkText = toHTMLString( {
+						value: removeFormat(
+							captionEl,
+							'core/link',
+							0,
+							captionEl.text.length
+						),
+					} );
+				}
+				const link = create( {
+					html: `<a href="${ url }">${ linkText }</a>`,
+				} );
 				return createBlock( 'core/paragraph', {
-					content: renderToString( link ),
+					content: toHTMLString( { value: link } ),
 				} );
 			},
 		},

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { toHTMLString, removeFormat, create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -35,24 +34,15 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			isMatch: ( { url } ) => !! url,
 			transform: ( { url, caption } ) => {
-				let linkText = url;
+				const values = [ `<a href="${ url }">${ url }</a>` ];
 				if ( caption?.trim() ) {
-					const captionEl = create( { html: caption } );
-					linkText = toHTMLString( {
-						value: removeFormat(
-							captionEl,
-							'core/link',
-							0,
-							captionEl.text.length
-						),
-					} );
+					values.push( caption );
 				}
-				const link = create( {
-					html: `<a href="${ url }">${ linkText }</a>`,
-				} );
-				return createBlock( 'core/paragraph', {
-					content: toHTMLString( { value: link } ),
-				} );
+				return values.map( ( value ) =>
+					createBlock( 'core/paragraph', {
+						content: value,
+					} )
+				);
 			},
 		},
 	],


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes: https://github.com/WordPress/gutenberg/issues/32265

Currently when we have an `embed` block and we have added rich text formats to its caption (bold, link, color, etc..), if we transform to a `paragraph` all the html tags will be pulled into the text node. This PR solves that.

In addition I have added an `isMatch` for this transform, so it is shown only if we have a `url`. You can test the existing behavior by inserting a `Youtube` block without adding a `url` and observe that the convert to paragraph option is available.
<!-- Please describe what you have changed or added -->

## Testing instructions
1. Go to the page/post editor
2. Add any embed block (like YouTube, Vimeo, Twitter etc.)
3. Add a caption, and add some styling to it (like bold, color, etc.. )
4. Convert the whole block to a Paragraph block


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
