### PR TITLE
Image Block: Fix cover block exists check

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -61,6 +61,27 @@ function getFilename( url ) {
 	}
 }
 
+/**
+ * Checks if the given block is registered and is in the allowed blocks list.
+ *
+ * @param {string}        name Block name.
+ * @param {boolean|Array} list Allowed block types.
+ *
+ * @return {boolean}           Whether the block exists.
+ */
+function checkBlockExists( name, list ) {
+	if ( ! getBlockType( name ) ) {
+		return false;
+	}
+
+	// The allowed blocks list has a boolean value so return it.
+	if ( ! Array.isArray( list ) ) {
+		return list;
+	}
+
+	return list.includes( name );
+}
+
 export default function Image( {
 	temporaryURL,
 	attributes: {
@@ -111,17 +132,22 @@ export default function Image( {
 		},
 		[ id, isSelected ]
 	);
-	const { imageEditing, imageSizes, maxWidth, mediaUpload } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			return pick( getSettings(), [
-				'imageEditing',
-				'imageSizes',
-				'maxWidth',
-				'mediaUpload',
-			] );
-		}
-	);
+	const {
+		allowedBlockTypes,
+		imageEditing,
+		imageSizes,
+		maxWidth,
+		mediaUpload,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return pick( getSettings(), [
+			'allowedBlockTypes',
+			'imageEditing',
+			'imageSizes',
+			'maxWidth',
+			'mediaUpload',
+		] );
+	} );
 	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		noticesStore
@@ -140,8 +166,11 @@ export default function Image( {
 		( { name, slug } ) => ( { value: slug, label: name } )
 	);
 
-	// Check if the cover block is registered.
-	const coverBlockExists = !! getBlockType( 'core/cover' );
+	// Check if the cover block is registered and in allowed block list.
+	const coverBlockExists = checkBlockExists(
+		'core/cover',
+		allowedBlockTypes
+	);
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,


### PR DESCRIPTION
## Description
Updates `coverBlockExists` check to include checking against `allowedBlockTypes` list.

Fixes #32094.

## How has this been tested?
1. Filter allowed block types list to remove the cover block:
```php
add_filter( 'allowed_block_types', function() {
    return [
        'core/image',
        'core/paragraph',
        'core/heading',
        'core/list'
    ];
} );
```
2. Create a post.
3. Add image block.
4. Toolbar shouldn't render the "Add text over the image" button.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ x My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
