### PR TITLE
Writing flow: Fix focus trap on non-text `input` types

### DIFF
--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -21,7 +21,10 @@ import isInputOrTextArea from './is-input-or-text-area';
  * @return {boolean} True if at the edge, false if not.
  */
 export default function isEdge( container, isReverse, onlyVertical = false ) {
-	if ( isInputOrTextArea( container ) ) {
+	if (
+		isInputOrTextArea( container ) &&
+		typeof container.selectionStart === 'number'
+	) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
 		}

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -84,6 +84,14 @@ describe( 'DOM', () => {
 			expect( isHorizontalEdge( div, true ) ).toBe( true );
 			expect( isHorizontalEdge( div, false ) ).toBe( true );
 		} );
+
+		it( 'should return true for input types that do not have selection ranges', () => {
+			const input = document.createElement( 'input' );
+			input.setAttribute( 'type', 'checkbox' );
+			parent.appendChild( input );
+			expect( isHorizontalEdge( input, true ) ).toBe( true );
+			expect( isHorizontalEdge( input, false ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'placeCaretAtHorizontalEdge', () => {


### PR DESCRIPTION
Fixes #32712

## Description

Some existing logic to handle keydown events on `input` elements does not completely account for the fact that a lot of input types [do not support](https://html.spec.whatwg.org/multipage/input.html#concept-input-apply) selection ranges, which means we can't always assume they are "text fields".

This PR addresses the most serious problem caused by this naive handling, which is a focus trap on non-text inputs.

The downside to the simple fix in this PR is that up/down arrow keydowns will no longer trigger the native behavior for input types like `number`. I think this is a reasonable trade-off though, since a keyboard user has alternative ways to modify a `number` input but no way out of the focus trap. Smarter handling of various `input` types will require a more complex system, since they each react to arrow keys in different ways.

The rest of the user-facing issues caused by naive `input` handling seem to be less serious, and merely inconveniences, e.g. #32713 and #32715.

## How has this been tested?

- Unit tests pass.
- The repro steps in the original issues are fixed (using non-text input types like `color` and `file`).

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/555336/122110496-914bb080-ce59-11eb-9ec9-5da65061d8a5.gif" alt="Down arrow navigates through a checkbox" width="400">

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
