### PR TITLE
Widgets: Try to fix color inheritance for social links.

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -69,7 +69,7 @@
 	}
 }
 
-.wp-social-link {
+.wp-block-social-link {
 	display: block;
 	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
 	transition: transform 0.1s ease;
@@ -84,20 +84,22 @@
 		transition: transform 0.1s ease;
 	}
 
-	a,
-	a:hover,
-	a:active,
-	a:visited,
-	svg {
-		color: currentColor;
-		fill: currentColor;
-	}
-
 	&:hover {
 		transform: scale(1.1);
 	}
 }
 
+// This needs specificity because themes usually override it with things like .widget-area a.
+.wp-block-social-links .wp-block-social-link .wp-block-social-link-anchor {
+	&,
+	&:hover,
+	&:active,
+	&:visited,
+	svg {
+		color: currentColor;
+		fill: currentColor;
+	}
+}
 
 // Provide colors for a range of icons.
 .wp-block-social-links:not(.is-style-logos-only) {


### PR DESCRIPTION
## Description

Fixes #32602. This increases specificity of the color inheritance rules, so that they override the `.widget-area a` rule that themes like TT1 provide. Before:

<img width="1148" alt="Screenshot 2021-06-11 at 16 28 08" src="https://user-images.githubusercontent.com/1204802/121703300-f8bcd580-cad2-11eb-973f-b31bbb52362c.png">

<img width="220" alt="Screenshot 2021-06-11 at 16 28 18" src="https://user-images.githubusercontent.com/1204802/121703293-f6f31200-cad2-11eb-908a-49b17aa08092.png">

After:

<img width="263" alt="Screenshot 2021-06-11 at 16 33 10" src="https://user-images.githubusercontent.com/1204802/121703360-07a38800-cad3-11eb-825f-2ed04e1bbc92.png">

<img width="1282" alt="Screenshot 2021-06-11 at 16 33 34" src="https://user-images.githubusercontent.com/1204802/121703366-08d4b500-cad3-11eb-8394-09fbbb321e7f.png">

<img width="308" alt="Screenshot 2021-06-11 at 16 33 42" src="https://user-images.githubusercontent.com/1204802/121703368-0a05e200-cad3-11eb-93de-6add50db7e5e.png">

Generally it's always bad to add specificity. I don't love htat we do it here. But I've segmented the rule to only apply to the color inheritance stuff so it should be okay.

## How has this been tested?

Use TT1, insert social links in the new widget screen, test that colors are correct on the frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
