### PR TITLE
Fix widgets background when loading theme styles

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -13,8 +13,6 @@ import { useCallback, useMemo } from '@wordpress/element';
  */
 import transformStyles from '../../utils/transform-styles';
 
-const EDITOR_STYLES_SELECTOR = '.editor-styles-wrapper';
-
 function useDarkThemeBodyClassName( styles ) {
 	return useCallback(
 		( node ) => {
@@ -24,12 +22,17 @@ function useDarkThemeBodyClassName( styles ) {
 
 			const { ownerDocument } = node;
 			const { defaultView, body } = ownerDocument;
-			const canvas = ownerDocument.querySelector(
-				EDITOR_STYLES_SELECTOR
-			);
+
+			// The real .editor-styles-wrapper element might not exist in the
+			// DOM, so calculate the background color by creating a fake
+			// wrapper.
+			const canvas = ownerDocument.createElement( 'div' );
+			canvas.classList.add( 'editor-styles-wrapper' );
+			body.appendChild( canvas );
 			const backgroundColor = defaultView
 				.getComputedStyle( canvas, null )
 				.getPropertyValue( 'background-color' );
+			body.removeChild( canvas );
 
 			// If background is transparent, it should be treated as light color.
 			if (
@@ -47,7 +50,7 @@ function useDarkThemeBodyClassName( styles ) {
 
 export default function EditorStyles( { styles } ) {
 	const transformedStyles = useMemo(
-		() => transformStyles( styles, EDITOR_STYLES_SELECTOR ),
+		() => transformStyles( styles, '.editor-styles-wrapper' ),
 		[ styles ]
 	);
 	return (

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -13,6 +13,8 @@ import { useCallback, useMemo } from '@wordpress/element';
  */
 import transformStyles from '../../utils/transform-styles';
 
+const EDITOR_STYLES_SELECTOR = '.editor-styles-wrapper';
+
 function useDarkThemeBodyClassName( styles ) {
 	return useCallback(
 		( node ) => {
@@ -22,17 +24,30 @@ function useDarkThemeBodyClassName( styles ) {
 
 			const { ownerDocument } = node;
 			const { defaultView, body } = ownerDocument;
+			const canvas = ownerDocument.querySelector(
+				EDITOR_STYLES_SELECTOR
+			);
 
-			// The real .editor-styles-wrapper element might not exist in the
-			// DOM, so calculate the background color by creating a fake
-			// wrapper.
-			const canvas = ownerDocument.createElement( 'div' );
-			canvas.classList.add( 'editor-styles-wrapper' );
-			body.appendChild( canvas );
-			const backgroundColor = defaultView
-				.getComputedStyle( canvas, null )
-				.getPropertyValue( 'background-color' );
-			body.removeChild( canvas );
+			let backgroundColor;
+
+			if ( ! canvas ) {
+				// The real .editor-styles-wrapper element might not exist in the
+				// DOM, so calculate the background color by creating a fake
+				// wrapper.
+				const tempCanvas = ownerDocument.createElement( 'div' );
+				tempCanvas.classList.add( EDITOR_STYLES_SELECTOR );
+				body.appendChild( tempCanvas );
+
+				backgroundColor = defaultView
+					.getComputedStyle( tempCanvas, null )
+					.getPropertyValue( 'background-color' );
+
+				body.removeChild( tempCanvas );
+			} else {
+				backgroundColor = defaultView
+					.getComputedStyle( canvas, null )
+					.getPropertyValue( 'background-color' );
+			}
 
 			// If background is transparent, it should be treated as light color.
 			if (
@@ -50,7 +65,7 @@ function useDarkThemeBodyClassName( styles ) {
 
 export default function EditorStyles( { styles } ) {
 	const transformedStyles = useMemo(
-		() => transformStyles( styles, '.editor-styles-wrapper' ),
+		() => transformStyles( styles, EDITOR_STYLES_SELECTOR ),
 		[ styles ]
 	);
 	return (

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-/**
  * WordPress dependencies
  */
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
@@ -58,11 +54,9 @@ export default function WidgetAreaEdit( {
 	}, [ isOpen, isDragging, isDraggingWithin, openedWhileDragging ] );
 
 	return (
-		<Panel
-			className={ classnames( className, 'editor-styles-wrapper' ) }
-			ref={ wrapper }
-		>
+		<Panel className={ className } ref={ wrapper }>
 			<PanelBody
+				className="editor-styles-wrapper"
 				title={ name }
 				opened={ isOpen }
 				onToggle={ () => {

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -56,7 +56,6 @@ export default function WidgetAreaEdit( {
 	return (
 		<Panel className={ className } ref={ wrapper }>
 			<PanelBody
-				className="editor-styles-wrapper"
 				title={ name }
 				opened={ isOpen }
 				onToggle={ () => {
@@ -65,16 +64,20 @@ export default function WidgetAreaEdit( {
 				scrollAfterOpen={ ! isDragging }
 			>
 				{ ( { opened } ) => (
-					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
-					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
+					// This is required to ensure LegacyWidget blocks are not
+					// unmounted when the panel is collapsed. Unmounting legacy
+					// widgets may have unintended consequences (e.g.  TinyMCE
+					// not being properly reinitialized)
 					<DisclosureContent visible={ opened }>
-						<EntityProvider
-							kind="root"
-							type="postType"
-							id={ `widget-area-${ id }` }
-						>
-							<WidgetAreaInnerBlocks />
-						</EntityProvider>
+						<div className="editor-styles-wrapper">
+							<EntityProvider
+								kind="root"
+								type="postType"
+								id={ `widget-area-${ id }` }
+							>
+								<WidgetAreaInnerBlocks />
+							</EntityProvider>
+						</div>
 					</DisclosureContent>
 				) }
 			</PanelBody>

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
  * WordPress dependencies
  */
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
@@ -54,7 +58,10 @@ export default function WidgetAreaEdit( {
 	}, [ isOpen, isDragging, isDraggingWithin, openedWhileDragging ] );
 
 	return (
-		<Panel className={ className } ref={ wrapper }>
+		<Panel
+			className={ classnames( className, 'editor-styles-wrapper' ) }
+			ref={ wrapper }
+		>
 			<PanelBody
 				title={ name }
 				opened={ isOpen }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -5,17 +5,23 @@
 
 	.components-panel__body > .components-panel__body-title {
 		font-family: $default-font;
+		margin-bottom: 0;
 
 		// Remove default hover background in panel title. See #25752.
 		&:hover {
 			background: inherit;
 		}
 	}
+
+	.components-panel__body .editor-styles-wrapper {
+		margin: 0 (-$grid-unit-20) (-$grid-unit-20) (-$grid-unit-20);
+		padding: $grid-unit-20;
+	}
 }
 
 // Add some spacing above the inner blocks so that the block toolbar doesn't
 // overlap the panel header.
-.wp-block-widget-area > .components-panel__body > div > .block-editor-inner-blocks {
+.wp-block-widget-area > .components-panel__body > div > .editor-styles-wrapper > .block-editor-inner-blocks {
 	padding-top: $grid-unit-30;
 
 	// Ensure the widget area block lists have a minimum height so that it doesn't

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -17,6 +17,10 @@
 		margin: 0 (-$grid-unit-20) (-$grid-unit-20) (-$grid-unit-20);
 		padding: $grid-unit-20;
 	}
+
+	.block-list-appender.wp-block {
+		width: initial;
+	}
 }
 
 // Add some spacing above the inner blocks so that the block toolbar doesn't

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -122,6 +122,13 @@ export default function MoreMenu() {
 									'Contain text cursor inside block deactivated'
 								) }
 							/>
+							<FeatureToggle
+								feature="themeStyles"
+								info={ __(
+									'Make the editor look like your theme.'
+								) }
+								label={ __( 'Use theme styles' ) }
+							/>
 							{ isLargeViewport && (
 								<FeatureToggle
 									feature="showBlockBreadcrumbs"

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -39,16 +39,14 @@ export default function WidgetAreasBlockEditorContent( {
 			<BlockTools>
 				<KeyboardShortcuts />
 				<BlockEditorKeyboardShortcuts />
-				<div className="editor-styles-wrapper">
-					<EditorStyles styles={ styles } />
-					<BlockSelectionClearer>
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList className="edit-widgets-main-block-list" />
-							</ObserveTyping>
-						</WritingFlow>
-					</BlockSelectionClearer>
-				</div>
+				<EditorStyles styles={ styles } />
+				<BlockSelectionClearer>
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList className="edit-widgets-main-block-list" />
+						</ObserveTyping>
+					</WritingFlow>
+				</BlockSelectionClearer>
 			</BlockTools>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -10,16 +10,29 @@ import {
 	ObserveTyping,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Notices from '../notices';
 import KeyboardShortcuts from '../keyboard-shortcuts';
+import { store as editWidgetsStore } from '../../store';
 
 export default function WidgetAreasBlockEditorContent( {
 	blockEditorSettings,
 } ) {
+	const { hasThemeStyles } = useSelect( ( select ) => ( {
+		hasThemeStyles: select( editWidgetsStore ).__unstableIsFeatureActive(
+			'themeStyles'
+		),
+	} ) );
+
+	const styles = useMemo( () => {
+		return hasThemeStyles ? blockEditorSettings.styles : [];
+	}, [ blockEditorSettings, hasThemeStyles ] );
+
 	return (
 		<div className="edit-widgets-block-editor">
 			<Notices />
@@ -27,7 +40,7 @@ export default function WidgetAreasBlockEditorContent( {
 				<KeyboardShortcuts />
 				<BlockEditorKeyboardShortcuts />
 				<div className="editor-styles-wrapper">
-					<EditorStyles styles={ blockEditorSettings.styles } />
+					<EditorStyles styles={ styles } />
 					<BlockSelectionClearer>
 						<WritingFlow>
 							<ObserveTyping>

--- a/packages/edit-widgets/src/store/defaults.js
+++ b/packages/edit-widgets/src/store/defaults.js
@@ -3,5 +3,6 @@ export const PREFERENCES_DEFAULTS = {
 		fixedToolbar: false,
 		welcomeGuide: true,
 		showBlockBreadcrumbs: true,
+		themeStyles: true,
 	},
 };

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -60,6 +60,15 @@ body.widgets-php {
 	.components-panel__body-title.components-panel__body-title.components-panel__body-title:hover {
 		background-color: $white;
 	}
+	// Override for Twenty Twenty theme styles.
+	.components-panel__body-title.components-panel__body-title {
+		margin: 0;
+
+		// Override for Twenty Nineteen theme styles.
+		&::before {
+			content: none;
+		}
+	}
 	// Remove unwanted styles from .editor-styles-wrapper in the widget area.
 	.wp-block-widget-area.editor-styles-wrapper {
 		padding: 0;

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -48,35 +48,6 @@ body.widgets-php {
 	.interface-interface-skeleton__content {
 		background-color: $gray-100;
 	}
-
-	// Widget areas should inherit the theme background color if it exists,
-	// but the editor background shouldn't.
-	.edit-widgets-block-editor > .editor-styles-wrapper {
-		background-color: transparent;
-	}
-	// The widget area heading should always have a white background.
-	// Needs additional specificity on hover to override default styles.
-	.components-panel__body-title,
-	.components-panel__body-title.components-panel__body-title.components-panel__body-title:hover {
-		background-color: $white;
-	}
-	// Override for Twenty Twenty theme styles.
-	.components-panel__body-title.components-panel__body-title {
-		margin: 0;
-
-		// Override for Twenty Nineteen theme styles.
-		&::before {
-			content: none;
-		}
-	}
-	// Remove unwanted styles from .editor-styles-wrapper in the widget area.
-	.components-panel__body.editor-styles-wrapper {
-		padding: 0;
-
-		.block-editor-block-list__layout {
-			padding: $grid-unit-20;
-		}
-	}
 }
 
 .blocks-widgets-container .editor-styles-wrapper {

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -45,6 +45,10 @@ body.widgets-php {
 		min-height: calc(100vh - #{ $admin-bar-height });
 	}
 
+	.interface-interface-skeleton__content {
+		background-color: $gray-100;
+	}
+
 	// Widget areas should inherit the theme background color if it exists,
 	// but the editor background shouldn't.
 	.edit-widgets-block-editor > .editor-styles-wrapper {

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -45,9 +45,9 @@ body.widgets-php {
 		min-height: calc(100vh - #{ $admin-bar-height });
 	}
 
-	// Widget areas should inherit the theme background color if it exists.
-	.edit-widgets-block-editor,
-	.components-panel {
+	// Widget areas should inherit the theme background color if it exists,
+	// but the editor background shouldn't.
+	.edit-widgets-block-editor > .editor-style-wrapper {
 		background-color: transparent;
 	}
 	// The widget area heading should always have a white background.

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -56,6 +56,10 @@ body.widgets-php {
 	.components-panel__body-title.components-panel__body-title.components-panel__body-title:hover {
 		background-color: $white;
 	}
+	// Remove unwanted styles from .editor-styles-wrapper in the widget area.
+	.wp-block-widget-area.editor-styles-wrapper {
+		padding: 0;
+	}
 }
 
 .blocks-widgets-container .editor-styles-wrapper {

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -51,7 +51,9 @@ body.widgets-php {
 		background-color: transparent;
 	}
 	// The widget area heading should always have a white background.
-	.components-panel__body-title {
+	// Needs additional specificity on hover to override default styles.
+	.components-panel__body-title,
+	.components-panel__body-title.components-panel__body-title.components-panel__body-title:hover {
 		background-color: $white;
 	}
 }

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -45,14 +45,20 @@ body.widgets-php {
 		min-height: calc(100vh - #{ $admin-bar-height });
 	}
 
-	// Widget areas should inherit the theme background color if it exists
-	.edit-widgets-block-editor {
-		background-color: transparent;
-	}
+	// Widget areas should inherit the theme background color if it exists.
+	.edit-widgets-block-editor,
 	.components-panel {
 		background-color: transparent;
-		border-color: $gray-900;
 	}
+	// The widget area heading should always have a white background.
+	.components-panel__body-title {
+		background-color: $white;
+	}
+}
+
+// Light background specific styles
+:not(.is-dark-theme) .block-widgets-container {
+	.components-panel,
 	.components-panel__body {
 		border-color: $gray-900;
 	}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -45,8 +45,16 @@ body.widgets-php {
 		min-height: calc(100vh - #{ $admin-bar-height });
 	}
 
-	.interface-interface-skeleton__content {
-		background-color: $gray-100;
+	// Widget areas should inherit the theme background color if it exists
+	.edit-widgets-block-editor {
+		background-color: transparent;
+	}
+	.components-panel {
+		background-color: transparent;
+		border-color: $gray-900;
+	}
+	.components-panel__body {
+		border-color: $gray-900;
 	}
 }
 

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -70,8 +70,12 @@ body.widgets-php {
 		}
 	}
 	// Remove unwanted styles from .editor-styles-wrapper in the widget area.
-	.wp-block-widget-area.editor-styles-wrapper {
+	.components-panel__body.editor-styles-wrapper {
 		padding: 0;
+
+		.block-editor-block-list__layout {
+			padding: $grid-unit-20;
+		}
 	}
 }
 

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -58,14 +58,6 @@ body.widgets-php {
 	}
 }
 
-// Light background specific styles
-:not(.is-dark-theme) .block-widgets-container {
-	.components-panel,
-	.components-panel__body {
-		border-color: $gray-900;
-	}
-}
-
 .blocks-widgets-container .editor-style-wrapper {
 	max-width: $widget-area-width;
 	margin: auto;

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -47,7 +47,7 @@ body.widgets-php {
 
 	// Widget areas should inherit the theme background color if it exists,
 	// but the editor background shouldn't.
-	.edit-widgets-block-editor > .editor-style-wrapper {
+	.edit-widgets-block-editor > .editor-styles-wrapper {
 		background-color: transparent;
 	}
 	// The widget area heading should always have a white background.
@@ -58,7 +58,7 @@ body.widgets-php {
 	}
 }
 
-.blocks-widgets-container .editor-style-wrapper {
+.blocks-widgets-container .editor-styles-wrapper {
 	max-width: $widget-area-width;
 	margin: auto;
 }

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -95,3 +95,9 @@
 		min-height: 50px;
 	}
 }
+
+.wp-block-legacy-widget {
+	.components-select-control__input {
+		padding: 0;
+	}
+}

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -99,5 +99,6 @@
 .wp-block-legacy-widget {
 	.components-select-control__input {
 		padding: 0;
+		font-family: system-ui;
 	}
 }

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -90,7 +90,6 @@ function handle_legacy_widget_preview_iframe() {
 		<style>
 			/* Reset theme styles */
 			html, body, #page, #content {
-				background: #FFF !important;
 				padding: 0 !important;
 				margin: 0 !important;
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

https://github.com/WordPress/wordpress-develop/pull/1369 fixes #26163. This PR updates the editor styles so whatever background color the theme sets is reflected in the editor, and changes the widget area border color so it's visible on a light background unless a dark background is set.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

To test, build local environment with https://github.com/WordPress/wordpress-develop/pull/1369, then apply these changes. Check that with Twenty Twenty One, the editor and the widget area backgrounds match the theme styles, and widget area borders are visible whether the background color is light or dark.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
