### PR TITLE
Compose: Deprecate `withState` in favor of `useState`

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   `withState` HOC has been deprecated. Use `useState` hook instead.
+
 ## 4.1.0 (2021-05-20)
 
 ## 4.0.0 (2021-05-14)

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -529,6 +529,8 @@ _Returns_
 
 <a name="withState" href="#withState">#</a> **withState**
 
+> **Deprecated** Use `useState` instead.
+
 A Higher Order Component used to provide and manage internal component state
 via props.
 

--- a/packages/compose/src/higher-order/with-state/README.md
+++ b/packages/compose/src/higher-order/with-state/README.md
@@ -1,5 +1,7 @@
 # withState
 
+**Deprecated**
+
 `withState` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) which enables a function component to have internal state.
 
 Wrapping a component with `withState` provides state as props to the wrapped component, along with a `setState` updater function.

--- a/packages/compose/src/higher-order/with-state/index.js
+++ b/packages/compose/src/higher-order/with-state/index.js
@@ -21,10 +21,7 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  */
 export default function withState( initialState = {} ) {
 	deprecated( 'wp.compose.withState', {
-		since: '10.8',
-		plugin: 'Gutenberg',
 		alternative: 'wp.element.useState',
-		version: '11.1',
 	} );
 
 	return createHigherOrderComponent( ( OriginalComponent ) => {

--- a/packages/compose/src/higher-order/with-state/index.js
+++ b/packages/compose/src/higher-order/with-state/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -12,11 +13,20 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  * A Higher Order Component used to provide and manage internal component state
  * via props.
  *
+ * @deprecated Use `useState` instead.
+ *
  * @param {?Object} initialState Optional initial state of the component.
  *
  * @return {WPComponent} Wrapped component.
  */
 export default function withState( initialState = {} ) {
+	deprecated( 'wp.compose.withState', {
+		since: '10.8',
+		plugin: 'Gutenberg',
+		alternative: 'wp.element.useState',
+		version: '11.1',
+	} );
+
 	return createHigherOrderComponent( ( OriginalComponent ) => {
 		return class WrappedComponent extends Component {
 			constructor() {

--- a/packages/compose/src/higher-order/with-state/test/index.js
+++ b/packages/compose/src/higher-order/with-state/test/index.js
@@ -41,9 +41,11 @@ describe( 'withState', () => {
 		const wrapper = TestUtils.renderIntoDocument(
 			getTestComponent( EnhancedComponent )
 		);
+
 		const buttonElement = () =>
 			TestUtils.findRenderedDOMComponentWithTag( wrapper, 'button' );
 
+		expect( console ).toHaveWarned();
 		expect( buttonElement().outerHTML ).toBe( '<button>0</button>' );
 		TestUtils.Simulate.click( buttonElement() );
 		expect( buttonElement().outerHTML ).toBe( '<button>1</button>' );


### PR DESCRIPTION
## Description
Deprecates `withState` in favor of `useState`. It's no longer used in core as of #32349.

## How has this been tested?
Tested deprecation for `wp.compose.withState` in Browser console.

```js
wp.compose.withState();
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-06-01 at 14 54 44](https://user-images.githubusercontent.com/240569/120312773-30b16500-c2ea-11eb-96dc-c651c35a1b40.png)


## Types of changes
Deprecation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
