### PR TITLE
Fix scroll jitter in Customize Widgets

### DIFF
--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -14,13 +14,13 @@
 	// Override the inline styles added via JS that make the section title
 	// sticky feature work. The customize widget block-editor disables this
 	// sticky title.
-	padding-top: 10px !important;
+	padding-top: 12px !important;
 
 	.customize-section-title {
 		// Disable the sticky title. `!important` as this overrides inline
 		// styles added via JavaScript.
 		position: static !important;
-		top: 0 !important;
+		margin-top: -12px !important;
 		width: unset !important;
 	}
 }


### PR DESCRIPTION
Follow up of #32140 which has left the editor with some scroll jitter. No separate issue is made so including reproduction steps here for confirmation of the issue.

UPDATE: So far I can only reproduce this with the Twenty Twenty theme active. It's not clear why other themes seem to prevent the sticky behavior of the Customizer header only in the widgets editor.

## Steps to reproduce
1. With Twenty Twenty theme active, navigate to a widget area in the Customizer
2. If there's not enough content to cause overflow, either add enough content or shorten the window.
3. Scroll down and then scroll up just a bit
4. Observe the jitter or repeat step 3 several times as it does not always cause the jitter
5. Alternatively, scroll back to the top while looking out for the jump of the header as seen a the beginning of the video below

## Screen recording
The video first shows how the jump can be spotted when returning to the top of the scroll. A bit later, it is shown how the jitter may be triggered.

https://user-images.githubusercontent.com/9000376/120966046-85097a00-c71a-11eb-8924-ae5e73322d5c.mp4

## About the apparent cause and changes in the PR
The negative `margin-top` of the sticky header is cleared during upward scrolling as part of the customizer’s js-controlled “sticky” positioning. Overriding that to keep the margin constantly applied avoids the issue.

## How has this been tested?
In the customizer trying and failing to recreate the problems shown in the screen recording.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
