### PR TITLE
Fix abort error thrown by `api-fetch` and add documentation

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New feature
+
+-   `AbortError` being thrown by the default fetch handler can now be caught and handled separately in user-land. Add documentation about aborting a request ([#32530](https://github.com/WordPress/gutenberg/pull/32530)).
+
 ## 5.1.0 (2021-05-20)
 
 ## 5.0.0 (2021-05-14)

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -54,6 +54,29 @@ Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the par
 
 Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
 
+### Aborting a request
+
+Aborting a request can be done by using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) as the same as in `fetch`. For legacy browsers that don't support `AbortController`, you should provide your own polyfill of `AbortController` if you still want it to be abort-able, or simply ignore it as shown in the example below.
+
+**Example**
+
+```js
+const controller = typeof AbortController === 'undefined'
+	? undefined
+	: new AbortController();
+
+apiFetch( { path: '/wp/v2/posts', signal: controller?.signal } )
+	.catch( ( error ) => {
+		// If the browser doesn't support AbortController then it will never log.
+		// It should be fine in most cases when it's considered to be a progressive improvement.
+		if (error.name === 'AbortError') {
+			console.log( 'Request has been aborted' );
+		}
+	} );
+
+controller?.abort();
+```
+
 ### Middlewares
 
 the `api-fetch` package supports middlewares. Middlewares are functions you can use to wrap the `apiFetch` calls to perform any pre/post process to the API requests.

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -69,7 +69,7 @@ apiFetch( { path: '/wp/v2/posts', signal: controller?.signal } )
 	.catch( ( error ) => {
 		// If the browser doesn't support AbortController then it will never log.
 		// It should be fine in most cases when it's considered to be a progressive improvement.
-		if (error.name === 'AbortError') {
+		if ( error.name === 'AbortError' ) {
 			console.log( 'Request has been aborted' );
 		}
 	} );

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -56,7 +56,12 @@ Shorthand to be used in place of `body`, accepts an object value to be stringifi
 
 ### Aborting a request
 
-Aborting a request can be done by using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) as the same as in `fetch`. For legacy browsers that don't support `AbortController`, you should provide your own polyfill of `AbortController` if you still want it to be abort-able, or simply ignore it as shown in the example below.
+Aborting a request can be achieved through the use of [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) in the same way as you would when using the native `fetch` API. 
+
+For legacy browsers that don't support `AbortController`, you can either:
+
+* Provide your own polyfill of `AbortController` if you still want it to be abortable. 
+* Ignore it as shown in the example below.
 
 **Example**
 
@@ -67,8 +72,8 @@ const controller = typeof AbortController === 'undefined'
 
 apiFetch( { path: '/wp/v2/posts', signal: controller?.signal } )
 	.catch( ( error ) => {
-		// If the browser doesn't support AbortController then it will never log.
-		// It should be fine in most cases when it's considered to be a progressive improvement.
+		// If the browser doesn't support AbortController then the code below will never log.
+		// However, in most cases this should be fine as it can be considered to be a progressive enhancement.
 		if ( error.name === 'AbortError' ) {
 			console.log( 'Request has been aborted' );
 		}

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -109,28 +109,28 @@ const defaultFetchHandler = ( nextOptions ) => {
 		}
 	);
 
-	return (
-		responsePromise
-			// Return early if fetch errors. If fetch error, there is most likely no
-			// network connection. Unfortunately fetch just throws a TypeError and
-			// the message might depend on the browser.
-			.then(
-				( value ) =>
-					Promise.resolve( value )
-						.then( checkStatus )
-						.catch( ( response ) =>
-							parseAndThrowError( response, parse )
-						)
-						.then( ( response ) =>
-							parseResponseAndNormalizeError( response, parse )
-						),
-				() => {
-					throw {
-						code: 'fetch_error',
-						message: __( 'You are probably offline.' ),
-					};
-				}
-			)
+	return responsePromise.then(
+		( value ) =>
+			Promise.resolve( value )
+				.then( checkStatus )
+				.catch( ( response ) => parseAndThrowError( response, parse ) )
+				.then( ( response ) =>
+					parseResponseAndNormalizeError( response, parse )
+				),
+		( err ) => {
+			// Return early if fetch throws a TypeError, there is most likely no network connection.
+			// Unfortunately the message might depend on the browser.
+			if ( err instanceof TypeError ) {
+				throw {
+					code: 'fetch_error',
+					message: __( 'You are probably offline.' ),
+				};
+			}
+
+			// Otherwise, it could be an AbortError.
+			// Simply re-throw it to let the user handle it.
+			throw err;
+		}
 	);
 };
 

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -118,18 +118,17 @@ const defaultFetchHandler = ( nextOptions ) => {
 					parseResponseAndNormalizeError( response, parse )
 				),
 		( err ) => {
-			// Return early if fetch throws a TypeError, there is most likely no network connection.
-			// Unfortunately the message might depend on the browser.
-			if ( err instanceof TypeError ) {
-				throw {
-					code: 'fetch_error',
-					message: __( 'You are probably offline.' ),
-				};
+			// Re-throw AbortError for the users to handle it themselves.
+			if ( err && err.name === 'AbortError' ) {
+				throw err;
 			}
 
-			// Otherwise, it could be an AbortError.
-			// Simply re-throw it to let the user handle it.
-			throw err;
+			// Otherwise, there is most likely no network connection.
+			// Unfortunately the message might depend on the browser.
+			throw {
+				code: 'fetch_error',
+				message: __( 'You are probably offline.' ),
+			};
 		}
 	);
 };

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -168,7 +168,7 @@ describe( 'apiFetch', () => {
 	} );
 
 	it( 'should return offline error when fetch errors', () => {
-		window.fetch.mockReturnValue( Promise.reject( new TypeError() ) );
+		window.fetch.mockReturnValue( Promise.reject() );
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
 			expect( body ).toEqual( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Idea coming from #31464.

If a request is being canceled by a `AbortController`, then the error will be a DOMException error with the name of `AbortError`. It's specced and well-supported in modern browsers. Instead of swallowing it in `defaultFetchHandler`, we want to just forward it to user-land and let the user handles it.

Documentation is also added to encourage the use of `AbortController` for better UX.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added unit test.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

However, we could also consider it as a bug though.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
