### PR TITLE
Fix Safari 13 issue.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -119,7 +119,7 @@ export default function VisualEditor( { styles } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
-		height: '100%',
+		minHeight: '100%',
 		width: '100%',
 		margin: 0,
 		display: 'flex',

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -61,6 +61,9 @@
 
 .edit-post-visual-editor__content-area {
 	width: 100%;
-	height: 100%;
+	// If this is set to height: 100%; it breaks in Safari 13, which calculates the height relatively to the incorrect flex container.
+	// By setting it as a min-height instead, it appears to work in all cases.
+	min-height: 100%;
 	position: relative;
+	display: flex;
 }


### PR DESCRIPTION
## Description

Safari 13 — not 14 — has an issue where flex containers that serve as ancestores, can make child flex items have their height calculated incorrectly. This causes a gray background in some themes, like so:

![test](https://user-images.githubusercontent.com/1204802/121509254-be760a00-c9e6-11eb-922e-4a9331c41077.gif)

This PR changes a height value to a min-height, fixing that. 

## How has this been tested?

I had access to Browserstack and was able to test. It's "fine" in Safari 14 (though there's some separate flickering that is not fixed by this PR, but is fixed by #32575). 

Be sure to use an older theme, like TwentyNineteen, then add more content than the height of the viewport allows.

With zero and with lots of contents, you should only ever see a white background.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
