### PR TITLE
[Search Block]: Add color support to search button

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -42,7 +42,7 @@
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"color": {
-			"gradient": true,
+			"gradients": true,
 			"__experimentalSkipSerialization": true
 		},
 		"__experimentalBorder": {

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -50,7 +50,8 @@
 			"radius": true,
 			"__experimentalSkipSerialization": true
 		},
-		"html": false
+		"html": false,
+		"__experimentalSelector": ".wp-block-search__button"
 	},
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -50,8 +50,7 @@
 			"radius": true,
 			"__experimentalSkipSerialization": true
 		},
-		"html": false,
-		"__experimentalSelector": ".wp-block-search__button"
+		"html": false
 	},
 	"editorStyle": "wp-block-search-editor",
 	"style": "wp-block-search"

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -41,6 +41,10 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
+		"color": {
+			"gradient": true,
+			"__experimentalSkipSerialization": true
+		},
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -217,8 +217,7 @@ export default function SearchEdit( {
 			...colorProps.style,
 			...( isButtonPositionInside
 				? { borderRadius }
-				: borderProps.style
-			)
+				: borderProps.style ),
 		};
 
 		return (

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -13,6 +13,7 @@ import {
 	RichText,
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUnitControl as UnitControl,
+	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarDropdownMenu,
@@ -82,6 +83,7 @@ export default function SearchEdit( {
 		borderProps.style.borderRadius = `${ borderRadius }px`;
 	}
 
+	const colorProps = useColorProps( attributes );
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 	const isButtonPositionInside = 'button-inside' === buttonPosition;
@@ -208,11 +210,19 @@ export default function SearchEdit( {
 		// If the button is inside the wrapper, the wrapper gets the border color styles/classes, not the button.
 		const buttonClasses = classnames(
 			'wp-block-search__button',
+			colorProps.className,
 			isButtonPositionInside ? undefined : borderProps.className
 		);
-		const buttonStyles = isButtonPositionInside
-			? { borderRadius }
-			: borderProps.style;
+		// const borderStyles = isButtonPositionInside
+		// 	? { borderRadius }
+		// 	: borderProps.style;
+		const buttonStyles = {
+			...colorProps.style,
+			...( isButtonPositionInside
+				? borderRadius
+				: borderProps.style
+			)
+		};
 
 		return (
 			<>

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -213,13 +213,10 @@ export default function SearchEdit( {
 			colorProps.className,
 			isButtonPositionInside ? undefined : borderProps.className
 		);
-		// const borderStyles = isButtonPositionInside
-		// 	? { borderRadius }
-		// 	: borderProps.style;
 		const buttonStyles = {
 			...colorProps.style,
 			...( isButtonPositionInside
-				? borderRadius
+				? { borderRadius }
 				: borderProps.style
 			)
 		};

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -263,6 +263,16 @@ function styles_for_block_core_search( $attributes ) {
 			$wrapper_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
 		} else {
 			$shared_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
+
+	// Add color styles.
+	$has_colors = ! empty( $attributes['style']['color'] );
+
+	if ( $has_colors ) {
+		if ( ! empty( $attributes['style']['color']['text'] ) ) {
+			$button_styles[] = sprintf( 'color: %s;', esc_attr( $attributes['style']['color']['text'] ) );
+		}
+		if ( ! empty( $attributes['style']['color']['background'] ) ) {
+			$button_styles[] = sprintf( 'background-color: %s;', esc_attr( $attributes['style']['color']['background'] ) );
 		}
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -37,7 +37,7 @@ function render_block_core_search( $attributes ) {
 	$input_markup     = '';
 	$button_markup    = '';
 	$inline_styles    = styles_for_block_core_search( $attributes );
-	$color_classes   = get_color_classes_for_block_core_search( $attributes );
+	$color_classes    = get_color_classes_for_block_core_search( $attributes );
 	$is_button_inside = ! empty( $attributes['buttonPosition'] ) &&
 		'button-inside' === $attributes['buttonPosition'];
 	// Border color classes need to be applied to the elements that have a border color.
@@ -215,7 +215,7 @@ function styles_for_block_core_search( $attributes ) {
 					$name = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $key ) );
 
 					// Add shared styles for individual border radii for input & button.
-					$border_style = sprintf(
+					$border_style    = sprintf(
 						'border-%s-radius: %s;',
 						esc_attr( $name ),
 						esc_attr( $value )
@@ -322,7 +322,7 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	$classnames = array();
 
 	// Text color.
-	$has_named_text_color = ! empty( $attributes['textColor'] );
+	$has_named_text_color  = ! empty( $attributes['textColor'] );
 	$has_custom_text_color = ! empty( $attributes['style']['color']['text'] );
 	if ( $has_named_text_color ) {
 		$classnames[] = sprintf( 'has-text-color has-%s-color', $attributes['textColor'] );
@@ -332,10 +332,10 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	}
 
 	// Background color.
-	$has_named_background_color = ! empty( $attributes['backgroundColor'] );
+	$has_named_background_color  = ! empty( $attributes['backgroundColor'] );
 	$has_custom_background_color = ! empty( $attributes['style']['color']['background'] );
-	$has_named_gradient = ! empty( $attributes['gradient'] );
-	$has_custom_gradient = ! empty( $attributes['style']['color']['gradient'] );
+	$has_named_gradient          = ! empty( $attributes['gradient'] );
+	$has_custom_gradient         = ! empty( $attributes['style']['color']['gradient'] );
 	if (
 		$has_named_background_color ||
 		$has_custom_background_color ||

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -301,20 +301,22 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	$classnames = array();
 
 	// Text color.
+	$has_preset_text_color = ! empty( $attributes['textColor'] );
 	$has_custom_text_color = ! empty( $attributes['style']['color']['text'] );
-	if ( ! empty( $attributes['textColor'] ) ) {
+	if ( $has_preset_text_color ) {
 		$classnames[] = sprintf( 'has-text-color has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
-		// If there's no 'textColor' text string but there is a custom text color style, still add the generic `has-text-color` class.
+		// If a custom 'textColor' was selected instead of a preset, still add the generic `has-text-color` class.
 		$classnames[] = 'has-text-color';
 	}
 
 	// Background color.
+	$has_preset_background_color = ! empty( $attributes['backgroundColor'] );
 	$has_custom_background_color = ! empty( $attributes['style']['color']['background'] );
-	if ( ! empty( $attributes['backgroundColor'] ) ) {
+	if ( $has_preset_background_color ) {
 		$classnames[] = sprintf( 'has-background has-%s-background-color', $attributes['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
-		// If there's no 'backgroundColor' text string but there is a custom background color style, still add the generic `has-background` class.
+		// If a custom 'backgroundColor' was selected instead of a preset, still add the generic `has-background` class.
 		$classnames[] = 'has-background';
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -272,15 +272,19 @@ function styles_for_block_core_search( $attributes ) {
 	}
 
 	// Add color styles.
-	$has_colors = ! empty( $attributes['style']['color'] );
+	$has_text_color = ! empty( $attributes['style']['color']['text'] );
+	if ( $has_text_color ) {
+		$button_styles[] = sprintf( 'color: %s;', esc_attr( $attributes['style']['color']['text'] ) );
+	}
 
-	if ( $has_colors ) {
-		if ( ! empty( $attributes['style']['color']['text'] ) ) {
-			$button_styles[] = sprintf( 'color: %s;', esc_attr( $attributes['style']['color']['text'] ) );
-		}
-		if ( ! empty( $attributes['style']['color']['background'] ) ) {
-			$button_styles[] = sprintf( 'background-color: %s;', esc_attr( $attributes['style']['color']['background'] ) );
-		}
+	$has_background_color = ! empty( $attributes['style']['color']['background'] );
+	if ( $has_background_color ) {
+		$button_styles[] = sprintf( 'background-color: %s;', esc_attr( $attributes['style']['color']['background'] ) );
+	}
+
+	$has_custom_gradient = ! empty( $attributes['style']['color']['gradient'] );
+	if ( $has_custom_gradient ) {
+		$button_styles[] = sprintf( 'background: %s;', $attributes['style']['color']['gradient'] );
 	}
 
 	return array(
@@ -318,9 +322,9 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	$classnames = array();
 
 	// Text color.
-	$has_preset_text_color = ! empty( $attributes['textColor'] );
+	$has_named_text_color = ! empty( $attributes['textColor'] );
 	$has_custom_text_color = ! empty( $attributes['style']['color']['text'] );
-	if ( $has_preset_text_color ) {
+	if ( $has_named_text_color ) {
 		$classnames[] = sprintf( 'has-text-color has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// If a custom 'textColor' was selected instead of a preset, still add the generic `has-text-color` class.
@@ -328,13 +332,23 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	}
 
 	// Background color.
-	$has_preset_background_color = ! empty( $attributes['backgroundColor'] );
+	$has_named_background_color = ! empty( $attributes['backgroundColor'] );
 	$has_custom_background_color = ! empty( $attributes['style']['color']['background'] );
-	if ( $has_preset_background_color ) {
-		$classnames[] = sprintf( 'has-background has-%s-background-color', $attributes['backgroundColor'] );
-	} elseif ( $has_custom_background_color ) {
-		// If a custom 'backgroundColor' was selected instead of a preset, still add the generic `has-background` class.
+	$has_named_gradient = ! empty( $attributes['gradient'] );
+	$has_custom_gradient = ! empty( $attributes['style']['color']['gradient'] );
+	if (
+		$has_named_background_color ||
+		$has_custom_background_color ||
+		$has_named_gradient ||
+		$has_custom_gradient
+	) {
 		$classnames[] = 'has-background';
+	}
+	if ( $has_named_background_color ) {
+		$classnames[] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
+	}
+	if ( $has_named_gradient ) {
+		$classnames[] = sprintf( 'has-%s-gradient-background', $attributes['gradient'] );
 	}
 
 	return implode( ' ', $classnames );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -181,7 +181,6 @@ function classnames_for_block_core_search( $attributes ) {
  * @return array Style HTML attribute.
  */
 function styles_for_block_core_search( $attributes ) {
-	$shared_styles  = array();
 	$wrapper_styles = array();
 	$button_styles  = array();
 	$input_styles   = array();
@@ -305,7 +304,7 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	$has_custom_text_color = ! empty( $attributes['style']['color']['text'] );
 	if ( ! empty( $attributes['textColor'] ) ) {
 		$classnames[] = sprintf( 'has-text-color has-%s-color', $attributes['textColor'] );
-	} elseif( $has_custom_text_color ) {
+	} elseif ( $has_custom_text_color ) {
 		// If there's no 'textColor' text string but there is a custom text color style, still add the generic `has-text-color` class.
 		$classnames[] = 'has-text-color';
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -75,7 +75,7 @@ function render_block_core_search( $attributes ) {
 		$button_internal_markup = '';
 		$button_classes         = $color_classes;
 
-		if ( $is_button_inside ) {
+		if ( ! $is_button_inside ) {
 			$button_classes .= $border_color_classes;
 		}
 		if ( ! $use_icon_button ) {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -215,11 +215,13 @@ function styles_for_block_core_search( $attributes ) {
 					$name = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $key ) );
 
 					// Add shared styles for individual border radii for input & button.
-					$shared_styles[] = sprintf(
+					$border_style = sprintf(
 						'border-%s-radius: %s;',
 						esc_attr( $name ),
 						esc_attr( $value )
 					);
+					$input_styles[]  = $border_style;
+					$button_styles[] = $border_style;
 
 					// Add adjusted border radius styles for the wrapper element
 					// if button is positioned inside.
@@ -236,7 +238,9 @@ function styles_for_block_core_search( $attributes ) {
 		} else {
 			// Numeric check is for backwards compatibility purposes.
 			$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
-			$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
+			$border_style    = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
+			$input_styles[]  = $border_style;
+			$button_styles[] = $border_style;
 
 			if ( $is_button_inside && intval( $border_radius ) !== 0 ) {
 				// Adjust wrapper border radii to maintain visual consistency
@@ -262,7 +266,8 @@ function styles_for_block_core_search( $attributes ) {
 		if ( $is_button_inside ) {
 			$wrapper_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
 		} else {
-			$shared_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
+			$button_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
+			$input_styles[]  = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
 		}
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -263,6 +263,8 @@ function styles_for_block_core_search( $attributes ) {
 			$wrapper_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
 		} else {
 			$shared_styles[] = sprintf( 'border-color: %s;', esc_attr( $border_color ) );
+		}
+	}
 
 	// Add color styles.
 	$has_colors = ! empty( $attributes['style']['color'] );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -37,6 +37,7 @@ function render_block_core_search( $attributes ) {
 	$input_markup     = '';
 	$button_markup    = '';
 	$inline_styles    = styles_for_block_core_search( $attributes );
+	$color_classes   = get_color_classes_for_block_core_search( $attributes );
 	$is_button_inside = ! empty( $attributes['buttonPosition'] ) &&
 		'button-inside' === $attributes['buttonPosition'];
 	// Border color classes need to be applied to the elements that have a border color.
@@ -66,14 +67,17 @@ function render_block_core_search( $attributes ) {
 			$input_classes,
 			esc_attr( get_search_query() ),
 			esc_attr( $attributes['placeholder'] ),
-			$inline_styles['shared']
+			$inline_styles['input']
 		);
 	}
 
 	if ( $show_button ) {
 		$button_internal_markup = '';
-		$button_classes         = ! $is_button_inside ? $border_color_classes : '';
+		$button_classes         = $color_classes;
 
+		if ( $is_button_inside ) {
+			$button_classes .= $border_color_classes;
+		}
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
 				$button_internal_markup = $attributes['buttonText'];
@@ -89,7 +93,7 @@ function render_block_core_search( $attributes ) {
 		$button_markup = sprintf(
 			'<button type="submit" class="wp-block-search__button %s" %s>%s</button>',
 			$button_classes,
-			$inline_styles['shared'],
+			$inline_styles['button'],
 			$button_internal_markup
 		);
 	}
@@ -179,6 +183,8 @@ function classnames_for_block_core_search( $attributes ) {
 function styles_for_block_core_search( $attributes ) {
 	$shared_styles  = array();
 	$wrapper_styles = array();
+	$button_styles  = array();
+	$input_styles   = array();
 
 	// Add width styles.
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
@@ -262,7 +268,8 @@ function styles_for_block_core_search( $attributes ) {
 	}
 
 	return array(
-		'shared'  => ! empty( $shared_styles ) ? sprintf( ' style="%s"', implode( ' ', $shared_styles ) ) : '',
+		'input'   => ! empty( $input_styles ) ? sprintf( ' style="%s"', implode( ' ', $input_styles ) ) : '',
+		'button'  => ! empty( $button_styles ) ? sprintf( ' style="%s"', implode( ' ', $button_styles ) ) : '',
 		'wrapper' => ! empty( $wrapper_styles ) ? sprintf( ' style="%s"', implode( ' ', $wrapper_styles ) ) : '',
 	);
 }
@@ -282,4 +289,35 @@ function get_border_color_classes_for_block_core_search( $attributes ) {
 		$border_color_classes = 'has-border-color';
 	}
 	return $border_color_classes;
+}
+
+/**
+ * Returns color classnames depending on whether there are named or custom text and background colors.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string The color classnames to be applied to the block elements.
+ */
+function get_color_classes_for_block_core_search( $attributes ) {
+	$classnames = array();
+
+	// Text color.
+	$has_custom_text_color = ! empty( $attributes['style']['color']['text'] );
+	if ( ! empty( $attributes['textColor'] ) ) {
+		$classnames[] = sprintf( 'has-text-color has-%s-color', $attributes['textColor'] );
+	} elseif( $has_custom_text_color ) {
+		// If there's no 'textColor' text string but there is a custom text color style, still add the generic `has-text-color` class.
+		$classnames[] = 'has-text-color';
+	}
+
+	// Background color.
+	$has_custom_background_color = ! empty( $attributes['style']['color']['background'] );
+	if ( ! empty( $attributes['backgroundColor'] ) ) {
+		$classnames[] = sprintf( 'has-background has-%s-background-color', $attributes['backgroundColor'] );
+	} elseif ( $has_custom_background_color ) {
+		// If there's no 'backgroundColor' text string but there is a custom background color style, still add the generic `has-background` class.
+		$classnames[] = 'has-background';
+	}
+
+	return implode( ' ', $classnames );
 }

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -15,6 +15,7 @@
 		svg {
 			min-width: 1.5em;
 			min-height: 1.5em;
+			fill: currentColor;
 		}
 	}
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,10 +1,8 @@
 .wp-block-search {
 
 	.wp-block-search__button {
-		background: #f7f7f7;
 		border: 1px solid #ccc;
 		padding: 0.375em 0.625em;
-		color: #32373c;
 		margin-left: 0.625em;
 		word-break: normal;
 
@@ -63,5 +61,11 @@
 	&.aligncenter .wp-block-search__inside-wrapper {
 		margin: auto;
 	}
+}
+
+// Decreased specificity allows themes to provide colors.
+.wp-block-search__button {
+	background: #f7f7f7;
+	color: #32373c;
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,8 +1,10 @@
 .wp-block-search {
 
 	.wp-block-search__button {
+		background: #f7f7f7;
 		border: 1px solid #ccc;
 		padding: 0.375em 0.625em;
+		color: #32373c;
 		margin-left: 0.625em;
 		word-break: normal;
 
@@ -61,11 +63,5 @@
 	&.aligncenter .wp-block-search__inside-wrapper {
 		margin: auto;
 	}
-}
-
-// Decreased specificity allows themes to provide colors.
-.wp-block-search__button {
-	background: #f7f7f7;
-	color: #32373c;
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR adds color support to the button in the Search block.

Note: Initially I included support for setting colors in `theme.json`, for example like:
```
"core/search": {
	"color": {
		"text": "blue",
		"background": "yellow"
	}
}
```
I decided to **remove** this, so it is no longer included in this PR. Using `__experimentalSkipSelector` to support this would cause problems down the road when adding other block supports that don't need skip serialization (eg width/typography). Issue #32417 opened to discuss.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

**Test Setup**
Note your theme will need to opt into color support in its `theme.json`.

**Test Instructions**

1. Create a post, add a search block.
2. Select the search block and confirm color controls appear in the sidebar.
3. Test changing the text and background color.
3. Save the post and confirm the colors are visually correct on the frontend.

## Screenshots <!-- if applicable -->
![Screen Capture on 2021-06-02 at 15-59-47](https://user-images.githubusercontent.com/63313398/120562667-b2bd8e80-c3bb-11eb-9961-48a645902b55.gif)
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
