### PR TITLE
Update: Skip typography serialization

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -88,13 +88,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
 
-	$skip_font_size_support_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipFontSizeSerialization' ), false );
-
-	// Covers all typography features _except_ font size.
-	$skip_typography_serialization = _wp_array_get( $block_type->supports, array( '__experimentalSkipTypographySerialization' ), false );
+	// Covers all typography features.
+	$skip_typography_serialization = _wp_array_get( $typography_supports, array( '__experimentalSkipSerialization' ), false );
 
 	// Font Size.
-	if ( $has_font_size_support && ! $skip_font_size_support_serialization ) {
+	if ( $has_font_size_support && ! $skip_typography_serialization ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -58,7 +58,10 @@ function addSaveProps( props, blockType, attributes ) {
 	}
 
 	if (
-		hasBlockSupport( blockType, '__experimentalSkipFontSizeSerialization' )
+		hasBlockSupport(
+			blockType,
+			'typography.__experimentalSkipSerialization'
+		)
 	) {
 		return props;
 	}
@@ -182,7 +185,7 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
 			hasBlockSupport(
 				blockName,
-				'__experimentalSkipFontSizeSerialization'
+				'typography.__experimentalSkipSerialization'
 			) ||
 			! fontSize ||
 			style?.typography?.fontSize

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -3,18 +3,15 @@
  */
 import {
 	capitalize,
-	find,
 	first,
 	forEach,
 	get,
 	has,
 	isEmpty,
-	isEqual,
 	kebabCase,
 	map,
 	omit,
 	startsWith,
-	without,
 } from 'lodash';
 import classnames from 'classnames';
 
@@ -35,8 +32,11 @@ import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
  */
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
-import { FONT_SIZE_SUPPORT_KEY } from './font-size';
-import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
+import {
+	TypographyPanel,
+	TYPOGRAPHY_SUPPORT_KEY,
+	TYPOGRAPHY_SUPPORT_KEYS,
+} from './typography';
 import { SPACING_SUPPORT_KEY, SpacingPanel } from './spacing';
 import useDisplayBlockControls from '../components/use-display-block-controls';
 
@@ -140,19 +140,12 @@ const skipSerializationPaths = {
 	[ `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		COLOR_SUPPORT_KEY,
 	],
+	[ `${ TYPOGRAPHY_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+		TYPOGRAPHY_SUPPORT_KEY,
+	],
 	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		'spacing',
 	],
-	[ `__experimentalSkipFontSizeSerialization` ]: [ 'typography', 'fontSize' ],
-	[ `__experimentalSkipTypographySerialization` ]: without(
-		TYPOGRAPHY_SUPPORT_KEYS,
-		FONT_SIZE_SUPPORT_KEY
-	).map(
-		( feature ) =>
-			find( STYLE_PROPERTY, ( property ) =>
-				isEqual( property.support, [ feature ] )
-			)?.value
-	),
 };
 
 /**

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -50,6 +50,7 @@ import {
 	useIsLetterSpacingDisabled,
 } from './letter-spacing';
 
+export const TYPOGRAPHY_SUPPORT_KEY = 'typography';
 export const TYPOGRAPHY_SUPPORT_KEYS = [
 	LINE_HEIGHT_SUPPORT_KEY,
 	FONT_SIZE_SUPPORT_KEY,


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/32252

This PR updates the typography skip serialization mechanism to use a single flag inside typography to be consistent with what happens with colors. Currently, two flags outside the typography structure are used __experimentalSkipFontSizeSerialization and __experimentalSkipTypographySerialization.



## How has this been tested?
I added the flags to paragraph and post-author block.json and verified serialization was skipped.
