### PR TITLE
Update iOS Simulator device command in React Native docs

### DIFF
--- a/docs/contributors/code/getting-started-native-mobile.md
+++ b/docs/contributors/code/getting-started-native-mobile.md
@@ -56,16 +56,16 @@ which will attempt to open your app in the iOS Simulator if you're on a Mac and 
 
 ### Running on Other iOS Device Simulators
 
-To compile and run the app using a different device simulator, use:
+To compile and run the app using a different device simulator, use the following, noting the double sets of `--` to pass the simulator option down to the `react-native` CLI.
 
 ```
-npm run native ios --simulator="DEVICE_NAME"
+npm run native ios -- -- --simulator="DEVICE_NAME"
 ```
 
 For example, if you'd like to run in an iPhone Xs Max, try:
 
 ```
-npm run native ios --simulator="iPhone Xs Max"
+npm run native ios -- -- --simulator="iPhone Xs Max"
 ```
 
 To see a list of all of your available iOS devices, use `xcrun simctl list devices`.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

While working through the getting started with native mobile docs, I noticed that I couldn't get `npm run native ios` to launch the iOS simulator with a custom device specified. Despite specifying a device, it would be stuck launching the iPhone 11.

It looks as thought we might need to pass the `--simulator` option down a couple of levels through npm when running the command. If I add two sets of `--` before the `--simulator` option then I can see in the terminal that the `react-native` command gets the appropriate option. Without this, the `--simulator` is passed to either `npm`, or the next level down, which  also appears to be npm via `npm run --prefix packages/react-native-editor`.

CC: @gwwar as I know you've been looking at getting up and running with native mobile.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Follow the instructions in the document and attempt to launch the React Native environment while specifying a custom device. For me, here are the results:

```sh
npm run native ios --simulator="iPhone 8 Plus" # ❌ Doesn't pick up custom device
npm run native ios -- --simulator="iPhone 8 Plus" # ❌ Doesn't pick up custom device
npm run native ios -- -- --simulator="iPhone 8 Plus" # ✅ Launches with iPhone 8 Plus
```

A question for the reader: can you replicate the issue above where it only works with the extra sets of double dashes (`--`)?

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested (tested the documentation update manually)
- (N/A) My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- (N/A) My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- (N/A) I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- (N/A) My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- (N/A) I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
