### PR TITLE
Try: Separate safari fix.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -62,6 +62,9 @@
 
 	// Gradients
 	@include gradient-colors();
+
+	// Safari flickering fix.
+	transform: translateZ(0);
 }
 
 // Font sizes.

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -63,4 +63,9 @@
 	width: 100%;
 	height: 100%;
 	position: relative;
+
+	// Safari flickering fix.
+	> div {
+		transform: translateZ(0);
+	}
 }


### PR DESCRIPTION
## Description

When using an old WordPress theme that doesn't provide an editor style, in Safari, there can be some background flickering. Here's Independent Publisher 2:

![test](https://user-images.githubusercontent.com/1204802/121326761-22c79980-c913-11eb-9da5-e5e2676e0d87.gif)

This fix, which I don't love, fixes it:

![attempt](https://user-images.githubusercontent.com/1204802/121326782-26f3b700-c913-11eb-8561-a3d99b107cd0.gif)

I don't love the fix because:

- Transforms change the rendering onto the GPU, part of the fix, but there are usually overflow-related side effects.
- It isn't clear when this regression initially happend. We've been looking separately at Safari related issues in #32188, which were also fixed by rendering on the GPU. 
- The original issue was reported [here](https://github.com/Automattic/wp-calypso/issues/53401), but I haven't been able to reproduce the precise issue, so I'm not even sure this is a fix. 

## How has this been tested?

Use an old theme, use Safari, and use a lot of content on the page, then scroll quickly.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
