### PR TITLE
[WIP] Trial custom shape divider block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -57,6 +57,7 @@ function gutenberg_reregister_core_block_types() {
 				'pullquote',
 				'quote',
 				'separator',
+				'shape-divider',
 				'social-links',
 				'spacer',
 				'table',

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -234,8 +234,8 @@
 			]
 		},
 		"spacing": {
-			"customMargin": false,
-			"customPadding": false,
+			"customMargin": true,
+			"customPadding": true,
 			"units": [ "px", "em", "rem", "vh", "vw" ]
 		},
 		"border": {

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -35,6 +35,8 @@
 @import "./rss/editor.scss";
 @import "./search/editor.scss";
 @import "./separator/editor.scss";
+@import "./separator/editor.scss";
+@import "./shape-divider/editor.scss";
 @import "./shortcode/editor.scss";
 @import "./site-logo/editor.scss";
 @import "./social-link/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -52,6 +52,7 @@ import * as rss from './rss';
 import * as search from './search';
 import * as group from './group';
 import * as separator from './separator';
+import * as shapeDivider from './shape-divider';
 import * as shortcode from './shortcode';
 import * as spacer from './spacer';
 import * as table from './table';
@@ -158,6 +159,7 @@ export const __experimentalGetCoreBlocks = () => [
 	rss,
 	search,
 	separator,
+	shapeDivider,
 	reusableBlock,
 	socialLinks,
 	socialLink,

--- a/packages/block-library/src/shape-divider/block.json
+++ b/packages/block-library/src/shape-divider/block.json
@@ -1,0 +1,49 @@
+{
+	"apiVersion": 2,
+	"name": "core/shape-divider",
+	"title": "Shape Divider",
+	"category": "design",
+	"description": "Create a break between ideas or sections with a custom shape divider.",
+	"keywords": [ "shape", "divider" ],
+	"textdomain": "default",
+	"attributes": {
+		"flipHorizontal": {
+			"type": "boolean"
+		},
+		"flipVertical": {
+			"type": "boolean"
+		},
+		"height": {
+			"type": "number",
+			"default": 160
+		},
+		"shapes": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": [ {
+				"type": null,
+				"style": null,
+				"seed": null,
+				"color": null,
+				"complexity": 5,
+				"height": 50,
+				"opacity": 1,
+				"path": null
+			} ]
+		}
+	},
+	"supports": {
+		"align": [ "center", "wide", "full" ],
+		"color": {
+			"background": true,
+			"gradients": false,
+			"text": false,
+			"link": false
+		},
+		"spacing": {
+			"margin": [ "top", "bottom" ]
+		}
+	}
+}

--- a/packages/block-library/src/shape-divider/controls/flip-toolbar-group.js
+++ b/packages/block-library/src/shape-divider/controls/flip-toolbar-group.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { flipHorizontal, flipVertical } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+const FlipToolbarGroup = ( { attributes, setAttributes } ) => {
+	const {
+		flipHorizontal: flipHorizontalValue,
+		flipVertical: flipVerticalValue,
+	} = attributes;
+
+	return (
+		<ToolbarGroup>
+			<ToolbarButton
+				title={ __( 'Flip horizontal' ) }
+				icon={ flipHorizontal }
+				isPressed={ flipHorizontalValue }
+				onClick={ () => setAttributes( {
+					flipHorizontal: ! flipHorizontalValue,
+				} ) }
+			/>
+			<ToolbarButton
+				title={ __( 'Flip vertical' ) }
+				icon={ flipVertical }
+				isPressed={ flipVerticalValue }
+				onClick={ () => setAttributes( {
+					flipVertical: ! flipVerticalValue,
+				} ) }
+			/>
+		</ToolbarGroup>
+	);
+};
+
+export default FlipToolbarGroup;

--- a/packages/block-library/src/shape-divider/controls/index.js
+++ b/packages/block-library/src/shape-divider/controls/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import FlipToolbarGroup from './flip-toolbar-group';
+import ShapeDividerPanel from './shape-divider-panel';
+import ShapesPanel from './shapes-panel';
+
+const ShapeDividerControls = ( props ) => (
+	<>
+		<BlockControls>
+			<FlipToolbarGroup { ...props } />
+		</BlockControls>
+		<InspectorControls>
+			<ShapeDividerPanel { ...props } />
+			<ShapesPanel { ...props } />
+		</InspectorControls>
+	</>
+);
+
+export default ShapeDividerControls;

--- a/packages/block-library/src/shape-divider/controls/shape-controls.js
+++ b/packages/block-library/src/shape-divider/controls/shape-controls.js
@@ -1,0 +1,146 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useSetting,
+	__experimentalColorGradientControl as ColorGradientControl,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	RangeControl,
+	SelectControl,
+	TextareaControl,
+} from '@wordpress/components';
+import { edit, reusableBlock } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SHAPE_TYPES, CUSTOM_SHAPE_STYLES, generateShapeSeed } from '../shapes';
+
+// Defining empty array here instead of inline avoids unnecessary re-renders of
+// color control.
+const EMPTY_ARRAY = [];
+
+const getTypeLabel = ( type ) => {
+	return SHAPE_TYPES.find( ( shapeType ) => shapeType.value === type )?.label;
+};
+
+const ShapeControls = ( { shape, onChange } ) => {
+	const {
+		color,
+		complexity,
+		customCode,
+		delta,
+		height,
+		opacity,
+		style,
+		type,
+	} = shape;
+
+	const isCustomShape = type === 'custom';
+	const isUserSupplied = type === 'user';
+
+	const colors = useSetting( 'color.palette' ) || EMPTY_ARRAY;
+	const disableCustomColors = ! useSetting( 'color.custom' );
+	const disableCustomGradients = ! useSetting( 'color.customGradient' );
+
+	return (
+		<>
+			<h3 className="shape-divider-controls__subtitle">
+				{ getTypeLabel( type ) }
+				<span>
+					{ isCustomShape && (
+						<Button
+							icon={ reusableBlock }
+							label={ __( 'Randomize shape' ) }
+							onClick={ () => onChange( {
+								seed: generateShapeSeed(),
+							} ) }
+						/>
+					) }
+					<Button
+						icon={ edit }
+						label={ __( 'Change shape type' ) }
+						onClick={ () => onChange( {
+							type: undefined,
+							style: undefined,
+						} ) }
+					/>
+				</span>
+			</h3>
+			{ isCustomShape && (
+				<div className="shape-divider-controls__style">
+					<SelectControl
+						label={ __( 'Style' ) }
+						value={ style }
+						options={ CUSTOM_SHAPE_STYLES }
+						onChange={ ( value ) => onChange( { style: value } ) }
+					/>
+				</div>
+			) }
+			{ isCustomShape && (
+				<RangeControl
+					label={ __( 'Complexity' ) }
+					value={ complexity }
+					onChange={ ( value ) => onChange( { complexity: value } ) }
+					min={ 2 }
+					max={ 40 }
+					withInputField={ false }
+				/>
+			) }
+			{ isCustomShape && (
+				<RangeControl
+					label={ __( 'Delta' ) }
+					value={ delta }
+					onChange={ ( value ) => onChange( { delta: value } ) }
+					min={ 0 }
+					max={ 75 }
+					withInputField={ false }
+				/>
+			) }
+			{ ! isUserSupplied && (
+				<>
+					<RangeControl
+						className={ 'shape-divider-controls__height' }
+						label={ __( 'Height' ) }
+						value={ height }
+						onChange={ ( value ) => onChange( { height: value } ) }
+						min={ 1 }
+						max={ 100 }
+						withInputField={ false }
+					/>
+					<RangeControl
+						label={ __( 'Opacity' ) }
+						value={ opacity }
+						onChange={ ( value ) => onChange( { opacity: value } ) }
+						min={ 0 }
+						max={ 1 }
+						step={ 0.01 }
+						withInputField={ false }
+					/>
+					<ColorGradientControl
+						label={ __( 'Color' ) }
+						value={ color }
+						colors={ colors }
+						gradients={ undefined }
+						disableCustomColors={ disableCustomColors }
+						disableCustomGradients={ disableCustomGradients }
+						onColorChange={ ( value ) => onChange( { color: value } ) }
+					/>
+				</>
+			) }
+			{ isUserSupplied && (
+				<TextareaControl
+					className="shape-divider-controls__custom-code"
+					label={ __( 'SVG' ) }
+					value={ customCode }
+					onChange={ ( value ) => onChange( { customCode: value } ) }
+				/>
+			) }
+		</>
+	);
+};
+
+export default ShapeControls;

--- a/packages/block-library/src/shape-divider/controls/shape-divider-panel.js
+++ b/packages/block-library/src/shape-divider/controls/shape-divider-panel.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_BOX_HEIGHT, generatePathValue } from '../shapes';
+
+const ShapeDividerPanel = ( { attributes, setAttributes } ) => {
+	const { height, shapes } = attributes;
+
+	const handleHeightChange = ( newHeight ) => {
+		const updatedShapes = shapes.map( ( shape ) => {
+			return {
+				...shape,
+				path: generatePathValue( shape, newHeight ),
+			};
+		} );
+
+		setAttributes( { height: newHeight, shapes: updatedShapes } );
+	}
+
+	return (
+		<PanelBody title={ __( 'Divider settings' ) }>
+			<RangeControl
+				label={ __( 'Height in pixels' ) }
+				min={ 5 }
+				max={ Math.max( VIEW_BOX_HEIGHT, height ) }
+				value={ height }
+				onChange={ handleHeightChange }
+			/>
+		</PanelBody>
+	)
+};
+
+export default ShapeDividerPanel;

--- a/packages/block-library/src/shape-divider/controls/shape-panel.js
+++ b/packages/block-library/src/shape-divider/controls/shape-panel.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ShapeControls from './shape-controls';
+import ShapeSelectionPanel from './shape-selection-panel';
+import { generatePathValue, PATH_RELATED_PROPS } from '../shapes';
+
+const ShapePanel = ( { dividerHeight, shape, index, updateShape } ) => {
+	const { type } = shape;
+	const shapeLabel = sprintf(
+		// translators: %d is the shape's index.
+		__( 'Shape %d' ),
+		index + 1
+	);
+
+	const changeShape = ( newConfig ) => {
+		const newShape = {
+			...shape,
+			...newConfig,
+		};
+
+		// Regenerate shape's SVG path if its config affecting it has changed.
+		const newConfigProps = Object.keys( newConfig );
+		const updatedPathProps = PATH_RELATED_PROPS.filter( ( prop ) =>
+			newConfigProps.includes( prop )
+		);
+
+		if ( updatedPathProps.length ) {
+			newShape.path = generatePathValue( newShape, dividerHeight );
+		}
+
+		// Replace the original shape with the updated one.
+		updateShape( newShape, index );
+	}
+
+	return (
+		<PanelBody
+			className="shape-divider-controls__shape"
+			initialOpen={ ! type }
+			title={ shapeLabel }
+		>
+			{ !! type ? (
+				<ShapeControls shape={ shape } onChange={ changeShape } />
+			) : (
+				<ShapeSelectionPanel onClick={ changeShape } />
+			) }
+		</PanelBody>
+	);
+};
+
+export default ShapePanel;

--- a/packages/block-library/src/shape-divider/controls/shape-selection-panel.js
+++ b/packages/block-library/src/shape-divider/controls/shape-selection-panel.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_PATH_TYPE, SHAPE_TYPES, generateShapeSeed } from '../shapes';
+
+const ShapeSelectionPanel = ( { onClick } ) => {
+
+	const handleClick = ( value ) => {
+		const newConfig = { type: value };
+
+		if ( value === 'custom' ) {
+			newConfig.style = DEFAULT_PATH_TYPE;
+			newConfig.seed = generateShapeSeed();
+			newConfig.delta = 75;
+		}
+
+		onClick( newConfig );
+	};
+
+	return (
+		<>
+			{ SHAPE_TYPES.map( ( { value, label } ) => (
+				<Button
+					variant="tertiary"
+					onClick={ () => handleClick( value ) }
+					key={ `shape-type-button-${ value }` }
+				>
+					{ label }
+				</Button>
+			) ) }
+		</>
+	);
+}
+
+export default ShapeSelectionPanel;

--- a/packages/block-library/src/shape-divider/controls/shapes-dropdown-menu.js
+++ b/packages/block-library/src/shape-divider/controls/shapes-dropdown-menu.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { check, moreHorizontal } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+const ShapesDropdownMenu = ( { shapes, addShape, removeShape } ) => (
+	<DropdownMenu icon={ moreHorizontal } label={ __( 'Shapes' ) }>
+		{ ( { onClose } ) => (
+			<>
+				<MenuGroup label={ __( 'Shapes' ) }>
+					{ shapes.map( ( shape, index ) => {
+						const shapeLabel = sprintf(
+							// translators: %d is the shape's index.
+							__( 'Shape %d' ),
+							index + 1
+						);
+
+						return (
+							<MenuItem
+								key={ `shape-menu-item-${ index }` }
+								icon={ check }
+								onClick={ () => {
+									removeShape( index );
+									onClose();
+								} }
+								role="menuitemcheckbox"
+							>
+								{ shapeLabel }
+							</MenuItem>
+						);
+					} ) }
+				</MenuGroup>
+				<MenuGroup>
+					<MenuItem
+						onClick={ () => {
+							addShape();
+							onClose();
+						} }
+					>
+						{ __( 'Add shape' ) }
+					</MenuItem>
+				</MenuGroup>
+			</>
+		) }
+	</DropdownMenu>
+);
+
+export default ShapesDropdownMenu;

--- a/packages/block-library/src/shape-divider/controls/shapes-panel.js
+++ b/packages/block-library/src/shape-divider/controls/shapes-panel.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_SHAPE } from '../shapes';
+import ShapePanel from './shape-panel';
+import ShapesDropdownMenu from './shapes-dropdown-menu';
+
+const ShapesPanel = ( { attributes, setAttributes } )  => {
+	const { height, shapes } = attributes;
+
+	const addShape = () => {
+		setAttributes( { shapes: [ ...shapes, DEFAULT_SHAPE ] } );
+	};
+
+	const removeShape = ( index ) => {
+		const newShapes = [ ...shapes ];
+		newShapes.splice( index, 1 );
+		setAttributes( { shapes: newShapes } );
+	};
+
+	const updateShape = ( shape, index ) => {
+		const newShapes = [ ...shapes ];
+		newShapes.splice( index, 1, shape );
+		setAttributes( { shapes: newShapes } );
+	};
+
+	return (
+		<div className="shape-divider-controls">
+			<h2 className="shape-divider-controls__title">
+				{ __( 'Shapes' ) }
+				<ShapesDropdownMenu
+					shapes={ shapes }
+					addShape={ addShape }
+					removeShape={ removeShape }
+				/>
+			</h2>
+			{ shapes.map( ( shape, index ) => (
+				<ShapePanel
+					key={ `shape-divider-shape-${ index }` }
+					shape={ shape }
+					index={ index }
+					dividerHeight={ height }
+					updateShape={ updateShape }
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export default ShapesPanel;

--- a/packages/block-library/src/shape-divider/edit.js
+++ b/packages/block-library/src/shape-divider/edit.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { ResizableBox } from '@wordpress/components';
+import { SVG } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import ShapeDividerControls from './controls';
+import {
+	VIEW_BOX_WIDTH,
+	VIEW_BOX_HEIGHT,
+	generatePathValue,
+	getShapePath,
+} from './shapes';
+
+function ShapeDividerEdit( props ) {
+	const { attributes, isSelected, setAttributes, toggleSelection } = props;
+	const { flipHorizontal, flipVertical, height, shapes } = attributes;
+
+	const classes = classnames( {
+		[ `flip-horizontal` ]: flipHorizontal,
+		[ `flip-vertical` ]: flipVertical,
+	} );
+	const styles = { height: `${ height }px` };
+	const blockProps = useBlockProps( { className: classes } );
+	const viewBox = `0 0 ${ VIEW_BOX_WIDTH } ${ height || VIEW_BOX_HEIGHT }`;
+
+	// Resizing the divider changes the available height for the inner shapes.
+	// Recalculate them when the height changes.
+	const handleResize = ( newHeight ) => {
+		const updatedShapes = shapes.map( ( shape ) => {
+			return {
+				...shape,
+				path: generatePathValue( shape, newHeight ),
+			};
+		} );
+
+		setAttributes( {
+			height: newHeight,
+			shapes: updatedShapes,
+		} );
+	};
+
+	return (
+		<>
+			<div { ...blockProps }>
+				<ResizableBox
+					size={ { height, width: '100%' } }
+					minHeight={ 5 }
+					maxHeight={ Math.max( VIEW_BOX_HEIGHT, height ) }
+					enable={ {
+						top: true,
+						right: false,
+						bottom: true,
+						left: false,
+						topRight: false,
+						bottomRight: false,
+						bottomLeft: false,
+						topLeft: false,
+					} }
+					onResize={ ( event, direction, elt ) => {
+						handleResize( parseInt( elt.offsetHeight, 10 ) );
+						toggleSelection( false );
+					} }
+					onResizeStop={ ( event, direction, elt, delta ) => {
+						handleResize( parseInt( height + delta.height, 10 ) );
+						toggleSelection( true );
+					} }
+					showHandle={ isSelected }
+				>
+					<SVG
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox={ viewBox }
+						width="100%"
+						preserveAspectRatio="none meet"
+					>
+						{ shapes.map( ( shape, index ) =>
+							getShapePath( shape, index, height )
+						) }
+					</SVG>
+				</ResizableBox>
+			</div>
+			<ShapeDividerControls { ...props } />
+		</>
+	);
+}
+
+export default ShapeDividerEdit;

--- a/packages/block-library/src/shape-divider/editor.scss
+++ b/packages/block-library/src/shape-divider/editor.scss
@@ -1,0 +1,106 @@
+.wp-block-shape-divider {
+	.components-resizable-box__container {
+		display: flex;
+		align-items: flex-end;
+	}
+
+	&.flip-vertical {
+		.components-resizable-box__container {
+			align-items: flex-start;
+		}
+	}
+}
+
+.shape-divider-controls {
+	border-top: $border-width solid $gray-200;
+	padding: $grid-unit-20;
+	margin-top: -1px;
+
+	.shape-divider-controls__title {
+		align-items: center;
+		display: flex;
+		font-size: inherit;
+		font-weight: 500;
+		justify-content: space-between;
+		line-height: normal;
+		margin: 0;
+
+		.components-dropdown-menu {
+			height: $grid-unit-30;
+			margin-top: -4px;
+			margin-bottom: -4px;
+		}
+
+		.components-dropdown-menu__toggle {
+			padding: 0;
+			min-width: $grid-unit-30;
+			width: $grid-unit-30;
+			height: $grid-unit-30;
+		}
+
+		&:not(:last-child) {
+			padding-bottom: $grid-unit-20;
+		}
+	}
+
+	.shape-divider-controls__subtitle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin: 0;
+
+		span {
+			line-height: 1;
+		}
+
+		.components-button {
+			padding: 0;
+			min-width: $grid-unit-30;
+			width: $grid-unit-30;
+			height: $grid-unit-30;
+		}
+
+		.components-button + .components-button {
+			margin-left: $grid-unit-10;
+		}
+	}
+
+	.shape-divider-controls__shape {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: $grid-unit-20;
+
+		> * {
+			margin-bottom: 0;
+		}
+
+		> h2,
+		> h3,
+		.shape-divider-controls__style,
+		.block-editor-color-gradient-control,
+		.shape-divider-controls__custom-code {
+			grid-column: span 2;
+		}
+
+		.components-base-control__label,
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+
+		.components-range-control__root {
+			> span {
+				margin-right: 0;
+			}
+		}
+
+		> .components-button {
+			border-width: 1px;
+			border-style: solid;
+			justify-content: center;
+		}
+	}
+
+	.shape-divider-controls__shape:last-child:not(.is-opened) {
+		border-bottom: $border-width solid $gray-200;
+	}
+}

--- a/packages/block-library/src/shape-divider/index.js
+++ b/packages/block-library/src/shape-divider/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { separator as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+	save,
+};

--- a/packages/block-library/src/shape-divider/save.js
+++ b/packages/block-library/src/shape-divider/save.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { SVG } from '@wordpress/primitives';
+import { VIEW_BOX_WIDTH, VIEW_BOX_HEIGHT, getShapePath } from './shapes';
+
+export default function shapeDividerSave( { attributes } ) {
+	const { flipHorizontal, flipVertical, height, shapes } = attributes;
+	const classes = classnames( {
+		[ `flip-horizontal` ]: flipHorizontal,
+		[ `flip-vertical` ]: flipVertical,
+	} );
+	const viewBox = `0 0 ${ VIEW_BOX_WIDTH } ${ height || VIEW_BOX_HEIGHT }`;
+
+	return (
+		<div { ...useBlockProps.save( { className: classes } ) }>
+			<SVG width="100%" viewBox={ viewBox } xmlns="http://www.w3.org/2000/svg">
+				{ shapes.map( ( shape, index ) =>
+					getShapePath( shape, index, height )
+				) }
+			</SVG>
+		</div>
+	);
+}

--- a/packages/block-library/src/shape-divider/shapes/custom/blocks.js
+++ b/packages/block-library/src/shape-divider/shapes/custom/blocks.js
@@ -1,0 +1,96 @@
+/**
+ * Internal dependencies
+ */
+import { VIEW_BOX_WIDTH, VIEW_BOX_HEIGHT, generateShapeSeed } from '../';
+
+/**
+ * Very basic seeded pseudo random number generator.
+ *
+ * IMPORTANT TODO: This should be replaced with something serious. Only here
+ * for the purposes of testing randomizing the custom shape's seed and seeing
+ * a new seed reflected in the actual line's shape.
+ *
+ * @param {number} seed Seed for varying the line shape.
+ */
+ function* pseudoRandom( seed ) {
+	let value = seed;
+
+	while( true ) {
+		value = ( value * Math.PI * 1000 ) % 2147483647;
+		yield value;
+	}
+}
+
+/**
+ * Calculates the points required to build a path representing blocks.
+ *
+ * @param  {Object}  config Shape config containing complexity, height etc.
+ * @param  {integer} seed   Seed to create randomness in the calculated points.
+ *
+ * @return {Array} Points matching supplied config to build SVG path from.
+ */
+const calculatePoints = ( config ) => {
+	const { complexity, delta, height, seed } = config;
+	const points = [];
+
+	const blocksSeed = seed || generateShapeSeed();
+	const heightGenerator = pseudoRandom( blocksSeed );
+
+	// Calculate the actual shape height, then apply delta to get min. Finally,
+	// convert them to SVG coords.
+	const cartesianHeight = height / 100 * VIEW_BOX_HEIGHT;
+	const cartesianMin = ( 1 - ( delta / 100 ) ) * cartesianHeight;
+	const max = VIEW_BOX_HEIGHT - cartesianHeight;
+	const min = VIEW_BOX_HEIGHT - cartesianMin;
+
+	let i;
+	for ( i = 0; i < complexity; i++ ) {
+		let heightSeed = heightGenerator.next().value;
+		heightSeed = heightSeed - Math.floor( heightSeed );
+
+		points.push( {
+			x: ( i / complexity * VIEW_BOX_WIDTH ),
+			y: ( Math.floor( heightSeed * ( max - min + 1 ) + min ) ),
+		} );
+	}
+
+	return points;
+ };
+
+/**
+ * Builds an SVG path string for the blocks shape.
+ *
+ * @param  {Object} shapeConfig Config options for the blocks shape.
+ * @return {String} SVG path representing a blocks shape.
+ */
+export const buildBlocksPath = ( shapeConfig ) => {
+	// Use the shape's config to determine points as a base for the path.
+	const points = calculatePoints( shapeConfig );
+
+	if ( ! points?.length ) {
+		return;
+	}
+
+	// Start building path string.
+	const blocks = [ `M 0 ${ points[ 0 ].y }` ];
+	let previous = { x: 0, y: points[ 0 ].y };
+
+	// Add the very end of the SVG view box as a point. Needs same treatment
+	// as the other points.
+	points.push( { x: VIEW_BOX_WIDTH, y: VIEW_BOX_HEIGHT } );
+
+	points.forEach( ( point ) => {
+		// Horizontal line to this point's x coordinate.
+		blocks.push( ' h ', point.x - previous.x );
+
+		// Vertical line up/down to this point's y coordinate.
+		blocks.push( ' L ', point.x, point.y );
+
+		previous = point;
+	} );
+
+	// Return back to starting edge, then close path.
+	blocks.push( ' L 0 ', VIEW_BOX_HEIGHT, ' Z' );
+
+	return blocks.join( ' ' );
+};

--- a/packages/block-library/src/shape-divider/shapes/custom/lines.js
+++ b/packages/block-library/src/shape-divider/shapes/custom/lines.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+ import { clamp } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_BOX_WIDTH, VIEW_BOX_HEIGHT, generateShapeSeed } from '../';
+
+/**
+ * Very basic seeded pseudo random number generator.
+ *
+ * IMPORTANT TODO: This should be replaced with something serious. Only here
+ * for the purposes of testing randomizing the custom shape's seed and seeing
+ * a new seed reflected in the actual line's shape.
+ *
+ * @param {number} seed Seed for varying the line shape.
+ */
+ function* pseudoRandom( seed ) {
+	let value = seed;
+
+	while( true ) {
+		value = ( value * Math.PI * 1000 ) % 2147483647;
+		yield value;
+	}
+}
+
+/**
+ * Calculates the points required to build a path representing a line graph.
+ *
+ * @param  {Object}  config Shape config containing complexity, height etc.
+ * @return {Array} Points matching supplied config to build SVG path from.
+ */
+const calculatePoints = ( config ) => {
+	const { complexity, delta, height, seed } = config;
+	const points = [];
+
+	const lineSeed = seed || generateShapeSeed();
+	const heightGenerator = pseudoRandom( lineSeed );
+
+	// Calculate the actual shape height, then apply delta to get min. Finally,
+	// convert them to SVG coords.
+	const cartesianHeight = height / 100 * VIEW_BOX_HEIGHT;
+	const cartesianMin = ( 1 - ( delta / 100 ) ) * cartesianHeight;
+	const max = VIEW_BOX_HEIGHT - cartesianHeight;
+	const min = VIEW_BOX_HEIGHT - cartesianMin;
+
+	let i;
+	for ( i = 0; i < complexity; i++ ) {
+		let heightSeed = heightGenerator.next().value;
+		heightSeed = heightSeed - Math.floor( heightSeed );
+
+		points.push( {
+			x: ( i / complexity * VIEW_BOX_WIDTH ),
+			y: ( Math.floor( heightSeed * ( max - min + 1 ) + min ) ),
+		} );
+	}
+
+	return points;
+ };
+
+/**
+ * Builds an SVG path string for the lines shape.
+ *
+ * @param  {Object} shapeConfig Config options for the lines shape.
+ * @return {String} SVG path representing a lines shape.
+ */
+export const buildLinesPath = ( shapeConfig ) => {
+	// Use the shape's config to determine points as a base for the path.
+	const points = calculatePoints( shapeConfig );
+
+	if ( ! points?.length ) {
+		return;
+	}
+
+	// Start building path string.
+	const lines = [ `M 0 ${ VIEW_BOX_HEIGHT }` ];
+
+	lines.push( ' L ', 0, VIEW_BOX_HEIGHT );
+
+	points.forEach( ( point ) => {
+		lines.push( ' L ', point.x, point.y );
+	} );
+
+	lines.push( ' L ', VIEW_BOX_WIDTH, VIEW_BOX_HEIGHT );
+	lines.push( ' L 0 ', VIEW_BOX_HEIGHT, ' Z' );
+
+	return lines.join( ' ' );
+};

--- a/packages/block-library/src/shape-divider/shapes/custom/waves.js
+++ b/packages/block-library/src/shape-divider/shapes/custom/waves.js
@@ -1,0 +1,118 @@
+/**
+ * Internal dependencies
+ */
+import { VIEW_BOX_WIDTH, VIEW_BOX_HEIGHT, DEFAULT_SEED, MAX_SEED } from '../';
+
+/**
+ * Very basic seeded pseudo random number generator.
+ *
+ * IMPORTANT TODO: This should be replaced with something serious. Only here
+ * for the purposes of testing randomizing the custom shape's seed and seeing
+ * a new seed reflected in the actual wave's shape.
+ *
+ * @param {number} seed Seed for varying the wave shape.
+ */
+function* pseudoRandom( seed ) {
+	let value = seed;
+
+	while( true ) {
+		value = ( value * Math.PI * 1000 ) % 2147483647;
+		yield value;
+	}
+}
+
+/**
+ * Calculates the points required to build a path representing a wave.
+ *
+ * @param  {Object}  config      Shape config containing complexity, height etc.
+ * @param  {integer} totalHeight Total height in pixels of the divider block.
+ *
+ * @return {Array} Points matching supplied config to build SVG path from.
+ */
+const calculatePoints = ( config, totalHeight ) => {
+	const { complexity, height, delta, seed = DEFAULT_SEED } = config;
+	const points = [];
+
+	const availableHeight = totalHeight || VIEW_BOX_HEIGHT;
+	const decimalHeight = height / 100;
+	const enforcedDelta = delta || availableHeight / 8;
+	const deltaHeight = Math.round( decimalHeight * enforcedDelta );
+	const waveHeight = Math.round( ( 1 - decimalHeight ) * availableHeight );
+
+	const sinSeedGenerator = pseudoRandom( seed );
+
+	let i;
+	for ( i = 0; i < complexity; i++ ) {
+		const sinSeed = sinSeedGenerator.next().value;
+		const sinHeight = Math.sin( sinSeed ) * deltaHeight;
+
+		points.push( {
+			x: ( i / complexity * VIEW_BOX_WIDTH ),
+			y: ( Math.sin( sinSeed ) * sinHeight + waveHeight ),
+		} );
+	}
+
+	return points;
+};
+
+/**
+ * Determines XY coordinates for a curve point from the current and previous
+ * points.
+ *
+ * @param  {Object} currentPoint  Object containing x,y coordinates.
+ * @param  {Object} previousPoint Object containing x,y coordinates.
+ *
+ * @return {Object} Point to use in curve path.
+ */
+const getCurvePoint = ( currentPoint, previousPoint ) => {
+	return {
+		x: ( currentPoint.x - previousPoint.x ) + currentPoint.x,
+		y: ( currentPoint.y - previousPoint.y ) + currentPoint.y,
+	};
+}
+
+/**
+ * Builds an SVG path string in the shape of a wave.
+ *
+ * @param  {Object} shapeConfig Config options for the waves shape.
+ * @return {String} SVG path representing a waves shape.
+ */
+export const buildWavesPath = ( shapeConfig, height ) => {
+	// Use the shape's config to determine points as a base for the path.
+	const points = calculatePoints( shapeConfig, height );
+
+	if ( ! points?.length ) {
+		return;
+	}
+
+	const totalHeight = height || VIEW_BOX_HEIGHT;
+
+	// Start building path string.
+	const curves = [ `M 0 ${ totalHeight }` ];
+
+	const first = {
+		x: ( points[1].x - points[0].x ) / 2,
+		y: ( points[1].y - points[0].y ) + points[0].y + ( points[1].y - points[0].y ),
+	};
+
+	curves.push( ' C ', first.x, first.y,  first.x, first.y, points[1].x, points[1].y );
+
+	let i;
+	let previous = first;
+
+	for( i = 1; i < points.length; i++ ) {
+		const point = points[ i ];
+		const next = i + 1 < points.length
+			? points[ i + 1 ]
+			: { x: VIEW_BOX_WIDTH, y: totalHeight };
+		const curvePoint = getCurvePoint( point, previous );
+
+		curves.push( ' C ', curvePoint.x, curvePoint.y, curvePoint.x, curvePoint.y, next.x, next.y );
+		previous = curvePoint;
+	}
+
+	// Close out the path.
+	curves.push( ' L 0 ', totalHeight, ' Z' );
+
+	return curves.join( ' ' );
+};

--- a/packages/block-library/src/shape-divider/shapes/index.js
+++ b/packages/block-library/src/shape-divider/shapes/index.js
@@ -1,0 +1,164 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Path } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import { buildBlocksPath } from './custom/blocks';
+import { buildLinesPath } from './custom/lines';
+import { buildWavesPath } from './custom/waves';
+import {
+	WavyShape,
+	WavesShape,
+	SlopedShape,
+	RoundedShape,
+	AngledShape,
+	TriangleShape,
+	PointedShape,
+	HillsShape,
+} from './standard-shapes';
+
+// Pixel width of the SVG's ViewBox.
+export const VIEW_BOX_WIDTH = 610;
+export const VIEW_BOX_HEIGHT = 160;
+
+// Default shape style. Used as fallback if unknown style given.
+export const DEFAULT_PATH_TYPE = 'waves';
+
+// Default to be used as a template when adding a new shape.
+export const DEFAULT_SHAPE = {
+	complexity: 5,
+	height: 50,
+	opacity: 1,
+};
+
+// Available standard shape type options. This includes options for custom
+// shapes and pastes/uploaded paths.
+export const SHAPE_TYPES = [
+	{ value: 'wavy', label: __( 'Wavy' ) },
+	{ value: 'waves', label: __( 'Waves' ) },
+	{ value: 'sloped', label: __( 'Sloped' ) },
+	{ value: 'rounded', label: __( 'Rounded' ) },
+	{ value: 'angled', label: __( 'Angled' ) },
+	{ value: 'triangle', label: __( 'Triangle' ) },
+	{ value: 'pointed', label: __( 'Pointed' ) },
+	{ value: 'hills', label: __( 'Hills' ) },
+	{ value: 'custom', label: __( 'Custom' ) },
+	{ value: 'user', label: __( 'User Supplied' ) },
+];
+
+// Available custom shape style options.
+export const CUSTOM_SHAPE_STYLES = [
+	{ value: 'blocks', label: __( 'Blocks' ) },
+	{ value: 'lines', label: __( 'Lines' ) },
+	{ value: 'waves', label: __( 'Waves' ) },
+];
+
+// Shape config properties impacting path generation and force redraw.
+export const PATH_RELATED_PROPS = [
+	'style',
+	'height',
+	'complexity',
+	'delta',
+	'seed',
+];
+
+// Default seed for custom shape types to use.
+export const DEFAULT_SEED = 1000;
+
+// Maximum seed value.
+export const MAX_SEED = 10000;
+
+// Collection of functions to map shape styles to functions that generate the
+// appropriate path for that style.
+const pathGenerators = {
+	blocks: buildBlocksPath,
+	lines: buildLinesPath,
+	waves: buildWavesPath,
+};
+
+// Collection of functions to map standard shapes to functions that return
+// the appropriate path or that shape.
+const standardShapePaths = {
+	wavy: WavyShape,
+	waves: WavesShape,
+	sloped: SlopedShape,
+	rounded: RoundedShape,
+	angled: AngledShape,
+	triangle: TriangleShape,
+	pointed: PointedShape,
+	hills: HillsShape,
+};
+
+/**
+ * Randomly generate another value to be used as a seed when creating custom
+ * shapes.
+ *
+ * @return {number} Generated seed value.
+ */
+export const generateShapeSeed = () => {
+	return Math.floor( Math.random() * MAX_SEED );
+}
+
+/**
+ * Generates an SVG path attribute string from the supplied shape configuration.
+ *
+ * @param  {Object}  shapeConfig Configuration to vary shape path by.
+ * @param  {integer} height      Height in pixels of the shape divider block.
+ *
+ * @return {string}  SVG Path `d` attribute value.
+ */
+export const generatePathValue = ( shapeConfig, height ) => {
+	const { style } = shapeConfig;
+	const pathType = pathGenerators?.[ style ] ? style : DEFAULT_PATH_TYPE;
+
+	return pathGenerators[ pathType ]( shapeConfig, height );
+};
+
+/**
+ * Creates SVG Path element/s from the shape config. For custom shapes, it will
+ * return the previously saved path if available or generate one.
+ *
+ * @param  {Object}  shapeConfig Configuration to vary shape by.
+ * @param  {integer} shapeIndex  Position of the shape within the divider.
+ * @param  {integer} height      Height in pixels of the shape divider block.
+ *
+ * @return {Path} SVG Path element.
+ */
+export const getShapePath = ( shapeConfig, shapeIndex, height ) => {
+	const { color, customCode, opacity, path, type } = shapeConfig;
+
+	// Skip if this is a new placeholder shape.
+	if ( ! type ) {
+		return;
+	}
+
+	// Handle user supplied SVG
+	//
+	// IMPORTANT TODO: Use image from media library to avoid
+	// any further screening/security issues from custom code. Outside of scope
+	// for this proof of concept.
+	if ( type === 'user' ) {
+		return customCode;
+	}
+
+	// Handle custom shape path.
+	if ( type === 'custom' ) {
+		const pathAttribute = path || generatePathValue( shapeConfig, height );
+
+		return (
+			<Path
+				d={ pathAttribute }
+				fill={ color }
+				opacity={ opacity } // fillOpacity gets saved incorrectly.
+				key={ `shape-${ shapeIndex }` }
+			/>
+		);
+	}
+
+	// Return path/s for standard shape types.
+	return standardShapePaths[ type ]( shapeConfig, `shape-${ shapeIndex }` );
+}

--- a/packages/block-library/src/shape-divider/shapes/standard-shapes.js
+++ b/packages/block-library/src/shape-divider/shapes/standard-shapes.js
@@ -1,0 +1,177 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/primitives';
+
+// IMPORTANT: All these are placeholder shapes to be replaced with custom designs
+
+const getScaleTransform = ( height ) => {
+	return height < 100 ? `scale(1,${ height / 100 })` : '';
+}
+
+const getScaleAndTranslate = ( height, totalHeight ) => {
+	if ( height === 100 ) {
+		return '';
+	}
+
+	const decimalHeight = height / 100;
+	const translateY = ( 1 - decimalHeight ) * totalHeight;
+
+	return `translate(0,${ translateY }) scale(1,${ decimalHeight })`;
+}
+
+// WavyShape nests SVG to make drawing the path easier while still supporting
+// varying divider heights.
+export const WavyShape = ( { color, height, opacity }, key ) => {
+	const transform = `matrix(1 0 0 -1 0 10) ${ getScaleTransform( height ) }`;
+
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 100 10"
+			preserveAspectRatio="none"
+			key={ key }
+		>
+			<Path
+				d="m42.19.65c2.26-.25 5.15.04 7.55.53 2.36.49 7.09 2.35 10.05 3.57 7.58 3.22 13.37 4.45 19.26 4.97 2.36.21 4.87.35 10.34-.25s10.62-2.56 10.62-2.56v-6.91h-100.01v3.03s7.2 3.26 15.84 3.05c3.92-.07 9.28-.67 13.4-2.24 2.12-.81 5.22-1.82 7.97-2.42 2.72-.63 3.95-.67 4.98-.77z"
+				fill={ color }
+				opacity={ opacity }
+				transform={ transform }
+			/>
+		</SVG>
+	)
+};
+
+export const WavesShape = ( { color, height, opacity }, key ) => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 1000 300"
+			preserveAspectRatio="none"
+			key={ key }
+		>
+			<G transform={ getScaleAndTranslate( height, 300 ) }>
+				<Path
+					d="M 1000 299 l 2 -279 c -155 -36 -310 135 -415 164 c -102.64 28.35 -149 -32 -232 -31 c -80 1 -142 53 -229 80 c -65.54 20.34 -101 15 -126 11.61 v 54.39 z"
+					fill={ color }
+					opacity={ opacity * 0.15 }
+				/>
+				<Path
+					d="M 1000 286 l 2 -252 c -157 -43 -302 144 -405 178 c -101.11 33.38 -159 -47 -242 -46 c -80 1 -145.09 54.07 -229 87 c -65.21 25.59 -104.07 16.72 -126 10.61 v 22.39 z"
+					fill={ color }
+					opacity={ opacity * 0.3 }
+				/>
+				<Path
+					d="M 1000 300 l 1 -230.29 c -217 -12.71 -300.47 129.15 -404 156.29 c -103 27 -174 -30 -257 -29 c -80 1 -130.09 37.07 -214 70 c -61.23 24 -108 15.61 -126 10.61 v 22.39 z"
+					fill={ color }
+					opacity={ opacity }
+				/>
+			</G>
+		</SVG>
+	);
+};
+
+export const SlopedShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 100 100"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<Path
+			d="M0 100 C 20 0 50 0 100 100 Z"
+			fill={ color }
+			opacity={ opacity }
+			transform={ getScaleAndTranslate( height, 100 ) }
+		/>
+	</SVG>
+);
+
+export const RoundedShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 240 24"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<Path
+			d="M119.849,0C47.861,0,0,24,0,24h240C240,24,191.855,0.021,119.849,0z"
+			fill={ color }
+			opacity={ opacity }
+			key={ key }
+			transform={ getScaleAndTranslate( height, 24 ) }
+		/>
+	</SVG>
+);
+
+export const AngledShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 100 100"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<Path
+			d="M 0 100 L 100 0 L 100 100 Z"
+			fill={ color }
+			opacity={ opacity }
+			transform={ getScaleAndTranslate( height, 100 ) }
+		/>
+	</SVG>
+);
+
+export const TriangleShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 100 100"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<Path
+			d="M0 0 L 50 100 L 100 0Z"
+			fill={ color }
+			opacity={ opacity }
+			transform={ `matrix(1 0 0 -1 0 100) ${ getScaleTransform( height ) }` }
+		/>
+	</SVG>
+);
+
+export const PointedShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 1000 100"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<Path
+			d="M737.9,94.7L0,0v100h1000V0L737.9,94.7z"
+			fill={ color }
+			opacity={ opacity }
+			transform={ getScaleAndTranslate( height, 100 ) }
+		/>
+	</SVG>
+);
+
+export const HillsShape = ( { color, height, opacity }, key ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 1920 105"
+		preserveAspectRatio="none"
+		key={ key }
+	>
+		<G transform={ getScaleAndTranslate( height, 105 ) }>
+			<Path
+				d="m1920 14.8827052c-116.23325 0-224.05162 88.3906828-395.09265 88.3906828-160.92196 0-254.53172-83.4344997-444.90735-83.4344997-154.297581 0-240.095847 39.6344097-367.66819 39.6344097-154.121863 0-198.902329-36.1223133-349.458242-36.1223133-144.878137 0-241.175717 80.8685493-362.873568 80.8685493 0-34.0793243 0-68.1494291 0-102.219534h1920z"
+				fill={ color }
+				opacity={ opacity }
+				transform="matrix(1 0 0 -1 0 105)"
+			/>
+			<Path
+				d="m1920 14.6612844c-116.11434 0-223.9659 88.8291396-395.06196 88.8291396-160.92415 0-254.54487-83.7874573-444.93804-83.7874573-154.317311 0-240.088941 39.8974838-367.565152 39.8974838-154.034172 0-198.792715-36.4840402-349.164477-36.4840402-144.965828 0-241.283139 81.1250467-363.270371 81.1250467 0-34.7474052 0-69.4948104 0-104.241457h1920z"
+				fill={ color }
+				opacity={ opacity }
+				transform="matrix(1 0 0 -1 0 105)"
+			/>
+		</G>
+	</SVG>
+);

--- a/packages/block-library/src/shape-divider/style.scss
+++ b/packages/block-library/src/shape-divider/style.scss
@@ -1,0 +1,26 @@
+.wp-block-shape-divider {
+	display: flex;
+
+	svg {
+		max-height: 100%;
+	}
+
+	// Target SVG rather than the block for editor compatibility.
+	&.flip-horizontal {
+		svg {
+			transform: scaleX(-1);
+		}
+	}
+
+	&.flip-vertical {
+		svg {
+			transform: scaleY(-1);
+		}
+	}
+
+	&.flip-horizontal.flip-vertical {
+		svg {
+			transform: scale(-1);
+		}
+	}
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -40,6 +40,7 @@
 @import "./rss/style.scss";
 @import "./search/style.scss";
 @import "./separator/style.scss";
+@import "./shape-divider/style.scss";
 @import "./site-logo/style.scss";
 @import "./social-links/style.scss";
 @import "./spacer/style.scss";


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/16351

## Description

TBA.

This is simply a proof of concept to try out some possibilities with add a shape divider block to Gutenberg that allows some degree of custom shapes, multiple shapes per divider as well as color and opacity controls. The UI is completely thrown together so is meant as a functional placeholder more than anything.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Note: If taking this for a spin, you'll need to enable custom margin/padding in your theme.json file.

## Screenshots <!-- if applicable -->

| Random Demos | Creating Shapes | Multiple Shapes |
|---|---|---|
| ![ShapeDividerDemos](https://user-images.githubusercontent.com/60436221/121889588-c6bea400-cd5c-11eb-84b2-f37f909debcf.gif) | ![ShapeDividerDemo2](https://user-images.githubusercontent.com/60436221/121889616-cfaf7580-cd5c-11eb-865d-0c03ee08f588.gif) | ![ShapeDividerDemo3](https://user-images.githubusercontent.com/60436221/121889630-d50cc000-cd5c-11eb-929c-5ee99740743b.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
