### PR TITLE
Navigation: avoid rerendering when placeholder does not change

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -78,6 +78,11 @@ function Navigation( {
 		clientId
 	);
 
+	const placeholder = useRef();
+	useEffect( () => {
+		placeholder.current = <PlaceholderPreview />;
+	}, [] );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -98,7 +103,7 @@ function Navigation( {
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
 			__experimentalLayout: LAYOUT,
-			placeholder: <PlaceholderPreview />,
+			placeholder: placeholder?.current,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -78,11 +78,6 @@ function Navigation( {
 		clientId
 	);
 
-	const placeholder = useRef();
-	useEffect( () => {
-		placeholder.current = <PlaceholderPreview />;
-	}, [] );
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -103,7 +98,8 @@ function Navigation( {
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
 			__experimentalLayout: LAYOUT,
-			placeholder: placeholder?.current,
+			// Placeholder component is wrapped with memo HoC to avoid unneeded re-renders
+			placeholder: <PlaceholderPreview />,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -25,7 +25,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useBlockNavigator from './use-block-navigator';
-
 import NavigationPlaceholder from './placeholder';
 import PlaceholderPreview from './placeholder-preview';
 import ResponsiveWrapper from './responsive-wrapper';
@@ -78,6 +77,8 @@ function Navigation( {
 		clientId
 	);
 
+	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -98,8 +99,7 @@ function Navigation( {
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
 			__experimentalLayout: LAYOUT,
-			// Placeholder component is wrapped with memo HoC to avoid unneeded re-renders
-			placeholder: <PlaceholderPreview />,
+			placeholder,
 		}
 	);
 

--- a/packages/block-library/src/navigation/placeholder-preview.js
+++ b/packages/block-library/src/navigation/placeholder-preview.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Icon, search } from '@wordpress/icons';
+import { memo } from '@wordpress/element';
 
 const PlaceholderPreview = () => {
 	return (
@@ -14,4 +15,4 @@ const PlaceholderPreview = () => {
 	);
 };
 
-export default PlaceholderPreview;
+export default memo( PlaceholderPreview );

--- a/packages/block-library/src/navigation/placeholder-preview.js
+++ b/packages/block-library/src/navigation/placeholder-preview.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { Icon, search } from '@wordpress/icons';
-import { memo } from '@wordpress/element';
 
 const PlaceholderPreview = () => {
 	return (
@@ -15,4 +14,4 @@ const PlaceholderPreview = () => {
 	);
 };
 
-export default memo( PlaceholderPreview );
+export default PlaceholderPreview;


### PR DESCRIPTION
When editing a post with a lot of navigation links, typing in a paragraph block is slowed down considerably. One of the top reasons for re-renders is the placeholder component passed to innerBlocks.

Before:

https://user-images.githubusercontent.com/1270189/120244832-26c32f80-c220-11eb-8e20-f174335e68e3.mp4

After:

https://user-images.githubusercontent.com/1270189/120244838-2c207a00-c220-11eb-965a-55e2966a8755.mp4

### Testing instructions

- In the post (/wp-admin/post.php) or site editor, try adding a navigation block by typing `/navigation` and selecting the navigation block
- Deselect the block so we see the placeholder, which should appear as 3 rectangles and a search icon. Make sure this doesn't differ in behavior from trunk.
<img width="558" alt="Screen Shot 2021-05-31 at 2 15 56 PM" src="https://user-images.githubusercontent.com/1270189/120244917-6be76180-c220-11eb-9afa-0ce3c3eea504.png">
- Add a number of navigation links and try to type in another paragraph
- In trunk: confirm that one of the main reasons for re-render is the placeholder prop in the react profiler (see before video)
- On this branch: verify that the placeholder prop no longer shows up as a reason for rerender (see after video)


