### PR TITLE
Widgets: Don't delete a widget if it is moved to a different area

### DIFF
--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -281,10 +281,14 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.6.0
 	 *
+	 * @global array $wp_registered_widget_updates The registered widget update functions.
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function delete_item( $request ) {
+		global $wp_registered_widget_updates;
+
 		$widget_id  = $request['id'];
 		$sidebar_id = wp_find_widgets_sidebar( $widget_id );
 
@@ -299,17 +303,46 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$request['context'] = 'edit';
 
 		if ( $request['force'] ) {
-			$prepared = $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
+			$response = $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
+
+			$parsed_id = wp_parse_widget_id( $widget_id );
+			$id_base   = $parsed_id['id_base'];
+
+			$original_post    = $_POST;
+			$original_request = $_REQUEST;
+
+			$_POST    = array(
+				'sidebar'         => $sidebar_id,
+				"widget-$id_base" => array(),
+				'the-widget-id'   => $widget_id,
+				'delete_widget'   => '1',
+			);
+			$_REQUEST = $_POST;
+
+			$callback = $wp_registered_widget_updates[ $id_base ]['callback'];
+			$params   = $wp_registered_widget_updates[ $id_base ]['params'];
+
+			if ( is_callable( $callback ) ) {
+				ob_start();
+				call_user_func_array( $callback, $params );
+				ob_end_clean();
+			}
+
+			$_POST    = $original_post;
+			$_REQUEST = $original_request;
+
 			wp_assign_widget_to_sidebar( $widget_id, '' );
-			$prepared->set_data(
+
+			$response->set_data(
 				array(
 					'deleted'  => true,
-					'previous' => $prepared->get_data(),
+					'previous' => $response->get_data(),
 				)
 			);
 		} else {
 			wp_assign_widget_to_sidebar( $widget_id, 'wp_inactive_widgets' );
-			$prepared = $this->prepare_item_for_response(
+
+			$response = $this->prepare_item_for_response(
 				array(
 					'sidebar_id' => 'wp_inactive_widgets',
 					'widget_id'  => $widget_id,
@@ -318,7 +351,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		return $prepared;
+		return $response;
 	}
 
 	/**

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -120,13 +120,20 @@ export function* saveWidgetArea( widgetAreaId ) {
 		return true;
 	} );
 
-	// Get all widgets that have been deleted
-	const deletedWidgets = areaWidgets.filter(
-		( { id } ) =>
-			! widgetsBlocks.some(
-				( widgetBlock ) => getWidgetIdFromBlock( widgetBlock ) === id
-			)
-	);
+	// Determine which widgets have been deleted. We can tell if a widget is
+	// deleted and not just moved to a different area by looking to see if
+	// getWidgetAreaForWidgetId() finds something.
+	const deletedWidgets = [];
+	for ( const widget of areaWidgets ) {
+		const widgetsNewArea = yield select(
+			editWidgetsStoreName,
+			'getWidgetAreaForWidgetId',
+			widget.id
+		);
+		if ( ! widgetsNewArea ) {
+			deletedWidgets.push( widget );
+		}
+	}
 
 	const batchMeta = [];
 	const batchTasks = [];


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/32583.

`saveWidgetArea()` was issuing the `DELETE /wp/v2/widgets/:id` request whenever a widget had no associated block within the area being saved.

https://github.com/WordPress/gutenberg/blob/5940426a811b05b2893a890ee1b6744d3cd260b6/packages/edit-widgets/src/store/actions.js#L123-L129

https://github.com/WordPress/gutenberg/blob/5940426a811b05b2893a890ee1b6744d3cd260b6/packages/edit-widgets/src/store/actions.js#L188-L194

This isn't right though because the block might not be in the area being saved because it was moved to a different area e.g. Inactive Widgets.

This means we delete the widget and then try to reference the deleted widget when sending `PUT /wp/v2/sidebars/:id`.

## How has this been tested?

I tested by inspecting the stored widget data using WP CLI, which is a little convoluted, but here's a video:

https://user-images.githubusercontent.com/612155/121634743-77f8dc00-cac8-11eb-99d9-a56e611515db.mp4

I tried to write an E2E test but couldn't get one to fail with the bug present. I think this is because, in our simple E2E environment, everything looks visually OK because the block is deleted and then re-created...

On Monday I might spend some time making sure we have E2E tests for creating, updating, moving between areas, moving to inactive, deleting.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->