### PR TITLE
Fix duotone support docs

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -86,7 +86,7 @@ supports: {
 -   Default value: null
 -   Subproperties:
     -   `background`: type `boolean`, default value `true`
-    -   `duotone`: type `string`, default value undefined
+    -   `__experimentalDuotone`: type `string`, default value undefined
     -   `gradients`: type `boolean`, default value `false`
     -   `text`: type `boolean`, default value `true`
 
@@ -196,7 +196,7 @@ supports: {
 
 Duotone presets are sourced from `color.duotone` in [theme.json](/docs/how-to-guides/themes/theme-json.md).
 
-When the block declares support for `color.duotone`, the attributes definition is extended to include the attribute `style`:
+When the block declares support for `color.__experimentalDuotone`, the attributes definition is extended to include the attribute `style`:
 
 - `style`: attribute of `object` type with no default assigned.
 
@@ -210,7 +210,7 @@ When the block declares support for `color.duotone`, the attributes definition i
               color: {
                   duotone: [
                       '#FFF',
-                      '#000
+                      '#000'
                   ]
               }
           }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes the duotone docs for block supports as mentioned in https://github.com/WordPress/gutenberg/issues/32365#issuecomment-852949258.

- `color.duotone` replaced with `color.__experimentalDuotone` for supports. (`color.duotone` for theme.json is still correct.)
- Fixes closing `'` single quote in attribute example.