### PR TITLE
Safari: see if changing overflow stops flickering scroll

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -83,7 +83,7 @@ html.interface-interface-skeleton__html-container {
 	// Beyond the medium breakpoint, we allow the sidebar.
 	// The sidebar should scroll independently, so enable scroll here also.
 
-	overflow: auto;
+	overflow: visible;
 
 }
 


### PR DESCRIPTION
Quick draft to see if this fixes the black flashing in safari during scrolling. If it works for others we'll want to look into workarounds for any functionality this breaks.

Before:

https://user-images.githubusercontent.com/1270189/121753323-01a7aa00-cac7-11eb-97c4-3046b9591e1f.mp4

After:

https://user-images.githubusercontent.com/1270189/121753345-0a987b80-cac7-11eb-8626-d3be1a11875d.mp4


