### PR TITLE
[Block Attributes]: Add support for non-duplicable block attributes

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -167,17 +167,19 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 // }
 ```
 
-## Unique Attributes
+## Duplicable Attributes
 
-The `unique` key is used to mark block attributes that should not be copied when a block is duplicated. By default all attribute values will be cloned to the duplicate block. If an attribute sets the `unique` key to `true`, its value will not be copied, and it will instead fall back to the default value if one is supplied.
+The `duplicable` key is used to indicate whether a block attribute should be copied when a block is duplicated. If an attribute sets the `duplicable` key to `false`, its value will not be copied, and it will instead fall back to the default value if one is supplied. If the key is not explicitly set, the attribute will be considered duplicable by default.
 
-_Example_: A `resourceId` attribute is marked as `unique` so that it will not be copied to duplicate blocks.
+The `duplicable` key should not be used for attributes that are extracted from block content using an [attribute source](#common-sources).
+
+_Example_: A `resourceId` attribute which should not be copied to duplicate blocks.
 
 ```js
 {
 	resourceId: {
 		type: 'string',
-		unique: true
+		duplicable: false
 	}
 }
 ```

--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -167,6 +167,21 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 // }
 ```
 
+## Unique Attributes
+
+The `unique` key is used to mark block attributes that should not be copied when a block is duplicated. By default all attribute values will be cloned to the duplicate block. If an attribute sets the `unique` key to `true`, its value will not be copied, and it will instead fall back to the default value if one is supplied.
+
+_Example_: A `resourceId` attribute is marked as `unique` so that it will not be copied to duplicate blocks.
+
+```js
+{
+	resourceId: {
+		type: 'string',
+		unique: true
+	}
+}
+```
+
 ## Meta (deprecated)
 
 <div class="callout callout-alert">

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -115,7 +115,8 @@ export function __experimentalCloneSanitizedBlock(
 		{
 			...block.attributes,
 			...mergeAttributes,
-		}
+		},
+		true
 	);
 
 	return {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -116,7 +116,7 @@ export function __experimentalCloneSanitizedBlock(
 			...block.attributes,
 			...mergeAttributes,
 		},
-		true
+		{ shouldRemoveDuplicateAttributes: true }
 	);
 
 	return {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -453,27 +453,27 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
-					uniqueAttribute: {
+					nonDuplicableAttr: {
 						type: 'string',
-						unique: true,
+						duplicable: false,
 					},
-					uniqueAttributeWithDefault: {
+					nonDuplicableAttrWithDefault: {
 						type: 'string',
-						unique: true,
+						duplicable: false,
 						default: 'default-value',
 					},
 				},
 			} );
 
 			const block = createBlock( 'core/test-block', {
-				uniqueAttribute: 'unique-value',
-				uniqueAttributeWithDefault: 'unique-non-default-value',
+				nonDuplicableAttr: 'unique-value',
+				nonDuplicableAttrWithDefault: 'unique-non-default-value',
 			} );
 
 			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
 
 			expect( clonedBlock.attributes ).toEqual( {
-				uniqueAttributeWithDefault: 'default-value',
+				nonDuplicableAttrWithDefault: 'default-value',
 			} );
 		} );
 	} );

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -473,7 +473,7 @@ describe( 'block factory', () => {
 			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
 
 			expect( clonedBlock.attributes ).toEqual( {
-				uniqueAttribueWithDefault: 'default-value',
+				uniqueAttributeWithDefault: 'default-value',
 			} );
 		} );
 	} );

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -448,6 +448,34 @@ describe( 'block factory', () => {
 
 			expect( clonedBlock.attributes ).toEqual( {} );
 		} );
+
+		it( 'should not duplicate unique attributes, but fallback to available defaults', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					uniqueAttribute: {
+						type: 'string',
+						unique: true,
+					},
+					uniqueAttributeWithDefault: {
+						type: 'string',
+						unique: true,
+						default: 'default-value',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				uniqueAttribute: 'unique-value',
+				uniqueAttributeWithDefault: 'unique-non-default-value',
+			} );
+
+			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
+
+			expect( clonedBlock.attributes ).toEqual( {
+				uniqueAttribueWithDefault: 'default-value',
+			} );
+		} );
 	} );
 
 	describe( 'getPossibleBlockTransformations()', () => {

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -280,12 +280,12 @@ describe( 'sanitizeBlockAttributes', () => {
 		} );
 	} );
 
-	it( 'does not strip unique attributes by default', () => {
+	it( 'does not strip non-duplicable attributes by default', () => {
 		registerBlockType( 'core/test-block', {
 			attributes: {
-				uniqueAttr: {
+				nonDupicableAttr: {
 					type: 'string',
-					unique: true,
+					duplicable: false,
 				},
 			},
 			title: 'Test block',
@@ -294,25 +294,25 @@ describe( 'sanitizeBlockAttributes', () => {
 		const attributes = __experimentalSanitizeBlockAttributes(
 			'core/test-block',
 			{
-				uniqueAttr: 'unique-value',
+				nonDupicableAttr: 'unique-value',
 			}
 		);
 
 		expect( attributes ).toEqual( {
-			uniqueAttr: 'unique-value',
+			nonDupicableAttr: 'unique-value',
 		} );
 	} );
 
-	it( 'sanitizes unique attributes and falls back to defaults when sanitizeUniqueAttributes is true', () => {
+	it( 'removes non-duplicable attributes and falls back to defaults when shouleRemoveDuplicateAttributes is true', () => {
 		registerBlockType( 'core/test-block', {
 			attributes: {
-				uniqueAttr: {
+				nonDuplicableAttr: {
 					type: 'string',
-					unique: true,
+					duplicable: false,
 				},
-				uniqueAttrWithDefault: {
+				nonDuplicableAttrWithDefault: {
 					type: 'string',
-					unique: true,
+					duplicable: false,
 					default: 'default-value',
 				},
 			},
@@ -322,14 +322,14 @@ describe( 'sanitizeBlockAttributes', () => {
 		const attributes = __experimentalSanitizeBlockAttributes(
 			'core/test-block',
 			{
-				uniqueAttr: 'unique-value',
-				uniqueAttrWithDefault: 'unique-non-default-value',
+				nonDuplicableAttr: 'unique-value',
+				nonDuplicableAttrWithDefault: 'unique-non-default-value',
 			},
-			true
+			{ shouldRemoveDuplicateAttributes: true }
 		);
 
 		expect( attributes ).toEqual( {
-			uniqueAttrWithDefault: 'default-value',
+			nonDuplicableAttrWithDefault: 'default-value',
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -280,6 +280,59 @@ describe( 'sanitizeBlockAttributes', () => {
 		} );
 	} );
 
+	it( 'does not strip unique attributes by default', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				uniqueAttr: {
+					type: 'string',
+					unique: true,
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{
+				uniqueAttr: 'unique-value',
+			}
+		);
+
+		expect( attributes ).toEqual( {
+			uniqueAttr: 'unique-value',
+		} );
+	} );
+
+	it( 'sanitizes unique attributes and falls back to defaults when sanitizeUniqueAttributes is true', () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				uniqueAttr: {
+					type: 'string',
+					unique: true,
+				},
+				uniqueAttrWithDefault: {
+					type: 'string',
+					unique: true,
+					default: 'default-value',
+				},
+			},
+			title: 'Test block',
+		} );
+
+		const attributes = __experimentalSanitizeBlockAttributes(
+			'core/test-block',
+			{
+				uniqueAttr: 'unique-value',
+				uniqueAttrWithDefault: 'unique-non-default-value',
+			},
+			true
+		);
+
+		expect( attributes ).toEqual( {
+			uniqueAttrWithDefault: 'default-value',
+		} );
+	} );
+
 	it( 'handles node and children sources as arrays', () => {
 		registerBlockType( 'core/test-block', {
 			attributes: {

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -237,15 +237,15 @@ export function getAccessibleBlockLabel(
  * Ensure attributes contains only values defined by block type, and merge
  * default values for missing attributes.
  *
- * @param {string}  name                     The block's name.
- * @param {Object}  attributes               The block's attributes.
- * @param {boolean} sanitizeUniqueAttributes Whether to sanitize unique attributes.
+ * @param {string}  name                            The block's name.
+ * @param {Object}  attributes                      The block's attributes.
+ * @param {boolean} shouldRemoveDuplicateAttributes Whether to remove non-duplicable attributes.
  * @return {Object} The sanitized attributes.
  */
 export function __experimentalSanitizeBlockAttributes(
 	name,
 	attributes,
-	sanitizeUniqueAttributes = false
+	{ shouldRemoveDuplicateAttributes = false } = {}
 ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
@@ -260,12 +260,14 @@ export function __experimentalSanitizeBlockAttributes(
 			const value = attributes[ key ];
 
 			if ( undefined !== value ) {
-				if ( sanitizeUniqueAttributes ) {
-					// Remove unique attributes and merge default values.
-					const unique =
-						schema.hasOwnProperty( 'unique' ) && schema.unique;
+				// Remove non-duplicable attributes and merge default values.
+				if ( shouldRemoveDuplicateAttributes ) {
+					// An attribute is duplicable by default if not specified in the schema.
+					const duplicable =
+						! schema.hasOwnProperty( 'duplicable' ) ||
+						schema.duplicable;
 
-					if ( ! unique ) {
+					if ( duplicable ) {
 						accumulator[ key ] = value;
 					} else if ( schema.hasOwnProperty( 'default' ) ) {
 						accumulator[ key ] = schema.default;

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -237,11 +237,16 @@ export function getAccessibleBlockLabel(
  * Ensure attributes contains only values defined by block type, and merge
  * default values for missing attributes.
  *
- * @param {string} name       The block's name.
- * @param {Object} attributes The block's attributes.
+ * @param {string}  name                     The block's name.
+ * @param {Object}  attributes               The block's attributes.
+ * @param {boolean} sanitizeUniqueAttributes Whether to sanitize unique attributes.
  * @return {Object} The sanitized attributes.
  */
-export function __experimentalSanitizeBlockAttributes( name, attributes ) {
+export function __experimentalSanitizeBlockAttributes(
+	name,
+	attributes,
+	sanitizeUniqueAttributes = false
+) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 
@@ -255,7 +260,19 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 			const value = attributes[ key ];
 
 			if ( undefined !== value ) {
-				accumulator[ key ] = value;
+				if ( sanitizeUniqueAttributes ) {
+					// Remove unique attributes and merge default values.
+					const unique =
+						schema.hasOwnProperty( 'unique' ) && schema.unique;
+
+					if ( ! unique ) {
+						accumulator[ key ] = value;
+					} else if ( schema.hasOwnProperty( 'default' ) ) {
+						accumulator[ key ] = schema.default;
+					}
+				} else {
+					accumulator[ key ] = value;
+				}
 			} else if ( schema.hasOwnProperty( 'default' ) ) {
 				accumulator[ key ] = schema.default;
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Closes #29693

This PR adds the ability to mark block attributes as `unique`, such that they will not be copied on block duplication. The goal is to allow blocks to use attributes to store unique properties that persist across page loads (unlike `clientId`).

For just one example, the Jetpack `Pay with Paypal` block uses a `productId` attribute to identify the actual product record referenced by the block. This data is meant to be internal to the block and should not be exposed to the user. When the user duplicates the block, we want to copy the other attributes used to store price info and other details, but create a brand new product record/`productId`.

The behavior is opt-in, so blocks do not have to explicitly set `unique: false`. By default all attributes will continue to be copied on duplication.

## Notes
* Is `unique` the best name for this attribute field?
    * An option is `duplicable`, but the conditional logic is simpler/clearer if the field is `false` by default (ie, it's confusing that an attribute is considered 'duplicable' if the field is explicitly set to true _or if it not defined_). 
    * Another option is something along the lines of `private`, to suggest that it should not be copied. My concern is this, like `unique`, may be an overloaded term.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

You can test by adding `unique: true` to any block attribute, but the Jetpack `Pay with Paypal` block is a particularly illustrative example. Update its block registration in [`index.js`](https://github.com/Automattic/jetpack/blob/091739c10da641424433c8a219b1aba0c2966d55/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js#L133):

```
{
    productId: {
        type: 'number',
        unique: true,
    }
}
```

1. Add a Pay with Paypal block to a new post and fill out its fields.
2. Duplicate the block.
3. Inspect the blocks in the code editor and verify that while all other attributes have been copied, they have different `productId`s.
4. Edit the fields of the duplicated block.
5. Save the post.
6. Reload the page.
7. The blocks should appear as expected -- edits only affected the second block. Without this changeset applied, the edits would affect _both_ blocks, since they would be applied to the same underlying product resource.


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
