### PR TITLE
Home Link: remove ability to edit home link label

### DIFF
--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -6,11 +6,7 @@
 	"title": "Home Link",
 	"description": "Create a link that always points to the homepage of the site. Usually not necessary if there is already a site title link present in the header.",
 	"textdomain": "default",
-	"attributes": {
-		"label": {
-			"type": "string"
-		}
-	},
+	"attributes": {},
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -6,20 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect } from '@wordpress/element';
 
 const preventDefault = ( event ) => event.preventDefault();
 
-export default function HomeEdit( {
-	attributes,
-	setAttributes,
-	context,
-	clientId,
-} ) {
+export default function HomeEdit( { context, clientId } ) {
 	const { homeUrl } = useSelect(
 		( select ) => {
 			const {
@@ -46,14 +40,6 @@ export default function HomeEdit( {
 		},
 	} );
 
-	const { label } = attributes;
-
-	useEffect( () => {
-		if ( label === undefined ) {
-			setAttributes( { label: __( 'Home' ) } );
-		}
-	}, [ clientId, label ] );
-
 	return (
 		<>
 			<li { ...blockProps }>
@@ -62,23 +48,10 @@ export default function HomeEdit( {
 					href={ homeUrl }
 					onClick={ preventDefault }
 				>
-					<RichText
-						identifier="label"
-						className="wp-block-home-link__label"
-						value={ label }
-						onChange={ ( labelValue ) => {
-							setAttributes( { label: labelValue } );
-						} }
-						aria-label={ __( 'Home link text' ) }
-						placeholder={ __( 'Add home link' ) }
-						withoutInteractiveFormatting
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
-					/>
+					{ _x(
+						'Home',
+						'Label for a link that points at the website home, home_url()'
+					) }
 				</a>
 			</li>
 		</>

--- a/packages/block-library/src/home-link/index.js
+++ b/packages/block-library/src/home-link/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
 import { home } from '@wordpress/icons';
 
 /**
@@ -23,8 +22,6 @@ export const settings = {
 	save,
 
 	example: {
-		attributes: {
-			label: _x( 'Home Link', 'block example' ),
-		},
+		attributes: {},
 	},
 };

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -121,43 +121,14 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
  * @return string Returns the post content with the home url added.
  */
 function render_block_core_home_link( $attributes, $content, $block ) {
-	if ( empty( $attributes['label'] ) ) {
-		return '';
-	}
 
 	$wrapper_attributes = block_core_home_link_build_li_wrapper_attributes( $block->context );
-
-	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content"';
-
-	// Start appending HTML attributes to anchor tag.
-	$html .= ' href="' . esc_url( home_url() ) . '"';
-
-	// End appending HTML attributes to anchor tag.
-	$html .= '>';
-
-	if ( isset( $attributes['label'] ) ) {
-		$html .= wp_kses(
-			$attributes['label'],
-			array(
-				'code'   => array(),
-				'em'     => array(),
-				'img'    => array(
-					'scale' => array(),
-					'class' => array(),
-					'style' => array(),
-					'src'   => array(),
-					'alt'   => array(),
-				),
-				's'      => array(),
-				'span'   => array(
-					'style' => array(),
-				),
-				'strong' => array(),
-			)
-		);
-	}
-
-	$html .= '</a></li>';
+	$html               = sprintf(
+		'<li %1$s><a href="%2$s" class="wp-block-home-link__content">%3$s</a></li>',
+		$wrapper_attributes,
+		esc_url( home_url() ),
+		_x( 'Home', 'Label for a link that points at the website home, home_url().' )
+	);
 	return $html;
 }
 

--- a/packages/e2e-tests/fixtures/blocks/core__home-link.html
+++ b/packages/e2e-tests/fixtures/blocks/core__home-link.html
@@ -1,1 +1,1 @@
-<!-- wp:home-link {"label":"Home"} /-->
+<!-- wp:home-link /-->

--- a/packages/e2e-tests/fixtures/blocks/core__home-link.json
+++ b/packages/e2e-tests/fixtures/blocks/core__home-link.json
@@ -3,9 +3,7 @@
 		"clientId": "_clientId_0",
 		"name": "core/home-link",
 		"isValid": true,
-		"attributes": {
-			"label": "Home"
-		},
+		"attributes": {},
 		"innerBlocks": [],
 		"originalContent": ""
 	}

--- a/packages/e2e-tests/fixtures/blocks/core__home-link.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__home-link.parsed.json
@@ -1,9 +1,7 @@
 [
 	{
 		"blockName": "core/home-link",
-		"attrs": {
-			"label": "Home"
-		},
+		"attrs": {},
 		"innerBlocks": [],
 		"innerHTML": "",
 		"innerContent": []

--- a/packages/e2e-tests/fixtures/blocks/core__home-link.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__home-link.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:home-link {"label":"Home"} /-->
+<!-- wp:home-link /-->


### PR DESCRIPTION
To make the Home Link block more straightfoward to use, changes here remove the ability to provide custom label text to the Home Link. Note that since this is a dynamic block and we're removing an attribute, it doesn't look like we need to add a deprecated version. (Let me know if we still should do this).

### Behavior Changes:
- Any existing Home Links labels will be updated to "Home". Any existing custom labels will be ignored. 
- No rich text label when editing the Home block

### Testing Instructions:
- In trunk add a navigation block, and a home link block. Add some custom text.
- Add some custom styling to the navigation block by picking a font/font-size/colors. Changes in the home link block should be reflected in the edit and published view.
- Switch to this branch. Verify that the published and edit page show the link with a "Home" label and the expected styling.
- Add a new Navigation block with home link and verify that we can't add a custom label.
- Verify that Navigation styling still works.

Before:

https://user-images.githubusercontent.com/1270189/121943449-71f03e80-cd06-11eb-905d-17914e35c31f.mp4

After:

https://user-images.githubusercontent.com/1270189/121943468-761c5c00-cd06-11eb-8ab5-406893f3d35c.mp4



