### PR TITLE
Fix block crashes when an inner block is deleted in certain cases

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -93,7 +93,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				index: getBlockIndex( clientId, rootClientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
-				blockTitle: getBlockType( blockName ).title,
+				blockTitle: getBlockType( blockName )?.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
 					isSelected || isFirstMultiSelectedBlock( clientId ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -49,11 +49,12 @@ export function useBlockClassNames( clientId ) {
 			const activeEntityBlockId = getActiveBlockIdByBlockNames(
 				spotlightEntityBlocks
 			);
+			const blockType = getBlockType( name );
 			return classnames( {
 				'is-selected': isSelected,
 				'is-highlighted': isBlockHighlighted( clientId ),
 				'is-multi-selected': isBlockMultiSelected( clientId ),
-				'is-reusable': isReusableBlock( getBlockType( name ) ),
+				'is-reusable': blockType && isReusableBlock( blockType ),
 				'is-dragging': isDragging,
 				'has-child-selected': isAncestorOfSelectedBlock,
 				'has-active-entity': activeEntityBlockId,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
@@ -25,13 +25,17 @@ export function useBlockCustomClassName( clientId ) {
 			const { getBlockName, getBlockAttributes } = select(
 				blockEditorStore
 			);
-			const { className } = getBlockAttributes( clientId );
 
+			const { className } = getBlockAttributes( clientId ) || {};
 			if ( ! className ) {
 				return;
 			}
 
 			const blockType = getBlockType( getBlockName( clientId ) );
+			if ( ! blockType ) {
+				return;
+			}
+
 			const hasLightBlockWrapper =
 				blockType.apiVersion > 1 ||
 				hasBlockSupport( blockType, 'lightBlockWrapper', false );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
@@ -26,6 +26,10 @@ export function useBlockDefaultClassName( clientId ) {
 		( select ) => {
 			const name = select( blockEditorStore ).getBlockName( clientId );
 			const blockType = getBlockType( name );
+			if ( ! blockType ) {
+				return;
+			}
+
 			const hasLightBlockWrapper =
 				blockType.apiVersion > 1 ||
 				hasBlockSupport( blockType, 'lightBlockWrapper', false );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Fixes https://github.com/WordPress/gutenberg/issues/31115

## Description
In certain cases when you delete an inner block using backspace, then the inner block crashes before it's actually removed. Looks like it's something similar to https://github.com/WordPress/gutenberg/issues/17013 . I tried to find the root of the issue but I just couldn't. Everything seems fine in the state object when the delete happens, but the inner block is still rendered after the data related to the inner block is removed from the store. 

I was hoping https://github.com/WordPress/gutenberg/pull/17092 should fix this as well. But looks like it's not 😄

## How has this been tested?
1. Create a new post
2. Add a Group block
3. Add an Image block inside the Group block
4. Publish / Save
5. Refresh
6. Select the Image block
7. Press BACKSPACE
8. Make sure no crashes are happening

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
