### PR TITLE
Header toolbar: useCallback to avoid unnecessary rerenders

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -29,6 +29,7 @@ import { store as editPostStore } from '../../../store';
 const preventDefault = ( event ) => {
 	event.preventDefault();
 };
+
 function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } = useDispatch(

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/editor';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
-import { useRef } from '@wordpress/element';
+import { useRef, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
@@ -26,6 +26,9 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import TemplateTitle from '../template-title';
 import { store as editPostStore } from '../../../store';
 
+const preventDefault = ( event ) => {
+	event.preventDefault();
+};
 function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened, setIsListViewOpened } = useDispatch(
@@ -73,6 +76,10 @@ function HeaderToolbar() {
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
 
+	const toggleListView = useCallback(
+		() => setIsListViewOpened( ! isListViewOpen ),
+		[ setIsListViewOpened, isListViewOpen ]
+	);
 	const overflowItems = (
 		<>
 			<ToolbarItem
@@ -90,13 +97,20 @@ function HeaderToolbar() {
 				isPressed={ isListViewOpen }
 				/* translators: button label text should, if possible, be under 16 characters. */
 				label={ __( 'List View' ) }
-				onClick={ () => setIsListViewOpened( ! isListViewOpen ) }
+				onClick={ toggleListView }
 				shortcut={ listViewShortcut }
 				showTooltip={ ! showIconLabels }
 			/>
 		</>
 	);
-
+	const openInserter = useCallback( () => {
+		if ( isInserterOpened ) {
+			// Focusing the inserter button closes the inserter popover
+			inserterButton.current.focus();
+		} else {
+			setIsInserterOpened( true );
+		}
+	}, [ isInserterOpened, setIsInserterOpened ] );
 	return (
 		<NavigableToolbar
 			className="edit-post-header-toolbar"
@@ -109,17 +123,8 @@ function HeaderToolbar() {
 					className="edit-post-header-toolbar__inserter-toggle"
 					variant="primary"
 					isPressed={ isInserterOpened }
-					onMouseDown={ ( event ) => {
-						event.preventDefault();
-					} }
-					onClick={ () => {
-						if ( isInserterOpened ) {
-							// Focusing the inserter button closes the inserter popover
-							inserterButton.current.focus();
-						} else {
-							setIsInserterOpened( true );
-						}
-					} }
+					onMouseDown={ preventDefault }
+					onClick={ openInserter }
 					disabled={ ! isInserterEnabled }
 					icon={ plus }
 					/* translators: button label text should, if possible, be under 16

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
@@ -26,6 +26,10 @@ import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import TemplateDetails from '../template-details';
 import { store as editSiteStore } from '../../store';
+
+const preventDefault = ( event ) => {
+	event.preventDefault();
+};
 
 export default function Header( {
 	openEntitiesSavedStates,
@@ -86,6 +90,20 @@ export default function Header( {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
+	const openInserter = useCallback( () => {
+		if ( isInserterOpen ) {
+			// Focusing the inserter button closes the inserter popover
+			inserterButton.current.focus();
+		} else {
+			setIsInserterOpened( true );
+		}
+	}, [ isInserterOpen, setIsInserterOpened ] );
+
+	const toggleListView = useCallback(
+		() => setIsListViewOpened( ! isListViewOpen ),
+		[ setIsListViewOpened, isListViewOpen ]
+	);
+
 	return (
 		<div className="edit-site-header">
 			<div className="edit-site-header_start">
@@ -95,17 +113,8 @@ export default function Header( {
 						variant="primary"
 						isPressed={ isInserterOpen }
 						className="edit-site-header-toolbar__inserter-toggle"
-						onMouseDown={ ( event ) => {
-							event.preventDefault();
-						} }
-						onClick={ () => {
-							if ( isInserterOpen ) {
-								// Focusing the inserter button closes the inserter popover
-								inserterButton.current.focus();
-							} else {
-								setIsInserterOpened( true );
-							}
-						} }
+						onMouseDown={ preventDefault }
+						onClick={ openInserter }
 						icon={ plus }
 						label={ _x(
 							'Toggle block inserter',
@@ -123,9 +132,7 @@ export default function Header( {
 								isPressed={ isListViewOpen }
 								/* translators: button label text should, if possible, be under 16 characters. */
 								label={ __( 'List View' ) }
-								onClick={ () =>
-									setIsListViewOpened( ! isListViewOpen )
-								}
+								onClick={ toggleListView }
 								shortcut={ listViewShortcut }
 							/>
 						</>


### PR DESCRIPTION
The ListView and Inserter Toolbar buttons show up next in the react profiler for many renders on a page with many navigation links, while typing in a new paragraph. In the header toolbar we can use `useCallback` to avoid passing a new function each time.

This is also not a silver bullet for making things fast, but it does improve things and with this change in place NavigationLink will show up as a top slow area in the react profiler. (I'll look at that next).

See previous performance tweaks in: https://github.com/WordPress/gutenberg/pull/32380, https://github.com/WordPress/gutenberg/pull/32357, https://github.com/WordPress/gutenberg/pull/32356

Before:

https://user-images.githubusercontent.com/1270189/120517090-ea5d1400-c384-11eb-87cf-20eec69d4c00.mp4

After:

https://user-images.githubusercontent.com/1270189/120523018-48402a80-c38a-11eb-92fe-5e99f3baebdd.mp4

### Testing Instructions

- In trunk, verify that the toolbar buttons show up as a top slow area while profiling. (See before video. It's easier setting this up with a post that has many buttons or navigation links, then type).
- In this branch, verify that ListView and the inserter button still toggle open and close correctly in the post and site editor
- In this branch verify that the buttons no longer show up as a top slow area in the profiler.
- Feel free to leave a comment or DM me if folks need help with any of the testing instructions.