### PR TITLE
[Block Library - Post blocks]: Make post blocks uneditable when inside Query block

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -19,9 +19,21 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
-function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
+/**
+ * Internal dependencies
+ */
+import { useIsEditablePostBlock } from '../utils/hooks';
+
+function PostAuthorEdit( {
+	clientId,
+	isSelected,
+	context,
+	attributes,
+	setAttributes,
+} ) {
 	const { postType, postId } = context;
 
+	const isEditable = useIsEditablePostBlock( clientId );
 	const { authorId, authorDetails, authors } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, getUser, getUsers } = select(
@@ -66,7 +78,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Author Settings' ) }>
-					{ !! authors?.length && (
+					{ isEditable && !! authors?.length && (
 						<SelectControl
 							label={ __( 'Author' ) }
 							value={ authorId }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -26,10 +26,21 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { edit } from '@wordpress/icons';
 
-export default function PostDateEdit( { attributes, context, setAttributes } ) {
+/**
+ * Internal dependencies
+ */
+import { useIsEditablePostBlock } from '../utils/hooks';
+
+export default function PostDateEdit( {
+	clientId,
+	attributes,
+	context,
+	setAttributes,
+} ) {
 	const { textAlign, format, isLink } = attributes;
 	const { postId, postType } = context;
 
+	const isEditable = useIsEditablePostBlock( clientId );
 	const [ siteFormat ] = useEntityProp( 'root', 'site', 'date_format' );
 	const [ date, setDate ] = useEntityProp(
 		'postType',
@@ -98,7 +109,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 					} }
 				/>
 
-				{ date && (
+				{ date && isEditable && (
 					<ToolbarButton
 						icon={ edit }
 						title={ __( 'Change Date' ) }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -19,6 +19,11 @@ import {
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useIsEditablePostBlock } from '../utils/hooks';
+
 function usePostContentExcerpt( wordCount, postId, postType ) {
 	// Don't destrcuture items from content here, it can be undefined.
 	const [ , , content ] = useEntityProp(
@@ -41,11 +46,13 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 }
 
 export default function PostExcerptEditor( {
+	clientId,
 	attributes: { textAlign, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
 	context: { postId, postType },
 } ) {
+	const isEditable = useIsEditablePostBlock( clientId );
 	const [ excerpt, setExcerpt ] = useEntityProp(
 		'postType',
 		postType,
@@ -84,6 +91,23 @@ export default function PostExcerptEditor( {
 			}
 		/>
 	);
+	const excerptContent = isEditable ? (
+		<RichText
+			className={
+				! showMoreOnNewLine &&
+				'wp-block-post-excerpt__excerpt is-inline'
+			}
+			aria-label={ __( 'Post excerpt text' ) }
+			value={
+				excerpt ||
+				postContentExcerpt ||
+				( isSelected ? '' : __( 'No post excerpt found' ) )
+			}
+			onChange={ setExcerpt }
+		/>
+	) : (
+		excerpt || postContentExcerpt || __( 'No post excerpt found' )
+	);
 	return (
 		<>
 			<BlockControls>
@@ -119,19 +143,7 @@ export default function PostExcerptEditor( {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<RichText
-					className={
-						! showMoreOnNewLine &&
-						'wp-block-post-excerpt__excerpt is-inline'
-					}
-					aria-label={ __( 'Post excerpt text' ) }
-					value={
-						excerpt ||
-						postContentExcerpt ||
-						( isSelected ? '' : __( 'No post excerpt found' ) )
-					}
-					onChange={ setExcerpt }
-				/>
+				{ excerptContent }
 				{ ! showMoreOnNewLine && ' ' }
 				{ showMoreOnNewLine ? (
 					<p className="wp-block-post-excerpt__more-text">

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -20,6 +20,11 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { postFeaturedImage } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { useIsEditablePostBlock } from '../utils/hooks';
+
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const placeholderChip = (
 	<div className="post-featured-image_placeholder">
@@ -29,12 +34,14 @@ const placeholderChip = (
 );
 
 function PostFeaturedImageDisplay( {
+	clientId,
 	attributes: { isLink },
 	setAttributes,
 	context: { postId, postType },
 	noticeUI,
 	noticeOperations,
 } ) {
+	const isEditable = useIsEditablePostBlock( clientId );
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',
 		postType,
@@ -46,6 +53,7 @@ function PostFeaturedImageDisplay( {
 			featuredImage && select( coreStore ).getMedia( featuredImage ),
 		[ featuredImage ]
 	);
+	const blockProps = useBlockProps();
 	const onSelectImage = ( value ) => {
 		if ( value?.id ) {
 			setFeaturedImage( value.id );
@@ -56,6 +64,9 @@ function PostFeaturedImageDisplay( {
 		noticeOperations.createErrorNotice( message );
 	}
 	let image;
+	if ( ! featuredImage && ! isEditable ) {
+		return <div { ...blockProps }>{ placeholderChip }</div>;
+	}
 	if ( ! featuredImage ) {
 		image = (
 			<MediaPlaceholder
@@ -100,8 +111,8 @@ function PostFeaturedImageDisplay( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<BlockControls group="other">
-				{ !! media && (
+			{ !! media && isEditable && (
+				<BlockControls group="other">
 					<MediaReplaceFlow
 						mediaId={ featuredImage }
 						mediaURL={ media.source_url }
@@ -110,9 +121,9 @@ function PostFeaturedImageDisplay( {
 						onSelect={ onSelectImage }
 						onError={ onUploadError }
 					/>
-				) }
-			</BlockControls>
-			<figure { ...useBlockProps() }>{ image }</figure>
+				</BlockControls>
+			) }
+			<figure { ...blockProps }>{ image }</figure>
 		</>
 	);
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -22,7 +22,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
-import { useIsEditable } from '../utils/hooks';
+import { useIsEditablePostBlock } from '../utils/hooks';
 
 export default function PostTitleEdit( {
 	clientId,
@@ -31,7 +31,7 @@ export default function PostTitleEdit( {
 	context: { postType, postId },
 } ) {
 	const TagName = 0 === level ? 'p' : 'h' + level;
-	const isEditable = useIsEditable( clientId );
+	const isEditable = useIsEditablePostBlock( clientId );
 	const post = useSelect(
 		( select ) =>
 			select( coreStore ).getEditedEntityRecord(

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -22,14 +22,16 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
+import { useIsEditable } from '../utils/hooks';
 
 export default function PostTitleEdit( {
+	clientId,
 	attributes: { level, textAlign, isLink, rel, linkTarget },
 	setAttributes,
 	context: { postType, postId },
 } ) {
 	const TagName = 0 === level ? 'p' : 'h' + level;
-
+	const isEditable = useIsEditable( clientId );
 	const post = useSelect(
 		( select ) =>
 			select( coreStore ).getEditedEntityRecord(
@@ -60,7 +62,7 @@ export default function PostTitleEdit( {
 	);
 
 	if ( postType && postId ) {
-		titleElement = (
+		titleElement = isEditable ? (
 			<PlainText
 				tagName={ TagName }
 				placeholder={ __( 'No Title' ) }
@@ -73,11 +75,13 @@ export default function PostTitleEdit( {
 				__experimentalVersion={ 2 }
 				{ ...( isLink ? {} : blockProps ) }
 			/>
+		) : (
+			<TagName { ...( isLink ? {} : blockProps ) }>{ title }</TagName>
 		);
 	}
 
 	if ( isLink ) {
-		titleElement = (
+		titleElement = isEditable ? (
 			<TagName { ...blockProps }>
 				<PlainText
 					tagName="a"
@@ -93,6 +97,17 @@ export default function PostTitleEdit( {
 					}
 					__experimentalVersion={ 2 }
 				/>
+			</TagName>
+		) : (
+			<TagName { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ title }
+				</a>
 			</TagName>
 		);
 	}

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -10,7 +10,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import queryMetaData from '../query/block.json';
 const { name: queryBlockName } = queryMetaData;
 
-export function useIsEditable( clientId ) {
+export function useIsEditablePostBlock( clientId ) {
 	return useSelect(
 		( select ) => {
 			const { getBlockParents, getBlockName } = select(
@@ -27,4 +27,4 @@ export function useIsEditable( clientId ) {
 	);
 }
 
-export default { useIsEditable };
+export default { useIsEditablePostBlock };

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import queryMetaData from '../query/block.json';
+const { name: queryBlockName } = queryMetaData;
+
+export function useIsEditable( clientId ) {
+	return useSelect(
+		( select ) => {
+			const { getBlockParents, getBlockName } = select(
+				blockEditorStore
+			);
+			const blockParents = getBlockParents( clientId );
+			const hasQueryParent = blockParents.some(
+				( parentClientId ) =>
+					getBlockName( parentClientId ) === queryBlockName
+			);
+			return ! hasQueryParent;
+		},
+		[ clientId ]
+	);
+}
+
+export default { useIsEditable };

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -10,6 +10,17 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import queryMetaData from '../query/block.json';
 const { name: queryBlockName } = queryMetaData;
 
+/**
+ * Hook that determines if a Post block is editable or not.
+ * The returned value is used to determine if the specific
+ * Post block will be rendered in `readonly` mode or not.
+ *
+ * For now this is checking if a Post block is nested in
+ * a Query block. If it is, the block should not be editable.
+ *
+ * @param {string} clientId The ID of the block to be checked.
+ * @return {boolean} Whether the block can be edited or not.
+ */
 export function useIsEditablePostBlock( clientId ) {
 	return useSelect(
 		( select ) => {


### PR DESCRIPTION
Related #32317 #30910
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR will make Post blocks uneditable when inside Query block.
Affected blocks are:
1. Post Ttile
2. Post Excerpt
3. Post Content
4. Post Author
5. Post Featured Image
6. Post Date
<!-- Please describe what you have changed or added -->

## Testing instructions
1. In a page/post add Post blocks in the content and the same Post blocks inside Query block.
2. Observe that the blocks inside the content are editable but if are inside `Query` block are readonly

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
