### PR TITLE
Chore: Remove check for core files on typography supports migration.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -473,8 +473,7 @@ function gutenberg_block_has_support( $block_type, $feature, $default = false ) 
  * @return array          Metadata for registering a block type with the supports shape updated.
  */
 function gutenberg_migrate_old_typography_shape( $metadata ) {
-	// Temporarily disable migrations from core blocks until core block.json are updated.
-	if ( isset( $metadata['supports'] ) && false === strpos( $metadata['file'], '/wp-includes/blocks/' ) ) {
+	if ( isset( $metadata['supports'] ) ) {
 		$typography_keys = array(
 			'__experimentalFontFamily',
 			'__experimentalFontStyle',


### PR DESCRIPTION
Core block.json files are updated this check is not needed anymore.
