### PR TITLE
[Image Block]: Fix block validation errors when clearing height/width

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -59,7 +59,7 @@ export default function ImageSizeControl( {
 								onChange( {
 									width:
 										value === ''
-											? null
+											? undefined
 											: parseInt( value, 10 ),
 								} )
 							}
@@ -74,7 +74,7 @@ export default function ImageSizeControl( {
 								onChange( {
 									height:
 										value === ''
-											? null
+											? undefined
 											: parseInt( value, 10 ),
 								} )
 							}

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -36,13 +36,8 @@ export default function ImageSizeControl( {
 		currentHeight,
 		currentWidth,
 		updateDimension,
+		updateDimensions,
 	} = useDimensionHandler( height, width, imageHeight, imageWidth, onChange );
-
-	function updateDimensions( nextWidth, nextHeight ) {
-		return () => {
-			onChange( { width: nextWidth, height: nextHeight } );
-		};
-	}
 
 	return (
 		<>
@@ -92,8 +87,8 @@ export default function ImageSizeControl( {
 								);
 
 								const isCurrent =
-									width === scaledWidth &&
-									height === scaledHeight;
+									currentWidth === scaledWidth &&
+									currentHeight === scaledHeight;
 
 								return (
 									<Button
@@ -103,17 +98,19 @@ export default function ImageSizeControl( {
 											isCurrent ? 'primary' : undefined
 										}
 										isPressed={ isCurrent }
-										onClick={ updateDimensions(
-											scaledWidth,
-											scaledHeight
-										) }
+										onClick={ () =>
+											updateDimensions(
+												scaledHeight,
+												scaledWidth
+											)
+										}
 									>
 										{ scale }%
 									</Button>
 								);
 							} ) }
 						</ButtonGroup>
-						<Button isSmall onClick={ updateDimensions() }>
+						<Button isSmall onClick={ () => updateDimensions() }>
 							{ __( 'Reset' ) }
 						</Button>
 					</div>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -56,7 +56,12 @@ export default function ImageSizeControl( {
 							value={ width ?? imageWidth ?? '' }
 							min={ 1 }
 							onChange={ ( value ) =>
-								onChange( { width: parseInt( value, 10 ) } )
+								onChange( {
+									width:
+										value === ''
+											? null
+											: parseInt( value, 10 ),
+								} )
 							}
 						/>
 						<TextControl
@@ -67,7 +72,10 @@ export default function ImageSizeControl( {
 							min={ 1 }
 							onChange={ ( value ) =>
 								onChange( {
-									height: parseInt( value, 10 ),
+									height:
+										value === ''
+											? null
+											: parseInt( value, 10 ),
 								} )
 							}
 						/>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -14,6 +14,11 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import useDimensionHandler from './use-dimension-handler';
+
 const IMAGE_SIZE_PRESETS = [ 25, 50, 75, 100 ];
 
 export default function ImageSizeControl( {
@@ -27,6 +32,12 @@ export default function ImageSizeControl( {
 	onChange,
 	onChangeImage = noop,
 } ) {
+	const {
+		currentHeight,
+		currentWidth,
+		updateDimension,
+	} = useDimensionHandler( height, width, imageHeight, imageWidth, onChange );
+
 	function updateDimensions( nextWidth, nextHeight ) {
 		return () => {
 			onChange( { width: nextWidth, height: nextHeight } );
@@ -53,30 +64,20 @@ export default function ImageSizeControl( {
 							type="number"
 							className="block-editor-image-size-control__width"
 							label={ __( 'Width' ) }
-							value={ width ?? imageWidth ?? '' }
+							value={ currentWidth }
 							min={ 1 }
 							onChange={ ( value ) =>
-								onChange( {
-									width:
-										value === ''
-											? undefined
-											: parseInt( value, 10 ),
-								} )
+								updateDimension( 'width', value )
 							}
 						/>
 						<TextControl
 							type="number"
 							className="block-editor-image-size-control__height"
 							label={ __( 'Height' ) }
-							value={ height ?? imageHeight ?? '' }
+							value={ currentHeight }
 							min={ 1 }
 							onChange={ ( value ) =>
-								onChange( {
-									height:
-										value === ''
-											? undefined
-											: parseInt( value, 10 ),
-								} )
+								updateDimension( 'height', value )
 							}
 						/>
 					</div>

--- a/packages/block-editor/src/components/image-size-control/test/index.js
+++ b/packages/block-editor/src/components/image-size-control/test/index.js
@@ -6,66 +6,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useDimensionHandler from '../use-dimension-handler';
+import ImageSizeControl from '../index';
 
-describe( 'useDimensionHandler hook', () => {
+describe( 'ImageSizeControl', () => {
 	const mockOnChange = jest.fn();
-	const getHeightInput = () => screen.getByTestId( 'heightInput' );
-	const getWidthInput = () => screen.getByTestId( 'widthInput' );
-
-	function TestComponent( {
-		height,
-		width,
-		imageHeight,
-		imageWidth,
-		onChange,
-	} ) {
-		const {
-			currentHeight,
-			currentWidth,
-			updateDimension,
-			updateDimensions,
-		} = useDimensionHandler(
-			height,
-			width,
-			imageHeight,
-			imageWidth,
-			onChange
-		);
-
-		return (
-			<>
-				<input
-					data-testid="heightInput"
-					type="text"
-					value={ currentHeight }
-					onChange={ ( event ) =>
-						updateDimension( 'height', event.target.value )
-					}
-				/>
-				<input
-					data-testid="widthInput"
-					type="text"
-					value={ currentWidth }
-					onChange={ ( event ) =>
-						updateDimension( 'width', event.target.value )
-					}
-				/>
-
-				{ /* Contrived example with hard-coded value serves to demonstrate updates. */ }
-				<input
-					type="button"
-					value="Update"
-					onClick={ () => updateDimensions( 200, 300 ) }
-				/>
-				<input
-					value="Reset"
-					type="button"
-					onClick={ () => updateDimensions() }
-				/>
-			</>
-		);
-	}
+	const getHeightInput = () => screen.getByLabelText( 'Height' );
+	const getWidthInput = () => screen.getByLabelText( 'Width' );
 
 	afterEach( () => {
 		// cleanup on exiting
@@ -74,24 +20,12 @@ describe( 'useDimensionHandler hook', () => {
 
 	it( 'returns custom dimensions when they exist', () => {
 		render(
-			<TestComponent
-				height="100"
-				width="200"
-				imageHeight="300"
-				imageWidth="400"
-				onChange={ mockOnChange }
-			/>
-		);
-
-		expect( getHeightInput().value ).toBe( '100' );
-		expect( getWidthInput().value ).toBe( '200' );
-	} );
-
-	it( 'returns default dimensions when custom dimensions are undefined', () => {
-		render(
-			<TestComponent
-				imageHeight="300"
-				imageWidth="400"
+			<ImageSizeControl
+				imageHeight="100"
+				imageWidth="200"
+				height="300"
+				width="400"
+				slug=""
 				onChange={ mockOnChange }
 			/>
 		);
@@ -100,8 +34,21 @@ describe( 'useDimensionHandler hook', () => {
 		expect( getWidthInput().value ).toBe( '400' );
 	} );
 
+	it( 'returns default dimensions when custom dimensions are undefined', () => {
+		render(
+			<ImageSizeControl
+				imageHeight="100"
+				imageWidth="200"
+				onChange={ mockOnChange }
+			/>
+		);
+
+		expect( getHeightInput().value ).toBe( '100' );
+		expect( getWidthInput().value ).toBe( '200' );
+	} );
+
 	it( 'returns empty string when custom and default dimensions are undefined', () => {
-		render( <TestComponent onChange={ mockOnChange } /> );
+		render( <ImageSizeControl onChange={ mockOnChange } /> );
 
 		expect( getHeightInput().value ).toBe( '' );
 		expect( getWidthInput().value ).toBe( '' );
@@ -111,7 +58,7 @@ describe( 'useDimensionHandler hook', () => {
 		// Simulates an initial render with custom and default dimensions undefined.
 		// This occurs when an image is uploaded for the first time, for example.
 		const { rerender } = render(
-			<TestComponent onChange={ mockOnChange } />
+			<ImageSizeControl onChange={ mockOnChange } />
 		);
 
 		const heightInput = getHeightInput();
@@ -124,7 +71,7 @@ describe( 'useDimensionHandler hook', () => {
 		// When new default dimensions are passed on a rerender (for example after they
 		// are calculated following an image upload), update values to the new defaults.
 		rerender(
-			<TestComponent
+			<ImageSizeControl
 				imageHeight="300"
 				imageWidth="400"
 				onChange={ mockOnChange }
@@ -136,12 +83,12 @@ describe( 'useDimensionHandler hook', () => {
 		expect( widthInput.value ).toBe( '400' );
 	} );
 
-	describe( 'updateDimension', () => {
+	describe( 'updating dimension inputs', () => {
 		it( 'updates height and calls onChange', async () => {
-			render( <TestComponent onChange={ mockOnChange } /> );
+			render( <ImageSizeControl onChange={ mockOnChange } /> );
 
-			const heightInput = screen.getByTestId( 'heightInput' );
-			const widthInput = screen.getByTestId( 'widthInput' );
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
 
 			expect( heightInput.value ).toBe( '' );
 			expect( widthInput.value ).toBe( '' );
@@ -158,7 +105,7 @@ describe( 'useDimensionHandler hook', () => {
 		} );
 
 		it( 'updates width and calls onChange', async () => {
-			render( <TestComponent onChange={ mockOnChange } /> );
+			render( <ImageSizeControl onChange={ mockOnChange } /> );
 
 			const heightInput = getHeightInput();
 			const widthInput = getWidthInput();
@@ -178,7 +125,7 @@ describe( 'useDimensionHandler hook', () => {
 
 		it( 'updates height and calls onChange for empty value', async () => {
 			render(
-				<TestComponent
+				<ImageSizeControl
 					imageHeight="100"
 					imageWidth="100"
 					onChange={ mockOnChange }
@@ -208,7 +155,7 @@ describe( 'useDimensionHandler hook', () => {
 
 		it( 'updates width and calls onChange for empty value', async () => {
 			render(
-				<TestComponent
+				<ImageSizeControl
 					imageHeight="100"
 					imageWidth="100"
 					onChange={ mockOnChange }
@@ -237,12 +184,14 @@ describe( 'useDimensionHandler hook', () => {
 		} );
 	} );
 
-	describe( 'updateDimensions', () => {
-		it( 'updates both height and width', async () => {
+	describe( 'reset button', () => {
+		it( 'resets both height and width to default values', async () => {
 			render(
-				<TestComponent
+				<ImageSizeControl
 					imageHeight="100"
-					imageWidth="100"
+					imageWidth="200"
+					height="300"
+					width="400"
 					onChange={ mockOnChange }
 				/>
 			);
@@ -251,53 +200,21 @@ describe( 'useDimensionHandler hook', () => {
 			const widthInput = getWidthInput();
 
 			// The initial dimension values display first.
-			expect( heightInput.value ).toBe( '100' );
-			expect( widthInput.value ).toBe( '100' );
-
-			fireEvent.click( screen.getByText( 'Update' ) );
-
-			await waitFor( () => {
-				// onChange is called with values for both dimensions.
-				expect( mockOnChange ).toHaveBeenCalledWith( {
-					height: 200,
-					width: 300,
-				} );
-
-				// The new dimension values have been set.
-				expect( heightInput.value ).toBe( '200' );
-				expect( widthInput.value ).toBe( '300' );
-			} );
-		} );
-		it( 'resets dimensions to defaults when values not provided', async () => {
-			render(
-				<TestComponent
-					imageHeight="100"
-					imageWidth="100"
-					height="200"
-					width="200"
-					onChange={ mockOnChange }
-				/>
-			);
-
-			const heightInput = getHeightInput();
-			const widthInput = getWidthInput();
-
-			// The initial dimension values display first.
-			expect( heightInput.value ).toBe( '200' );
-			expect( widthInput.value ).toBe( '200' );
+			expect( heightInput.value ).toBe( '300' );
+			expect( widthInput.value ).toBe( '400' );
 
 			fireEvent.click( screen.getByText( 'Reset' ) );
 
 			await waitFor( () => {
-				// The attributes are set to undefined when values were not provided.
+				// Both attributes are set to undefined to clear custom values.
 				expect( mockOnChange ).toHaveBeenCalledWith( {
 					height: undefined,
 					width: undefined,
 				} );
 
-				// The display values are reset to defaults even though the attributes are undefined.
+				// The inputs display the default values once more.
 				expect( heightInput.value ).toBe( '100' );
-				expect( widthInput.value ).toBe( '100' );
+				expect( widthInput.value ).toBe( '200' );
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/components/image-size-control/test/index.js
+++ b/packages/block-editor/src/components/image-size-control/test/index.js
@@ -10,6 +10,7 @@ import ImageSizeControl from '../index';
 
 describe( 'ImageSizeControl', () => {
 	const mockOnChange = jest.fn();
+	const mockOnChangeImage = jest.fn();
 	const getHeightInput = () => screen.getByLabelText( 'Height' );
 	const getWidthInput = () => screen.getByLabelText( 'Width' );
 
@@ -215,6 +216,94 @@ describe( 'ImageSizeControl', () => {
 				// The inputs display the default values once more.
 				expect( heightInput.value ).toBe( '100' );
 				expect( widthInput.value ).toBe( '200' );
+			} );
+		} );
+	} );
+
+	describe( 'image size percentage presets', () => {
+		it( 'updates height and width attributes on selection', async () => {
+			render(
+				<ImageSizeControl
+					imageHeight="100"
+					imageWidth="201"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			fireEvent.click( screen.getByText( '50%' ) );
+
+			await waitFor( () => {
+				expect( screen.getByText( '50%' ) ).toHaveClass( 'is-pressed' );
+
+				// Both attributes are set to the rounded scaled value.
+				expect( mockOnChange ).toHaveBeenCalledWith( {
+					height: 50,
+					width: 101,
+				} );
+			} );
+		} );
+
+		it( 'updates height and width inputs on selection', async () => {
+			render(
+				<ImageSizeControl
+					imageHeight="100"
+					imageWidth="201"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			fireEvent.click( screen.getByText( '50%' ) );
+
+			await waitFor( () => {
+				// Both attributes are set to the rounded scaled value.
+				expect( getHeightInput().value ).toBe( '50' );
+				expect( getWidthInput().value ).toBe( '101' );
+			} );
+		} );
+	} );
+
+	describe( 'image size slug presets', () => {
+		const IMAGE_SIZE_OPTIONS = [
+			{ value: 'thumbnail', label: 'Thumbnail' },
+			{ value: 'medium', label: 'Medium' },
+			{ value: 'large', label: 'Large' },
+		];
+
+		it( 'displays the selected slug', () => {
+			render(
+				<ImageSizeControl
+					imageSizeOptions={ IMAGE_SIZE_OPTIONS }
+					slug="medium"
+					onChange={ mockOnChange }
+					onChangeImage={ mockOnChangeImage }
+				/>
+			);
+
+			expect( screen.getByLabelText( 'Image size' ).value ).toBe(
+				'medium'
+			);
+		} );
+
+		it( 'calls onChangeImage with selected slug on selection', async () => {
+			render(
+				<ImageSizeControl
+					imageSizeOptions={ IMAGE_SIZE_OPTIONS }
+					slug="Medium"
+					onChange={ mockOnChange }
+					onChangeImage={ mockOnChangeImage }
+				/>
+			);
+
+			fireEvent.change( screen.getByLabelText( 'Image size' ), {
+				target: { value: 'thumbnail' },
+			} );
+
+			await waitFor( () => {
+				// onChangeImage is called with the slug and the event.
+				expect( mockOnChangeImage ).toHaveBeenCalledWith(
+					'thumbnail',
+					expect.any( Object )
+				);
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/components/image-size-control/test/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/test/use-dimension-handler.js
@@ -1,0 +1,304 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useDimensionHandler from '../use-dimension-handler';
+
+describe( 'useDimensionHandler hook', () => {
+	const mockOnChange = jest.fn();
+	const getHeightInput = () => screen.getByTestId( 'heightInput' );
+	const getWidthInput = () => screen.getByTestId( 'widthInput' );
+
+	function TestComponent( {
+		height,
+		width,
+		imageHeight,
+		imageWidth,
+		onChange,
+	} ) {
+		const {
+			currentHeight,
+			currentWidth,
+			updateDimension,
+			updateDimensions,
+		} = useDimensionHandler(
+			height,
+			width,
+			imageHeight,
+			imageWidth,
+			onChange
+		);
+
+		return (
+			<>
+				<input
+					data-testid="heightInput"
+					type="text"
+					value={ currentHeight }
+					onChange={ ( event ) =>
+						updateDimension( 'height', event.target.value )
+					}
+				/>
+				<input
+					data-testid="widthInput"
+					type="text"
+					value={ currentWidth }
+					onChange={ ( event ) =>
+						updateDimension( 'width', event.target.value )
+					}
+				/>
+
+				{ /* Contrived example with hard-coded value serves to demonstrate updates. */ }
+				<input
+					type="button"
+					value="Update"
+					onClick={ () => updateDimensions( 200, 300 ) }
+				/>
+				<input
+					value="Reset"
+					type="button"
+					onClick={ () => updateDimensions() }
+				/>
+			</>
+		);
+	}
+
+	afterEach( () => {
+		// cleanup on exiting
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns custom dimensions when they exist', () => {
+		render(
+			<TestComponent
+				height="100"
+				width="200"
+				imageHeight="300"
+				imageWidth="400"
+				onChange={ mockOnChange }
+			/>
+		);
+
+		expect( getHeightInput().value ).toBe( '100' );
+		expect( getWidthInput().value ).toBe( '200' );
+	} );
+
+	it( 'returns default dimensions when custom dimensions are undefined', () => {
+		render(
+			<TestComponent
+				imageHeight="300"
+				imageWidth="400"
+				onChange={ mockOnChange }
+			/>
+		);
+
+		expect( getHeightInput().value ).toBe( '300' );
+		expect( getWidthInput().value ).toBe( '400' );
+	} );
+
+	it( 'returns empty string when custom and default dimensions are undefined', () => {
+		render( <TestComponent onChange={ mockOnChange } /> );
+
+		expect( getHeightInput().value ).toBe( '' );
+		expect( getWidthInput().value ).toBe( '' );
+	} );
+
+	it( 'returns default dimensions when initially undefined defaults are defined on rerender', () => {
+		// Simulates an initial render with custom and default dimensions undefined.
+		// This occurs when an image is uploaded for the first time, for example.
+		const { rerender } = render(
+			<TestComponent onChange={ mockOnChange } />
+		);
+
+		const heightInput = getHeightInput();
+		const widthInput = getWidthInput();
+
+		// The dimensions are initially set to an empty string.
+		expect( heightInput.value ).toBe( '' );
+		expect( widthInput.value ).toBe( '' );
+
+		// When new default dimensions are passed on a rerender (for example after they
+		// are calculated following an image upload), update values to the new defaults.
+		rerender(
+			<TestComponent
+				imageHeight="300"
+				imageWidth="400"
+				onChange={ mockOnChange }
+			/>
+		);
+
+		// The dimensions should update to the defaults.
+		expect( heightInput.value ).toBe( '300' );
+		expect( widthInput.value ).toBe( '400' );
+	} );
+
+	describe( 'updateDimension', () => {
+		it( 'updates height and calls onChange', async () => {
+			render( <TestComponent onChange={ mockOnChange } /> );
+
+			const heightInput = screen.getByTestId( 'heightInput' );
+			const widthInput = screen.getByTestId( 'widthInput' );
+
+			expect( heightInput.value ).toBe( '' );
+			expect( widthInput.value ).toBe( '' );
+
+			fireEvent.change( heightInput, { target: { value: '500' } } );
+
+			await waitFor( () => {
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenCalledWith( { height: 500 } );
+			} );
+
+			expect( heightInput.value ).toBe( '500' );
+			expect( widthInput.value ).toBe( '' );
+		} );
+
+		it( 'updates width and calls onChange', async () => {
+			render( <TestComponent onChange={ mockOnChange } /> );
+
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
+
+			expect( heightInput.value ).toBe( '' );
+			expect( widthInput.value ).toBe( '' );
+
+			fireEvent.change( widthInput, { target: { value: '500' } } );
+			await waitFor( () => {
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenCalledWith( { width: 500 } );
+			} );
+
+			expect( heightInput.value ).toBe( '' );
+			expect( widthInput.value ).toBe( '500' );
+		} );
+
+		it( 'updates height and calls onChange for empty value', async () => {
+			render(
+				<TestComponent
+					imageHeight="100"
+					imageWidth="100"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
+
+			expect( heightInput.value ).toBe( '100' );
+			expect( widthInput.value ).toBe( '100' );
+
+			fireEvent.change( heightInput, { target: { value: '' } } );
+
+			await waitFor( () => {
+				// onChange is called and sets the dimension to undefined rather than
+				// the empty string.
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenCalledWith( {
+					height: undefined,
+				} );
+			} );
+			// Height is updated to empty value and does not reset to default.
+			expect( heightInput.value ).toBe( '' );
+			expect( widthInput.value ).toBe( '100' );
+		} );
+
+		it( 'updates width and calls onChange for empty value', async () => {
+			render(
+				<TestComponent
+					imageHeight="100"
+					imageWidth="100"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
+
+			expect( heightInput.value ).toBe( '100' );
+			expect( widthInput.value ).toBe( '100' );
+
+			fireEvent.change( widthInput, { target: { value: '' } } );
+
+			await waitFor( () => {
+				// onChange is called and sets the dimension to undefined rather than
+				// the empty string.
+				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnChange ).toHaveBeenCalledWith( {
+					width: undefined,
+				} );
+			} );
+			// Width is updated to empty value and does not reset to default.
+			expect( heightInput.value ).toBe( '100' );
+			expect( widthInput.value ).toBe( '' );
+		} );
+	} );
+
+	describe( 'updateDimensions', () => {
+		it( 'updates both height and width', async () => {
+			render(
+				<TestComponent
+					imageHeight="100"
+					imageWidth="100"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
+
+			// The initial dimension values display first.
+			expect( heightInput.value ).toBe( '100' );
+			expect( widthInput.value ).toBe( '100' );
+
+			fireEvent.click( screen.getByText( 'Update' ) );
+
+			await waitFor( () => {
+				// onChange is called with values for both dimensions.
+				expect( mockOnChange ).toHaveBeenCalledWith( {
+					height: 200,
+					width: 300,
+				} );
+
+				// The new dimension values have been set.
+				expect( heightInput.value ).toBe( '200' );
+				expect( widthInput.value ).toBe( '300' );
+			} );
+		} );
+		it( 'resets dimensions to defaults when values not provided', async () => {
+			render(
+				<TestComponent
+					imageHeight="100"
+					imageWidth="100"
+					height="200"
+					width="200"
+					onChange={ mockOnChange }
+				/>
+			);
+
+			const heightInput = getHeightInput();
+			const widthInput = getWidthInput();
+
+			// The initial dimension values display first.
+			expect( heightInput.value ).toBe( '200' );
+			expect( widthInput.value ).toBe( '200' );
+
+			fireEvent.click( screen.getByText( 'Reset' ) );
+
+			await waitFor( () => {
+				// The attributes are set to undefined when values were not provided.
+				expect( mockOnChange ).toHaveBeenCalledWith( {
+					height: undefined,
+					width: undefined,
+				} );
+
+				// The display values are reset to defaults even though the attributes are undefined.
+				expect( heightInput.value ).toBe( '100' );
+				expect( widthInput.value ).toBe( '100' );
+			} );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -29,7 +29,7 @@ export default function useDimensionHander(
 		}
 	}, [ defaultWidth, defaultHeight ] );
 
-	function updateDimension( dimension, value ) {
+	const updateDimension = ( dimension, value ) => {
 		if ( dimension === 'width' ) {
 			setCurrentWidth( value );
 		} else {
@@ -38,11 +38,18 @@ export default function useDimensionHander(
 		onChange( {
 			[ dimension ]: value === '' ? undefined : parseInt( value, 10 ),
 		} );
-	}
+	};
+
+	const updateDimensions = ( nextHeight, nextWidth ) => {
+		setCurrentHeight( nextHeight ?? defaultHeight );
+		setCurrentWidth( nextWidth ?? defaultWidth );
+		onChange( { height: nextHeight, width: nextWidth } );
+	};
 
 	return {
 		currentHeight,
 		currentWidth,
 		updateDimension,
+		updateDimensions,
 	};
 }

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+export default function useDimensionHander(
+	customHeight,
+	customWidth,
+	defaultHeight,
+	defaultWidth,
+	onChange
+) {
+	const [ currentWidth, setCurrentWidth ] = useState(
+		customWidth ?? defaultWidth ?? ''
+	);
+	const [ currentHeight, setCurrentHeight ] = useState(
+		customHeight ?? defaultHeight ?? ''
+	);
+
+	// When an image is first inserted, the default dimensions are initially
+	// undefined. This effect updates the dimensions when the default values
+	// come through.
+	useEffect( () => {
+		if ( customWidth === undefined && defaultWidth !== undefined ) {
+			setCurrentWidth( defaultWidth );
+		}
+		if ( customHeight === undefined && defaultHeight !== undefined ) {
+			setCurrentHeight( defaultHeight );
+		}
+	}, [ defaultWidth, defaultHeight ] );
+
+	function updateDimension( dimension, value ) {
+		if ( dimension === 'width' ) {
+			setCurrentWidth( value );
+		} else {
+			setCurrentHeight( value );
+		}
+		onChange( {
+			[ dimension ]: value === '' ? undefined : parseInt( value, 10 ),
+		} );
+	}
+
+	return {
+		currentHeight,
+		currentWidth,
+		updateDimension,
+	};
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Issue #30131

When you change the 'width' or 'height' fields on an image block, it attempts to parse the new value as an Integer before passing it to `setAttributes`. This causes block invalidation errors if you empty out the field and save the post (because of the resulting `NaN` attributes).

This PR just checks for the empty string before attempting to parse and sets the attribute to `null` instead.

**Note:** This has the side effect of making it impossible to "clear out" the input, because the `ImageSizeControl` falls back to displaying the default image height/width when the custom height/width attributes are null. The intention is that the input is always displaying the actual values used. If this is instead deemed confusing when the user tries to clear the input, we could alternatively only fallback to the default image dimensions when first rendering the form.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Create a new post and insert an Image block. Select or upload an image.
2. Save and verify the width and height are set to "auto" by inspecting the element in the console.
3. In the Inspector Controls, set a custom height/width and save. Verify that the image updates visually and that the height and width are set correctly by inspecting the element in the console.
4. In the Inspector Controls, delete the custom height/width. The input should update to read the default dimension. Save the post and verify that there are no validation errors, and that the inline height and width are once again "auto".


## Screenshots <!-- if applicable -->
![Screen Capture on 2021-06-08 at 10-34-14](https://user-images.githubusercontent.com/63313398/121231376-2e4c8f00-c845-11eb-8c3a-506f9b336d8a.gif)
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
