### PR TITLE
Use a different cache key for the PR automation workflow

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pm-automation-cache-${{ hashFiles('**/package-lock.json') }}
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pr-automation-cache-${{ hashFiles('**/package-lock.json') }}
 
             # Changing into the action's directory and running `npm install` is much
             # faster than a full project-wide `npm ci`.

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -29,11 +29,13 @@ jobs:
               with:
                   # npm cache files are stored in `~/.npm` on Linux/macOS
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pm-automation-cache-${{ hashFiles('**/package-lock.json') }}
 
             # Changing into the action's directory and running `npm install` is much
             # faster than a full project-wide `npm ci`.
-            - run: cd packages/project-management-automation && npm install
+            - name: Install NPM dependencies
+              run: npm install
+              working-directory: packages/project-management-automation
 
             - uses: ./packages/project-management-automation
               with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25055,9 +25055,9 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+			"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -25065,12 +25065,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -25096,9 +25095,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
 		"babel-plugin-transform-remove-console": "6.9.4",
 		"benchmark": "2.1.4",
 		"browserslist": "4.16.6",
-		"chalk": "4.0.0",
+		"chalk": "4.1.1",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "5.1.2",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In #32458, cache keys were made more consistent in order to increase the likelihood a cache hit would occur, which speeds up `npm install` and `npm ci` commands.

However, this introduced a bug where the Pull Request Automation workflow would also share an NPM cache with all of the other workflows. This is problematic because this workflows runs `npm install` from within the `packages/project-management-automation` directory (which only installs dependencies needed for this package). When this workflow runs and attempts to write the cache first (which is likely to happen often, as this workflow usually completes before other workflows even get started), this results in the NPM cache for Node 14 being bad or incomplete.

This can be seen [here](https://github.com/WordPress/gutenberg/runs/2784728153#step:11:1). The `package-lock.json` file changed in the connected commit (734fc41cd19b02998802dcdb24a9f401d4c7df5f), causing a cache invalidation (a portion of the cache key is the hash of the `package-lock.json` file), and the results of this workflow were cached. 

The [Build Plugin ZIP workflow](https://github.com/WordPress/gutenberg/runs/2784729180), which started enough time after the cache was created then used this small cache.

This only affects jobs running on `ubuntu-latest` with NodeJS 14. MacOS and NodeJS 12 jobs have different cache keys.

I am also updating the `chalk` dependency in this PR in order to trigger a cache flush. The two releases since the version being used currently [have only minor changes](https://github.com/chalk/chalk/compare/v4.0.0...v4.1.1).

### Related

There have been an increased number of workflows failing randomly that display the following error: `npm ERR! cb() never called!`. Based on some quick Googling, it seems the recommended remedy for this is `npm cache clean --force`, which indicates it's being caused by a bad cache. The hope is that this change will also fix these random failures happening after the cache key is reset.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
