### PR TITLE
Revert "Chore: Remove check for core files on typography supports migration."

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -473,7 +473,8 @@ function gutenberg_block_has_support( $block_type, $feature, $default = false ) 
  * @return array          Metadata for registering a block type with the supports shape updated.
  */
 function gutenberg_migrate_old_typography_shape( $metadata ) {
-	if ( isset( $metadata['supports'] ) ) {
+	// Temporarily disable migrations from core blocks to avoid warnings on versions older than 5.8.
+	if ( isset( $metadata['supports'] ) && false === strpos( $metadata['file'], '/wp-includes/blocks/' ) ) {
 		$typography_keys = array(
 			'__experimentalFontFamily',
 			'__experimentalFontStyle',


### PR DESCRIPTION
Reverts WordPress/gutenberg#32634
Fixes: https://github.com/WordPress/gutenberg/issues/32670