### PR TITLE
Only add skip-link for block themes & templates on the frontend

### DIFF
--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -188,8 +188,14 @@ function gutenberg_the_skip_link() {
 		return;
 	}
 
-	// Early exit if not an FSE theme.
+	// Early exit if not a block theme.
 	if ( ! gutenberg_supports_block_templates() ) {
+		return;
+	}
+
+	// Early exit if not a block template.
+	global $_wp_current_template_content;
+	if ( ! $_wp_current_template_content ) {
 		return;
 	}
 	?>
@@ -249,7 +255,12 @@ function gutenberg_the_skip_link() {
 
 		// Get the site wrapper.
 		// The skip-link will be injected in the beginning of it.
-		parentEl = document.querySelector( '.wp-site-blocks' ) || document.body,
+		parentEl = document.querySelector( '.wp-site-blocks' );
+
+		// Early exit if the root element was not found.
+		if ( ! parentEl ) {
+			return;
+		}
 
 		// Get the skip-link target's ID, and generate one if it doesn't exist.
 		skipLinkTargetID = skipLinkTarget.id;


### PR DESCRIPTION
## Description
Fixes #32433 

The problem is that we're checking with `current_theme_supports( 'block-templates' )` which is by opt-out, and as a result, it's not a good way to detect a block theme or template.
To get around that, this PR adds a check to make sure that the `$_wp_current_template_content` global is set. That global var is only set when a block template gets rendered, so it's a way to detect if we're on a block template/theme or not.

## How has this been tested?
* Tested a block theme - skip-link gets added :heavy_check_mark: 
* Tested a classic theme - skip-link doesn't get added :heavy_check_mark: 
* Tested a classic theme with a block template, content inside a group block using `<main>` -  skip-link gets added :heavy_check_mark: 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
