### PR TITLE
Block categories: Clean these up by moving several blocks from Design to Theme

### DIFF
--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/loginout",
 	"title": "Login/out",
-	"category": "design",
+	"category": "theme",
 	"description": "Show login & logout links.",
 	"keywords": [ "login", "logout", "form" ],
 	"textdomain": "default",

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/navigation",
 	"title": "Navigation",
-	"category": "design",
+	"category": "theme",
 	"description": "A collection of blocks that allow visitors to get around your site.",
 	"keywords": [
 		"menu",

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/nextpage",
 	"title": "Page Break",
-	"category": "theme",
+	"category": "design",
 	"description": "Separate your content into a multi-page experience.",
 	"keywords": [ "next page", "pagination" ],
 	"parent": [ "core/post-content" ],

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/nextpage",
 	"title": "Page Break",
-	"category": "design",
+	"category": "theme",
 	"description": "Separate your content into a multi-page experience.",
 	"keywords": [ "next page", "pagination" ],
 	"parent": [ "core/post-content" ],

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-author",
 	"title": "Post Author",
-	"category": "design",
+	"category": "theme",
 	"description": "Add the author of this post.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-comment/block.json
+++ b/packages/block-library/src/post-comment/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-comment",
 	"title": "Post Comment",
-	"category": "design",
+	"category": "theme",
 	"description": "Post comment.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-comments-count",
 	"title": "Post Comments Count",
-	"category": "design",
+	"category": "theme",
 	"description": "Display a post's comments count.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-comments-form",
 	"title": "Post Comments Form",
-	"category": "design",
+	"category": "theme",
 	"description": "Display a post's comments form.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-comments-link",
 	"title": "Post Comments Link",
-	"category": "design",
+	"category": "theme",
 	"description": "Displays the link to the current post comments.",
 	"textdomain": "default",
 	"usesContext": [ "postType", "postId" ],

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-comments",
 	"title": "Post Comments",
-	"category": "design",
+	"category": "theme",
 	"description": "Display a post's comments.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-content",
 	"title": "Post Content",
-	"category": "design",
+	"category": "theme",
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-date",
 	"title": "Post Date",
-	"category": "design",
+	"category": "theme",
 	"description": "Add the date of this post.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-excerpt",
 	"title": "Post Excerpt",
-	"category": "design",
+	"category": "theme",
 	"description": "Display a post's excerpt.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-featured-image",
 	"title": "Post Featured Image",
-	"category": "design",
+	"category": "theme",
 	"description": "Display a post's featured image.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-navigation-link",
 	"title": "Post Navigation Link",
-	"category": "design",
+	"category": "theme",
 	"description": "Displays the next or previous post link that is adjacent to the current post.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/post-title",
 	"title": "Post Title",
-	"category": "design",
+	"category": "theme",
 	"description": "Displays the title of a post, page, or any other content-type.",
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/query",
 	"title": "Query Loop",
-	"category": "design",
+	"category": "theme",
 	"description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "core/term-description",
 	"title": "Term Description",
-	"category": "design",
+	"category": "theme",
 	"description": "Display the description of categories, tags and custom taxonomies when viewing an archive.",
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
Cleaning up the block categories within the Block Inserter. This PR moves the following blocks from the Design category to the Theme category, based on the intended usage of the blocks. 

- Navigation (vertical)
- Navigation (horizontal)
- Login/out
- Query
- Post Title
- Post Content
- Post Date
- Post Excerpt
- Post Featured Image
- Post Author
- Post Comment
- Post Comments
- Post Comments Count
- Post Comments Form
- Post Comments Link
- Term Description
- Next post
- Previous post