### PR TITLE
Try: Safari flickering fix round 3.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -126,4 +126,9 @@
 		cursor: revert;
 		transform: revert;
 	}
+
+	// Safari has trouble rendering items without flickering.
+	// This renders it on the GPU, avoiding that.
+	// @todo: this should be retired if a future version makes it unnecessary.
+	transform: translate3d(0, 0, 0);
 }

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -161,6 +161,11 @@ $arrow-size: 8px;
 	&.is-from-right:not(.is-from-top):not(.is-from-bottom) {
 		margin-right: $grid-unit-15;
 	}
+
+	// Safari has trouble rendering items without flickering.
+	// This renders it on the GPU, avoiding that.
+	// @todo: this should be retired if a future version makes it unnecessary.
+	transform: translate3d(0, 0, 0);
 }
 
 .components-popover__content {

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -63,4 +63,11 @@
 	width: 100%;
 	height: 100%;
 	position: relative;
+
+	> div {
+		// Safari has trouble rendering items without flickering.
+		// This renders it on the GPU, avoiding that.
+		// @todo: this should be retired if a future version makes it unnecessary.
+		transform: translate3d(0, 0, 0);
+	}
 }


### PR DESCRIPTION
## Description

Fixes #30803. Safari has occasional flickering when _scrolling fast_, or _scrolling a gallery_. It appears to be related to a combination of fixed-position, z-index, and updating top/left properties of elements. But it may also just be a general performance issue. Here's how it looks:

![bug](https://user-images.githubusercontent.com/1204802/121483118-1ce2be80-c9ce-11eb-867f-536b2098be41.gif)

This PR forces 3 layers onto the GPU, fixing the issue:

![fix](https://user-images.githubusercontent.com/1204802/121483163-279d5380-c9ce-11eb-8e3a-70746088fa36.gif)

It would be nice to explore separate improvements, that make these changes unnecessary, as this change might cause higher memory usage. But this patch may also be a good temporary bandaid, and I have added comments that suggest as much.

One of the downsides of putting items on the GPU is that they can affect how relative positioning, fixed positioning, or overflow behave. So as you test this, outside of the performance, be sure to look for anything that's clipped or cropped, or incorrectly positioned. As far as I can tell, there are no downsides.

One theoretical upside is smoother animation, as the layers are now rendered on the GPU. 


## How has this been tested?

Here's some test content:

```
<!-- wp:paragraph -->
<p>The rabbit-hole went straight on like a tunnel for some way, and then dipped suddenly down, so suddenly that Alice had not a moment to think about stopping herself before she found herself falling down a very deep well.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Either the well was very deep, or she fell very slowly, for she had plenty of time as she went down to look about her and to wonder what was going to happen next. First, she tried to look down and make out what she was coming to, but it was too dark to see anything; then she looked at the sides of the well, and noticed that they were filled with cupboards and book-shelves; here and there she saw maps and pictures hung upon pegs. She took down a jar from one of the shelves as she passed; it was labelled “ORANGE MARMALADE”, but to her great disappointment it was empty: she did not like to drop the jar for fear of killing somebody underneath, so managed to put it into one of the cupboards as she fell past it.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>“Well!” thought Alice to herself, “after such a fall as this, I shall think nothing of tumbling down stairs! How brave they’ll all think me at home! Why, I wouldn’t say anything about it, even if I fell off the top of the house!” (Which was very likely true.)</p>
<!-- /wp:paragraph -->

<!-- wp:gallery {"ids":[1837,1836,1835,1834,1833,1832],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-5-1024x1008.jpg" alt="" data-id="1837" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-5.jpg" data-link="http://localhost:8888/?attachment_id=1837" class="wp-image-1837"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-4-1024x1008.jpg" alt="" data-id="1836" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-4.jpg" data-link="http://localhost:8888/?attachment_id=1836" class="wp-image-1836"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-3-1024x1008.jpg" alt="" data-id="1835" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-3.jpg" data-link="http://localhost:8888/?attachment_id=1835" class="wp-image-1835"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-2-1024x1008.jpg" alt="" data-id="1834" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-2.jpg" data-link="http://localhost:8888/?attachment_id=1834" class="wp-image-1834"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-1-1024x1008.jpg" alt="" data-id="1833" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-1.jpg" data-link="http://localhost:8888/?attachment_id=1833" class="wp-image-1833"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://localhost:8888/wp-content/uploads/2021/05/duotone_before-1024x1008.jpg" alt="" data-id="1832" data-full-url="http://localhost:8888/wp-content/uploads/2021/05/duotone_before.jpg" data-link="http://localhost:8888/?attachment_id=1832" class="wp-image-1832"/></figure></li></ul></figure>
<!-- /wp:gallery -->

<!-- wp:paragraph -->
<p>Down, down, down. Would the fall never come to an end? “I wonder how many miles I’ve fallen by this time?” she said aloud. “I must be getting somewhere near the centre of the earth. Let me see: that would be four thousand miles down, I think—” (for, you see, Alice had learnt several things of this sort in her lessons in the schoolroom, and though this was not a very good opportunity for showing off her knowledge, as there was no one to listen to her, still it was good practice to say it over) “—yes, that’s about the right distance—but then I wonder what Latitude or Longitude I’ve got to?” (Alice had no idea what Latitude was, or Longitude either, but thought they were nice grand words to say.)</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Presently she began again. “I wonder if I shall fall right through the earth! How funny it’ll seem to come out among the people that walk with their heads downward! The Antipathies, I think—” (she was rather glad there was no one listening, this time, as it didn’t sound at all the right word) “—but I shall have to ask them what the name of the country is, you know. Please, Ma’am, is this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy curtseying as you’re falling through the air! Do you think you could manage it?) “And what an ignorant little girl she’ll think me for asking! No, it’ll never do to ask: perhaps I shall see it written up somewhere.”</p>
<!-- /wp:paragraph -->
```

Scroll that up and down very fast, ideally in a classic theme that does not provide an editor style. Also try selecting an image in the gallery, then scroll down until the toolbar detaches.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
