### PR TITLE
Define Nav block allowed inner blocks via block supports mechanism

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -72,7 +72,15 @@
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true
 		},
-		"color": true
+		"color": true,
+		"__experimentalAllowedBlocks": [
+			"core/navigation-link",
+			"core/search",
+			"core/social-links",
+			"core/page-list",
+			"core/spacer",
+			"core/home-link"
+		]
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -47,7 +47,7 @@ function Navigation( {
 	className,
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
-	allowBlocksList,
+	allowedBlocks,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -77,7 +77,7 @@ function Navigation( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			allowedBlocks: allowBlocksList,
+			allowedBlocks,
 			orientation: attributes.orientation || 'horizontal',
 			renderAppender:
 				( isImmediateParentOfSelectedBlock &&
@@ -177,7 +177,7 @@ function Navigation( {
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockSupport } = select( blocksStore );
-		const allowBlocksList = getBlockSupport(
+		const allowedBlocks = getBlockSupport(
 			'core/navigation',
 			'__experimentalAllowedBlocks',
 			[ 'core/navigation-link' ] // default to the basic link block only.
@@ -202,7 +202,7 @@ export default compose( [
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
 			hasExistingNavItems: !! innerBlocks.length,
-            allowBlocksList,
+			allowedBlocks,
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -28,15 +28,7 @@ import useBlockNavigator from './use-block-navigator';
 import NavigationPlaceholder from './placeholder';
 import PlaceholderPreview from './placeholder-preview';
 import ResponsiveWrapper from './responsive-wrapper';
-
-const ALLOWED_BLOCKS = [
-	'core/navigation-link',
-	'core/search',
-	'core/social-links',
-	'core/page-list',
-	'core/spacer',
-	'core/home-link',
-];
+import { store as blocksStore } from '@wordpress/blocks';
 
 const LAYOUT = {
 	type: 'default',
@@ -55,6 +47,7 @@ function Navigation( {
 	className,
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
+	allowBlocksList,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -84,7 +77,7 @@ function Navigation( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			allowedBlocks: ALLOWED_BLOCKS,
+			allowedBlocks: allowBlocksList,
 			orientation: attributes.orientation || 'horizontal',
 			renderAppender:
 				( isImmediateParentOfSelectedBlock &&
@@ -183,6 +176,13 @@ function Navigation( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
+		const { getBlockSupport } = select( blocksStore );
+		const allowBlocksList = getBlockSupport(
+			'core/navigation',
+			'__experimentalAllowedBlocks',
+			[ 'core/navigation-link' ] // default to the basic link block only.
+		);
+
 		const innerBlocks = select( blockEditorStore ).getBlocks( clientId );
 		const {
 			getClientIdsOfDescendants,
@@ -202,7 +202,7 @@ export default compose( [
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
 			hasExistingNavItems: !! innerBlocks.length,
-
+            allowBlocksList,
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -16,6 +16,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { getBlockSupport } from '@wordpress/blocks';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
@@ -28,7 +29,6 @@ import useBlockNavigator from './use-block-navigator';
 import NavigationPlaceholder from './placeholder';
 import PlaceholderPreview from './placeholder-preview';
 import ResponsiveWrapper from './responsive-wrapper';
-import { store as blocksStore } from '@wordpress/blocks';
 
 const LAYOUT = {
 	type: 'default',
@@ -176,11 +176,9 @@ function Navigation( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockSupport } = select( blocksStore );
 		const allowedBlocks = getBlockSupport(
 			'core/navigation',
-			'__experimentalAllowedBlocks',
-			[ 'core/navigation-link' ] // default to the basic link block only.
+			'__experimentalAllowedBlocks'
 		);
 
 		const innerBlocks = select( blockEditorStore ).getBlocks( clientId );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/30007 we are discussing how best to enable/remove features of the Nav block to make it easier for the Nav Editor screen to configure the block (via some unknown mechanic).

This PR is a PoC to explore if/how it's possible to customise the blocks that are allowed as child blocks of the Nav block using the block supports mechanic.

This area is largely unknown to me at this stage so the PR will evolve as my understanding grows.

Currently, it uses a new field called `__experimentalAllowedBlocks` in `block.json` to define which blocks are allowed as child blocks. This is then used in the block's `edit.js` to define which blocks are passed as `allowedBlocks` to `<InnerBlocks>`.

## Problems

- [ ] [Defining `parent` in `block.json` causes the `allowedBlocks` prop of `<InnerBlocks>` to be ignored. See `core/navigation-link` and `core/home-link` which both specify `core/navigation` as `parent` and are therefore _always_ shown in the inspector](https://github.com/WordPress/gutenberg/issues/32436).


## How has this been tested?

1. Open `packages/block-library/src/navigation/block.json`.
2. Go to the `__experimentalAllowedBlocks` field and note the available blocks.
3. Open up the editor and create a Navigation Block. Add some blocks and notice that only these blocks (+ their variations) are available.
4. Back in `block.json` remove a block from the list (which does not have `parent` defined in its own `block.json`. Why? Because currently [defining a `parent` will overide the `allowedBlocks` API of `InnerBlocks`](https://github.com/WordPress/gutenberg/issues/32436) which will mean it will always appear no matter what blocks we list here). I'd recommend removing `core/social-links` as this does not define a `parent` field in its`block.json`.

```
"__experimentalAllowedBlocks": [
    "core/navigation-link",
    "core/search",
    "core/social-links", // remove this one!
    "core/page-list",
    "core/spacer",
    "core/home-link"
]
```
5. Built the build and reload the editor.
6. Create a Navigation Block. Try adding some blocks and notice the social links block is no longer available.

Note if you try removing other blocks you will find they remain in the inserter. To make this work you'll need to find the block in question (eg: `core/navigation-link`) and find its `block.json` file and remove the `parent` field entry. Once you reload you'll find the `__experimentalAllowedBlocks` API is now working as expected.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
