### PR TITLE
Remove the widget switcher block toolbar button

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -97,15 +97,11 @@ function NotEmpty( {
 	const { widgetType, hasResolvedWidgetType, isNavigationMode } = useSelect(
 		( select ) => {
 			const widgetTypeId = id ?? idBase;
-			const hiddenIds =
-				select( blockEditorStore ).getSettings()
-					?.widgetTypesToHideFromLegacyWidgetBlock ?? [];
 			return {
 				widgetType: select( coreStore ).getWidgetType( widgetTypeId ),
 				hasResolvedWidgetType: select(
 					coreStore
 				).hasFinishedResolution( 'getWidgetType', [ widgetTypeId ] ),
-				isWidgetTypeHidden: hiddenIds.includes( widgetTypeId ),
 				isNavigationMode: select( blockEditorStore ).isNavigationMode(),
 			};
 		},

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -13,8 +13,8 @@ import {
 	BlockIcon,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { ToolbarButton, Spinner, Placeholder } from '@wordpress/components';
-import { brush as brushIcon, update as updateIcon } from '@wordpress/icons';
+import { Spinner, Placeholder } from '@wordpress/components';
+import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -94,12 +94,7 @@ function NotEmpty( {
 } ) {
 	const [ hasPreview, setHasPreview ] = useState( null );
 
-	const {
-		widgetType,
-		hasResolvedWidgetType,
-		isWidgetTypeHidden,
-		isNavigationMode,
-	} = useSelect(
+	const { widgetType, hasResolvedWidgetType, isNavigationMode } = useSelect(
 		( select ) => {
 			const widgetTypeId = id ?? idBase;
 			const hiddenIds =
@@ -144,22 +139,6 @@ function NotEmpty( {
 
 	return (
 		<>
-			{ ! isWidgetTypeHidden && (
-				<BlockControls group="block">
-					<ToolbarButton
-						label={ __( 'Change widget' ) }
-						icon={ updateIcon }
-						onClick={ () =>
-							setAttributes( {
-								id: null,
-								idBase: null,
-								instance: null,
-							} )
-						}
-					/>
-				</BlockControls>
-			) }
-
 			{ idBase === 'text' && (
 				<BlockControls group="other">
 					<ConvertToBlocksButton


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

Fixes #32004.

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Removes the Widget switcher block toolbar button for the Legacy Widget.

## How has this been tested?

Tested locally.

## Screenshots <!-- if applicable -->

<img width="771" alt="Screen Shot 2021-06-16 at 14 48 40" src="https://user-images.githubusercontent.com/107534/122213780-fcc16c80-ceb1-11eb-8801-963e948b37f4.png">

