### PR TITLE
Navigation: Use gap instead of margin.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -11,6 +11,13 @@
 		margin-left: 0;
 		padding-left: 0;
 	}
+
+	// Revert any left/right margins.
+	// This also makes it work with classic theme auto margins.
+	.wp-block-navigation-item.wp-block {
+		margin-left: revert;
+		margin-right: revert;
+	}
 }
 
 // This element is inline on the frontend but needs to be editable, therefore inline-block, in the editor.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -211,7 +211,7 @@
  */
 
 // Menu items with no background.
-.wp-block-navigation__container .wp-block-page-list,
+.wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container {
 	gap: 0.5em 2em;
 }
@@ -221,7 +221,7 @@
 // That way if padding is set in theme.json, it still wins.
 // https://css-tricks.com/almanac/selectors/w/where/
 .wp-block-navigation:where(.has-background) {
-	.wp-block-navigation__container .wp-block-page-list,
+	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
 		gap: 0 0.5em;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -208,19 +208,12 @@
 
 /**
  * Margins
- * @todo: refactor this to use gap.
  */
 
 // Menu items with no background.
-.wp-block-page-list,
-.wp-block-page-list > .wp-block-navigation-item,
-.wp-block-navigation__container > .wp-block-navigation-item {
-	margin: 0 2em 0 0;
-
-	// Margin of right-most margin should be zero, for right aligned or justified items.
-	&:last-child {
-		margin-right: 0;
-	}
+.wp-block-navigation__container .wp-block-page-list,
+.wp-block-navigation__container {
+	gap: 0.5em 2em;
 }
 
 // Menu items with background.
@@ -228,15 +221,9 @@
 // That way if padding is set in theme.json, it still wins.
 // https://css-tricks.com/almanac/selectors/w/where/
 .wp-block-navigation:where(.has-background) {
-	.wp-block-page-list,
-	.wp-block-page-list > .wp-block-navigation-item,
-	.wp-block-navigation__container > .wp-block-navigation-item {
-		margin: 0 0.5em 0 0;
-
-		// Don't show right margin on the last child.
-		&:last-child {
-			margin: 0;
-		}
+	.wp-block-navigation__container .wp-block-page-list,
+	.wp-block-navigation__container {
+		gap: 0 0.5em;
 	}
 }
 
@@ -357,7 +344,6 @@
 	align-items: flex-end;
 
 	.wp-block-navigation-item {
-		margin-right: 0;
 		justify-content: flex-end;
 	}
 }


### PR DESCRIPTION
## Description

This PR refactors the navigation block to use `gap` instead of margins for spacing items out. The rules remain the same, if a navigation block has a background color, it has a smaller gap, than if it doesn't.

Submenu items should be unaffected, as those are not spaced out using margins at all, purely the padding of items themselves.

This comes with a few benefits:

- If nav items wrap, the right-most item on row 1 doesn't have margin on its right.
- The CSS is vastly simplified and reduced, making it easier for themes to override.
- Paired with #32366, this could provide a neat interface directly in the navigation block for controlling item-spacing. 

## Testing instructions

Compare this branch with trunk, and the spacing should be the same. Before:

<img width="684" alt="before" src="https://user-images.githubusercontent.com/1204802/120309164-39e40700-c2d5-11eb-867d-f155f2371906.png">

After:

<img width="684" alt="after" src="https://user-images.githubusercontent.com/1204802/120309172-3cdef780-c2d5-11eb-86f4-7cdeb4b257f9.png">

Please test with and without backgrounds, vertical and horizontal, frontend and backend. Test a few themes. Some themes like TwentyTwentyOne provide style overrides for the navigation block that are obsolete, so won't necessarily be accurate, see also https://core.trac.wordpress.org/ticket/53220.

## Screenshots

<img width="170" alt="Screenshot 2021-06-01 at 12 25 32" src="https://user-images.githubusercontent.com/1204802/120309604-b545b880-c2d5-11eb-9067-7d0169593266.png">

<img width="324" alt="Screenshot 2021-06-01 at 12 25 45" src="https://user-images.githubusercontent.com/1204802/120309606-b676e580-c2d5-11eb-9467-c204ff891968.png">

<img width="834" alt="colors" src="https://user-images.githubusercontent.com/1204802/120309608-b7a81280-c2d5-11eb-91a0-1b0fb55c5e11.png">

<img width="800" alt="Screenshot 2021-06-01 at 12 28 00" src="https://user-images.githubusercontent.com/1204802/120309612-b8d93f80-c2d5-11eb-913f-9279856d2ac6.png">

<img width="697" alt="Screenshot 2021-06-01 at 12 28 12" src="https://user-images.githubusercontent.com/1204802/120309616-ba0a6c80-c2d5-11eb-8ecb-998841518dba.png">

<img width="724" alt="Screenshot 2021-06-01 at 12 28 16" src="https://user-images.githubusercontent.com/1204802/120309622-bb3b9980-c2d5-11eb-943b-ffcc8d96a606.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
