### PR TITLE
[RNMobile] Android Only - Fix Gboard enter detection in EnterPressedWatcher

### DIFF
--- a/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
+++ b/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
@@ -43,13 +43,11 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
             // if new text length is longer than original text by 1
             if (textBefore?.length == newTextCopy.length - 1) {
                 // now check that the inserted character is actually a NEWLINE
-                val enterPosition = newTextCopy.lastIndexOf(Constants.NEWLINE)
-                if (-1 < enterPosition) {
+                if (newTextCopy[this.start] == Constants.NEWLINE) {
                     done = false
-                    aztecText.editableText.setSpan(EnterPressedUnderway(), enterPosition,
-                            enterPosition, Spanned.SPAN_USER)
+                    aztecText.editableText.setSpan(EnterPressedUnderway(), 0, 0, Spanned.SPAN_USER)
                     aztecKeyListener.onEnterKey(
-                            newTextCopy.replace(enterPosition, enterPosition + 1, ""),
+                            newTextCopy.replace(this.start, this.start + 1, ""),
                             true,
                             selStart,
                             selEnd
@@ -60,15 +58,12 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
     }
 
     override fun afterTextChanged(text: Editable) {
-        aztecTextRef.get()?.editableText?.getSpans(0, text.length,
-                EnterPressedUnderway::class.java)?.forEach { it ->
+        aztecTextRef.get()?.editableText?.getSpans(0, 0, EnterPressedUnderway::class.java)?.forEach {
             if (!done) {
                 done = true
-                if (enterDeleter.shouldDeleteEnter()) {
-                    val enterStart = text.getSpanStart(it)
-                    text.replace(enterStart, enterStart + 1, "")
+                if (enterDeleter.shouldDeleteEnter())
+                    text.replace(start, start + 1, "")
                 }
-            }
             aztecTextRef.get()?.editableText?.removeSpan(it)
         }
     }

--- a/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
+++ b/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
@@ -43,11 +43,13 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
             // if new text length is longer than original text by 1
             if (textBefore?.length == newTextCopy.length - 1) {
                 // now check that the inserted character is actually a NEWLINE
-                if (newTextCopy[this.start] == Constants.NEWLINE) {
+                val enterPosition = newTextCopy.lastIndexOf(Constants.NEWLINE)
+                if (-1 < enterPosition) {
                     done = false
-                    aztecText.editableText.setSpan(EnterPressedUnderway(), 0, 0, Spanned.SPAN_USER)
+                    aztecText.editableText.setSpan(EnterPressedUnderway(), enterPosition,
+                            enterPosition, Spanned.SPAN_USER)
                     aztecKeyListener.onEnterKey(
-                            newTextCopy.replace(this.start, this.start + 1, ""),
+                            newTextCopy.replace(enterPosition, enterPosition + 1, ""),
                             true,
                             selStart,
                             selEnd
@@ -58,12 +60,15 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
     }
 
     override fun afterTextChanged(text: Editable) {
-        aztecTextRef.get()?.editableText?.getSpans(0, 0, EnterPressedUnderway::class.java)?.forEach {
+        aztecTextRef.get()?.editableText?.getSpans(0, text.length,
+                EnterPressedUnderway::class.java)?.forEach { it ->
             if (!done) {
                 done = true
-                if (enterDeleter.shouldDeleteEnter())
-                    text.replace(start, start + 1, "")
+                if (enterDeleter.shouldDeleteEnter()) {
+                    val enterStart = text.getSpanStart(it)
+                    text.replace(enterStart, enterStart + 1, "")
                 }
+            }
             aztecTextRef.get()?.editableText?.removeSpan(it)
         }
     }

--- a/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
+++ b/packages/react-native-aztec/android/src/main/kotlin/org/wordpress/mobile/ReactNativeAztec/EnterPressedWatcher.kt
@@ -24,6 +24,9 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
     private var selEnd: Int = 0
     var done = false
 
+    private var gboardReplacement: CharSequence? = null
+
+
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
         val aztecText = aztecTextRef.get()
         if (aztecText?.getAztecKeyListener() != null && !aztecText.isTextChangedListenerDisabled()) {
@@ -32,6 +35,13 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
             this.start = start
             this.selStart = aztecText.selectionStart
             this.selEnd = aztecText.selectionEnd
+
+            if (selStart == selEnd && 0 < count && count < after) {
+                // possible gboard replacement detected
+                gboardReplacement = text.subSequence(start, start + count)
+            } else {
+                gboardReplacement = null
+            }
         }
     }
 
@@ -40,14 +50,25 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
         val aztecKeyListener = aztecText?.getAztecKeyListener()
         if (aztecText != null && !aztecText.isTextChangedListenerDisabled() && aztecKeyListener != null) {
             val newTextCopy = SpannableStringBuilder(text)
+
+            var gboardOffset = this.start
+            // If gboard replacement is happening, we offset the start position by the length
+            // of the gboard replacement
+            if (gboardReplacement != null) {
+                val gboardRestored = newTextCopy.subSequence(start, start + before)
+                if (gboardRestored.toString() == gboardReplacement.toString()) {
+                    gboardOffset += gboardRestored.length
+                }
+            }
+
             // if new text length is longer than original text by 1
             if (textBefore?.length == newTextCopy.length - 1) {
                 // now check that the inserted character is actually a NEWLINE
-                if (newTextCopy[this.start] == Constants.NEWLINE) {
+                if (newTextCopy[gboardOffset] == Constants.NEWLINE) {
                     done = false
                     aztecText.editableText.setSpan(EnterPressedUnderway(), 0, 0, Spanned.SPAN_USER)
                     aztecKeyListener.onEnterKey(
-                            newTextCopy.replace(this.start, this.start + 1, ""),
+                            newTextCopy.replace(gboardOffset, gboardOffset + 1, ""),
                             true,
                             selStart,
                             selEnd
@@ -61,9 +82,12 @@ class EnterPressedWatcher(aztecText: AztecText, var enterDeleter: EnterDeleter) 
         aztecTextRef.get()?.editableText?.getSpans(0, 0, EnterPressedUnderway::class.java)?.forEach {
             if (!done) {
                 done = true
-                if (enterDeleter.shouldDeleteEnter())
-                    text.replace(start, start + 1, "")
+                if (enterDeleter.shouldDeleteEnter()) {
+                    var gboardOffset = start
+                    gboardReplacement?.let { replacement -> gboardOffset += replacement.length }
+                    text.replace(gboardOffset, gboardOffset + 1, "")
                 }
+            }
             aztecTextRef.get()?.editableText?.removeSpan(it)
         }
     }


### PR DESCRIPTION
**Gutenberg-mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3590

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3316. This PR is an updated version of [this older draft PR](https://github.com/WordPress/gutenberg/pull/30368) by @mkevins and uses a new branch created by @hypest. I tested the fixes on the following physical devices:

Phone | OS
-- | --
Pixel 2 | Android 10
Pixel 4 | Android 11

Ran through all these writing flow tests first using the default Gboard. I then installed the Microsoft Swift Keyboard and ran through the tests again. Both keyboard's failed **TC002** in the **Splitting and merging** group of test cases. The test that failed was the one where you first split a paragraph block, then add text to the beginning of the second block and then select that new text and delete it. Tapping delete again will not merge the two blocks back into a single block. 

I also tested all the **known issues** with the two keyboards. Only one existing issue was fixed **for both keyboards**: 
- **\[Android\]** Cannot split blocks immediately after prepending to a "swiped" word [wordpress-mobile/gutenberg-mobile#2372](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2372)

However, **all known issues** were not an issue for the Swift keyboard. 

## Description

The approach used in this PR adds logic to detect when we've encountered the unusual behavior exhibited by Gboard which leads to a failure to detect onEnter keypresses. When such behavior is detected, it calculates new offsets to be used in string comparison and processing to conform to the original intention of this TextWatcher.

Note: This is probably not enough, since this only addresses when the caret is at the end of the word, but Gboard may exhibit the unusual behavior also when the caret is in the middle or start of the word. Some consideration should be made for those other conditions as well.

## How has this been tested

[The **Writing Flow Tests** in a comment below](https://github.com/WordPress/gutenberg/pull/32471#issuecomment-855083670) should be completed using a physical device with a and without a GBoard keyboard:

- [x] Physical device using the GBoard keyboard
- [x] Physical device using a non-Gboard keyboard

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
