### PR TITLE
Use block supports API to check for Nav Block feature support

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -72,7 +72,9 @@
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true
 		},
-		"color": true
+		"color": true,
+		"__experimentalSubmenuIndicatorSetting": true,
+		"__experimentalItemJustificationControls": true
 	},
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -20,6 +20,7 @@ import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -53,8 +54,6 @@ function Navigation( {
 	isSelected,
 	updateInnerBlocks,
 	className,
-	hasSubmenuIndicatorSetting = true,
-	hasItemJustificationControls = true,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -101,6 +100,16 @@ function Navigation( {
 			__experimentalLayout: LAYOUT,
 			placeholder,
 		}
+	);
+
+	const hasSubmenuIndicatorSetting = getBlockSupport(
+		'core/navigation',
+		'__experimentalSubmenuIndicatorSetting'
+	);
+
+	const hasItemJustificationControls = getBlockSupport(
+		'core/navigation',
+		'__experimentalItemJustificationControls'
 	);
 
 	if ( isPlaceholderShown ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
A PoC PR which is part of https://github.com/WordPress/gutenberg/issues/30007#issuecomment-857710021.

This aims to control the availability of two "features" of the Navigation block via the Block Supports API:

1. The submenu indicator setting.
2. The item justification controls.

This works apart from the fact that the block PHP rendering function no longer has access to the (now removed) attributes via the block's context. We'd need to solve this issue.


## How has this been tested?

* Create post
* Create Nav block.
* You should see both features available.
* Save you post.
* Go to `core/navigation`s `block.json`.
* Change one or both of the following to `false`:

```
		"__experimentalSubmenuIndicatorSetting": true,
		"__experimentalItemJustificationControls": true
```

* Build Gutenberg.
* Go back to your post. See the features you toggled to `false` are no longer available.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
