### PR TITLE
Try: Alternate spacer min-height fix.

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -4,9 +4,15 @@
 		content: "";
 		display: block;
 		position: absolute;
-		width: 100%;
-		height: $grid-unit-10;
 		z-index: 1;
+
+		// Horizontal spacer: span the full width, and provide a min-height for when it's 1px tall.
+		width: 100%;
+		min-height: $grid-unit-10;
+
+		// Vertical spacer: span the height width, and provide a min-width for when it's 1px wide.
+		min-width: $grid-unit-10;
+		height: 100%;
 	}
 }
 

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -5,8 +5,8 @@
 		display: block;
 		position: absolute;
 		width: 100%;
-		height: $button-size-small;
-		transform: translateY(-#{$button-size-small / 2});
+		height: $grid-unit-10;
+		z-index: 1;
 	}
 }
 


### PR DESCRIPTION
## Description

In #25528, I added a small overlay on the Spacer block giving it a min-height so that it's selectable even if it's only 1px tall. This was built in context of every single block in the editing canvas having a top and bottom margin, always.

Block themes do not have this margin anymore, relying instead only on margins that the theme provides. In that context, this extra tap-overlay is now conflicting with selecting blocks, shown here in red:

![before](https://user-images.githubusercontent.com/1204802/121342988-83aa9e00-c922-11eb-8715-5eac24e5a503.gif)

This PR does two things:

1. It makes that tappable min-height overlay way smaller, 8px tall. If you're using a spacer block, most of the time, I would expect, you do it to add space. So a >8px tall spacer I would count among the edgecases we shouldn't optimize for. 8px makes it selectable in the canvas, with minimum cost to adjacent blocks.
2. It makes this min-height go _downwards_ rather than _upwards_. That means it does still cover 7px of the _next_ block, if the block is 1px tall. The benefit of pointing downwards means the extra space only comes into play when the Spacer is less than 8px tall, whereas before when it covered upwards even when the block was plenty tappable and tall.

![after](https://user-images.githubusercontent.com/1204802/121343444-f7e54180-c922-11eb-8dc9-38e9bed0934b.gif)

## How has this been tested?

1. Use a block theme, such as [Empty Theme](https://github.com/Automattic/block-experiments).
2. Insert a navigation block (which doesn't come with a built-in margin) and a spacer block.
3. Select the navigation block, it should be easy to select.
4. Now insert a 1px tall spacer block. It might be hard to select those 8px, but it's there as a minimum.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
