### PR TITLE
Correct the format used for duplicate hook docs

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -42,7 +42,7 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
  */
 function render_block_core_latest_comments( $attributes = array() ) {
 	$comments = get_comments(
-		// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
 		apply_filters(
 			'widget_comments_args',
 			array(


### PR DESCRIPTION
## Description

This fixes the format used for a duplicate hook doc.

This should use a block-level comment instead of an inline comment. The inline comment format causes WP Parser to see the hook as undocumented.

## How has this been tested?

I confirmed that [WP Parser Lib](https://github.com/johnbillion/wp-parser-lib) no longer treats this as an undocumented hook.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
