### PR TITLE
Try: Fix navigation onselect alignment.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -10,9 +10,9 @@
 		max-width: none;
 	}
 
-	// Add a little left margin when used horizontally.
-	// The right margin should be set to auto, so as to not shift layout in flex containers.
-	margin: 0 auto 0 $grid-unit-10;
+	// Add a uniform margin around the block.
+	// This can hopefully avoid havoc in flex containers.
+	margin: $grid-unit-10;
 
 	// ... unless it's the only child.
 	&:first-child {


### PR DESCRIPTION
## Description

Fixes #32539.

Before:

![before](https://user-images.githubusercontent.com/1204802/121478736-9fb54a80-c9c9-11eb-9766-f79e5d9cedc4.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/121478745-a217a480-c9c9-11eb-9089-0fc11e782b0d.gif)

Note that the previous behavior was "intentional" insofar as the flex container used to have trouble with the in-canvas appender. However revisiting this, things appear to work as they should. Nevertheless, this issue shows just another reason why it'd be good to explore a solution to the in-canvas appender causing layout shifts.

## How has this been tested?

The margin applied to the in canvas plus was added to fix problems with flex containers, notably navigation, buttons, social links. Because this PR doubles back on that, it is important to test this with a bunch of themes and a bunch of blocks. At the very least, a block theme and a classic theme, both with navigation and button blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
