### PR TITLE
Widgets editor: Fix error when saving empty Legacy Widget block

### DIFF
--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -37,7 +37,11 @@ export function transformWidgetToBlock( widget ) {
 export function transformBlockToWidget( block, relatedWidget = {} ) {
 	let widget;
 
-	if ( block.name === 'core/legacy-widget' ) {
+	const isValidLegacyWidgetBlock =
+		block.name === 'core/legacy-widget' &&
+		( block.attributes.id || block.attributes.instance );
+
+	if ( isValidLegacyWidgetBlock ) {
 		widget = {
 			...relatedWidget,
 			id: block.attributes.id ?? relatedWidget.id,
@@ -55,13 +59,6 @@ export function transformBlockToWidget( block, relatedWidget = {} ) {
 			},
 		};
 	}
-
-	// Delete deprecated properties.
-	delete widget.description;
-	delete widget.name;
-	delete widget.number;
-	delete widget.settings;
-	delete widget.widget_class;
 
 	// Delete read-only properties.
 	delete widget.rendered;


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/28561.

Changes the Widgets editor to store an empty Legacy Widget block as a block widget instead of as a non-block widget. By definition one cannot convert an empty Legacy Widget block to a non-block widget as you cannot have a widget without a widget type.

Similar logic already exists in the Customizer. Unfortunately we can't really reuse logic because the Customizer and the REST API represent widgets in a different way.

## How has this been tested?

Follow steps in https://github.com/WordPress/gutenberg/issues/28561.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->