### PR TITLE
Try: Alternate menu item setup state with inheritance.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -77,52 +77,35 @@
  * Menu item setup state. Is shown when a menu item has no URL configured.
  */
 
-.wp-block-navigation-link__placeholder {
+a.wp-block-navigation-link__placeholder.wp-block-navigation-link__placeholder {
 	position: relative;
-
-	// Provide a little margin to show each placeholder as a separate unit.
-	margin: 2px;
-
-	.wp-block-navigation-link__placeholder-text {
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding-left: 4px;
-		padding-right: 4px;
-
-	}
-
-	// This needs extra specificity.
-	&.wp-block-navigation-link__content {
-		cursor: pointer;
-	}
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	cursor: pointer;
 
 	&::before {
-		content: "";
+		content: "\200b"; // Zero width space.
 		display: block;
 		position: absolute;
-		top: 0;
+		z-index: 0;
 		right: 0;
-		bottom: 0;
 		left: 0;
-		border-radius: $radius-block-ui;
-		opacity: 0.1;
+		opacity: 0.3;
+		background: currentColor;
+		line-height: 1;
+
+		// Tweak the currentcolor to give some highlighting.
+		$color-filter: sepia() saturate(10000%) hue-rotate(315deg); // Yellowish.
+		filter: invert(100%) $color-filter;
 
 		.is-dark-theme & {
-			opacity: 0.2;
-		}
-
-		.is-editing & {
-			background: currentColor;
+			filter: $color-filter;
 		}
 	}
-}
 
-// We had to add extra classes to override the color from
-// .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content
-.wp-block-navigation
-.wp-block-navigation-link:not(.is-editing)
-.wp-block-navigation-link__content.wp-block-navigation-link__placeholder {
-	box-shadow: inset 0 0 0 $border-width $gray-700;
-	border-radius: $radius-block-ui;
-	color: var(--wp-admin-theme-color);
+	.wp-block-navigation-link__placeholder-text {
+		position: relative;
+		z-index: 1;
+	}
 }


### PR DESCRIPTION
## Description

Alternative to #32512, but hopes to accomplish the same: provide indication that a menu item is in an incomplete state, but still allow inheritance of font and color so as to allow more elaborate patterns.

This one was inspired by the error state in the Macos finder where a partial character, ¨, is used. Or more specifically — that umlaut isn't meant to stand alone, you press it first, then press the character it is meant to overlay. The finder shows a colored background until the character is complete:

<img width="126" alt="Screenshot 2021-06-10 at 09 55 04" src="https://user-images.githubusercontent.com/1204802/121492151-eb222580-c9d6-11eb-8595-f4eafca5ef2d.png">

This branch is currently using `currentColor` but with an elaborate CSS filter applied to accomplish a color that should work in most contexts — but I'm still tinkering with that bit. But here's what it looks like:

<img width="660" alt="Screenshot 2021-06-10 at 10 26 01" src="https://user-images.githubusercontent.com/1204802/121492384-202e7800-c9d7-11eb-901b-8405c5fdcdd8.png">

<img width="655" alt="Screenshot 2021-06-10 at 10 26 44" src="https://user-images.githubusercontent.com/1204802/121492392-215fa500-c9d7-11eb-9d29-3b482119c849.png">

<img width="580" alt="Screenshot 2021-06-10 at 10 25 50" src="https://user-images.githubusercontent.com/1204802/121492401-2290d200-c9d7-11eb-9db3-0b7c566ea53b.png">

<img width="700" alt="Screenshot 2021-06-10 at 10 26 13" src="https://user-images.githubusercontent.com/1204802/121492407-245a9580-c9d7-11eb-9281-e9f7f355783d.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
