### PR TITLE
Fix inspector opening on click outside widget area

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -78,16 +78,16 @@ export default function Sidebar() {
 
 		const selectedBlock = getSelectedBlock();
 
-		let activeArea = getActiveComplementaryArea( editWidgetsStore.name );
-		if ( ! activeArea ) {
+		const activeArea = getActiveComplementaryArea( editWidgetsStore.name );
+
+		let currentSelection = activeArea;
+		if ( ! currentSelection ) {
 			if ( selectedBlock ) {
-				activeArea = BLOCK_INSPECTOR_IDENTIFIER;
+				currentSelection = BLOCK_INSPECTOR_IDENTIFIER;
 			} else {
-				activeArea = WIDGET_AREAS_IDENTIFIER;
+				currentSelection = WIDGET_AREAS_IDENTIFIER;
 			}
 		}
-
-		const isSidebarOpen = !! activeArea;
 
 		let widgetAreaBlock;
 		if ( selectedBlock ) {
@@ -104,11 +104,11 @@ export default function Sidebar() {
 		}
 
 		return {
-			currentArea: activeArea,
+			currentArea: currentSelection,
 			hasSelectedNonAreaBlock: !! (
 				selectedBlock && selectedBlock.name !== 'core/widget-area'
 			),
-			isGeneralSidebarOpen: isSidebarOpen,
+			isGeneralSidebarOpen: !! activeArea,
 			selectedWidgetAreaBlock: widgetAreaBlock,
 		};
 	}, [] );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #26152. 

The issue was `isGeneralSidebarOpen` was always true, so we need to distinguish between the open state of the sidebar and currently selected block/widget area.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
