### PR TITLE
Fixes getColorClassName regression

### DIFF
--- a/packages/block-editor/src/components/colors/test/utils.js
+++ b/packages/block-editor/src/components/colors/test/utils.js
@@ -114,5 +114,23 @@ describe( 'color utils', () => {
 				getColorClassName( 'background', 'Light   Purple veryDark' )
 			).toBe( 'has-Light-Purple-veryDark-background' );
 		} );
+
+		it( 'should throw a warning if the color slug is not a string', () => {
+			expect( getColorClassName( 'background', 123456 ) ).toBe(
+				'has-123456-background'
+			);
+			expect( console ).toHaveWarnedWith(
+				'The color slug should be a string.'
+			);
+		} );
+
+		it( 'should throw a warning if the color slug contains special characters', () => {
+			expect( getColorClassName( 'background', '#abcdef' ) ).toBe(
+				'has-abcdef-background'
+			);
+			expect( console ).toHaveWarnedWith(
+				'The color slug should not have any special character.'
+			);
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -64,7 +64,7 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	// see https://github.com/WordPress/gutenberg/issues/32347
 	// However, we need to make sure the generated class
 	// doesn't contain spaces, or any special characters.
-	const slug = colorSlug.replace( /[^a-zA-Z0-9 ]/g, '' );
+	const slug = colorSlug.replace( /[^a-zA-Z0-9\- ]/g, '' );
 	return `has-${ slug.replace( /\s+/g, '-' ) }-${ colorContextName.replace(
 		/\s+/g,
 		'-'

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -76,7 +76,7 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	// In the past, we used lodash's kebabCase to process slugs.
 	// By doing so, this method also stripped special characters
 	// such as the # in "#FFFFF". Some plugins relied on this behavior.
-	const slug = colorSlug.replace( /[^a-zA-Z0-9\-]/g, '' );
+	const slug = colorSlug.replace( /[^a-zA-Z0-9\-\s]/g, '' );
 	if ( slug !== colorSlug ) {
 		deprecated( 'The color slug should not have any special character.' );
 	}

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -5,11 +5,6 @@ import { find, map } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 /**
- * WordPress dependencies
- */
-import deprecated from '@wordpress/deprecated';
-
-/**
  * Provided an array of color objects as set by the theme or by the editor defaults,
  * and the values of the defined color or custom color returns a color object describing the color.
  *
@@ -70,7 +65,8 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	// into strings. Some plugins relied on this behavior.
 	if ( 'string' !== typeof colorSlug ) {
 		colorSlug = String( colorSlug );
-		deprecated( 'The color slug should be a string.' );
+		// eslint-disable-next-line no-console
+		console.warn( 'The color slug should be a string.' );
 	}
 
 	// In the past, we used lodash's kebabCase to process slugs.
@@ -78,7 +74,8 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	// such as the # in "#FFFFF". Some plugins relied on this behavior.
 	const slug = colorSlug.replace( /[^a-zA-Z0-9\-\s]/g, '' );
 	if ( slug !== colorSlug ) {
-		deprecated( 'The color slug should not have any special character.' );
+		// eslint-disable-next-line no-console
+		console.warn( 'The color slug should not have any special character.' );
 	}
 
 	// We don't want to use kebabCase from lodash here

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -5,6 +5,11 @@ import { find, map } from 'lodash';
 import tinycolor from 'tinycolor2';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Provided an array of color objects as set by the theme or by the editor defaults,
  * and the values of the defined color or custom color returns a color object describing the color.
  *
@@ -60,11 +65,26 @@ export function getColorClassName( colorContextName, colorSlug ) {
 		return undefined;
 	}
 
+	// In the past, we used lodash's kebabCase to process slugs.
+	// By doing so, this method also accepted and converted non string values
+	// into strings. Some plugins relied on this behavior.
+	if ( 'string' !== typeof colorSlug ) {
+		colorSlug = String( colorSlug );
+		deprecated( 'The color slug should be a string.' );
+	}
+
+	// In the past, we used lodash's kebabCase to process slugs.
+	// By doing so, this method also stripped special characters
+	// such as the # in "#FFFFF". Some plugins relied on this behavior.
+	const slug = colorSlug.replace( /[^a-zA-Z0-9\-]/g, '' );
+	if ( slug !== colorSlug ) {
+		deprecated( 'The color slug should not have any special character.' );
+	}
+
 	// We don't want to use kebabCase from lodash here
 	// see https://github.com/WordPress/gutenberg/issues/32347
 	// However, we need to make sure the generated class
-	// doesn't contain spaces, or any special characters.
-	const slug = colorSlug.replace( /[^a-zA-Z0-9\- ]/g, '' );
+	// doesn't contain spaces.
 	return `has-${ slug.replace( /\s+/g, '-' ) }-${ colorContextName.replace(
 		/\s+/g,
 		'-'

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -63,11 +63,12 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	// We don't want to use kebabCase from lodash here
 	// see https://github.com/WordPress/gutenberg/issues/32347
 	// However, we need to make sure the generated class
-	// doesn't contain spaces.
-	return `has-${ colorSlug.replace(
+	// doesn't contain spaces, or any special characters.
+	const slug = colorSlug.replace( /[^a-zA-Z0-9 ]/g, '' );
+	return `has-${ slug.replace( /\s+/g, '-' ) }-${ colorContextName.replace(
 		/\s+/g,
 		'-'
-	) }-${ colorContextName.replace( /\s+/g, '-' ) }`;
+	) }`;
 }
 
 /**


### PR DESCRIPTION
## Description
The removal of lodash kebabCase from getColorClassName meant that special characters where not being stripped from the resulting classnames, so blocks that were passing in `#ffffff` as the color slug were expecting to see `has-ffffff-border-color` as the classname, but method is now returning `has-#ffffff-border-color`

Fixes: #32721

## Step-by-step reproduction instructions

- Install and activate Jetpack on a site. This requires a public site. You can created one at jurassic.ninja for example.
- Install the gutenberg plugin from this PR: `npm install && npm run build:plugin-zip` and upload.
- Activate the subscription form block with [these instructions](https://jetpack.com/support/jetpack-blocks/subscription-form-block/).
- Insert following code into code view of editor

```
<!-- wp:jetpack/subscriptions {"customButtonBackgroundColor":"#151516","fontSize":16,"customFontSize":16,"borderRadius":3,"borderColor":"#ffffff","customBorderColor":"#ffffff"} -->
<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline">[jetpack_subscription_form show_subscribers_total="false" button_on_newline="false" custom_background_button_color="#151516" custom_font_size="16" custom_border_radius="3" custom_border_weight="1" custom_border_color="#ffffff" custom_padding="15" custom_spacing="10" submit_button_classes="has-16-font-size has-ffffff-border-color" email_field_classes="has-16-font-size has-ffffff-border-color" show_only_email_and_button="true"]</div>
<!-- /wp:jetpack/subscriptions -->
```

Block should display as valid.

