### PR TITLE
Number Control: Add option to skip rounding of value for BoxControl

### DIFF
--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -80,7 +80,7 @@ export default function AllInputControl( {
 			onHoverOn={ handleOnHoverOn }
 			onHoverOff={ handleOnHoverOff }
 			placeholder={ allPlaceholder }
-			round={ false }
+			allowDecimal={ true }
 		/>
 	);
 }

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -72,6 +72,7 @@ export default function AllInputControl( {
 	return (
 		<UnitControl
 			{ ...props }
+			allowDecimal={ true }
 			disableUnits={ isMixed }
 			isOnly
 			value={ allValue }
@@ -80,7 +81,6 @@ export default function AllInputControl( {
 			onHoverOn={ handleOnHoverOn }
 			onHoverOff={ handleOnHoverOff }
 			placeholder={ allPlaceholder }
-			allowDecimal={ true }
 		/>
 	);
 }

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -80,6 +80,7 @@ export default function AllInputControl( {
 			onHoverOn={ handleOnHoverOn }
 			onHoverOff={ handleOnHoverOff }
 			placeholder={ allPlaceholder }
+			round={ false }
 		/>
 	);
 }

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -86,6 +86,7 @@ export default function BoxInputControls( {
 				{ filteredSides.map( ( side ) => (
 					<UnitControl
 						{ ...props }
+						allowDecimal={ true }
 						isFirst={ first === side }
 						isLast={ last === side }
 						isOnly={ only === side }
@@ -96,7 +97,6 @@ export default function BoxInputControls( {
 						onHoverOff={ createHandleOnHoverOff( side ) }
 						label={ LABELS[ side ] }
 						key={ `box-control-${ side }` }
-						allowDecimal={ true }
 					/>
 				) ) }
 			</Layout>

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -96,7 +96,7 @@ export default function BoxInputControls( {
 						onHoverOff={ createHandleOnHoverOff( side ) }
 						label={ LABELS[ side ] }
 						key={ `box-control-${ side }` }
-						round={ false }
+						allowDecimal={ true }
 					/>
 				) ) }
 			</Layout>

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -96,6 +96,7 @@ export default function BoxInputControls( {
 						onHoverOff={ createHandleOnHoverOff( side ) }
 						label={ LABELS[ side ] }
 						key={ `box-control-${ side }` }
+						round={ false }
 					/>
 				) ) }
 			</Layout>

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -95,6 +95,7 @@ export default function VerticalHorizontalInputControls( {
 			{ filteredSides.map( ( side ) => (
 				<UnitControl
 					{ ...props }
+					allowDecimal={ true }
 					isFirst={ first === side }
 					isLast={ last === side }
 					isOnly={ only === side }

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -27,6 +27,14 @@ const Example = () => {
 
 ## Props
 
+### allowDecimal
+
+Allow committing custom decimal values, rounded to 5 decimal places.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`
+
 ### dragDirection
 
 Determines the drag axis to increment/decrement the value.

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -18,7 +18,7 @@ import {
 	inputControlActionTypes,
 	composeStateReducers,
 } from '../input-control/state';
-import { add, subtract, roundClamp } from '../utils/math';
+import { add, getNumber, subtract, roundClamp } from '../utils/math';
 import { useJumpStep } from '../utils/hooks';
 import { isValueEmpty } from '../utils/values';
 
@@ -160,7 +160,7 @@ export function NumberControl(
 			if ( round ) {
 				state.value = roundClamp( currentValue, min, max );
 			} else {
-				state.value = clamp( currentValue, min, max );
+				state.value = clamp( getNumber( currentValue ), min, max );
 			}
 		}
 

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -34,6 +35,7 @@ export function NumberControl(
 		min = -Infinity,
 		shiftStep = 10,
 		step = 1,
+		round = true,
 		type: typeProp = 'number',
 		value: valueProp,
 		...props
@@ -155,7 +157,11 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_ENTER ||
 			type === inputControlActionTypes.COMMIT
 		) {
-			state.value = roundClamp( currentValue, min, max );
+			if ( round ) {
+				state.value = roundClamp( currentValue, min, max );
+			} else {
+				state.value = clamp( currentValue, min, max );
+			}
 		}
 
 		return state;

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -17,13 +17,7 @@ import {
 	inputControlActionTypes,
 	composeStateReducers,
 } from '../input-control/state';
-import {
-	add,
-	decimalClamp,
-	getNumber,
-	roundClamp,
-	subtract,
-} from '../utils/math';
+import { add, decimalClamp, roundClamp, subtract } from '../utils/math';
 import { useJumpStep } from '../utils/hooks';
 import { isValueEmpty } from '../utils/values';
 

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,7 +17,13 @@ import {
 	inputControlActionTypes,
 	composeStateReducers,
 } from '../input-control/state';
-import { add, getNumber, subtract, roundClamp } from '../utils/math';
+import {
+	add,
+	decimalClamp,
+	getNumber,
+	roundClamp,
+	subtract,
+} from '../utils/math';
 import { useJumpStep } from '../utils/hooks';
 import { isValueEmpty } from '../utils/values';
 
@@ -35,7 +40,7 @@ export function NumberControl(
 		min = -Infinity,
 		shiftStep = 10,
 		step = 1,
-		round = true,
+		allowDecimal = false,
 		type: typeProp = 'number',
 		value: valueProp,
 		...props
@@ -157,10 +162,10 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_ENTER ||
 			type === inputControlActionTypes.COMMIT
 		) {
-			if ( round ) {
-				state.value = roundClamp( currentValue, min, max );
+			if ( allowDecimal ) {
+				state.value = decimalClamp( currentValue, min, max, 5 );
 			} else {
-				state.value = clamp( getNumber( currentValue ), min, max );
+				state.value = roundClamp( currentValue, min, max );
 			}
 		}
 

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -82,6 +82,42 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '0' );
 		} );
 
+		it( 'should round clamped value on ENTER keypress when round is set to true', () => {
+			render(
+				<NumberControl
+					value={ 5 }
+					min={ 0 }
+					max={ 10 }
+					round={ true }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '1.125' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '1' );
+		} );
+
+		it( 'should not round clamped value on ENTER keypress when round is set to false', () => {
+			render(
+				<NumberControl
+					value={ 5 }
+					min={ 0 }
+					max={ 10 }
+					round={ false }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '1.125' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '1.125' );
+		} );
+
 		it( 'should parse to number value on ENTER keypress', () => {
 			render( <NumberControl value={ 5 } /> );
 

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -82,13 +82,13 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '0' );
 		} );
 
-		it( 'should round clamped value on ENTER keypress when round is set to true', () => {
+		it( 'should round clamped value on ENTER keypress when allowDecimal is set to false', () => {
 			render(
 				<NumberControl
 					value={ 5 }
 					min={ 0 }
 					max={ 10 }
-					round={ true }
+					allowDecimal={ false }
 				/>
 			);
 
@@ -100,13 +100,13 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '1' );
 		} );
 
-		it( 'should not round clamped value on ENTER keypress when round is set to false', () => {
+		it( 'should not round clamped value on ENTER keypress when allowDecimal is set to true', () => {
 			render(
 				<NumberControl
 					value={ 5 }
 					min={ 0 }
 					max={ 10 }
-					round={ false }
+					allowDecimal={ true }
 				/>
 			);
 
@@ -116,6 +116,24 @@ describe( 'NumberControl', () => {
 			fireKeyDown( { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '1.125' );
+		} );
+
+		it( 'should limit to five decimal places on ENTER keypress when allowDecimal is set to true', () => {
+			render(
+				<NumberControl
+					value={ 5 }
+					min={ 0 }
+					max={ 10 }
+					allowDecimal={ true }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '1.123456789' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '1.12346' );
 		} );
 
 		it( 'should parse to number value on ENTER keypress', () => {

--- a/packages/components/src/utils/math.js
+++ b/packages/components/src/utils/math.js
@@ -98,3 +98,25 @@ export function roundClamp(
 export function roundClampString( ...args ) {
 	return roundClamp( ...args ).toString();
 }
+
+/**
+ * Clamps a value based on a min/max range without step value and
+ * with allowed decimal places.
+ *
+ * @param {number} value The value.
+ * @param {number} min The minimum range.
+ * @param {number} max The maximum range.
+ * @param {number} precision Number of decimal places allowed.
+ *
+ * @return {number} The rounded and clamped value.
+ */
+export function decimalClamp(
+	value = 0,
+	min = Infinity,
+	max = Infinity,
+	precision = 5
+) {
+	return getNumber(
+		clamp( getNumber( value ), min, max ).toFixed( precision )
+	);
+}

--- a/packages/components/src/utils/test/math.js
+++ b/packages/components/src/utils/test/math.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { add, subtract, roundClamp } from '../math';
+import { add, decimalClamp, subtract, roundClamp } from '../math';
 
 describe( 'add', () => {
 	it( 'should add string and number values', () => {
@@ -76,5 +76,39 @@ describe( 'roundClamp', () => {
 		expect( roundClamp( 40.05, 1, 100, 0.01 ) ).toBe( 40.05 );
 		expect( roundClamp( 40.06, 1, 100, 0.1 ) ).toBe( 40.1 );
 		expect( roundClamp( 40.123005, 1, 100, 0.001 ) ).toBe( 40.123 );
+	} );
+} );
+
+describe( 'decimalClamp', () => {
+	it( 'should clamp a value between min and max', () => {
+		expect( decimalClamp( 10, 1, 10 ) ).toBe( 10 );
+		expect( decimalClamp( 1, 1, 10 ) ).toBe( 1 );
+		expect( decimalClamp( 0, 1, 10 ) ).toBe( 1 );
+
+		expect( decimalClamp( 50, 1, 10 ) ).toBe( 10 );
+		expect( decimalClamp( 50, -10, 10 ) ).toBe( 10 );
+		expect( decimalClamp( -50, -10, 10 ) ).toBe( -10 );
+
+		expect( decimalClamp( '50', 1, 10 ) ).toBe( 10 );
+		expect( decimalClamp( '50', -10, 10 ) ).toBe( 10 );
+		expect( decimalClamp( -50, -10, '10' ) ).toBe( -10 );
+	} );
+
+	it( 'should clamp number or string values', () => {
+		expect( decimalClamp( '50', 1, 10 ) ).toBe( 10 );
+		expect( decimalClamp( '50', -10, 10 ) ).toBe( 10 );
+		expect( decimalClamp( -50, -10, '10' ) ).toBe( -10 );
+	} );
+
+	it( 'should allow decimal values without steps rounded to 5 places', () => {
+		expect( decimalClamp( 3.12345, 1, 10 ) ).toBe( 3.12345 );
+		expect( decimalClamp( -2.12, -10, 10 ) ).toBe( -2.12 );
+		expect( decimalClamp( 25.1234567, 0, 30 ) ).toBe( 25.12346 );
+	} );
+
+	it( 'should allow specifying a custom precision', () => {
+		expect( decimalClamp( 3.12345, 1, 10, 2 ) ).toBe( 3.12 );
+		expect( decimalClamp( -2.12, -10, 10, 1 ) ).toBe( -2.1 );
+		expect( decimalClamp( 25.123456789, 0, 30, 9 ) ).toBe( 25.123456789 );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to: #31964 

Currently, the NumberControl component clamps and rounds the input value when the value is committed (either pressing enter or tabbing out of the field), which will round the value to the nearest step value. However, in controls like the BoxControl, we need to allow the user to commit values with decimal places, which is not currently supported. To enable, for example, padding values of `1.25em` or `1.5rem`, this change proposes adding an `allowDecimal` prop to the NumberControl, defaulted to `false` so that we can switch off the rounding when we'd like to.

My working assumption here is that while we might want to use step values for pressing up and down in an input field, or for drag behaviour, we might still want to allow users to set specific values within those step ranges. For example, to allow folks to design or use block patterns that might need to conform to a highly specific scale ratio (e.g. like some of those from: https://type-scale.com/)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Add a Group block to a post or page. Under Spacing, select a non-px unit, e.g. `em` or `rem` and manually enter a value with a decimal place, e.g. `1.5em`. When you press enter or tab out of the field, the value should stick, where it did not before.

Run tests locally:

```
npm run test-unit -- packages/components/src/number-control/test/index.js
npm run test-unit -- packages/components/src/utils/test/math.js
```

## Screenshots <!-- if applicable -->

![number-control-sml](https://user-images.githubusercontent.com/14988353/120976202-758b3f00-c7b5-11eb-89c1-d95ac5e0ab02.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. (tested via keyboard) <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
