### PR TITLE
Fix component inspector error in React Native

### DIFF
--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -18,7 +18,7 @@ import {
 	validateThemeColors,
 	validateThemeGradients,
 } from '@wordpress/block-editor';
-import { unregisterBlockType } from '@wordpress/blocks';
+import { unregisterBlockType, getBlockType } from '@wordpress/blocks';
 
 const reactNativeSetup = () => {
 	// Disable warnings as they disrupt the user experience in dev mode
@@ -58,7 +58,10 @@ const setupInitHooks = () => {
 			setupLocale( props.locale, props.translations );
 
 			const capabilities = props.capabilities ?? {};
-			if ( capabilities.reusableBlock !== true ) {
+			if (
+				getBlockType( 'core/block' ) !== undefined &&
+				capabilities.reusableBlock !== true
+			) {
 				unregisterBlockType( 'core/block' );
 			}
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
An issue cropped up where the inspector (Debug Menu > Show Inspector) showed a red screen when loading. This happens because on loading the inspector, a hook is called which checks the editor capabilities. If the reusable block capability is `false`, the reusable block type is then unregistered.

What seems to happen when opening the inspector is that the editor does not fully reload, so the reusable block is already unregistered and the app tries to unregister it again, causing a red screen.

The fix here is to only unregister the block if it's currently registered. An alternative approach might be to put the code that unregisters the block in a hook that's only called when the editor is first loaded, not when it's only partially reloaded by the inspector.

See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3612

## How has this been tested?
I tested the inspector on both the Android and iOS Gutenberg demo apps.

## Screenshots <!-- if applicable -->

Not applicable.

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
