### PR TITLE
Fix allowed patterns check

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/use-patterns-setup.js
+++ b/packages/block-editor/src/components/block-pattern-setup/use-patterns-setup.js
@@ -14,23 +14,17 @@ function usePatternsSetup( clientId, blockName, filterPatternsFn ) {
 			const {
 				getBlockRootClientId,
 				__experimentalGetPatternsByBlockTypes,
-				__experimentalGetParsedPattern,
 				__experimentalGetAllowedPatterns,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
-			let patterns = [];
 			if ( filterPatternsFn ) {
-				patterns = __experimentalGetAllowedPatterns(
-					rootClientId
-				).filter( filterPatternsFn );
-			} else {
-				patterns = __experimentalGetPatternsByBlockTypes(
-					blockName,
-					rootClientId
+				return __experimentalGetAllowedPatterns( rootClientId ).filter(
+					filterPatternsFn
 				);
 			}
-			return patterns.map( ( { name } ) =>
-				__experimentalGetParsedPattern( name )
+			return __experimentalGetPatternsByBlockTypes(
+				blockName,
+				rootClientId
 			);
 		},
 		[ clientId, blockName, filterPatternsFn ]

--- a/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
+++ b/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
@@ -3,13 +3,11 @@
  */
 import { useMemo } from '@wordpress/element';
 import { cloneBlock } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getMatchingBlockByName, getRetainedBlockAttributes } from './utils';
-import { store as blockEditorStore } from '../../store';
 
 /**
  * Mutate the matched block's attributes by getting
@@ -96,19 +94,9 @@ export const getPatternTransformedBlocks = (
  */
 // TODO tests
 const useTransformedPatterns = ( patterns, selectedBlocks ) => {
-	const parsedPatterns = useSelect(
-		( select ) =>
-			patterns.map( ( { name } ) =>
-				select( blockEditorStore ).__experimentalGetParsedPattern(
-					name
-				)
-			),
-		[ patterns ]
-	);
-
 	return useMemo(
 		() =>
-			parsedPatterns.reduce( ( accumulator, _pattern ) => {
+			patterns.reduce( ( accumulator, _pattern ) => {
 				const transformedBlocks = getPatternTransformedBlocks(
 					selectedBlocks,
 					_pattern.blocks
@@ -121,7 +109,7 @@ const useTransformedPatterns = ( patterns, selectedBlocks ) => {
 				}
 				return accumulator;
 			}, [] ),
-		[ parsedPatterns, selectedBlocks ]
+		[ patterns, selectedBlocks ]
 	);
 };
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -30,7 +30,6 @@ import {
 } from '@wordpress/blocks';
 import { SVG, Rect, G, Path } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
-import { parse as parseBlocks } from '@wordpress/block-serialization-default-parser';
 
 /**
  * A block selection object.
@@ -1837,10 +1836,14 @@ const getAllAllowedPatterns = createSelector(
 			// the raw blocks parser, also known as the "stage I" block parser.
 			// This is about 250x faster than the full parse that the Block API
 			// offers.
-			blockNodes: parseBlocks( pattern.content ),
+			__unstableBlockNodes: parse( pattern.content ),
 		} ) );
-		const allowedPatterns = parsedPatterns.filter( ( { blockNodes } ) =>
-			checkAllowListRecursive( blockNodes, allowedBlockTypes )
+		const allowedPatterns = parsedPatterns.filter(
+			( { __unstableBlockNodes } ) =>
+				checkAllowListRecursive(
+					__unstableBlockNodes,
+					allowedBlockTypes
+				)
 		);
 		return allowedPatterns;
 	},
@@ -1863,11 +1866,12 @@ export const __experimentalGetAllowedPatterns = createSelector(
 		const availableParsedPatterns = getAllAllowedPatterns( state );
 		const patternsAllowed = filter(
 			availableParsedPatterns,
-			( { blockNodes } ) =>
-				blockNodes.every( ( { blockName } ) =>
-					canInsertBlockType( state, blockName, rootClientId )
+			( { __unstableBlockNodes } ) =>
+				__unstableBlockNodes.every( ( { name } ) =>
+					canInsertBlockType( state, name, rootClientId )
 				)
 		);
+
 		return patternsAllowed;
 	},
 	( state, rootClientId ) => [


### PR DESCRIPTION
closes #32139 

For performance reasons, we only used a partial parsing to check the blocks used in a pattern, the issue with that is that the second step for parsing performs a lot of block normalizations:

 - apply the fallback block type.
 - rename some old renamed blocks.
 - Run deprecations and upgrade some blocks.

So it has the potential to change the blocks used in a block pattern meaning the performance optimization actually breaks the logic. Potentially we could consider building a dedicated "parse" function that only returns the list of blocks used in an HTML string.

**Testing instructions**

 - Register a pattern with whitespace, example:

```
		register_block_pattern(
			'twentyfourteen/about',
			array(
				'title'         => esc_html__( 'About', 'twentyfourteen' ),
				'categories'    => array( 'buttons' ),
				'viewportWidth' => 1000,
				'content'       => '<!-- wp:image {"id":31,"sizeSlug":"large","linkDestination":"none"} -->
									<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/images/person.jpg" alt="' . esc_attr__( 'A person standing in front of a lake', 'twentyfourteen' ) . '" class="wp-image-31"/></figure>
									<!-- /wp:image -->
									<!-- wp:heading {"fontSize":"large","style":{"typography":{"lineHeight":"1.4"}}} -->
									<h2 class="has-large-font-size" style="line-height:1.4">' . esc_html__( 'Hello, my name is Joan. I am passionate about writing, travel, and photography.', 'twentyfourteen' ) . '</h2>
									<!-- /wp:heading -->
									<!-- wp:paragraph -->
									<p>' . esc_html__( 'I’ve traveled to over 60 countries, and have made many friends along the way. I created this website to keep track of the memories I’ve made in my years of traveling.', 'twentyfourteen' ) . '</p>
									<!-- /wp:paragraph -->',
			)
		);
```

Makes sure it appears in the patterns inserter.