### PR TITLE
Try: Align widget sidebar button.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -154,11 +154,16 @@
 		white-space: nowrap;
 		color: var(--wp-admin-theme-color);
 		background: transparent;
-		padding: 6px; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
+		padding: $grid-unit-15 / 2; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
 
 		.dashicon {
 			display: inline-block;
 			flex: 0 0 auto;
+		}
+
+		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.
+		p + & {
+			margin-left: -($grid-unit-15 / 2);
 		}
 	}
 


### PR DESCRIPTION
## Description

Very small improvement to the Button component, specifically the tertiary style, so that it aligns vertically if shown next to a description. For example in the new widgets editor, before:

<img width="404" alt="before" src="https://user-images.githubusercontent.com/1204802/122236390-c4745b00-cebe-11eb-985f-0d53204ff631.png">

After:

<img width="398" alt="Screenshot 2021-06-16 at 16 17 40" src="https://user-images.githubusercontent.com/1204802/122236403-c6d6b500-cebe-11eb-832e-33c56861769c.png">


## How has this been tested?

This negative margin for alignment should only apply in the right contexts. In my testing, it does, but please look for any tertiaty buttons that look pulled left when they shouldn't be.

<img width="665" alt="Screenshot 2021-06-16 at 16 18 01" src="https://user-images.githubusercontent.com/1204802/122236508-dce47580-cebe-11eb-91b6-e8cbfecb5ee5.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
