### PR TITLE
Block Support: Add width block support feature

### DIFF
--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -61,7 +61,19 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	// Width support to be added in near future.
+	// Width.
+
+	// Width support flag can be true|false|"segmented" cannot use
+	// `gutenberg_block_has_support` which checked for boolean true or array.
+	$has_width_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions', 'width' ), false );
+
+	if ( $has_width_support ) {
+		$width_value = _wp_array_get( $block_attributes, array( 'style', 'dimensions', 'width' ), null );
+
+		if ( null !== $width_value ) {
+			$styles[] = sprintf( 'width: %s;', $width_value );
+		}
+	}
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
 }

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -167,6 +167,7 @@ class WP_Theme_JSON_5_9 {
 		'font-size'                  => array( 'typography', 'fontSize' ),
 		'font-style'                 => array( 'typography', 'fontStyle' ),
 		'font-weight'                => array( 'typography', 'fontWeight' ),
+		'height'                     => array( 'dimensions', 'height' ),
 		'letter-spacing'             => array( 'typography', 'letterSpacing' ),
 		'line-height'                => array( 'typography', 'lineHeight' ),
 		'margin'                     => array( 'spacing', 'margin' ),
@@ -238,6 +239,9 @@ class WP_Theme_JSON_5_9 {
 			'text'             => null,
 		),
 		'custom'          => null,
+		'dimensions'      => array(
+			'height' => null,
+		),
 		'layout'          => array(
 			'contentSize' => null,
 			'wideSize'    => null,
@@ -273,6 +277,9 @@ class WP_Theme_JSON_5_9 {
 			'radius' => null,
 			'style'  => null,
 			'width'  => null,
+		),
+		'dimensions' => array(
+			'height' => null,
 		),
 		'color'      => array(
 			'background' => null,

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -185,7 +185,8 @@
 			"text": true
 		},
 		"dimensions": {
-			"height": false
+			"height": false,
+			"width": false
 		},
 		"spacing": {
 			"blockGap": null,

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -54,6 +54,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'text-decoration'            => array( 'typography', 'textDecoration' ),
 		'text-transform'             => array( 'typography', 'textTransform' ),
 		'filter'                     => array( 'filter', 'duotone' ),
+		'width'                      => array( 'dimensions', 'width' ),
 	);
 
 	/**
@@ -85,6 +86,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'custom'          => null,
 		'dimensions'      => array(
 			'height' => null,
+			'width'  => null,
 		),
 		'layout'          => array(
 			'contentSize' => null,
@@ -129,6 +131,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		),
 		'dimensions' => array(
 			'height' => null,
+			'width'  => null,
 		),
 		'filter'     => array(
 			'duotone' => null,

--- a/packages/block-editor/src/components/width-control/index.js
+++ b/packages/block-editor/src/components/width-control/index.js
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	ButtonGroup,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { edit } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_WIDTHS = [ '25%', '50%', '75%', '100%' ];
+const DEFAULT_UNIT = '%';
+const MIN_WIDTH = 0;
+
+/**
+ * Determines the CSS unit within the supplied width value.
+ *
+ * @param {string} value Value including CSS unit.
+ * @param {Array}  units Available CSS units to validate against.
+ *
+ * @return {string} CSS unit extracted from supplied value.
+ */
+const parseUnit = ( value, units ) => {
+	let unit = String( value )
+		.trim()
+		.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
+
+	if ( ! unit ) {
+		return DEFAULT_UNIT;
+	}
+
+	unit = unit.toLowerCase();
+	unit = units.find( ( item ) => item.value === unit );
+
+	return unit?.value || DEFAULT_UNIT;
+};
+
+/**
+ * Width control that will display as either a simple `UnitControl` or a
+ * segmented control containing preset percentage widths. The segmented version
+ * contains a toggle to switch to a UnitControl and Slider for explicit control.
+ *
+ * @param {Object} props Component props.
+ * @return {WPElement} Width control.
+ */
+export default function WidthControl( props ) {
+	const {
+		label = __( 'Width' ),
+		onChange,
+		units,
+		value,
+		isSegmentedControl = false,
+		min = MIN_WIDTH,
+		presetWidths = DEFAULT_WIDTHS,
+	} = props;
+
+	const ref = useRef();
+	const hasCustomValue = value && ! presetWidths.includes( value );
+	const [ customView, setCustomView ] = useState( hasCustomValue );
+	const currentUnit = parseUnit( value, units );
+
+	// When switching to the custom view, move focus to the UnitControl.
+	useEffect( () => {
+		if ( customView && ref.current ) {
+			ref.current.focus();
+		}
+	}, [ customView ] );
+
+	// Unless segmented control is desired return a normal UnitControl.
+	if ( ! isSegmentedControl ) {
+		return (
+			<UnitControl
+				label={ label }
+				min={ min }
+				unit={ currentUnit }
+				{ ...props }
+			/>
+		);
+	}
+
+	const toggleCustomView = () => {
+		setCustomView( ! customView );
+	};
+
+	const handlePresetChange = ( selectedValue ) => {
+		const newWidth = selectedValue === value ? undefined : selectedValue;
+		onChange( newWidth );
+	};
+
+	const renderCustomView = () => (
+		<UnitControl
+			ref={ ref }
+			min={ min }
+			unit={ currentUnit }
+			{ ...props }
+		/>
+	);
+
+	const renderPresetView = () => (
+		<ButtonGroup aria-label={ __( 'Button width' ) }>
+			{ presetWidths.map( ( width ) => (
+				<Button
+					key={ width }
+					isSmall
+					variant={ value === width ? 'primary' : undefined }
+					onClick={ () => handlePresetChange( width ) }
+				>
+					{ width }
+				</Button>
+			) ) }
+		</ButtonGroup>
+	);
+
+	return (
+		<fieldset className="components-width-control is-segmented">
+			<legend>{ label }</legend>
+			<div className="components-width-control__wrapper">
+				{ customView ? renderCustomView() : renderPresetView() }
+				<Button
+					icon={ edit }
+					isSmall
+					isPressed={ customView }
+					onClick={ toggleCustomView }
+				/>
+			</div>
+		</fieldset>
+	);
+}

--- a/packages/block-editor/src/components/width-control/style.scss
+++ b/packages/block-editor/src/components/width-control/style.scss
@@ -1,0 +1,34 @@
+.components-width-control.is-segmented {
+	legend {
+		margin-bottom: $grid-unit-10;
+	}
+
+	.components-width-control__wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.components-unit-control-wrapper {
+		flex: 1;
+		margin-right: $grid-unit-10;
+		max-width: 80px;
+	}
+
+	.components-range-control {
+		flex: 1;
+		margin-bottom: 0;
+
+		.components-base-control__field {
+			margin-bottom: 0;
+			height: 30px;
+		}
+	}
+
+	.components-button.is-small.has-icon:not(.has-text) {
+		margin-left: $grid-unit-20;
+		min-width: 30px;
+		height: 30px;
+		padding: 0 4px;
+	}
+}

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -38,6 +38,13 @@ import {
 	resetPadding,
 	useIsPaddingDisabled,
 } from './padding';
+import {
+	WidthEdit,
+	hasWidthSupport,
+	hasWidthValue,
+	resetWidth,
+	useIsWidthDisabled,
+} from './width';
 
 export const DIMENSIONS_SUPPORT_KEY = '__experimentalDimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -55,6 +62,7 @@ export function DimensionsPanel( props ) {
 	const isPaddingDisabled = useIsPaddingDisabled( props );
 	const isMarginDisabled = useIsMarginDisabled( props );
 	const isHeightDisabled = useIsHeightDisabled( props );
+	const isWidthDisabled = useIsWidthDisabled( props );
 	const isDisabled = useIsDimensionsDisabled( props );
 	const isSupported = hasDimensionsSupport( props.name );
 
@@ -101,6 +109,21 @@ export function DimensionsPanel( props ) {
 					panelId={ props.clientId }
 				>
 					<HeightEdit { ...props } />
+				</ToolsPanelItem>
+			) }
+			{ ! isWidthDisabled && (
+				<ToolsPanelItem
+					hasValue={ () => hasWidthValue( props ) }
+					label={ __( 'Width' ) }
+					onDeselect={ () => resetWidth( props ) }
+					resetAllFilter={ createResetAllFilter(
+						'width',
+						'dimensions'
+					) }
+					isShownByDefault={ defaultDimensionsControls?.width }
+					panelId={ props.clientId }
+				>
+					<WidthEdit { ...props } />
 				</ToolsPanelItem>
 			) }
 			{ ! isPaddingDisabled && (
@@ -167,6 +190,7 @@ export function hasDimensionsSupport( blockName ) {
 	return (
 		hasGapSupport( blockName ) ||
 		hasHeightSupport( blockName ) ||
+		hasWidthSupport( blockName ) ||
 		hasPaddingSupport( blockName ) ||
 		hasMarginSupport( blockName )
 	);
@@ -181,10 +205,17 @@ export function hasDimensionsSupport( blockName ) {
 const useIsDimensionsDisabled = ( props = {} ) => {
 	const gapDisabled = useIsGapDisabled( props );
 	const heightDisabled = useIsHeightDisabled( props );
+	const widthDisabled = useIsWidthDisabled( props );
 	const paddingDisabled = useIsPaddingDisabled( props );
 	const marginDisabled = useIsMarginDisabled( props );
 
-	return gapDisabled && heightDisabled && paddingDisabled && marginDisabled;
+	return (
+		gapDisabled &&
+		heightDisabled &&
+		widthDisabled &&
+		paddingDisabled &&
+		marginDisabled
+	);
 };
 
 /**

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -25,6 +25,7 @@ describe( 'getInlineStyles', () => {
 				},
 				dimensions: {
 					height: '500px',
+					width: '100%',
 				},
 				spacing: {
 					blockGap: '1em',
@@ -44,6 +45,7 @@ describe( 'getInlineStyles', () => {
 			height: '500px',
 			marginBottom: '15px',
 			paddingTop: '10px',
+			width: '100%',
 		} );
 	} );
 

--- a/packages/block-editor/src/hooks/width.js
+++ b/packages/block-editor/src/hooks/width.js
@@ -1,0 +1,131 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { __experimentalUseCustomUnits as useCustomUnits } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import WidthControl from '../components/width-control';
+import useSetting from '../components/use-setting';
+import { DIMENSIONS_SUPPORT_KEY } from './dimensions';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Determines if there is width support.
+ *
+ * @param {string|Object} blockType Block name or Block Type object.
+ * @return {boolean}                 Whether there is support.
+ */
+export function hasWidthSupport( blockType ) {
+	const support = getBlockSupport( blockType, DIMENSIONS_SUPPORT_KEY );
+	return !! ( true === support || support?.width );
+}
+
+/**
+ * Checks if there is a current value in the width block support attributes.
+ *
+ * @param {Object} props Block props.
+ * @return {boolean}      Whether or not the block has a width value set.
+ */
+export function hasWidthValue( props ) {
+	return props.attributes.style?.dimensions?.width !== undefined;
+}
+
+/**
+ * Checks whether the segmented width control was opted into via the block's
+ * support configuration.
+ *
+ * @param {string|Object} blockType Block name or Block Type object.
+ * @return {boolean} Whether width control should display as segmented control.
+ */
+export function useIsSegmentedControl( blockType ) {
+	const support = getBlockSupport( blockType, DIMENSIONS_SUPPORT_KEY );
+	return support?.width === 'segmented';
+}
+
+/**
+ * Resets the width block support attributes. This can be used when
+ * disabling the width support controls for a block via a progressive
+ * discovery panel.
+ *
+ * @param {Object} props               Block props.
+ * @param {Object} props.attributes    Block's attributes.
+ * @param {Object} props.setAttributes Function to set block's attributes.
+ */
+export function resetWidth( { attributes = {}, setAttributes } ) {
+	const { style } = attributes;
+
+	setAttributes( {
+		style: {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				width: undefined,
+			},
+		},
+	} );
+}
+
+/**
+ * Custom hook that checks if width controls have been disabled.
+ *
+ * @param {string} name The name of the block.
+ * @return {boolean}     Whether width control is disabled.
+ */
+export function useIsWidthDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useSetting( 'dimensions.width' );
+	return ! hasWidthSupport( blockName ) || isDisabled;
+}
+
+/**
+ * Inspector control panel containing the width related configuration.
+ *
+ * @param {Object} props Block props.
+ * @return {WPElement}    Edit component for width.
+ */
+export function WidthEdit( props ) {
+	const {
+		attributes: { style },
+		name,
+		setAttributes,
+	} = props;
+
+	const isSegmentedControl = useIsSegmentedControl( name );
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'dimensions.units' ) || [
+			'%',
+			'px',
+			'em',
+			'rem',
+			'vh',
+			'vw',
+		],
+	} );
+
+	if ( useIsWidthDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( next ) => {
+		const newStyle = {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				width: next,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+	};
+
+	return (
+		<WidthControl
+			value={ style?.dimensions?.width }
+			units={ units }
+			onChange={ onChange }
+			isSegmentedControl={ isSegmentedControl }
+		/>
+	);
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -51,6 +51,7 @@
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./components/warning/style.scss";
+@import "./components/width-control/style.scss";
 @import "./hooks/anchor.scss";
 @import "./hooks/layout.scss";
 @import "./hooks/border.scss";

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -29,6 +29,12 @@
 				"text": true
 			}
 		},
+		"__experimentalDimensions": {
+			"height": true,
+			"__experimentalDefaultControls": {
+				"height": true
+			}
+		},
 		"spacing": {
 			"padding": true,
 			"blockGap": true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -117,6 +117,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'typography', 'letterSpacing' ],
 		support: [ 'typography', '__experimentalLetterSpacing' ],
 	},
+	width: {
+		value: [ 'dimensions', 'width' ],
+		support: [ '__experimentalDimensions', 'width' ],
+	},
 	'--wp--style--block-gap': {
 		value: [ 'spacing', 'blockGap' ],
 		support: [ 'spacing', 'blockGap' ],

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -47,6 +47,7 @@ function useUniqueId( idProp ) {
 	return idProp || instanceId;
 }
 export default function BoxControl( {
+	className,
 	id: idProp,
 	inputProps = defaultInputProps,
 	onChange = noop,
@@ -133,7 +134,12 @@ export default function BoxControl( {
 	};
 
 	return (
-		<Root id={ id } role="region" aria-labelledby={ headingId }>
+		<Root
+			id={ id }
+			role="region"
+			aria-labelledby={ headingId }
+			className={ className }
+		>
 			<Header className="component-box-control__header">
 				<FlexItem>
 					<Text

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -23,8 +23,9 @@ export function useHasDimensionsPanel( name ) {
 	const hasMargin = useHasMargin( name );
 	const hasGap = useHasGap( name );
 	const hasHeight = useHasHeight( name );
+	const hasWidth = useHasWidth( name );
 
-	return hasPadding || hasMargin || hasGap || hasHeight;
+	return hasPadding || hasMargin || hasGap || hasHeight || hasWidth;
 }
 
 function useHasPadding( name ) {
@@ -53,6 +54,13 @@ function useHasHeight( name ) {
 	const [ settings ] = useSetting( 'dimensions.height', name );
 
 	return settings && supports.includes( 'height' );
+}
+
+function useHasWidth( name ) {
+	const supports = getSupportedGlobalStylesPanels( name );
+	const [ settings ] = useSetting( 'dimensions.width', name );
+
+	return settings && supports.includes( 'width' );
 }
 
 function filterValuesBySides( values, sides ) {
@@ -98,12 +106,14 @@ export default function DimensionsPanel( { name } ) {
 	const showMarginControl = useHasMargin( name );
 	const showGapControl = useHasGap( name );
 	const showHeightControl = useHasHeight( name );
+	const showWidthControl = useHasWidth( name );
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units', name )[ 0 ] || [
 			'%',
 			'px',
 			'em',
 			'rem',
+			'vh',
 			'vw',
 		],
 	} );
@@ -153,8 +163,14 @@ export default function DimensionsPanel( { name } ) {
 	const resetHeightValue = () => setHeightValue( undefined );
 	const hasHeightValue = () => !! heightValue;
 
+	// Width.
+	const [ widthValue, setWidthValue ] = useStyle( 'dimensions.width', name );
+	const resetWidthValue = () => setWidthValue( undefined );
+	const hasWidthValue = () => !! widthValue;
+
 	const resetAll = () => {
 		resetHeightValue();
+		resetWidthValue();
 		resetPaddingValue();
 		resetMarginValue();
 		resetGapValue();
@@ -174,6 +190,23 @@ export default function DimensionsPanel( { name } ) {
 						label={ __( 'Height' ) }
 						value={ heightValue }
 						onChange={ setHeightValue }
+						units={ units }
+						min={ 0 }
+					/>
+				</ToolsPanelItem>
+			) }
+			{ showWidthControl && (
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ hasWidthValue }
+					label={ __( 'Width' ) }
+					onDeselect={ resetWidthValue }
+					isShownByDefault={ true }
+				>
+					<UnitControl
+						label={ __( 'Width' ) }
+						value={ widthValue }
+						onChange={ setWidthValue }
 						units={ units }
 						min={ 0 }
 					/>


### PR DESCRIPTION
Related: 
- #28356

Depends on: 
- #32392
- #32499

## Description
- Adds width block support and includes in new Dimensions panel.
- Adds new segmented width control

## How has this been tested?
Style.js test:
`npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`

#### Manual Test Instructions

1. Checkout this PR and build
2. Enable custom dimensions support including height, width, padding and margin - [theme.json gist](https://gist.github.com/aaronrobertshaw/31c37eaca2a17a877ed71e8369e91775)
3. Enable dimensions block support for Group block - [block.json gist](https://gist.github.com/aaronrobertshaw/ea7337b794bc44d7017bf4e82988c756)
4. Create a post, switch to code editor view and paste in the snippet of block code below:
```html
<!-- wp:group {"backgroundColor":"gray"} -->
<div class="wp-block-group has-gray-background-color has-background"><!-- wp:group {"backgroundColor":"white"} -->
<div class="wp-block-group has-white-background-color has-background"></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
5. Switch back to the visual editor and select the white inner group block
6. Ensure dimensions panel appears in the sidebar
7. Open the dimension panel's more menu and toggle on the width control
8. Adjust the width and confirm the block's width gets adjusted. Inspect element in dev tools to confirm CSS style
9. Click on the edit button beside the preset percentage widths and configure an explicit width for the group
10. Test clearing the width by toggling off the width control from the panel's ellipsis menu
11. Save post and view on the frontend. The width style should be applied correctly
12. Repeat the process for a dynamic block, e.g. site title, ensuring correct styles on the frontend
13. Update your block.json you've been testing with to set the width block support feature flag to `true` instead of `"segmented"`. Repeat the test process this time ensuring the width control is a standard `UnitControl`

## Screenshots <!-- if applicable -->
![WidthSupport-Latest](https://user-images.githubusercontent.com/60436221/123211041-3d4e6500-d506-11eb-97f7-b2d3ac8f48a0.gif)

## Possible Next Steps
- [ ] Possibly add min/max width support alongside this? 

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
