### PR TITLE
Post Editor: use the post type singular_name as the root Block Breadcrumb label

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -19,7 +19,7 @@ import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	ComplementaryArea,
 	FullscreenMode,
@@ -128,7 +128,7 @@ function Layout( { styles } ) {
 				'showBlockBreadcrumbs'
 			),
 			// translators: Default label for the Document in the Block Breadcrumb.
-			documentLabel: postTypeLabel || __( 'Document' ),
+			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -28,7 +28,6 @@ import {
 } from '@wordpress/interface';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -89,10 +88,9 @@ function Layout( { styles } ) {
 		isTemplateMode,
 		documentLabel,
 	} = useSelect( ( select ) => {
-		const { getEditorSettings, getCurrentPostType } = select( editorStore );
+		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
 		const editorSettings = getEditorSettings();
-		const currentPostType = getCurrentPostType();
-		const postType = select( coreStore ).getPostType( currentPostType );
+		const postTypeLabel = getPostTypeLabel();
 
 		return {
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
@@ -129,12 +127,7 @@ function Layout( { styles } ) {
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
 			),
-			documentLabel:
-				// Disable reason: Post type labels object is shaped like this.
-				// eslint-disable-next-line camelcase
-				postType?.labels?.singular_name ??
-				// translators: Default label for the Document sidebar tab, not selected.
-				__( 'Document' ),
+			documentLabel: postTypeLabel || __( 'Document' ),
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -28,6 +28,7 @@ import {
 } from '@wordpress/interface';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -86,8 +87,13 @@ function Layout( { styles } ) {
 		hasReducedUI,
 		showBlockBreadcrumbs,
 		isTemplateMode,
+		documentLabel,
 	} = useSelect( ( select ) => {
-		const editorSettings = select( editorStore ).getEditorSettings();
+		const { getEditorSettings, getCurrentPostType } = select( editorStore );
+		const editorSettings = getEditorSettings();
+		const currentPostType = getCurrentPostType();
+		const postType = select( coreStore ).getPostType( currentPostType );
+
 		return {
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 			hasFixedToolbar: select( editPostStore ).isFeatureActive(
@@ -123,6 +129,12 @@ function Layout( { styles } ) {
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
 			),
+			documentLabel:
+				// Disable reason: Post type labels object is shaped like this.
+				// eslint-disable-next-line camelcase
+				postType?.labels?.singular_name ??
+				// translators: Default label for the Document sidebar tab, not selected.
+				__( 'Document' ),
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
@@ -247,7 +259,7 @@ function Layout( { styles } ) {
 					isRichEditingEnabled &&
 					mode === 'visual' && (
 						<div className="edit-post-layout__footer">
-							<BlockBreadcrumb />
+							<BlockBreadcrumb rootLabelText={ documentLabel } />
 						</div>
 					)
 				}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -127,6 +127,7 @@ function Layout( { styles } ) {
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
 			),
+			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || __( 'Document' ),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -22,7 +22,7 @@ const SettingsHeader = ( { sidebarName } ) => {
 
 		return {
 			// translators: Default label for the Document sidebar tab, not selected.
-			documentLabel: postTypeLabel || __( 'Document' ),
+			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -21,6 +21,7 @@ const SettingsHeader = ( { sidebarName } ) => {
 		const postTypeLabel = select( editorStore ).getPostTypeLabel();
 
 		return {
+			// translators: Default label for the Document sidebar tab, not selected.
 			documentLabel: postTypeLabel || __( 'Document' ),
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -4,7 +4,6 @@
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -19,16 +18,10 @@ const SettingsHeader = ( { sidebarName } ) => {
 	const openBlockSettings = () => openGeneralSidebar( 'edit-post/block' );
 
 	const { documentLabel, isTemplateMode } = useSelect( ( select ) => {
-		const currentPostType = select( editorStore ).getCurrentPostType();
-		const postType = select( coreStore ).getPostType( currentPostType );
+		const postTypeLabel = select( editorStore ).getPostTypeLabel();
 
 		return {
-			documentLabel:
-				// Disable reason: Post type labels object is shaped like this.
-				// eslint-disable-next-line camelcase
-				postType?.labels?.singular_name ??
-				// translators: Default label for the Document sidebar tab, not selected.
-				__( 'Document' ),
+			documentLabel: postTypeLabel || __( 'Document' ),
 			isTemplateMode: select( editPostStore ).isEditingTemplate(),
 		};
 	}, [] );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1763,6 +1763,5 @@ export const getPostTypeLabel = createRegistrySelector(
 		// Disable reason: Post type labels object is shaped like this.
 		// eslint-disable-next-line camelcase
 		return postType?.labels?.singular_name || null;
-		// translators: Default label for the Document sidebar tab, not selected.
 	}
 );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1748,3 +1748,21 @@ export function __experimentalGetTemplateInfo( state, template ) {
 		icon: templateIcon,
 	};
 }
+
+/**
+ * Returns a post type label depending on the current post.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string|null} The post type label if available, otherwise null.
+ */
+export const getPostTypeLabel = createRegistrySelector(
+	( select ) => ( state ) => {
+		const currentPostType = getCurrentPostType( state );
+		const postType = select( coreStore ).getPostType( currentPostType );
+		// Disable reason: Post type labels object is shaped like this.
+		// eslint-disable-next-line camelcase
+		return postType?.labels?.singular_name || null;
+		// translators: Default label for the Document sidebar tab, not selected.
+	}
+);

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1754,7 +1754,7 @@ export function __experimentalGetTemplateInfo( state, template ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {string|null} The post type label if available, otherwise null.
+ * @return {string|undefined} The post type label if available, otherwise undefined.
  */
 export const getPostTypeLabel = createRegistrySelector(
 	( select ) => ( state ) => {
@@ -1762,6 +1762,6 @@ export const getPostTypeLabel = createRegistrySelector(
 		const postType = select( coreStore ).getPostType( currentPostType );
 		// Disable reason: Post type labels object is shaped like this.
 		// eslint-disable-next-line camelcase
-		return postType?.labels?.singular_name || null;
+		return postType?.labels?.singular_name;
 	}
 );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -3062,11 +3062,11 @@ describe( 'selectors', () => {
 			);
 		} );
 
-		it( 'should return null when the post type label does not exist', () => {
+		it( 'should return `undefined` when the post type label does not exist', () => {
 			const postTypes = [ {}, { postType: 'humpty' } ];
 
 			postTypes.forEach( ( state ) =>
-				expect( getPostTypeLabel( state ) ).toBeNull()
+				expect( getPostTypeLabel( state ) ).toBeUndefined()
 			);
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -112,6 +112,19 @@ selectorNames.forEach( ( name ) => {
 			getAutosave() {
 				return state.getAutosave && state.getAutosave();
 			},
+
+			getPostType() {
+				const postTypeLabel = {
+					post: 'Post',
+					page: 'Page',
+				}[ state.postType ];
+
+				return {
+					labels: {
+						singular_name: postTypeLabel,
+					},
+				};
+			},
 		} );
 
 		selectorNames.forEach( ( otherName ) => {
@@ -169,6 +182,7 @@ const {
 	isPostSavingLocked,
 	isPostAutosavingLocked,
 	canUserUseUnfilteredHTML,
+	getPostTypeLabel,
 	__experimentalGetDefaultTemplateType,
 	__experimentalGetDefaultTemplateTypes,
 	__experimentalGetTemplateInfo,
@@ -3023,6 +3037,37 @@ describe( 'selectors', () => {
 				title: 'template part, area = footer',
 				icon: footer,
 			} );
+		} );
+	} );
+
+	describe( 'getPostTypeLabel', () => {
+		it( 'should return the correct label for the current post type', () => {
+			const postTypes = [
+				{
+					state: {
+						postType: 'page',
+					},
+					expected: 'Page',
+				},
+				{
+					state: {
+						postType: 'post',
+					},
+					expected: 'Post',
+				},
+			];
+
+			postTypes.forEach( ( { state, expected } ) =>
+				expect( getPostTypeLabel( state ) ).toBe( expected )
+			);
+		} );
+
+		it( 'should return null when the post type label does not exist', () => {
+			const postTypes = [ {}, { postType: 'humpty' } ];
+
+			postTypes.forEach( ( state ) =>
+				expect( getPostTypeLabel( state ) ).toBeNull()
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION

## Description
https://github.com/WordPress/gutenberg/pull/17311 introduced post type labels as the document label in the sidebar.

This PR does the same trick, but for the Block Breadcrumb.

Context: https://github.com/WordPress/gutenberg/pull/32528#issuecomment-857375548

This PR only affects the post editor. If a post type is unknown or cannot be found, we default back to `__( 'Document' )`.

## How has this been tested?

1. Open a post. Check that the sidebar document label is "Post" and matches the Block Breadcrumb root label, which should also be "Post"
2. Open a page. Check that the sidebar document label is "Page" and matches the Block Breadcrumb root label, which should also be "Page"


Unit test for the selector:
```js
npm run test-unit packages/editor/src/store/test/selectors.js
```

## Screenshots <!-- if applicable -->
<img width="866" alt="Screen Shot 2021-06-11 at 3 53 44 pm" src="https://user-images.githubusercontent.com/6458278/121638244-fc019280-cacd-11eb-886d-075a2828ac43.png">
<img width="1041" alt="Screen Shot 2021-06-11 at 3 54 15 pm" src="https://user-images.githubusercontent.com/6458278/121638252-ff951980-cacd-11eb-9ee9-d5454b8ceb6a.png">


## Types of changes
Adds the post type label to the Block Breadcrumb root label.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
