### PR TITLE
[Social Link]: Correctly position the link popover when List View is open

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -12,7 +12,7 @@ import {
 	URLInput,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment, useState, useRef } from '@wordpress/element';
 import {
 	Button,
 	PanelBody,
@@ -27,6 +27,42 @@ import { keyboardReturn } from '@wordpress/icons';
  */
 import { getIconBySite, getNameBySite } from './social-list';
 
+const SocialLinkURLPopover = ( {
+	url,
+	setAttributes,
+	setPopover,
+	anchorRef,
+} ) => (
+	<URLPopover
+		anchorRef={ anchorRef?.current }
+		onClose={ () => setPopover( false ) }
+	>
+		<form
+			className="block-editor-url-popover__link-editor"
+			onSubmit={ ( event ) => {
+				event.preventDefault();
+				setPopover( false );
+			} }
+		>
+			<div className="block-editor-url-input">
+				<URLInput
+					value={ url }
+					onChange={ ( nextURL ) =>
+						setAttributes( { url: nextURL } )
+					}
+					placeholder={ __( 'Enter address' ) }
+					disableSuggestions={ true }
+				/>
+			</div>
+			<Button
+				icon={ keyboardReturn }
+				label={ __( 'Apply' ) }
+				type="submit"
+			/>
+		</form>
+	</URLPopover>
+);
+
 const SocialLinkEdit = ( {
 	attributes,
 	context,
@@ -40,6 +76,7 @@ const SocialLinkEdit = ( {
 		'wp-social-link__is-incomplete': ! url,
 	} );
 
+	const ref = useRef();
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
 	const blockProps = useBlockProps( {
@@ -76,34 +113,15 @@ const SocialLinkEdit = ( {
 				</PanelBody>
 			</InspectorControls>
 			<li { ...blockProps }>
-				<Button onClick={ () => setPopover( true ) }>
+				<Button ref={ ref } onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					{ isSelected && showURLPopover && (
-						<URLPopover onClose={ () => setPopover( false ) }>
-							<form
-								className="block-editor-url-popover__link-editor"
-								onSubmit={ ( event ) => {
-									event.preventDefault();
-									setPopover( false );
-								} }
-							>
-								<div className="block-editor-url-input">
-									<URLInput
-										value={ url }
-										onChange={ ( nextURL ) =>
-											setAttributes( { url: nextURL } )
-										}
-										placeholder={ __( 'Enter address' ) }
-										disableSuggestions={ true }
-									/>
-								</div>
-								<Button
-									icon={ keyboardReturn }
-									label={ __( 'Apply' ) }
-									type="submit"
-								/>
-							</form>
-						</URLPopover>
+						<SocialLinkURLPopover
+							url={ url }
+							setAttributes={ setAttributes }
+							setPopover={ setPopover }
+							anchorRef={ ref }
+						/>
 					) }
 				</Button>
 			</li>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Issue #30120

When the List View is open in the site editor, if you click on an icon in the `Social Icons` block to edit the url, the popover will float quite far away from the block. This PR updates the block to pass an `anchorRef` to the `URLPopover` so that it can correctly position the control even when the List View is open.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
(See screenshots)
1. In the site editor, add a Social Icons block and add a few icons.
2. Click on one of the icons to edit the url. Notice that the popover is positioned as expected, by the element being edited.
3. Open the List View and click on another icon. Verify that the popover is still positioned correctly.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
| ![Screen Capture on 2021-06-08 at 12-00-00](https://user-images.githubusercontent.com/63313398/121242922-f4ce5080-c851-11eb-838e-ae1be14820d7.gif) | ![Screen Capture on 2021-06-08 at 11-48-33](https://user-images.githubusercontent.com/63313398/121242951-fdbf2200-c851-11eb-8458-96a5e041480d.gif) |



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
