### PR TITLE
Enqueue global styles in editor only once

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -130,6 +130,14 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			'__experimentalNoWrapper' => true,
 		);
 
+		// Reset existing global styles.
+		foreach( $settings['styles'] as $key => $style ) {
+			if ( isset( $style['__experimentalGlobalStyles'] ) ) {
+				unset( $settings['styles'][ $key ] );
+			}
+		}
+
+		// Add the new ones.
 		$settings['styles'][] = $css_variables;
 		$settings['styles'][] = $block_styles;
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -131,7 +131,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		);
 
 		// Reset existing global styles.
-		foreach( $settings['styles'] as $key => $style ) {
+		foreach ( $settings['styles'] as $key => $style ) {
 			if ( isset( $style['__experimentalGlobalStyles'] ) ) {
 				unset( $settings['styles'][ $key ] );
 			}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -132,7 +132,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 		// Reset existing global styles.
 		foreach ( $settings['styles'] as $key => $style ) {
-			if ( isset( $style['__experimentalGlobalStyles'] ) ) {
+			if ( isset( $style['__unstableType'] ) && 'globalStyles' === $style['__unstableType'] ) {
 				unset( $settings['styles'][ $key ] );
 			}
 		}


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/32372

This relies on a core change https://github.com/WordPress/wordpress-develop/pull/1326 to remove the styles that come from WordPress core before adding the styles from the plugin.

