### PR TITLE
Try: Fix vertical scroll in horizontal toolbar.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -6,8 +6,11 @@
 	display: flex;
 	flex-grow: 1;
 	width: 100%;
-	overflow: auto; // Allow horizontal scrolling on mobile.
 	position: relative;
+
+	// Allow horizontal scrolling on mobile.
+	overflow-y: hidden;
+	overflow-x: auto;
 
 	// Animation
 	transition: border-color 0.1s linear, box-shadow 0.1s linear;


### PR DESCRIPTION
## Description

Some block toolbars can grow long. Like Image or List. Pending better solutions (custom styled scrollbar?), we currently allow a horizontal scrollbar to let you scroll the toolbar. However this also causes a vertical scrollbar in some cases:

<img width="530" alt="Screenshot 2021-06-14 at 11 22 14" src="https://user-images.githubusercontent.com/1204802/121870337-3d2eb800-cd03-11eb-899d-d94ea29d1f94.png">

This PR serves as a small fix to remove that vertical scrollbar:

<img width="491" alt="Screenshot 2021-06-14 at 11 23 38" src="https://user-images.githubusercontent.com/1204802/121870371-461f8980-cd03-11eb-871f-8563069f8104.png">

As far as I can tell, this fixes the issue entirely, i.e. even using touch controls there isn't actually any space to scroll vertically. So the fact that the vertical toolbar appeared seems circular: it's there to let you scroll to see space that was made necessary by the presence of a vertical scrollbar.

## How has this been tested?

Insert a list and/or an image. Make the viewport small or test on a mobile device. Observe a horizontal, but not vertical scrollbar, in the block toolbar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
