### PR TITLE
Workflows: Allow point releases after a new RC is out

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -32,8 +32,8 @@ jobs:
                     -H "Accept: application/vnd.github.v3+json" \
                     -o latest.json \
                     "https://api.github.com/repos/${{ github.repository }}/releases/latest"
-                  LATEST_STABLE_VERSION=$(jq --raw-output '.name' latest.json)
-                  IFS='.' read LATEST_STABLE_MAJOR LATEST_STABLE_MINOR LATEST_STABLE_PATCH <<< "$LATEST_STABLE_VERSION"
+                  LATEST_STABLE_TAG=$(jq --raw-output '.tag_name' latest.json)
+                  IFS='.' read LATEST_STABLE_MAJOR LATEST_STABLE_MINOR LATEST_STABLE_PATCH <<< "${LATEST_STABLE_TAG#v}"
                   echo "::set-output name=current_stable_branch::release/${LATEST_STABLE_MAJOR}.${LATEST_STABLE_MINOR}"
                   if [[ ${LATEST_STABLE_MINOR} == "9" ]]; then
                     echo "::set-output name=next_stable_branch::release/$((LATEST_STABLE_MAJOR + 1)).0"

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -145,7 +145,12 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: always()
+        if: |
+            always() && (
+              github.event_name == 'pull_request' ||
+              github.event_name == 'workflow_dispatch' ||
+              github.repository == 'WordPress/gutenberg'
+            )
 
         steps:
             - name: Checkout code

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -145,12 +145,7 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: |
-            always() && (
-              github.event_name == 'pull_request' ||
-              github.event_name == 'workflow_dispatch' ||
-              github.repository == 'WordPress/gutenberg'
-            )
+        if: always()
 
         steps:
             - name: Checkout code

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -18,17 +18,46 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    compute-stable-branches:
+        name: Compute current and next stable release branches
+        runs-on: ubuntu-latest
+        outputs:
+            current_stable_branch: ${{ steps.get_branches.outputs.current_stable_branch }}
+            next_stable_branch: ${{ steps.get_branches.outputs.next_stable_branch }}
+        steps:
+            - name: Get current and next stable release branches
+              id: get_branches
+              run: |
+                  curl \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -o latest.json \
+                    "https://api.github.com/repos/${{ github.repository }}/releases/latest"
+                  LATEST_STABLE_VERSION=$(jq --raw-output '.name' latest.json)
+                  IFS='.' read LATEST_STABLE_MAJOR LATEST_STABLE_MINOR LATEST_STABLE_PATCH <<< "$LATEST_STABLE_VERSION"
+                  echo "::set-output name=current_stable_branch::release/${LATEST_STABLE_MAJOR}.${LATEST_STABLE_MINOR}"
+                  if [[ ${LATEST_STABLE_MINOR} == "9" ]]; then
+                    echo "::set-output name=next_stable_branch::release/$((LATEST_STABLE_MAJOR + 1)).0"
+                  else
+                    echo "::set-output name=next_stable_branch::release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))"
+                  fi
+
     bump-version:
         name: Bump version
         runs-on: ubuntu-latest
+        needs: compute-stable-branches
         if: |
             github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'workflow_dispatch' && (
-              github.ref == 'refs/heads/trunk' ||
-              startsWith( github.ref, 'refs/heads/release/' )
-            ) && (
-              github.event.inputs.version == 'rc' ||
-              github.event.inputs.version == 'stable'
+              (
+                github.ref == 'refs/heads/trunk' ||
+                endsWith( github.ref, needs.compute-stable-branches.outputs.next_stable_branch )
+              ) && (
+                github.event.inputs.version == 'rc' ||
+                github.event.inputs.version == 'stable'
+              ) || (
+                endsWith( github.ref, needs.compute-stable-branches.outputs.current_stable_branch ) &&
+                github.event.inputs.version == 'stable'
+              )
             )
         outputs:
             old_version: ${{ steps.get_version.outputs.old_version }}

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -46,6 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: compute-stable-branches
         if: |
+            github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'workflow_dispatch' && (
               (
                 github.ref == 'refs/heads/trunk' ||
@@ -145,7 +146,7 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: always()
+        if: ${{ ( github.repository == 'WordPress/gutenberg' && always() ) || ( github.event_name == 'pull_request' && always() ) }}
 
         steps:
             - name: Checkout code
@@ -203,6 +204,7 @@ jobs:
         name: Create Release Draft and Attach Asset
         needs: [bump-version, build]
         runs-on: ubuntu-latest
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
 
         steps:
             - name: Set Release Version

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -46,7 +46,6 @@ jobs:
         runs-on: ubuntu-latest
         needs: compute-stable-branches
         if: |
-            github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'workflow_dispatch' && (
               (
                 github.ref == 'refs/heads/trunk' ||
@@ -142,7 +141,7 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: ${{ ( github.repository == 'WordPress/gutenberg' && always() ) || ( github.event_name == 'pull_request' && always() ) }}
+        if: always()
 
         steps:
             - name: Checkout code
@@ -200,7 +199,6 @@ jobs:
         name: Create Release Draft and Attach Asset
         needs: [bump-version, build]
         runs-on: ubuntu-latest
-        if: ${{ github.repository == 'WordPress/gutenberg' }}
 
         steps:
             - name: Set Release Version

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -23,8 +23,10 @@ jobs:
         runs-on: ubuntu-latest
         if: |
             github.repository == 'WordPress/gutenberg' &&
-            github.event_name == 'workflow_dispatch' &&
-            github.ref == 'refs/heads/trunk' && (
+            github.event_name == 'workflow_dispatch' && (
+              github.ref == 'refs/heads/trunk' ||
+              startsWith( github.ref, 'refs/heads/release/' )
+            ) && (
               github.event.inputs.version == 'rc' ||
               github.event.inputs.version == 'stable'
             )

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -91,13 +91,13 @@ jobs:
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" gutenberg.php
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" readme.txt
 
-            - name: Commit the version bump
+            - name: Commit the version bump to the release branch
               run: |
                   git add gutenberg.php package.json package-lock.json readme.txt
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
 
-            - name: Cherry-pick to trunk
+            - name: Cherry-pick the version bump commit to trunk
               run: |
                   git checkout trunk
                   git pull

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -127,6 +127,10 @@ jobs:
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
 
+            - name: Fetch trunk
+              if: ${{ github.ref != 'refs/heads/trunk' }}
+              run: git fetch --depth=1 origin trunk
+
             - name: Cherry-pick the version bump commit to trunk
               run: |
                   git checkout trunk


### PR DESCRIPTION
## Description
Our plugin release workflow currently allows publishing point releases only for the current version range. However, we've recently faced a situation where we had to publish a point release for a series (10.7.x) after the release candidate for the next series had already been published (10.8.0-rc.1). Since our automated workflow didn't allow for that, we had to take care of the plugin build manually 😕 

This PR aims to allow publishing point releases for older version ranges, by selecting the relevant branch from the `workflow_dispatch` trigger dropdown.

It's fairly straightforward to cover the scenario described above, so for starters, this PR will only allow that. Allowing publishing of point releases even later (after a new _stable_ release has been published) will require more work (mostly on the SVN side of things -- probably will need the concept of SVN release branches, in order to keep SVN history intact).

## Screenshots

![image](https://user-images.githubusercontent.com/96308/121400511-fa15c300-c957-11eb-8d64-04c3c2f43c9b.png)

## How has this been tested?

On my fork: https://github.com/ockham/gutenberg/actions/runs/950100605

I've used this to create a [`10.8.1` point release](https://github.com/ockham/gutenberg/releases/tag/v10.8.1) after `10.9.0-rc.1` had already been created. Note that the [version bump commit](https://github.com/ockham/gutenberg/commit/dd6c0db1ef72798540eaf03d676caa38444d1ace) was only[ pushed to the `release/10.8` branch](https://github.com/ockham/gutenberg/blob/release/10.8/package.json#L3), [but not `trunk`](https://github.com/ockham/gutenberg/blob/trunk/package.json#L3).

Conversely, when attempting to publish an RC on an already-stable branch (`release/10.8`), the version bump and release draft creation jobs aren't run: https://github.com/ockham/gutenberg/actions/runs/950185263

## Types of changes
Releases tooling.