### PR TITLE
Rnmobile/fix/disable controls when template lock is set

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -219,11 +219,13 @@ const BlockActionsMenu = ( {
 
 	// End early if there are no options to show.
 	if ( ! options.length ) {
-		return <ToolbarButton
-			title={ __( 'Open Block Actions Menu' ) }
-			icon={ moreHorizontalMobile }
-			disabled={ true }
-		/>
+		return (
+			<ToolbarButton
+				title={ __( 'Open Block Actions Menu' ) }
+				icon={ moreHorizontalMobile }
+				disabled={ true }
+			/>
+		);
 	}
 
 	function onPasteBlock() {

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -219,7 +219,11 @@ const BlockActionsMenu = ( {
 
 	// End early if there are no options to show.
 	if ( ! options.length ) {
-		return null;
+		return <ToolbarButton
+			title={ __( 'Open Block Actions Menu' ) }
+			icon={ moreHorizontalMobile }
+			disabled={ true }
+		/>
 	}
 
 	function onPasteBlock() {

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Platform, findNodeHandle } from 'react-native';
-import { partial, first, castArray, last, compact } from 'lodash';
+import { partial, first, castArray, last, compact, every } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -15,6 +15,7 @@ import {
 import {
 	getBlockType,
 	getDefaultBlockName,
+	hasBlockSupport,
 	serialize,
 	rawHandler,
 	createBlock,
@@ -43,6 +44,8 @@ const BlockActionsMenu = ( {
 	canInsertBlockType,
 	getBlocksByClientId,
 	isEmptyDefaultBlock,
+	isLocked,
+	canDuplicate,
 	isFirst,
 	isLast,
 	isReusableBlockType,
@@ -203,15 +206,21 @@ const BlockActionsMenu = ( {
 		wrapBlockMover && allOptions.backwardButton,
 		wrapBlockMover && allOptions.forwardButton,
 		wrapBlockSettings && allOptions.settings,
-		selectedBlockPossibleTransformations.length &&
+		! isLocked &&
+			selectedBlockPossibleTransformations.length &&
 			allOptions.transformButton,
-		allOptions.copyButton,
-		allOptions.cutButton,
-		isPasteEnabled && allOptions.pasteButton,
-		allOptions.duplicateButton,
+		canDuplicate && allOptions.copyButton,
+		canDuplicate && allOptions.cutButton,
+		canDuplicate && isPasteEnabled && allOptions.pasteButton,
+		canDuplicate && allOptions.duplicateButton,
 		isReusableBlockType && allOptions.convertToRegularBlocks,
-		allOptions.delete,
+		! isLocked && allOptions.delete,
 	] );
+
+	// End early if there are no options to show.
+	if ( ! options.length ) {
+		return null;
+	}
 
 	function onPasteBlock() {
 		if ( ! clipboard ) {
@@ -290,6 +299,7 @@ export default compose(
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			canInsertBlockType,
+			getTemplateLock,
 		} = select( blockEditorStore );
 		const normalizedClientIds = castArray( clientIds );
 		const block = getBlock( normalizedClientIds );
@@ -306,11 +316,22 @@ export default compose(
 			rootClientId
 		);
 
+		const innerBlocks = getBlocksByClientId( clientIds );
+
+		const canDuplicate = every( innerBlocks, ( innerBlock ) => {
+			return (
+				!! innerBlock &&
+				hasBlockSupport( innerBlock.name, 'multiple', true ) &&
+				canInsertBlockType( innerBlock.name, rootClientId )
+			);
+		} );
+
 		const isDefaultBlock = blockName === getDefaultBlockName();
 		const isEmptyContent = block?.attributes.content === '';
 		const isExactlyOneBlock = blockOrder.length === 1;
 		const isEmptyDefaultBlock =
 			isExactlyOneBlock && isDefaultBlock && isEmptyContent;
+		const isLocked = !! getTemplateLock( rootClientId );
 
 		const selectedBlockClientId = first( getSelectedBlockClientIds() );
 		const selectedBlock = selectedBlockClientId
@@ -335,6 +356,8 @@ export default compose(
 			currentIndex: firstIndex,
 			getBlocksByClientId,
 			isEmptyDefaultBlock,
+			isLocked,
+			canDuplicate,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
 			isReusableBlockType,

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -110,16 +110,28 @@ function HeaderToolbar( {
 }
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		hasRedo: select( editorStore ).hasEditorRedo(),
-		hasUndo: select( editorStore ).hasEditorUndo(),
-		// This setting (richEditingEnabled) should not live in the block editor's setting.
-		showInserter:
-			select( editPostStore ).getEditorMode() === 'visual' &&
-			select( editorStore ).getEditorSettings().richEditingEnabled,
-		isTextModeEnabled: select( editPostStore ).getEditorMode() === 'text',
-		isRTL: select( blockEditorStore ).getSettings().isRTL,
-	} ) ),
+	withSelect( ( select ) => {
+		const {
+			getBlockRootClientId,
+			getBlockSelectionEnd,
+			hasInserterItems,
+			getEditorSettings,
+		} = select( editorStore );
+		return {
+			hasRedo: select( editorStore ).hasEditorRedo(),
+			hasUndo: select( editorStore ).hasEditorUndo(),
+			// This setting (richEditingEnabled) should not live in the block editor's setting.
+			showInserter:
+				select( editPostStore ).getEditorMode() === 'visual' &&
+				getEditorSettings().richEditingEnabled &&
+				hasInserterItems(
+					getBlockRootClientId( getBlockSelectionEnd() )
+				),
+			isTextModeEnabled:
+				select( editPostStore ).getEditorMode() === 'text',
+			isRTL: select( blockEditorStore ).getSettings().isRTL,
+		};
+	} ),
 	withDispatch( ( dispatch ) => {
 		const { clearSelectedBlock } = dispatch( blockEditorStore );
 		const { togglePostTitleSelection } = dispatch( editorStore );

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 
 data class GutenbergProps @JvmOverloads constructor(
     val enableContactInfoBlock: Boolean,
+    val enableLayoutGridBlock: Boolean,
     val enableMediaFilesCollectionBlocks: Boolean,
     val enableMentions: Boolean,
     val enableXPosts: Boolean,
@@ -42,6 +43,7 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_MENTIONS, enableMentions)
         putBoolean(PROP_CAPABILITIES_XPOSTS, enableXPosts)
         putBoolean(PROP_CAPABILITIES_CONTACT_INFO_BLOCK, enableContactInfoBlock)
+        putBoolean(PROP_CAPABILITIES_LAYOUT_GRID_BLOCK, enableLayoutGridBlock)
         putBoolean(PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK, enableMediaFilesCollectionBlocks)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
@@ -70,6 +72,7 @@ data class GutenbergProps @JvmOverloads constructor(
 
         const val PROP_CAPABILITIES = "capabilities"
         const val PROP_CAPABILITIES_CONTACT_INFO_BLOCK = "contactInfoBlock"
+        const val PROP_CAPABILITIES_LAYOUT_GRID_BLOCK = "layoutGridBlock"
         const val PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK = "mediaFilesCollectionBlock"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"
         const val PROP_CAPABILITIES_XPOSTS = "xposts"

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -17,6 +17,7 @@ public struct MediaInfo: Encodable {
 /// Definition of capabilities to enable in the Block Editor
 public enum Capabilities: String {
     case contactInfoBlock
+    case layoutGridBlock
     case mediaFilesCollectionBlock
     case mentions
     case xposts


### PR DESCRIPTION
This PR combines the WordPress/gutenberg#31777 and fixes:
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/3582
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/3583


## Description
This Pr helps us test the new layout grid block on the mobile editor. 

It fixes the issues found in the layout grid block while testing https://github.com/wordpress-mobile/gutenberg-mobile/pull/3513. 

It fixes them by showing the disabled the add new block action went the block is set to insert any new blocks. 
This happens when the parent defines a `templateLock="all"`. Which makes the mobile implementation match what we have on the web. Fixing https://github.com/wordpress-mobile/gutenberg-mobile/issues/3583

See
<img width="200" alt="Screen Shot 2021-06-07 at 12 05 13 PM" src="https://user-images.githubusercontent.com/115071/121074377-9e490f80-c788-11eb-9dd0-d57874b2b9ae.png">


It also make the block action marked as disabled if the block does not present any block actions on the block.
Fixing https://github.com/wordpress-mobile/gutenberg-mobile/issues/3582 

See 
<img width="200" alt="Screen Shot 2021-06-07 at 12 05 59 PM" src="https://user-images.githubusercontent.com/115071/121074453-b9b41a80-c788-11eb-9014-88e837a369a1.png">


## How has this been tested?
Build the iOS app using 
https://github.com/wordpress-mobile/WordPress-iOS/pull/16543

1. Add the layout grid block. 
2. Notice that the single-column layout grid block has the add block (+ icon in the bottom left) disabled. Clicking doesn't do anything. 
3. Notice that the single-column layout grid block has the block actions disabled ( three dot menu) and clicking it doesn't do anything. 

## Screenshots <!-- if applicable -->
See

https://user-images.githubusercontent.com/115071/121076182-f7b23e00-c78a-11eb-99e2-b9a191d713ca.mp4



## Types of changes
Bug fixes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
