### PR TITLE
Fix unwanted rich previews for internal urls

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -23,6 +23,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
+	$settings['__experimentalBaseUrl']                 = get_site_url();
 
 	if ( gutenberg_is_fse_theme() ) {
 		$settings['defaultTemplatePartAreas'] = gutenberg_get_allowed_template_part_areas();

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -90,7 +90,7 @@ export default function LinkPreview( {
 				<ViewerSlot fillProps={ value } />
 			</div>
 
-			{ ( hasRichData || isFetching ) && (
+			{ hasRichPreviews && ( hasRichData || isFetching ) && (
 				<div className="block-editor-link-control__search-item-bottom">
 					<div
 						aria-hidden={ ! richData?.image }

--- a/packages/block-editor/src/components/link-control/use-remote-url-data.js
+++ b/packages/block-editor/src/components/link-control/use-remote-url-data.js
@@ -39,12 +39,19 @@ function useRemoteUrlData( url ) {
 		isFetching: false,
 	} );
 
-	const { fetchRemoteUrlData } = useSelect( ( select ) => {
+	const { fetchRemoteUrlData, baseUrl } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return {
+			baseUrl: getSettings().__experimentalBaseUrl,
 			fetchRemoteUrlData: getSettings().__experimentalFetchRemoteUrlData,
 		};
 	}, [] );
+
+	// We only want to fetch info for remote (external) URLS.
+	// URL is considered internal if:
+	// 1. We haven't got a base URL (yet).
+	// 2. The URL is being requested includes the base URL.
+	const isInternal = !! ( baseUrl && url?.includes( baseUrl ) );
 
 	useEffect( () => {
 		// Only make the request if we have an actual URL
@@ -52,6 +59,7 @@ function useRemoteUrlData( url ) {
 		// there may not be such a util.
 		if (
 			url?.length &&
+			! isInternal &&
 			fetchRemoteUrlData &&
 			typeof AbortController !== 'undefined'
 		) {

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -33,10 +33,11 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		reusableBlocks,
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
+		baseUrl,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
-		const { canUser } = select( coreStore );
+		const { canUser, getUnstableBase } = select( coreStore );
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),
@@ -51,6 +52,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				canUser( 'create', 'media' ),
 				true
 			),
+			baseUrl: getUnstableBase()?.url,
 		};
 	}, [] );
 
@@ -106,6 +108,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,
+			__experimentalBaseUrl: baseUrl,
 		} ),
 		[
 			settings,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -33,11 +33,10 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		reusableBlocks,
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
-		baseUrl,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
-		const { canUser, getUnstableBase } = select( coreStore );
+		const { canUser } = select( coreStore );
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),
@@ -52,7 +51,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				canUser( 'create', 'media' ),
 				true
 			),
-			baseUrl: getUnstableBase()?.url,
 		};
 	}, [] );
 
@@ -69,6 +67,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
+				'__experimentalBaseUrl',
 				'alignWide',
 				'allowedBlockTypes',
 				'bodyPlaceholder',
@@ -108,7 +107,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,
-			__experimentalBaseUrl: baseUrl,
 		} ),
 		[
 			settings,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Due to the introduction of loading placeholders towards the end of https://github.com/WordPress/gutenberg/pull/31464, internal URLs will now briefly showing a "loading" state. This is not desireable.

This PR fixes this by testing against a base URL which is used to test if the URL being previewed is an internal URL. If it is then we bail out.

This `baseURL` has been added to the `@wordpress/editor` block editor settings as we cannot apply the test directly in `<LInkControl>` as this must remain WordPress agnostic. Note however, that the concept of a internal URL applies to all types of application.

Closes https://github.com/WordPress/gutenberg/issues/32657

## Questions

* Can we add the `baseURL` to the settings on the server side to ensure it's populated "early" and doesn't require a fetch?

## How has this been tested?

* Create post with text in it.
* Add x2 links - one to an internal page/post and one to a remote URL (eg: `www.wordpress.org`).
* Click on both links to preview them one by one.
* Only the external link should show the rich preview.
* Only the external link should show a loading state whilst fetching (trying throttling your network connection).
* The internal URL should not show a loading state or any form of "rich" preview.

## Screenshots <!-- if applicable -->

### Before
![Screen Capture on 2021-06-11 at 09-30-22](https://user-images.githubusercontent.com/444434/121656826-ca6dd480-ca97-11eb-8518-2bb1161785e8.gif)

### After
![Screen Capture on 2021-06-11 at 09-31-00](https://user-images.githubusercontent.com/444434/121656833-ccd02e80-ca97-11eb-9bf1-56364500d9a8.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
