### PR TITLE
Update the template creation modal

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -118,7 +118,7 @@ function PostTemplateActions() {
 								/>
 							</FlexItem>
 						</Flex>
-						
+
 						<Flex
 							className="edit-post-template__modal-actions"
 							justify="flex-end"

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -128,9 +128,9 @@ function PostTemplateActions() {
 						</Flex>
 						<div className="edit-post-template-modal__tip">
 							<Tip>
-								{__(
+								{ __(
 									'A custom template can be applied to any post or page on your site.'
-								)}
+								) }
 							</Tip>
 						</div>
 					</form>

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -13,6 +13,7 @@ import {
 	TextControl,
 	Flex,
 	FlexItem,
+	Tip,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -100,9 +101,12 @@ function PostTemplateActions() {
 							label={ __( 'Name' ) }
 							value={ title }
 							onChange={ setTitle }
+							help={ __(
+								'Give the template a name that describes its purpose, e.g. "Full Width". If you\'re unsure don\'t worry – the name can be changed later.'
+							) }
 						/>
 						<Flex
-							className="edit-post-post-template__modal-actions"
+							className="edit-post-template__modal-actions"
 							justify="flex-end"
 						>
 							<FlexItem>
@@ -122,6 +126,13 @@ function PostTemplateActions() {
 								</Button>
 							</FlexItem>
 						</Flex>
+						<div className="edit-post-template-modal__tip">
+							<Tip>
+								{__(
+									'A custom template can be applied to any post or page on your site.'
+								)}
+							</Tip>
+						</div>
 					</form>
 				</Modal>
 			) }

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -97,17 +97,32 @@ function PostTemplateActions() {
 							setIsModalOpen( false );
 						} }
 					>
-						<TextControl
-							label={ __( 'Name' ) }
-							value={ title }
-							onChange={ setTitle }
-							help={ __(
-								'Give the template a name that describes its purpose, e.g. "Full Width". If you\'re unsure don\'t worry – the name can be changed later.'
-							) }
-						/>
+						<Flex align="flex-start" gap={ 8 }>
+							<FlexItem>
+								<div className="edit-post-template-modal__tip">
+									<Tip>
+										{ __(
+											'A custom template can be applied to any post or page on your site.'
+										) }
+									</Tip>
+								</div>
+							</FlexItem>
+							<FlexItem>
+								<TextControl
+									label={ __( 'Name' ) }
+									value={ title }
+									onChange={ setTitle }
+									help={ __(
+										'Give the template a name that describes its purpose, e.g. "Full Width". If you\'re unsure don\'t worry – the name can be changed later.'
+									) }
+								/>
+							</FlexItem>
+						</Flex>
+						
 						<Flex
 							className="edit-post-template__modal-actions"
 							justify="flex-end"
+							expanded={ false }
 						>
 							<FlexItem>
 								<Button
@@ -126,13 +141,6 @@ function PostTemplateActions() {
 								</Button>
 							</FlexItem>
 						</Flex>
-						<div className="edit-post-template-modal__tip">
-							<Tip>
-								{ __(
-									'A custom template can be applied to any post or page on your site.'
-								) }
-							</Tip>
-						</div>
 					</form>
 				</Modal>
 			) }

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -13,7 +13,6 @@ import {
 	TextControl,
 	Flex,
 	FlexItem,
-	Tip,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -68,7 +67,7 @@ function PostTemplateActions() {
 			</div>
 			{ isModalOpen && (
 				<Modal
-					title={ __( 'Create a custom template' ) }
+					title={ __( 'Create custom template' ) }
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ () => {
 						setIsModalOpen( false );
@@ -99,21 +98,12 @@ function PostTemplateActions() {
 					>
 						<Flex align="flex-start" gap={ 8 }>
 							<FlexItem>
-								<div className="edit-post-template-modal__tip">
-									<Tip>
-										{ __(
-											'A custom template can be applied to any post or page on your site.'
-										) }
-									</Tip>
-								</div>
-							</FlexItem>
-							<FlexItem>
 								<TextControl
 									label={ __( 'Name' ) }
 									value={ title }
 									onChange={ setTitle }
 									help={ __(
-										'Give the template a name that describes its purpose, e.g. "Full Width". If you\'re unsure don\'t worry – the name can be changed later.'
+										'Describe the purpose of the template, e.g. "Full Width". Custom templates can be applied to any post or page.'
 									) }
 								/>
 							</FlexItem>
@@ -126,7 +116,7 @@ function PostTemplateActions() {
 						>
 							<FlexItem>
 								<Button
-									variant="secondary"
+									variant="tertiary"
 									onClick={ () => {
 										setIsModalOpen( false );
 										setTitle( '' );

--- a/packages/edit-post/src/components/sidebar/template/style.scss
+++ b/packages/edit-post/src/components/sidebar/template/style.scss
@@ -4,21 +4,24 @@
 			width: $grid-unit * 40;
 		}
 	}
+
+	.components-modal__header {
+		border-bottom: none;
+	}
+
+	.components-modal__content::before {
+		margin-bottom: $grid-unit-05;
+	}
 }
 
 .edit-post-template__modal-actions {
-	margin-bottom: -$grid-unit-30;
-	margin-top: $grid-unit-30;
-	margin-left: -$grid-unit-40;
-	margin-right: -$grid-unit-40;
-	padding: $grid-unit-20 $grid-unit-40;
-	border-top: $border-width solid $gray-300;
+	margin-top: $grid-unit-15;
 }
 
 .edit-post-template-modal__tip {
 	padding: $grid-unit-20 $grid-unit-30;
 	background: $gray-100;
-	border-radius: 2px;
+	border-radius: $radius-block-ui;
 
 	@include break-medium() {
 		width: $grid-unit * 30;

--- a/packages/edit-post/src/components/sidebar/template/style.scss
+++ b/packages/edit-post/src/components/sidebar/template/style.scss
@@ -1,23 +1,27 @@
 .edit-post-template__modal {
-	.components-modal__frame {
-		max-width: $grid-unit * 40;
+	.components-base-control {
+		@include break-medium() {
+			width: $grid-unit * 40;
+		}
 	}
 }
 
 .edit-post-template__modal-actions {
-	padding-top: $grid-unit-15;
-}
-
-.edit-post-template-modal__tip {
 	margin-bottom: -$grid-unit-30;
 	margin-top: $grid-unit-30;
 	margin-left: -$grid-unit-40;
 	margin-right: -$grid-unit-40;
 	padding: $grid-unit-20 $grid-unit-40;
 	border-top: $border-width solid $gray-300;
+}
 
-	.components-tip {
-		align-items: center;
+.edit-post-template-modal__tip {
+	padding: $grid-unit-20 $grid-unit-30;
+	background: $gray-100;
+	border-radius: 2px;
+
+	@include break-medium() {
+		width: $grid-unit * 30;
 	}
 }
 

--- a/packages/edit-post/src/components/sidebar/template/style.scss
+++ b/packages/edit-post/src/components/sidebar/template/style.scss
@@ -1,5 +1,24 @@
+.edit-post-template__modal {
+	.components-modal__frame {
+		max-width: $grid-unit * 40;
+	}
+}
+
 .edit-post-template__modal-actions {
 	padding-top: $grid-unit-15;
+}
+
+.edit-post-template-modal__tip {
+	margin-bottom: -$grid-unit-30;
+	margin-top: $grid-unit-30;
+	margin-left: -$grid-unit-40;
+	margin-right: -$grid-unit-40;
+	padding: $grid-unit-20 $grid-unit-40;
+	border-top: $border-width solid $gray-300;
+
+	.components-tip {
+		align-items: center;
+	}
 }
 
 .edit-post-template__actions {


### PR DESCRIPTION
Based on designs in https://github.com/WordPress/gutenberg/issues/31591 this PR updates the template creation modal to make it a little more user-friendly by:

* Explaining that custom templates can be applied to more than one document
* Re-assuring the user that they can change the template name later

Here's before:


https://user-images.githubusercontent.com/846565/120641267-4e5a0800-c46b-11eb-9a70-e919fcb8c667.mp4



And after:


https://user-images.githubusercontent.com/846565/120641181-35515700-c46b-11eb-9239-b96e71a64d77.mp4

