### PR TITLE
Limit latest-post authors dropdown to users with published posts

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -195,7 +195,6 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
  * @return array Returns modified $prepared_args.
  */
 function gutenberg_rest_user_query_has_published_posts( $prepared_args, $request ) {
-	error_log( print_r( $prepared_args, true ) );
 	if ( ! empty( $request['who'] ) && 'has_published_posts' === $request['who'] ) {
 		$prepared_args['has_published_posts'] = get_post_types( array( 'show_in_rest' => true ), 'names' );
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -183,3 +183,38 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
+
+/**
+ * Filters WP_User_Query arguments when querying users via the REST API.
+ *
+ * Allow who=has_published_post.
+ *
+ * @param array           $prepared_args Array of arguments for WP_User_Query.
+ * @param WP_REST_Request $request       The REST API request.
+ *
+ * @return array Returns modified $prepared_args.
+ */
+function gutenberg_rest_user_query_has_published_posts( $prepared_args, $request ) {
+	error_log( print_r( $prepared_args, true ) );
+	if ( ! empty( $request['who'] ) && 'has_published_posts' === $request['who'] ) {
+		$prepared_args['has_published_posts'] = get_post_types( array( 'show_in_rest' => true ), 'names' );
+	}
+	return $prepared_args;
+}
+add_filter( 'rest_user_query', 'gutenberg_rest_user_query_has_published_posts', 10, 2 );
+
+
+/**
+ * Filters REST API collection parameters for the users controller.
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ *
+ * @return array Returns the $query_params with "has_published_posts".
+ */
+function gutenberg_rest_user_collection_params_has_published_posts( $query_params ) {
+	if ( ! in_array( 'has_published_posts', $query_params['who']['enum'], true ) ) {
+		$query_params['who']['enum'][] = 'has_published_posts';
+	}
+	return $query_params;
+}
+add_filter( 'rest_user_collection_params', 'gutenberg_rest_user_collection_params_has_published_posts' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -195,8 +195,10 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
  * @return array Returns modified $prepared_args.
  */
 function gutenberg_rest_user_query_has_published_posts( $prepared_args, $request ) {
-	if ( ! empty( $request['has_published_posts'] ) && true === $request['has_published_posts'] ) {
-		$prepared_args['has_published_posts'] = get_post_types( array( 'show_in_rest' => true ), 'names' );
+	if ( ! empty( $request['has_published_posts'] ) ) {
+		$prepared_args['has_published_posts'] = ( true === $request['has_published_posts'] )
+			? get_post_types( array( 'show_in_rest' => true ), 'names' )
+			: (array) $request['has_published_posts'];
 	}
 	return $prepared_args;
 }
@@ -213,7 +215,10 @@ add_filter( 'rest_user_query', 'gutenberg_rest_user_query_has_published_posts', 
 function gutenberg_rest_user_collection_params_has_published_posts( $query_params ) {
 	$query_params['has_published_posts'] = array(
 		'description' => __( 'Limit result set to users who have published posts.', 'gutenberg' ),
-		'type'        => 'boolean',
+		'type'        => array( 'boolean', 'array' ),
+		'items'       => array(
+			'type' => 'string',
+		),
 	);
 	return $query_params;
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -195,7 +195,7 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
  * @return array Returns modified $prepared_args.
  */
 function gutenberg_rest_user_query_has_published_posts( $prepared_args, $request ) {
-	if ( ! empty( $request['who'] ) && 'has_published_posts' === $request['who'] ) {
+	if ( ! empty( $request['has_published_posts'] ) && true === $request['has_published_posts'] ) {
 		$prepared_args['has_published_posts'] = get_post_types( array( 'show_in_rest' => true ), 'names' );
 	}
 	return $prepared_args;
@@ -211,9 +211,10 @@ add_filter( 'rest_user_query', 'gutenberg_rest_user_query_has_published_posts', 
  * @return array Returns the $query_params with "has_published_posts".
  */
 function gutenberg_rest_user_collection_params_has_published_posts( $query_params ) {
-	if ( ! in_array( 'has_published_posts', $query_params['who']['enum'], true ) ) {
-		$query_params['who']['enum'][] = 'has_published_posts';
-	}
+	$query_params['has_published_posts'] = array(
+		'description' => __( 'Limit result set to users who have published posts.', 'gutenberg' ),
+		'type'        => 'boolean',
+	);
 	return $query_params;
 }
 add_filter( 'rest_user_collection_params', 'gutenberg_rest_user_collection_params_has_published_posts' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -187,7 +187,7 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
 /**
  * Filters WP_User_Query arguments when querying users via the REST API.
  *
- * Allow who=has_published_post.
+ * Allow using the has_published_post argument.
  *
  * @param array           $prepared_args Array of arguments for WP_User_Query.
  * @param WP_REST_Request $request       The REST API request.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -218,6 +218,7 @@ function gutenberg_rest_user_collection_params_has_published_posts( $query_param
 		'type'        => array( 'boolean', 'array' ),
 		'items'       => array(
 			'type' => 'string',
+			'enum' => get_post_types( array( 'show_in_rest' => true ), 'names' ),
 		),
 	);
 	return $query_params;

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -52,7 +52,7 @@ const CATEGORIES_LIST_QUERY = {
 };
 const USERS_LIST_QUERY = {
 	per_page: -1,
-	has_published_posts: true,
+	has_published_posts: [ 'post' ],
 };
 
 export default function LatestPostsEdit( { attributes, setAttributes } ) {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -52,7 +52,7 @@ const CATEGORIES_LIST_QUERY = {
 };
 const USERS_LIST_QUERY = {
 	per_page: -1,
-	who: 'has_published_posts',
+	has_published_posts: true,
 };
 
 export default function LatestPostsEdit( { attributes, setAttributes } ) {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -52,6 +52,7 @@ const CATEGORIES_LIST_QUERY = {
 };
 const USERS_LIST_QUERY = {
 	per_page: -1,
+	who: 'has_published_posts',
 };
 
 export default function LatestPostsEdit( { attributes, setAttributes } ) {

--- a/phpunit/class-wp-test-rest-users-controller.php
+++ b/phpunit/class-wp-test-rest-users-controller.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Unit tests covering WP_REST_Users_Controller functionality.
+ *
+ * @package WordPress
+ * @subpackage REST API
+ */
+
+/**
+ * @group restapi
+ */
+class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
+	protected static $superadmin;
+	protected static $user;
+	protected static $editor;
+	protected static $draft_editor;
+	protected static $subscriber;
+
+	protected static $authors     = array();
+	protected static $posts       = array();
+	protected static $user_ids    = array();
+	protected static $total_users = 30;
+	protected static $per_page    = 50;
+
+	protected static $site;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$superadmin   = $factory->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'superadmin',
+			)
+		);
+		self::$user         = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$editor       = $factory->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => 'editor@example.com',
+			)
+		);
+		self::$draft_editor = $factory->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => 'draft-editor@example.com',
+			)
+		);
+		self::$subscriber   = $factory->user->create(
+			array(
+				'role'         => 'subscriber',
+				'display_name' => 'subscriber',
+				'user_email'   => 'subscriber@example.com',
+			)
+		);
+
+		foreach ( array( true, false ) as $show_in_rest ) {
+			foreach ( array( true, false ) as $public ) {
+				$post_type_name = 'r_' . json_encode( $show_in_rest ) . '_p_' . json_encode( $public );
+				register_post_type(
+					$post_type_name,
+					array(
+						'public'                   => $public,
+						'show_in_rest'             => $show_in_rest,
+						'tests_no_auto_unregister' => true,
+					)
+				);
+				self::$authors[ $post_type_name ] = $factory->user->create(
+					array(
+						'role'       => 'editor',
+						'user_email' => 'author_' . $post_type_name . '@example.com',
+					)
+				);
+				self::$posts[ $post_type_name ]   = $factory->post->create(
+					array(
+						'post_type'   => $post_type_name,
+						'post_author' => self::$authors[ $post_type_name ],
+					)
+				);
+			}
+		}
+
+		self::$posts['post']                = $factory->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_author' => self::$editor,
+			)
+		);
+		self::$posts['r_true_p_true_DRAFT'] = $factory->post->create(
+			array(
+				'post_type'   => 'r_true_p_true',
+				'post_author' => self::$draft_editor,
+				'post_status' => 'draft',
+			)
+		);
+
+		if ( is_multisite() ) {
+			self::$site = $factory->blog->create(
+				array(
+					'domain' => 'rest.wordpress.org',
+					'path'   => '/',
+				)
+			);
+			update_site_option( 'site_admins', array( 'superadmin' ) );
+		}
+
+		// Set up users for pagination tests.
+		for ( $i = 0; $i < self::$total_users - 10; $i++ ) {
+			self::$user_ids[] = $factory->user->create(
+				array(
+					'role'         => 'contributor',
+					'display_name' => "User {$i}",
+				)
+			);
+		}
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$user );
+		self::delete_user( self::$editor );
+		self::delete_user( self::$draft_editor );
+
+		foreach ( self::$posts as $post ) {
+			wp_delete_post( $post, true );
+		}
+
+		foreach ( self::$authors as $author ) {
+			self::delete_user( $author );
+		}
+
+		_unregister_post_type( 'r_true_p_true' );
+		_unregister_post_type( 'r_true_p_false' );
+		_unregister_post_type( 'r_false_p_true' );
+		_unregister_post_type( 'r_false_p_false' );
+
+		if ( is_multisite() ) {
+			wp_delete_site( self::$site );
+		}
+
+		// Remove users for pagination tests.
+		foreach ( self::$user_ids as $user_id ) {
+			self::delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * This function is run before each method
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WP_REST_Users_Controller();
+	}
+
+	/**
+	 * The following methods are implemented in core and tested.
+	 * We need to define them here because they exist in the abstract parent.
+	 */
+	public function test_register_routes() {}
+	public function test_context_param() {}
+	public function test_get_item() {}
+	public function test_prepare_item() {}
+	public function test_create_item() {}
+	public function test_update_item() {}
+	public function test_delete_item() {}
+	public function test_get_items() {}
+	public function test_get_item_schema() {}
+
+	public function test_registered_query_params() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$keys     = array_keys( $data['endpoints'][0]['args'] );
+		sort( $keys );
+		$this->assertSame(
+			array(
+				'context',
+				'exclude',
+				'has_published_posts',
+				'include',
+				'offset',
+				'order',
+				'orderby',
+				'page',
+				'per_page',
+				'roles',
+				'search',
+				'slug',
+				'who',
+			),
+			$keys
+		);
+	}
+
+	/**
+	 * Test the has_published_posts param.
+	 */
+	public function test_get_items_has_published_posts_query() {
+		wp_set_current_user( self::$superadmin );
+
+		// Test all users who have authored a post.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'has_published_posts', true );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 3, $response->get_data() );
+
+		// Test users for a specific post-type.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'has_published_posts', array( 'r_true_p_true' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+
+		// Test users for non-existent post-type.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'has_published_posts', array( 'dummy' ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 0, $response->get_data() );
+	}
+}

--- a/phpunit/class-wp-test-rest-users-controller.php
+++ b/phpunit/class-wp-test-rest-users-controller.php
@@ -203,21 +203,31 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'has_published_posts', true );
 		$response = rest_get_server()->dispatch( $request );
+		// Make sure the response status is successful.
 		$this->assertSame( 200, $response->get_status() );
+		// Make sure we have 3 authors.
 		$this->assertCount( 3, $response->get_data() );
+		// Make sure we have the right author IDs.
+		$this->assertSame( 4, $response->get_data()[0]['id'] );
+		$this->assertSame( 7, $response->get_data()[1]['id'] );
+		$this->assertSame( 8, $response->get_data()[2]['id'] );
 
 		// Test users for a specific post-type.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'has_published_posts', array( 'r_true_p_true' ) );
 		$response = rest_get_server()->dispatch( $request );
+		// Make sure the response status is successful.
 		$this->assertSame( 200, $response->get_status() );
+		// Make sure we only have 1 author.
 		$this->assertCount( 1, $response->get_data() );
+		// Make sure we got the correct author.
+		$this->assertSame( 7, $response->get_data()[0]['id'] );
 
-		// Test users for non-existent post-type.
+		// Test invalid post-type.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'has_published_posts', array( 'dummy' ) );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertCount( 0, $response->get_data() );
+		// Make sure the response has a status of 400.
+		$this->assertSame( 400, $response->get_status() );
 	}
 }


### PR DESCRIPTION
## Description
* Adds a `has_published_posts` argument for the user query in the users REST API.
* Limits the latest-post block's "author" dropdown to only users with published posts.
 
Fixes #32620 

## How has this been tested?
In a test-site with 10k users, adding a latest-posts block was causing significant server load (see description in #32620). After this PR, the request is almost instant and only shows the 5 users that have published posts on my localhost instead of a dropdown with 10k users.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
