### PR TITLE
[RNMobile] Improve unsupported block message for reusable block

### DIFF
--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -12,23 +12,30 @@ import {
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import {
 	useEntityBlockEditor,
 	useEntityProp,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { BottomSheet, Icon, Disabled } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import {
+	BottomSheet,
+	Icon,
+	Disabled,
+	TextControl,
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
 	InnerBlocks,
 	Warning,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { help } from '@wordpress/icons';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -57,6 +64,14 @@ export default function ReusableBlockEdit( {
 	const infoSheetIconStyle = usePreferredColorSchemeStyle(
 		styles.infoSheetIcon,
 		styles.infoSheetIconDark
+	);
+	const infoDescriptionStyle = usePreferredColorSchemeStyle(
+		styles.infoDescription,
+		styles.infoDescriptionDark
+	);
+	const actionButtonStyle = usePreferredColorSchemeStyle(
+		styles.actionButton,
+		styles.actionButtonDark
 	);
 	const spinnerStyle = usePreferredColorSchemeStyle(
 		styles.spinner,
@@ -88,6 +103,12 @@ export default function ReusableBlockEdit( {
 		[ ref, clientId ]
 	);
 
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const {
+		__experimentalConvertBlockToStatic: convertBlockToStatic,
+	} = useDispatch( reusableBlocksStore );
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'wp_block',
@@ -104,13 +125,30 @@ export default function ReusableBlockEdit( {
 		setShowHelp( false );
 	}
 
+	const onConvertToRegularBlocks = useCallback( () => {
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: name of the reusable block */
+				__( '%s converted to regular blocks' ),
+				title
+			)
+		);
+
+		clearSelectedBlock();
+		// Convert action is executed at the end of the current JavaScript execution block
+		// to prevent issues related to undo/redo actions.
+		setImmediate( () => convertBlockToStatic( clientId ) );
+	}, [ title, clientId ] );
+
 	function renderSheet() {
 		const infoTitle =
 			Platform.OS === 'android'
 				? __(
-						"Reusable blocks aren't editable on WordPress for Android"
+						'Editing reusable blocks is not yet supported on WordPress for Android'
 				  )
-				: __( "Reusable blocks aren't editable on WordPress for iOS" );
+				: __(
+						'Editing reusable blocks is not yet supported on WordPress for iOS'
+				  );
 
 		return (
 			<BottomSheet
@@ -127,6 +165,17 @@ export default function ReusableBlockEdit( {
 					<Text style={ [ infoTextStyle, infoTitleStyle ] }>
 						{ infoTitle }
 					</Text>
+					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
+						{ __(
+							'Alternatively, you can select "Convert to regular blocks" if you wish to make any changes to the block on this page or post only.'
+						) }
+					</Text>
+					<TextControl
+						label={ __( 'Convert to regular blocks' ) }
+						separatorType="topFullWidth"
+						onPress={ onConvertToRegularBlocks }
+						labelStyle={ actionButtonStyle }
+					/>
 				</View>
 			</BottomSheet>
 		);

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -167,7 +167,7 @@ export default function ReusableBlockEdit( {
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
 						{ __(
-							'Alternatively, you can select "Convert to regular blocks" if you wish to make any changes to the block on this page or post only.'
+							'Alternatively, you can detach and edit these blocks separately by tapping "Convert to regular blocks".'
 						) }
 					</Text>
 					<TextControl

--- a/packages/block-library/src/block/editor.native.scss
+++ b/packages/block-library/src/block/editor.native.scss
@@ -94,6 +94,24 @@
 	color: $white;
 }
 
+.infoDescription {
+	padding-bottom: 24;
+	font-size: 16;
+	color: $gray-darken-20;
+}
+
+.infoDescriptionDark {
+	color: $gray-20;
+}
+
+.actionButton {
+	color: $blue-50;
+}
+
+.actionButtonDark {
+	color: $blue-30;
+}
+
 .spinner {
 	height: $grid-unit-60;
 	border-width: $border-width;


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3621

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The unsupported block message has been updated and the convert to regular blocks button has been also included.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a reusable block to a post/page.
2. Tap on the block to edit it.
3. Observe that the unsupported block message has been updated and provides an alternative to edit the block.
4. Tap on "Convert to regular blocks".
5. Observe that the reusable block is converted to regular blocks.

## Screenshots <!-- if applicable -->

iOS - Light|iOS- Dark|Android- Light|Andoid - Dark
--|--|--|--
<img width="455" src="https://user-images.githubusercontent.com/14905380/122185717-9d516580-ce8d-11eb-894b-b71ab0ab1443.png">|<img width="453" src="https://user-images.githubusercontent.com/14905380/122185724-9e829280-ce8d-11eb-91ce-44c4b2f1a169.png">|<img src=https://user-images.githubusercontent.com/14905380/122185733-a0e4ec80-ce8d-11eb-8f3f-bb5081cbdb17.jpg width=400>|<img src=https://user-images.githubusercontent.com/14905380/122185742-a3474680-ce8d-11eb-83ee-5205cccddab2.jpg width=400>


https://user-images.githubusercontent.com/14905380/122185556-7b57e300-ce8d-11eb-856a-3fb927b80af1.mp4


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
