### PR TITLE
Performance: Remove `is-typing` root class

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,12 +15,7 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import {
-	withDispatch,
-	withSelect,
-	useDispatch,
-	useSelect,
-} from '@wordpress/data';
+import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
@@ -87,15 +82,6 @@ function BlockListBlock( {
 } ) {
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
-
-	const removeBlockOutline = useSelect(
-		( select ) => {
-			const { isTyping, getSettings } = select( blockEditorStore );
-			const isOutlineMode = getSettings().outlineMode;
-			return isOutlineMode && isSelected && isTyping();
-		},
-		[ clientId, isSelected ]
-	);
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -173,9 +159,7 @@ function BlockListBlock( {
 
 	const value = {
 		clientId,
-		className: removeBlockOutline
-			? classnames( className, 'remove-outline' )
-			: className,
+		className,
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 		isAligned,
 	};

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,7 +15,12 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
+import {
+	withDispatch,
+	withSelect,
+	useDispatch,
+	useSelect,
+} from '@wordpress/data';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
@@ -82,6 +87,15 @@ function BlockListBlock( {
 } ) {
 	const { removeBlock } = useDispatch( blockEditorStore );
 	const onRemove = useCallback( () => removeBlock( clientId ), [ clientId ] );
+
+	const removeBlockOutline = useSelect(
+		( select ) => {
+			const { isTyping, getSettings } = select( blockEditorStore );
+			const isOutlineMode = getSettings().outlineMode;
+			return isOutlineMode && isSelected && isTyping();
+		},
+		[ clientId, isSelected ]
+	);
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -159,7 +173,9 @@ function BlockListBlock( {
 
 	const value = {
 		clientId,
-		className,
+		className: removeBlockOutline
+			? classnames( className, 'remove-outline' )
+			: className,
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 		isAligned,
 	};

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -27,25 +27,20 @@ export const IntersectionObserver = createContext();
 
 function Root( { className, children } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const {
-		isTyping,
-		isOutlineMode,
-		isFocusMode,
-		isNavigationMode,
-	} = useSelect( ( select ) => {
-		const {
-			isTyping: _isTyping,
-			getSettings,
-			isNavigationMode: _isNavigationMode,
-		} = select( blockEditorStore );
-		const { outlineMode, focusMode } = getSettings();
-		return {
-			isTyping: _isTyping(),
-			isOutlineMode: outlineMode,
-			isFocusMode: focusMode,
-			isNavigationMode: _isNavigationMode(),
-		};
-	}, [] );
+	const { isOutlineMode, isFocusMode, isNavigationMode } = useSelect(
+		( select ) => {
+			const { getSettings, isNavigationMode: _isNavigationMode } = select(
+				blockEditorStore
+			);
+			const { outlineMode, focusMode } = getSettings();
+			return {
+				isOutlineMode: outlineMode,
+				isFocusMode: focusMode,
+				isNavigationMode: _isNavigationMode(),
+			};
+		},
+		[]
+	);
 	return (
 		<div
 			ref={ useMergeRefs( [
@@ -57,7 +52,6 @@ function Root( { className, children } ) {
 				'block-editor-block-list__layout is-root-container',
 				className,
 				{
-					'is-typing': isTyping,
 					'is-outline-mode': isOutlineMode,
 					'is-focus-mode': isFocusMode && isLargeViewport,
 					'is-navigate-mode': isNavigationMode,

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -261,7 +261,7 @@
 	}
 }
 
-.is-outline-mode:not(.is-typing) .block-editor-block-list__block {
+.is-outline-mode .block-editor-block-list__block:not(:focus-within) {
 	&.is-hovered {
 		cursor: default;
 
@@ -285,12 +285,6 @@
 			right: $border-width;
 			bottom: $border-width;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-		}
-
-		&:focus {
-			&::after {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -261,7 +261,7 @@
 	}
 }
 
-.is-outline-mode .block-editor-block-list__block:not(:focus-within) {
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
 	&.is-hovered {
 		cursor: default;
 
@@ -285,6 +285,12 @@
 			right: $border-width;
 			bottom: $border-width;
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+		}
+
+		&:focus {
+			&::after {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -32,10 +32,12 @@ export function useBlockClassNames( clientId ) {
 				getBlockName,
 				getSettings,
 				hasSelectedInnerBlock,
+				isTyping,
 				__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
 			} = select( blockEditorStore );
 			const {
 				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
+				outlineMode,
 			} = getSettings();
 			const isDragging = isBlockBeingDragged( clientId );
 			const isSelected = isBlockSelected( clientId );
@@ -59,6 +61,7 @@ export function useBlockClassNames( clientId ) {
 				'has-active-entity': activeEntityBlockId,
 				// Determine if there is an active entity area to spotlight.
 				'is-active-entity': activeEntityBlockId === clientId,
+				'remove-outline': isSelected && outlineMode && isTyping(),
 			} );
 		},
 		[ clientId ]


### PR DESCRIPTION
When we start typing in a block, the `is-typing` class is added to the root element. Doing so triggers a re-render of all children, even if child props do not change. This is a PR to see what performance impact this has if we do not update the class on the root element. 

I re-ran the performance job multiple times, each showing around a 100ms difference for maxType. (Click into the performance test, (eg https://github.com/WordPress/gutenberg/runs/2788795658 ) and look at "compare performance with trunk logs".

### What `is-typing` is used for

Currently there's only one piece of functionality that uses this class. **This is only used in the site-editor**. We apply a hover outline to help find blocks, but remove this when folks begin typing. 

https://user-images.githubusercontent.com/1270189/121579300-705e0800-c9e0-11eb-88d9-98e864221700.mp4

There are two potential approaches so far. 

What's current in this branch adds a `remove-outline` class on the active block that's being typed when isOutline mode is active. We shouldn't see any behavior changes in the site-editor.

Alternatively in https://github.com/WordPress/gutenberg/commit/b62f8b45e0a58018f049c9b615cfef705b96e314 I use `:focus-within` to achieve a similar effect. One main difference is that the outline is removed on input focus, rather than typing. ~~**An alternative would be to only apply the `is-typing` class when outlineMode is enabled to avoid re-renders in other block editors.**~~ cc @jasmussen if you think the behavior here is okay.

### Performance Runs

a005470
```
>> post-editor

┌──────────────────┬──────────────────────────────────────────┬──────────────┐
│     (index)      │ 9e8e45d775216b917fc62dfc56163c01cdf6cc89 │    trunk     │
├──────────────────┼──────────────────────────────────────────┼──────────────┤
│       load       │               '7580.4 ms'                │ '7577.4 ms'  │
│       type       │                '46.55 ms'                │  '45.7 ms'   │
│     minType      │                '39.28 ms'                │  '37.84 ms'  │
│     maxType      │               '343.91 ms'                │ '441.54 ms'  │
│      focus       │               '115.92 ms'                │ '113.08 ms'  │
│     minFocus     │                '66.86 ms'                │  '68.43 ms'  │
│     maxFocus     │               '336.85 ms'                │ '334.52 ms'  │
│   inserterOpen   │               '597.13 ms'                │ '612.08 ms'  │
│ minInserterOpen  │               '522.71 ms'                │ '518.33 ms'  │
│ maxInserterOpen  │               '1026.31 ms'               │ '1062.56 ms' │
│  inserterHover   │                '28.39 ms'                │  '27.47 ms'  │
│ minInserterHover │                '24.15 ms'                │  '21.84 ms'  │
│ maxInserterHover │                '35.65 ms'                │  '38.27 ms'  │
└──────────────────┴──────────────────────────────────────────┴──────────────┘

>> site-editor

┌─────────┬──────────────────────────────────────────┬─────────────┐
│ (index) │ 9e8e45d775216b917fc62dfc56163c01cdf6cc89 │    trunk    │
├─────────┼──────────────────────────────────────────┼─────────────┤
│  load   │               '6370.33 ms'               │  '6392 ms'  │
│  type   │                '50.76 ms'                │  '55.3 ms'  │
│ minType │                '42.23 ms'                │  '46.4 ms'  │
│ maxType │                '79.75 ms'                │ '176.73 ms' │
└─────────┴──────────────────────────────────────────┴─────────────┘
```

7069153 
```
┌──────────────────┬──────────────────────────────────────────┬──────────────┐
│     (index)      │ e1067864ac01510fc827d1d471d8d935220a176d │    trunk     │
├──────────────────┼──────────────────────────────────────────┼──────────────┤
│       load       │               '7263.2 ms'                │  '7206 ms'   │
│       type       │                '39.33 ms'                │  '38.79 ms'  │
│     minType      │                '31.6 ms'                 │  '30.49 ms'  │
│     maxType      │               '309.43 ms'                │ '410.15 ms'  │
│      focus       │                '99.95 ms'                │  '95.42 ms'  │
│     minFocus     │                '61.28 ms'                │  '57.71 ms'  │
│     maxFocus     │               '318.49 ms'                │ '319.61 ms'  │
│   inserterOpen   │               '570.22 ms'                │ '577.28 ms'  │
│ minInserterOpen  │               '503.79 ms'                │ '503.34 ms'  │
│ maxInserterOpen  │                '990.9 ms'                │ '1011.72 ms' │
│  inserterHover   │                '24.5 ms'                 │  '23.48 ms'  │
│ minInserterHover │                '20.02 ms'                │  '19.78 ms'  │
│ maxInserterHover │                '36.23 ms'                │  '32.86 ms'  │
└──────────────────┴──────────────────────────────────────────┴──────────────┘
```

Run 2
```
┌──────────────────┬──────────────────────────────────────────┬─────────────┐
│     (index)      │ e1067864ac01510fc827d1d471d8d935220a176d │    trunk    │
├──────────────────┼──────────────────────────────────────────┼─────────────┤
│       load       │                '5583 ms'                 │ '5920.8 ms' │
│       type       │                '35.21 ms'                │ '35.59 ms'  │
│     minType      │                '30.07 ms'                │ '29.25 ms'  │
│     maxType      │                '239.2 ms'                │ '346.12 ms' │
│      focus       │                '86.52 ms'                │ '91.52 ms'  │
│     minFocus     │                '53.87 ms'                │ '57.07 ms'  │
│     maxFocus     │               '270.02 ms'                │ '267.54 ms' │
│   inserterOpen   │               '455.57 ms'                │ '482.83 ms' │
│ minInserterOpen  │               '392.18 ms'                │ '420.32 ms' │
│ maxInserterOpen  │                 '764 ms'                 │ '839.14 ms' │
│  inserterHover   │                '24.43 ms'                │ '21.66 ms'  │
│ minInserterHover │                '20.43 ms'                │ '17.93 ms'  │
│ maxInserterHover │                '33.14 ms'                │ '28.04 ms'  │
└──────────────────┴──────────────────────────────────────────┴─────────────┘
```

Run 3
```
┌──────────────────┬──────────────────────────────────────────┬──────────────┐
│     (index)      │ e1067864ac01510fc827d1d471d8d935220a176d │    trunk     │
├──────────────────┼──────────────────────────────────────────┼──────────────┤
│       load       │               '8437.4 ms'                │  '8439 ms'   │
│       type       │                '41.6 ms'                 │  '43.29 ms'  │
│     minType      │                '33.58 ms'                │  '33.47 ms'  │
│     maxType      │               '409.51 ms'                │ '553.71 ms'  │
│      focus       │               '116.96 ms'                │ '114.46 ms'  │
│     minFocus     │                '60.11 ms'                │  '62.07 ms'  │
│     maxFocus     │               '409.59 ms'                │ '435.73 ms'  │
│   inserterOpen   │               '725.56 ms'                │ '737.36 ms'  │
│ minInserterOpen  │               '635.77 ms'                │ '646.38 ms'  │
│ maxInserterOpen  │               '1236.41 ms'               │ '1280.89 ms' │
│  inserterHover   │                '23.06 ms'                │  '21.93 ms'  │
│ minInserterHover │                '17.23 ms'                │  '16.7 ms'   │
│ maxInserterHover │                '37.02 ms'                │  '36.99 ms'  │
└──────────────────┴──────────────────────────────────────────┴──────────────┘
```

https://github.com/WordPress/gutenberg/commit/b62f8b45e0a58018f049c9b615cfef705b96e314 Run 4
```
┌──────────────────┬──────────────────────────────────────────┬─────────────┐
│     (index)      │ f34eddeddfa79e6541833756f684a8cf990239e1 │    trunk    │
├──────────────────┼──────────────────────────────────────────┼─────────────┤
│       load       │               '6465.2 ms'                │ '6094.6 ms' │
│       type       │                '38.37 ms'                │ '37.71 ms'  │
│     minType      │                '30.21 ms'                │ '27.29 ms'  │
│     maxType      │               '276.73 ms'                │ '374.8 ms'  │
│      focus       │                '93.88 ms'                │ '86.98 ms'  │
│     minFocus     │                '54.68 ms'                │ '56.57 ms'  │
│     maxFocus     │                '290.9 ms'                │ '273.71 ms' │
│   inserterOpen   │               '530.31 ms'                │ '523.58 ms' │
│ minInserterOpen  │                '447.1 ms'                │ '445.06 ms' │
│ maxInserterOpen  │               '921.96 ms'                │ '906.93 ms' │
│  inserterHover   │                '23.24 ms'                │  '22.6 ms'  │
│ minInserterHover │                '18.73 ms'                │ '18.64 ms'  │
│ maxInserterHover │                '31.7 ms'                 │ '30.88 ms'  │
└──────────────────┴──────────────────────────────────────────┴─────────────┘
```

### Testing Instructions

- In the site editor, try selecting and editing inputs. Do we see any regressions with selection/outline behavior?
- In the post editor, verify that the `is-typing` class is not applied when we type. A block with a class of `remove-outline` should not appear either.
- In the site editor verify that only one block has `remove-outline` when typing
- In a post with many blocks (an easy one to try is adding a lot of buttons) try typing. Typing speed should feel less delayed than editing the same post in trunk.