### PR TITLE
Fix insertion point displaying when there are no inserter items

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1215,7 +1215,17 @@ export function getBlockInsertionPoint( state ) {
  * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return state.insertionPoint !== null;
+	const insertionPoint = state.insertionPoint;
+
+	if ( ! state.insertionPoint ) {
+		return false;
+	}
+
+	if ( getTemplateLock( state, insertionPoint.rootClientId ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2255,12 +2255,43 @@ describe( 'selectors', () => {
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
 		} );
 
+		it( 'should return false if the rootClientId has a truthy template lock', () => {
+			const state = {
+				insertionPoint: {
+					rootClientId: 'testClientId',
+					index: 5,
+				},
+				blockListSettings: {
+					testClientId: {
+						templateLock: 'all',
+					},
+				},
+			};
+
+			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if the rootClientId is undefined, and the settings has a template lock', () => {
+			const state = {
+				insertionPoint: {
+					rootClientId: undefined,
+					index: 5,
+				},
+				settings: {
+					templateLock: 'all',
+				},
+			};
+
+			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
+		} );
+
 		it( 'should return true if assigned insertion point', () => {
 			const state = {
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 5,
 				},
+				settings: {},
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );


### PR DESCRIPTION
## Description
Fixes #28123

In locked template areas (and other between blocks places where blocks can't be inserted), the insertion point indicator was still being displayed, though just the blue line without an inserter button.

To solve this, the `isInsertionPointVisible` selector now checks whether the insertion point's root client id has a template lock.

<strike>To solve this, the `InsertionPointPopover` component needs to do its own check for `hasInserterItems` to get around this issue. This matches what the inserter button does:
- https://github.com/WordPress/gutenberg/blob/3c722bf9ab1266a7e29d0aa4e28c21283e7220b9/packages/block-editor/src/components/inserter/index.js#L225
- https://github.com/WordPress/gutenberg/blob/3c722bf9ab1266a7e29d0aa4e28c21283e7220b9/packages/block-editor/src/components/inserter/index.js#L296-L299</strike>

## How has this been tested?
1. In the widget editor, hover between widget areas
2. The insertion point should not be shown

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
