### PR TITLE
BoxControl: Add support for grouped directions (vertical and horizontal controls)

### DIFF
--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -105,6 +105,14 @@ If this property is true, a button to reset the box control is rendered.
 - Required: No
 - Default: `true`
 
+### isGroupedDirections
+
+If this property is true, when the box control is unlinked, vertical and horizontal controls can be used instead of updating individual sides.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
 ### inputProps
 
 Props for the internal [InputControl](../input-control) components.

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -105,7 +105,7 @@ If this property is true, a button to reset the box control is rendered.
 - Required: No
 - Default: `true`
 
-### isGroupedDirections
+### splitOnAxis
 
 If this property is true, when the box control is unlinked, vertical and horizontal controls can be used instead of updating individual sides.
 

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -31,7 +31,7 @@ export default function AllInputControl( {
 		const nextValues = { ...values };
 
 		if ( sides?.length ) {
-			sides.forEach( side => {
+			sides.forEach( ( side ) => {
 				if ( side === 'vertical' ) {
 					nextValues.top = next;
 					nextValues.bottom = next;
@@ -43,7 +43,9 @@ export default function AllInputControl( {
 				}
 			} );
 		} else {
-			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => ( nextValues[ side ] = next ) );
+			[ 'top', 'right', 'bottom', 'left' ].forEach(
+				( side ) => ( nextValues[ side ] = next )
+			);
 		}
 
 		onChange( nextValues );

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -29,11 +29,22 @@ export default function AllInputControl( {
 
 	const handleOnChange = ( next ) => {
 		const nextValues = { ...values };
-		const selectedSides = sides?.length
-			? sides
-			: [ 'top', 'right', 'bottom', 'left' ];
 
-		selectedSides.forEach( ( side ) => ( nextValues[ side ] = next ) );
+		if ( sides?.length ) {
+			sides.forEach( side => {
+				if ( side === 'vertical' ) {
+					nextValues.top = next;
+					nextValues.bottom = next;
+				} else if ( side === 'horizontal' ) {
+					nextValues.left = next;
+					nextValues.right = next;
+				} else {
+					nextValues[ side ] = next;
+				}
+			} );
+		} else {
+			[ 'top', 'right', 'bottom', 'left' ].forEach( ( side ) => ( nextValues[ side ] = next ) );
+		}
 
 		onChange( nextValues );
 	};

--- a/packages/components/src/box-control/icon.js
+++ b/packages/components/src/box-control/icon.js
@@ -21,7 +21,7 @@ export default function BoxControlIcon( {
 	const isSideDisabled = ( value ) =>
 		sides?.length && ! sides.includes( value );
 
-	const getSide = ( value ) => {
+	const hasSide = ( value ) => {
 		if ( isSideDisabled( value ) ) {
 			return false;
 		}
@@ -29,10 +29,10 @@ export default function BoxControlIcon( {
 		return side === 'all' || side === value;
 	};
 
-	const top = getSide( 'top' ) || getSide( 'vertical' );
-	const right = getSide( 'right' ) || getSide( 'horizontal' );
-	const bottom = getSide( 'bottom' ) || getSide( 'vertical' );
-	const left = getSide( 'left' ) || getSide( 'horizontal' );
+	const top = hasSide( 'top' ) || hasSide( 'vertical' );
+	const right = hasSide( 'right' ) || hasSide( 'horizontal' );
+	const bottom = hasSide( 'bottom' ) || hasSide( 'vertical' );
+	const left = hasSide( 'left' ) || hasSide( 'horizontal' );
 
 	// Simulates SVG Icon scaling
 	const scale = size / BASE_ICON_SIZE;

--- a/packages/components/src/box-control/icon.js
+++ b/packages/components/src/box-control/icon.js
@@ -29,10 +29,10 @@ export default function BoxControlIcon( {
 		return side === 'all' || side === value;
 	};
 
-	const top = getSide( 'top' );
-	const right = getSide( 'right' );
-	const bottom = getSide( 'bottom' );
-	const left = getSide( 'left' );
+	const top = getSide( 'top' ) || getSide( 'vertical' );
+	const right = getSide( 'right' ) || getSide( 'horizontal' );
+	const bottom = getSide( 'bottom' ) || getSide( 'vertical' );
+	const left = getSide( 'left' ) || getSide( 'horizontal' );
 
 	// Simulates SVG Icon scaling
 	const scale = size / BASE_ICON_SIZE;

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -54,7 +54,7 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
-	isGroupedDirections = false,
+	splitOnAxis = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
 } ) {
@@ -71,7 +71,7 @@ export default function BoxControl( {
 	);
 
 	const [ side, setSide ] = useState(
-		getInitialSide( isLinked, isGroupedDirections )
+		getInitialSide( isLinked, splitOnAxis )
 	);
 
 	const id = useUniqueId( idProp );
@@ -79,7 +79,7 @@ export default function BoxControl( {
 
 	const toggleLinked = () => {
 		setIsLinked( ! isLinked );
-		setSide( getInitialSide( ! isLinked, isGroupedDirections ) );
+		setSide( getInitialSide( ! isLinked, splitOnAxis ) );
 	};
 
 	const handleOnFocus = ( event, { side: nextSide } ) => {
@@ -155,7 +155,7 @@ export default function BoxControl( {
 						/>
 					</FlexBlock>
 				) }
-				{ ! isLinked && isGroupedDirections && (
+				{ ! isLinked && splitOnAxis && (
 					<FlexBlock>
 						<VerticalHorizontalInputControls
 							{ ...inputControlProps }
@@ -171,7 +171,7 @@ export default function BoxControl( {
 					</FlexItem>
 				) }
 			</HeaderControlWrapper>
-			{ ! isLinked && ! isGroupedDirections && (
+			{ ! isLinked && ! splitOnAxis && (
 				<InputControls { ...inputControlProps } />
 			) }
 		</Root>

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -70,7 +70,9 @@ export default function BoxControl( {
 		! hasInitialValue || ! isValuesMixed( inputValues ) || hasOneSide
 	);
 
-	const [ side, setSide ] = useState( getInitialSide( isLinked, groupedDirections) );
+	const [ side, setSide ] = useState(
+		getInitialSide( isLinked, groupedDirections )
+	);
 
 	const id = useUniqueId( idProp );
 	const headingId = `${ id }-heading`;

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -157,7 +157,9 @@ export default function BoxControl( {
 				) }
 				{ ! isLinked && isGroupedDirections && (
 					<FlexBlock>
-					<VerticalHorizontalInputControls { ...inputControlProps } />
+						<VerticalHorizontalInputControls
+							{ ...inputControlProps }
+						/>
 					</FlexBlock>
 				) }
 				{ ! hasOneSide && (

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -54,7 +54,7 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
-	groupedDirections = true,
+	isGroupedDirections = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
 } ) {
@@ -71,7 +71,7 @@ export default function BoxControl( {
 	);
 
 	const [ side, setSide ] = useState(
-		getInitialSide( isLinked, groupedDirections )
+		getInitialSide( isLinked, isGroupedDirections )
 	);
 
 	const id = useUniqueId( idProp );
@@ -79,7 +79,7 @@ export default function BoxControl( {
 
 	const toggleLinked = () => {
 		setIsLinked( ! isLinked );
-		setSide( getInitialSide( ! isLinked, groupedDirections ) );
+		setSide( getInitialSide( ! isLinked, isGroupedDirections ) );
 	};
 
 	const handleOnFocus = ( event, { side: nextSide } ) => {
@@ -155,8 +155,10 @@ export default function BoxControl( {
 						/>
 					</FlexBlock>
 				) }
-				{ ! isLinked && groupedDirections && (
+				{ ! isLinked && isGroupedDirections && (
+					<FlexBlock>
 					<VerticalHorizontalInputControls { ...inputControlProps } />
+					</FlexBlock>
 				) }
 				{ ! hasOneSide && (
 					<FlexItem>
@@ -167,7 +169,7 @@ export default function BoxControl( {
 					</FlexItem>
 				) }
 			</HeaderControlWrapper>
-			{ ! isLinked && ! groupedDirections && (
+			{ ! isLinked && ! isGroupedDirections && (
 				<InputControls { ...inputControlProps } />
 			) }
 		</Root>

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -17,6 +17,7 @@ import Button from '../button';
 import { FlexItem, FlexBlock } from '../flex';
 import AllInputControl from './all-input-control';
 import InputControls from './input-controls';
+import VerticalHorizontalInputControls from './vertical-horizontal-input-controls';
 import BoxControlIcon from './icon';
 import { Text } from '../text';
 import LinkedButton from './linked-button';
@@ -29,6 +30,7 @@ import {
 import {
 	DEFAULT_VALUES,
 	DEFAULT_VISUALIZER_VALUES,
+	getInitialSide,
 	isValuesMixed,
 	isValuesDefined,
 } from './utils';
@@ -52,6 +54,7 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 	sides,
+	groupedDirections = true,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
 } ) {
@@ -67,14 +70,14 @@ export default function BoxControl( {
 		! hasInitialValue || ! isValuesMixed( inputValues ) || hasOneSide
 	);
 
-	const [ side, setSide ] = useState( isLinked ? 'all' : 'top' );
+	const [ side, setSide ] = useState( getInitialSide( isLinked, groupedDirections) );
 
 	const id = useUniqueId( idProp );
 	const headingId = `${ id }-heading`;
 
 	const toggleLinked = () => {
 		setIsLinked( ! isLinked );
-		setSide( ! isLinked ? 'all' : 'top' );
+		setSide( getInitialSide( ! isLinked, groupedDirections ) );
 	};
 
 	const handleOnFocus = ( event, { side: nextSide } ) => {
@@ -150,6 +153,9 @@ export default function BoxControl( {
 						/>
 					</FlexBlock>
 				) }
+				{ ! isLinked && groupedDirections && (
+					<VerticalHorizontalInputControls { ...inputControlProps } />
+				) }
 				{ ! hasOneSide && (
 					<FlexItem>
 						<LinkedButton
@@ -159,7 +165,9 @@ export default function BoxControl( {
 					</FlexItem>
 				) }
 			</HeaderControlWrapper>
-			{ ! isLinked && <InputControls { ...inputControlProps } /> }
+			{ ! isLinked && ! groupedDirections && (
+				<InputControls { ...inputControlProps } />
+			) }
 		</Root>
 	);
 }

--- a/packages/components/src/box-control/stories/index.js
+++ b/packages/components/src/box-control/stories/index.js
@@ -30,7 +30,7 @@ const defaultSideValues = {
 function DemoExample( {
 	sides,
 	defaultValues = defaultSideValues,
-	isGroupedDirections = false,
+	splitOnAxis = false,
 } ) {
 	const [ values, setValues ] = useState( defaultValues );
 	const [ showVisualizer, setShowVisualizer ] = useState( {} );
@@ -45,7 +45,7 @@ function DemoExample( {
 						sides={ sides }
 						onChange={ setValues }
 						onChangeShowVisualizer={ setShowVisualizer }
-						isGroupedDirections={ isGroupedDirections }
+						splitOnAxis={ splitOnAxis }
 					/>
 				</Content>
 			</FlexBlock>
@@ -87,16 +87,16 @@ export const singleSide = () => {
 	);
 };
 
-export const groupedDirections = () => {
-	return <DemoExample isGroupedDirections={ true } />;
+export const verticalHorizontalControls = () => {
+	return <DemoExample splitOnAxis={ true } />;
 };
 
-export const groupedDirectionsWithSingleSide = () => {
+export const verticalHorizontalControlsWithSingleSide = () => {
 	return (
 		<DemoExample
 			sides={ [ 'horizontal' ] }
 			defaultValues={ { left: '10px', right: '10px' } }
-			isGroupedDirections={ true }
+			splitOnAxis={ true }
 		/>
 	);
 };

--- a/packages/components/src/box-control/stories/index.js
+++ b/packages/components/src/box-control/stories/index.js
@@ -27,7 +27,11 @@ const defaultSideValues = {
 	left: '10px',
 };
 
-function DemoExample( { sides, defaultValues = defaultSideValues } ) {
+function DemoExample( {
+	sides,
+	defaultValues = defaultSideValues,
+	isGroupedDirections = false,
+} ) {
 	const [ values, setValues ] = useState( defaultValues );
 	const [ showVisualizer, setShowVisualizer ] = useState( {} );
 
@@ -41,6 +45,7 @@ function DemoExample( { sides, defaultValues = defaultSideValues } ) {
 						sides={ sides }
 						onChange={ setValues }
 						onChangeShowVisualizer={ setShowVisualizer }
+						isGroupedDirections={ isGroupedDirections }
 					/>
 				</Content>
 			</FlexBlock>
@@ -78,6 +83,20 @@ export const singleSide = () => {
 		<DemoExample
 			sides={ [ 'bottom' ] }
 			defaultValues={ { bottom: '10px' } }
+		/>
+	);
+};
+
+export const groupedDirections = () => {
+	return <DemoExample isGroupedDirections={ true } />;
+};
+
+export const groupedDirectionsWithSingleSide = () => {
+	return (
+		<DemoExample
+			sides={ [ 'horizontal' ] }
+			defaultValues={ { left: '10px', right: '10px' } }
+			isGroupedDirections={ true }
 		/>
 	);
 };

--- a/packages/components/src/box-control/styles/box-control-styles.js
+++ b/packages/components/src/box-control/styles/box-control-styles.js
@@ -24,6 +24,7 @@ export const Header = styled( Flex )`
 
 export const HeaderControlWrapper = styled( Flex )`
 	min-height: 30px;
+	gap: 0;
 `;
 
 export const UnitControlWrapper = styled.div`
@@ -59,8 +60,8 @@ const unitControlBorderRadiusStyles = ( { isFirst, isLast, isOnly } ) => {
 	} );
 };
 
-const unitControlMarginStyles = ( { isFirst } ) => {
-	const marginLeft = isFirst ? 0 : -1;
+const unitControlMarginStyles = ( { isFirst, isOnly } ) => {
+	const marginLeft = isFirst || isOnly ? 0 : -1;
 
 	return rtl( { marginLeft } )();
 };

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -125,4 +125,71 @@ describe( 'BoxControl', () => {
 			expect( unitSelect.value ).toBe( 'px' );
 		} );
 	} );
+
+	describe( 'Unlinked Sides', () => {
+		it( 'should update a single side value when unlinked', () => {
+			let state = {};
+			const setState = ( newState ) => ( state = newState );
+
+			const { container, getByLabelText } = render(
+				<BoxControl
+					values={ state }
+					onChange={ ( next ) => setState( next ) }
+				/>
+			);
+
+			const unlink = getByLabelText( /Unlink Sides/ );
+			fireEvent.click( unlink );
+
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( 'px' );
+
+			expect( state ).toEqual( {
+				top: '100px',
+				right: undefined,
+				bottom: undefined,
+				left: undefined,
+			} );
+		} );
+
+		it( 'should update a whole axis when value is changed when unlinked', () => {
+			let state = {};
+			const setState = ( newState ) => ( state = newState );
+
+			const { container, getByLabelText } = render(
+				<BoxControl
+					values={ state }
+					onChange={ ( next ) => setState( next ) }
+					splitOnAxis={ true }
+				/>
+			);
+
+			const unlink = getByLabelText( /Unlink Sides/ );
+			fireEvent.click( unlink );
+
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( 'px' );
+
+			expect( state ).toEqual( {
+				top: '100px',
+				right: undefined,
+				bottom: '100px',
+				left: undefined,
+			} );
+		} );
+	} );
 } );

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -124,17 +124,17 @@ export function isValuesDefined( values ) {
 
 /**
  * Get initial selected side, factoring in whether the sides are linked,
- * and whether or not the vertical / horizontal directions are grouped.
+ * and whether the vertical / horizontal directions are grouped via splitOnAxis.
  *
  * @param {boolean} isLinked
- * @param {boolean} isGroupedDirections
+ * @param {boolean} splitOnAxis
  * @return {string} The initial side.
  */
-export function getInitialSide( isLinked, isGroupedDirections ) {
+export function getInitialSide( isLinked, splitOnAxis ) {
 	let initialSide = 'all';
 
 	if ( ! isLinked ) {
-		initialSide = isGroupedDirections ? 'vertical' : 'top';
+		initialSide = splitOnAxis ? 'vertical' : 'top';
 	}
 
 	return initialSide;

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -20,6 +20,8 @@ export const LABELS = {
 	left: __( 'Left' ),
 	right: __( 'Right' ),
 	mixed: __( 'Mixed' ),
+	vertical: __( 'Vertical' ),
+	horizontal: __( 'Horizontal' ),
 };
 
 export const DEFAULT_VALUES = {
@@ -118,4 +120,22 @@ export function isValuesDefined( values ) {
 			)
 		)
 	);
+}
+
+/**
+ * Get initial selected side, factoring in whether the sides are linked,
+ * and whether or not the vertical / horizontal directions are grouped.
+ *
+ * @param {boolean} isLinked
+ * @param {boolean} isGroupedDirections
+ * @return {string} The initial side.
+ */
+export function getInitialSide( isLinked, isGroupedDirections ) {
+	let initialSide = 'all';
+
+	if ( ! isLinked ) {
+		initialSide = isGroupedDirections ? 'vertical' : 'top';
+	}
+
+	return initialSide;
 }

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import UnitControl from './unit-control';
+import { LABELS } from './utils';
+
+const groupedSides = [ 'vertical', 'horizontal' ];
+
+export default function VerticalHorizontalInputControls( {
+	onChange = noop,
+	onFocus = noop,
+	onHoverOn = noop,
+	onHoverOff = noop,
+	values,
+	sides,
+	...props
+} ) {
+	const createHandleOnFocus = ( side ) => ( event ) => {
+		// TODO: Check if this is okay.
+		onFocus( event, { side } );
+	};
+
+	const createHandleOnHoverOn = ( side ) => () => {
+		if ( side === 'vertical' ) {
+			onHoverOn( {
+				top: true,
+				bottom: true,
+				left: false,
+				right: false,
+			} );
+		} else {
+			onHoverOn( {
+				top: false,
+				bottom: false,
+				left: true,
+				right: true,
+			} );
+		}
+	};
+
+	const createHandleOnHoverOff = ( side ) => () => {
+		if ( side === 'vertical' ) {
+			onHoverOff( {
+				top: true,
+				bottom: true,
+				left: false,
+				right: false,
+			} );
+		} else {
+			onHoverOff( {
+				top: false,
+				bottom: false,
+				left: true,
+				right: true,
+			} );
+		}
+	};
+
+	const handleOnChange = ( nextValues ) => {
+		onChange( nextValues );
+	};
+
+	const createHandleOnChange = ( side ) => ( next ) => {
+		const nextValues = { ...values };
+
+		if ( side === 'vertical' ) {
+			nextValues.top = next;
+			nextValues.bottom = next;
+		}
+		if ( side === 'horizontal' ) {
+			nextValues.left = next;
+			nextValues.right = next;
+		}
+
+		handleOnChange( nextValues );
+	};
+
+	// Filter sides if custom configuration provided, maintaining default order.
+	// const filteredSides = sides?.length
+	// 	? allSides.filter( ( side ) => sides.includes( side ) )
+	// 	: allSides;
+
+	// TODO: Allow filtering of sides so that you can have it be just vertical or just horizontal
+
+	const filteredSides = groupedSides;
+
+	const first = filteredSides[ 0 ];
+	const last = filteredSides[ filteredSides.length - 1 ];
+	const only = first === last && first;
+
+	return (
+		<>
+			{ filteredSides.map( ( side ) => (
+				<UnitControl
+					{ ...props }
+					isFirst={ first === side }
+					isLast={ last === side }
+					isOnly={ only === side }
+					value={ 'vertical' === side ? values.top : values.left }
+					onChange={ createHandleOnChange( side ) }
+					onFocus={ createHandleOnFocus( side ) }
+					onHoverOn={ createHandleOnHoverOn( side ) }
+					onHoverOff={ createHandleOnHoverOff( side ) }
+					label={ LABELS[ side ] }
+					key={ `box-control-${ side }` }
+				/>
+			) ) }
+		</>
+	);
+}

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -71,7 +71,7 @@ export default function VerticalHorizontalInputControls( {
 
 	const first = filteredSides[ 0 ];
 	const last = filteredSides[ filteredSides.length - 1 ];
-	const only = first === last && first;
+	const only = first === last;
 
 	return (
 		<Layout

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -91,7 +91,7 @@ export default function VerticalHorizontalInputControls( {
 					onHoverOn={ createHandleOnHoverOn( side ) }
 					onHoverOff={ createHandleOnHoverOff( side ) }
 					label={ LABELS[ side ] }
-					key={ `box-control-${ side }` }
+					key={ side }
 				/>
 			) ) }
 		</Layout>

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -5,23 +5,28 @@ import UnitControl from './unit-control';
 import { LABELS } from './utils';
 import { Layout } from './styles/box-control-styles';
 
-const noop = () => {};
 const groupedSides = [ 'vertical', 'horizontal' ];
 
 export default function VerticalHorizontalInputControls( {
-	onChange = noop,
-	onFocus = noop,
-	onHoverOn = noop,
-	onHoverOff = noop,
+	onChange,
+	onFocus,
+	onHoverOn,
+	onHoverOff,
 	values,
 	sides,
 	...props
 } ) {
 	const createHandleOnFocus = ( side ) => ( event ) => {
+		if ( ! onFocus ) {
+			return;
+		}
 		onFocus( event, { side } );
 	};
 
 	const createHandleOnHoverOn = ( side ) => () => {
+		if ( ! onHoverOn ) {
+			return;
+		}
 		if ( side === 'vertical' ) {
 			onHoverOn( {
 				top: true,
@@ -37,6 +42,9 @@ export default function VerticalHorizontalInputControls( {
 	};
 
 	const createHandleOnHoverOff = ( side ) => () => {
+		if ( ! onHoverOff ) {
+			return;
+		}
 		if ( side === 'vertical' ) {
 			onHoverOff( {
 				top: false,
@@ -52,6 +60,9 @@ export default function VerticalHorizontalInputControls( {
 	};
 
 	const createHandleOnChange = ( side ) => ( next ) => {
+		if ( ! onChange ) {
+			return;
+		}
 		const nextValues = { ...values };
 
 		if ( side === 'vertical' ) {

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  */
 import UnitControl from './unit-control';
 import { LABELS } from './utils';
+import { Layout } from './styles/box-control-styles';
 
 const groupedSides = [ 'vertical', 'horizontal' ];
 
@@ -21,7 +22,6 @@ export default function VerticalHorizontalInputControls( {
 	...props
 } ) {
 	const createHandleOnFocus = ( side ) => ( event ) => {
-		// TODO: Check if this is okay.
 		onFocus( event, { side } );
 	};
 
@@ -30,13 +30,9 @@ export default function VerticalHorizontalInputControls( {
 			onHoverOn( {
 				top: true,
 				bottom: true,
-				left: false,
-				right: false,
 			} );
 		} else {
 			onHoverOn( {
-				top: false,
-				bottom: false,
 				left: true,
 				right: true,
 			} );
@@ -46,23 +42,15 @@ export default function VerticalHorizontalInputControls( {
 	const createHandleOnHoverOff = ( side ) => () => {
 		if ( side === 'vertical' ) {
 			onHoverOff( {
-				top: true,
-				bottom: true,
-				left: false,
-				right: false,
+				top: false,
+				bottom: false,
 			} );
 		} else {
 			onHoverOff( {
-				top: false,
-				bottom: false,
-				left: true,
-				right: true,
+				left: false,
+				right: false,
 			} );
 		}
-	};
-
-	const handleOnChange = ( nextValues ) => {
-		onChange( nextValues );
 	};
 
 	const createHandleOnChange = ( side ) => ( next ) => {
@@ -77,24 +65,24 @@ export default function VerticalHorizontalInputControls( {
 			nextValues.right = next;
 		}
 
-		handleOnChange( nextValues );
+		onChange( nextValues );
 	};
 
 	// Filter sides if custom configuration provided, maintaining default order.
-	// const filteredSides = sides?.length
-	// 	? allSides.filter( ( side ) => sides.includes( side ) )
-	// 	: allSides;
-
-	// TODO: Allow filtering of sides so that you can have it be just vertical or just horizontal
-
-	const filteredSides = groupedSides;
+	const filteredSides = sides?.length
+		? groupedSides.filter( ( side ) => sides.includes( side ) )
+		: groupedSides;
 
 	const first = filteredSides[ 0 ];
 	const last = filteredSides[ filteredSides.length - 1 ];
 	const only = first === last && first;
 
 	return (
-		<>
+		<Layout
+			gap={ 0 }
+			align="top"
+			className="component-box-control__vertical-horizontal-input-controls"
+		>
 			{ filteredSides.map( ( side ) => (
 				<UnitControl
 					{ ...props }
@@ -110,6 +98,6 @@ export default function VerticalHorizontalInputControls( {
 					key={ `box-control-${ side }` }
 				/>
 			) ) }
-		</>
+		</Layout>
 	);
 }

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import UnitControl from './unit-control';
 import { LABELS } from './utils';
 import { Layout } from './styles/box-control-styles';
 
+const noop = () => {};
 const groupedSides = [ 'vertical', 'horizontal' ];
 
 export default function VerticalHorizontalInputControls( {

--- a/packages/components/src/box-control/vertical-horizontal-input-controls.js
+++ b/packages/components/src/box-control/vertical-horizontal-input-controls.js
@@ -27,7 +27,8 @@ export default function VerticalHorizontalInputControls( {
 				top: true,
 				bottom: true,
 			} );
-		} else {
+		}
+		if ( side === 'horizontal' ) {
 			onHoverOn( {
 				left: true,
 				right: true,
@@ -41,7 +42,8 @@ export default function VerticalHorizontalInputControls( {
 				top: false,
 				bottom: false,
 			} );
-		} else {
+		}
+		if ( side === 'horizontal' ) {
 			onHoverOff( {
 				left: false,
 				right: false,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to (and potential use case in): https://github.com/WordPress/gutenberg/issues/32366

This PR adds a `splitOnAxis` prop to the `BoxControl` component, allowing grouped vertical and horizontal controls. The use case for this is for Gap support, where top/bottom and left/right values need to be grouped together to be used in the `row-gap` and `column-gap` CSS properties, respectively.

The behaviour in this PR is that with `splitOnAxis` set to `true`, when unlinking the box control, two unit controls will be displayed for the user to work with, and they'll be displayed inline, instead of on a following row.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Check out this PR, and start up Storybook with `npm run storybook:dev`
2. Open up Storybook in your browser and navigate to `http://localhost:50240/?path=/story/components-boxcontrol--grouped-directions` to test out this variation of the BoxControl
3. To test out on a block within the block editor, switch the default value of `splitOnAxis` to `true` on this line: https://github.com/andrewserong/gutenberg/blob/43c68cb18cbdaf712c183d539efdd5e07c4d5099/packages/components/src/box-control/index.js#L57-L57
4. To run the JS tests locally, use `npm run test-unit -- packages/components/src/box-control/test/`

Then, in the post editor, add a Group block, and test out using the padding spacing control. It should work as expected updating the padding vertically and horizontally when unlinked.

---

~A question for anyone reviewing: do the property names make sense? Can you think of a better name than `isGroupedDirections`?~ Sara gave the suggestion to use a name like `splitOnAxis` 👍

## Screenshots <!-- if applicable -->

![box-control-grouped-directions](https://user-images.githubusercontent.com/14988353/121641816-03776a80-cad3-11eb-85f9-ac566499a762.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. (tested via keyboard) <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
