### PR TITLE
Fix image border radius.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -23,7 +23,7 @@ figure.wp-block-image:not(.wp-block) {
 		margin-left: -9px;
 	}
 
-	&:not(.is-style-rounded) > div {
+	&:not(.is-style-rounded) > div:not(.components-placeholder) {
 		border-radius: inherit;
 	}
 }


### PR DESCRIPTION
## Description

The border radius on the image placeholder is wrong:

<img width="766" alt="before" src="https://user-images.githubusercontent.com/1204802/120453461-5b0b2d00-c393-11eb-86be-907882de2353.png">

It's supposed to be 2px, and this PR fixes that:

<img width="742" alt="after" src="https://user-images.githubusercontent.com/1204802/120453477-5d6d8700-c393-11eb-8a2d-78d5c6a3d7da.png">

I'm honestly not quite sure what the rule is meant to do in the first place. Can we remove it entirely?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
