### PR TITLE
Block API: Allow more than 1 block stylesheets

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -525,7 +525,7 @@ if ( ! function_exists( 'wp_migrate_old_typography_shape' ) ) {
  *
  * @return void
  */
-function gutenberg_enqueue_block_style( $block_name, $args ) {
+function wp_enqueue_block_style( $block_name, $args ) {
 	$args = wp_parse_args(
 		$args,
 		array(
@@ -599,7 +599,7 @@ function gutenberg_multiple_block_styles( $metadata ) {
 		if ( ! empty( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
 			$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
-				gutenberg_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );
+				wp_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );
 			}
 
 			// Only return the 1st item in the array.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -596,7 +596,7 @@ function gutenberg_enqueue_block_style( $block_name, $args ) {
  */
 function gutenberg_multiple_block_styles( $metadata ) {
 	foreach ( array( 'style', 'editorStyle' ) as $key ) {
-		if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+		if ( ! empty( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
 			$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
 				gutenberg_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -572,7 +572,7 @@ function gutenberg_enqueue_block_style( $block_name, $args ) {
 	add_filter( $hook, $callback );
 
 	// Enqueue assets in the editor.
-	add_action( 'enqueue_block_editor_assets', $callback );
+	add_action( 'enqueue_block_assets', $callback );
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -567,7 +567,7 @@ function gutenberg_enqueue_block_style( $block_name, $args, $register = true ) {
 	};
 
 	$hook = did_action( 'wp_enqueue_scripts' ) ? 'wp_footer' : 'wp_enqueue_scripts';
-	if ( gutenberg_should_load_separate_block_assets() ) {
+	if ( wp_should_load_separate_core_block_assets() ) {
 		$hook = "render_block_$block_name";
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -512,3 +512,43 @@ function gutenberg_migrate_old_typography_shape( $metadata ) {
 if ( ! function_exists( 'wp_migrate_old_typography_shape' ) ) {
 	add_filter( 'block_type_metadata', 'gutenberg_migrate_old_typography_shape' );
 }
+
+/**
+ * Allow multiple block styles.
+ *
+ * @param array $metadata Metadata for registering a block type.
+ *
+ * @return array
+ */
+function gutenberg_multiple_block_styles( $metadata ) {
+	foreach ( array( 'style', 'editorStyle' ) as $key ) {
+		if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+
+			// Enqueue multiple styles on block render.
+			add_filter(
+				"render_block_{$metadata['name']}",
+				/**
+				 * Filters the content of a single block.
+				 *
+				 * @since 5.0.0
+				 *
+				 * @param string $block_content The block content about to be appended.
+				 * @param array  $block         The full block, including name and attributes.
+				 */
+				function( $block_content, $block ) use ( $metadata, $key ) {
+					foreach ( $metadata[ $key ] as $handle ) {
+						wp_enqueue_style( $handle );
+					}
+					return $block_content;
+				},
+				10,
+				2
+			);
+
+			// Only return the 1st item in the array.
+			$metadata[ $key ] = $metadata[ $key ][0];
+		}
+	}
+	return $metadata;
+}
+add_filter( 'block_type_metadata', 'gutenberg_multiple_block_styles' );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -555,6 +555,18 @@ function gutenberg_enqueue_block_style( $block_name, $args ) {
 		// Add `path` data if provided.
 		if ( isset( $args['path'] ) ) {
 			wp_style_add_data( $args['handle'], 'path', $args['path'] );
+
+			// Get the RTL file path.
+			$rtl_file_path = str_replace( '.css', '-rtl.css', $args['path'] );
+
+			// Add RTL stylesheet.
+			if ( file_exists( $rtl_file_path ) ) {
+				wp_style_add_data( $args['hanle'], 'rtl', 'replace' );
+
+				if ( is_rtl() ) {
+					wp_style_add_data( $args['handle'], 'path', $rtl_file_path );
+				}
+			}
 		}
 
 		// Enqueue the stylesheet.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -522,13 +522,10 @@ if ( ! function_exists( 'wp_migrate_old_typography_shape' ) ) {
  *
  * @param string $block_name The block-name, including namespace.
  * @param array  $args       An array of arguments [handle,src,deps,ver,media].
- * @param bool   $register   Whether the stylesheet should be registered.
- *                           If set to false, then assume it has already been registered,
- *                           and only enqueue it.
  *
  * @return void
  */
-function gutenberg_enqueue_block_style( $block_name, $args, $register = true ) {
+function gutenberg_enqueue_block_style( $block_name, $args ) {
 	$args = wp_parse_args(
 		$args,
 		array(
@@ -549,9 +546,9 @@ function gutenberg_enqueue_block_style( $block_name, $args, $register = true ) {
 	 *
 	 * @return string
 	 */
-	$callback = function( $content ) use ( $args, $register ) {
+	$callback = function( $content ) use ( $args ) {
 		// Register the stylesheet.
-		if ( $register ) {
+		if ( ! empty( $args['src'] ) ) {
 			wp_register_style( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['media'] );
 		}
 
@@ -589,11 +586,7 @@ function gutenberg_multiple_block_styles( $metadata ) {
 	foreach ( array( 'style', 'editorStyle' ) as $key ) {
 		if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
 			foreach ( $metadata[ $key ] as $handle ) {
-				gutenberg_enqueue_block_style(
-					$metadata['name'],
-					array( 'handle' => $handle ),
-					false
-				);
+				gutenberg_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );
 			}
 
 			// Only return the 1st item in the array.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -585,12 +585,13 @@ function gutenberg_enqueue_block_style( $block_name, $args ) {
 function gutenberg_multiple_block_styles( $metadata ) {
 	foreach ( array( 'style', 'editorStyle' ) as $key ) {
 		if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+			$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
 				gutenberg_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );
 			}
 
 			// Only return the 1st item in the array.
-			$metadata[ $key ] = $metadata[ $key ][0];
+			$metadata[ $key ] = $default_style;
 		}
 	}
 	return $metadata;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -604,7 +604,7 @@ function gutenberg_multiple_block_styles( $metadata ) {
 				$args = array( 'handle' => $handle );
 				if ( 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
 					$style_path = remove_block_asset_path_prefix( $handle );
-					$args = array(
+					$args       = array(
 						'handle' => $style_path,
 						'src'    => plugins_url( $style_path, $metadata['file'] ),
 					);

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -605,7 +605,7 @@ function gutenberg_multiple_block_styles( $metadata ) {
 				if ( 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
 					$style_path = remove_block_asset_path_prefix( $handle );
 					$args       = array(
-						'handle' => $style_path,
+						'handle' => sanitize_key( "{$metadata['name']}-{$style_path}" ),
 						'src'    => plugins_url( $style_path, $metadata['file'] ),
 					);
 				}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -601,7 +601,16 @@ function gutenberg_multiple_block_styles( $metadata ) {
 		if ( ! empty( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
 			$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
-				wp_enqueue_block_style( $metadata['name'], array( 'handle' => $handle ) );
+				$args = array( 'handle' => $handle );
+				if ( 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
+					$style_path = remove_block_asset_path_prefix( $handle );
+					$args = array(
+						'handle' => $style_path,
+						'src'    => plugins_url( $style_path, $metadata['file'] ),
+					);
+				}
+
+				wp_enqueue_block_style( $metadata['name'], $args );
 			}
 
 			// Only return the 1st item in the array.

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -22,5 +22,5 @@
 			"lineHeight": true
 		}
 	},
-	"style": "wp-block-post-comments-form"
+	"style": [ "wp-block-post-comments-form", "wp-block-buttons", "wp-block-button" ]
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -61,17 +61,3 @@ function gutenberg_comment_form_block_form_defaults( $fields ) {
 	return $fields;
 }
 add_filter( 'comment_form_defaults', 'gutenberg_comment_form_block_form_defaults' );
-
-add_action(
-	'wp_enqueue_scripts',
-	/**
-	 * Add the button stylesheet as a dependency for the post-comment form stylesheet.
-	 */
-	function() {
-		global $wp_styles;
-		if ( ! empty( $wp_styles->registered ) && ! empty( $wp_styles->registered['wp-block-post-comments-form'] ) ) {
-			$wp_styles->registered['wp-block-post-comments-form']->deps[] = 'wp-block-button';
-		}
-	},
-	1
-);

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets.php
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed Multiple Stylesheets
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-multiple-stylesheets
+ */
+
+add_action(
+	'setup_theme',
+	function() {
+		add_theme_support( 'block-templates' );
+	}
+);
+
+add_action(
+	'init',
+	function() {
+		wp_register_script(
+			'iframed-multiple-stylesheets-editor-script',
+			plugin_dir_url( __FILE__ ) . 'iframed-multiple-stylesheets/editor.js',
+			array(
+				'wp-blocks',
+				'wp-block-editor',
+				'wp-element',
+			),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-multiple-stylesheets/editor.js' )
+		);
+		wp_register_style(
+			'iframed-multiple-stylesheets-style',
+			plugin_dir_url( __FILE__ ) . 'iframed-multiple-stylesheets/style.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-multiple-stylesheets/style.css' )
+		);
+		wp_register_style(
+			'iframed-multiple-stylesheets-style2',
+			plugin_dir_url( __FILE__ ) . 'iframed-multiple-stylesheets/style2.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-multiple-stylesheets/style2.css' )
+		);
+		register_block_type_from_metadata( __DIR__ . '/iframed-multiple-stylesheets' );
+	}
+);

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
@@ -1,0 +1,15 @@
+{
+	"apiVersion": 2,
+	"name": "test/iframed-multiple-stylesheets",
+	"title": "Iframed Multiple Stylesheets",
+	"category": "text",
+	"icon": "smiley",
+	"description": "",
+	"supports": {
+		"html": false
+	},
+	"textdomain": "iframed-multiple-stylesheets",
+	"editorScript": "iframed-multiple-stylesheets-editor-script",
+	"editorStyle": "file:./editor.css",
+	"style": ["iframed-multiple-stylesheets-style", "iframed-multiple-stylesheets-style2"]
+}

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
@@ -11,5 +11,5 @@
 	"textdomain": "iframed-multiple-stylesheets",
 	"editorScript": "iframed-multiple-stylesheets-editor-script",
 	"editorStyle": "file:./editor.css",
-	"style": [ "iframed-multiple-stylesheets-style", "iframed-multiple-stylesheets-style2" ]
+	"style": [ "iframed-multiple-stylesheets-style", "iframed-multiple-stylesheets-style2", "file:./style3.css" ]
 }

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/block.json
@@ -11,5 +11,5 @@
 	"textdomain": "iframed-multiple-stylesheets",
 	"editorScript": "iframed-multiple-stylesheets-editor-script",
 	"editorStyle": "file:./editor.css",
-	"style": ["iframed-multiple-stylesheets-style", "iframed-multiple-stylesheets-style2"]
+	"style": [ "iframed-multiple-stylesheets-style", "iframed-multiple-stylesheets-style2" ]
 }

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.css
@@ -1,0 +1,6 @@
+/**
+ * The following styles get applied inside the editor only.
+ */
+.wp-block-test-iframed-inline-styles {
+	border: 1px dotted #f00;
+}

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.js
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/editor.js
@@ -1,0 +1,15 @@
+( ( { wp: { element, blocks, blockEditor } } ) => {
+	const { createElement: el } = element;
+	const { registerBlockType } = blocks;
+	const { useBlockProps } = blockEditor;
+
+	registerBlockType( 'test/iframed-multiple-stylesheets', {
+		apiVersion: 2,
+		edit: function Edit() {
+			return el( 'div', useBlockProps(), 'Edit' );
+		},
+		save: function Save() {
+			return el( 'div', useBlockProps.save(), 'Save' );
+		},
+	} );
+} )( window );

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style.css
@@ -1,0 +1,7 @@
+/**
+ * The following styles get applied both on the front of your site and in the
+ * editor.
+ */
+.wp-block-test-iframed-multiple-stylesheets {
+	border-width: 2px !important;
+}

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style.css
@@ -3,5 +3,5 @@
  * editor.
  */
 .wp-block-test-iframed-multiple-stylesheets {
-	border-width: 2px !important;
+	border-style: dashed;
 }

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style2.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style2.css
@@ -3,5 +3,5 @@
  * editor.
  */
 .wp-block-test-iframed-multiple-stylesheets {
-	border-color: #ff0000 !important;
+	border-color: #f00 !important;
 }

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style2.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style2.css
@@ -1,0 +1,7 @@
+/**
+ * The following styles get applied both on the front of your site and in the
+ * editor.
+ */
+.wp-block-test-iframed-multiple-stylesheets {
+	border-color: #ff0000 !important;
+}

--- a/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style3.css
+++ b/packages/e2e-tests/plugins/iframed-multiple-stylesheets/style3.css
@@ -1,0 +1,7 @@
+/**
+ * The following styles get applied both on the front of your site and in the
+ * editor.
+ */
+ .wp-block-test-iframed-multiple-stylesheets {
+	background-color: #000 !important;
+}

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-multiple-block-stylesheets.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-multiple-block-stylesheets.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iframed multiple block stylesheets should load multiple block stylesheets in iframe 1`] = `
+"<!-- wp:test/iframed-multiple-stylesheets -->
+<div class=\\"wp-block-test-iframed-multiple-stylesheets\\">Save</div>
+<!-- /wp:test/iframed-multiple-stylesheets -->"
+`;

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-multiple-block-stylesheets.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-multiple-block-stylesheets.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`iframed multiple block stylesheets should load multiple block stylesheets in iframe 1`] = `
-"<!-- wp:test/iframed-multiple-stylesheets -->
-<div class=\\"wp-block-test-iframed-multiple-stylesheets\\">Save</div>
-<!-- /wp:test/iframed-multiple-stylesheets -->"
-`;

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+	getEditedPostContent,
+} from '@wordpress/e2e-test-utils';
+
+async function getComputedStyle( context, property ) {
+	await context.waitForSelector(
+		'.wp-block-test-iframed-multiple-stylesheets'
+	);
+	return await context.evaluate( ( prop ) => {
+		const container = document.querySelector(
+			'.wp-block-test-iframed-multiple-stylesheets'
+		);
+		return window.getComputedStyle( container )[ prop ];
+	}, property );
+}
+
+describe( 'iframed multiple block stylesheets', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-iframed-multiple-stylesheets' );
+		await createNewPost( { postType: 'page' } );
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-iframed-multiple-stylesheets' );
+	} );
+
+	it( 'should load multiple block stylesheets in iframe', async () => {
+		await insertBlock( 'Iframed Multiple Stylesheets' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		expect( await getComputedStyle( page, 'border-width' ) ).toBe( '2px' );
+		expect( await getComputedStyle( page, 'border-color' ) ).toBe(
+			'#ff0000'
+		);
+
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -7,6 +7,9 @@ import {
 	deactivatePlugin,
 	insertBlock,
 	getEditedPostContent,
+	openDocumentSettingsSidebar,
+	clickButton,
+	canvas,
 } from '@wordpress/e2e-test-utils';
 
 async function getComputedStyle( context, property ) {
@@ -35,9 +38,24 @@ describe( 'iframed multiple block stylesheets', () => {
 		await insertBlock( 'Iframed Multiple Stylesheets' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		expect( await getComputedStyle( page, 'border-width' ) ).toBe( '2px' );
-		expect( await getComputedStyle( page, 'border-color' ) ).toBe(
-			'#ff0000'
+		await openDocumentSettingsSidebar();
+		await clickButton( 'Page' );
+		await clickButton( 'Template' );
+		await clickButton( 'New' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'Iframed Test' );
+		await clickButton( 'Create' );
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+
+		// Style loaded from the main stylesheet.
+		expect( await getComputedStyle( canvas(), 'border-style' ) ).toBe(
+			'dashed'
+		);
+
+		// Style loaded from the additional stylesheet.
+		expect( await getComputedStyle( canvas(), 'border-color' ) ).toBe(
+			'rgb(255, 0, 0)'
 		);
 
 		expect( console ).toHaveErrored();

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -59,6 +59,8 @@ describe( 'iframed multiple block stylesheets', () => {
 			'rgb(255, 0, 0)'
 		);
 
+		// Skip errors related to block-styles enqueing and the use of add_editor_style.
+		// The issue is tracked on https://github.com/WordPress/gutenberg/issues/33212.
 		expect( console ).toHaveErrored();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -59,6 +59,11 @@ describe( 'iframed multiple block stylesheets', () => {
 			'rgb(255, 0, 0)'
 		);
 
+		// Style loaded from the a stylesheet using path instead of handle.
+		expect( await getComputedStyle( canvas(), 'background-color' ) ).toBe(
+			'rgb(0, 0, 0)'
+		);
+
 		// Skip errors related to block-styles enqueing and the use of add_editor_style.
 		// The issue is tracked on https://github.com/WordPress/gutenberg/issues/33212.
 		expect( console ).toHaveErrored();

--- a/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-multiple-block-stylesheets.test.js
@@ -6,7 +6,6 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	insertBlock,
-	getEditedPostContent,
 	openDocumentSettingsSidebar,
 	clickButton,
 	canvas,
@@ -37,7 +36,9 @@ describe( 'iframed multiple block stylesheets', () => {
 	it( 'should load multiple block stylesheets in iframe', async () => {
 		await insertBlock( 'Iframed Multiple Stylesheets' );
 
-		expect( await getEditedPostContent() ).toMatchSnapshot();
+		await page.waitForSelector(
+			'.wp-block-test-iframed-multiple-stylesheets'
+		);
 		await openDocumentSettingsSidebar();
 		await clickButton( 'Page' );
 		await clickButton( 'Template' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR aims to allow enqueing multiple stylesheets per-block.

### Inside a `block.json` file:
Allow defining `style` and `editorStyle` as an array. In the case of the `post-comments-form` block we needed to also enqueue styles for the `button` block. This is now possible by changing the value from 
```json
{
	"style": "wp-block-post-comments-form"
}
```
to
```json
{
 	"style": [ "wp-block-post-comments-form", "wp-block-buttons", "wp-block-button" ]
}
```

### From a theme/plugin
If a theme needs to add styles to a block, they can now do it using the `wp_enqueue_block_style` function:
```php
add_action( 
	'after_setup_theme',
	function() {
		$args = array( // Same args used for wp_enqueue_style().
			'handle' => 'my-theme-site-title',
			'src'    => get_theme_file_uri( 'assets/blocks/site-title.css' ),
		);
		// Add "path" to allow inlining asset if the theme opts-in.
		$args['path'] = get_theme_file_path( 'assets/blocks/site-title.css' );

		// Enqueue asset.
		wp_enqueue_block_style( 'core/site-title', $args );
	}
);
```
## How has this been tested?
* Tested in a block theme, confirming that the post-comments-form block still loads the button block assets.
* Added a file in a block-based theme, `assets/blocks/site-title.css` and confirmed that the code above adds the styles when the template contains a site-title block.
* Added the same file in a classic theme and confirmed the same behavior.
* Confirmed the same behavior both in the frontend and the editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
