### PR TITLE
Fix site-logo not getting removed on remove_theme_mod

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -111,24 +111,27 @@ add_filter( 'theme_mod_custom_logo', '_override_custom_logo_theme_mod' );
 /**
  * Updates the site_logo option when the custom_logo theme-mod gets updated.
  *
- * @param string $custom_logo The custom logo set by a theme.
+ * This function is hooked on "update_option_theme_mods_$theme" and not
+ * "pre_set_theme_mod_custom_logo" because by hooking in `update_option`
+ * the function accounts for remove_theme_mod() as well.
  *
- * @return string The custom logo.
+ * @param mixed $old_value The old option value.
+ * @param mixed $value     The new option value.
  */
-function _sync_custom_logo_to_site_logo( $custom_logo ) {
+function _sync_custom_logo_to_site_logo( $old_value, $value ) {
 	// Delete the option when the custom logo does not exist or was removed.
 	// This step ensures the option stays in sync.
-	if ( empty( $custom_logo ) ) {
+	if ( empty( $value['custom_logo'] ) ) {
 		delete_option( 'site_logo' );
 	} else {
 		remove_action( 'update_option_site_logo', '_sync_site_logo_to_custom_logo' );
-		update_option( 'site_logo', $custom_logo );
+		update_option( 'site_logo', $value['custom_logo'] );
 		add_action( 'update_option_site_logo', '_sync_site_logo_to_custom_logo', 10, 2 );
 	}
-	return $custom_logo;
 }
 
-add_filter( 'pre_set_theme_mod_custom_logo', '_sync_custom_logo_to_site_logo' );
+$theme = get_option( 'stylesheet' );
+add_action( "update_option_theme_mods_$theme", '_sync_custom_logo_to_site_logo', 10, 2 );
 
 /**
  * Updates the custom_logo theme-mod when the site_logo option gets updated.

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -130,7 +130,16 @@ function _sync_custom_logo_to_site_logo( $old_value, $value ) {
 	}
 }
 
-add_action( 'update_option_theme_mods_' . get_option( 'stylesheet' ), '_sync_custom_logo_to_site_logo', 10, 2 );
+/**
+ * Hooks `_sync_custom_logo_to_site_logo` in `update_option_theme_mods_$theme`.
+ *
+ * Runs on `setup_theme` to account for dynamically-switched themes in the Customizer.
+ */
+function _sync_custom_logo_to_site_logo_on_setup_theme() {
+	$theme = get_option( 'stylesheet' );
+	add_action( "update_option_theme_mods_$theme", '_sync_custom_logo_to_site_logo', 10, 2 );
+}
+add_action( 'setup_theme', '_sync_custom_logo_to_site_logo_on_setup_theme', 11 );
 
 /**
  * Updates the custom_logo theme-mod when the site_logo option gets updated.

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -130,8 +130,7 @@ function _sync_custom_logo_to_site_logo( $old_value, $value ) {
 	}
 }
 
-$theme = get_option( 'stylesheet' );
-add_action( "update_option_theme_mods_$theme", '_sync_custom_logo_to_site_logo', 10, 2 );
+add_action( 'update_option_theme_mods_' . get_option('stylesheet'), '_sync_custom_logo_to_site_logo', 10, 2 );
 
 /**
  * Updates the custom_logo theme-mod when the site_logo option gets updated.

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -130,7 +130,7 @@ function _sync_custom_logo_to_site_logo( $old_value, $value ) {
 	}
 }
 
-add_action( 'update_option_theme_mods_' . get_option('stylesheet'), '_sync_custom_logo_to_site_logo', 10, 2 );
+add_action( 'update_option_theme_mods_' . get_option( 'stylesheet' ), '_sync_custom_logo_to_site_logo', 10, 2 );
 
 /**
  * Updates the custom_logo theme-mod when the site_logo option gets updated.


### PR DESCRIPTION
## Description
This is a backport of tweaks to the site-logo block PR in core: https://github.com/WordPress/wordpress-develop/pull/1275
There was a failing phpunit test in core because the site-logo was not getting removed on `remove_theme_mod`.
This PR changes the hook so it runs on `update_option_theme_mods_$theme` instead. This runs when a theme-mod gets updated **and deleted** as opposed to `pre_set_theme_mod_custom_logo` which only runs on updating.

## How has this been tested?

Tested by going to the customizer, changing the site-logo and confirming that the site-logo block also gets the updated logo. Then tested the reverse, changing the site-logo block and confirming that custom_logo gets updated in the customizer. Then tested removing the image from the media-library (this triggers remove_theme_mod), and confirming both the customizer and the site-logo get properly updated.At each step I confirmed the findings both in the UI and by manually examining the database entries.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
