### PR TITLE
Mobile - Floating Toolbar - Disable touch events when its hidden

### DIFF
--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -7,7 +7,7 @@ import { Animated, Easing, View, Platform } from 'react-native';
  * WordPress dependencies
  */
 import { ToolbarButton, Toolbar } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -24,8 +24,6 @@ const EASE_IN_DURATION = 250;
 const EASE_OUT_DURATION = 80;
 const TRANSLATION_RANGE = 8;
 
-const opacity = new Animated.Value( 0 );
-
 const FloatingToolbar = ( {
 	selectedClientId,
 	parentId,
@@ -33,6 +31,7 @@ const FloatingToolbar = ( {
 	onNavigateUp,
 	isRTL,
 } ) => {
+	const opacity = useRef( new Animated.Value( 0 ) ).current;
 	// Sustain old selection for proper block selection button rendering when exit animation is ongoing.
 	const [ previousSelection, setPreviousSelection ] = useState( {} );
 
@@ -79,7 +78,10 @@ const FloatingToolbar = ( {
 
 	return (
 		!! opacity && (
-			<Animated.View style={ [ styles.floatingToolbar, animationStyle ] }>
+			<Animated.View
+				style={ [ styles.floatingToolbar, animationStyle ] }
+				pointerEvents={ showFloatingToolbar ? 'auto' : 'none' }
+			>
 				{ showNavUpButton && (
 					<Toolbar passedStyle={ styles.toolbar }>
 						<ToolbarButton


### PR DESCRIPTION
## Description
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3574

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3499

This PR fixes an issue on **iOS only** where the Floating toolbar prevents scrolling when it's hidden and you start dragging right on top of where it shows up.

## How has this been tested?

### Test case 1 - Floating toolbar hidden

- Open the app with metro running
- Add different blocks to have content to be able to scroll through
- Without selecting any block try to scroll right from the place where the Floating bar shows up
- **Expect** to be able to scroll without any issues
- Select a Paragraph block that's in the root level (not an inner block)
- The Floating toolbar should be hidden
- **Expect** to be able to scroll right from the place where the Floating bar shows up

### Test case 2 - Floating toolbar visible (Check possible regressions)

- Open the app with metro running
- Add a block with inner blocks like `Group block`
- Select an inner block
- **Expect** to see the Floating toolbar and that you are able to **tap** on the arrow to select the parent block (see image below)
<img width="224" alt="Screenshot 2021-06-02 at 13 23 03" src="https://user-images.githubusercontent.com/4885740/120472104-ca8a1800-c3a5-11eb-91cb-55a07ab0b5d6.png">

## Screenshots <!-- if applicable -->
Before|After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/120474209-37061680-c3a8-11eb-8a3d-da9d274fb8fc.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/120474253-438a6f00-c3a8-11eb-9782-5df16121c563.gif" width="250" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
