### PR TITLE
Avoid enqueuing global styles twice when running on WordPress 5.8

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -48,6 +48,10 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
+	// Gutenberg will take care of enqueuing the corresponding styles,
+	// so we tell core not to enqueue its own.
+	wp_deregister_style( 'global-styles' );
+
 	if (
 		! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
 		! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
@@ -62,9 +66,9 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 		return;
 	}
 
-	wp_register_style( 'global-styles', false, array(), true, true );
-	wp_add_inline_style( 'global-styles', $stylesheet );
-	wp_enqueue_style( 'global-styles' );
+	wp_register_style( 'global-styles-gutenberg', false, array(), true, true );
+	wp_add_inline_style( 'global-styles-gutenberg', $stylesheet );
+	wp_enqueue_style( 'global-styles-gutenberg' );
 }
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -48,10 +48,6 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	// Gutenberg will take care of enqueuing the corresponding styles,
-	// so we tell core not to enqueue its own.
-	wp_deregister_style( 'global-styles' );
-
 	if (
 		! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
 		! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
@@ -66,9 +62,13 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 		return;
 	}
 
-	wp_register_style( 'global-styles-gutenberg', false, array(), true, true );
-	wp_add_inline_style( 'global-styles-gutenberg', $stylesheet );
-	wp_enqueue_style( 'global-styles-gutenberg' );
+	if ( isset( wp_styles()->registered['global-styles'] ) ) {
+		wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
+	} else {
+		wp_register_style( 'global-styles', false, array(), true, true );
+		wp_add_inline_style( 'global-styles', $stylesheet );
+		wp_enqueue_style( 'global-styles' );
+	}
 }
 
 /**


### PR DESCRIPTION
The Gutenberg plugin embeds a stylesheet that contains the global styles of the site. WordPress 5.8 does the same. So, when the plugin runs on WordPress 5.8 we need to tell WordPress core not to enqueue its styles to prevent conflicts and avoid enqueueing them twice.

## Types of changes

If there's a `global-styles` style handle, the plugin will overwrite the contents of the first style element (styles that come from WordPress core). If there's not, it'll enqueue a new stylesheet with that style handle.

## How to test

Test the following scenarios and verify that when visiting the front end, there's a  `global-styles-inline-css` stylesheet.

- WordPress <5.8 with Gutenberg
- WordPress 5.8 with and without Gutenberg

## Alternatives considered

An alternative I've tried (see https://github.com/WordPress/gutenberg/pull/32372/commits/aa6e0fa536ced6d4513b80def92091f010858060) was to make the plugin use a different style handle (`global-styles-gutenberg`) and deregister core's if there was one. However, maintaining the style handle consistent allows third-party to hook into it as well.
