### PR TITLE
Fix in-between inserter not showing for wrapping horizontal block lists

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -91,6 +91,19 @@ export function useInBetweenInserter() {
 							? [ 'left', 'right' ]
 							: [ 'top', 'bottom' ];
 					const elementRect = blockEl.getBoundingClientRect();
+
+					// Check cursor is between blocks.
+					if (
+						( orientation === 'horizontal' &&
+							( event.clientY > elementRect.bottom ||
+								event.clientY < elementRect.top ) ) ||
+						( orientation === 'vertical' &&
+							( event.clientX > elementRect.right ||
+								event.clientX < elementRect.left ) )
+					) {
+						return;
+					}
+
 					const [ distance, edge ] = getDistanceToNearestEdge(
 						position,
 						elementRect,

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -86,10 +86,6 @@ export function useInBetweenInserter() {
 				let indexOffset;
 
 				children.forEach( ( blockEl ) => {
-					const allowedEdges =
-						orientation === 'horizontal'
-							? [ 'left', 'right' ]
-							: [ 'top', 'bottom' ];
 					const elementRect = blockEl.getBoundingClientRect();
 
 					// Check cursor is between blocks.
@@ -104,12 +100,19 @@ export function useInBetweenInserter() {
 						return;
 					}
 
+					// Find the nearest block 'edge' for the orientation.
+					const allowedEdges =
+						orientation === 'horizontal'
+							? [ 'left', 'right' ]
+							: [ 'top', 'bottom' ];
+
 					const [ distance, edge ] = getDistanceToNearestEdge(
 						position,
 						elementRect,
 						allowedEdges
 					);
 
+					// If this block is nearest, set is as the target.
 					if ( ! elementDistance || distance < elementDistance ) {
 						element = blockEl;
 						elementDistance = distance;

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -533,7 +533,7 @@ describe( 'Writing Flow', () => {
 		const paragraph = await page.$( '[data-type="core/paragraph"]' );
 		const paragraphRect = await paragraph.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
-		const y = paragraphRect.y + paragraphRect.height + 1;
+		const y = paragraphRect.y + paragraphRect.height + 16;
 
 		await page.mouse.move( x, y );
 		await page.waitForSelector(
@@ -575,7 +575,7 @@ describe( 'Writing Flow', () => {
 		const paragraph = await page.$( '[data-type="core/paragraph"]' );
 		const paragraphRect = await paragraph.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
-		const y = paragraphRect.y + paragraphRect.height + 1;
+		const y = paragraphRect.y + paragraphRect.height + 16;
 
 		await page.mouse.move( x, y );
 		await page.waitForSelector(


### PR DESCRIPTION
## Description
Fixes the issue mentioned here - https://github.com/WordPress/gutenberg/pull/32589#pullrequestreview-681552500

Uses the same edge detection system as drag and drop to determine in which position to show the in-between inserter.

Performance might be a little worse, but hopefully not too much of an impact.

## How has this been tested?
1. Add enough button blocks in a buttons block that they wrap to two full lines
2. Try hovering between the buttons on the second line
3. The in-between insert should show.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
