### PR TITLE
Fix alligned blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -161,6 +161,7 @@ function BlockListBlock( {
 		clientId,
 		className,
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
+		isAligned,
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -58,7 +58,7 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  * @return {Object} Props to pass to the element to mark as a block.
  */
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
-	const { clientId, className, wrapperProps = {} } = useContext(
+	const { clientId, className, wrapperProps = {}, isAligned } = useContext(
 		BlockListBlockContext
 	);
 	const {
@@ -141,7 +141,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		'data-title': blockTitle,
 		className: classnames(
 			// The wp-block className is important for editor styles.
-			'wp-block block-editor-block-list__block',
+			classnames( 'block-editor-block-list__block', {
+				'wp-block': ! isAligned,
+			} ),
 			className,
 			props.className,
 			wrapperProps.className,

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -1,5 +1,3 @@
-// Consider the block appender to be a child block of its own, which also has
-// this class.
 const BLOCK_SELECTOR = '.block-editor-block-list__block';
 
 /**

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -1,6 +1,6 @@
 // Consider the block appender to be a child block of its own, which also has
 // this class.
-const BLOCK_SELECTOR = '.wp-block';
+const BLOCK_SELECTOR = '.block-editor-block-list__block';
 
 /**
  * Returns true if two elements are contained within the same block.

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -197,10 +197,15 @@ export default compose( [
 		const selectedBlockHasDescendants = !! getClientIdsOfDescendants( [
 			selectedBlockId,
 		] )?.length;
+
 		return {
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
 			hasExistingNavItems: !! innerBlocks.length,
+
+			// This prop is already available but computing it here ensures it's
+			// fresh compared to isImmediateParentOfSelectedBlock
+			isSelected: selectedBlockId === clientId,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {


### PR DESCRIPTION
closes #32274 

This bug happened because of a series of unrelated changes:

 - First this PR #30995 updated the Async mode to make all blocks in view synchronous. The PR also updated the block selector used in some block Dom utilities. I'm not sure why this change has been done though, the reasoning is not clear.
 - The PR above broke selection of aligned blocks because of the change in the "block selector" used in these utilities, so #31904 fixed this by making sure the new selector (`wp-block`) is applied to other blocks. I'm not sure why we didn't just revert the change to the block selector in these Dom utilities instead.
 - The problem though is that `wp-block` has an important meaning that is broken by #31904, it's the class that theme authors use to define the width of blocks and should only be applied to the top wrapper elements of blocks, so in case of aligned blocks, it should only be applied to the wrapper that has the `data-aligned` attribute. This means that #31904 broke the width of the aligned blocks.

--
I'm fixing both bugs (selection and widths) by only applying `wp-block` to the external wrapper and reverting the selector used for the Dom utilities. While this works in my testing, I'm still unsure why the selector has been changed in the first place in #30995 so we need to test this properly.