### PR TITLE
Update Legacy Widget docs with new info on `show_instance_in_rest` feature

### DIFF
--- a/docs/how-to-guides/widgets/legacy-widget-block.md
+++ b/docs/how-to-guides/widgets/legacy-widget-block.md
@@ -17,9 +17,9 @@ If the widget uses JavaScript in its form, it is important that events are added
 For example, a widget might want to show a "Password" field when the "Change password" checkbox is checked.
 
 ```js
-( function( $ ) {
-	$( document ).on( 'widget-added', function( $control ) {
-		$control.find( '.change-password' ).on( 'change', function() {
+( function ( $ ) {
+	$( document ).on( 'widget-added', function ( $control ) {
+		$control.find( '.change-password' ).on( 'change', function () {
 			var isChecked = $( this ).prop( 'checked' );
 			$control.find( '.password' ).toggleClass( 'hidden', ! isChecked );
 		} );
@@ -66,10 +66,32 @@ First, we need to tell WordPress that it is OK to display your widget's instance
 
 This can be safely done if:
 
-- You know that all of the values stored by your widget in `$instance` can be represented as JSON; and
-- You know that your widget does not store any private data in `$instance` that should be kept hidden from users that have permission to customize the site.
+-   You know that all of the values stored by your widget in `$instance` can be represented as JSON; and
+-   You know that your widget does not store any private data in `$instance` that should be kept hidden from users that have permission to customize the site.
 
-If it is safe to do so, then set `$show_instance_in_rest` to `true` in the class that extends `WP_Widget`.
+If it is safe to do so, then include a widget option named `show_instance_in_rest` with its value set to `true` when registering your widget.
+
+```php
+class ExampleWidget extends WP_Widget {
+	...
+	/**
+	 * Sets up the widget
+	 */
+	public function __construct() {
+		$widget_ops = array(
+			// ...other options here
+			'show_instance_in_rest' => true,
+			// ...other options here
+		);
+		parent::__construct( 'example_widget', 'ExampleWidget', $widget_ops );
+	}
+	...
+}
+```
+
+This allows the block editor and other REST API clients to see your widget's instance array by accessing `instance.raw` in the REST API response.
+
+Note that [versions of WordPress prior to 5.8.0 allowed you to enable this feature by setting `$show_instance_in_rest` to `true`](https://core.trac.wordpress.org/ticket/53332) in the class that extends `WP_Widget`.
 
 ```php
 class ExampleWidget extends WP_Widget {
@@ -79,7 +101,7 @@ class ExampleWidget extends WP_Widget {
 }
 ```
 
-This allows the block editor and other REST API clients to see your widget's instance array by accessing `instance.raw` in the REST API response.
+This is now deprecated in favour of the widget option method.
 
 #### 2) Add a block transform
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://core.trac.wordpress.org/ticket/53332 we learnt that whilst the documentation page and the Gutenberg plugin are using the Widget's class `$show_instance_in_rest property` WordPress decided to stop checking this property into the Widgets REST endpoints in favour of looking into the `$widget_options['show_instance_in_rest']` property.

This PR updates the Widget docs to account for this whilst also retaining a reference back to the original method for users on older versions of WordPress.

## How has this been tested?
* Read the doc changes.
* Check for spelling grammar.
* Check the code for accuracy.

Note I'm not super familiar with Widgets so happy to make changes as required 🙇 

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
