### PR TITLE
Simplify frontend script for button-only search

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -47,8 +47,6 @@ import {
 	PX_WIDTH_DEFAULT,
 	MIN_WIDTH,
 	MIN_WIDTH_UNIT,
-	showSearchField,
-	hideSearchField,
 } from './utils.js';
 
 // Used to calculate border radius adjustment to avoid "fat" corners when
@@ -88,23 +86,6 @@ export default function SearchEdit( {
 		availableUnits: [ '%', 'px' ],
 		defaultValues: { '%': PC_WIDTH_DEFAULT, px: PX_WIDTH_DEFAULT },
 	} );
-
-	useEffect( () => {
-		if ( isSearchFieldHidden ) {
-			hideSearchField(
-				searchFieldRef.current.offsetParent,
-				searchFieldRef.current,
-				buttonRef.current
-			);
-		} else {
-			showSearchField(
-				searchFieldRef.current.offsetParent,
-				searchFieldRef.current,
-				width,
-				widthUnit
-			);
-		}
-	}, [ isSearchFieldHidden, buttonUseIcon ] );
 
 	useEffect( () => {
 		if ( 'button-only' === buttonPosition && ! isSelected ) {

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -30,4 +30,10 @@
 	&__components-button-group {
 		margin-top: 10px;
 	}
+
+	&.wp-block-search__button-behavior-expand {
+		.wp-block-search__input {
+			transition-duration: 300ms;
+		}
+	}
 }

--- a/packages/block-library/src/search/frontend.js
+++ b/packages/block-library/src/search/frontend.js
@@ -1,85 +1,63 @@
-/**
- * Internal dependencies
- */
-import { showSearchField, hideSearchField } from './utils.js';
-
-const wpBlockSearch = ( block ) => {
-	const attributeContainer = block.querySelector(
-		'.wp-block-search__attributes'
-	);
-
-	if ( ! attributeContainer ) {
-		return;
-	}
-
-	let attributes;
-	try {
-		attributes = JSON.parse( attributeContainer.text );
-	} catch ( e ) {
-		return;
-	}
-	attributeContainer.remove();
-
-	const hiddenClass = 'wp-block-search__searchfield-hidden';
-	const wrapperClass = '.wp-block-search__inside-wrapper';
-	const buttonClass = '.wp-block-search__button';
-
-	const wrapper = block.querySelector( wrapperClass );
-	const searchField = block.querySelector( '.wp-block-search__input' );
-	const button = block.querySelector( buttonClass );
-
-	const toggleSearchField = ( e ) => {
-		if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
-			return false;
-		}
-
-		e.preventDefault();
-
-		return block.classList.contains( hiddenClass )
-			? doShowSearchField()
-			: doHideSearchField();
-	};
-
-	const doShowSearchField = () => {
-		showSearchField(
-			wrapper,
-			searchField,
-			attributes.width,
-			attributes.widthUnit
-		);
-		block.classList.remove( hiddenClass );
-		searchField.focus();
-
-		wrapper.removeEventListener( 'click', toggleSearchField );
-		document.body.addEventListener( 'click', doBlur );
-	};
-
-	const doHideSearchField = ( animate = true ) => {
-		hideSearchField( wrapper, searchField, button, animate );
-		block.classList.add( hiddenClass );
-	};
-
-	const doBlur = ( e ) => {
-		if ( e.target.closest( wrapperClass ) ) {
-			return false;
-		}
-
-		doHideSearchField();
-		document.body.removeEventListener( 'click', doBlur );
-		wrapper.addEventListener( 'click', toggleSearchField );
-	};
-
-	wrapper.addEventListener( 'click', toggleSearchField );
-	doHideSearchField( false );
-};
-
 // eslint-disable-next-line @wordpress/no-global-event-listener
 document.addEventListener( 'DOMContentLoaded', () => {
+	const transitionDuration = 300;
+
 	Array.from(
 		document.getElementsByClassName(
 			'wp-block-search__button-behavior-expand'
 		)
 	).forEach( ( block ) => {
-		wpBlockSearch( block );
+		const hiddenClass = 'wp-block-search__searchfield-hidden';
+		const wrapperClass = '.wp-block-search__inside-wrapper';
+		const buttonClass = '.wp-block-search__button';
+
+		const wrapper = block.querySelector( wrapperClass );
+		const searchField = block.querySelector( '.wp-block-search__input' );
+		const button = block.querySelector( buttonClass );
+
+		// Hide search on init.
+		block.classList.add( hiddenClass );
+		setTimeout(
+			() =>
+				( searchField.style.transitionDuration = `${ transitionDuration }ms` ),
+			transitionDuration
+		);
+
+		const toggleSearchField = ( e ) => {
+			if ( e.target !== button && ! e.target.closest( buttonClass ) ) {
+				return false;
+			}
+
+			e.preventDefault();
+
+			return block.classList.contains( hiddenClass )
+				? doShowSearchField()
+				: doHideSearchField();
+		};
+
+		const doShowSearchField = () => {
+			block.classList.remove( hiddenClass );
+			searchField.focus();
+
+			wrapper.removeEventListener( 'click', toggleSearchField );
+			document.body.addEventListener( 'click', doSearch );
+		};
+
+		const doHideSearchField = () => {
+			block.classList.add( hiddenClass );
+		};
+
+		const doSearch = ( e ) => {
+			if ( e.target.closest( wrapperClass ) ) {
+				return false;
+			}
+
+			doHideSearchField();
+
+			document.body.removeEventListener( 'click', doSearch );
+			wrapper.addEventListener( 'click', toggleSearchField );
+		};
+
+		wrapper.addEventListener( 'click', toggleSearchField );
 	} );
 } );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -189,7 +189,7 @@ function styles_for_block_core_search( $attributes ) {
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
 	$button_only = ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'];
 
-	if ( $has_width && ! $button_only ) {
+	if ( $has_width ) {
 		$wrapper_styles[] = sprintf(
 			'width: %d%s;',
 			esc_attr( $attributes['width'] ),

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -91,17 +91,9 @@ function render_block_core_search( $attributes ) {
 		$input_markup . $button_markup
 	);
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
-	$block_attributes   = '';
 
 	if ( ! empty( $attributes['buttonPosition'] ) && ! empty( $attributes['buttonBehavior'] ) ) {
 		if ( 'button-only' === $attributes['buttonPosition'] && 'expand-searchfield' === $attributes['buttonBehavior'] ) {
-			$block_attributes = '<script type="application/json" class="wp-block-search__attributes">' .
-				wp_json_encode( (object) array(
-					'width' => $attributes['width'],
-					'widthUnit' => $attributes['widthUnit']
-				) ) .
-			'</script>';
-
 			wp_enqueue_script( 'wp-block-library-search', plugins_url( 'search/frontend.js', __FILE__ ) );
 		}
 	}
@@ -110,7 +102,7 @@ function render_block_core_search( $attributes ) {
 		'<form role="search" method="get" action="%s" %s>%s</form>',
 		esc_url( home_url( '/' ) ),
 		$wrapper_attributes,
-		$label_markup . $field_markup . $block_attributes
+		$label_markup . $field_markup
 	);
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -68,6 +68,12 @@
 			min-width: 0 !important;
 		}
 
+		.wp-block-search__input {
+			transition-property: all;
+			transition-duration: 0;
+			flex-basis: 100%;
+		}
+
 		// !important here to override inline styles on button only deselected view.
 		&.wp-block-search__searchfield-hidden {
 			overflow: hidden;
@@ -85,6 +91,7 @@
 				border-right-width: 0 !important;
 				flex-grow: 0;
 				margin: 0;
+				flex-basis: 0 !important;
 			}
 		}
 	}

--- a/packages/block-library/src/search/utils.js
+++ b/packages/block-library/src/search/utils.js
@@ -5,7 +5,6 @@ export const PC_WIDTH_DEFAULT = 50;
 export const PX_WIDTH_DEFAULT = 350;
 export const MIN_WIDTH = 220;
 export const MIN_WIDTH_UNIT = 'px';
-export const SEARCHFIELD_ANIMATION_DURATION = 300;
 
 /**
  * Returns a boolean whether passed unit is percentage
@@ -16,33 +15,4 @@ export const SEARCHFIELD_ANIMATION_DURATION = 300;
  */
 export function isPercentageUnit( unit ) {
 	return unit === '%';
-}
-
-export function hideSearchField( wrapper, searchField, button, animate = true ) {
-	const duration = animate ? SEARCHFIELD_ANIMATION_DURATION : 0;
-
-	searchField.style.transitionDuration = `${ duration }ms`;
-	wrapper.style.transitionDuration = `${ duration }ms`;
-	wrapper.style.width = `${ button.offsetWidth }px`;
-
-	const removeTransitions = setTimeout( () => {
-		wrapper.style.transitionDuration = 'unset';
-
-		clearTimeout( removeTransitions );
-	}, duration );
-}
-
-export function showSearchField( wrapper, searchField, width, widthUnit, animate = true ) {
-	const duration = animate ? SEARCHFIELD_ANIMATION_DURATION : 0;
-
-	searchField.style.transitionDuration = `${ duration }ms`;
-	wrapper.style.transitionDuration = `${ duration }ms`;
-	wrapper.style.width = `${ width }${ widthUnit }`;
-
-	const removeTransitions = setTimeout( () => {
-		searchField.style.width = `${ width }${ widthUnit }`;
-		wrapper.style.transitionDuration = 'unset';
-
-		clearTimeout( removeTransitions );
-	}, duration );
 }


### PR DESCRIPTION
## Description
Simplifies the frontend script for button-only search.
This is not a PR against `trunk`, it is an addition to https://github.com/WordPress/gutenberg/pull/31719

## How has this been tested?
Tested editor & frontend behavior

## Types of changes
Most of the JS was there to make transitions work. Migrated some of that behavior to CSS.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
