### PR TITLE
Avoid generic function names for page list block internal functions

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -93,7 +93,7 @@ function block_core_page_list_build_css_font_sizes( $context ) {
  *
  * @return string List markup.
  */
-function render_nested_page_list( $nested_pages, $active_page_ancestor_ids = array() ) {
+function block_core_page_list_render_nested_page_list( $nested_pages, $active_page_ancestor_ids = array() ) {
 	if ( empty( $nested_pages ) ) {
 		return;
 	}
@@ -111,7 +111,7 @@ function render_nested_page_list( $nested_pages, $active_page_ancestor_ids = arr
 		) . '</a>';
 		if ( isset( $page['children'] ) ) {
 			$markup .= '<span class="wp-block-page-list__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
-			$markup .= '<ul class="submenu-container">' . render_nested_page_list( $page['children'], $active_page_ancestor_ids ) . '</ul>';
+			$markup .= '<ul class="submenu-container">' . block_core_page_list_render_nested_page_list( $page['children'], $active_page_ancestor_ids ) . '</ul>';
 		}
 		$markup .= '</li>';
 	}
@@ -126,13 +126,13 @@ function render_nested_page_list( $nested_pages, $active_page_ancestor_ids = arr
  *
  * @return array The nested array of pages.
  */
-function nest_pages( $current_level, $children ) {
+function block_core_page_list_nest_pages( $current_level, $children ) {
 	if ( empty( $current_level ) ) {
 		return;
 	}
 	foreach ( (array) $current_level as $key => $current ) {
 		if ( isset( $children[ $key ] ) ) {
-			$current_level[ $key ]['children'] = nest_pages( $children[ $key ], $children );
+			$current_level[ $key ]['children'] = block_core_page_list_nest_pages( $children[ $key ], $children );
 		}
 	}
 	return $current_level;
@@ -194,11 +194,11 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		}
 	}
 
-	$nested_pages = nest_pages( $top_level_pages, $pages_with_children );
+	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
 	$wrapper_markup = '<ul %1$s>%2$s</ul>';
 
-	$items_markup = render_nested_page_list( $nested_pages, $active_page_ancestor_ids );
+	$items_markup = block_core_page_list_render_nested_page_list( $nested_pages, $active_page_ancestor_ids );
 
 	$colors          = block_core_page_list_build_css_colors( $block->context );
 	$font_sizes      = block_core_page_list_build_css_font_sizes( $block->context );


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/28265#discussion_r647620889

I'm not sure these are the best names but I tried renaming these functions so they don't look as generic WP APIs and more internal functions used by the block's server side code.