### PR TITLE
Fix the layout definition in the template mode

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -224,7 +224,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 		);
 		const selectorsGroup = selectorsScoped.join( ', ' );
 
-		const className = classnames( props?.classname, id );
+		const className = classnames( props?.className, id );
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -268,11 +268,12 @@ const withElementsStyles = createHigherOrderComponent(
 				<BlockListBlock
 					{ ...props }
 					className={
-						elements &&
-						classnames(
-							props.classname,
-							blockElementsContainerIdentifier
-						)
+						elements
+							? classnames(
+									props.className,
+									blockElementsContainerIdentifier
+							  )
+							: props.className
 					}
 				/>
 			</>

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -84,7 +84,9 @@ function PostTemplateActions() {
 								createBlock( 'core/site-tagline' ),
 								createBlock( 'core/separator' ),
 								createBlock( 'core/post-title' ),
-								createBlock( 'core/post-content' ),
+								createBlock( 'core/post-content', {
+									layout: { inherit: true },
+								} ),
 							];
 							__unstableSwitchToTemplateMode( {
 								slug:

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -171,6 +171,10 @@ export default function VisualEditor( { styles } ) {
 	);
 
 	const layout = useMemo( () => {
+		if ( isTemplateMode ) {
+			return { type: 'default' };
+		}
+
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
@@ -183,7 +187,7 @@ export default function VisualEditor( { styles } ) {
 			};
 		}
 		return undefined;
-	}, [ themeSupportsLayout, contentSize, wideSize ] );
+	}, [ isTemplateMode, themeSupportsLayout, contentSize, wideSize ] );
 
 	return (
 		<div
@@ -222,7 +226,7 @@ export default function VisualEditor( { styles } ) {
 							styles={ styles }
 							style={ { paddingBottom } }
 						>
-							{ themeSupportsLayout && (
+							{ themeSupportsLayout && ! isTemplateMode && (
 								<LayoutStyle
 									selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
 									layout={ defaultLayout }


### PR DESCRIPTION
closes #32069
 
The template mode is the equivalent of the site editor, so the default layout shouldn't apply there but instead it should applied to the default post content created for empty templates.

Also, I noticed a regression where the layout is not applied properly because some hooks were not passing the className prop down properly. 
