### PR TITLE
Define / constrainNav block orientation via block supports

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -73,7 +73,7 @@
 			"__experimentalTextDecoration": true
 		},
 		"color": true,
-		"__experimentalAllowedOrientations": ["horiztonal", "vertical"]
+		"__experimentalAllowedOrientations": ["horizontal", "vertical"]
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -73,7 +73,7 @@
 			"__experimentalTextDecoration": true
 		},
 		"color": true,
-		"__experimentalAllowedOrientations": ["vertical"]
+		"__experimentalAllowedOrientations": ["horiztonal", "vertical"]
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -72,7 +72,8 @@
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true
 		},
-		"color": true
+		"color": true,
+		"__experimentalAllowedOrientations": ["vertical"]
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -20,6 +20,7 @@ import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -55,6 +56,7 @@ function Navigation( {
 	className,
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
+	allowedOrientations,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -78,6 +80,14 @@ function Navigation( {
 	);
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
+
+	useEffect( () => {
+		if ( ! allowedOrientations?.includes( attributes.orientation ) ) {
+			setAttributes( {
+				orientation: allowedOrientations[ 0 ],
+			} );
+		}
+	}, [ allowedOrientations ] );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
@@ -183,6 +193,11 @@ function Navigation( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
+		const allowedOrientations = getBlockSupport(
+			'core/navigation',
+			'__experimentalAllowedOrientations'
+		);
+
 		const innerBlocks = select( blockEditorStore ).getBlocks( clientId );
 		const {
 			getClientIdsOfDescendants,
@@ -206,6 +221,7 @@ export default compose( [
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,
+			allowedOrientations,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
A PoC PR which works as part of https://github.com/WordPress/gutenberg/issues/30007#issuecomment-857710021.

The aim is to be able to restrict the orientation of the Nav Block via block supports.

## How has this been tested?

* In `block.json` for the `core/navigation` block change the following to only include one or other of the orientations:

```js
"__experimentalAllowedOrientations": ["horiztonal", "vertical"]
```

* Build Gutenberg.
* Create a post and create a Nav block.
* You should only be able to create Nav Blocks in the orientation you have left in `__experimentalAllowedOrientations`.

Unfortunately the variations still show up but this is a PoC and we can explore that later.



## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
