### PR TITLE
Add `__experimentalFeatures` default data for `block-editor` package

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -232,4 +232,214 @@ export const SETTINGS_DEFAULTS = {
 			slug: 'midnight',
 		},
 	],
+
+	// These are the same as the core theme.json.
+	// Added them here as well as per this conversation
+	// https://github.com/WordPress/gutenberg/pull/32482#discussion_r648956243
+	__experimentalFeatures: {
+		color: {
+			custom: true,
+			customGradient: true,
+			duotone: [
+				{
+					name: 'Dark grayscale',
+					colors: [ '#000000', '#7f7f7f' ],
+					slug: 'dark-grayscale',
+				},
+				{
+					name: 'Grayscale',
+					colors: [ '#000000', '#ffffff' ],
+					slug: 'grayscale',
+				},
+				{
+					name: 'Purple and yellow',
+					colors: [ '#8c00b7', '#fcff41' ],
+					slug: 'purple-yellow',
+				},
+				{
+					name: 'Blue and red',
+					colors: [ '#000097', '#ff4747' ],
+					slug: 'blue-red',
+				},
+				{
+					name: 'Midnight',
+					colors: [ '#000000', '#00a5ff' ],
+					slug: 'midnight',
+				},
+				{
+					name: 'Magenta and yellow',
+					colors: [ '#c7005a', '#fff278' ],
+					slug: 'magenta-yellow',
+				},
+				{
+					name: 'Purple and green',
+					colors: [ '#a60072', '#67ff66' ],
+					slug: 'purple-green',
+				},
+				{
+					name: 'Blue and orange',
+					colors: [ '#1900d8', '#ffa96b' ],
+					slug: 'blue-orange',
+				},
+			],
+			gradients: [
+				{
+					name: 'Vivid cyan blue to vivid purple',
+					gradient:
+						'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+					slug: 'vivid-cyan-blue-to-vivid-purple',
+				},
+				{
+					name: 'Light green cyan to vivid green cyan',
+					gradient:
+						'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
+					slug: 'light-green-cyan-to-vivid-green-cyan',
+				},
+				{
+					name: 'Luminous vivid amber to luminous vivid orange',
+					gradient:
+						'linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)',
+					slug: 'luminous-vivid-amber-to-luminous-vivid-orange',
+				},
+				{
+					name: 'Luminous vivid orange to vivid red',
+					gradient:
+						'linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)',
+					slug: 'luminous-vivid-orange-to-vivid-red',
+				},
+				{
+					name: 'Very light gray to cyan bluish gray',
+					gradient:
+						'linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)',
+					slug: 'very-light-gray-to-cyan-bluish-gray',
+				},
+				{
+					name: 'Cool to warm spectrum',
+					gradient:
+						'linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)',
+					slug: 'cool-to-warm-spectrum',
+				},
+				{
+					name: 'Blush light purple',
+					gradient:
+						'linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)',
+					slug: 'blush-light-purple',
+				},
+				{
+					name: 'Blush bordeaux',
+					gradient:
+						'linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)',
+					slug: 'blush-bordeaux',
+				},
+				{
+					name: 'Luminous dusk',
+					gradient:
+						'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)',
+					slug: 'luminous-dusk',
+				},
+				{
+					name: 'Pale ocean',
+					gradient:
+						'linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)',
+					slug: 'pale-ocean',
+				},
+				{
+					name: 'Electric grass',
+					gradient:
+						'linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)',
+					slug: 'electric-grass',
+				},
+				{
+					name: 'Midnight',
+					gradient:
+						'linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)',
+					slug: 'midnight',
+				},
+			],
+			link: false,
+			palette: [
+				{
+					name: 'Black',
+					slug: 'black',
+					color: '#000000',
+				},
+				{
+					name: 'Cyan bluish gray',
+					slug: 'cyan-bluish-gray',
+					color: '#abb8c3',
+				},
+				{
+					name: 'White',
+					slug: 'white',
+					color: '#ffffff',
+				},
+				{
+					name: 'Pale pink',
+					slug: 'pale-pink',
+					color: '#f78da7',
+				},
+				{
+					name: 'Vivid red',
+					slug: 'vivid-red',
+					color: '#cf2e2e',
+				},
+				{
+					name: 'Luminous vivid orange',
+					slug: 'luminous-vivid-orange',
+					color: '#ff6900',
+				},
+				{
+					name: 'Luminous vivid amber',
+					slug: 'luminous-vivid-amber',
+					color: '#fcb900',
+				},
+				{
+					name: 'Light green cyan',
+					slug: 'light-green-cyan',
+					color: '#7bdcb5',
+				},
+				{
+					name: 'Vivid green cyan',
+					slug: 'vivid-green-cyan',
+					color: '#00d084',
+				},
+				{
+					name: 'Pale cyan blue',
+					slug: 'pale-cyan-blue',
+					color: '#8ed1fc',
+				},
+				{
+					name: 'Vivid cyan blue',
+					slug: 'vivid-cyan-blue',
+					color: '#0693e3',
+				},
+				{
+					name: 'Vivid purple',
+					slug: 'vivid-purple',
+					color: '#9b51e0',
+				},
+			],
+		},
+		typography: {
+			customFontSize: true,
+			customFontStyle: true,
+			customFontWeight: true,
+			customLetterSpacing: true,
+			customLineHeight: false,
+			customTextDecorations: true,
+			customTextTransforms: true,
+			dropCap: true,
+		},
+		spacing: {
+			customMargin: false,
+			customPadding: false,
+			units: [ 'px', 'em', 'rem', 'vh', 'vw' ],
+		},
+		border: {
+			customColor: false,
+			customRadius: false,
+			customStyle: false,
+			customWidth: false,
+		},
+	},
 };


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/32482#discussion_r648956243

Add a default value for `__experimentalFeatures`, so the `@wordpress/block-editor` as a package doesn't require any other external data source to have default settings.

## How to test

- Run this branch on a WordPress 5.7 enviroment.
- In `global-styles.php` disable hooking the filter to the `gutenberg_experimental_global_styles_settings` (comment lines 328 to 333)
- Go to the post editor and verify that the `block-editor` store has defauls for `settings.__experimentalFeatures`.
