### PR TITLE
Reduce code duplication for defined units

### DIFF
--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -11,135 +11,117 @@ import { Platform } from '@wordpress/element';
 
 const isWeb = Platform.OS === 'web';
 
-/**
- * An array of all available CSS length units.
- */
-export const ALL_CSS_UNITS = [
-	{
+const allUnits = {
+	px: {
 		value: 'px',
 		label: isWeb ? 'px' : __( 'Pixels (px)' ),
 		default: '',
 		a11yLabel: __( 'Pixels (px)' ),
 	},
-	{
+	percent: {
 		value: '%',
 		label: isWeb ? '%' : __( 'Percentage (%)' ),
 		default: '',
 		a11yLabel: __( 'Percent (%)' ),
 	},
-	{
+	em: {
 		value: 'em',
 		label: isWeb ? 'em' : __( 'Relative to parent font size (em)' ),
 		default: '',
-		a11yLabel: __( 'Relative to parent font size (em)' ),
+		a11yLabel: _x( 'ems', 'Relative to parent font size (em)' ),
 	},
-	{
+	rem: {
 		value: 'rem',
 		label: isWeb ? 'rem' : __( 'Relative to root font size (rem)' ),
 		default: '',
-		a11yLabel: __( 'Relative to root font size (rem)' ),
+		a11yLabel: _x( 'rems', 'Relative to root font size (rem)' ),
 	},
-	{
+	vw: {
 		value: 'vw',
 		label: isWeb ? 'vw' : __( 'Viewport width (vw)' ),
 		default: '',
 		a11yLabel: __( 'Viewport width (vw)' ),
 	},
-	{
+	vh: {
 		value: 'vh',
 		label: isWeb ? 'vh' : __( 'Viewport height (vh)' ),
 		default: '',
 		a11yLabel: __( 'Viewport height (vh)' ),
 	},
-	{
+	vmin: {
 		value: 'vmin',
 		label: isWeb ? 'vmin' : __( 'Viewport smallest dimension (vmin)' ),
 		default: '',
 		a11yLabel: __( 'Viewport smallest dimension (vmin)' ),
 	},
-	{
+	vmax: {
 		value: 'vmax',
 		label: isWeb ? 'vmax' : __( 'Viewport largest dimension (vmax)' ),
 		default: '',
 		a11yLabel: __( 'Viewport largest dimension (vmax)' ),
 	},
-	{
+	ch: {
 		value: 'ch',
 		label: isWeb ? 'ch' : __( 'Width of the zero (0) character (ch)' ),
 		default: '',
 		a11yLabel: __( 'Width of the zero (0) character (ch)' ),
 	},
-	{
+	ex: {
 		value: 'ex',
 		label: isWeb ? 'ex' : __( 'x-height of the font (ex)' ),
 		default: '',
 		a11yLabel: __( 'x-height of the font (ex)' ),
 	},
-	{
+	cm: {
 		value: 'cm',
 		label: isWeb ? 'cm' : __( 'Centimeters (cm)' ),
 		default: '',
 		a11yLabel: __( 'Centimeters (cm)' ),
 	},
-	{
+	mm: {
 		value: 'mm',
 		label: isWeb ? 'mm' : __( 'Millimeters (mm)' ),
 		default: '',
 		a11yLabel: __( 'Millimeters (mm)' ),
 	},
-	{
+	in: {
 		value: 'in',
 		label: isWeb ? 'in' : __( 'Inches (in)' ),
 		default: '',
 		a11yLabel: __( 'Inches (in)' ),
 	},
-	{
+	pc: {
 		value: 'pc',
 		label: isWeb ? 'pc' : __( 'Picas (pc)' ),
 		default: '',
 		a11yLabel: __( 'Picas (pc)' ),
 	},
-	{
+	pt: {
 		value: 'pt',
 		label: isWeb ? 'pt' : __( 'Points (pt)' ),
 		default: '',
 		a11yLabel: __( 'Points (pt)' ),
 	},
-];
+};
+
+/**
+ * An array of all available CSS length units.
+ */
+export const ALL_CSS_UNITS = Object.values( allUnits );
 
 /**
  * Units of measurements. `a11yLabel` is used by screenreaders.
  */
 export const CSS_UNITS = [
-	{ value: 'px', label: 'px', default: 0, a11yLabel: __( 'pixels' ) },
-	{ value: '%', label: '%', default: 10, a11yLabel: __( 'percent' ) },
-	{
-		value: 'em',
-		label: 'em',
-		default: 0,
-		a11yLabel: _x( 'ems', 'Relative to parent font size (em)' ),
-	},
-	{
-		value: 'rem',
-		label: 'rem',
-		default: 0,
-		a11yLabel: _x( 'rems', 'Relative to root font size (rem)' ),
-	},
-	{
-		value: 'vw',
-		label: 'vw',
-		default: 10,
-		a11yLabel: __( 'viewport widths' ),
-	},
-	{
-		value: 'vh',
-		label: 'vh',
-		default: 10,
-		a11yLabel: __( 'viewport heights' ),
-	},
+	allUnits.px,
+	allUnits.percent,
+	allUnits.em,
+	allUnits.rem,
+	allUnits.vw,
+	allUnits.vh,
 ];
 
-export const DEFAULT_UNIT = CSS_UNITS[ 0 ];
+export const DEFAULT_UNIT = allUnits.px;
 
 /**
  * Handles legacy value + unit handling.

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -113,12 +113,12 @@ export const ALL_CSS_UNITS = Object.values( allUnits );
  * Units of measurements. `a11yLabel` is used by screenreaders.
  */
 export const CSS_UNITS = [
-	allUnits.px,
-	allUnits.percent,
-	allUnits.em,
-	allUnits.rem,
-	allUnits.vw,
-	allUnits.vh,
+	{ ...allUnits.px, default: 0 },
+	{ ...allUnits.percent, default: 0 },
+	{ ...allUnits.em, default: 0 },
+	{ ...allUnits.rem, default: 0 },
+	{ ...allUnits.vw, default: 10 },
+	{ ...allUnits.vh, default: 10 },
 ];
 
 export const DEFAULT_UNIT = allUnits.px;

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -113,12 +113,12 @@ export const ALL_CSS_UNITS = Object.values( allUnits );
  * Units of measurements. `a11yLabel` is used by screenreaders.
  */
 export const CSS_UNITS = [
-	{ ...allUnits.px, default: 0 },
-	{ ...allUnits.percent, default: 0 },
-	{ ...allUnits.em, default: 0 },
-	{ ...allUnits.rem, default: 0 },
-	{ ...allUnits.vw, default: 10 },
-	{ ...allUnits.vh, default: 10 },
+	allUnits.px,
+	allUnits.percent,
+	allUnits.em,
+	allUnits.rem,
+	allUnits.vw,
+	allUnits.vh,
 ];
 
 export const DEFAULT_UNIT = allUnits.px;


### PR DESCRIPTION
## Description
Some CSS units were being defined twice. This PR reduces code duplication by making them more consistent.

## How has this been tested?

The change is pretty simple and nothing breaks. Tested the post-editor and confirmed that controls like padding (which uses the units) haven't changed and everything works as expected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
