### PR TITLE
Widgets Editor: add show block bread crumbs feature toggle to more menu

### DIFF
--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -120,6 +120,7 @@ function Interface( { blockEditorSettings } ) {
 				/>
 			}
 			footer={
+				hasBlockBreadCrumbsEnabled &&
 				! isMobileViewport && (
 					<div className="edit-widgets-layout__footer">
 						<BlockBreadcrumb rootLabelText={ __( 'Widgets' ) } />

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -47,12 +47,19 @@ function Interface( { blockEditorSettings } ) {
 	);
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
-	const { hasSidebarEnabled, isInserterOpened } = useSelect(
+	const {
+		hasBlockBreadCrumbsEnabled,
+		hasSidebarEnabled,
+		isInserterOpened,
+	} = useSelect(
 		( select ) => ( {
 			hasSidebarEnabled: !! select(
 				interfaceStore
 			).getActiveComplementaryArea( editWidgetsStore.name ),
 			isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
+			hasBlockBreadCrumbsEnabled: select(
+				editWidgetsStore
+			).__unstableIsFeatureActive( 'showBlockBreadcrumbs' ),
 		} ),
 		[]
 	);

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -117,6 +117,19 @@ export default function MoreMenu() {
 									'Contain text cursor inside block deactivated'
 								) }
 							/>
+							<FeatureToggle
+								feature="showBlockBreadcrumbs"
+								label={ __( 'Display block breadcrumbs' ) }
+								info={ __(
+									'Shows block breadcrumbs at the bottom of the editor.'
+								) }
+								messageActivated={ __(
+									'Display block breadcrumbs activated'
+								) }
+								messageDeactivated={ __(
+									'Display block breadcrumbs deactivated'
+								) }
+							/>
 						</MenuGroup>
 					</>
 				) }

--- a/packages/edit-widgets/src/store/defaults.js
+++ b/packages/edit-widgets/src/store/defaults.js
@@ -2,5 +2,6 @@ export const PREFERENCES_DEFAULTS = {
 	features: {
 		fixedToolbar: false,
 		welcomeGuide: true,
+		showBlockBreadcrumbs: true,
 	},
 };

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -238,5 +238,5 @@ export const canInsertBlockInWidgetArea = createRegistrySelector(
  * @return {boolean} Is active.
  */
 export function __unstableIsFeatureActive( state, feature ) {
-	return get( state.preferences.features, [ feature ], false );
+	return get( state.preferences, [ 'features', feature ], false );
 }

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -238,5 +238,5 @@ export const canInsertBlockInWidgetArea = createRegistrySelector(
  * @return {boolean} Is active.
  */
 export function __unstableIsFeatureActive( state, feature ) {
-	return get( state.preferences, [ 'features', feature ], false );
+	return get( state.preferences.features, [ feature ], false );
 }

--- a/packages/edit-widgets/src/store/test/selectors.js
+++ b/packages/edit-widgets/src/store/test/selectors.js
@@ -25,12 +25,5 @@ describe( 'selectors', () => {
 				__unstableIsFeatureActive( state, 'didILeaveTheOvenOn' )
 			).toBe( false );
 		} );
-
-		it( 'should return false where the state is empty', () => {
-			const state = {};
-			expect(
-				__unstableIsFeatureActive( state, 'didILeaveTheOvenOn' )
-			).toBe( false );
-		} );
 	} );
 } );

--- a/packages/edit-widgets/src/store/test/selectors.js
+++ b/packages/edit-widgets/src/store/test/selectors.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+
+import { __unstableIsFeatureActive } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '__unstableIsFeatureActive', () => {
+		it( 'should return the feature value when present', () => {
+			const state = {
+				preferences: {
+					features: { isNightVisionActivated: true },
+				},
+			};
+			expect(
+				__unstableIsFeatureActive( state, 'isNightVisionActivated' )
+			).toBe( true );
+		} );
+
+		it( 'should return false where feature is not found', () => {
+			const state = {
+				preferences: {},
+			};
+			expect(
+				__unstableIsFeatureActive( state, 'didILeaveTheOvenOn' )
+			).toBe( false );
+		} );
+
+		it( 'should return false where the state is empty', () => {
+			const state = {};
+			expect(
+				__unstableIsFeatureActive( state, 'didILeaveTheOvenOn' )
+			).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description

¡Hola!

This PR follows up on https://github.com/WordPress/gutenberg/pull/32498#issuecomment-857676935, where it was suggested we add a `showBlockBreadcrumbs` feature to the more menu in the Widgets Editor.


## How has this been tested?

1. Fire up this branch and head over to the Widgets editor at `/wp-admin/themes.php?page=gutenberg-widgets`
2. Check that the breadcrumbs block appears in the footer when you select a block in the widget editor. (It should be on by default)
3. Open the More menu and toggle Block breadcrumbs 🍞 Check that the feature toggles on and off. 
4. Try coconut sugar as a substitute for cane sugar if you like caramely flavours.

Unit test for the selector:

```js
npm run test-unit packages/edit-widgets/src/store/test/selectors.js
```

## Screenshots 

![Jun-10-2021 14-05-44](https://user-images.githubusercontent.com/6458278/121463307-2cc1c900-c9f5-11eb-8d91-40f57e6af615.gif)



## Types of changes
New feature toggle for the Widgets Editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
