### PR TITLE
Experimental Layout: pass the same object when no data changes

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
@@ -29,10 +30,21 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { tagName: TagName = 'div', templateLock, layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
-	const alignments =
-		contentSize || wideSize
-			? [ 'wide', 'full' ]
-			: [ 'left', 'center', 'right' ];
+	const _layout = useMemo( () => {
+		if ( themeSupportsLayout ) {
+			const alignments =
+				contentSize || wideSize
+					? [ 'wide', 'full' ]
+					: [ 'left', 'center', 'right' ];
+			return {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments,
+			};
+		}
+		return undefined;
+	}, [ themeSupportsLayout, contentSize, wideSize ] );
+
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps(
 		themeSupportsLayout
@@ -43,11 +55,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
-			__experimentalLayout: {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments: themeSupportsLayout ? alignments : undefined,
-			},
+			__experimentalLayout: _layout,
 		}
 	);
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -12,6 +12,7 @@ import {
 	Warning,
 } from '@wordpress/block-editor';
 import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useMemo } from '@wordpress/element';
 
 function Content( { layout, postType, postId } ) {
 	const themeSupportsLayout = useSelect( ( select ) => {
@@ -21,10 +22,20 @@ function Content( { layout, postType, postId } ) {
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
-	const alignments =
-		contentSize || wideSize
-			? [ 'wide', 'full' ]
-			: [ 'left', 'center', 'right' ];
+	const _layout = useMemo( () => {
+		if ( themeSupportsLayout ) {
+			const alignments =
+				contentSize || wideSize
+					? [ 'wide', 'full' ]
+					: [ 'left', 'center', 'right' ];
+			return {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments,
+			};
+		}
+		return undefined;
+	}, [ themeSupportsLayout, contentSize, wideSize ] );
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,
@@ -36,11 +47,7 @@ function Content( { layout, postType, postId } ) {
 			value: blocks,
 			onInput,
 			onChange,
-			__experimentalLayout: {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments: themeSupportsLayout ? alignments : undefined,
-			},
+			__experimentalLayout: _layout,
 		}
 	);
 	return <div { ...props } />;

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorAdvancedControls,
@@ -44,18 +44,24 @@ export function QueryContent( { attributes, setAttributes } ) {
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
-	const alignments =
-		contentSize || wideSize
-			? [ 'wide', 'full' ]
-			: [ 'left', 'center', 'right' ];
 	const blockProps = useBlockProps();
+	const _layout = useMemo( () => {
+		if ( themeSupportsLayout ) {
+			const alignments =
+				contentSize || wideSize
+					? [ 'wide', 'full' ]
+					: [ 'left', 'center', 'right' ];
+			return {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments,
+			};
+		}
+		return undefined;
+	}, [ themeSupportsLayout, contentSize, wideSize ] );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
-		__experimentalLayout: {
-			type: 'default',
-			// Find a way to inject this in the support flag code (hooks).
-			alignments: themeSupportsLayout ? alignments : undefined,
-		},
+		__experimentalLayout: _layout,
 	} );
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -9,6 +9,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 export default function TemplatePartInnerBlocks( {
 	postId: id,
@@ -24,10 +25,21 @@ export default function TemplatePartInnerBlocks( {
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { contentSize, wideSize } = usedLayout;
-	const alignments =
-		contentSize || wideSize
-			? [ 'wide', 'full' ]
-			: [ 'left', 'center', 'right' ];
+	const _layout = useMemo( () => {
+		if ( themeSupportsLayout ) {
+			const alignments =
+				contentSize || wideSize
+					? [ 'wide', 'full' ]
+					: [ 'left', 'center', 'right' ];
+			return {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments,
+			};
+		}
+		return undefined;
+	}, [ themeSupportsLayout, contentSize, wideSize ] );
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'wp_template_part',
@@ -40,11 +52,7 @@ export default function TemplatePartInnerBlocks( {
 		renderAppender: hasInnerBlocks
 			? undefined
 			: InnerBlocks.ButtonBlockAppender,
-		__experimentalLayout: {
-			type: 'default',
-			// Find a way to inject this in the support flag code (hooks).
-			alignments: themeSupportsLayout ? alignments : undefined,
-		},
+		__experimentalLayout: _layout,
 	} );
 	return <TagName { ...innerBlocksProps } />;
 }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -31,7 +31,7 @@ import {
 	__unstableIframe as Iframe,
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
 } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
+import { useRef, useMemo } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
@@ -137,10 +137,6 @@ export default function VisualEditor( { styles } ) {
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
 	const defaultLayout = useSetting( 'layout' );
 	const { contentSize, wideSize } = defaultLayout || {};
-	const alignments =
-		contentSize || wideSize
-			? [ 'wide', 'full' ]
-			: [ 'left', 'center', 'right' ];
 
 	let animatedStyles = isTemplateMode
 		? templateModeStyles
@@ -173,6 +169,21 @@ export default function VisualEditor( { styles } ) {
 		wrapperUniqueId,
 		wrapperBlockName
 	);
+
+	const layout = useMemo( () => {
+		if ( themeSupportsLayout ) {
+			const alignments =
+				contentSize || wideSize
+					? [ 'wide', 'full' ]
+					: [ 'left', 'center', 'right' ];
+			return {
+				type: 'default',
+				// Find a way to inject this in the support flag code (hooks).
+				alignments,
+			};
+		}
+		return undefined;
+	}, [ themeSupportsLayout, contentSize, wideSize ] );
 
 	return (
 		<div
@@ -225,17 +236,7 @@ export default function VisualEditor( { styles } ) {
 								) }
 								<RecursionProvider>
 									<BlockList
-										__experimentalLayout={
-											themeSupportsLayout
-												? {
-														type: 'default',
-														// Find a way to inject this in the support flag code (hooks).
-														alignments: themeSupportsLayout
-															? alignments
-															: undefined,
-												  }
-												: undefined
-										}
+										__experimentalLayout={ layout }
 									/>
 								</RecursionProvider>
 							</WritingFlow>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -30,6 +30,12 @@ import { SidebarInspectorFill } from '../sidebar';
 import { store as editSiteStore } from '../../store';
 import BlockInspectorButton from './block-inspector-button';
 
+const LAYOUT = {
+	type: 'default',
+	// At the root level of the site editor, no alignments should be allowed.
+	alignments: [],
+};
+
 export default function BlockEditor( { setIsInserterOpen } ) {
 	const { settings, templateType, page, deviceType } = useSelect(
 		( select ) => {
@@ -94,11 +100,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						<WritingFlow>
 							<BlockList
 								className="edit-site-block-editor__block-list"
-								__experimentalLayout={ {
-									type: 'default',
-									// At the root level of the site editor, no alignments should be allowed.
-									alignments: [],
-								} }
+								__experimentalLayout={ LAYOUT }
 							/>
 						</WritingFlow>
 					</Iframe>


### PR DESCRIPTION
For performance reasons React does not make deep equality checks. One area that continues to cause trouble is passing a new array, object or Components even when data doesn’t change. This PR updates passing of __experimentalLayout to a memo'd object so re-renders are not triggered when layout data doesn't change.

This removes one of the top reasons for BlockList to rerender. This isn't a silver bullet but should help performance in the site and post editor.

Before:

https://user-images.githubusercontent.com/1270189/120372448-0cdf2680-c2cc-11eb-9d60-294c10eb044a.mp4

After

https://user-images.githubusercontent.com/1270189/120372535-297b5e80-c2cc-11eb-92a8-1631a846c69a.mp4

### Testing Instructions

- No regressions with layouts in Site and Post Editor
- Verify that __experimentalLayout no longer shows as a top reason in the react profilers. See example video for steps.

### Bonus Points

Verify that __experimentalLayout does not trigger a render inappropriately with some local logging.

We can add a line above in BlockList items https://github.com/WordPress/gutenberg/blob/c02903a4c7f964e96e27e0fae49df975f97e39ac/packages/block-editor/src/components/block-list/index.js#L90
```jsx
useLogIfChanged( 'layout', layout );
```

```jsx
import { useRef } from '@wordpress/element';
import { isEqual } from 'lodash';
function useLogIfChanged( name, value ) {
	const previous = useRef( value );
	if ( ! Object.is( previous.current, value ) ) {
		console.log(
			`${ name } changed`,
			'Old:',
			previous.current,
			'New:',
			value
		);
		for ( const key in value ) {
			console.log( `${ name }===>>>`, key, ' deep equal ', isEqual( value[ key ], previous?.current?.[ key ] ), ' ref equal', value[ key ] === previous?.current?.[ key ] );
		}
		previous.current = value;
                //console.trace(); //if you'd like to see which component is triggering this
	}
}
```


