### PR TITLE
Template Mode: Translate delete template confirmation message

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -53,9 +53,11 @@ export default function DeleteTemplate() {
 					if (
 						// eslint-disable-next-line no-alert
 						window.confirm(
-							/* translators: %1$s: template name */
 							sprintf(
-								'Are you sure you want to delete the %s template? It may be used by other pages or posts.',
+								/* translators: %s: template name */
+								__(
+									'Are you sure you want to delete the %s template? It may be used by other pages or posts.'
+								),
 								templateTitle
 							)
 						)


### PR DESCRIPTION
## Description
Adds missing l10n to the "Delete Template" confirmation message.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
