### PR TITLE
Add lock feature for Reusable Blocks to protect inner blocks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -7,7 +7,6 @@ import {
 	useEntityProp,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	Placeholder,
 	Spinner,
@@ -27,6 +26,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	Warning,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import { ungroup } from '@wordpress/icons';
@@ -108,11 +108,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		innerBlocks = <Disabled> { innerBlocks } </Disabled>;
 	}
 
-	let lockContainerClass = isLocked ? 'is-locked' : 'is-unlocked';
+	const lockContainerClass = isLocked ? 'is-locked' : 'is-unlocked';
 
 	// lock the blocks when deselected
 	useEffect( () => {
-		let isInnerBlock = parentBlockName === 'core/block'; // first check if selectedblock is inner block
+		const isInnerBlock = parentBlockName === 'core/block'; // first check if selectedblock is inner block
 		if ( ! isInnerBlock ) {
 			setIsLocked( true );
 		}
@@ -172,7 +172,14 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 				</InspectorControls>
 				<div
 					className="block-library-block__reusable-block-container"
+					role="button"
+					tabIndex={ 0 }
 					onClick={ () => setIsLocked( false ) }
+					onKeyDown={ ( e ) => {
+						if ( e.key === 85 ) {
+							setIsLocked( false );
+						}
+					} }
 				>
 					<div
 						className={ `reusable-block-lock-container ${ lockContainerClass }` }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -128,8 +128,8 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 						<ToolbarButton
 							label={
 								isLocked
-								? __( 'Unlock inner blocks' )
-								: __( 'Lock inner blocks' ) 
+									? __( 'Unlock inner blocks' )
+									: __( 'Lock inner blocks' )
 							}
 							showTooltip
 							onClick={ () => setIsLocked( ! isLocked ) }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -14,6 +14,7 @@ import {
 	ToolbarButton,
 	TextControl,
 	PanelBody,
+	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -88,7 +89,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	// states for lock
 	const [ isLocked, setIsLocked ] = useState( true );
 
-	const lockContainerClass = isLocked && 'is-locked';
+	let innerBlocks = <div { ...innerBlocksProps } />;
+
+	if ( isLocked ) {
+		innerBlocks = <Disabled> { innerBlocks } </Disabled>;
+	}
 
 	if ( hasAlreadyRendered ) {
 		return (
@@ -158,14 +163,7 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 					</PanelBody>
 				</InspectorControls>
 				<div className="block-library-block__reusable-block-container">
-					{
-						<>
-							<div
-								className={ `reusable-block-lock-container ${ lockContainerClass }` }
-							></div>
-							<div { ...innerBlocksProps } />
-						</>
-					}
+					{ innerBlocks }
 				</div>
 			</div>
 		</RecursionProvider>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -35,7 +35,12 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
 		ref
 	);
-	const { isMissing, hasResolved, parentBlockName } = useSelect(
+	const {
+		isMissing,
+		hasResolved,
+		parentBlockName,
+		selectedBlock,
+	} = useSelect(
 		( select ) => {
 			const persistedBlock = select( coreStore ).getEntityRecord(
 				'postType',
@@ -65,6 +70,7 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 				hasResolved: hasResolvedBlock,
 				isMissing: hasResolvedBlock && ! persistedBlock,
 				parentBlockName: _parentBlockName,
+				selectedBlock: currentBlockId,
 			};
 		},
 		[ ref, clientId ]
@@ -116,7 +122,7 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		if ( ! isInnerBlock ) {
 			setIsLocked( true );
 		}
-	}, [ parentBlockName ] );
+	}, [ parentBlockName, selectedBlock ] );
 
 	if ( hasAlreadyRendered ) {
 		return (

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -16,6 +16,7 @@ import {
 	PanelBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import {
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
@@ -84,6 +85,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 
 	const blockProps = useBlockProps();
 
+	// states for lock
+	const [ isLocked, setIsLocked ] = useState( true );
+
+	const lockContainerClass = isLocked && 'is-locked';
+
 	if ( hasAlreadyRendered ) {
 		return (
 			<div { ...blockProps }>
@@ -120,6 +126,21 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 				<BlockControls>
 					<ToolbarGroup>
 						<ToolbarButton
+							label={
+								isLocked
+								? __( 'Unlock inner blocks' )
+								: __( 'Lock inner blocks' ) 
+							}
+							showTooltip
+							onClick={ () => setIsLocked( ! isLocked ) }
+						>
+							{ isLocked
+								? __( 'Unlock inner blocks' )
+								: __( 'Lock inner blocks' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+					<ToolbarGroup>
+						<ToolbarButton
 							onClick={ () => convertBlockToStatic( clientId ) }
 							label={ __( 'Convert to regular blocks' ) }
 							icon={ ungroup }
@@ -137,7 +158,14 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 					</PanelBody>
 				</InspectorControls>
 				<div className="block-library-block__reusable-block-container">
-					{ <div { ...innerBlocksProps } /> }
+					{
+						<>
+							<div
+								className={ `reusable-block-lock-container ${ lockContainerClass }` }
+							></div>
+							<div { ...innerBlocksProps } />
+						</>
+					}
 				</div>
 			</div>
 		</RecursionProvider>

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -13,4 +13,11 @@
 	.components-disabled .block-list-appender {
 		display: none;
 	}
+
+	.is-locked {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+	}
 }

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -22,8 +22,8 @@
 		z-index: 1;
 		border: 0;
 		&:hover {
-			background-color: rgba( $color: #bbffe4, $alpha: 0.3 );
-			border: 1px solid #00b06f;
+			background-color: rgba(#bbffe4, 0.3);
+			border: 1px solid#00b06f;
 		}
 	}
 }

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -13,4 +13,17 @@
 	.components-disabled .block-list-appender {
 		display: none;
 	}
+
+	.is-locked {
+		position: absolute;
+		cursor: pointer;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+		border: 0;
+		&:hover {
+			background-color: rgba( $color: #bbffe4, $alpha: 0.3 );
+			border: 1px solid #00b06f;
+		}
+	}
 }

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -13,11 +13,4 @@
 	.components-disabled .block-list-appender {
 		display: none;
 	}
-
-	.is-locked {
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		z-index: 1;
-	}
 }


### PR DESCRIPTION
## Description
Fixes #32461

Add lock option for the Reusable Blocks in the parent toolbar. 
Protects the inner blocks from accidental edits.

Unlock Icon is not available in @wordpress/icons package. So as of now, I have used plain text to display the lock and unlock state in the toolbar.


## How has this been tested?
1. Select a Reusable Block
2. Try selecting the inner blocks directly
3. You should not be able to select them 
4. Unlock the block from the toolbar
5. Select inner block
6. Lock the block again to prevent accidental changes

## Screenshots 

https://user-images.githubusercontent.com/69596988/122112263-3c4e7100-ce3e-11eb-9c44-063ef8688202.mov


## Types of changes
New Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

