### PR TITLE
Try: Reduce specificity of reset & classic styles.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -5,7 +5,9 @@
  * of the editor by themes.
  */
 
-.editor-styles-wrapper {
+// We use :where to keep specificity minimal.
+// https://css-tricks.com/almanac/selectors/w/where/
+html :where(.editor-styles-wrapper) {
 	padding: 8px;
 
 	/**

--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -1,15 +1,7 @@
-// We use :where to keep specificity minimal.
-// https://css-tricks.com/almanac/selectors/w/where/
 // Provide baseline auto margin for centering blocks.
-.editor-styles-wrapper :where(.wp-block) {
-	margin-left: auto;
-	margin-right: auto;
-}
-
-// This needs specificity to override theme editor styles
-// such as ol { margin-left: 0; }.
-.editor-styles-wrapper ol.wp-block,
-.editor-styles-wrapper ul.wp-block {
+// Specificity is kept at this level as many classic themes output
+// rules like figure { margin: 0; } which would break centering.
+.editor-styles-wrapper .wp-block {
 	margin-left: auto;
 	margin-right: auto;
 }

--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -1,12 +1,22 @@
-// This needs specificity to override the editor styles.
-.editor-styles-wrapper .wp-block {
+// We use :where to keep specificity minimal.
+// https://css-tricks.com/almanac/selectors/w/where/
+// Provide baseline auto margin for centering blocks.
+.editor-styles-wrapper :where(.wp-block) {
 	margin-left: auto;
 	margin-right: auto;
 }
 
-// Depreacted style needed for the block widths and alignments.
-// for themes that don't support the new layout (theme.json)
-.wp-block {
+// This needs specificity to override theme editor styles
+// such as ol { margin-left: 0; }.
+.editor-styles-wrapper ol.wp-block,
+.editor-styles-wrapper ul.wp-block {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+// Deprecated style needed for the block widths and alignments.
+// for themes that don't support the new layout (theme.json).
+html :where(.wp-block) {
 	max-width: $content-width;
 
 	// Provide every block with a default base margin. This margin provides a consistent spacing


### PR DESCRIPTION
## Description

We have two stylesheets that are created to normalize the editing canvas: `reset.scss` and `classic.scss`.

- The first one exists because the editing canvas in the post editor is not inside an iframe, so it is subject to CSS bleed from wp-admin and other styles. The reset unsets a number of element styles to provide a blank canvas to build theme styles on.
- The other one, `classic.scss` is loaded for classic themes, and primarily serves to provide left/right/wide/full-wide alignment styles. Block themes do not need these, as those alignments are served by a `layout` property and handled by the system.

In both cases, while the styles are necessary, they should have as low specificity as is possible. The lower the specificity, the easier it is for a theme to style things in a nice way. 

There is a new selector, called `:where`, which is able to provide default styles with lowered specificity. Some of the details on how that works are outlined in [this article](https://css-tricks.com/almanac/selectors/w/where/), but you can also check out [this codepen for an example](https://codepen.io/joen/pen/abJVrGX). That selector is theoretically ideal for these resets, because it allows us to reduce the specificity quite a bit, letting both theme and block styles win any specificity fight they get into. In this PR, I tried employing that selector for those resets. 

Overall, it worked very well, especially for the reset which just feels perfect. Here's before and after using "empty theme" — and they should look identical, only with the new version having lower specificity:

<img width="932" alt="Screenshot 2021-06-14 at 12 39 12" src="https://user-images.githubusercontent.com/1204802/121880710-9e0fbd80-cd0e-11eb-85e0-c14fc7e20837.png">

After:

<img width="947" alt="Screenshot 2021-06-14 at 12 40 05" src="https://user-images.githubusercontent.com/1204802/121880715-a0721780-cd0e-11eb-81b5-421897181e96.png">

For other themes, here I tested TT1, it solved [this problem](https://github.com/WordPress/gutenberg/pull/32574#pullrequestreview-682298435) surfaced by @carolinan, where `margin-left: auto; margin-right: auto;` overrides the default navigation item margin, causing them to collapse. Before:

<img width="885" alt="beftt1" src="https://user-images.githubusercontent.com/1204802/121880874-d0b9b600-cd0e-11eb-9a37-4836c3d2d22e.png">

(don't mind the padding, that's a separate issue)

After:

<img width="832" alt="afttt1" src="https://user-images.githubusercontent.com/1204802/121880915-db744b00-cd0e-11eb-9d7a-3b3f868c4229.png">

_In these screenshots, the navigation menu is justified right_.

The primary "gotcha" I encountered is that themes commonly apply a `margin-left: 0;` on `ol` and `ul` elements, which seems an innocent and sensible change over the defaults. The problem is that for classic themes, the `margin-left: auto; margin-right: auto;` rules exist (along with a `max-width`) to center a _block_ inside a post content column that supports wide and fullwide images. When left margins are zeroed out, it effectively means a left-aligned list block. In trunk, the auto-margins win due to their intrinsic specificity. But with the lowered specificity of this branch, the zero margin now wins. 

For that reason, I included [a targeted](https://github.com/WordPress/gutenberg/compare/try/reduced-specificity-resets?expand=1#diff-5763ee427967f4474bd5a1cd169547cd483a1955b2b705e8c61b898da999f5cbR11) rule for `ol` and `ul` elements, to keep their specificity. It's not an inclusion I love, but it feels necessary as the change feels very common. What do you think?

## How has this been tested?

- Please test a variety of blocks and content in this branch. The demo content is good, but please at least include a justified-right navigation block, an image, and a list block. 
- Please test wide and fullwide blocks.
- Please test primarily in classic themes like TT1 or older.
- Please also test Empty Theme and verify that before and after are identical.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
