### PR TITLE
Widgets editor: decode HTML entities for name and description props

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -210,8 +210,10 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			$parsed_id     = wp_parse_widget_id( $widget['id'] );
 			$widget_object = gutenberg_get_widget_object( $parsed_id['id_base'] );
 
-			$widget['id']       = $parsed_id['id_base'];
-			$widget['is_multi'] = (bool) $widget_object;
+			$widget['id']          = $parsed_id['id_base'];
+			$widget['is_multi']    = (bool) $widget_object;
+			$widget['name']        = html_entity_decode( $widget['name'] );
+			$widget['description'] = html_entity_decode( $widget['description'] );
 
 			unset( $widget['callback'] );
 


### PR DESCRIPTION
## Description

HTML entities appear in Legacy Widget's description. For example: 

`A monthly archive of your site&#8217;s Posts.` 😱 

This commit converts widget name and description HTML entities to their corresponding characters using [html_entity_decode](https://www.php.net/manual/en/function.html-entity-decode.php).

The decoding occurs before the call to `prepare_item_for_response` which sanitizes the value.

### Questions
❓ Does this seem like the right way to go about it?
❓ Do we need to decode name as well? Seems like a safe change.


Resolves https://github.com/WordPress/gutenberg/issues/31023 (maybe)

## How has this been tested?

Manually

1. Head over to `/wp-admin/themes.php?page=gutenberg-widgets` and select a widget block.
2. Check out the description in the inspector controls. Do you see any characters?

## Screenshots 

**Before**
<img width="345" alt="Screen Shot 2021-06-08 at 4 39 52 pm" src="https://user-images.githubusercontent.com/6458278/121135806-3671f200-c878-11eb-9cf9-876cc51734c3.png">


**After**
<img width="404" alt="Screen Shot 2021-06-08 at 4 39 24 pm" src="https://user-images.githubusercontent.com/6458278/121135794-33770180-c878-11eb-9afa-6759d19ef9a0.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue



