### PR TITLE
Navigation block: Add an unstable location attribute

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -42,6 +42,9 @@
 		"isResponsive": {
 			"type": "boolean",
 			"default": false
+		},
+		"__unstable__location": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -86,6 +86,36 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 }
 
 /**
+ * Renders a Navigation Block derived from data from the theme_location assigned
+ * via the block attribute 'location'.
+ *
+ * If the theme doesn't explicity support 'block-nav-menus' or no location was provided
+ * as a block attribute then an empty string is returned.
+ *
+ * @param  array $attributes Navigation block attributes.
+ * @return string HTML markup of a generated Navigation Block.
+ */
+function get_classic_navigation_elements( $attributes ) {
+	if ( ! array_key_exists( '__unstable__location', $attributes ) ) {
+		return '';
+	}
+
+	$block_attributes = $attributes;
+	unset( $block_attributes['__unstable__location'] );
+
+	return wp_nav_menu(
+		array(
+			'theme_location'   => $attributes['__unstable__location'],
+			'block_attributes' => $block_attributes,
+			'container'        => '',
+			'items_wrap'       => '%3$s',
+			'fallback_cb'      => false,
+			'echo'             => false,
+		)
+	);
+}
+
+/**
  * Returns the top-level submenu SVG chevron icon.
  *
  * @return string
@@ -133,7 +163,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $block->inner_blocks ) ) {
-		return '';
+		return get_classic_navigation_elements( $attributes );
 	}
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -106,7 +106,7 @@ function render_classic_location_menu( $location, $attributes ) {
 
 	return wp_nav_menu(
 		array(
-			'theme_location'   => $attributes['__unstable__location'],
+			'theme_location'   => $location,
 			'block_attributes' => $block_attributes,
 			'container'        => '',
 			'items_wrap'       => '%3$s',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -92,7 +92,7 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * If the theme doesn't explicity support 'block-nav-menus' or no location was provided
  * as a block attribute then an empty string is returned.
  *
- * @param  array $location The location of the classic menu to display
+ * @param  array $location The location of the classic menu to display.
  * @param  array $attributes Navigation block attributes.
  * @return string|false HTML markup of a generated Navigation Block or false if no location is specified.
  */
@@ -165,7 +165,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	if ( empty( $block->inner_blocks ) ) {
 		if ( array_key_exists( '__unstable__location', $attributes ) ) {
-			$location = $attributes['__unstable__location'];
+			$location                 = $attributes['__unstable__location'];
 			$maybe_classic_navigation = render_classic_location_menu( $location, $attributes );
 			if ( $maybe_classic_navigation ) {
 				return $maybe_classic_navigation;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -92,12 +92,13 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * If the theme doesn't explicity support 'block-nav-menus' or no location was provided
  * as a block attribute then an empty string is returned.
  *
+ * @param  array $location The location of the classic menu to display
  * @param  array $attributes Navigation block attributes.
- * @return string HTML markup of a generated Navigation Block.
+ * @return string|false HTML markup of a generated Navigation Block or false if no location is specified.
  */
-function get_classic_navigation_elements( $attributes ) {
-	if ( ! array_key_exists( '__unstable__location', $attributes ) ) {
-		return '';
+function render_classic_location_menu( $location, $attributes ) {
+	if ( empty( $location ) ) {
+		return false;
 	}
 
 	$block_attributes = $attributes;
@@ -163,7 +164,15 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $block->inner_blocks ) ) {
-		return get_classic_navigation_elements( $attributes );
+		if ( array_key_exists( '__unstable__location', $attributes ) ) {
+			$location = $attributes['__unstable__location'];
+			$maybe_classic_navigation = render_classic_location_menu( $location, $attributes );
+			if ( $maybe_classic_navigation ) {
+				return $maybe_classic_navigation;
+			}
+		}
+
+		return '';
 	}
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );


### PR DESCRIPTION
## Description
This is a simplified version of https://github.com/WordPress/gutenberg/pull/30852.

All it does is add an `__unstable__location` attribute to the block and then, if that is set, render a classic menu in its place.

This opens some questions about if/how this should be handled in the UI but these can be dealt with in followup PRs if necessary.

## How has this been tested?
- Add a menu to a menu location for your site
- Add a navigation block with the "__unstable__location" attribute set to the location of the menu
- Confirm that you can see the classic menu rendering
- I tested with the Quadrat theme:

## Screenshots <!-- if applicable -->
<img width="541" alt="Screenshot 2021-06-07 at 17 47 20" src="https://user-images.githubusercontent.com/275961/121058613-6fe32880-c7b8-11eb-8fac-04a270e16788.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
