### PR TITLE
Widget Editor: Hide some settings from the "Options" menu on small screens

### DIFF
--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -122,19 +122,21 @@ export default function MoreMenu() {
 									'Contain text cursor inside block deactivated'
 								) }
 							/>
-							<FeatureToggle
-								feature="showBlockBreadcrumbs"
-								label={ __( 'Display block breadcrumbs' ) }
-								info={ __(
-									'Shows block breadcrumbs at the bottom of the editor.'
-								) }
-								messageActivated={ __(
-									'Display block breadcrumbs activated'
-								) }
-								messageDeactivated={ __(
-									'Display block breadcrumbs deactivated'
-								) }
-							/>
+							{ isLargeViewport && (
+								<FeatureToggle
+									feature="showBlockBreadcrumbs"
+									label={ __( 'Display block breadcrumbs' ) }
+									info={ __(
+										'Shows block breadcrumbs at the bottom of the editor.'
+									) }
+									messageActivated={ __(
+										'Display block breadcrumbs activated'
+									) }
+									messageDeactivated={ __(
+										'Display block breadcrumbs deactivated'
+									) }
+								/>
+							) }
 						</MenuGroup>
 					</>
 				) }

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -12,6 +12,7 @@ import { __, _x } from '@wordpress/i18n';
 import { external, moreVertical } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -43,6 +44,8 @@ export default function MoreMenu() {
 		}
 	);
 
+	const isLargeViewport = useViewportMatch( 'medium' );
+
 	return (
 		<>
 			<DropdownMenu
@@ -55,21 +58,23 @@ export default function MoreMenu() {
 			>
 				{ () => (
 					<>
-						<MenuGroup label={ _x( 'View', 'noun' ) }>
-							<FeatureToggle
-								feature="fixedToolbar"
-								label={ __( 'Top toolbar' ) }
-								info={ __(
-									'Access all block and document tools in a single place'
-								) }
-								messageActivated={ __(
-									'Top toolbar activated'
-								) }
-								messageDeactivated={ __(
-									'Top toolbar deactivated'
-								) }
-							/>
-						</MenuGroup>
+						{ isLargeViewport && (
+							<MenuGroup label={ _x( 'View', 'noun' ) }>
+								<FeatureToggle
+									feature="fixedToolbar"
+									label={ __( 'Top toolbar' ) }
+									info={ __(
+										'Access all block and document tools in a single place'
+									) }
+									messageActivated={ __(
+										'Top toolbar activated'
+									) }
+									messageDeactivated={ __(
+										'Top toolbar deactivated'
+									) }
+								/>
+							</MenuGroup>
+						) }
 						<MenuGroup label={ __( 'Tools' ) }>
 							<MenuItem
 								onClick={ () => {


### PR DESCRIPTION
## Description
Adds checks to remove the "Top toolbar" and "Show Block Breadcrumbs" settings on small screens.

Fixes #32630.

## How has this been tested?
1. Go to Appearance > Widgets
2. Click on the "Options" menu (top right corner).
3. See the "Top toolbar" menu item.
4. Resize browser screen to small viewport < 782px.
5. "Top toolbar" menu item shouldn't be visible.
6. "Show Block Breadcrumbs" menu item shouldn't be visible.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/122045214-83ad1100-cdee-11eb-8d1d-16af4ecaa3f8.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
