### PR TITLE
Widgets editor: Add Breadcrumbs Block

### DIFF
--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -7,7 +7,10 @@ import {
 	useViewportMatch,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
-import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import {
+	__experimentalLibrary as Library,
+	BlockBreadcrumb,
+} from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -32,6 +35,8 @@ const interfaceLabels = {
 	body: __( 'Widgets and blocks' ),
 	/* translators: accessibility text for the widgets screen settings landmark region. */
 	sidebar: __( 'Widgets settings' ),
+	/* translators: accessibility text for the widgets screen footer landmark region. */
+	footer: __( 'Widgets footer' ),
 };
 
 function Interface( { blockEditorSettings } ) {
@@ -42,12 +47,21 @@ function Interface( { blockEditorSettings } ) {
 	);
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
-	const { hasSidebarEnabled, isInserterOpened } = useSelect(
+	const {
+		hasSidebarEnabled,
+		isInserterOpened,
+		/*		mode,
+		showBlockBreadcrumbs,*/
+	} = useSelect(
 		( select ) => ( {
 			hasSidebarEnabled: !! select(
 				interfaceStore
 			).getActiveComplementaryArea( editWidgetsStore.name ),
 			isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
+			/*			showBlockBreadcrumbs: select( interfaceStore ).isFeatureActive(
+				'showBlockBreadcrumbs'
+			),
+			mode: select( interfaceStore ).getEditorMode(),*/
 		} ),
 		[]
 	);
@@ -68,7 +82,7 @@ function Interface( { blockEditorSettings } ) {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );
-
+	console.log( 'isMobileViewport', isMobileViewport );
 	return (
 		<InterfaceSkeleton
 			labels={ interfaceLabels }
@@ -106,6 +120,15 @@ function Interface( { blockEditorSettings } ) {
 				<WidgetAreasBlockEditorContent
 					blockEditorSettings={ blockEditorSettings }
 				/>
+			}
+			footer={
+				/*				showBlockBreadcrumbs &&
+				mode === 'visual' &&*/
+				! isMobileViewport && (
+					<div className="edit-widgets-layout__footer">
+						<BlockBreadcrumb />
+					</div>
+				)
 			}
 		/>
 	);

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -47,21 +47,12 @@ function Interface( { blockEditorSettings } ) {
 	);
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
-	const {
-		hasSidebarEnabled,
-		isInserterOpened,
-		/*		mode,
-		showBlockBreadcrumbs,*/
-	} = useSelect(
+	const { hasSidebarEnabled, isInserterOpened } = useSelect(
 		( select ) => ( {
 			hasSidebarEnabled: !! select(
 				interfaceStore
 			).getActiveComplementaryArea( editWidgetsStore.name ),
 			isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
-			/*			showBlockBreadcrumbs: select( interfaceStore ).isFeatureActive(
-				'showBlockBreadcrumbs'
-			),
-			mode: select( interfaceStore ).getEditorMode(),*/
 		} ),
 		[]
 	);
@@ -82,7 +73,7 @@ function Interface( { blockEditorSettings } ) {
 	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
 		onClose: () => setIsInserterOpened( false ),
 	} );
-	console.log( 'isMobileViewport', isMobileViewport );
+
 	return (
 		<InterfaceSkeleton
 			labels={ interfaceLabels }
@@ -122,8 +113,6 @@ function Interface( { blockEditorSettings } ) {
 				/>
 			}
 			footer={
-				/*				showBlockBreadcrumbs &&
-				mode === 'visual' &&*/
 				! isMobileViewport && (
 					<div className="edit-widgets-layout__footer">
 						<BlockBreadcrumb />

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -115,7 +115,7 @@ function Interface( { blockEditorSettings } ) {
 			footer={
 				! isMobileViewport && (
 					<div className="edit-widgets-layout__footer">
-						<BlockBreadcrumb />
+						<BlockBreadcrumb rootLabelText={ __( 'Widgets' ) } />
 					</div>
 				)
 			}


### PR DESCRIPTION
## Description

This PR adds `<BlockBreadcrumb />` to the Widgets Editor so we can navigate through the blocks in the editor.

Resolves https://github.com/WordPress/gutenberg/issues/32418

## How has this been tested?
Manually.

1. Fire up this branch and head over to `/wp-admin/themes.php?page=gutenberg-widgets`
2. Check that the breadcrumbs block appears in the footer when you select a block in the widget editor.
3. Also make sure that the breadcrumb block doesn't appear in mobile viewports.
4. 🎉 


## Screenshots 

<img width="979" alt="Screen Shot 2021-06-08 at 12 13 10 pm" src="https://user-images.githubusercontent.com/6458278/121111930-0ebc6300-c853-11eb-820e-5064bc3d17aa.png">

<img width="338" alt="Screen Shot 2021-06-08 at 1 40 51 pm" src="https://user-images.githubusercontent.com/6458278/121119619-4af5c080-c85f-11eb-987a-70b567d4317f.png">



## Types of changes
Adding existing [Breadcrumb block](https://github.com/WordPress/gutenberg/tree/9df736c678b2e8ef00c355e6cc9fb8092fe25484/packages/block-editor/src/components/block-breadcrumb) to the Widgets interface.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
