### PR TITLE
Add Unlink button to LinkControl popover

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -127,6 +127,14 @@ This `suggestion` will then be _automatically_ passed to the `onChange` handler 
 
 As a result of the above, this prop is often used to allow on the fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on the fly from within the Block itself.
 
+### onRemove
+
+-   Type: `Function`
+-   Required: No
+-   Default: null
+
+An optional handler, which when passed will trigger the display of an `Unlink` UI within the control. This handler is expected to remove the current `value` of the control thus resetting it back to a default state. The key use case for this is allowing users to remove a link from the control without relying on there being an "unlink" control in the block toolbar.
+
 #### Search `suggestion` values
 
 A `suggestion` should have the following shape:

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -260,11 +260,25 @@ function LinkControl( {
 				/>
 			) }
 
-			<LinkControlSettingsDrawer
-				value={ value }
-				settings={ settings }
-				onChange={ onChange }
-			/>
+			<div className="block-editor-link-control__tools">
+				<LinkControlSettingsDrawer
+					value={ value }
+					settings={ settings }
+					onChange={ onChange }
+				/>
+				{ value && ! isEditingLink && ! isCreatingPage && (
+					<Button
+						className="block-editor-link-control__unlink"
+						isDestructive
+						variant="link"
+						onClick={ () => {
+							onChange( null );
+						} }
+					>
+						{ __( 'Unlink' ) }
+					</Button>
+				) }
+			</div>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, isFunction } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -267,20 +267,16 @@ function LinkControl( {
 					settings={ settings }
 					onChange={ onChange }
 				/>
-				{ onRemove &&
-					isFunction( onRemove ) &&
-					value &&
-					! isEditingLink &&
-					! isCreatingPage && (
-						<Button
-							className="block-editor-link-control__unlink"
-							isDestructive
-							variant="link"
-							onClick={ onRemove }
-						>
-							{ __( 'Unlink' ) }
-						</Button>
-					) }
+				{ onRemove && value && ! isEditingLink && ! isCreatingPage && (
+					<Button
+						className="block-editor-link-control__unlink"
+						isDestructive
+						variant="link"
+						onClick={ onRemove }
+					>
+						{ __( 'Unlink' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { noop, isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -106,6 +106,7 @@ function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
+	onRemove,
 	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
@@ -266,18 +267,20 @@ function LinkControl( {
 					settings={ settings }
 					onChange={ onChange }
 				/>
-				{ value && ! isEditingLink && ! isCreatingPage && (
-					<Button
-						className="block-editor-link-control__unlink"
-						isDestructive
-						variant="link"
-						onClick={ () => {
-							onChange( null );
-						} }
-					>
-						{ __( 'Unlink' ) }
-					</Button>
-				) }
+				{ onRemove &&
+					isFunction( onRemove ) &&
+					value &&
+					! isEditingLink &&
+					! isCreatingPage && (
+						<Button
+							className="block-editor-link-control__unlink"
+							isDestructive
+							variant="link"
+							onClick={ onRemove }
+						>
+							{ __( 'Unlink' ) }
+						</Button>
+					) }
 			</div>
 		</div>
 	);

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -380,10 +380,23 @@ $preview-image-height: 140px;
 	padding: 10px;
 }
 
-.block-editor-link-control__settings {
+.block-editor-link-control__tools {
+	display: flex;
+	align-items: center;
 	border-top: $border-width solid $gray-300;
 	margin: 0;
 	padding: $grid-unit-20 $grid-unit-30;
+}
+
+.block-editor-link-control__unlink {
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
+}
+
+.block-editor-link-control__settings {
+	flex: 1;
+	margin: 0;
+
 
 	:last-child {
 		margin-bottom: 0;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -227,6 +227,43 @@ describe( 'Basic rendering', () => {
 			expect( isEditing() ).toBe( false );
 		} );
 	} );
+
+	describe( 'Unlinking', () => {
+		it( 'should not show "Unlink" button if no onRemove handler is provided', () => {
+			act( () => {
+				render(
+					<LinkControl value={ { url: 'https://example.com' } } />,
+					container
+				);
+			} );
+
+			const unLinkButton = queryByText( container, 'Unlink' );
+
+			expect( unLinkButton ).toBeNull();
+		} );
+
+		it( 'should show "Unlink" button if a onRemove handler is provided', () => {
+			const mockOnRemove = jest.fn();
+			act( () => {
+				render(
+					<LinkControl
+						value={ { url: 'https://example.com' } }
+						onRemove={ mockOnRemove }
+					/>,
+					container
+				);
+			} );
+
+			const unLinkButton = queryByText( container, 'Unlink' );
+			expect( unLinkButton ).toBeTruthy();
+
+			act( () => {
+				Simulate.click( unLinkButton );
+			} );
+
+			expect( mockOnRemove ).toHaveBeenCalled();
+		} );
+	} );
 } );
 
 describe( 'Searching for a link', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -237,9 +237,12 @@ describe( 'Basic rendering', () => {
 				);
 			} );
 
-			const unLinkButton = queryByText( container, 'Unlink' );
+			const unLinkButton = queryByRole( container, 'button', {
+				name: 'Unlink',
+			} );
 
 			expect( unLinkButton ).toBeNull();
+			expect( unLinkButton ).not.toBeInTheDocument();
 		} );
 
 		it( 'should show "Unlink" button if a onRemove handler is provided', () => {
@@ -254,8 +257,11 @@ describe( 'Basic rendering', () => {
 				);
 			} );
 
-			const unLinkButton = queryByText( container, 'Unlink' );
+			const unLinkButton = queryByRole( container, 'button', {
+				name: 'Unlink',
+			} );
 			expect( unLinkButton ).toBeTruthy();
+			expect( unLinkButton ).toBeInTheDocument();
 
 			act( () => {
 				Simulate.click( unLinkButton );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -11,6 +11,7 @@ import {
 	isCollapsed,
 	applyFormat,
 	useAnchorRef,
+	removeFormat,
 } from '@wordpress/rich-text';
 import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
 
@@ -49,6 +50,15 @@ function InlineLinkUI( {
 	};
 
 	function onChangeLink( nextValue ) {
+		// null values trigger removal of link format.
+		if ( null === nextValue ) {
+			const newValue = removeFormat( value, 'core/link' );
+			onChange( newValue );
+			stopAddingLink();
+			speak( __( 'Link removed.' ), 'assertive' );
+			return;
+		}
+
 		// Merge with values from state, both for the purpose of assigning the
 		// next state value, and for use in constructing the new link format if
 		// the link is ready to be applied.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -57,10 +57,6 @@ function InlineLinkUI( {
 	}
 
 	function onChangeLink( nextValue ) {
-		if ( null === nextValue ) {
-			return removeLink();
-		}
-
 		// Merge with values from state, both for the purpose of assigning the
 		// next state value, and for use in constructing the new link format if
 		// the link is ready to be applied.

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -49,14 +49,16 @@ function InlineLinkUI( {
 		...nextLinkValue,
 	};
 
+	function removeLink() {
+		const newValue = removeFormat( value, 'core/link' );
+		onChange( newValue );
+		stopAddingLink();
+		speak( __( 'Link removed.' ), 'assertive' );
+	}
+
 	function onChangeLink( nextValue ) {
-		// null values trigger removal of link format.
 		if ( null === nextValue ) {
-			const newValue = removeFormat( value, 'core/link' );
-			onChange( newValue );
-			stopAddingLink();
-			speak( __( 'Link removed.' ), 'assertive' );
-			return;
+			return removeLink();
 		}
 
 		// Merge with values from state, both for the purpose of assigning the
@@ -149,6 +151,7 @@ function InlineLinkUI( {
 			<LinkControl
 				value={ linkValue }
 				onChange={ onChangeLink }
+				onRemove={ removeLink }
 				forceIsEditingLink={ addingLink }
 				hasRichPreviews
 			/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/31464 we discovered that the rich preview can _occasionally_ obscure the `Unlink` item in the block toolbar.

As `<Popover>` is not aware of the block toolbar, @javierarce suggested adding an `Unlink` button to the `<LinkControl>` UI would be a good compromise. 

Here is the design for the unlink UI provided by @javierarce which is PR implements:

![image](https://user-images.githubusercontent.com/4933/121180537-40d4c180-c861-11eb-975e-7359470513e9.png)

This PR ~is a WIP which~ implements that. For reasons of backwards compatibility it does this via the introduction of a new `onRemove` property which when passed will:

1. Cause the `Unlink` button to be shown in the `<LinkControl>`'s UI.
2. Be called whenever the `Unlink` button is clicked.

As the consumer of `<LinkControl>` must ensure that the handler passed as `onRemove` will remove the current `value` of `<LinkControl>` we have made the `onRemove` prop opt-in in order that other uses of `<LinkControl>` both within and outside of Core will not be effected.

However, this PR does add this `Unlink` behaviour for the format library implementation which means that paragraph and rich text will receive this functionality by default.

In addition, the default `onChange` handler for the format library has been updated so that when it is called with `null` it treats this as a signal to remove the link.

## We need to consider:

- [x] Adding the Unlink button
- [x] Wiring up the button so it is handled in the `@wordpress/format-library` where it consumes `<LinkControl>` to ensure it actually works.
- [x] Consider backwards compatibility - most consumers of `<LinkControl>` will not expect  `null` as the value of `<LinkControl>` and thus we may need to make this an opt in feature or fix all the instances in Core we're in control of. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Create a new post and add some text in the paragraph block.
* Add a link to a piece of text.
* Click away from the link to close the Link UI.
* Click on the link again to activate the Link UI preview.
* You should see a `Unlink` button in the bottom corner of the UI.
* Try this with various types of links - ie: internal/external...etc.

Now check it doesn't appear in other uses of `<LinkControl>` within Core. For example the Nav block.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/123783879-c252c900-d8ce-11eb-9f58-076a65a8b7d0.mov


## Types of changes
Non breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->


