### PR TITLE
Unhide the classic menu widget

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -145,7 +145,6 @@ function gutenberg_get_legacy_widget_settings() {
 			'recent-comments',
 			'rss',
 			'tag_cloud',
-			'nav_menu',
 			'custom_html',
 			'block',
 		)
@@ -181,7 +180,6 @@ function gutenberg_get_legacy_widget_settings() {
 				'WP_Widget_Recent_Comments',
 				'WP_Widget_RSS',
 				'WP_Widget_Tag_Cloud',
-				'WP_Nav_Menu_Widget',
 				'WP_Widget_Custom_HTML',
 			)
 		);
@@ -276,7 +274,7 @@ add_action( 'widgets_init', 'gutenberg_register_block_widget' );
 
 /**
  * Sets show_instance_in_rest to true on all of the core WP_Widget subclasses.
- * When merge dto Core, this property should be added to WP_Widget and set to
+ * When merged to Core, this property should be added to WP_Widget and set to
  * true on each WP_Widget subclass.
  */
 function gutenberg_set_show_instance_in_rest_on_core_widgets() {


### PR DESCRIPTION
## Description

According to the [Track ticket 53301](https://core.trac.wordpress.org/ticket/53301) 

> The legacy "Navigation Menu" widget is missing from the block-widget inserter

All the classic widgets have been replaced by blocks and hence the decision to hide them from being used makes sense. However the "Navigation Menu" widget is not fully replaced by the `Navigation` because the `Navigation` block is currently missing the ability to update itself if a classic menu has been changed. The `Navigation` block can only import a classic menu, creating a static copy of it. This behavior is different and unexpected in the widgets context.

While the `LegacyWidget` block does display the "Navigation Menu" widget, adding new ones is not possible without this change. It should be possible, considering we don't even have a transform yet from the "Navigation Menu" widget to the `Navigatioin` block, liike all the other core classic widgets do.

## How has this been tested?

1. With Gutenberg trunk active
2. Go to Appearance > Widgets
3. Open the inserter from the top blue plus button
4. Insert a "Navigation Menu" from the "Widgets" section
5. It should work.

## Screenshots <!-- if applicable -->

<img width="745" alt="navigation-menu-widget" src="https://user-images.githubusercontent.com/107534/120650463-7dca3e00-c486-11eb-98a3-6e992443925d.png">

## Types of changes

Removed the `nav_menu` widget from the `widget_types_to_hide_from_legacy_widget_block` filter.
Also fixed a typo in a comment.