### PR TITLE
Introduce Block type level lock control

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -549,7 +549,26 @@ A block may want to disable the ability of being converted into a reusable block
 ```js
 supports: {
 	// Don't allow the block to be converted into a reusable block.
-	reusable: false;
+	reusable: false,
+}
+```
+
+## lock
+
+-   Type: `Object`
+-   Default value: null
+-   Subproperties:
+    -   `remove`: type `boolean`, default value depend on parent templateLock
+    -   `move`: type `boolean`, default value depend on parent templateLock.
+A block may want to disable the ability of being removed or moved around. By default all blocks can be removed or moved. You can also restrict removing or moving by changing the `templateLock` value to `"all"` or `"insert"` but this value will supersede it.
+
+```js
+supports: {
+	// Prevent a block from being moved or removed.
+	lock: {
+		remove: true,
+		move: true,
+	}
 }
 ```
 

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -553,25 +553,6 @@ supports: {
 }
 ```
 
-## lock
-
--   Type: `Object`
--   Default value: null
--   Subproperties:
-    -   `remove`: type `boolean`, default value depend on parent templateLock
-    -   `move`: type `boolean`, default value depend on parent templateLock.
-A block may want to disable the ability of being removed or moved around. By default all blocks can be removed or moved. You can also restrict removing or moving by changing the `templateLock` value to `"all"` or `"insert"` but this value will supersede it.
-
-```js
-supports: {
-	// Prevent a block from being moved or removed.
-	lock: {
-		remove: true,
-		move: true,
-	}
-}
-```
-
 ## spacing
 
 -   Type: `Object`

--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -96,7 +96,7 @@ function myplugin_register_book_post_type() {
 add_action( 'init', 'myplugin_register_book_post_type' );
 ```
 
-### Locking
+## Locking
 
 Sometimes the intention might be to lock the template on the UI so that the blocks presented cannot be manipulated. This is achieved with a `template_lock` property.
 
@@ -119,6 +119,26 @@ _Options:_
 -   `insert` — prevents inserting or removing blocks, but allows moving existing blocks.
 
 Lock settings can be inherited by InnerBlocks. If `templateLock` is not set in an InnerBlocks area, the locking of the parent InnerBlocks area is used. If the block is a top level block, the locking configuration of the current post type is used.
+
+## Individual block locking
+
+Alongside template level locking, you can lock individual blocks; you can do this using a `lock` attribute on the attributes level. Block-level lock takes priority over the `templateLock` feature. Currently, you can lock moving and removing blocks.
+
+**Block level locking is an exprimental feature.**
+```js
+attributes: {
+  // Prevent a block from being moved or removed.
+  lock: {
+    remove: true,
+    move: true,
+  }
+}
+```
+_Options:_
+-   `remove` — Locks the ability of a block from being removed.
+-   `move` — Locks the ability of a block from being moved.
+
+You can use this with `templateLock` to lock all blocks except a single block bypassing `false` in `remove` or `move`.
 
 ## Nested Templates
 

--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -124,7 +124,7 @@ Lock settings can be inherited by InnerBlocks. If `templateLock` is not set in a
 
 Alongside template level locking, you can lock individual blocks; you can do this using a `lock` attribute on the attributes level. Block-level lock takes priority over the `templateLock` feature. Currently, you can lock moving and removing blocks.
 
-**Block level locking is an exprimental feature.**
+**Block-level locking is an experimental feature that may be removed or change anytime.**
 ```js
 attributes: {
   // Prevent a block from being moved or removed.

--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -138,7 +138,7 @@ _Options:_
 -   `remove` — Locks the ability of a block from being removed.
 -   `move` — Locks the ability of a block from being moved.
 
-You can use this with `templateLock` to lock all blocks except a single block bypassing `false` in `remove` or `move`.
+You can use this with `templateLock` to lock all blocks except a single block by using `false` in `remove` or `move`.
 
 ## Nested Templates
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -48,6 +48,62 @@ _Returns_
 
 -   `boolean`: Whether the given block type is allowed to be inserted.
 
+### canMoveBlock
+
+Determines if the given block is allowed to be moved.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientId_ `string`: The block client Id.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `boolean`: Whether the given block is allowed to be moved.
+
+### canMoveBlocks
+
+Determines if the given blocks are allowed to be moved.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientIds_ `string`: The block client IDs to be moved.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `boolean`: Whether the given blocks are allowed to be moved.
+
+### canRemoveBlock
+
+Determines if the given block is allowed to be deleted.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientId_ `string`: The block client Id.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `boolean`: Whether the given block is allowed to be removed.
+
+### canRemoveBlocks
+
+Determines if the given blocks are allowed to be removed.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientIds_ `string`: The block client IDs to be removed.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `boolean`: Whether the given blocks are allowed to be removed.
+
 ### didAutomaticChange
 
 Returns true if the last change was an automatic change, false otherwise.

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -28,6 +28,7 @@ export default function BlockActions( {
 		canInsertBlockType,
 		getBlockRootClientId,
 		getBlocksByClientId,
+		canRemoveBlocks,
 		getTemplateLock,
 	} = useSelect( ( select ) => select( blockEditorStore ), [] );
 	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
@@ -50,6 +51,8 @@ export default function BlockActions( {
 		rootClientId
 	);
 
+	const canRemove = canRemoveBlocks( clientIds, rootClientId );
+
 	const {
 		removeBlocks,
 		replaceBlocks,
@@ -67,6 +70,7 @@ export default function BlockActions( {
 	return children( {
 		canDuplicate,
 		canInsertDefaultBlock,
+		canRemove,
 		isLocked: !! getTemplateLock( rootClientId ),
 		rootClientId,
 		blocks,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -103,7 +103,7 @@ function BlockListBlock( {
 			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }
 			onReplace={ canRemove ? onReplace : undefined }
 			onRemove={ canRemove ? onRemove : undefined }
-			mergeBlocks={ isLocked ? undefined : onMerge }
+			mergeBlocks={ canRemove ? onMerge : undefined }
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }
 			toggleSelection={ toggleSelection }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -202,8 +202,8 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 	const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 	const isSelected = isBlockSelected( clientId );
 	const templateLock = getTemplateLock( rootClientId );
-	const canRemove = canRemoveBlock( clientId );
-	const canMove = canMoveBlock( clientId );
+	const canRemove = canRemoveBlock( clientId, rootClientId );
+	const canMove = canMoveBlock( clientId, rootClientId );
 
 	// The fallback to `{}` is a temporary fix.
 	// This function should never be called when a block is not present in

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -72,6 +72,7 @@ function Block( { children, isHtml, ...props } ) {
 function BlockListBlock( {
 	mode,
 	isLocked,
+	canRemove,
 	clientId,
 	isSelected,
 	isSelectionEnabled,
@@ -100,8 +101,8 @@ function BlockListBlock( {
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }
-			onReplace={ isLocked ? undefined : onReplace }
-			onRemove={ isLocked ? undefined : onRemove }
+			onReplace={ canRemove ? onReplace : undefined }
+			onRemove={ canRemove ? onRemove : undefined }
 			mergeBlocks={ isLocked ? undefined : onMerge }
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }
@@ -195,10 +196,15 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		isSelectionEnabled,
 		getTemplateLock,
 		__unstableGetBlockWithoutInnerBlocks,
+		canRemoveBlock,
+		canMoveBlock,
 	} = select( blockEditorStore );
 	const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 	const isSelected = isBlockSelected( clientId );
 	const templateLock = getTemplateLock( rootClientId );
+	const canRemove = canRemoveBlock( clientId );
+	const canMove = canMoveBlock( clientId );
+
 	// The fallback to `{}` is a temporary fix.
 	// This function should never be called when a block is not present in
 	// the state. It happens now because the order in withSelect rendering
@@ -211,6 +217,8 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		mode: getBlockMode( clientId ),
 		isSelectionEnabled: isSelectionEnabled(),
 		isLocked: !! templateLock,
+		canRemove,
+		canMove,
 		// Users of the editor.BlockListBlock filter used to be able to
 		// access the block prop.
 		// Ideally these blocks would rely on the clientId prop only.

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -26,7 +26,7 @@ function BlockMover( {
 	isFirst,
 	isLast,
 	clientIds,
-	isLocked,
+	canMove,
 	isHidden,
 	rootClientId,
 	orientation,
@@ -37,7 +37,7 @@ function BlockMover( {
 	const onFocus = () => setIsFocused( true );
 	const onBlur = () => setIsFocused( false );
 
-	if ( isLocked || ( isFirst && isLast && ! rootClientId ) ) {
+	if ( ! canMove || ( isFirst && isLast && ! rootClientId ) ) {
 		return null;
 	}
 
@@ -100,7 +100,7 @@ export default withSelect( ( select, { clientIds } ) => {
 		getBlock,
 		getBlockIndex,
 		getBlockListSettings,
-		getTemplateLock,
+		canMoveBlocks,
 		getBlockOrder,
 		getBlockRootClientId,
 	} = select( blockEditorStore );
@@ -119,7 +119,7 @@ export default withSelect( ( select, { clientIds } ) => {
 
 	return {
 		blockType: block ? getBlockType( block.name ) : null,
-		isLocked: getTemplateLock( rootClientId ) === 'all',
+		canMove: canMoveBlocks( clientIds, rootClientId ),
 		rootClientId,
 		firstIndex,
 		isFirst,

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -26,7 +26,7 @@ export const BLOCK_MOVER_DIRECTION_BOTTOM =
 export const BlockMover = ( {
 	isFirst,
 	isLast,
-	isLocked,
+	canMove,
 	onMoveDown,
 	onMoveUp,
 	onLongMove,
@@ -86,7 +86,7 @@ export const BlockMover = ( {
 		if ( option && option.onSelect ) option.onSelect();
 	};
 
-	if ( isLocked || ( isFirst && isLast && ! rootClientId ) ) {
+	if ( ! canMove || ( isFirst && isLast && ! rootClientId ) ) {
 		return null;
 	}
 
@@ -130,7 +130,7 @@ export default compose(
 	withSelect( ( select, { clientIds } ) => {
 		const {
 			getBlockIndex,
-			getTemplateLock,
+			canMoveBlocks,
 			getBlockRootClientId,
 			getBlockOrder,
 		} = select( blockEditorStore );
@@ -149,7 +149,7 @@ export default compose(
 			numberOfBlocks: blockOrder.length - 1,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
-			isLocked: getTemplateLock( rootClientId ) === 'all',
+			canMove: canMoveBlocks( clientIds, rootClientId ),
 			rootClientId,
 		};
 	} ),

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -26,7 +26,7 @@ export const BLOCK_MOVER_DIRECTION_BOTTOM =
 export const BlockMover = ( {
 	isFirst,
 	isLast,
-	canMove,
+	cannotMove,
 	onMoveDown,
 	onMoveUp,
 	onLongMove,
@@ -86,7 +86,7 @@ export const BlockMover = ( {
 		if ( option && option.onSelect ) option.onSelect();
 	};
 
-	if ( ! canMove || ( isFirst && isLast && ! rootClientId ) ) {
+	if ( cannotMove || ( isFirst && isLast && ! rootClientId ) ) {
 		return null;
 	}
 
@@ -149,7 +149,7 @@ export default compose(
 			numberOfBlocks: blockOrder.length - 1,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
-			canMove: canMoveBlocks( clientIds, rootClientId ),
+			cannotMove: ! canMoveBlocks( clientIds, rootClientId ),
 			rootClientId,
 		};
 	} ),

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -26,7 +26,7 @@ export const BLOCK_MOVER_DIRECTION_BOTTOM =
 export const BlockMover = ( {
 	isFirst,
 	isLast,
-	cannotMove,
+	canMove,
 	onMoveDown,
 	onMoveUp,
 	onLongMove,
@@ -86,7 +86,7 @@ export const BlockMover = ( {
 		if ( option && option.onSelect ) option.onSelect();
 	};
 
-	if ( cannotMove || ( isFirst && isLast && ! rootClientId ) ) {
+	if ( ! canMove || ( isFirst && isLast && ! rootClientId ) ) {
 		return null;
 	}
 
@@ -149,7 +149,7 @@ export default compose(
 			numberOfBlocks: blockOrder.length - 1,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
-			cannotMove: ! canMoveBlocks( clientIds, rootClientId ),
+			canMove: canMoveBlocks( clientIds, rootClientId ),
 			rootClientId,
 		};
 	} ),

--- a/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-mover/test/__snapshots__/index.native.js.snap
@@ -5,7 +5,7 @@ exports[`Block Mover Picker should match snapshot 1`] = `
   <ForwardRef(ToolbarButton)
     extraProps={
       Object {
-        "hint": "Double tap to move the block up",
+        "hint": "Double tap to move the block to the left",
       }
     }
     icon={
@@ -14,17 +14,19 @@ exports[`Block Mover Picker should match snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <Path
-          d="M12.5 3.9L6.7 9.7l1.1 1.1 4-4V20h1.4V6.7l4.5 4.1 1.1-1.1z"
+          d="M20 10.8H6.7l4.1-4.5-1.1-1.1-5.8 6.3 5.8 5.8 1.1-1.1-4-3.9H20z"
         />
       </SVG>
     }
+    isDisabled={false}
+    onClick={[MockFunction]}
     onLongPress={[Function]}
-    title="Move block up from row NaN to row NaN"
+    title="Move block left from position 2 to position 1"
   />
   <ForwardRef(ToolbarButton)
     extraProps={
       Object {
-        "hint": "Double tap to move the block down",
+        "hint": "Double tap to move the block to the right",
       }
     }
     icon={
@@ -33,12 +35,14 @@ exports[`Block Mover Picker should match snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <Path
-          d="M16.2 13.2l-4 4V4h-1.5v13.3l-4.5-4.1-1 1.1 6.2 5.8 5.8-5.8-1-1.1z"
+          d="M14.3 6.7l-1.1 1.1 4 4H4v1.5h13.3l-4.1 4.4 1.1 1.1 5.8-6.3z"
         />
       </SVG>
     }
+    isDisabled={true}
+    onClick={[MockFunction]}
     onLongPress={[Function]}
-    title="Move block down from row NaN to row NaN"
+    title="Move block right"
   />
   <Picker
     hideCancelButton={true}

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -14,7 +14,7 @@ describe( 'Block Mover Picker', () => {
 			context: {
 				isFirst: false,
 				isLast: true,
-				isLocked: false,
+				canMove: true,
 				numberOfBlocks: 2,
 				firstIndex: 1,
 
@@ -34,7 +34,7 @@ describe( 'Block Mover Picker', () => {
 			context: {
 				isFirst: false,
 				isLast: true,
-				isLocked: false,
+				canMove: true,
 				numberOfBlocks: 2,
 				firstIndex: 1,
 

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -14,7 +14,7 @@ describe( 'Block Mover Picker', () => {
 			context: {
 				isFirst: false,
 				isLast: true,
-				canMove: true,
+				cannotMove: false,
 				numberOfBlocks: 2,
 				firstIndex: 1,
 
@@ -34,7 +34,7 @@ describe( 'Block Mover Picker', () => {
 			context: {
 				isFirst: false,
 				isLast: true,
-				canMove: true,
+				cannotMove: false,
 				numberOfBlocks: 2,
 				firstIndex: 1,
 

--- a/packages/block-editor/src/components/block-mover/test/index.native.js
+++ b/packages/block-editor/src/components/block-mover/test/index.native.js
@@ -10,42 +10,40 @@ import { BlockMover } from '../index';
 
 describe( 'Block Mover Picker', () => {
 	it( 'renders without crashing', () => {
-		const wrapper = shallow( <BlockMover />, {
-			context: {
-				isFirst: false,
-				isLast: true,
-				cannotMove: false,
-				numberOfBlocks: 2,
-				firstIndex: 1,
+		const props = {
+			isFirst: false,
+			isLast: true,
+			canMove: true,
+			numberOfBlocks: 2,
+			firstIndex: 1,
 
-				onMoveDown: jest.fn(),
-				onMoveUp: jest.fn(),
-				onLongPress: jest.fn(),
+			onMoveDown: jest.fn(),
+			onMoveUp: jest.fn(),
+			onLongPress: jest.fn(),
 
-				rootClientId: '',
-				isStackedHorizontally: true,
-			},
-		} );
+			rootClientId: '',
+			isStackedHorizontally: true,
+		};
+		const wrapper = shallow( <BlockMover { ...props } /> );
 		expect( wrapper ).toBeTruthy();
 	} );
 
 	it( 'should match snapshot', () => {
-		const wrapper = shallow( <BlockMover />, {
-			context: {
-				isFirst: false,
-				isLast: true,
-				cannotMove: false,
-				numberOfBlocks: 2,
-				firstIndex: 1,
+		const props = {
+			isFirst: false,
+			isLast: true,
+			canMove: true,
+			numberOfBlocks: 2,
+			firstIndex: 1,
 
-				onMoveDown: jest.fn(),
-				onMoveUp: jest.fn(),
-				onLongPress: jest.fn(),
+			onMoveDown: jest.fn(),
+			onMoveUp: jest.fn(),
+			onLongPress: jest.fn(),
 
-				rootClientId: '',
-				isStackedHorizontally: true,
-			},
-		} );
+			rootClientId: '',
+			isStackedHorizontally: true,
+		};
+		const wrapper = shallow( <BlockMover { ...props } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 } );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -90,10 +90,11 @@ export function BlockSettingsDropdown( {
 			{ ( {
 				canDuplicate,
 				canInsertDefaultBlock,
-				isLocked,
+				canRemove,
 				onDuplicate,
 				onInsertAfter,
 				onInsertBefore,
+				isLocked,
 				onRemove,
 				onCopy,
 				onMoveTo,
@@ -179,8 +180,8 @@ export function BlockSettingsDropdown( {
 								: Children.map( ( child ) =>
 										cloneElement( child, { onClose } )
 								  ) }
-							<MenuGroup>
-								{ ! isLocked && (
+							{ canRemove && (
+								<MenuGroup>
 									<MenuItem
 										onClick={ flow(
 											onClose,
@@ -191,8 +192,8 @@ export function BlockSettingsDropdown( {
 									>
 										{ removeBlockLabel }
 									</MenuItem>
-								) }
-							</MenuGroup>
+								</MenuGroup>
+							) }
 						</>
 					) }
 				</DropdownMenu>

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -76,7 +76,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					blocks,
 					rootClientId
 				),
-				canRemove: canRemoveBlocks( clientIds ),
+				canRemove: canRemoveBlocks( clientIds, rootClientId ),
 				hasBlockStyles: !! styles?.length,
 				icon: _icon,
 				blockTitle: getBlockType( firstBlockName ).title,

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -38,6 +38,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const blockInformation = useBlockDisplayInformation( blocks[ 0 ].clientId );
 	const {
 		possibleBlockTransformations,
+		canRemove,
 		hasBlockStyles,
 		icon,
 		blockTitle,
@@ -50,6 +51,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				__experimentalGetPatternTransformItems,
 			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType } = select( blocksStore );
+			const { canRemoveBlocks } = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId(
 				castArray( clientIds )[ 0 ]
 			);
@@ -74,6 +76,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					blocks,
 					rootClientId
 				),
+				canRemove: canRemoveBlocks( clientIds ),
 				hasBlockStyles: !! styles?.length,
 				icon: _icon,
 				blockTitle: getBlockType( firstBlockName ).title,
@@ -95,8 +98,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	// Pattern transformation through the `Patterns` API.
 	const onPatternTransform = ( transformedBlocks ) =>
 		replaceBlocks( clientIds, transformedBlocks );
-	const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;
-	const hasPatternTransformation = !! patterns?.length;
+	const hasPossibleBlockTransformations =
+		!! possibleBlockTransformations.length && canRemove;
+	const hasPatternTransformation = !! patterns?.length && canRemove;
 	if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
 		return (
 			<ToolbarGroup>

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -120,6 +120,7 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				{ name: 'core/heading', frecency: 1 },
 				{ name: 'core/paragraph', frecency: 1 },
 			],
+			canRemove: true,
 		} ) );
 		const wrapper = shallow(
 			<BlockSwitcherDropdownMenu blocks={ [ headingBlock1 ] } />
@@ -146,6 +147,7 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				{ name: 'core/heading', frecency: 1 },
 				{ name: 'core/paragraph', frecency: 1 },
 			],
+			canRemove: true,
 		} ) );
 		const wrapper = shallow(
 			<BlockSwitcherDropdownMenu
@@ -161,6 +163,7 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 				possibleBlockTransformations: [
 					{ name: 'core/paragraph', frecency: 3 },
 				],
+				canRemove: true,
 			} ) );
 		} );
 		const getDropdown = () =>

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import './align';
+import './lock';
 import './anchor';
 import './custom-class-name';
 import './generated-class-name';

--- a/packages/block-editor/src/hooks/lock.js
+++ b/packages/block-editor/src/hooks/lock.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { has } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Filters registered block settings, extending attributes to include `lock`.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addAttribute( settings ) {
+	// allow blocks to specify their own attribute definition with default values if needed.
+	if ( has( settings.attributes, [ 'lock', 'type' ] ) ) {
+		return settings;
+	}
+	// Gracefully handle if settings.attributes is undefined.
+	settings.attributes = {
+		...settings.attributes,
+		lock: {
+			type: 'object',
+		},
+	};
+
+	return settings;
+}
+
+addFilter( 'blocks.registerBlockType', 'core/lock/addAttribute', addAttribute );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -513,6 +513,13 @@ export function* moveBlocksToPosition(
 		fromRootClientId
 	);
 
+	const canRemoveBlocks = yield controls.select(
+		blockEditorStoreName,
+		'canRemoveBlocks',
+		clientIds,
+		fromRootClientId
+	);
+
 	// If one of the blocks is locked or the parent is locked, we cannot move any block.
 	if ( ! canMoveBlocks ) {
 		return;
@@ -529,6 +536,12 @@ export function* moveBlocksToPosition(
 	// If moving inside the same root block the move is always possible.
 	if ( fromRootClientId === toRootClientId ) {
 		yield action;
+		return;
+	}
+
+	// If we're moving to another block, it means we're deleting blocks from
+	// the original block, so we need to check if removing is possible.
+	if ( ! canRemoveBlocks ) {
 		return;
 	}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -464,7 +464,7 @@ export function replaceBlock( clientId, block ) {
  *
  * @return {Function} Action creator.
  */
-function* createOnMove( type ) {
+function createOnMove( type ) {
 	return function* ( clientIds, rootClientId ) {
 		const canMoveBlocks = yield controls.select(
 			blockEditorStoreName,
@@ -478,7 +478,7 @@ function* createOnMove( type ) {
 			return;
 		}
 
-		return {
+		yield {
 			clientIds: castArray( clientIds ),
 			type,
 			rootClientId,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -25,7 +25,6 @@ import {
 	getBlockType,
 	getBlockTypes,
 	hasBlockSupport,
-	getBlockSupport,
 	getPossibleBlockTransformations,
 	parse,
 } from '@wordpress/blocks';
@@ -1304,30 +1303,16 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
 }
 
 /**
- * Determines if the given block type is allowed to be deleted.
+ * Determines if the given block is allowed to be deleted.
  *
- * @param {Object}         state        Editor state.
- * @param {string|Object}  blockName    The block type object, e.g., the response
- *                                      from the block directory; or a string name of
- *                                      an installed block type, e.g.' core/paragraph'.
- * @param {?string}        rootClientId Optional root client ID of block list.
+ * @param {Object}  state        Editor state.
+ * @param {string}  clientId     The block client Id.
+ * @param {?string} rootClientId Optional root client ID of block list.
  *
- * @return {boolean} Whether the given block type is allowed to be removed.
+ * @return {boolean} Whether the given block is allowed to be removed.
  */
-export function canRemoveBlockType( state, blockName, rootClientId = null ) {
-	let blockType;
-	if ( blockName && 'object' === typeof blockName ) {
-		blockType = blockName;
-		blockName = blockType.name;
-	} else {
-		blockType = getBlockType( blockName );
-	}
-	// undefined blocks can still be deleted.
-	if ( ! blockType ) {
-		return true;
-	}
-
-	const lock = getBlockSupport( blockName, 'lock', null );
+export function canRemoveBlock( state, clientId, rootClientId = null ) {
+	const { lock } = getBlockAttributes( state, clientId );
 	const parentIsLocked = !! getTemplateLock( state, rootClientId );
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
 	if ( lock === null || lock?.remove === undefined ) {
@@ -1348,31 +1333,22 @@ export function canRemoveBlockType( state, blockName, rootClientId = null ) {
  * @return {boolean} Whether the given blocks are allowed to be removed.
  */
 export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
-	return clientIds.every( ( id ) =>
-		canRemoveBlockType( state, getBlockName( state, id ), rootClientId )
+	return clientIds.every( ( clientId ) =>
+		canRemoveBlock( state, clientId, rootClientId )
 	);
 }
 
 /**
- * Determines if the given block type can be moved.
+ * Determines if the given block is allowed to be moved.
  *
- * @param {Object}         state        Editor state.
- * @param {string|Object}  blockName    The block type object, e.g., the response
- *                                      from the block directory; or a string name of
- *                                      an installed block type, e.g.' core/paragraph'.
- * @param {?string}        rootClientId Optional root client ID of block list.
+ * @param {Object}  state        Editor state.
+ * @param {string}  clientId     The block client Id.
+ * @param {?string} rootClientId Optional root client ID of block list.
  *
- * @return {boolean} Whether the given block type can be moved.
+ * @return {boolean} Whether the given block is allowed to be moved.
  */
-export function canMoveBlockType( state, blockName, rootClientId = null ) {
-	if ( blockName && 'object' === typeof blockName ) {
-		blockName = blockName.name;
-	}
-
-	if ( ! blockName ) {
-		return false;
-	}
-	const lock = getBlockSupport( blockName, 'lock', null );
+export function canMoveBlock( state, clientId, rootClientId = null ) {
+	const { lock } = getBlockAttributes( state, clientId );
 	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
 	if ( lock === null || lock?.move === undefined ) {
@@ -1393,8 +1369,8 @@ export function canMoveBlockType( state, blockName, rootClientId = null ) {
  * @return {boolean} Whether the given blocks are allowed to be moved.
  */
 export function canMoveBlocks( state, clientIds, rootClientId = null ) {
-	return clientIds.every( ( id ) =>
-		canMoveBlockType( state, getBlockName( state, id ), rootClientId )
+	return clientIds.every( ( clientId ) =>
+		canMoveBlock( state, clientId, rootClientId )
 	);
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1322,12 +1322,12 @@ export function canRemoveBlock( state, clientId, rootClientId = null ) {
 	const { lock } = attributes;
 	const parentIsLocked = !! getTemplateLock( state, rootClientId );
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock.remove === undefined ) {
+	if ( lock?.remove === undefined ) {
 		return ! parentIsLocked;
 	}
 
 	// when remove is true, it means we cannot remove it.
-	return ! lock.remove;
+	return ! lock?.remove;
 }
 
 /**
@@ -1363,12 +1363,12 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
 	const { lock } = attributes;
 	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock.move === undefined ) {
+	if ( lock?.move === undefined ) {
 		return ! parentIsLocked;
 	}
 
 	// when move is true, it means we cannot move it.
-	return ! lock.move;
+	return ! lock?.move;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1322,7 +1322,7 @@ export function canRemoveBlock( state, clientId, rootClientId = null ) {
 	const { lock } = attributes;
 	const parentIsLocked = !! getTemplateLock( state, rootClientId );
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock === undefined || lock?.remove === undefined ) {
+	if ( lock.remove === undefined ) {
 		return ! parentIsLocked;
 	}
 
@@ -1363,7 +1363,7 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
 	const { lock } = attributes;
 	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock === undefined || lock?.move === undefined ) {
+	if ( lock.move === undefined ) {
 		return ! parentIsLocked;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1337,11 +1337,12 @@ export function canRemoveBlockType( state, blockName, rootClientId = null ) {
 	// when remove is true, it means we cannot remove it.
 	return ! lock.remove;
 }
+
 /**
  * Determines if the given blocks are allowed to be removed.
  *
  * @param {Object}  state        Editor state.
- * @param {string}  clientIds    The block client IDs to be remove.
+ * @param {string}  clientIds    The block client IDs to be removed.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
  * @return {boolean} Whether the given blocks are allowed to be removed.
@@ -1349,6 +1350,51 @@ export function canRemoveBlockType( state, blockName, rootClientId = null ) {
 export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
 	return clientIds.every( ( id ) =>
 		canRemoveBlockType( state, getBlockName( state, id ), rootClientId )
+	);
+}
+
+/**
+ * Determines if the given block type can be moved.
+ *
+ * @param {Object}         state        Editor state.
+ * @param {string|Object}  blockName    The block type object, e.g., the response
+ *                                      from the block directory; or a string name of
+ *                                      an installed block type, e.g.' core/paragraph'.
+ * @param {?string}        rootClientId Optional root client ID of block list.
+ *
+ * @return {boolean} Whether the given block type can be moved.
+ */
+export function canMoveBlockType( state, blockName, rootClientId = null ) {
+	if ( blockName && 'object' === typeof blockName ) {
+		blockName = blockName.name;
+	}
+
+	if ( ! blockName ) {
+		return false;
+	}
+	const lock = getBlockSupport( blockName, 'lock', null );
+	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
+	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
+	if ( lock === null || lock?.move === undefined ) {
+		return ! parentIsLocked;
+	}
+
+	// when move is true, it means we cannot move it.
+	return ! lock.move;
+}
+
+/**
+ * Determines if the given blocks are allowed to be moved.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {string}  clientIds    The block client IDs to be moved.
+ * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @return {boolean} Whether the given blocks are allowed to be moved.
+ */
+export function canMoveBlocks( state, clientIds, rootClientId = null ) {
+	return clientIds.every( ( id ) =>
+		canMoveBlockType( state, getBlockName( state, id ), rootClientId )
 	);
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1312,10 +1312,17 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean} Whether the given block is allowed to be removed.
  */
 export function canRemoveBlock( state, clientId, rootClientId = null ) {
-	const { lock } = getBlockAttributes( state, clientId );
+	const attributes = getBlockAttributes( state, clientId );
+
+	// attributes can be null if the block is already deleted.
+	if ( attributes === null ) {
+		return;
+	}
+
+	const { lock } = attributes;
 	const parentIsLocked = !! getTemplateLock( state, rootClientId );
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock === null || lock?.remove === undefined ) {
+	if ( lock === undefined || lock?.remove === undefined ) {
 		return ! parentIsLocked;
 	}
 
@@ -1348,10 +1355,15 @@ export function canRemoveBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean} Whether the given block is allowed to be moved.
  */
 export function canMoveBlock( state, clientId, rootClientId = null ) {
-	const { lock } = getBlockAttributes( state, clientId );
+	const attributes = getBlockAttributes( state, clientId );
+	if ( attributes === null ) {
+		return;
+	}
+
+	const { lock } = attributes;
 	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock === null || lock?.move === undefined ) {
+	if ( lock === undefined || lock?.move === undefined ) {
 		return ! parentIsLocked;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1316,13 +1316,13 @@ export function canRemoveBlock( state, clientId, rootClientId = null ) {
 
 	// attributes can be null if the block is already deleted.
 	if ( attributes === null ) {
-		return;
+		return true;
 	}
 
 	const { lock } = attributes;
 	const parentIsLocked = !! getTemplateLock( state, rootClientId );
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock?.remove === undefined ) {
+	if ( lock === undefined || lock?.remove === undefined ) {
 		return ! parentIsLocked;
 	}
 
@@ -1363,7 +1363,7 @@ export function canMoveBlock( state, clientId, rootClientId = null ) {
 	const { lock } = attributes;
 	const parentIsLocked = getTemplateLock( state, rootClientId ) === 'all';
 	// If we don't have a lock on the blockType level, we differ to the parent templateLock.
-	if ( lock?.move === undefined ) {
+	if ( lock === undefined || lock?.move === undefined ) {
 		return ! parentIsLocked;
 	}
 


### PR DESCRIPTION
Parts of https://github.com/WordPress/gutenberg/issues/29864

## Description
This PR introduces parts of #29864 mainly, it adds:
- Attribute level support for locking a block from being moved/removed.
- Hides the block moving arrows and delete button if a block is locked.

The PR also adds checks at the datastore level for both moving and removing blocks.

## API definition
When defining a block, the value is set at the attributes level.

```
attributes: {
	lock: {
		type: 'object',
		default: {
			move: true,
			remove: true,	
		},
	},
},
```
This would lock the block ability to be moved or removed.

## How has this been tested?
- Modify any block attributes to include moving or removing.
- modify any innerBlocks templateLock to be `insert`, `all`, or `false` to see the all the possible combinations.
- Try to move or remove the block, it should respect your choices.

This table shows the intersect of conditions between `templateLock` and `lock`

For removing:
| lock.remove\templateLock | `"all"`      | `"insert"`   | `false`      |
|--------------------------|--------------|--------------|--------------|
| `true`                   | can't Remove | can't Remove | can't Remove |
| `false`                  | can Remove   | can Remove   | can Remove   |
| `undefined`              | can't Remove | can't Remove | can Remove   |

For moving:
| lock.move\templateLock | `"all"`    | `"insert"` | `false`    |
|------------------------|------------|------------|------------|
| `true`                 | can't Move | can't Move | can't Move |
| `false`                | can Move   | can Move   | can Move   |
| `undefined`            | can't Move | can Move   | can Move   |


## Screenshots <!-- if applicable -->

In this example. the parent block is locked to `all`, the first block "Contact information" has locking disabled for move and remove, which means it can be moved or removed.
https://user-images.githubusercontent.com/6165348/120816789-fc87af80-c548-11eb-821e-227083a9badf.mov


## Use case
There are several valid uses cases outlined in #29864
Another use case that we're building for is having a Checkout Block with different blocks that act as fundamental steps, we don't want people to delete or move those steps since they're fundamental and their order is also important, but we want to allow people to select them, access settings, and insert blocks in between them.