### PR TITLE
Remove unused select block function

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -7,7 +7,7 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -77,7 +77,6 @@ export default function useMultiSelection() {
 		hasMultiSelection,
 		selectedBlockClientId,
 	} = useSelect( selector, [] );
-	const { selectBlock } = useDispatch( blockEditorStore );
 	const selectedRef = useBlockRef( selectedBlockClientId );
 	// These must be in the right DOM order.
 	const startRef = useBlockRef( first( multiSelectedBlockClientIds ) );
@@ -149,7 +148,6 @@ export default function useMultiSelection() {
 		hasMultiSelection,
 		isMultiSelecting,
 		multiSelectedBlockClientIds,
-		selectBlock,
 		selectedBlockClientId,
 	] );
 


### PR DESCRIPTION
## Description
Really minor PR that removes an unused action dispatch function. Linting didn't catch it as it was declared as a hook dependency, and there's no linting that catches unused dependencies either.