### PR TITLE
Fix to locations

### DIFF
--- a/packages/edit-navigation/src/components/header/manage-locations.js
+++ b/packages/edit-navigation/src/components/header/manage-locations.js
@@ -34,7 +34,7 @@ export default function ManageLocations() {
 			labelPosition="top"
 			value={ menuLocation.menu }
 			options={ [
-				{ value: 0, label: __( '-' ) },
+				{ value: 0, label: __( 'Select a Menu' ) },
 				...menus.map( ( menu ) => ( {
 					value: menu.id,
 					label: menu.name,


### PR DESCRIPTION
new fix to "Navigation screen: regression of improved menu locations select placeholder #30330

Closes https://github.com/WordPress/gutenberg/issues/30330