### PR TITLE
FSE: Template resolution for new posts and pages

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -19,6 +19,11 @@ function gutenberg_add_template_loader_filters() {
 		}
 		add_filter( str_replace( '-', '', $template_type ) . '_template', 'gutenberg_override_query_template', 20, 3 );
 	}
+
+	// Request to resolve a template.
+	if ( isset( $_GET['_wp-find-template'] ) ) {
+		add_filter( 'pre_get_posts', 'gutenberg_resolve_template_for_new_post' );
+	}
 }
 
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
@@ -236,3 +241,28 @@ function gutenberg_template_render_without_post_block_context( $context ) {
 	return $context;
 }
 add_filter( 'render_block_context', 'gutenberg_template_render_without_post_block_context' );
+
+
+/**
+ * Sets the current WP_Query to return auto-draft posts.
+ *
+ * The auto-draft status indicates a new post, so allow the the WP_Query instance to
+ * return an auto-draft post for template resolution when editing a new post.
+ *
+ * @param WP_Query $wp_query Current WP_Query instance, passed by reference.
+ * @return void
+ */
+function gutenberg_resolve_template_for_new_post( $wp_query ) {
+	remove_filter( 'pre_get_posts', 'gutenberg_resolve_template_for_new_post' );
+
+	$p    = isset( $wp_query->query['p'] ) ? $wp_query->query['p'] : null;
+	$post = get_post( $p );
+
+	if (
+		$post &&
+		'auto-draft' === $post->post_status &&
+		current_user_can( 'edit_post', $post->ID )
+	) {
+		$wp_query->set( 'post_status', 'auto-draft' );
+	}
+}

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -255,8 +255,14 @@ add_filter( 'render_block_context', 'gutenberg_template_render_without_post_bloc
 function gutenberg_resolve_template_for_new_post( $wp_query ) {
 	remove_filter( 'pre_get_posts', 'gutenberg_resolve_template_for_new_post' );
 
-	$p    = isset( $wp_query->query['p'] ) ? $wp_query->query['p'] : null;
-	$post = get_post( $p );
+	// Pages.
+	$page_id = isset( $wp_query->query['page_id'] ) ? $wp_query->query['page_id'] : null;
+
+	// Posts, including custom post types.
+	$p = isset( $wp_query->query['p'] ) ? $wp_query->query['p'] : null;
+
+	$post_id = $page_id ? $page_id : $p;
+	$post    = get_post( $post_id );
 
 	if (
 		$post &&

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -386,7 +386,7 @@ export const getEditedPostTemplate = createRegistrySelector(
 		}
 
 		const post = select( editorStore ).getCurrentPost();
-		if ( post.link && post.status !== 'auto-draft' ) {
+		if ( post.link ) {
 			return select( coreStore ).__experimentalGetTemplateForLink(
 				post.link
 			);


### PR DESCRIPTION
## Description

Resolve the block based template when editing a new post or page.

The template resolution system makes a request like `/?page_id=1234&_wp-find-template=true`, depending on WP_Query to resolve a page or post using the `page_id` or `p` (post_id) in the query string. With new posts/pages, a placeholder post with the status `auto-draft` is created. But by default WP_Query will not resolve these posts, unless the query is specifically set to look for them (the post is removed from the query output on this line: https://github.com/WordPress/wordpress-develop/blob/abb27bc8daf03cebb5e39abad986177d77377416/src/wp-includes/class-wp-query.php#L3117)

Resolves #27391

## How has this been tested?

- Activate a block based theme, such as tt1-blocks
- Open a new post or page in the editor (including for custom post types)
- See that the template resolves in the Template settings (in the sidebar)

## Screenshots <!-- if applicable -->

| **Before** | **After** |
| - | - |
| <img width="813" alt="Screen Shot 2021-06-03 at 15 12 27" src="https://user-images.githubusercontent.com/1699996/120706391-a6e6d080-c47e-11eb-8bdf-9ba26d2c3178.png"> | <img width="813" alt="Screen Shot 2021-06-03 at 15 12 45" src="https://user-images.githubusercontent.com/1699996/120706398-a817fd80-c47e-11eb-9e56-8c90d751a182.png"> |



## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
