### PR TITLE
Fix bug with pasting into rich text blocks

### DIFF
--- a/packages/block-editor/src/components/rich-text/utils.js
+++ b/packages/block-editor/src/components/rich-text/utils.js
@@ -5,7 +5,7 @@ import { regexp } from '@wordpress/shortcode';
 import deprecated from '@wordpress/deprecated';
 
 export function addActiveFormats( value, activeFormats ) {
-	if ( activeFormats.length ) {
+	if ( activeFormats?.length ) {
 		let index = value.formats.length;
 
 		while ( index-- ) {


### PR DESCRIPTION
Add optional chaining to prevent exception if activeFormats not defined.

Fixes #32526

## Description
Currently when pasting into a rich text block like paragraph multiple times an exception is thrown and the text does not appear in the editor

## Testing
- In the editor try and paste some text into a paragraph block, and then paste the same text again
- Make sure there are no console errors and that both lots of text appear in the editor

## Screenshots

Before:
![paste-2-before](https://user-images.githubusercontent.com/3629020/121277660-31b74780-c925-11eb-8446-e446bbef9e33.gif)

After:
![paste-after](https://user-images.githubusercontent.com/3629020/121274514-c1a5c300-c91e-11eb-8ed9-c80813c55aaf.gif)
