### PR TITLE
Update WP_Theme_JSON API so presets are always keyed by origin

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -19,14 +19,6 @@ class WP_Theme_JSON_Gutenberg {
 	private $theme_json = null;
 
 	/**
-	 * What source of data this object represents.
-	 * One of VALID_ORIGINS.
-	 *
-	 * @var string
-	 */
-	private $origin = null;
-
-	/**
 	 * Holds block metadata extracted from block.json
 	 * to be shared among all instances so we don't
 	 * process it twice.
@@ -295,10 +287,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $origin What source of data this object represents. One of core, theme, or user. Default: theme.
 	 */
 	public function __construct( $theme_json = array(), $origin = 'theme' ) {
-		if ( in_array( $origin, self::VALID_ORIGINS, true ) ) {
-			$this->origin = $origin;
-		} else {
-			$this->origin = 'theme';
+		if ( ! in_array( $origin, self::VALID_ORIGINS, true ) ) {
+			$origin = 'theme';
 		}
 
 		// The old format is not meant to be ported to core.
@@ -322,16 +312,6 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Returns the origin of data.
-	 * One of the valid origins: core, theme, user.
-	 *
-	 * @return string
-	 */
-	private function get_origin() {
-		return $this->origin;
 	}
 
 	/**
@@ -1177,7 +1157,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param WP_Theme_JSON $incoming Data to merge.
 	 */
 	public function merge( $incoming ) {
-		$origin           = $incoming->get_origin();
 		$incoming_data    = $incoming->get_raw_data();
 		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -45,7 +45,7 @@ class WP_Theme_JSON_Gutenberg {
 	const VALID_ORIGINS = array(
 		'core',
 		'theme',
-		'user '
+		'user',
 	);
 
 	const VALID_TOP_LEVEL_KEYS = array(
@@ -291,11 +291,11 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Constructor.
 	 *
-	 * @param array $theme_json A structure that follows the theme.json schema.
+	 * @param array  $theme_json A structure that follows the theme.json schema.
 	 * @param string $origin What source of data this object represents. One of core, theme, or user. Default: theme.
 	 */
 	public function __construct( $theme_json = array(), $origin = 'theme' ) {
-		if ( in_array( $origin, self::VALID_ORIGINS ) ) {
+		if ( in_array( $origin, self::VALID_ORIGINS, true ) ) {
 			$this->origin = $origin;
 		} else {
 			$this->origin = 'theme';
@@ -700,7 +700,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array Array of presets where each key is a slug and each value is the preset value.
 	 */
 	private static function get_merged_preset_by_slug( $preset_per_origin, $value_key ) {
-		$result  = array();
+		$result = array();
 		foreach ( self::VALID_ORIGINS as $origin ) {
 			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
 				continue;

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -250,7 +250,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$config     = self::read_json_file( __DIR__ . '/experimental-default-theme.json' );
 		$config     = self::translate( $config );
-		self::$core = new WP_Theme_JSON_Gutenberg( $config );
+		self::$core = new WP_Theme_JSON_Gutenberg( $config, 'core' );
 
 		return self::$core;
 	}
@@ -290,7 +290,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * to override the ones declared via add_theme_support.
 		 */
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
-		$with_theme_supports->merge( self::$theme, 'theme' );
+		$with_theme_supports->merge( self::$theme );
 
 		return $with_theme_supports;
 	}
@@ -368,7 +368,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
 				trigger_error( 'Error when decoding a theme.json schema for user data. ' . json_last_error_msg() );
-				return new WP_Theme_JSON_Gutenberg( $config );
+				return new WP_Theme_JSON_Gutenberg( $config, 'user' );
 			}
 
 			// Very important to verify if the flag isGlobalStylesUserThemeJSON is true.
@@ -382,7 +382,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				$config = $decoded_data;
 			}
 		}
-		self::$user = new WP_Theme_JSON_Gutenberg( $config );
+		self::$user = new WP_Theme_JSON_Gutenberg( $config, 'user' );
 
 		return self::$user;
 	}
@@ -415,11 +415,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
 
 		$result = new WP_Theme_JSON_Gutenberg();
-		$result->merge( self::get_core_data(), 'core' );
-		$result->merge( self::get_theme_data( $theme_support_data ), 'theme' );
+		$result->merge( self::get_core_data() );
+		$result->merge( self::get_theme_data( $theme_support_data ) );
 
 		if ( 'user' === $origin ) {
-			$result->merge( self::get_user_data(), 'user' );
+			$result->merge( self::get_user_data() );
 		}
 
 		return $result;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -240,7 +240,7 @@ function gutenberg_global_styles_filter_post( $content ) {
 		$decoded_data['isGlobalStylesUserThemeJSON']
 	) {
 		unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
-		$theme_json = new WP_Theme_JSON_Gutenberg( $decoded_data );
+		$theme_json = new WP_Theme_JSON_Gutenberg( $decoded_data, 'user' );
 		$theme_json->remove_insecure_properties();
 		$data_to_encode                                = $theme_json->get_raw_data();
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -240,9 +240,9 @@ function gutenberg_global_styles_filter_post( $content ) {
 		$decoded_data['isGlobalStylesUserThemeJSON']
 	) {
 		unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
-		$theme_json = new WP_Theme_JSON_Gutenberg( $decoded_data, 'user' );
-		$theme_json->remove_insecure_properties();
-		$data_to_encode                                = $theme_json->get_raw_data();
+
+		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data );
+
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
 		return wp_json_encode( $data_to_encode );
 	}

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -155,15 +155,17 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'color'  => array(
 					'palette' => array(
-						array(
-							'slug'  => 'light',
-							'name'  => 'Jasny',
-							'color' => '#f5f7f9',
-						),
-						array(
-							'slug'  => 'dark',
-							'name'  => 'Ciemny',
-							'color' => '#000',
+						'theme' => array(
+							array(
+								'slug'  => 'light',
+								'name'  => 'Jasny',
+								'color' => '#f5f7f9',
+							),
+							array(
+								'slug'  => 'dark',
+								'name'  => 'Ciemny',
+								'color' => '#000',
+							),
 						),
 					),
 					'custom'  => false,
@@ -172,10 +174,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 					'core/paragraph' => array(
 						'color' => array(
 							'palette' => array(
-								array(
-									'slug'  => 'light',
-									'name'  => 'Jasny',
-									'color' => '#f5f7f9',
+								'theme' => array(
+									array(
+										'slug'  => 'light',
+										'name'  => 'Jasny',
+										'color' => '#f5f7f9',
+									),
 								),
 							),
 						),

--- a/phpunit/class-wp-theme-json-schema-v0-test.php
+++ b/phpunit/class-wp-theme-json-schema-v0-test.php
@@ -283,9 +283,11 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 				'custom'         => false,
 				'customGradient' => false,
 				'palette'        => array(
-					array(
-						'slug'  => 'grey',
-						'color' => 'grey',
+					'theme' => array(
+						array(
+							'slug'  => 'grey',
+							'color' => 'grey',
+						),
 					),
 				),
 			),
@@ -295,9 +297,11 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 						'customGradient' => false,
 						'custom'         => false,
 						'palette'        => array(
-							array(
-								'slug'  => 'grey',
-								'color' => 'grey',
+							'theme' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
 							),
 						),
 					),
@@ -307,9 +311,11 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 						'customGradient' => false,
 						'custom'         => false,
 						'palette'        => array(
-							array(
-								'slug'  => 'grey',
-								'color' => 'grey',
+							'theme' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
 							),
 						),
 					),
@@ -319,9 +325,11 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 						'customGradient' => false,
 						'custom'         => false,
 						'palette'        => array(
-							array(
-								'slug'  => 'grey',
-								'color' => 'grey',
+							'theme' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
 							),
 						),
 					),
@@ -459,8 +467,7 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 					),
 					'misc'     => 'value',
 				)
-			),
-			'core'
+			)
 		);
 
 		$this->assertEquals(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -56,112 +56,233 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
-	function test_get_stylesheet() {
-		$theme_json = new WP_Theme_JSON_Gutenberg( array() );
-		$theme_json->merge(
-			new WP_Theme_JSON_Gutenberg(
-				array(
-					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-					'settings' => array(
-						'color'      => array(
-							'text'    => 'value',
-							'palette' => array(
-								array(
-									'slug'  => 'grey',
-									'color' => 'grey',
-								),
+	function test_get_settings_presets_are_keyed_by_origin() {
+		$core_origin = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'       => array(
+						'palette' => array(
+							array(
+								'slug'  => 'white',
+								'color' => 'white',
 							),
 						),
-						'typography' => array(
-							'fontFamilies' => array(
-								array(
-									'slug'       => 'small',
-									'fontFamily' => '14px',
-								),
-								array(
-									'slug'       => 'big',
-									'fontFamily' => '41px',
-								),
-							),
-						),
-						'misc'       => 'value',
-						'blocks'     => array(
-							'core/group' => array(
-								'custom' => array(
-									'base-font'   => 16,
-									'line-height' => array(
-										'small'  => 1.2,
-										'medium' => 1.4,
-										'large'  => 1.8,
+					),
+					'invalid/key' => 'value',
+					'blocks'      => array(
+						'core/group' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'white',
+										'color' => 'white',
 									),
 								),
 							),
 						),
 					),
-					'styles'   => array(
-						'color'    => array(
-							'text' => 'var:preset|color|grey',
-						),
-						'misc'     => 'value',
-						'elements' => array(
-							'link' => array(
-								'color' => array(
-									'text'       => '#111',
-									'background' => '#333',
-								),
-							),
-						),
-						'blocks'   => array(
-							'core/group'     => array(
-								'elements' => array(
-									'link' => array(
-										'color' => array(
-											'text' => '#111',
-										),
-									),
-								),
-								'spacing'  => array(
-									'padding' => array(
-										'top'    => '12px',
-										'bottom' => '24px',
-									),
-								),
-							),
-							'core/heading'   => array(
-								'color'    => array(
-									'text' => '#123456',
-								),
-								'elements' => array(
-									'link' => array(
-										'color'      => array(
-											'text'       => '#111',
-											'background' => '#333',
-										),
-										'typography' => array(
-											'fontSize' => '60px',
-										),
-									),
-								),
-							),
-							'core/post-date' => array(
-								'color'    => array(
-									'text' => '#123456',
-								),
-								'elements' => array(
-									'link' => array(
-										'color' => array(
-											'background' => '#777',
-											'text'       => '#555',
-										),
-									),
-								),
-							),
-						),
-					),
-					'misc'     => 'value',
-				)
+				),
 			),
 			'core'
+		);
+		$no_origin = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'       => array(
+						'palette' => array(
+							array(
+								'slug'  => 'black',
+								'color' => 'black',
+							),
+						),
+					),
+					'invalid/key' => 'value',
+					'blocks'      => array(
+						'core/group' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'black',
+										'color' => 'black',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$actual_core      = $core_origin->get_raw_data();
+		$actual_no_origin = $no_origin->get_raw_data();
+
+		$expected_core  = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'       => array(
+					'palette' => array(
+						'core' => array(
+							array(
+								'slug'  => 'white',
+								'color' => 'white',
+							),
+						),
+					),
+				),
+				'blocks'      => array(
+					'core/group' => array(
+						'color' => array(
+							'palette' => array(
+								'core' => array(
+									array(
+										'slug'  => 'white',
+										'color' => 'white',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		$expected_no_origin = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'       => array(
+					'palette' => array(
+						'theme' => array(
+							array(
+								'slug'  => 'black',
+								'color' => 'black',
+							),
+						),
+					),
+				),
+				'blocks'      => array(
+					'core/group' => array(
+						'color' => array(
+							'palette' => array(
+								'theme' => array(
+									array(
+										'slug'  => 'black',
+										'color' => 'black',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected_core, $actual_core );
+		$this->assertEqualSetsWithIndex( $expected_no_origin, $actual_no_origin );
+	}
+
+	function test_get_stylesheet() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'      => array(
+						'text'    => 'value',
+						'palette' => array(
+							array(
+								'slug'  => 'grey',
+								'color' => 'grey',
+							),
+						),
+					),
+					'typography' => array(
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'small',
+								'fontFamily' => '14px',
+							),
+							array(
+								'slug'       => 'big',
+								'fontFamily' => '41px',
+							),
+						),
+					),
+					'misc'       => 'value',
+					'blocks'     => array(
+						'core/group' => array(
+							'custom' => array(
+								'base-font'   => 16,
+								'line-height' => array(
+									'small'  => 1.2,
+									'medium' => 1.4,
+									'large'  => 1.8,
+								),
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'color'    => array(
+						'text' => 'var:preset|color|grey',
+					),
+					'misc'     => 'value',
+					'elements' => array(
+						'link' => array(
+							'color' => array(
+								'text'       => '#111',
+								'background' => '#333',
+							),
+						),
+					),
+					'blocks'   => array(
+						'core/group'     => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => '#111',
+									),
+								),
+							),
+							'spacing'  => array(
+								'padding' => array(
+									'top'    => '12px',
+									'bottom' => '24px',
+								),
+							),
+						),
+						'core/heading'   => array(
+							'color'    => array(
+								'text' => '#123456',
+							),
+							'elements' => array(
+								'link' => array(
+									'color'      => array(
+										'text'       => '#111',
+										'background' => '#333',
+									),
+									'typography' => array(
+										'fontSize' => '60px',
+									),
+								),
+							),
+						),
+						'core/post-date' => array(
+							'color'    => array(
+								'text' => '#123456',
+							),
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'background' => '#777',
+										'text'       => '#555',
+									),
+								),
+							),
+						),
+					),
+				),
+				'misc'     => 'value',
+			)
 		);
 
 		$this->assertEquals(
@@ -179,28 +300,24 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet_preset_classes_work_with_compounded_selectors() {
-		$theme_json = new WP_Theme_JSON_Gutenberg( array() );
-		$theme_json->merge(
-			new WP_Theme_JSON_Gutenberg(
-				array(
-					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-					'settings' => array(
-						'blocks' => array(
-							'core/heading' => array(
-								'color' => array(
-									'palette' => array(
-										array(
-											'slug'  => 'white',
-											'color' => '#fff',
-										),
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/heading' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'white',
+										'color' => '#fff',
 									),
 								),
 							),
 						),
 					),
-				)
-			),
-			'theme'
+				),
+			)
 		);
 
 		$this->assertEquals(
@@ -210,37 +327,33 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet_preset_rules_come_after_block_rules() {
-		$theme_json = new WP_Theme_JSON_Gutenberg( array() );
-		$theme_json->merge(
-			new WP_Theme_JSON_Gutenberg(
-				array(
-					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-					'settings' => array(
-						'blocks' => array(
-							'core/group' => array(
-								'color' => array(
-									'palette' => array(
-										array(
-											'slug'  => 'grey',
-											'color' => 'grey',
-										),
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/group' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'grey',
+										'color' => 'grey',
 									),
 								),
 							),
 						),
 					),
-					'styles'   => array(
-						'blocks' => array(
-							'core/group' => array(
-								'color' => array(
-									'text' => 'red',
-								),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/group' => array(
+							'color' => array(
+								'text' => 'red',
 							),
 						),
 					),
-				)
-			),
-			'theme'
+				),
+			)
 		);
 
 		$this->assertEquals(
@@ -254,36 +367,33 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_stylesheet_preset_values_are_marked_as_important() {
-		$theme_json = new WP_Theme_JSON_Gutenberg( array() );
-		$theme_json->merge(
-			new WP_Theme_JSON_Gutenberg(
-				array(
-					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-					'settings' => array(
-						'color' => array(
-							'palette' => array(
-								array(
-									'slug'  => 'grey',
-									'color' => 'grey',
-								),
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'grey',
+								'color' => 'grey',
 							),
 						),
 					),
-					'styles'   => array(
-						'blocks' => array(
-							'core/paragraph' => array(
-								'color'      => array(
-									'text'       => 'red',
-									'background' => 'blue',
-								),
-								'typography' => array(
-									'fontSize'   => '12px',
-									'lineHeight' => '1.3',
-								),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color'      => array(
+								'text'       => 'red',
+								'background' => 'blue',
+							),
+							'typography' => array(
+								'fontSize'   => '12px',
+								'lineHeight' => '1.3',
 							),
 						),
 					),
-				)
+				),
 			),
 			'core'
 		);
@@ -295,42 +405,37 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	public function test_merge_incoming_data() {
-		$theme_json = new WP_Theme_JSON_Gutenberg( array() );
-		$theme_json->merge(
-			new WP_Theme_JSON_Gutenberg(
-				array(
-					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-					'settings' => array(
-						'color'  => array(
-							'custom'  => false,
-							'palette' => array(
-								array(
-									'slug'  => 'red',
-									'color' => 'red',
-								),
-								array(
-									'slug'  => 'green',
-									'color' => 'green',
-								),
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'  => array(
+						'custom'  => false,
+						'palette' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
 							),
-						),
-						'blocks' => array(
-							'core/paragraph' => array(
-								'color' => array(
-									'custom' => false,
-								),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
 							),
 						),
 					),
-					'styles'   => array(
-						'typography' => array(
-							'fontSize' => '12',
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'custom' => false,
+							),
 						),
 					),
-
-				)
-			),
-			'core'
+				),
+				'styles'   => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+				),
+			)
 		);
 
 		$add_new_block = array(
@@ -460,7 +565,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'custom'         => true,
 					'customGradient' => true,
 					'palette'        => array(
-						'core' => array(
+						'theme' => array(
 							array(
 								'slug'  => 'blue',
 								'color' => 'blue',
@@ -468,7 +573,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'gradients'      => array(
-						'core' => array(
+						'theme' => array(
 							array(
 								'slug'     => 'gradient',
 								'gradient' => 'gradient',
@@ -478,7 +583,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'typography' => array(
 					'fontSizes'    => array(
-						'core' => array(
+						'theme' => array(
 							array(
 								'slug' => 'fontSize',
 								'size' => 'fontSize',
@@ -486,7 +591,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'fontFamilies' => array(
-						'core' => array(
+						'theme' => array(
 							array(
 								'slug'       => 'fontFamily',
 								'fontFamily' => 'fontFamily',
@@ -532,13 +637,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_new_block ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_key_in_settings ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $update_key_in_settings ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_styles ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_key_in_styles ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_invalid_context ), 'core' );
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $update_presets ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_new_block ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_key_in_settings ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $update_key_in_settings ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_styles ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_key_in_styles ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $add_invalid_context ) );
+		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $update_presets ) );
 		$actual = $theme_json->get_raw_data();
 
 		$this->assertEqualSetsWithIndex( $expected, $actual );
@@ -779,8 +884,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
-			true
+			)
 		);
 		$theme_json->remove_insecure_properties();
 		$result   = $theme_json->get_raw_data();
@@ -789,20 +893,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'  => array(
 					'palette' => array(
-						array(
-							'name'  => 'Red',
-							'slug'  => 'red',
-							'color' => '#ff0000',
-						),
-						array(
-							'name'  => 'Green',
-							'slug'  => 'green',
-							'color' => '#00ff00',
-						),
-						array(
-							'name'  => 'Blue',
-							'slug'  => 'blue',
-							'color' => '#0000ff',
+						'theme' => array(
+							array(
+								'name'  => 'Red',
+								'slug'  => 'red',
+								'color' => '#ff0000',
+							),
+							array(
+								'name'  => 'Green',
+								'slug'  => 'green',
+								'color' => '#00ff00',
+							),
+							array(
+								'name'  => 'Blue',
+								'slug'  => 'blue',
+								'color' => '#0000ff',
+							),
 						),
 					),
 				),
@@ -810,20 +916,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								array(
-									'name'  => 'Yellow',
-									'slug'  => 'yellow',
-									'color' => '#ff0000',
-								),
-								array(
-									'name'  => 'Pink',
-									'slug'  => 'pink',
-									'color' => '#00ff00',
-								),
-								array(
-									'name'  => 'Orange',
-									'slug'  => 'orange',
-									'color' => '#0000ff',
+								'theme' => array(
+									array(
+										'name'  => 'Yellow',
+										'slug'  => 'yellow',
+										'color' => '#ff0000',
+									),
+									array(
+										'name'  => 'Pink',
+										'slug'  => 'pink',
+										'color' => '#00ff00',
+									),
+									array(
+										'name'  => 'Orange',
+										'slug'  => 'orange',
+										'color' => '#0000ff',
+									),
 								),
 							),
 						),
@@ -916,8 +1024,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
-			true
+			)
 		);
 		$theme_json->remove_insecure_properties();
 		$result   = $theme_json->get_raw_data();
@@ -926,19 +1033,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'      => array(
 					'palette' => array(
-						array(
-							'name'  => 'Pink',
-							'slug'  => 'pink',
-							'color' => '#FFC0CB',
+						'theme' => array(
+							array(
+								'name'  => 'Pink',
+								'slug'  => 'pink',
+								'color' => '#FFC0CB',
+							),
 						),
 					),
 				),
 				'typography' => array(
 					'fontFamilies' => array(
-						array(
-							'name'       => 'Cambria',
-							'slug'       => 'cambria',
-							'fontFamily' => 'Cambria, Georgia, serif',
+						'theme' => array(
+							array(
+								'name'       => 'Cambria',
+								'slug'       => 'cambria',
+								'fontFamily' => 'Cambria, Georgia, serif',
+							),
 						),
 					),
 				),
@@ -946,10 +1057,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								array(
-									'name'  => 'Pink',
-									'slug'  => 'pink',
-									'color' => '#FFC0CB',
+								'theme' => array(
+									array(
+										'name'  => 'Pink',
+										'slug'  => 'pink',
+										'color' => '#FFC0CB',
+									),
 								),
 							),
 						),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -86,7 +86,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 			'core'
 		);
-		$no_origin = new WP_Theme_JSON_Gutenberg(
+		$no_origin   = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
@@ -112,16 +112,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
+			)
 		);
 
 		$actual_core      = $core_origin->get_raw_data();
 		$actual_no_origin = $no_origin->get_raw_data();
 
-		$expected_core  = array(
+		$expected_core      = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'color'       => array(
+				'color'  => array(
 					'palette' => array(
 						'core' => array(
 							array(
@@ -131,7 +131,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'blocks'      => array(
+				'blocks' => array(
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
@@ -150,7 +150,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected_no_origin = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'color'       => array(
+				'color'  => array(
 					'palette' => array(
 						'theme' => array(
 							array(
@@ -160,7 +160,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'blocks'      => array(
+				'blocks' => array(
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -650,7 +650,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_remove_insecure_properties_removes_unsafe_styles() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
@@ -687,11 +687,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
-			true
+			)
 		);
-		$theme_json->remove_insecure_properties();
-		$actual   = $theme_json->get_raw_data();
+
 		$expected = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
@@ -726,7 +724,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_remove_insecure_properties_removes_unsafe_styles_sub_properties() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
@@ -778,8 +776,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 			true
 		);
-		$theme_json->remove_insecure_properties();
-		$actual   = $theme_json->get_raw_data();
+
 		$expected = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
@@ -829,7 +826,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_remove_insecure_properties_removes_non_preset_settings() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
@@ -886,29 +883,26 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color'  => array(
 					'palette' => array(
-						'theme' => array(
-							array(
-								'name'  => 'Red',
-								'slug'  => 'red',
-								'color' => '#ff0000',
-							),
-							array(
-								'name'  => 'Green',
-								'slug'  => 'green',
-								'color' => '#00ff00',
-							),
-							array(
-								'name'  => 'Blue',
-								'slug'  => 'blue',
-								'color' => '#0000ff',
-							),
+						array(
+							'name'  => 'Red',
+							'slug'  => 'red',
+							'color' => '#ff0000',
+						),
+						array(
+							'name'  => 'Green',
+							'slug'  => 'green',
+							'color' => '#00ff00',
+						),
+						array(
+							'name'  => 'Blue',
+							'slug'  => 'blue',
+							'color' => '#0000ff',
 						),
 					),
 				),
@@ -916,22 +910,20 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								'theme' => array(
-									array(
-										'name'  => 'Yellow',
-										'slug'  => 'yellow',
-										'color' => '#ff0000',
-									),
-									array(
-										'name'  => 'Pink',
-										'slug'  => 'pink',
-										'color' => '#00ff00',
-									),
-									array(
-										'name'  => 'Orange',
-										'slug'  => 'orange',
-										'color' => '#0000ff',
-									),
+								array(
+									'name'  => 'Yellow',
+									'slug'  => 'yellow',
+									'color' => '#ff0000',
+								),
+								array(
+									'name'  => 'Pink',
+									'slug'  => 'pink',
+									'color' => '#00ff00',
+								),
+								array(
+									'name'  => 'Orange',
+									'slug'  => 'orange',
+									'color' => '#0000ff',
 								),
 							),
 						),
@@ -939,11 +931,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEqualSetsWithIndex( $expected, $result );
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	function test_remove_insecure_properties_removes_unsafe_preset_settings() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
@@ -1026,30 +1018,25 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color'      => array(
 					'palette' => array(
-						'theme' => array(
-							array(
-								'name'  => 'Pink',
-								'slug'  => 'pink',
-								'color' => '#FFC0CB',
-							),
+						array(
+							'name'  => 'Pink',
+							'slug'  => 'pink',
+							'color' => '#FFC0CB',
 						),
 					),
 				),
 				'typography' => array(
 					'fontFamilies' => array(
-						'theme' => array(
-							array(
-								'name'       => 'Cambria',
-								'slug'       => 'cambria',
-								'fontFamily' => 'Cambria, Georgia, serif',
-							),
+						array(
+							'name'       => 'Cambria',
+							'slug'       => 'cambria',
+							'fontFamily' => 'Cambria, Georgia, serif',
 						),
 					),
 				),
@@ -1057,12 +1044,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								'theme' => array(
-									array(
-										'name'  => 'Pink',
-										'slug'  => 'pink',
-										'color' => '#FFC0CB',
-									),
+								array(
+									'name'  => 'Pink',
+									'slug'  => 'pink',
+									'color' => '#FFC0CB',
 								),
 							),
 						),
@@ -1070,11 +1055,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEqualSetsWithIndex( $expected, $result );
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	function test_remove_insecure_properties_applies_safe_styles() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'styles'  => array(
@@ -1085,8 +1070,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 			true
 		);
-		$theme_json->remove_insecure_properties();
-		$result   = $theme_json->get_raw_data();
+
 		$expected = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
@@ -1095,7 +1079,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEqualSetsWithIndex( $expected, $result );
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	function test_get_custom_templates() {


### PR DESCRIPTION
This PR updates the implementation we introduced in https://github.com/WordPress/gutenberg/pull/32358 so presets are always keyed by origin.

## What's the issue

In https://github.com/WordPress/gutenberg/pull/32358 we updated the internal shape of the presets to be keyed by origin, one of `core`, `theme`, `user`. While consumers (core, theme, user data) continue to use the unkeyed format via a `theme.json` structure, internally, we adapted it to become:

```json
{
  "color": {
    "palette": {
      "core": [
        { "slug": "color-1", "value": "value-1" },
        { "slug": "color-2", "value": "value-2" }
      ],
      "theme": [
        { "slug": "color-3", "value": "value-3" },
        { "slug": "color-4", "value": "value-4" }
      ],
      "user": [
        { "slug": "color-5", "value": "value-5" },
        { "slug": "color-6", "value": "value-6" }
      ],
    }
  }
}
```

One of the unintended consequences of that PR was that we made a requirement for consumers of the API to pass the data through the `merge` method ― otherwise the presets won't be in the proper shape. This piece of code:

```php
$theme_json = new WP_Theme_JSON( $some_data_here );
$theme_json->get_settings();
```

would yield:

```json
{
  "color": {
    "palette": [
      { "slug": "color-1", "value": "value-2" },
      { "slug": "color-2", "value": "value-2" }
    ]
  }
}
```

Instead of:


```json
{
  "color": {
    "palette": {
      "theme": [
        { "slug": "color-1", "value": "value-2" },
        { "slug": "color-2", "value": "value-2" }
      ]
    }
  }
}
```

## What this PR changes

This PR assigns an origin in the object constructor instead and uses it to adapt the preset shape as part of the initial processing. Then, the `merge` algorithm is updated to simply make the origin part of the path to the setting.

## How to test

I've tested a number of scenarios in the post & site editors using TwentyTwentyOne and TT1-blocks:

- a theme that does not define any color palette => core colors are shown
- a theme with an empty array as color palette => no colors are shown
- a theme with a color palette => the theme colors are shown
- add user colors via the site editor => the modifications are shown everywhere

I've also verified that the classes and custom properties for core are present in addition to theme CSS.

As with https://github.com/WordPress/gutenberg/pull/32358 this should be tested with 5.7. In WordPress 5.8 the list of colors shown include both core and theme, but this is expected because this reverts a change we landed in 5.8 and we still need to port it to core ― once we do, it'll work as 5.7.
