### PR TITLE
Try: Alternate menu item setup state round 3

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -72,57 +72,38 @@
 	}
 }
 
-
 /**
  * Menu item setup state. Is shown when a menu item has no URL configured.
  */
 
-.wp-block-navigation-link__placeholder {
+a.wp-block-navigation-link__placeholder.wp-block-navigation-link__placeholder {
 	position: relative;
-
-	// Provide a little margin to show each placeholder as a separate unit.
-	margin: 2px;
-
-	.wp-block-navigation-link__placeholder-text {
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding-left: 4px;
-		padding-right: 4px;
-
-	}
-
-	// This needs extra specificity.
-	&.wp-block-navigation-link__content {
-		cursor: pointer;
-	}
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	cursor: pointer;
 
 	&::before {
-		content: "";
+		content: "\200b"; // Zero width space.
 		display: block;
 		position: absolute;
-		top: 0;
+		z-index: 0;
 		right: 0;
-		bottom: 0;
 		left: 0;
-		border-radius: $radius-block-ui;
-		opacity: 0.1;
+		opacity: 1;
+		background: currentColor;
+		line-height: 1;
 
-		.is-dark-theme & {
-			opacity: 0.2;
-		}
-
-		.is-editing & {
-			background: currentColor;
-		}
+		// Wavy underline.
+		mask-image: url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 6 3\"><path d=\"M0 .8c1.5 0 1.5 1.5 3 1.5S4.5.8 6 .8\" fill=\"none\" stroke-width=\"1.5\" stroke=\"black\" stroke-miterlimit=\"10\"/></svg>");
+		mask-size: 6px 3px;
+		mask-repeat: repeat-x;
+		mask-position: 0 100%;
+		padding-bottom: 3px;
 	}
-}
 
-// We had to add extra classes to override the color from
-// .editor-styles-wrapper .wp-block-navigation:not(.has-text-color) .wp-block-navigation-link__content
-.wp-block-navigation
-.wp-block-navigation-link:not(.is-editing)
-.wp-block-navigation-link__content.wp-block-navigation-link__placeholder {
-	box-shadow: inset 0 0 0 $border-width $gray-700;
-	border-radius: $radius-block-ui;
-	color: var(--wp-admin-theme-color);
+	.wp-block-navigation-link__placeholder-text {
+		position: relative;
+		z-index: 1;
+	}
 }


### PR DESCRIPTION
## Description

Alternative to #32512 and #32578. This one has better wavy underlines, a carefully crafted SVG that is positioned just right:

<img width="546" alt="Screenshot 2021-06-10 at 10 45 19" src="https://user-images.githubusercontent.com/1204802/121494357-f70ee700-c9d8-11eb-8905-009fe5568571.png">

I was able to make it inherit colors as well:

![option 3](https://user-images.githubusercontent.com/1204802/121494327-eeb6ac00-c9d8-11eb-9787-f7c11f4ed15b.gif)

I still like this as an option to indicate "there's something here", and it's easy to tweak the stroke-width. I'm still trying to figure out how to enable it to work, while wrapping text.