### PR TITLE
Avoid keeping the same client ID when transforming blocks

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import {
 	every,
 	castArray,
-	findIndex,
+	some,
 	isObjectLike,
 	filter,
 	first,
@@ -538,28 +538,18 @@ export function switchToBlockType( blocks, name ) {
 		return null;
 	}
 
-	const firstSwitchedBlock = findIndex(
+	const hasSwitchedBlock = some(
 		transformationResults,
 		( result ) => result.name === name
 	);
 
 	// Ensure that at least one block object returned by the transformation has
 	// the expected "destination" block type.
-	if ( firstSwitchedBlock < 0 ) {
+	if ( ! hasSwitchedBlock ) {
 		return null;
 	}
 
-	return transformationResults.map( ( result, index ) => {
-		const transformedBlock = {
-			...result,
-			// The first transformed block whose type matches the "destination"
-			// type gets to keep the existing client ID of the first block.
-			clientId:
-				index === firstSwitchedBlock
-					? firstBlock.clientId
-					: result.clientId,
-		};
-
+	const ret = transformationResults.map( ( result ) => {
 		/**
 		 * Filters an individual transform result from block transformation.
 		 * All of the original blocks are passed, since transformations are
@@ -570,10 +560,12 @@ export function switchToBlockType( blocks, name ) {
 		 */
 		return applyFilters(
 			'blocks.switchToBlockType.transformedBlock',
-			transformedBlock,
+			result,
 			blocks
 		);
 	} );
+
+	return ret;
 }
 
 /**

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1537,15 +1537,11 @@ describe( 'block factory', () => {
 			// to keep the existing block's client ID.
 			expect( transformedBlocks ).toHaveLength( 2 );
 			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'clientId' );
-			expect( transformedBlocks[ 0 ].clientId ).not.toBe(
-				block.clientId
-			);
 			expect( transformedBlocks[ 0 ].name ).toBe( 'core/text-block' );
 			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
 				value: 'chicken ribs',
 			} );
-			expect( transformedBlocks[ 1 ].clientId ).toBe( block.clientId );
 			expect( transformedBlocks[ 1 ] ).toHaveProperty( 'clientId' );
 			expect( transformedBlocks[ 1 ].name ).toBe(
 				'core/updated-text-block'


### PR DESCRIPTION
closes #32412 

I think we have this behavior from the start of Gutenberg: transforming block types retains the "clientId" of the block. The issue with that is that that clientId can have associated properties that don't translate to the newly created block: (like whether it's a controlled container block for the case of post content block).

This can cause issues like the one raised in #32412 

I tried testing transformations to try to understand why we did keep the id in the first place but I can't think of any reason. Any ideas?

**Testing instructions**

 - Open the template mode.
 - "Group" a post content block.
 - No error should be shown.