### PR TITLE
Set explicit z-index on interface body to ensure it’s pinned under interface header

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,6 +32,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
+	".interface-interface-skeleton__body": 20,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -63,11 +63,6 @@ html.interface-interface-skeleton__html-container {
 	// See also: https://drafts.csswg.org/css-overscroll/
 	overscroll-behavior-y: none;
 
-	// On Safari iOS on smaller viewports lack of a z-index causes the background
-	// to "bleed" through the header.
-	// See https://github.com/WordPress/gutenberg/issues/32631
-	z-index: z-index(".interface-interface-skeleton__body");
-
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {
@@ -87,8 +82,12 @@ html.interface-interface-skeleton__html-container {
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	// Beyond the medium breakpoint, we allow the sidebar.
 	// The sidebar should scroll independently, so enable scroll here also.
-
 	overflow: auto;
+
+	// On Safari iOS on smaller viewports lack of a z-index causes the background
+	// to "bleed" through the header.
+	// See https://github.com/WordPress/gutenberg/issues/32631
+	z-index: z-index(".interface-interface-skeleton__body");
 
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -63,6 +63,11 @@ html.interface-interface-skeleton__html-container {
 	// See also: https://drafts.csswg.org/css-overscroll/
 	overscroll-behavior-y: none;
 
+	// On Safari iOS on smaller viewports lack of a z-index causes the background
+	// to "bleed" through the header.
+	// See https://github.com/WordPress/gutenberg/issues/32631
+	z-index: z-index(".interface-interface-skeleton__body");
+
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

On smaller viewports on Safari iOS the interface header can (under limited circumstances) suffer a render glitch whereby the content below "bleeds" into it.

See screenshots for Before/After.

This PR fixes this by setting an explicit `z-index` for the interface skeleton ~"body"~ "content" and ensuring this is lower than that of the interface skeleton "header".

**Update**: we had to revert applying to the "body" because that caused the "actions" panel to sit under the header when publishing a post. Applying to "content" achieves the same fix but without the nasty knock on effects.

Fixes https://github.com/WordPress/gutenberg/issues/32631

## How has this been tested?

Either on a real iOS device on the iOS simular spin up Safari and load WP with this branch built and enabled.

### Before - verify the bug
* Using Twenty Fourteen as a theme
* Go to Appearance > Widgets
* Make sure to add some blocks to be able to scroll the page
* Scroll slowly
* Notice the black top bar sometimes appears

### After - verify the fix
* Using Twenty Fourteen as a theme
* Go to Appearance > Widgets
* Make sure to add some blocks to be able to scroll the page
* Scroll slowly
* Notice the top bar retains the "white" background and no black bleeds through.

Also verify this change does not break other screens such as Post Editor or Site Editor.

## Screenshots <!-- if applicable -->

### Before
https://user-images.githubusercontent.com/444434/122210810-f1644600-ce9d-11eb-9b22-1d0498d964e5.mp4

### After
https://user-images.githubusercontent.com/444434/122210806-f0cbaf80-ce9d-11eb-8b90-2f350190ed07.mp4





## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
