### PR TITLE
Do not migrate the old typography support if core already did it

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -500,4 +500,6 @@ function gutenberg_migrate_old_typography_shape( $metadata ) {
 	return $metadata;
 }
 
-add_filter( 'block_type_metadata', 'gutenberg_migrate_old_typography_shape' );
+if ( ! function_exists( 'wp_migrate_old_typography_shape' ) ) {
+	add_filter( 'block_type_metadata', 'gutenberg_migrate_old_typography_shape' );
+}


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/1338

We made a change to how the typography block supports are declared, from:

```json
supports: {
  "fontSize": true,
  "lineHeight": true
}
```

to 

```json
supports: {
  "typography": {
    "fontSize": true,
    "lineHeight": true
  }
}
```

for which we introduced a migration mechanism. This is being ported to WordPress 5.8, so we don't need to run it in the plugin if core already did it.
