### PR TITLE
Try: Menu item placeholder inheritance.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -430,23 +430,23 @@ export default function NavigationLinkEdit( {
 	switch ( type ) {
 		case 'post':
 			/* translators: label for missing post in navigation link block */
-			missingText = __( 'Select a post' );
+			missingText = __( 'Select post' );
 			break;
 		case 'page':
 			/* translators: label for missing page in navigation link block */
-			missingText = __( 'Select a page' );
+			missingText = __( 'Select page' );
 			break;
 		case 'category':
 			/* translators: label for missing category in navigation link block */
-			missingText = __( 'Select a category' );
+			missingText = __( 'Select category' );
 			break;
 		case 'tag':
 			/* translators: label for missing tag in navigation link block */
-			missingText = __( 'Select a tag' );
+			missingText = __( 'Select tag' );
 			break;
 		default:
 			/* translators: label for missing values in navigation link block */
-			missingText = __( 'Add a link' );
+			missingText = __( 'Add link' );
 	}
 
 	return (

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -80,49 +80,19 @@
 .wp-block-navigation-link__placeholder {
 	position: relative;
 
-	// Provide a little margin to show each placeholder as a separate unit.
-	margin: 2px;
-
 	.wp-block-navigation-link__placeholder-text {
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding-left: 4px;
-		padding-right: 4px;
-
+		background-image:
+			linear-gradient(135deg, transparent 10%, currentColor 10%, currentColor 30%, transparent 30%),
+			linear-gradient(45deg,  transparent 30%, currentColor 30%, currentColor 50%, transparent 50%),
+			linear-gradient(135deg, transparent 50%, currentColor 50%, currentColor 70%, transparent 70%),
+			linear-gradient(45deg,  transparent 70%, currentColor 70%, currentColor 90%, transparent 90%);
+		background-size: 10px 3px;
+		background-repeat: repeat-x;
+		background-position: 0 100%;
 	}
 
 	// This needs extra specificity.
 	&.wp-block-navigation-link__content {
 		cursor: pointer;
 	}
-
-	&::before {
-		content: "";
-		display: block;
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		border-radius: $radius-block-ui;
-		opacity: 0.1;
-
-		.is-dark-theme & {
-			opacity: 0.2;
-		}
-
-		.is-editing & {
-			background: currentColor;
-		}
-	}
-}
-
-// We had to add extra classes to override the color from
-// .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content
-.wp-block-navigation
-.wp-block-navigation-link:not(.is-editing)
-.wp-block-navigation-link__content.wp-block-navigation-link__placeholder {
-	box-shadow: inset 0 0 0 $border-width $gray-700;
-	border-radius: $radius-block-ui;
-	color: var(--wp-admin-theme-color);
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -80,14 +80,6 @@
 .wp-block-navigation-link__placeholder {
 	position: relative;
 
-	// Appear disabled to indicate incompleteness.
-	opacity: 0.6;
-	&:hover,
-	&:focus,
-	.is-selected > & {
-		opacity: 1;
-	}
-
 	// Draw a wavy underline.
 	.wp-block-navigation-link__placeholder-text {
 		$blur: 10%;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -80,15 +80,27 @@
 .wp-block-navigation-link__placeholder {
 	position: relative;
 
+	// Appear disabled to indicate incompleteness.
+	opacity: 0.6;
+	&:hover,
+	&:focus,
+	.is-selected > & {
+		opacity: 1;
+	}
+
+	// Draw a wavy underline.
 	.wp-block-navigation-link__placeholder-text {
+		$blur: 10%;
+		$width: 6%;
+		$stop1: 30%;
+		$stop2: 64%;
+
 		background-image:
-			linear-gradient(135deg, transparent 10%, currentColor 10%, currentColor 30%, transparent 30%),
-			linear-gradient(45deg,  transparent 30%, currentColor 30%, currentColor 50%, transparent 50%),
-			linear-gradient(135deg, transparent 50%, currentColor 50%, currentColor 70%, transparent 70%),
-			linear-gradient(45deg,  transparent 70%, currentColor 70%, currentColor 90%, transparent 90%);
-		background-size: 10px 3px;
-		background-repeat: repeat-x;
+			linear-gradient(45deg, transparent ($stop1 - $blur), currentColor $stop1, currentColor ($stop1 + $width), transparent ($stop1 + $width + $blur)),
+			linear-gradient(135deg, transparent ($stop2 - $blur), currentColor $stop2, currentColor ($stop2 + $width), transparent ($stop2 + $width + $blur));
 		background-position: 0 100%;
+		background-size: 6px 3px;
+		background-repeat: repeat-x;
 	}
 
 	// This needs extra specificity.


### PR DESCRIPTION
## Description

In #32373 we are discussing how the navigation block placeholder state can be improved. As part of the conversation, one idea is to de-emphasize the overall _navigation_ block placeholder state — after all, navigation can contain both links, spacers, search, social links — and instead focus in the _menu item_ placeholder state.

We already have one such, it looks like this:

![before](https://user-images.githubusercontent.com/1204802/121180795-87c2b700-c861-11eb-86a4-ad087712f142.gif)

This PR leverages that, but adds font, style and color inheritance, as well as a grammar-like wavy underline to indicate this item needs attention:

![after](https://user-images.githubusercontent.com/1204802/121180858-a0cb6800-c861-11eb-8d48-77bbc2d92b9a.gif)

I'm not entirely happy with the style of the wavy underline, and I'm exploring better alternatives in [this codepen](https://codepen.io/joen/pen/mdWxjry). Nevertheless the benefit of doing it this way is that it inherits color, making it work well on other theme backgrounds. Here are two twenties:

![after tt1](https://user-images.githubusercontent.com/1204802/121180943-c2c4ea80-c861-11eb-9bc2-9e8c52de79fb.gif)

![after tt](https://user-images.githubusercontent.com/1204802/121180949-c3f61780-c861-11eb-840a-2bfafde28b2e.gif)

Note, this PR is in a draft state because it is only an initial step at exploring the feasibility, the pros, and the cons of this appraoch. If we think there's potential — already in testing this branch, I'm rather convinced there is — it should be taken a few steps further:

- The block should stay in a setup state until both URL and Label are filled out
- At the moment, the placeholder requires a URL before you can set a label. We will likely need a new or enhanced link popover which also allows changing the label, but not set the URL, for creating patterns and avoiding the "Select a page".
- The setup state could/should expand to other "button blocks", such as Buttons and Social Links, so it should be a reusable generic component
- If you clear a link to a button block, or if you remove a label, the block reverts to its "placeholder state", i.e. the squiggly line returns, and the URL/Label picker opens immediately on click.

Depending on our approach, we can potentially defer some of those changes, but they are nevertheless part of the idea.

## How has this been tested?

Please insert a navigation block, start empty, and then insert page links or custom URLs or any other menu item links. But instead of choosing a page or pasting a URL in the dialog that follows, press Escape to close it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
