### PR TITLE
Editor Breadcrumb: add a `rootLabelText` prop

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -104,6 +104,11 @@ Undocumented declaration.
 
 Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
 
+_Parameters_
+
+-   _props_ `Object`: Component props.
+-   _props.rootLabelText_ `string`: Translated label for the root element of the breadcrumb trail.
+
 _Returns_
 
 -   `WPElement`: Block Breadcrumb.

--- a/packages/block-editor/src/components/block-breadcrumb/README.md
+++ b/packages/block-editor/src/components/block-breadcrumb/README.md
@@ -13,6 +13,15 @@ The block breadcrumb trail displays the hierarchy of the current block selection
 
 ## Development guidelines
 
+#### Props
+
+##### rootLabelText
+
+Label text for the root element (the first `<li />`) of the breadcrumb trail.
+
+-   Type: `String`
+-   Required: No
+
 ### Usage
 
 Renders a block breadcrumb with default style.

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -14,9 +14,11 @@ import { store as blockEditorStore } from '../../store';
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
  *
- * @return {WPElement} Block Breadcrumb.
+ * @param  {Object}   props               Component props.
+ * @param  {string}   props.rootLabelText Translated label for the root element of the breadcrumb trail.
+ * @return {WPElement}                    Block Breadcrumb.
  */
-function BlockBreadcrumb() {
+function BlockBreadcrumb( { rootLabelText } ) {
 	const { selectBlock, clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { clientId, parents, hasSelection } = useSelect( ( select ) => {
 		const {
@@ -31,6 +33,7 @@ function BlockBreadcrumb() {
 			hasSelection: !! getSelectionStart().clientId,
 		};
 	}, [] );
+	const rootLabel = rootLabelText || __( 'Document' );
 
 	/*
 	 * Disable reason: The `list` ARIA role is redundant but
@@ -57,10 +60,10 @@ function BlockBreadcrumb() {
 						variant="tertiary"
 						onClick={ clearSelectedBlock }
 					>
-						{ __( 'Document' ) }
+						{ rootLabel }
 					</Button>
 				) }
-				{ ! hasSelection && __( 'Document' ) }
+				{ ! hasSelection && rootLabel }
 			</li>
 			{ parents.map( ( parentClientId ) => (
 				<li key={ parentClientId }>

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BlockBreadcrumb should match snapshot 1`] = `
+<ul
+  aria-label="Block breadcrumb"
+  className="block-editor-block-breadcrumb"
+  role="list"
+>
+  <li
+    aria-current="true"
+    className="block-editor-block-breadcrumb__current"
+  >
+    Document
+  </li>
+</ul>
+`;
+
+exports[`BlockBreadcrumb should match snapshot with root label 1`] = `
+<ul
+  aria-label="Block breadcrumb"
+  className="block-editor-block-breadcrumb"
+  role="list"
+>
+  <li
+    aria-current="true"
+    className="block-editor-block-breadcrumb__current"
+  >
+    Tuhinga
+  </li>
+</ul>
+`;

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -1,31 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BlockBreadcrumb should match snapshot 1`] = `
+exports[`BlockBreadcrumb should render correctly 1`] = `
 <ul
   aria-label="Block breadcrumb"
-  className="block-editor-block-breadcrumb"
+  class="block-editor-block-breadcrumb"
   role="list"
 >
   <li
     aria-current="true"
-    className="block-editor-block-breadcrumb__current"
+    class="block-editor-block-breadcrumb__current"
   >
     Document
-  </li>
-</ul>
-`;
-
-exports[`BlockBreadcrumb should match snapshot with root label 1`] = `
-<ul
-  aria-label="Block breadcrumb"
-  className="block-editor-block-breadcrumb"
-  role="list"
->
-  <li
-    aria-current="true"
-    className="block-editor-block-breadcrumb__current"
-  >
-    Tuhinga
   </li>
 </ul>
 `;

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.js
@@ -21,7 +21,7 @@ describe( 'BlockBreadcrumb', () => {
 
 			const rootLabelTextDefault = screen.getByText( 'Document' );
 
-			expect( rootLabelTextDefault ).toBeDefined();
+			expect( rootLabelTextDefault ).toBeInTheDocument();
 		} );
 
 		test( 'should display `rootLabelText` value', () => {
@@ -31,7 +31,7 @@ describe( 'BlockBreadcrumb', () => {
 			const rootLabelTextDefault = screen.queryByText( 'Document' );
 
 			expect( rootLabelTextDefault ).toBeNull();
-			expect( rootLabelText ).toBeDefined();
+			expect( rootLabelText ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -9,13 +9,29 @@ import { shallow } from 'enzyme';
 import BlockBreadcrumb from '../';
 
 describe( 'BlockBreadcrumb', () => {
-	test( 'should match snapshot', () => {
-		const wrapper = shallow( <BlockBreadcrumb /> );
-		expect( wrapper ).toMatchSnapshot();
+	it( 'should render correctly', () => {
+		const { container } = render( <BlockBreadcrumb /> );
+
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
-	test( 'should match snapshot with root label', () => {
-		const wrapper = shallow( <BlockBreadcrumb rootLabelText="Tuhinga" /> );
-		expect( wrapper ).toMatchSnapshot();
+	describe( 'Root label text', () => {
+		test( 'should display default label of "Document"', () => {
+			render( <BlockBreadcrumb /> );
+
+			const rootLabelTextDefault = screen.getByText( 'Document' );
+
+			expect( rootLabelTextDefault ).toBeDefined();
+		} );
+
+		test( 'should display `rootLabelText` value', () => {
+			render( <BlockBreadcrumb rootLabelText="Tuhinga" /> );
+
+			const rootLabelText = screen.getByText( 'Tuhinga' );
+			const rootLabelTextDefault = screen.queryByText( 'Document' );
+
+			expect( rootLabelTextDefault ).toBeNull();
+			expect( rootLabelText ).toBeDefined();
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import BlockBreadcrumb from '../';
+
+describe( 'BlockBreadcrumb', () => {
+	test( 'should match snapshot', () => {
+		const wrapper = shallow( <BlockBreadcrumb /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should match snapshot with root label', () => {
+		const wrapper = shallow( <BlockBreadcrumb rootLabelText="Tuhinga" /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
Hi!

This PR adds a `rootLabelText` prop to `<BlockBreadcrumb />` so that we can have flexibility to change the label, or just provide a more appropriate label for the "root" element in different editor contexts, for example the Widgets editor root level could be "Widgets". 

See https://github.com/WordPress/gutenberg/pull/32498 for context.

One day we might like to replace "Document" in the Site Editor with the name of the the site template for example.

## How has this been tested?
Manually.

Apply the following patch to this branch. It adds the Breadcrumb block to the widgets editor.

<details>
  <summary>Click to see the patch code</summary>
  
```diff

diff --git a/packages/edit-widgets/src/components/layout/interface.js b/packages/edit-widgets/src/components/layout/interface.js
index 22320cac6b..cf69328dd4 100644
--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -7,7 +7,10 @@ import {
 	useViewportMatch,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
-import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import {
+	__experimentalLibrary as Library,
+	BlockBreadcrumb,
+} from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -32,6 +35,8 @@ const interfaceLabels = {
 	body: __( 'Widgets and blocks' ),
 	/* translators: accessibility text for the widgets screen settings landmark region. */
 	sidebar: __( 'Widgets settings' ),
+	/* translators: accessibility text for the widgets screen footer landmark region. */
+	footer: __( 'Widgets footer' ),
 };
 
 function Interface( { blockEditorSettings } ) {
@@ -107,6 +112,13 @@ function Interface( { blockEditorSettings } ) {
 					blockEditorSettings={ blockEditorSettings }
 				/>
 			}
+			footer={
+				! isMobileViewport && (
+					<div className="edit-widgets-layout__footer">
+						<BlockBreadcrumb rootLabelText={ __( 'Widgets' ) } />
+					</div>
+				)
+			}
 		/>
 	);
 }

```
</details>



Head over to /wp-admin/themes.php?page=gutenberg-widgets

Check that the breadcrumbs block appears in the footer when you select a block in the widget editor, and that the root element label is "Widgets".

<img width="698" alt="Screen Shot 2021-06-09 at 11 34 23 am" src="https://user-images.githubusercontent.com/6458278/121279255-a2576780-c917-11eb-9e4d-f4411495be09.png">

Go to the Editor and Site Editor and make sure the default is "Document".


<img width="398" alt="Screen Shot 2021-06-09 at 11 31 52 am" src="https://user-images.githubusercontent.com/6458278/121279252-a08da400-c917-11eb-989a-bf3bf90ace2f.png">





## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->

