### PR TITLE
Edit Post: Prevent locking users in saving state when saving meta boxes fails

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -383,14 +383,19 @@ export function* requestMetaBoxUpdates() {
 		formData.append( key, value )
 	);
 
-	// Save the metaboxes
-	yield apiFetch( {
-		url: window._wpMetaBoxUrl,
-		method: 'POST',
-		body: formData,
-		parse: false,
-	} );
-	yield controls.dispatch( editPostStore.name, 'metaBoxUpdatesSuccess' );
+	try {
+		// Save the metaboxes
+		yield apiFetch( {
+			url: window._wpMetaBoxUrl,
+			method: 'POST',
+			body: formData,
+			parse: false,
+		} );
+	} finally {
+		// Update meta box isSaving state even if apiFetch fails.
+		// This prevents locking the post editor in a saving state.
+		yield controls.dispatch( editPostStore.name, 'metaBoxUpdatesSuccess' );
+	}
 }
 
 /**

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -392,8 +392,9 @@ export function* requestMetaBoxUpdates() {
 			parse: false,
 		} );
 	} finally {
-		// Update meta box isSaving state even if apiFetch fails.
-		// This prevents locking the post editor in a saving state.
+		// The "metaBoxUpdatesSuccess" action sets isSavingMetaBoxes state to "false."
+		// This indicates that the meta boxes saving request is complete, regardless of whether it has succeeded or failed.
+		// Updating this state prevents locking the editor in the saving state.
 		yield controls.dispatch( editPostStore.name, 'metaBoxUpdatesSuccess' );
 	}
 }


### PR DESCRIPTION
## Description
Changes logic to update the `isSavingMetaBoxes` state even if the saving meta boxes request fails.

Fixes #6966.
Fixes #19780.

## How has this been tested?
1. Activate the "Gutenberg Test Plugin, Meta Box" plugin.
2. Create a post and enter some content.
3. Force maintenance mode by creating the `.maintenance` file in the WP root directory, with contents:
```php
<?php
$upgrading = time();
```
4. Return to the editor and click "Save draft."
5. Error notice should appear.
6. You should be able to click the "Save draft" or "Publish" button.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/121025413-30b3d800-c7b6-11eb-91f2-8bf50dded2ea.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
