### PR TITLE
Template creation: Fixed a problem that when a new template is created, the template is not displayed in the select box.

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -492,6 +492,22 @@ export function* __unstableSwitchToTemplateMode( template ) {
 			'wp_template',
 			template
 		);
+
+		const settings = yield controls.select(
+			editorStore.name,
+			'getEditorSettings'
+		);
+
+		const newAvailableTemplates = {
+			...settings.availableTemplates,
+			[ savedTemplate.slug ]: savedTemplate.title.rendered,
+		};
+
+		yield controls.dispatch( editorStore, 'updateEditorSettings', {
+			...settings,
+			availableTemplates: newAvailableTemplates,
+		} );
+
 		const post = yield controls.select(
 			editorStore.name,
 			'getCurrentPost'

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, reduce } from 'lodash';
+import { castArray, reduce, fromPairs } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -493,19 +493,26 @@ export function* __unstableSwitchToTemplateMode( template ) {
 			template
 		);
 
+		const templates = yield controls.resolveSelect(
+			coreStore.name,
+			'getEntityRecords',
+			'postType',
+			'wp_template',
+			{ per_page: -1 }
+		);
+
+		const availableTemplates = fromPairs(
+			templates.map( ( { slug, title } ) => [ slug, title.rendered ] )
+		);
+
 		const settings = yield controls.select(
 			editorStore.name,
 			'getEditorSettings'
 		);
 
-		const newAvailableTemplates = {
-			...settings.availableTemplates,
-			[ savedTemplate.slug ]: savedTemplate.title.rendered,
-		};
-
 		yield controls.dispatch( editorStore, 'updateEditorSettings', {
 			...settings,
-			availableTemplates: newAvailableTemplates,
+			availableTemplates,
 		} );
 
 		const post = yield controls.select(


### PR DESCRIPTION
## Description

When creating a new template and returning to the editor, the new template is not displayed in the select box. It shows up when the browser is reloaded. Fixed this problem.

https://user-images.githubusercontent.com/1908815/122216000-dc5fd500-cee6-11eb-81ff-170a2854e657.mov


## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
