### PR TITLE
[RNMobile] Make react-native-aztec publicly available

### DIFF
--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -2,7 +2,6 @@
 	"name": "@wordpress/react-native-aztec",
 	"version": "1.54.0",
 	"description": "Aztec view for react-native.",
-	"private": true,
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,15 +1,19 @@
 {
 	"name": "@wordpress/react-native-aztec",
 	"version": "1.54.0",
-	"description": "Aztec view for react-native.",
+	"description": "Aztec Native HTML editor view for React Native.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"react-native"
+    "rich-text",
+    "editor",
+		"react-native",
+    "ios",
+    "android"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-aztec/README.md",
-	"repository": {
+	"repository": { 
 		"type": "git",
 		"url": "https://github.com/WordPress/gutenberg.git",
 		"directory": "packages/react-native-aztec"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This updates the `@wordpress/react-native-aztec` package so that it is publicly available on NPM.

## How has this been tested?
NA

## Screenshots <!-- if applicable -->

## Types of changes


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
