### PR TITLE
Add title class name to latest posts Block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -536,7 +536,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									) }
 								</div>
 							) }
-							<a href={ post.link } rel="noreferrer noopener">
+							<a href={ post.link } rel="noreferrer noopener" className="wp-block-latest-posts__post-title">
 								{ titleTrimmed ? (
 									<RawHTML>{ titleTrimmed }</RawHTML>
 								) : (

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -536,7 +536,11 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									) }
 								</div>
 							) }
-							<a href={ post.link } rel="noreferrer noopener" className="wp-block-latest-posts__post-title">
+							<a
+								href={ post.link }
+								rel="noreferrer noopener"
+								className="wp-block-latest-posts__post-title"
+							>
 								{ titleTrimmed ? (
 									<RawHTML>{ titleTrimmed }</RawHTML>
 								) : (

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -103,7 +103,7 @@ function render_block_core_latest_posts( $attributes ) {
 			$title = __( '(no title)' );
 		}
 		$list_items_markup .= sprintf(
-			'<a href="%1$s">%2$s</a>',
+			'<a href="%1$s" class="wp-block-latest-posts__post-title">%2$s</a>',
 			$post_link,
 			$title
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I think the title element of the latest posts Block should contain the class name, just like the author, post date, etc.

related #22759

## How has this been tested?
1. You create a new post.
2. Add a latest post block, and save.

You will see the class name `wp-block-latest-posts__post-title` added to the `a` tag of the post title in the editor screen and on the front side using the dev tool.

## Screenshots <!-- if applicable -->
![ ss_2021-06-01 23 30 01](https://user-images.githubusercontent.com/487207/120341130-970da600-c331-11eb-81e4-4031533e1cab.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
