### PR TITLE
Build: Load .min.js files even in dev mode, output unminified assets only in prod

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -236,7 +236,7 @@ function gutenberg_register_packages_scripts( $scripts ) {
 	// When in production, use the plugin's version as the default asset version;
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? GUTENBERG_VERSION : time();
-	$suffix          = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '.js' : '.min.js';
+	$suffix          = '.min.js';
 
 	foreach ( glob( gutenberg_dir_path() . "build/*/index$suffix" ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -303,7 +303,7 @@ module.exports = {
 			] )
 		),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-		new ReadableJsAssetsWebpackPlugin(),
+		mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 	].filter( Boolean ),
 	watchOptions: {
 		ignored: [ '**/node_modules', '**/packages/*/src' ],


### PR DESCRIPTION
Attempt to fix broken sourcemaps in `npm run dev` reported by @talldan in #32617. Got broken in #31732.

What's going on? We're running a combination of `npm run wp-env start` (starts a WordPress instance in Docker) and `npm run dev` (compiles the Gutenberg plugin that runs in that instance).

The Docker WordPress runs with `SCRIPT_DEBUG=1` and after #31732, that loads the `index.js` unminified asset instead of the minified `index.min.js` one. But the unminified `index.js` doesn't have a sourcemap, so Devtools can't find it.

I fixed this by removing the `SCRIPT_DEBUG` condition from `lib/client-assets.php` and always loading `index.min.js`. In dev mode (that `npm run dev` uses) that file is unminified anyway, despite the suffix. That `index.min.js` now has a valid sourcemap, so we can debug individual module files instead of the webpack chunk that bundles them all together.

I also added a condition to output the unminified `index.js` files only in production build. We don't need them during development and their presence only creates confusion.

**How to test:**
Before this patch, browser loaded `index.js` files and didn't detect any sourcemaps for them.
After this patch, browser loads `index.min.js` files, shows the "Source map detected" notice, and the individual module files are part of the source tree.
