### PR TITLE
[Block Library - Query Loop]: Select first Query Loop found from pattern selection

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { cloneBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useMemo } from '@wordpress/element';
 import {
@@ -23,6 +24,7 @@ import QueryToolbar from './query-toolbar';
 import QueryInspectorControls from './query-inspector-controls';
 import QueryPlaceholder from './query-placeholder';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
+import { getFirstQueryClientIdFromBlocks } from '../utils';
 
 const TEMPLATE = [ [ 'core/post-template' ] ];
 export function QueryContent( { attributes, setAttributes } ) {
@@ -140,6 +142,17 @@ export function QueryContent( { attributes, setAttributes } ) {
 function QueryPatternSetup( props ) {
 	const { clientId, name: blockName } = props;
 	const blockProps = useBlockProps();
+	const { replaceBlock, selectBlock } = useDispatch( blockEditorStore );
+	const onBlockPatternSelect = ( blocks ) => {
+		const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
+		const firstQueryClientId = getFirstQueryClientIdFromBlocks(
+			clonedBlocks
+		);
+		replaceBlock( clientId, clonedBlocks );
+		if ( firstQueryClientId ) {
+			selectBlock( firstQueryClientId );
+		}
+	};
 	// `startBlankComponent` is what to render when clicking `Start blank`
 	// or if no matched patterns are found.
 	return (
@@ -148,6 +161,7 @@ function QueryPatternSetup( props ) {
 				blockName={ blockName }
 				clientId={ clientId }
 				startBlankComponent={ <QueryPlaceholder { ...props } /> }
+				onBlockPatternSelect={ onBlockPatternSelect }
 			/>
 		</div>
 	);

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -89,3 +89,23 @@ export const usePostTypes = () => {
 	);
 	return { postTypesTaxonomiesMap, postTypesSelectOptions };
 };
+
+/**
+ * Recurses over a list of blocks and returns the first found
+ * Query Loop block's clientId.
+ *
+ * @param {WPBlock[]} blocks The list of blocks to look through.
+ * @return {string} The first found Query Loop's clientId.
+ */
+export const getFirstQueryClientIdFromBlocks = ( blocks ) => {
+	const blocksQueue = [ ...blocks ];
+	while ( blocksQueue.length > 0 ) {
+		const block = blocksQueue.shift();
+		if ( block.name === 'core/query' ) {
+			return block.clientId;
+		}
+		block.innerBlocks?.forEach( ( innerBlock ) => {
+			blocksQueue.push( innerBlock );
+		} );
+	}
+};

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -95,7 +95,7 @@ export const usePostTypes = () => {
  * Query Loop block's clientId.
  *
  * @param {WPBlock[]} blocks The list of blocks to look through.
- * @return {string} The first found Query Loop's clientId.
+ * @return {string=} The first found Query Loop's clientId.
  */
 export const getFirstQueryClientIdFromBlocks = ( blocks ) => {
 	const blocksQueue = [ ...blocks ];


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/31252

After selecting a `Query Loop` pattern from the Placeholder during insertion, the selected block would be the last selected pattern's block. This doesn't need to be a `Query Loop` block necessarily.

This PR searches for the first `Query Loop` block in the pattern's blocks and selects it, after we choose a pattern.

## Testing Instructions
1. Insert a Query Loop and select the `Large title` pattern, which wraps the `Query Loop` with a `Group` block.
2. Observe that the `Query Loop` is selected.

Of course you can check with other patterns as well like `Offset` or any custom pattern.
