### PR TITLE
Don't hardcode CSS units

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -23,6 +23,7 @@ import useSetting from '../../components/use-setting';
 export default function LetterSpacingControl( { value, onChange } ) {
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+		defaultValues: { px: '2', em: '.2', rem: '.2' },
 	} );
 	return (
 		<UnitControl

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -1,29 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
-import { Platform } from '@wordpress/element';
+import {
+	__experimentalUnitControl as UnitControl,
+	__experimentalUseCustomUnits as useCustomUnits,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const isWeb = Platform.OS === 'web';
-
-const CSS_UNITS = [
-	{
-		value: 'px',
-		label: isWeb ? 'px' : __( 'Pixels (px)' ),
-		default: '2',
-	},
-	{
-		value: 'em',
-		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
-		default: '.2',
-	},
-	{
-		value: 'rem',
-		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
-		default: '.2',
-	},
-];
+/**
+ * Internal dependencies
+ */
+import useSetting from '../../components/use-setting';
 
 /**
  * Control for letter-spacing.
@@ -34,12 +21,15 @@ const CSS_UNITS = [
  * @return {WPElement}                      Letter-spacing control.
  */
 export default function LetterSpacingControl( { value, onChange } ) {
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+	} );
 	return (
 		<UnitControl
 			label={ __( 'Letter-spacing' ) }
 			value={ value }
 			__unstableInputWidth="60px"
-			units={ CSS_UNITS }
+			units={ units }
 			onChange={ onChange }
 		/>
 	);

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -1,15 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import {
+	__experimentalUnitControl as UnitControl,
+	__experimentalUseCustomUnits as useCustomUnits,
+} from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { CSS_UNITS, parseUnit } from './border';
+import { parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
+import useSetting from '../components/use-setting';
 
 const MIN_BORDER_RADIUS_VALUE = 0;
 
@@ -51,6 +55,10 @@ export function BorderRadiusEdit( props ) {
 		setAttributes( { style: newStyle } );
 	};
 
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+	} );
+
 	return (
 		<UnitControl
 			value={ style?.border?.radius }
@@ -59,7 +67,7 @@ export function BorderRadiusEdit( props ) {
 			onChange={ onChange }
 			onUnitChange={ onUnitChange }
 			step={ step }
-			units={ CSS_UNITS }
+			units={ units }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	parseUnit,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
 import useSetting from '../components/use-setting';
 
@@ -32,7 +32,8 @@ export function BorderRadiusEdit( props ) {
 
 	// Step value is maintained in state so step is appropriate for current unit
 	// even when current radius value is undefined.
-	const initialStep = parseUnit( style?.border?.radius ) === 'px' ? 1 : 0.25;
+	const initialStep =
+		parseUnit( style?.border?.radius )[ 1 ] === 'px' ? 1 : 0.25;
 	const [ step, setStep ] = useState( initialStep );
 
 	const onUnitChange = ( newUnit ) => {

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
-	parseUnit,
+	__experimentalParseUnit as parseUnit,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	parseUnit,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
 import useSetting from '../components/use-setting';
 
@@ -32,7 +32,8 @@ export const BorderWidthEdit = ( props ) => {
 
 	// Step value is maintained in state so step is appropriate for current unit
 	// even when current radius value is undefined.
-	const initialStep = parseUnit( style?.border?.width ) === 'px' ? 1 : 0.25;
+	const initialStep =
+		parseUnit( style?.border?.width )[ 1 ] === 'px' ? 1 : 0.25;
 	const [ step, setStep ] = useState( initialStep );
 
 	const onUnitChange = ( newUnit ) => {

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -1,15 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import {
+	__experimentalUnitControl as UnitControl,
+	__experimentalUseCustomUnits as useCustomUnits,
+} from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { CSS_UNITS, parseUnit } from './border';
+import { parseUnit } from './border';
 import { cleanEmptyObject } from './utils';
+import useSetting from '../components/use-setting';
 
 const MIN_BORDER_WIDTH = 0;
 
@@ -51,6 +55,10 @@ export const BorderWidthEdit = ( props ) => {
 		setAttributes( { style: newStyle } );
 	};
 
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+	} );
+
 	return (
 		<UnitControl
 			value={ style?.border?.width }
@@ -59,7 +67,7 @@ export const BorderWidthEdit = ( props ) => {
 			onChange={ onChange }
 			onUnitChange={ onUnitChange }
 			step={ step }
-			units={ CSS_UNITS }
+			units={ units }
 		/>
 	);
 };

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
-	parseUnit,
+	__experimentalParseUnit as parseUnit,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, ALL_CSS_UNITS } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -16,29 +16,7 @@ import { BorderRadiusEdit } from './border-radius';
 import { BorderStyleEdit } from './border-style';
 import { BorderWidthEdit } from './border-width';
 
-const isWeb = Platform.OS === 'web';
-
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
-export const CSS_UNITS = [
-	{
-		value: 'px',
-		label: isWeb ? 'px' : __( 'Pixels (px)' ),
-		default: '',
-		a11yLabel: __( 'Pixels (px)' ),
-	},
-	{
-		value: 'em',
-		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
-		default: '',
-		a11yLabel: __( 'Relative to parent font size (em)' ),
-	},
-	{
-		value: 'rem',
-		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
-		default: '',
-		a11yLabel: __( 'Relative to root font size (rem)' ),
-	},
-];
 
 /**
  * Parses a CSS unit from a border CSS value.
@@ -50,7 +28,7 @@ export function parseUnit( cssValue ) {
 	const value = String( cssValue ).trim();
 	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
 	const unit = unitMatch !== undefined ? unitMatch.toLowerCase() : '';
-	const currentUnit = CSS_UNITS.find( ( item ) => item.value === unit );
+	const currentUnit = ALL_CSS_UNITS.find( ( item ) => item.value === unit );
 
 	return currentUnit?.value || 'px';
 }

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
-import { PanelBody, ALL_CSS_UNITS } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -17,21 +17,6 @@ import { BorderStyleEdit } from './border-style';
 import { BorderWidthEdit } from './border-width';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
-
-/**
- * Parses a CSS unit from a border CSS value.
- *
- * @param {string} cssValue CSS value to parse e.g. `10px` or `1.5em`.
- * @return {string}          CSS unit from provided value or default 'px'.
- */
-export function parseUnit( cssValue ) {
-	const value = String( cssValue ).trim();
-	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
-	const unit = unitMatch !== undefined ? unitMatch.toLowerCase() : '';
-	const currentUnit = ALL_CSS_UNITS.find( ( item ) => item.value === unit );
-
-	return currentUnit?.value || 'px';
-}
 
 export function BorderPanel( props ) {
 	const isDisabled = useIsBorderDisabled( props );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -137,6 +137,7 @@ export { Truncate as __experimentalTruncate } from './truncate';
 export {
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
+	ALL_CSS_UNITS,
 } from './unit-control';
 export { default as VisuallyHidden } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -137,7 +137,7 @@ export { Truncate as __experimentalTruncate } from './truncate';
 export {
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
-	ALL_CSS_UNITS,
+	parseUnit,
 } from './unit-control';
 export { default as VisuallyHidden } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -137,7 +137,7 @@ export { Truncate as __experimentalTruncate } from './truncate';
 export {
 	default as __experimentalUnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
-	parseUnit,
+	parseUnit as __experimentalParseUnit,
 } from './unit-control';
 export { default as VisuallyHidden } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -200,5 +200,5 @@ function UnitControl(
 
 const ForwardedUnitControl = forwardRef( UnitControl );
 
-export { useCustomUnits } from './utils';
+export { ALL_CSS_UNITS, useCustomUnits } from './utils';
 export default ForwardedUnitControl;

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -200,5 +200,5 @@ function UnitControl(
 
 const ForwardedUnitControl = forwardRef( UnitControl );
 
-export { ALL_CSS_UNITS, useCustomUnits } from './utils';
+export { parseUnit, useCustomUnits } from './utils';
 export default ForwardedUnitControl;


### PR DESCRIPTION
Fixes #32478 

In https://github.com/WordPress/gutenberg/pull/31822 we replaced all hardcoded CSS units with calls to `useCustomUnits`, providing defaults and an array of units where appropriate.

Since that PR got merged, changes were pushed to border controls and letter-spacing, adding some more instances of hardcode CSS_UNITS. This PR replaces the new instances with calls to `useCustomUnits`, so we'll have a single source of truth for CSS units.

## How has this been tested?
Tested the letter-spacing and border-radius features, everything seems to be working fine.
Also added an array of units in the theme's `theme.json` file under `settings.layout.units` (formatted as `['px', 'em']`) and confirmed that the units defined are then used in these controls.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
