### PR TITLE
Make syntax errors in `theme.json` visible to users

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -74,7 +74,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
-				error_log( 'Error when decoding file schema: ' . json_last_error_msg() );
+				trigger_error( "Error when decoding a theme.json schema at path $file_path " . json_last_error_msg() );
 				return $config;
 			}
 
@@ -367,7 +367,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
-				error_log( 'Error when decoding user schema: ' . json_last_error_msg() );
+				trigger_error( "Error when decoding a theme.json schema for user data. " . json_last_error_msg() );
 				return new WP_Theme_JSON_Gutenberg( $config );
 			}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -367,7 +367,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
-				trigger_error( "Error when decoding a theme.json schema for user data. " . json_last_error_msg() );
+				trigger_error( 'Error when decoding a theme.json schema for user data. ' . json_last_error_msg() );
 				return new WP_Theme_JSON_Gutenberg( $config );
 			}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/32009
Alternative to https://github.com/WordPress/gutenberg/pull/32369

When we process `theme.json` data that has a syntax error according the JSON standard, we log an error to the console. Theme authors have expressed this is not enough. This PR makes the error visible in the browser as well.

See what happens when the `theme.json` has a syntax error:

![Captura de ecrã de 2021-06-02 17-55-15](https://user-images.githubusercontent.com/583546/120513460-9aa23b00-c3cc-11eb-830a-c1f3306f0187.png)

## How to test

- Use a theme with `theme.json` support.
- Remove one of the commas.
- Load the front end or editors.

The expected result is that you should see an error similar to the screenshot shared above.
