### PR TITLE
Fix bug with getFontSizeClass crashing if passed a number

### DIFF
--- a/packages/block-editor/src/components/font-sizes/test/utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/utils.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { logged } from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import { getFontSizeClass } from '../utils';
+
+describe( 'getFontSizeClass()', () => {
+	afterEach( () => {
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
+	} );
+
+	it( 'Should return the correct font size class when given a string', () => {
+		const fontSizeClass = getFontSizeClass( '14' );
+		expect( fontSizeClass ).toBe( 'has-14-font-size' );
+	} );
+
+	it( 'Should throw a warning when given a number', () => {
+		const fontSizeClass = getFontSizeClass( 16 );
+		expect( fontSizeClass ).toBe( 'has-16-font-size' );
+		expect( console ).toHaveWarnedWith(
+			'The font size slug should be a string.'
+		);
+	} );
+
+	it( 'Should throw a warning if the argument contains special characters', () => {
+		const fontSizeClass = getFontSizeClass( '#abcdef' );
+		expect( fontSizeClass ).toBe( 'has-#abcdef-font-size' );
+		expect( console ).toHaveWarnedWith(
+			'The font size slug should not have any special character.'
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/font-sizes/test/utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/utils.js
@@ -16,8 +16,8 @@ describe( 'getFontSizeClass()', () => {
 	} );
 
 	it( 'Should return the correct font size class when given a string', () => {
-		const fontSizeClass = getFontSizeClass( '14' );
-		expect( fontSizeClass ).toBe( 'has-14-font-size' );
+		const fontSizeClass = getFontSizeClass( '14px' );
+		expect( fontSizeClass ).toBe( 'has-14-px-font-size' );
 	} );
 
 	it( 'Should throw a warning when given a number', () => {

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -65,6 +65,8 @@ export function getFontSizeClass( fontSizeSlug ) {
 	// We don't want to use kebabCase from lodash here
 	// see https://github.com/WordPress/gutenberg/issues/32347
 	// However, we need to make sure the generated class
-	// doesn't contain spaces.
-	return `has-${ fontSizeSlug.replace( /\s+/g, '-' ) }-font-size`;
+	// doesn't contain spaces. The method used to accept numbers
+	// so we need to make sure we are working with a string for the
+	// sake of backwards compat.
+	return `has-${ fontSizeSlug.toString().replace( /\s+/g, '-' ) }-font-size`;
 }

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -4,11 +4,6 @@
 import { find } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import deprecated from '@wordpress/deprecated';
-
-/**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
  * 	If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
  *
@@ -72,7 +67,8 @@ export function getFontSizeClass( fontSizeSlug ) {
 	// into strings. Some plugins relied on this behavior.
 	if ( 'string' !== typeof fontSizeSlug ) {
 		fontSizeSlug = String( fontSizeSlug );
-		deprecated( 'The font size slug should be a string.' );
+		// eslint-disable-next-line no-console
+		console.warn( 'The font size slug should be a string.' );
 	}
 
 	// In the past, we used lodash's kebabCase to process slugs.
@@ -80,7 +76,8 @@ export function getFontSizeClass( fontSizeSlug ) {
 	// such as the # in "#FFFFF". Some plugins relied on this behavior.
 	const slug = fontSizeSlug.replace( /[^a-zA-Z0-9\-\s]/g, '' );
 	if ( slug !== fontSizeSlug ) {
-		deprecated(
+		// eslint-disable-next-line no-console
+		console.warn(
 			'The font size slug should not have any special character.'
 		);
 	}

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -62,11 +62,20 @@ export function getFontSizeClass( fontSizeSlug ) {
 		return;
 	}
 
+	// In the past, we used lodash's kebabCase to process slugs.
+	// By doing so, this method also accepted and converted non string values
+	// into strings. Some plugins relied on this behavior.
+	if ( 'string' !== typeof fontSizeSlug ) {
+		fontSizeSlug = String( fontSizeSlug );
+		// eslint-disable-next-line no-console
+		console.warn(
+			'The font size slug to be used in generated a font size class should be a string.'
+		);
+	}
+
 	// We don't want to use kebabCase from lodash here
 	// see https://github.com/WordPress/gutenberg/issues/32347
 	// However, we need to make sure the generated class
-	// doesn't contain spaces. The method used to accept numbers
-	// so we need to make sure we are working with a string for the
-	// sake of backwards compat.
-	return `has-${ fontSizeSlug.toString().replace( /\s+/g, '-' ) }-font-size`;
+	// doesn't contain spaces.
+	return `has-${ fontSizeSlug.replace( /\s+/g, '-' ) }-font-size`;
 }

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -68,9 +68,7 @@ export function getFontSizeClass( fontSizeSlug ) {
 	if ( 'string' !== typeof fontSizeSlug ) {
 		fontSizeSlug = String( fontSizeSlug );
 		// eslint-disable-next-line no-console
-		console.warn(
-			'The font size slug to be used in generated a font size class should be a string.'
-		);
+		console.warn( 'The font size slug should be a string.' );
 	}
 
 	// We don't want to use kebabCase from lodash here

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -4,6 +4,11 @@
 import { find } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+ import deprecated from '@wordpress/deprecated';
+
+/**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.
  * 	If namedFontSize is undefined or not found in fontSizes an object with just the size value based on customFontSize is returned.
  *
@@ -67,8 +72,17 @@ export function getFontSizeClass( fontSizeSlug ) {
 	// into strings. Some plugins relied on this behavior.
 	if ( 'string' !== typeof fontSizeSlug ) {
 		fontSizeSlug = String( fontSizeSlug );
-		// eslint-disable-next-line no-console
-		console.warn( 'The font size slug should be a string.' );
+		deprecated( 'The font size slug should be a string.' );
+	}
+
+	// In the past, we used lodash's kebabCase to process slugs.
+	// By doing so, this method also stripped special characters
+	// such as the # in "#FFFFF". Some plugins relied on this behavior.
+	const slug = fontSizeSlug.replace( /[^a-zA-Z0-9\-\s]/g, '' );
+	if ( slug !== fontSizeSlug ) {
+		deprecated(
+			'The font size slug should not have any special character.'
+		);
 	}
 
 	// We don't want to use kebabCase from lodash here

--- a/packages/block-editor/src/components/font-sizes/utils.js
+++ b/packages/block-editor/src/components/font-sizes/utils.js
@@ -6,7 +6,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
- import deprecated from '@wordpress/deprecated';
+import deprecated from '@wordpress/deprecated';
 
 /**
  *  Returns the font size object based on an array of named font sizes and the namedFontSize and customFontSize values.


### PR DESCRIPTION
## Description
With Gutenberg 10.8.1 block content fails to load in the editor if a number is passed to `getFontSizeClass` instead of a string. Previously lodash kebabCase was forgiving of this misdemeanor. This PR makes sure we have a string before running .replace  to ensure that existing third party blocks that are passing a number continue to work.

Fixes: #32719

## To test

- Install and activate Jetpack on a site. This requires a public site. You can created one at jurassic.ninja for example.
- Install the gutenberg plugin from this PR: `npm install && npm run build:plugin-zip` and upload.
- Activate the subscription form block with [these instructions](https://jetpack.com/support/jetpack-blocks/subscription-form-block/).
- Insert following code into code view of editor

```
<!-- wp:jetpack/subscriptions {"customButtonBackgroundColor":"#151516","fontSize":16,"customFontSize":16,"borderRadius":3,"borderColor":"#ffffff","customBorderColor":"#ffffff"} -->
<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" custom_background_button_color="#151516" custom_font_size="16" custom_border_radius="3" custom_border_weight="1" custom_border_color="#ffffff" custom_padding="15" custom_spacing="10" submit_button_classes="has-16-font-size has-ffffff-border-color" email_field_classes="has-16-font-size has-ffffff-border-color" show_only_email_and_button="true"]</div>
<!-- /wp:jetpack/subscriptions -->
```
Switch back to editor view and make sure the content displays, and that the following error does not show in the console. (there may be some other block invalidation issues - we are working on those separately)

```
Uncaught TypeError: fontSizeSlug.replace is not a function
    getFontSizeClass utils.js:69
    save editor-beta.js:31
    getSaveElement serializer.js:119
    getSaveContent serializer.js:184
    addParsedDifference custom-class-name.js:162