### PR TITLE
Docs: Update references to `register_block_type_from_metadata`

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -54,11 +54,11 @@ The same file is also used when [submitting block to Block Directory](/docs/gett
 
 ## Server-side registration
 
-There is also [`register_block_type_from_metadata`](https://developer.wordpress.org/reference/functions/register_block_type_from_metadata/) function that aims to simplify the block type registration on the server from metadata stored in the `block.json` file.
+The [`register_block_type`](https://developer.wordpress.org/reference/functions/register_block_type/) function that aims to simplify the block type registration on the server, can read metadata stored in the `block.json` file.
 
-This function takes two params:
+This function takes two params relevant in this context (`$block_type` accepts more types and variants):
 
--   `$path` (`string`) – path to the folder where the `block.json` file is located or full path to the metadata file if named differently.
+-   `$block_type` (`string`) – path to the folder where the `block.json` file is located or full path to the metadata file if named differently.
 -   `$args` (`array`) – an optional array of block type arguments. Default value: `[]`. Any arguments may be defined. However, the one described below is supported by default:
     -   `$render_callback` (`callable`) – callback used to render blocks of this block type.
 
@@ -67,7 +67,7 @@ It returns the registered block type (`WP_Block_Type`) on success or `false` on 
 **Example:**
 
 ```php
-register_block_type_from_metadata(
+register_block_type(
 	__DIR__ . '/notice',
 	array(
 		'render_callback' => 'render_block_core_notice',
@@ -453,9 +453,9 @@ WordPress string discovery system can automatically translate fields marked in t
 
 ### PHP
 
-In PHP, localized properties will be automatically wrapped in `_x` function calls on the backend of WordPress when executing `register_block_type_from_metadata`. These translations get added as an inline script to the plugin's script handle or to the `wp-block-library` script handle in WordPress core.
+In PHP, localized properties will be automatically wrapped in `_x` function calls on the backend of WordPress when executing `register_block_type`. These translations get added as an inline script to the plugin's script handle or to the `wp-block-library` script handle in WordPress core.
 
-The way `register_block_type_from_metadata` processes translatable values is roughly equivalent to the following code snippet:
+The way `register_block_type` processes translatable values is roughly equivalent to the following code snippet:
 
 ```php
 <?php
@@ -503,7 +503,9 @@ The following properties are going to be supported for backward compatibility re
 **Example**:
 
 ```js
-wp.blocks.registerBlockType( 'my-block/name', {
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'my-plugin/block-name', {
 	edit: function () {
 		// Edit definition goes here.
 	},
@@ -516,4 +518,4 @@ wp.blocks.registerBlockType( 'my-block/name', {
 } );
 ```
 
-In the case of [dynamic blocks](/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md) supported by WordPress, it should be still possible to register `render_callback` property using both [`register_block_type`](https://developer.wordpress.org/reference/functions/register_block_type/) and `register_block_type_from_metadata` functions on the server.
+In the case of [dynamic blocks](/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md) supported by WordPress, it should be still possible to register `render_callback` property using both [`register_block_type`](https://developer.wordpress.org/reference/functions/register_block_type/) function on the server.

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -36,7 +36,7 @@ function render_my_block() {
 }
 
 function register_block_my_block() {
-	register_block_type_from_metadata(
+	register_block_type(
 		__DIR__ . '/block-name',
 		array(
 			'render_callback' => 'render_my_block',

--- a/packages/block-library/src/navigation-link/fallback-variations.js
+++ b/packages/block-library/src/navigation-link/fallback-variations.js
@@ -10,9 +10,9 @@ import {
 } from '@wordpress/icons';
 
 // FALLBACK: this is only used when the server does not understand the variations property in the
-// register_block_type_from_metadata call. see navigation-link/index.php.
+// register_block_type call. see navigation-link/index.php.
 // Delete this file when supported WP ranges understand the `variations` property when passed to
-// register_block_type_from_metadata in index.php
+// register_block_type in index.php
 const fallbackVariations = [
 	{
 		name: 'link',

--- a/packages/block-library/src/navigation-link/hooks.js
+++ b/packages/block-library/src/navigation-link/hooks.js
@@ -35,7 +35,7 @@ export function enhanceNavigationLinkVariations( settings, name ) {
 	}
 
 	// Fallback handling may be deleted after supported WP ranges understand the `variations`
-	// property when passed to register_block_type_from_metadata in index.php
+	// property when passed to register_block_type in index.php
 	if ( ! settings.variations ) {
 		return {
 			...settings,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Changes required for the dev note for WordPress 5.8 announcing changes in Block API. Related issue: #32365.

Related ticket: https://core.trac.wordpress.org/ticket/53233.
Related PRs: [#30293](https://github.com/WordPress/gutenberg/pull/30293) and [#32030](https://github.com/WordPress/gutenberg/pull/32030).

The draft for dev note: https://gist.github.com/gziolo/cbea77500316a243e445d509ced3c231.

## Not included

We can't update `register_block_type_from_metadata` function calls until WordPress 5.8 becomes the lowest supported version in the Gutenberg plugin.

