### PR TITLE
Show all heading levels in toolbar group

### DIFF
--- a/packages/block-library/src/heading/editor.scss
+++ b/packages/block-library/src/heading/editor.scss
@@ -14,4 +14,7 @@
 // level toolbar.
 .block-library-heading-level-toolbar {
 	border: none;
+	.components-toolbar-group {
+		flex-wrap: nowrap;
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/30707

In `Heading`, `Post Title` and `Archive Title` blocks the heading level control in toolbar is not showing all the available options.

This PR fixes that. I have taken the approach used for other toolbar groups as in here: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-toolbar/style.scss#L104
<!-- Please describe what you have changed or added -->

### Before
![before](https://user-images.githubusercontent.com/16275880/120994884-9a6bbc00-c78d-11eb-9c78-2e35b4190740.gif)

### After
![after](https://user-images.githubusercontent.com/16275880/120994931-a35c8d80-c78d-11eb-83c5-59531318df9d.gif)
