### PR TITLE
Plugin: Copy `wp_should_load_separate_core_block_assets` function from core

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -165,7 +165,7 @@ add_action( 'init', 'gutenberg_reregister_core_block_types' );
  * @return void
  */
 function gutenberg_register_core_block_styles( $block_name ) {
-	if ( ! gutenberg_should_load_separate_block_assets() ) {
+	if ( ! wp_should_load_separate_core_block_assets() ) {
 		return;
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -331,7 +331,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 	$styles->add_data( 'wp-components', 'rtl', 'replace' );
 
-	$block_library_filename = gutenberg_should_load_separate_block_assets() ? 'common' : 'style';
+	$block_library_filename = wp_should_load_separate_core_block_assets() ? 'common' : 'style';
 	gutenberg_override_style(
 		$styles,
 		'wp-block-library',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -8,33 +8,30 @@
  * @package gutenberg
  */
 
-/**
- * Determine if the current theme needs to load separate block styles or not.
- *
- * @todo Remove this function when the minimum supported version is WordPress 5.8.
- *
- * @return bool
- */
-function gutenberg_should_load_separate_block_assets() {
-	if ( function_exists( 'wp_should_load_separate_core_block_assets' ) ) {
-		return wp_should_load_separate_core_block_assets();
-	}
-
-	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-		return false;
-	}
-
-	// The `should_load_separate_core_block_assets` filter was added in WP 5.8.
-	$load_separate_styles = apply_filters( 'should_load_separate_core_block_assets', gutenberg_is_fse_theme() );
-
+if ( ! function_exists( 'wp_should_load_separate_core_block_assets' ) ) {
 	/**
-	 * Determine if separate styles will be loaded for blocks on-render or not.
+	 * Checks whether separate assets should be loaded for core blocks on-render.
 	 *
-	 * @param bool $load_separate_styles Whether separate styles will be loaded or not.
+	 * @since 5.8.0
 	 *
-	 * @return bool
+	 * @return bool Whether separate assets will be loaded.
 	 */
-	return apply_filters( 'load_separate_block_assets', $load_separate_styles );
+	function wp_should_load_separate_core_block_assets() {
+		if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters the flag that decides whether separate scripts and styles
+		 * will be loaded for core blocks on-render.
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param bool $load_separate_assets Whether separate assets will be loaded.
+		 *                                   Default false.
+		 */
+		return apply_filters( 'should_load_separate_core_block_assets', false );
+	}
 }
 
 /**
@@ -58,7 +55,7 @@ add_filter(
  * @return void
  */
 function gutenberg_remove_hook_wp_enqueue_registered_block_scripts_and_styles() {
-	if ( gutenberg_should_load_separate_block_assets() ) {
+	if ( wp_should_load_separate_core_block_assets() ) {
 		/**
 		 * Avoid enqueueing block assets of all registered blocks for all posts, instead
 		 * deferring to block render mechanics to enqueue scripts, thereby ensuring only

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -8,6 +8,11 @@
  * @package gutenberg
  */
 
+/**
+ * Backporting wp_should_load_separate_core_block_assets from WP-Core.
+ *
+ * @todo Remove this function when the minimum supported version is WordPress 5.8.
+ */
 if ( ! function_exists( 'wp_should_load_separate_core_block_assets' ) ) {
 	/**
 	 * Checks whether separate assets should be loaded for core blocks on-render.


### PR DESCRIPTION
## Description
The `gutenberg_should_load_separate_block_assets` function was ported to core as `wp_should_load_separate_core_block_assets`. Instead of adding a `gutenberg_` function in the plugin and calling `wp_` inside it, we can simply do a `function_exists` check, and add the `wp_` function in the plugin if the function doesn't exist.

This will make maintenance easier and will allow for easier porting of future code in core.

## How has this been tested?
Tested with a block theme and a classic theme in WP5.8-trunk, everything works as expected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
