### PR TITLE
Update: Disable renaming templates named by core; Display descriptions.

### DIFF
--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -14,6 +14,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import DeleteTemplate from './delete-template';
 import EditTemplateTitle from './edit-template-title';
+import TemplateDescription from './template-description';
 
 function TemplateTitle() {
 	const { template, isEditing, title } = useSelect( ( select ) => {
@@ -87,7 +88,11 @@ function TemplateTitle() {
 						) }
 						renderContent={ () => (
 							<>
-								<EditTemplateTitle />
+								{ template.has_theme_file ? (
+									<TemplateDescription />
+								) : (
+									<EditTemplateTitle />
+								) }
 								<DeleteTemplate />
 							</>
 						) }

--- a/packages/edit-post/src/components/header/template-title/template-description.js
+++ b/packages/edit-post/src/components/header/template-title/template-description.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { __experimentalText as Text } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../../store';
+
+export default function TemplateDescription() {
+	const { description } = useSelect( ( select ) => {
+		const { getEditedPostTemplate } = select( editPostStore );
+		return {
+			description: getEditedPostTemplate().description,
+		};
+	}, [] );
+	if ( ! description ) {
+		return null;
+	}
+	return <Text size="body">{ description }</Text>;
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/32362

This PR disables changing the name of templates that have a theme file (named by core), and on those cases instead of showing the input field, we show a description of the template.


## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/121752176-7ef30f00-cb07-11eb-8464-271c78ba278f.png)
