### PR TITLE
Make customize widgets editor bar sticky

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -179,8 +179,8 @@ $z-layers: (
 	// Appear under the customizer heading UI, but over anything else.
 	".customize-widgets__topbar": 8,
 
-	// Appear under the topbar.
-	".customize-widgets__block-toolbar": 7,
+	// Appear over the topbar of both editor and customizer.
+	".customize-widgets__block-toolbar": 10,
 );
 
 @function z-index( $key ) {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -244,6 +244,7 @@ _Parameters_
 -   _$0_ `Object`: Props.
 -   _$0.children_ `Object`: The block content and style container.
 -   _$0.\_\_unstableContentRef_ `Object`: Ref holding the content scroll container.
+-   _$0.\_\_experimentalStickyTop_ `Object`: Offset for the top position of toolbars.
 
 <a name="BlockVerticalAlignmentControl" href="#BlockVerticalAlignmentControl">#</a> **BlockVerticalAlignmentControl**
 

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -17,7 +17,13 @@ import NavigableToolbar from '../navigable-toolbar';
 import BlockToolbar from '../block-toolbar';
 import { store as blockEditorStore } from '../../store';
 
-function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
+function BlockContextualToolbar( {
+	focusOnMount,
+	isFixed,
+	__experimentalStickyTop,
+	style = {},
+	...props
+} ) {
 	const { blockType, hasParents, showParentSelector } = useSelect(
 		( select ) => {
 			const {
@@ -59,12 +65,17 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 		'is-fixed': isFixed,
 	} );
 
+	if ( __experimentalStickyTop ) {
+		style.top = __experimentalStickyTop;
+	}
+
 	return (
 		<NavigableToolbar
 			focusOnMount={ focusOnMount }
 			className={ classes }
 			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
+			style={ style }
 			{ ...props }
 		>
 			<BlockToolbar hideDragHandle={ isFixed } />

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -54,6 +54,7 @@ function BlockPopover( {
 	capturingClientId,
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyTop,
 } ) {
 	const {
 		isNavigationMode,
@@ -213,6 +214,7 @@ function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ node }
 			shouldAnchorIncludePadding
+			__experimentalStickyTop={ __experimentalStickyTop }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div
@@ -324,6 +326,7 @@ function wrapperSelector( select ) {
 export default function WrappedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
+	__experimentalStickyTop,
 } ) {
 	const selected = useSelect( wrapperSelector, [] );
 
@@ -353,6 +356,7 @@ export default function WrappedBlockPopover( {
 			capturingClientId={ capturingClientId }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
+			__experimentalStickyTop={ __experimentalStickyTop }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -19,11 +19,16 @@ import { usePopoverScroll } from './use-popover-scroll';
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
  *
- * @param {Object} $0                      Props.
- * @param {Object} $0.children             The block content and style container.
- * @param {Object} $0.__unstableContentRef Ref holding the content scroll container.
+ * @param {Object} $0                         Props.
+ * @param {Object} $0.children                The block content and style container.
+ * @param {Object} $0.__unstableContentRef    Ref holding the content scroll container.
+ * @param {Object} $0.__experimentalStickyTop Offset for the top position of toolbars.
  */
-export default function BlockTools( { children, __unstableContentRef } ) {
+export default function BlockTools( {
+	children,
+	__unstableContentRef,
+	__experimentalStickyTop,
+} ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().hasFixedToolbar,
@@ -33,11 +38,17 @@ export default function BlockTools( { children, __unstableContentRef } ) {
 	return (
 		<InsertionPoint __unstableContentRef={ __unstableContentRef }>
 			{ ( hasFixedToolbar || ! isLargeViewport ) && (
-				<BlockContextualToolbar isFixed />
+				<BlockContextualToolbar
+					isFixed
+					__experimentalStickyTop={ __experimentalStickyTop }
+				/>
 			) }
 			{ /* Even if the toolbar is fixed, the block popover is still
                  needed for navigation mode. */ }
-			<BlockPopover __unstableContentRef={ __unstableContentRef } />
+			<BlockPopover
+				__unstableContentRef={ __unstableContentRef }
+				__experimentalStickyTop={ __experimentalStickyTop }
+			/>
 			{ /* Used for the inline rich text toolbar. */ }
 			<Popover.Slot
 				name="block-toolbar"

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -257,6 +257,7 @@ const Popover = (
 		__unstableBoundaryParent,
 		__unstableForcePosition,
 		__unstableForceXAlignment,
+		__experimentalStickyTop: stickyTop = 0,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -305,7 +306,7 @@ const Popover = (
 
 			const { offsetParent, ownerDocument } = containerRef.current;
 
-			let relativeOffsetTop = 0;
+			let relativeOffsetTop = -stickyTop;
 
 			// If there is a positioned ancestor element that is not the body,
 			// subtract the position from the anchor rect. If the position of
@@ -315,7 +316,7 @@ const Popover = (
 			if ( offsetParent && offsetParent !== ownerDocument.body ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
-				relativeOffsetTop = offsetParentRect.top;
+				relativeOffsetTop += offsetParentRect.top;
 				anchor = new window.DOMRect(
 					anchor.left - offsetParentRect.left,
 					anchor.top - offsetParentRect.top,
@@ -476,6 +477,7 @@ const Popover = (
 		position,
 		contentSize,
 		__unstableStickyBoundaryElement,
+		stickyTop,
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 	] );

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,4 +1,7 @@
 .customize-widgets-header {
+	position: sticky;
+	top: 0;
+
 	@include break-medium() {
 		// Make space for the floating toolbar.
 		margin-bottom: $grid-unit-60 + $default-block-margin;

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -33,6 +33,9 @@ import { store as customizeWidgetsStore } from '../../store';
 import WelcomeGuide from '../welcome-guide';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 
+// Used to offset the block toolbar’s sticky top
+const headerHeight = 49;
+
 export default function SidebarBlockEditor( {
 	blockEditorSettings,
 	sidebar,
@@ -113,7 +116,7 @@ export default function SidebarBlockEditor( {
 					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
-				<BlockTools>
+				<BlockTools __experimentalStickyTop={ headerHeight }>
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>

--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -12,13 +12,13 @@
 	// Override the inline styles added via JS that make the section title
 	// sticky feature work. The customize widget block-editor disables this
 	// sticky title.
-	padding-top: 10px !important;
+	padding-top: 12px !important;
 
 	.customize-section-title {
 		// Disable the sticky title. `!important` as this overrides inline
 		// styles added via JavaScript.
 		position: static !important;
-		top: 0 !important;
 		width: unset !important;
+		margin-top: -12px !important;
 	}
 }


### PR DESCRIPTION
This is here as a fallback/alternative to #32490 which improves on the interface in Widgets Customizer with less changes. It's actually just the first two commits from that PR so it could also be taken as a smaller step toward that one.

The changes:
- The editor bar is made sticky to fix #30912. In order for it to work without causing overlap of the block toolbar `BlockTools`, `BlockPopover` and `Popover` have changes to support adjusting the sticky top position of the toolbars.
- The floating block toolbar’s z-index is raised as suggested in https://github.com/WordPress/gutenberg/issues/32062#issue-897166549:
  >If it’s possible to bring the toolbar all the way to the foreground so that it scrolls in front of the top bar, I think it would help. It's not an ideal solution but at least it would look less like a bug than when the toolbar goes behind the top bar

## How has this been tested?
Lightly and manually…

## Screenshots

https://user-images.githubusercontent.com/9000376/121817287-4bae9e00-cc35-11eb-8af9-4005d9938eb2.mp4

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
