### PR TITLE
Prevent autosave when the post is locked

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -58,6 +58,20 @@ export function receiveCurrentUser( currentUser ) {
 }
 
 /**
+ * Returns an action object used to lock the editor.
+ *
+ * @param {Object} currentUserSession Meta information about the login session for current user.
+ *
+ * @return {Object} Action object.
+ */
+export function __experimentalUpdateCurrentUserSession( currentUserSession ) {
+	return {
+		type: 'UPDATE_CURRENT_USER_SESSION',
+		currentUserSession,
+	};
+}
+
+/**
  * Returns an action object used in adding new entities.
  *
  * @param {Array} entities Entities received.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -93,6 +93,29 @@ export function currentUser( state = {}, action ) {
 }
 
 /**
+ * Reducer returning the login session for current user.
+ *
+ * The default state is { isActive: true }. We are just going to assume that by default the user session is active.
+ * If the block editor is already being loaded for user and if the data store is already being initialised for the user,
+ * it means user is already logged in.
+ * Eventually Heartbeat API can update this state if the auth cookie either expires or is deleted for the user.
+ *
+ * @param {Object} state  Current state for login session.
+ * @param {Object} action Dispatched action.
+ */
+export function currentUserSession( state = { isActive: true }, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_CURRENT_USER_SESSION':
+			return {
+				...state,
+				...action.currentUserSession,
+			};
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing taxonomies.
  *
  * @param {Object} state  Current state.
@@ -629,6 +652,7 @@ export default combineReducers( {
 	currentTheme,
 	currentGlobalStylesId,
 	currentUser,
+	currentUserSession,
 	themeGlobalStyleVariations,
 	themeBaseGlobalStyles,
 	themeGlobalStyleRevisions,

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -36,6 +36,7 @@ export interface State {
 	currentGlobalStylesId: string;
 	currentTheme: string;
 	currentUser: ET.User< 'edit' >;
+	currentUserSession: { isActive: boolean };
 	embedPreviews: Record< string, { html: string } >;
 	entities: EntitiesState;
 	themeBaseGlobalStyles: Record< string, Object >;
@@ -183,6 +184,21 @@ export function getAuthors(
  */
 export function getCurrentUser( state: State ): ET.User< 'edit' > {
 	return state.currentUser;
+}
+
+/**
+ *Returns a boolean flag for current user's active login session.
+ *
+ * By default this returns true, because we assume that by default the user session is active.
+ * If the block editor is already being loaded for user and if the data store is already being initialised for the user,
+ * it means user is already logged in.
+ *
+ * @param {Object} state Current state data.
+ *
+ * @return {boolean} Whether the current user has active login maintained or not.
+ */
+export function __experimentalIsCurrentUserSessionActive( state: State ) {
+	return state.currentUserSession?.isActive ?? true;
 }
 
 /**

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -10,7 +10,11 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect, createInterpolateElement } from '@wordpress/element';
+import {
+	useEffect,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -21,10 +25,14 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 
 export default function PostLockedModal() {
+	const [ heartbeatTickTriggered, triggerHeartbeatTick ] = useState( false );
 	const instanceId = useInstanceId( PostLockedModal );
 	const hookName = 'core/editor/post-locked-modal-' + instanceId;
 	const { autosave, updatePostLock } = useDispatch( editorStore );
+	const { __experimentalUpdateCurrentUserSession: updateCurrentUserSession } =
+		useDispatch( coreStore );
 	const {
+		isDraft,
 		isLocked,
 		isTakeover,
 		user,
@@ -33,6 +41,7 @@ export default function PostLockedModal() {
 		activePostLock,
 		postType,
 		previewLink,
+		isCurrentUserSessionActive,
 	} = useSelect( ( select ) => {
 		const {
 			isPostLocked,
@@ -44,8 +53,12 @@ export default function PostLockedModal() {
 			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
-		const { getPostType } = select( coreStore );
+		const { getPostType, __experimentalIsCurrentUserSessionActive } =
+			select( coreStore );
 		return {
+			isDraft: [ 'draft', 'auto-draft' ].includes(
+				getEditedPostAttribute( 'status' )
+			),
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
 			user: getPostLockUser(),
@@ -54,8 +67,60 @@ export default function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
+			isCurrentUserSessionActive:
+				__experimentalIsCurrentUserSessionActive(),
 		};
 	}, [] );
+
+	useEffect( () => {
+		const checkUserLoginHookName = `core/editor/check-user-login/post-locked-modal-${ instanceId }`;
+
+		/**
+		 * Binds to the Heartbeat Tick event and checks if the user is logged in or not.
+		 *
+		 * @param {Object} data Data received in the heartbeat request
+		 */
+		function checkUserLogin( data ) {
+			// Bail early, if the heartbeat has neither auth check data attribute nor nonce expiry attribute.
+			if (
+				! [ 'wp-auth-check', 'nonces_expired' ].some( ( attr ) =>
+					Object.prototype.hasOwnProperty.call( data, attr )
+				)
+			) {
+				return;
+			}
+
+			if ( ! data[ 'wp-auth-check' ] && isCurrentUserSessionActive ) {
+				// Update login state to false,
+				// if server does not respond with auth check
+				// and current login state is true.
+				updateCurrentUserSession( { isActive: false } );
+			} else if ( ! isCurrentUserSessionActive && data.nonces_expired ) {
+				// If current login state is false and nonce is renewed,
+				// trigger a heartbeat tick to check for latest post lock.
+				// Because first heartbeat will only renew the nonce.
+				// It will not return any errors if the post is already locked by other user or not.
+				if ( window.wp?.heartbeat?.connectNow ) {
+					triggerHeartbeatTick( true );
+					window.wp.heartbeat.connectNow();
+				}
+			} else if (
+				! isCurrentUserSessionActive &&
+				heartbeatTickTriggered &&
+				data[ 'wp-auth-check' ]
+			) {
+				// If current login state is false and server responds with auth check for previously triggered heartbeat,
+				// update login state to true.
+				updateCurrentUserSession( { isActive: true } );
+			}
+		}
+
+		addAction( 'heartbeat.tick', checkUserLoginHookName, checkUserLogin );
+
+		return () => {
+			removeAction( 'heartbeat.tick', checkUserLoginHookName );
+		};
+	}, [ heartbeatTickTriggered, isCurrentUserSessionActive ] );
 
 	useEffect( () => {
 		/**
@@ -90,7 +155,12 @@ export default function PostLockedModal() {
 			const received = data[ 'wp-refresh-post-lock' ];
 			if ( received.lock_error ) {
 				// Auto save and display the takeover modal.
-				autosave();
+				// Meanwhile, other user may have opened the post and started to make new changes.
+				// Post may have been published or may have been switched back to draft.
+				// In either case, we don't want to accidentally loose the changes made by other user.
+				// If we perform server side autosave, and the post is in draft, previous changes will be overwritten in the database.
+				// Hence, we will only perform local autosave.
+				autosave( { local: true } );
 				updatePostLock( {
 					isLocked: true,
 					isTakeover: true,
@@ -141,7 +211,7 @@ export default function PostLockedModal() {
 			removeAction( 'heartbeat.tick', hookName );
 			window.removeEventListener( 'beforeunload', releasePostLock );
 		};
-	}, [] );
+	}, [ isDraft, isLocked ] );
 
 	if ( ! isLocked ) {
 		return null;

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -106,8 +106,8 @@ export default function PostPreviewButton( {
 	role,
 	onPreview,
 } ) {
-	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
-		useSelect( ( select ) => {
+	const { postId, currentPostLink, previewLink, isViewable } = useSelect(
+		( select ) => {
 			const editor = select( editorStore );
 			const core = select( coreStore );
 
@@ -119,10 +119,11 @@ export default function PostPreviewButton( {
 				postId: editor.getCurrentPostId(),
 				currentPostLink: editor.getCurrentPostAttribute( 'link' ),
 				previewLink: editor.getEditedPostPreviewLink(),
-				isSaveable: editor.isEditedPostSaveable(),
 				isViewable: postType?.viewable ?? false,
 			};
-		}, [] );
+		},
+		[]
+	);
 
 	const { __unstableSaveForPreview } = useDispatch( editorStore );
 
@@ -168,7 +169,6 @@ export default function PostPreviewButton( {
 			className={ className || 'editor-post-preview' }
 			href={ href }
 			target={ targetId }
-			disabled={ ! isSaveable }
 			onClick={ openPreviewWindow }
 			role={ role }
 		>

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -139,22 +139,6 @@ describe( 'PostPreviewButton', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should be disabled if post is not saveable.', () => {
-		mockUseSelect( { isEditedPostSaveable: () => false } );
-
-		render( <PostPreviewButton /> );
-
-		expect( screen.getByRole( 'button' ) ).toBeDisabled();
-	} );
-
-	it( 'should not be disabled if post is saveable.', () => {
-		mockUseSelect( { isEditedPostSaveable: () => true } );
-
-		render( <PostPreviewButton /> );
-
-		expect( screen.getByRole( 'button' ) ).toBeEnabled();
-	} );
-
 	it( 'should set `href` to edited post preview link if specified.', () => {
 		const url = 'https://wordpress.org';
 		mockUseSelect( {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -495,6 +495,10 @@ export function isEditedPostSaveable( state ) {
 		return false;
 	}
 
+	if ( isPostLocked( state ) ) {
+		return false;
+	}
+
 	// TODO: Post should not be saveable if not dirty. Cannot be added here at
 	// this time since posts where meta boxes are present can be saved even if
 	// the post is not dirty. Currently this restriction is imposed at UI, but

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1035,7 +1035,7 @@ export function getPermalinkParts( state ) {
  * @return {boolean} Is locked.
  */
 export function isPostLocked( state ) {
-	return state.postLock.isLocked;
+	return state.postLock?.isLocked ?? false;
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1421,6 +1421,27 @@ describe( 'selectors', () => {
 
 			expect( isEditedPostSaveable( state ) ).toBe( true );
 		} );
+
+		it( 'should return false if the post is locked', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							value: [],
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {},
+				saving: {},
+				postLock: {
+					isLocked: true,
+				},
+			};
+
+			expect( isEditedPostSaveable( state ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'isEditedPostAutosaveable', () => {


### PR DESCRIPTION
## Description
Fixes #13509. Potentially addresses #21236, #42400, #36118 as well. Also fixes a bug described below.

## Steps to reproduce
- Login as User A.
- Create a post in block editor. Let's say with Post ID - 1. Do not publish it.
- Make any changes right before the user session is about to expire and wait for session expiry and do not save the post.
  - Testing Note: One way to achieve this is by making some changes in the post content and immediately deleting all the cookies. Do not save the post.
- Wait for the on-page WordPress login popup to appear. Stay on the screen. Do not log back in just yet.
- Login as User B in different browser or incognito mode.
- Wait for the post lock to expire for User A on Post with ID - 1.
- Open the Post with ID - 1 as User B once post is not locked anymore.
- Observe that the post has last persisted changes made by User A.
- Make some changes in the post as User B and save it. Do not publish it.
- Leave this window open for User B.
- Meanwhile, go back to User A window and re-login.
- Notice from dev console that an autosave request is triggered with User A's last unsaved changes from the open browser.
- Also notice that until next heartbeat happens, you can actually go ahead and make changes and save the post as User A after re-login, even though the post is locked by User B.
- Come back to User B window and refresh the page.
- Notice that you lost changes made by User B.

## How has this been tested?
With the fix in this PR, I tested above reproduction steps. After User A re-logs in, there's not autosave request triggered, User A immediately sees the `PostLockedModal` preventing any further updates and User B is not loosing the content anymore.

## Types of changes
- Non-breaking change
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
