### PR TITLE
Fixed loss of list content when switching list types.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -229,7 +229,7 @@ function RichTextWrapper(
 		__unstableMultilineTag: multilineTag,
 		__unstableDisableFormats: disableFormats,
 		preserveWhiteSpace,
-		__unstableDependencies: dependencies,
+		__unstableDependencies: [ ...dependencies, tagName ],
 		__unstableAfterParse: addEditorOnlyFormats,
 		__unstableBeforeSerialize: removeEditorOnlyFormats,
 		__unstableAddInvisibleFormats: addInvisibleFormats,

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
@@ -202,7 +202,7 @@ exports[`List should insert a line break on shift+enter in a non trailing list i
 
 exports[`List should not change the contents when you change the list type to Unordered 1`] = `"<li>a</li><li>b</li><li>c</li>"`;
 
-exports[`List should not change the contents when you change the list type. 1`] = `"<li>1</li><li>2</li><li>3</li>"`;
+exports[`List should not change the contents when you change the list type to Ordered 1`] = `"<li>1</li><li>2</li><li>3</li>"`;
 
 exports[`List should not indent list on space with modifier 1`] = `
 "<!-- wp:list -->

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
@@ -200,6 +200,10 @@ exports[`List should insert a line break on shift+enter in a non trailing list i
 <!-- /wp:list -->"
 `;
 
+exports[`List should not change the contents when you change the list type to Unordered 1`] = `"<li>a</li><li>b</li><li>c</li>"`;
+
+exports[`List should not change the contents when you change the list type. 1`] = `"<li>1</li><li>2</li><li>3</li>"`;
+
 exports[`List should not indent list on space with modifier 1`] = `
 "<!-- wp:list -->
 <ul><li>1</li><li> </li></ul>

--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -507,4 +507,36 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not change the contents when you change the list type to Ordered', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await clickBlockToolbarButton( 'Ordered' );
+
+		const content = await page.$eval(
+			'.wp-block-list',
+			( el ) => el.innerHTML
+		);
+		expect( content ).toMatchSnapshot();
+	});
+
+	it( 'should not change the contents when you change the list type to Unordered', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1. a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'c' );
+		await clickBlockToolbarButton( 'Unordered' );
+
+		const content = await page.$eval(
+			'.wp-block-list',
+			( el ) => el.innerHTML
+		);
+		expect( content ).toMatchSnapshot();
+	});
 } );

--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -522,7 +522,7 @@ describe( 'List', () => {
 			( el ) => el.innerHTML
 		);
 		expect( content ).toMatchSnapshot();
-	});
+	} );
 
 	it( 'should not change the contents when you change the list type to Unordered', async () => {
 		await clickBlockAppender();
@@ -538,5 +538,5 @@ describe( 'List', () => {
 			( el ) => el.innerHTML
 		);
 		expect( content ).toMatchSnapshot();
-	});
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -75,17 +75,16 @@ export function useRichText( {
 	const record = useRef();
 
 	function setRecordFromProps() {
-		_value.current = value;
 		record.current = create( {
-			html: value,
+			html: _value.current,
 			multilineTag,
 			multilineWrapperTags:
 				multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
 			preserveWhiteSpace,
 		} );
 		if ( disableFormats ) {
-			record.current.formats = Array( value.length );
-			record.current.replacements = Array( value.length );
+			record.current.formats = Array( _value.current.length );
+			record.current.replacements = Array( _value.current.length );
 		}
 		record.current.formats = __unstableAfterParse( record.current );
 		record.current.start = selectionStart;
@@ -201,16 +200,7 @@ export function useRichText( {
 		useRefEffect( () => {
 			applyFromProps();
 			didMount.current = true;
-		}, [
-			placeholder,
-			...__unstableDependencies,
-			value,
-			multilineTag,
-			disableFormats,
-			__unstableAfterParse,
-			selectionStart,
-			selectionEnd,
-		] ),
+		}, [ placeholder, ...__unstableDependencies ] ),
 	] );
 
 	return {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -201,7 +201,7 @@ export function useRichText( {
 		useRefEffect( () => {
 			applyFromProps();
 			didMount.current = true;
-		}, [ placeholder, ...__unstableDependencies ] ),
+		}, [ placeholder, ...__unstableDependencies, value ] ),
 	] );
 
 	return {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -75,16 +75,17 @@ export function useRichText( {
 	const record = useRef();
 
 	function setRecordFromProps() {
+		_value.current = value;
 		record.current = create( {
-			html: _value.current,
+			html: value,
 			multilineTag,
 			multilineWrapperTags:
 				multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
 			preserveWhiteSpace,
 		} );
 		if ( disableFormats ) {
-			record.current.formats = Array( _value.current.length );
-			record.current.replacements = Array( _value.current.length );
+			record.current.formats = Array( value.length );
+			record.current.replacements = Array( value.length );
 		}
 		record.current.formats = __unstableAfterParse( record.current );
 		record.current.start = selectionStart;

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -201,7 +201,16 @@ export function useRichText( {
 		useRefEffect( () => {
 			applyFromProps();
 			didMount.current = true;
-		}, [ placeholder, ...__unstableDependencies, value ] ),
+		}, [
+			placeholder,
+			...__unstableDependencies,
+			value,
+			multilineTag,
+			disableFormats,
+			__unstableAfterParse,
+			selectionStart,
+			selectionEnd,
+		] ),
 	] );
 
 	return {


### PR DESCRIPTION
## Description
fixed: #32405

This is causing the old value to be used, and the contents of the list to be lost. 

## How has this been tested?
In any block editor:

1. add a list block
2. add some list items
3. from the block toolbar convert from unorererd to ordered


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
