### PR TITLE
Widget Editor: Fix button spacing in header

### DIFF
--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -25,6 +25,19 @@
 
 .edit-widgets-header__actions {
 	display: flex;
+
+	.components-button {
+		margin-right: $grid-unit-05;
+
+		@include break-small() {
+			margin-right: $grid-unit-15;
+		}
+	}
+
+	.edit-widgets-more-menu .components-button,
+	.interface-pinned-items .components-button {
+		margin-right: 0;
+	}
 }
 
 .edit-widgets-header-toolbar {


### PR DESCRIPTION
## Description
Updates button spacing in Widget Editor header to match the rest of the editors.

Fixes #32263.

## How has this been tested?
1. Go to the `Appearance > Widgets`
2. There should be more space between the "Update" and "Settings" buttons.

## Screenshots <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
| ![button-spacing-before](https://user-images.githubusercontent.com/240569/121522924-ae6e2280-ca06-11eb-9a88-cc80c58ee899.png)  | ![button-spacing-after](https://user-images.githubusercontent.com/240569/121522921-add58c00-ca06-11eb-866a-643ba3bc331c.png)  |




## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
