### PR TITLE
Widgets editor: Fix dirty state after adding new block

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -130,6 +130,16 @@ describe( 'Widgets screen', () => {
 	}
 
 	it( 'Should insert content using the global inserter', async () => {
+		const updateButton = await find( {
+			role: 'button',
+			name: 'Update',
+		} );
+
+		// Update button should start out disabled.
+		expect(
+			await updateButton.evaluate( ( button ) => button.disabled )
+		).toBe( true );
+
 		const widgetAreas = await findAll( {
 			role: 'group',
 			name: 'Block: Widget Area',
@@ -145,6 +155,11 @@ describe( 'Widgets screen', () => {
 		// );
 
 		await addParagraphBlock.click();
+
+		// Adding content should enable the Update button.
+		expect(
+			await updateButton.evaluate( ( button ) => button.disabled )
+		).toBe( false );
 
 		let addedParagraphBlockInFirstWidgetArea = await find(
 			{
@@ -215,6 +230,12 @@ describe( 'Widgets screen', () => {
 		// await page.keyboard.type( 'Third Paragraph' );
 
 		await saveWidgets();
+
+		// The Update button should be disabled again after saving.
+		expect(
+			await updateButton.evaluate( ( button ) => button.disabled )
+		).toBe( true );
+
 		const serializedWidgetAreas = await getSerializedWidgetAreas();
 		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -204,12 +204,9 @@ export function* saveWidgetArea( widgetAreaId ) {
 		const widget = preservedRecords[ i ];
 		const { block, position } = batchMeta[ i ];
 
-		yield dispatch(
-			'core/block-editor',
-			'updateBlockAttributes',
-			block.clientId,
-			{ __internalWidgetId: widget.id }
-		);
+		// Set __internalWidgetId on the block. This will be persisted to the
+		// store when we dispatch receiveEntityRecords( post ) below.
+		post.blocks[ position ].attributes.__internalWidgetId = widget.id;
 
 		const error = yield select(
 			'core',


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/32074.

The _Update_ button will show that there are changes whenever there are edits in one of the fake post entities that the widgets editor creates for each widget area.

https://github.com/WordPress/gutenberg/blob/7709d7b3868e20e4fe9124876fd8f2e7a56c7121/packages/edit-widgets/src/components/save-button/index.js#L20

https://github.com/WordPress/gutenberg/blob/7709d7b3868e20e4fe9124876fd8f2e7a56c7121/packages/edit-widgets/src/store/selectors.js#L96-L100

You can see these edits by calling `getEntityRecordNonTransientEdits()` on the fake post.

```js
wp.data.select( 'core' ).getEntityRecordNonTransientEdits( 'root', 'postType', 'widget-area-sidebar-1' )
```

These edits are supposed to be cleared out by `saveWidgetArea()` when it dispatches `receiveEntityRecords( post )`.

https://github.com/WordPress/gutenberg/blob/7709d7b3868e20e4fe9124876fd8f2e7a56c7121/packages/edit-widgets/src/store/actions.js#L253-L260

`post` comes from earlier in `saveWidgetArea()`.

https://github.com/WordPress/gutenberg/blob/7709d7b3868e20e4fe9124876fd8f2e7a56c7121/packages/edit-widgets/src/store/actions.js#L98-L104

But this does not clear the edits after a block has been inserted because the `blocks` that are in the store are different to `post.blocks`. Specifically, the `blocks` in the store have an added `__internalWidgetId` which is set in between when we obtain `post` and when we dispatch `receiveEntityRecords( post )`.

https://github.com/WordPress/gutenberg/blob/7709d7b3868e20e4fe9124876fd8f2e7a56c7121/packages/edit-widgets/src/store/actions.js#L207-L212

My fix therefore is to set `__internalWidgetId` by modifying `post.blocks` instead of by modifying the `blocks` in the store. The change will be persisted when we dispatch `receiveEntityRecords( post )`.

## How has this been tested?

1. Go to the new widgets screen.
2. Add a new block to a widget area.
3. Save changes.
4. See snackbar appear.
5. "Update" button should be disabled.

I also very quickly tested adding, saving and deleting blocks to make sure I didn't cause any regressions, but it would be good, dear reader, if you could double check this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->