### PR TITLE
Legacy Widget: Don't display "No preview" when widget has image tags

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/control.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/control.js
@@ -361,7 +361,24 @@ async function encodeWidget( { idBase, instance, number, formData = null } ) {
 function isEmptyHTML( html ) {
 	const element = document.createElement( 'div' );
 	element.innerHTML = html;
-	return element.innerText.trim() === '';
+	return isEmptyNode( element );
+}
+
+function isEmptyNode( node ) {
+	switch ( node.nodeType ) {
+		case node.TEXT_NODE:
+			return node.nodeValue.trim() === '';
+		case node.ELEMENT_NODE:
+			if ( node.tagName === 'IMG' ) {
+				return false;
+			}
+			if ( ! node.hasChildNodes() ) {
+				return true;
+			}
+			return Array.from( node.childNodes ).every( isEmptyNode );
+		default:
+			return true;
+	}
 }
 
 function serializeForm( form ) {

--- a/packages/widgets/src/blocks/legacy-widget/edit/control.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/control.js
@@ -367,14 +367,31 @@ function isEmptyHTML( html ) {
 function isEmptyNode( node ) {
 	switch ( node.nodeType ) {
 		case node.TEXT_NODE:
+			// Text nodes are empty if it's entirely whitespace.
 			return node.nodeValue.trim() === '';
 		case node.ELEMENT_NODE:
-			if ( node.tagName === 'IMG' ) {
+			// Elements that are "embedded content" are not empty.
+			// https://dev.w3.org/html5/spec-LC/content-models.html#embedded-content-0
+			if (
+				[
+					'AUDIO',
+					'CANVAS',
+					'EMBED',
+					'IFRAME',
+					'IMG',
+					'MATH',
+					'OBJECT',
+					'SVG',
+					'VIDEO',
+				].includes( node.tagName )
+			) {
 				return false;
 			}
+			// Elements with no children are empty.
 			if ( ! node.hasChildNodes() ) {
 				return true;
 			}
+			// Elements with children are empty if all their children are empty.
 			return Array.from( node.childNodes ).every( isEmptyNode );
 		default:
 			return true;


### PR DESCRIPTION
## Description

Fixes part of https://github.com/WordPress/gutenberg/issues/32523.

The Legacy Widget block displays a "No preview." message when it detects that the widget preview HTML has no text. This fails to account for a widget which consists entirely of `<img />`s, though.

The fix is to recurse through a DOM built from the HTML and look for `IMG` tags. This is similar to `wp.dom.isEmpty()` except that, in this case, we consider an empty element with attributes to be empty.

## How has this been tested?

To reproduce the issue you need the Polylang plugin in its development version retrieved from our github repository master branch because this is, at the moment, the branch which is compatible with the new block-based widgets screen.

You can follow instructions from its readme.md file to install Polylang, make it ready and activate it on your WordPress environment.

1. Go to Appearance > Widgets
3. Add only the language switcher legacy widget
5. Check only the `Displays flags` option alone or `Hides languages with no translation`.
You can simply uncheck the `Displays language names` option which checks automatically the `Displays flags` option
7. Click outside the language legacy widget to see what is previewed
8. You should see some country flags

## Screenshots 

https://user-images.githubusercontent.com/612155/121618623-6f91a880-caaa-11eb-814c-0e41fe616ebe.mp4

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->