### PR TITLE
wp-env: Bump TT1 Blocks to v0.4.7

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,9 +1,7 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [
-		"."
-	],
-	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.5" ],
+	"plugins": [ "." ],
+	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {
 		"tests": {
 			"mappings": {


### PR DESCRIPTION
## Description

Includes some GB compat updates (block renames etc).

## How has this been tested?
Verify that CI goes green.