### PR TITLE
Buttons: move options to constants to avoid unneeded renders

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -20,6 +20,17 @@ import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
+const LAYOUT = {
+	type: 'default',
+	alignments: [],
+};
+const VERTICAL_JUSTIFY_CONTROLS = [ 'left', 'center', 'right' ];
+const HORIZONTAL_JUSTIFY_CONTROLS = [
+	'left',
+	'center',
+	'right',
+	'space-between',
+];
 
 function ButtonsEdit( {
 	attributes: { contentJustification, orientation },
@@ -35,17 +46,14 @@ function ButtonsEdit( {
 		allowedBlocks: ALLOWED_BLOCKS,
 		template: BUTTONS_TEMPLATE,
 		orientation,
-		__experimentalLayout: {
-			type: 'default',
-			alignments: [],
-		},
+		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,
 	} );
 
 	const justifyControls =
 		orientation === 'vertical'
-			? [ 'left', 'center', 'right' ]
-			: [ 'left', 'center', 'right', 'space-between' ];
+			? VERTICAL_JUSTIFY_CONTROLS
+			: HORIZONTAL_JUSTIFY_CONTROLS;
 
 	return (
 		<>


### PR DESCRIPTION
For performance reasons, React does not make deep equality checks on arrays or objects when they are passed to see if a component should render or not. 

Updates in this PR avoid creating a new options object/array, so we can avoid unnecessary renders for child buttons.

This is similar to changes in https://github.com/WordPress/gutenberg/pull/30374

Before:

https://user-images.githubusercontent.com/1270189/120240024-713eaf00-c214-11eb-8f34-6d7bc8e64cb0.mp4

After:

https://user-images.githubusercontent.com/1270189/120240034-769bf980-c214-11eb-9379-c31a5d77e8ca.mp4

As an aside, do we expect a buttons block to rerender when we're typing in a sibling paragraph block?

### Testing Instructions

- In trunk: add a buttons block with many buttons, and try typing in another paragraph. Notice there there's considerable delay. When profiling `__experimentalLayout` as a reason for items rendering shows up in the ranked chart tab. (See before video).
- In this branch: add a buttons block and make sure the right justify alignment controls show up for a vertical or horizontal block variation
- In this branch: add a buttons block with many buttons, and try typing in another paragraph. Notice that there's less delay. When profiling `__experimentalLayout` no longer shows up as a rerender reason. (See after video). 