### PR TITLE
Fix deselecting block when inspector is opened

### DIFF
--- a/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
+++ b/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
@@ -29,8 +29,7 @@ export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
 
 	useEffect( () => {
 		if ( popoverRef.current && sidebarControl ) {
-			const inspectorContainer =
-				sidebarControl.inspector.contentContainer[ 0 ];
+			const inspector = sidebarControl.inspector;
 			const container = sidebarControl.container[ 0 ];
 			const ownerDocument = container.ownerDocument;
 			const ownerWindow = ownerDocument.defaultView;
@@ -42,11 +41,12 @@ export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
 					// 2. The element should exist in the DOM (not deleted).
 					element &&
 					ownerDocument.contains( element ) &&
-					// 3. It should also not exist in the container, inspector, nor the popover.
+					// 3. It should also not exist in the container, the popover, nor the dialog.
 					! container.contains( element ) &&
 					! popoverRef.current.contains( element ) &&
-					! inspectorContainer.contains( element ) &&
-					! element.closest( '[role="dialog"]' )
+					! element.closest( '[role="dialog"]' ) &&
+					// 4. The inspector should not be opened.
+					! inspector.expanded()
 				) {
 					clearSelectedBlock();
 				}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #32241.

Instead of checking if the focus is moved to the element inside inspector, we don't clear the selected block at all while the inspector is opened.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Appearance -> Customize -> Widgets
2. Add a paragraph (or any other block)
3. Open the inspector of that block (Block toolbar -> More menu -> Show more settings)
4. Click on the gray area of the inspector
5. The block shouldn't be deselected

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
