### PR TITLE
Fixed Random Collapse of Colors Setting Section

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -246,9 +246,7 @@ export const withBlockControls = createHigherOrderComponent(
 const withElementsStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const elements = props.attributes.style?.elements;
-		if ( ! elements ) {
-			return <BlockListBlock { ...props } />;
-		}
+
 		const blockElementsContainerIdentifier = `wp-elements-${ useInstanceId(
 			BlockListBlock
 		) }`;
@@ -259,17 +257,23 @@ const withElementsStyles = createHigherOrderComponent(
 
 		return (
 			<>
-				<style
-					dangerouslySetInnerHTML={ {
-						__html: styles,
-					} }
-				/>
+				{ elements && (
+					<style
+						dangerouslySetInnerHTML={ {
+							__html: styles,
+						} }
+					/>
+				) }
+
 				<BlockListBlock
 					{ ...props }
-					className={ classnames(
-						props.classname,
-						blockElementsContainerIdentifier
-					) }
+					className={
+						elements &&
+						classnames(
+							props.classname,
+							blockElementsContainerIdentifier
+						)
+					}
 				/>
 			</>
 		);


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/32295

## Description
Fixed Random Collapse of Colors Setting Section on various selection.

The collapse used to occur when the link color is:
1. selected for the first time
2. removed/cleared and text/Background color settings are selected right after that.

This was happening because the `withElementsStyles` HOC returned different components when the link color is set and when it's not. Instead, `withElementsStyles` HOC should return a single component with different props based on the link color using conditional rendering.

## How has this been tested?
1. Select Block which supports color settings (eg. paragraph block)
2. Open sidebar settings.
3. Open Colors and select a custom color from one of the options.
4. The color settings panel should not collapse like it used to before.


## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/69596988/120441568-54d07d00-c3a2-11eb-800e-57c60545be8c.mov



## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

``