### PR TITLE
Allow presets to provide an empty set of values

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -306,8 +306,8 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $nodes as $node ) {
 			foreach ( self::PRESETS_METADATA as $preset ) {
 				$path   = array_merge( $node['path'], $preset['path'] );
-				$preset = _wp_array_get( $this->theme_json, $path, array() );
-				if ( ! empty( $preset ) ) {
+				$preset = _wp_array_get( $this->theme_json, $path, null );
+				if ( null !== $preset ) {
 					gutenberg_experimental_set( $this->theme_json, $path, array( $origin => $preset ) );
 				}
 			}


### PR DESCRIPTION
This PR fixes a logic mistake. When backporting to the core in https://github.com/WordPress/wordpress-develop/pull/1368 I noticed that without this fix themes were not able to set an empty palette via add theme supports.
