### PR TITLE
Use button block appender in widget areas

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   `ButtonBlockerAppender` is now `ButtonBlockAppender`, the original name was a typo, but is being still exported for backward compatibility.
+
 ## 6.1.0 (2021-05-20)
 
 ## 6.0.0 (2021-05-14)

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   `ButtonBlockerAppender` is now `ButtonBlockAppender`, the original name was a typo, but is being still exported for backward compatibility.
+-   `ButtonBlockerAppender` is now `ButtonBlockAppender`, the original name was a typo, but is still being exported for backward compatibility.
 
 ## 6.1.0 (2021-05-20)
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -127,7 +127,7 @@ _Related_
 
 _Parameters_
 
--   _props_ `BlockContextProviderProps`:
+-   _props_ `BlockContextProviderProps`: 
 
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
@@ -222,7 +222,7 @@ _Usage_
 
 _Parameters_
 
--   _props_ `Object`:
+-   _props_ `Object`: 
 -   _props.clientId_ `string`: Client ID of block.
 
 _Returns_
@@ -258,6 +258,12 @@ Undocumented declaration.
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/button-block-appender/README.md>
+
+<a name="ButtonBlockerAppender" href="#ButtonBlockerAppender">#</a> **ButtonBlockerAppender**
+
+> **Deprecated** 
+
+Use `ButtonBlockAppender` instead.
 
 <a name="ColorPalette" href="#ColorPalette">#</a> **ColorPalette**
 
@@ -475,7 +481,7 @@ _Related_
 
 <a name="MultiSelectScrollIntoView" href="#MultiSelectScrollIntoView">#</a> **MultiSelectScrollIntoView**
 
-> **Deprecated**
+> **Deprecated** 
 
 Scrolls the multi block selection end into view if not in view already. This
 is important to do after selection by keyboard.
@@ -653,7 +659,7 @@ _Parameters_
 
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
--   _options.\_\_unstableIsHtml_ `boolean`:
+-   _options.\_\_unstableIsHtml_ `boolean`: 
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -127,7 +127,7 @@ _Related_
 
 _Parameters_
 
--   _props_ `BlockContextProviderProps`: 
+-   _props_ `BlockContextProviderProps`:
 
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
@@ -222,7 +222,7 @@ _Usage_
 
 _Parameters_
 
--   _props_ `Object`: 
+-   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
 
 _Returns_
@@ -253,7 +253,7 @@ Undocumented declaration.
 
 Undocumented declaration.
 
-<a name="ButtonBlockerAppender" href="#ButtonBlockerAppender">#</a> **ButtonBlockerAppender**
+<a name="ButtonBlockAppender" href="#ButtonBlockAppender">#</a> **ButtonBlockAppender**
 
 _Related_
 
@@ -475,7 +475,7 @@ _Related_
 
 <a name="MultiSelectScrollIntoView" href="#MultiSelectScrollIntoView">#</a> **MultiSelectScrollIntoView**
 
-> **Deprecated** 
+> **Deprecated**
 
 Scrolls the multi block selection end into view if not in view already. This
 is important to do after selection by keyboard.
@@ -653,7 +653,7 @@ _Parameters_
 
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
--   _options.\_\_unstableIsHtml_ `boolean`: 
+-   _options.\_\_unstableIsHtml_ `boolean`:
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -69,12 +69,12 @@ function Root( { className, children } ) {
 	);
 }
 
-export default function BlockList( { className, __experimentalLayout } ) {
+export default function BlockList( { className, ...props } ) {
 	usePreParsePatterns();
 	return (
 		<BlockToolsBackCompat>
 			<Root className={ className }>
-				<BlockListItems __experimentalLayout={ __experimentalLayout } />
+				<BlockListItems { ...props } />
 			</Root>
 		</BlockToolsBackCompat>
 	);

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -10,6 +10,7 @@ import { Button, Tooltip, VisuallyHidden } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -80,6 +81,19 @@ function ButtonBlockAppender(
 		/>
 	);
 }
+
+/**
+ * Use `ButtonBlockAppender` instead.
+ *
+ * @deprecated
+ */
+export const ButtonBlockerAppender = forwardRef( ( props, ref ) => {
+	deprecated( `wp.blockEditor.ButtonBlockerAppender`, {
+		alternative: 'wp.blockEditor.ButtonBlockAppender',
+	} );
+
+	return ButtonBlockAppender( props, ref );
+} );
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/button-block-appender/README.md

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -36,7 +36,7 @@ export {
 export { default as __experimentalBorderStyleControl } from './border-style-control';
 export {
 	// This is a typo, but kept here for back-compat.
-	default as ButtonBlockerAppender,
+	ButtonBlockerAppender,
 	default as ButtonBlockAppender,
 } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -34,7 +34,11 @@ export {
 	BlockVerticalAlignmentControl,
 } from './block-vertical-alignment-control';
 export { default as __experimentalBorderStyleControl } from './border-style-control';
-export { default as ButtonBlockerAppender } from './button-block-appender';
+export {
+	// This is a typo, but kept here for back-compat.
+	default as ButtonBlockerAppender,
+	default as ButtonBlockAppender,
+} from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPaletteControl } from './color-palette/control';
 export { default as ContrastChecker } from './contrast-checker';

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -18,6 +18,7 @@ import {
 	WritingFlow,
 	BlockEditorKeyboardShortcuts,
 	__unstableBlockSettingsMenuFirstItem,
+	ButtonBlockAppender,
 } from '@wordpress/block-editor';
 import { uploadMedia } from '@wordpress/media-utils';
 
@@ -116,7 +117,9 @@ export default function SidebarBlockEditor( {
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>
-								<BlockList />
+								<BlockList
+									renderAppender={ ButtonBlockAppender }
+								/>
 							</ObserveTyping>
 						</WritingFlow>
 					</BlockSelectionClearer>

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -122,13 +122,6 @@ describe( 'Widgets screen', () => {
 		).toBe( true );
 	}
 
-	async function getInlineInserterButton() {
-		return await find( {
-			role: 'combobox',
-			name: 'Add block',
-		} );
-	}
-
 	it( 'Should insert content using the global inserter', async () => {
 		const updateButton = await find( {
 			role: 'button',
@@ -273,7 +266,10 @@ describe( 'Widgets screen', () => {
 				10
 		);
 
-		let inlineInserterButton = await getInlineInserterButton();
+		let inlineInserterButton = await find( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
 		await inlineInserterButton.click();
 
 		let inlineQuickInserter = await find( {
@@ -333,7 +329,13 @@ describe( 'Widgets screen', () => {
 			secondParagraphBlockBoundingBox.y - 10
 		);
 
-		inlineInserterButton = await getInlineInserterButton();
+		// There will be 2 matches here.
+		// One is the in-between inserter,
+		// and the other one is the button block appender.
+		[ inlineInserterButton ] = await findAll( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
 		await inlineInserterButton.click();
 
 		// TODO: Convert to find() API from puppeteer-testing-library.

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -15,7 +15,7 @@ export default function WidgetAreaInnerBlocks() {
 			onInput={ onInput }
 			onChange={ onChange }
 			templateLock={ false }
-			renderAppender={ InnerBlocks.DefaultBlockAppender }
+			renderAppender={ InnerBlocks.ButtonBlockAppender }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close #26072, close #26177. close #27709.

To quote from @noisysocks:

> Without it, it’s weird, imo, that the block editor makes it easy to add 2-3 new paragraphs that can end up as 2-3 seperate columns in the frontend
> A more long term solution might be to have a “Widget Group” block which is what the :plus: button inserts that but this will do for now

Also fix a typo of accidentally naming `ButtonBlockAppender` to `ButtonBlockerAppender`. Alternative fix to #27709.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Appearance -> Widgets
2. There should be button block appender for each widget area.
3. Go to Appearance -> Customize -> Widgets
4. There should be button block appender for each widget.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/121487795-07d55200-ca05-11eb-9d54-772854729769.png)

![image](https://user-images.githubusercontent.com/7753001/121624895-fcd1fe80-caa4-11eb-9d74-367ab4927125.png)

Deprecation message when using `<ButtonBlockerAppender>` rather than `<ButtonBlockAppender>`:

![image](https://user-images.githubusercontent.com/7753001/121626011-2ee46000-caa7-11eb-9a01-9078f6c04c18.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
