### PR TITLE
Block Navigation: experiment with memoing the entire list

### DIFF
--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -56,7 +56,7 @@ export function BlockNavigationTree( {
 			selectBlock( clientId );
 			onSelect( clientId );
 		},
-		[ selectBlock ]
+		[ selectBlock, onSelect ]
 	);
 
 	let {

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -105,6 +105,7 @@ export function BlockNavigationTree( {
 		</TreeGrid>
 	);
 }
-export default memo( BlockNavigationTree, () => {
-	return true;
-} );
+function blockNavigationTreeIsEqual( prevProps, nextProps ) {
+	return prevProps?.blocks === nextProps?.blocks;
+}
+export default memo( BlockNavigationTree, blockNavigationTreeIsEqual );

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -4,7 +4,13 @@
 
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	memo,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -31,7 +37,7 @@ const noop = () => {};
  * @param {boolean}  props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean}  props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  */
-export default function BlockNavigationTree( {
+export function BlockNavigationTree( {
 	blocks,
 	showOnlyCurrentHierarchy,
 	onSelect = noop,
@@ -50,7 +56,7 @@ export default function BlockNavigationTree( {
 			selectBlock( clientId );
 			onSelect( clientId );
 		},
-		[ selectBlock, onSelect ]
+		[ selectBlock ]
 	);
 
 	let {
@@ -99,3 +105,6 @@ export default function BlockNavigationTree( {
 		</TreeGrid>
 	);
 }
+export default memo( BlockNavigationTree, () => {
+	return true;
+} );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -123,6 +123,15 @@ describe( 'Post Editor Performance', () => {
 		await closeGlobalBlockInserter();
 
 		// Measuring typing performance
+		// TODO: temporary: open persistent list view
+		await page.waitForSelector(
+			'.edit-post-header-toolbar__list-view-toggle[aria-pressed="false"]'
+		);
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		await page.waitForSelector(
+			'.edit-post-editor__list-view-panel-header'
+		);
+		// -- end of temporary script
 		await insertBlock( 'Paragraph' );
 		i = 200;
 		await page.tracing.start( {


### PR DESCRIPTION
This PR experiments with memoing the entire list view. 

Before:

When we type in a paragraph, every keypress triggers a render update of each listview child. Profiling shows that we spend a lot of time drawing each individual block icon:

https://user-images.githubusercontent.com/1270189/120719624-72bfdf80-c47f-11eb-9bb7-11c445daad83.mp4

After:

After the memo, we see that things mostly work without re-rendering the list while typing.

https://user-images.githubusercontent.com/1270189/120719750-abf84f80-c47f-11eb-8434-456e384308ce.mp4



