### PR TITLE
Try stickier block toolbars in Customize Widgets

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -179,8 +179,8 @@ $z-layers: (
 	// Appear under the customizer heading UI, but over anything else.
 	".customize-widgets__topbar": 8,
 
-	// Appear under the topbar.
-	".customize-widgets__block-toolbar": 7,
+	// Appear over the topbar of both editor and customizer.
+	".customize-widgets__block-toolbar": 10,
 );
 
 @function z-index( $key ) {

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -178,9 +178,6 @@ $z-layers: (
 
 	// Appear under the customizer heading UI, but over anything else.
 	".customize-widgets__topbar": 8,
-
-	// Appear over the topbar of both editor and customizer.
-	".customize-widgets__block-toolbar": 10,
 );
 
 @function z-index( $key ) {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -244,7 +244,10 @@ _Parameters_
 -   _$0_ `Object`: Props.
 -   _$0.children_ `Object`: The block content and style container.
 -   _$0.\_\_unstableContentRef_ `Object`: Ref holding the content scroll container.
--   _$0.\_\_experimentalStickyTop_ `Object`: Offset for the top position of toolbars.
+-   _$0.\_\_experimentalStickyBottom_ `number`: Bottom sticky position of floating toolbar.
+-   _$0.\_\_experimentalStickyTop_ `number`: Top sticky position of floating and top toolbar.
+-   _$0.\_\_experimentalStickyAreaBottom_ `number`: Offset of bottom side of sticky area.
+-   _$0.\_\_experimentalStickyAreaTop_ `number`: Offset of top side of sticky area.
 
 <a name="BlockVerticalAlignmentControl" href="#BlockVerticalAlignmentControl">#</a> **BlockVerticalAlignmentControl**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -244,10 +244,8 @@ _Parameters_
 -   _$0_ `Object`: Props.
 -   _$0.children_ `Object`: The block content and style container.
 -   _$0.\_\_unstableContentRef_ `Object`: Ref holding the content scroll container.
--   _$0.\_\_experimentalStickyBottom_ `number`: Bottom sticky position of floating toolbar.
--   _$0.\_\_experimentalStickyTop_ `number`: Top sticky position of floating and top toolbar.
--   _$0.\_\_experimentalStickyAreaBottom_ `number`: Offset of bottom side of sticky area.
--   _$0.\_\_experimentalStickyAreaTop_ `number`: Offset of top side of sticky area.
+-   _$0.\_\_experimentalStickyTop_ `number`: Top sticky position offset of floating and top toolbar.
+-   _$0.\_\_experimentalStickier_ `boolean`: Favor sticky position even if the block is out of view.
 
 <a name="BlockVerticalAlignmentControl" href="#BlockVerticalAlignmentControl">#</a> **BlockVerticalAlignmentControl**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -244,6 +244,7 @@ _Parameters_
 -   _$0_ `Object`: Props.
 -   _$0.children_ `Object`: The block content and style container.
 -   _$0.\_\_unstableContentRef_ `Object`: Ref holding the content scroll container.
+-   _$0.\_\_experimentalStickyTop_ `Object`: Offset for the top position of toolbars.
 
 <a name="BlockVerticalAlignmentControl" href="#BlockVerticalAlignmentControl">#</a> **BlockVerticalAlignmentControl**
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -17,7 +17,13 @@ import NavigableToolbar from '../navigable-toolbar';
 import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 
-function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
+function BlockContextualToolbar( {
+	focusOnMount,
+	isFixed,
+	__experimentalStickyTop,
+	style = {},
+	...props
+} ) {
 	const { blockType, hasParents, showParentSelector } = useSelect(
 		( select ) => {
 			const {
@@ -59,12 +65,17 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		'is-fixed': isFixed,
 	} );
 
+	if ( __experimentalStickyTop ) {
+		style.top = __experimentalStickyTop;
+	}
+
 	return (
 		<NavigableToolbar
 			focusOnMount={ focusOnMount }
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
+			style={ style }
 			{ ...props }
 		>
 			<BlockToolbar hideDragHandle={ isFixed } />

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -54,10 +54,8 @@ function BlockPopover( {
 	capturingClientId,
 	__unstablePopoverSlot,
 	__unstableContentRef,
-	__experimentalStickyBottom,
 	__experimentalStickyTop,
-	__experimentalStickyAreaBottom,
-	__experimentalStickyAreaTop,
+	__experimentalStickier,
 } ) {
 	const {
 		isNavigationMode,
@@ -217,10 +215,8 @@ function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ node }
 			shouldAnchorIncludePadding
-			__experimentalStickyBottom={ __experimentalStickyBottom }
 			__experimentalStickyTop={ __experimentalStickyTop }
-			__experimentalStickyAreaBottom={ __experimentalStickyAreaBottom }
-			__experimentalStickyAreaTop={ __experimentalStickyAreaTop }
+			__experimentalStickier={ __experimentalStickier }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div
@@ -332,10 +328,8 @@ function wrapperSelector( select ) {
 export default function WrappedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
-	__experimentalStickyBottom,
 	__experimentalStickyTop,
-	__experimentalStickyAreaBottom,
-	__experimentalStickyAreaTop,
+	__experimentalStickier,
 } ) {
 	const selected = useSelect( wrapperSelector, [] );
 
@@ -365,10 +359,8 @@ export default function WrappedBlockPopover( {
 			capturingClientId={ capturingClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
-			__experimentalStickyBottom={ __experimentalStickyBottom }
 			__experimentalStickyTop={ __experimentalStickyTop }
-			__experimentalStickyAreaBottom={ __experimentalStickyAreaBottom }
-			__experimentalStickyAreaTop={ __experimentalStickyAreaTop }
+			__experimentalStickier={ __experimentalStickier }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -54,7 +54,10 @@ function BlockPopover( {
 	capturingClientId,
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyBottom,
 	__experimentalStickyTop,
+	__experimentalStickyAreaBottom,
+	__experimentalStickyAreaTop,
 } ) {
 	const {
 		isNavigationMode,
@@ -214,7 +217,10 @@ function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ node }
 			shouldAnchorIncludePadding
+			__experimentalStickyBottom={ __experimentalStickyBottom }
 			__experimentalStickyTop={ __experimentalStickyTop }
+			__experimentalStickyAreaBottom={ __experimentalStickyAreaBottom }
+			__experimentalStickyAreaTop={ __experimentalStickyAreaTop }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div
@@ -326,7 +332,10 @@ function wrapperSelector( select ) {
 export default function WrappedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyBottom,
 	__experimentalStickyTop,
+	__experimentalStickyAreaBottom,
+	__experimentalStickyAreaTop,
 } ) {
 	const selected = useSelect( wrapperSelector, [] );
 
@@ -356,7 +365,10 @@ export default function WrappedBlockPopover( {
 			capturingClientId={ capturingClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
+			__experimentalStickyBottom={ __experimentalStickyBottom }
 			__experimentalStickyTop={ __experimentalStickyTop }
+			__experimentalStickyAreaBottom={ __experimentalStickyAreaBottom }
+			__experimentalStickyAreaTop={ __experimentalStickyAreaTop }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -54,6 +54,7 @@ function BlockPopover( {
 	capturingClientId,
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyTop,
 } ) {
 	const {
 		isNavigationMode,
@@ -213,6 +214,7 @@ function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ node }
 			shouldAnchorIncludePadding
+			__experimentalStickyTop={ __experimentalStickyTop }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div
@@ -324,6 +326,7 @@ function wrapperSelector( select ) {
 export default function WrappedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyTop,
 } ) {
 	const selected = useSelect( wrapperSelector, [] );
 
@@ -353,6 +356,7 @@ export default function WrappedBlockPopover( {
 			capturingClientId={ capturingClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
+			__experimentalStickyTop={ __experimentalStickyTop }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -19,21 +19,19 @@ import { usePopoverScroll } from './use-popover-scroll';
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
  *
- * @param {Object} $0                                Props.
- * @param {Object} $0.children                       The block content and style container.
- * @param {Object} $0.__unstableContentRef           Ref holding the content scroll container.
- * @param {number} $0.__experimentalStickyBottom     Bottom sticky position of floating toolbar.
- * @param {number} $0.__experimentalStickyTop        Top sticky position of floating and top toolbar.
- * @param {number} $0.__experimentalStickyAreaBottom Offset of bottom side of sticky area.
- * @param {number} $0.__experimentalStickyAreaTop    Offset of top side of sticky area.
+ * @param {Object}  $0                         Props.
+ * @param {Object}  $0.children                The block content and style container.
+ * @param {Object}  $0.__unstableContentRef    Ref holding the content scroll container.
+ * @param {number}  $0.__experimentalStickyTop Top sticky position offset of floating and
+ *                                             top toolbar.
+ * @param {boolean} $0.__experimentalStickier  Favor sticky position even if the block is
+                                               out of view.
  */
 export default function BlockTools( {
 	children,
 	__unstableContentRef,
-	__experimentalStickyBottom,
 	__experimentalStickyTop,
-	__experimentalStickyAreaBottom: stickyAreaBottom,
-	__experimentalStickyAreaTop: stickyAreaTop,
+	__experimentalStickier,
 } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
@@ -53,10 +51,8 @@ export default function BlockTools( {
                  needed for navigation mode. */ }
 			<BlockPopover
 				__unstableContentRef={ __unstableContentRef }
-				__experimentalStickyBottom={ __experimentalStickyBottom }
 				__experimentalStickyTop={ __experimentalStickyTop }
-				__experimentalStickyAreaBottom={ stickyAreaBottom }
-				__experimentalStickyAreaTop={ stickyAreaTop }
+				__experimentalStickier={ __experimentalStickier }
 			/>
 			{ /* Used for the inline rich text toolbar. */ }
 			<Popover.Slot

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -19,15 +19,21 @@ import { usePopoverScroll } from './use-popover-scroll';
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
  *
- * @param {Object} $0                         Props.
- * @param {Object} $0.children                The block content and style container.
- * @param {Object} $0.__unstableContentRef    Ref holding the content scroll container.
- * @param {Object} $0.__experimentalStickyTop Offset for the top position of toolbars.
+ * @param {Object} $0                                Props.
+ * @param {Object} $0.children                       The block content and style container.
+ * @param {Object} $0.__unstableContentRef           Ref holding the content scroll container.
+ * @param {number} $0.__experimentalStickyBottom     Bottom sticky position of floating toolbar.
+ * @param {number} $0.__experimentalStickyTop        Top sticky position of floating and top toolbar.
+ * @param {number} $0.__experimentalStickyAreaBottom Offset of bottom side of sticky area.
+ * @param {number} $0.__experimentalStickyAreaTop    Offset of top side of sticky area.
  */
 export default function BlockTools( {
 	children,
 	__unstableContentRef,
+	__experimentalStickyBottom,
 	__experimentalStickyTop,
+	__experimentalStickyAreaBottom: stickyAreaBottom,
+	__experimentalStickyAreaTop: stickyAreaTop,
 } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
@@ -47,7 +53,10 @@ export default function BlockTools( {
                  needed for navigation mode. */ }
 			<BlockPopover
 				__unstableContentRef={ __unstableContentRef }
+				__experimentalStickyBottom={ __experimentalStickyBottom }
 				__experimentalStickyTop={ __experimentalStickyTop }
+				__experimentalStickyAreaBottom={ stickyAreaBottom }
+				__experimentalStickyAreaTop={ stickyAreaTop }
 			/>
 			{ /* Used for the inline rich text toolbar. */ }
 			<Popover.Slot

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -19,11 +19,16 @@ import { usePopoverScroll } from './use-popover-scroll';
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
  *
- * @param {Object} $0                      Props.
- * @param {Object} $0.children             The block content and style container.
- * @param {Object} $0.__unstableContentRef Ref holding the content scroll container.
+ * @param {Object} $0                         Props.
+ * @param {Object} $0.children                The block content and style container.
+ * @param {Object} $0.__unstableContentRef    Ref holding the content scroll container.
+ * @param {Object} $0.__experimentalStickyTop Offset for the top position of toolbars.
  */
-export default function BlockTools( { children, __unstableContentRef } ) {
+export default function BlockTools( {
+	children,
+	__unstableContentRef,
+	__experimentalStickyTop,
+} ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().hasFixedToolbar,
@@ -33,11 +38,17 @@ export default function BlockTools( { children, __unstableContentRef } ) {
 	return (
 		<InsertionPoint __unstableContentRef={ __unstableContentRef }>
 			{ ( hasFixedToolbar || ! isLargeViewport ) && (
-				<BlockContextualToolbar isFixed />
+				<BlockContextualToolbar
+					isFixed
+					__experimentalStickyTop={ __experimentalStickyTop }
+				/>
 			) }
 			{ /* Even if the toolbar is fixed, the block popover is still
                  needed for navigation mode. */ }
-			<BlockPopover __unstableContentRef={ __unstableContentRef } />
+			<BlockPopover
+				__unstableContentRef={ __unstableContentRef }
+				__experimentalStickyTop={ __experimentalStickyTop }
+			/>
 			{ /* Used for the inline rich text toolbar. */ }
 			<Popover.Slot
 				name="block-toolbar"

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -319,26 +319,18 @@
 			margin-top: $grid-unit-15;
 			margin-bottom: $grid-unit-15;
 		}
+	}
 
-		// The class is-away and attribute data-away are used to hide 'stickier'
-		// toolbars when their block is out of view.
-		&[data-away] {
-			transition: transform 0.1s cubic-bezier(0, 0, 0.2, 1);
-		}
+	// The data-away attribute is used to hide the toolbar when its block is out of view.
+	&[data-away] {
+		transition: opacity 0.1s linear;
 
-		&[data-away="top"] {
-			transform-origin: center top;
+		&[data-away="true"] {
+			opacity: 0;
 
-			&.is-away {
-				transform: perspective(1000px) rotateX(-90deg);
-			}
-		}
-
-		&[data-away="bottom"] {
-			transform-origin: center bottom;
-
-			&.is-away {
-				transform: perspective(1000px) rotateX(90deg);
+			// Allow clicking through the transparent toolbar
+			.block-editor-block-contextual-toolbar {
+				pointer-events: none;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -319,6 +319,28 @@
 			margin-top: $grid-unit-15;
 			margin-bottom: $grid-unit-15;
 		}
+
+		// The class is-away and attribute data-away are used to hide 'stickier'
+		// toolbars when their block is out of view.
+		&[data-away] {
+			transition: transform 0.1s cubic-bezier(0, 0, 0.2, 1);
+		}
+
+		&[data-away="top"] {
+			transform-origin: center top;
+
+			&.is-away {
+				transform: perspective(1000px) rotateX(-90deg);
+			}
+		}
+
+		&[data-away="bottom"] {
+			transform-origin: center bottom;
+
+			&.is-away {
+				transform: perspective(1000px) rotateX(90deg);
+			}
+		}
 	}
 
 	// Hide the block toolbar if the insertion point is shown.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -257,10 +257,8 @@ const Popover = (
 		__unstableBoundaryParent,
 		__unstableForcePosition,
 		__unstableForceXAlignment,
-		__experimentalStickyBottom: stickyBottom = 0,
-		__experimentalStickyTop: stickyTop = 0,
-		__experimentalStickyAreaBottom: stickyAreaBottom = 0,
-		__experimentalStickyAreaTop: stickyAreaTop = 0,
+		__experimentalStickyTop,
+		__experimentalStickier,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -356,8 +354,8 @@ const Popover = (
 				boundaryElement,
 				__unstableForcePosition,
 				__unstableForceXAlignment,
-				{ top: stickyTop, bottom: stickyBottom },
-				{ top: stickyAreaTop, bottom: stickyAreaBottom }
+				__experimentalStickyTop,
+				__experimentalStickier
 			);
 
 			if (
@@ -482,10 +480,8 @@ const Popover = (
 		position,
 		contentSize,
 		__unstableStickyBoundaryElement,
-		stickyBottom,
-		stickyTop,
-		stickyAreaBottom,
-		stickyAreaTop,
+		__experimentalStickyTop,
+		__experimentalStickier,
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 	] );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -257,6 +257,7 @@ const Popover = (
 		__unstableBoundaryParent,
 		__unstableForcePosition,
 		__unstableForceXAlignment,
+		__experimentalStickyTop: stickyTop = 0,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -305,7 +306,7 @@ const Popover = (
 
 			const { offsetParent, ownerDocument } = containerRef.current;
 
-			let relativeOffsetTop = 0;
+			let relativeOffsetTop = -stickyTop;
 
 			// If there is a positioned ancestor element that is not the body,
 			// subtract the position from the anchor rect. If the position of
@@ -315,7 +316,7 @@ const Popover = (
 			if ( offsetParent && offsetParent !== ownerDocument.body ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
-				relativeOffsetTop = offsetParentRect.top;
+				relativeOffsetTop += offsetParentRect.top;
 				anchor = new window.DOMRect(
 					anchor.left - offsetParentRect.left,
 					anchor.top - offsetParentRect.top,
@@ -476,6 +477,7 @@ const Popover = (
 		position,
 		contentSize,
 		__unstableStickyBoundaryElement,
+		stickyTop,
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 	] );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -257,7 +257,10 @@ const Popover = (
 		__unstableBoundaryParent,
 		__unstableForcePosition,
 		__unstableForceXAlignment,
+		__experimentalStickyBottom: stickyBottom = 0,
 		__experimentalStickyTop: stickyTop = 0,
+		__experimentalStickyAreaBottom: stickyAreaBottom = 0,
+		__experimentalStickyAreaTop: stickyAreaTop = 0,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -306,7 +309,7 @@ const Popover = (
 
 			const { offsetParent, ownerDocument } = containerRef.current;
 
-			let relativeOffsetTop = -stickyTop;
+			let relativeOffsetTop = 0;
 
 			// If there is a positioned ancestor element that is not the body,
 			// subtract the position from the anchor rect. If the position of
@@ -316,7 +319,7 @@ const Popover = (
 			if ( offsetParent && offsetParent !== ownerDocument.body ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
-				relativeOffsetTop += offsetParentRect.top;
+				relativeOffsetTop = offsetParentRect.top;
 				anchor = new window.DOMRect(
 					anchor.left - offsetParentRect.left,
 					anchor.top - offsetParentRect.top,
@@ -352,7 +355,9 @@ const Popover = (
 				relativeOffsetTop,
 				boundaryElement,
 				__unstableForcePosition,
-				__unstableForceXAlignment
+				__unstableForceXAlignment,
+				{ top: stickyTop, bottom: stickyBottom },
+				{ top: stickyAreaTop, bottom: stickyAreaBottom }
 			);
 
 			if (
@@ -477,7 +482,10 @@ const Popover = (
 		position,
 		contentSize,
 		__unstableStickyBoundaryElement,
+		stickyBottom,
 		stickyTop,
+		stickyAreaBottom,
+		stickyAreaTop,
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 	] );

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -166,9 +166,15 @@ export function computePopoverXAxisPosition(
  *                                        switching between sticky and normal
  *                                        position.
  * @param {Element} anchorRef             The anchor element.
- * @param {Element} relativeOffsetTop     If applicable, top offset of the
+ * @param {number}  relativeOffsetTop     If applicable, top offset of the
  *                                        relative positioned parent container.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
+ * @param {Object}  sticky                Sticky positions per side.
+ * @param {number}  sticky.top            Top sticky position.
+ * @param {number}  sticky.bottom         Bottom sticky position.
+ * @param {Object}  stickyArea            Offsets relative to anchorRect.
+ * @param {number}  stickyArea.top        Offset from top.
+ * @param {number}  stickyArea.bottom     Offset from bottom.
  *
  * @return {Object} Popover xAxis position and constraints.
  */
@@ -180,18 +186,27 @@ export function computePopoverYAxisPosition(
 	stickyBoundaryElement,
 	anchorRef,
 	relativeOffsetTop,
-	forcePosition
+	forcePosition,
+	{ top, bottom },
+	{ top: start, bottom: end }
 ) {
 	const { height } = contentSize;
 
 	if ( stickyBoundaryElement ) {
 		const stickyRect = stickyBoundaryElement.getBoundingClientRect();
-		const stickyPosition = stickyRect.top + height - relativeOffsetTop;
-
-		if ( anchorRect.top <= stickyPosition ) {
+		top += stickyRect.top + height - relativeOffsetTop;
+		bottom = -bottom + stickyRect.bottom - relativeOffsetTop;
+		if ( anchorRect.top < top ) {
+			end += anchorRect.bottom;
 			return {
 				yAxis,
-				popoverTop: Math.min( anchorRect.bottom, stickyPosition ),
+				popoverTop: Math.min( end, top ),
+			};
+		} else if ( anchorRect.top > bottom ) {
+			start += anchorRect.top;
+			return {
+				yAxis,
+				popoverTop: Math.max( start, bottom ),
 			};
 		}
 	}
@@ -287,7 +302,9 @@ export function computePopoverYAxisPosition(
  *                                        relative positioned parent container.
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis
+ * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis.
+ * @param {Object}  sticky                Sticky positions per side.
+ * @param {Object}  stickyBounds          Boundary offsets relative to anchorRect.
  *
  * @return {Object} Popover position and constraints.
  */
@@ -300,7 +317,9 @@ export function computePopoverPosition(
 	relativeOffsetTop,
 	boundaryElement,
 	forcePosition,
-	forceXAlignment
+	forceXAlignment,
+	sticky,
+	stickyBounds
 ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
@@ -312,7 +331,9 @@ export function computePopoverPosition(
 		stickyBoundaryElement,
 		anchorRef,
 		relativeOffsetTop,
-		forcePosition
+		forcePosition,
+		sticky,
+		stickyBounds
 	);
 	const xAxisPosition = computePopoverXAxisPosition(
 		anchorRect,

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -169,12 +169,10 @@ export function computePopoverXAxisPosition(
  * @param {number}  relativeOffsetTop     If applicable, top offset of the
  *                                        relative positioned parent container.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {Object}  sticky                Sticky positions per side.
- * @param {number}  sticky.top            Top sticky position.
- * @param {number}  sticky.bottom         Bottom sticky position.
- * @param {Object}  stickyArea            Offsets relative to anchorRect.
- * @param {number}  stickyArea.top        Offset from top.
- * @param {number}  stickyArea.bottom     Offset from bottom.
+ * @param {number}  stickyTop             Sticky top position offset from the
+ *                                        boundaryElement.
+ * @param {boolean} stickier              Favor sticky position even if the
+ *                                        anchor is out of view.
  *
  * @return {Object} Popover xAxis position and constraints.
  */
@@ -187,23 +185,23 @@ export function computePopoverYAxisPosition(
 	anchorRef,
 	relativeOffsetTop,
 	forcePosition,
-	{ top, bottom },
-	{ top: start, bottom: end }
+	stickyTop,
+	stickier
 ) {
 	const { height } = contentSize;
 
 	if ( stickyBoundaryElement ) {
 		const stickyRect = stickyBoundaryElement.getBoundingClientRect();
-		top += stickyRect.top + height - relativeOffsetTop;
-		bottom = -bottom + stickyRect.bottom - relativeOffsetTop;
+		const top = stickyTop + stickyRect.top + height - relativeOffsetTop;
+		const bottom = stickyRect.bottom - relativeOffsetTop;
 		if ( anchorRect.top < top ) {
-			end += anchorRect.bottom;
+			const end = stickier ? Infinity : anchorRect.bottom;
 			return {
 				yAxis,
 				popoverTop: Math.min( end, top ),
 			};
 		} else if ( anchorRect.top > bottom ) {
-			start += anchorRect.top;
+			const start = stickier ? -Infinity : anchorRect.top;
 			return {
 				yAxis,
 				popoverTop: Math.max( start, bottom ),
@@ -303,8 +301,10 @@ export function computePopoverYAxisPosition(
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
  * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis.
- * @param {Object}  sticky                Sticky positions per side.
- * @param {Object}  stickyBounds          Boundary offsets relative to anchorRect.
+ * @param {number}  stickyTop             Sticky top position offset from the
+ *                                        boundaryElement.
+ * @param {boolean} stickier              Favor sticky position even if the
+ *                                        anchor is out of view.
  *
  * @return {Object} Popover position and constraints.
  */
@@ -318,8 +318,8 @@ export function computePopoverPosition(
 	boundaryElement,
 	forcePosition,
 	forceXAlignment,
-	sticky,
-	stickyBounds
+	stickyTop = 0,
+	stickier = false
 ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
@@ -332,8 +332,8 @@ export function computePopoverPosition(
 		anchorRef,
 		relativeOffsetTop,
 		forcePosition,
-		sticky,
-		stickyBounds
+		stickyTop,
+		stickier
 	);
 	const xAxisPosition = computePopoverXAxisPosition(
 		anchorRect,

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,4 +1,7 @@
 .customize-widgets-header {
+	position: sticky;
+	top: 0;
+
 	@include break-medium() {
 		// Make space for the floating toolbar.
 		margin-bottom: $grid-unit-60 + $default-block-margin;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -116,7 +116,16 @@ export default function SidebarBlockEditor( {
 					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
+<<<<<<< HEAD
 				<BlockTools __experimentalStickyTop={ headerHeight }>
+=======
+				<BlockTools
+					__experimentalStickyTop={ blockToolbarOffset }
+					__experimentalStickyAreaBottom={ Infinity }
+					__experimentalStickyBottom={ 0 }
+					__experimentalStickyAreaTop={ -Infinity }
+				>
+>>>>>>> 1cdc726440... Have floating block toolbar remain in view when block is out of view
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -116,16 +116,10 @@ export default function SidebarBlockEditor( {
 					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
-<<<<<<< HEAD
-				<BlockTools __experimentalStickyTop={ headerHeight }>
-=======
 				<BlockTools
-					__experimentalStickyTop={ blockToolbarOffset }
-					__experimentalStickyAreaBottom={ Infinity }
-					__experimentalStickyBottom={ 0 }
-					__experimentalStickyAreaTop={ -Infinity }
+					__experimentalStickyTop={ headerHeight }
+					__experimentalStickier
 				>
->>>>>>> 1cdc726440... Have floating block toolbar remain in view when block is out of view
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -33,6 +33,9 @@ import { store as customizeWidgetsStore } from '../../store';
 import WelcomeGuide from '../welcome-guide';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 
+// Used to offset the block toolbar’s sticky top
+const headerHeight = 49;
+
 export default function SidebarBlockEditor( {
 	blockEditorSettings,
 	sidebar,
@@ -113,7 +116,7 @@ export default function SidebarBlockEditor( {
 					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
-				<BlockTools>
+				<BlockTools __experimentalStickyTop={ headerHeight }>
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -9,10 +9,8 @@
 
 	// Scroll sideways.
 	overflow-y: auto;
-	z-index: z-index(".customize-widgets__block-toolbar");
 }
 
 .customize-control-sidebar_block_editor .block-editor-block-list__block-popover {
 	position: fixed;
-	z-index: z-index(".customize-widgets__block-toolbar");
 }

--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -12,13 +12,13 @@
 	// Override the inline styles added via JS that make the section title
 	// sticky feature work. The customize widget block-editor disables this
 	// sticky title.
-	padding-top: 10px !important;
+	padding-top: 12px !important;
 
 	.customize-section-title {
 		// Disable the sticky title. `!important` as this overrides inline
 		// styles added via JavaScript.
 		position: static !important;
-		top: 0 !important;
 		width: unset !important;
+		margin-top: -12px !important;
 	}
 }


### PR DESCRIPTION
An experiment in how to work out the recent toolbar overlapping issues in the Customize Widgets editor. The two high-level changes:
* The floating block toolbar is stickier (remains stuck at the edge of the scrolling context even when its block is out of view) which avoids a need for #32061.
* The editor header toolbar is made sticky and offsets the block toolbar (both floating and top/fixed) which will resolve #30912.

UPDATE: The floating block toolbar now hides when its block goes out of view (its position is still stuck to the scrolling boundaries to avoid overlap during transition).

## How has this been tested?
Manually…

## Screenshots

https://user-images.githubusercontent.com/9000376/122094839-76c5f880-cdc1-11eb-929b-5a9623021c3e.mp4

<details>
<summary>For posterity, the version with alternate transform transition of the toolbar</summary>

https://user-images.githubusercontent.com/9000376/121815962-c83d7e80-cc2d-11eb-9b42-6081e10caab5.mp4

</details>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
