### PR TITLE
Rename native editor onboarding properties for clarity

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -32,7 +32,7 @@ import { store as blockEditorStore } from '../../store';
 const VOICE_OVER_ANNOUNCEMENT_DELAY = 1000;
 
 const defaultRenderToggle = ( {
-	canViewEditorOnboarding,
+	enableEditorOnboarding,
 	onToggle,
 	disabled,
 	style,
@@ -40,7 +40,7 @@ const defaultRenderToggle = ( {
 } ) => (
 	<ToolbarButton
 		title={
-			canViewEditorOnboarding
+			enableEditorOnboarding
 				? __( 'Tap to add content' )
 				: __( 'Add block' )
 		}
@@ -51,7 +51,7 @@ const defaultRenderToggle = ( {
 				color={ style.color }
 			/>
 		}
-		showTooltip={ canViewEditorOnboarding }
+		showTooltip={ enableEditorOnboarding }
 		tooltipPosition="top right"
 		onClick={ onToggle }
 		extraProps={ {
@@ -64,7 +64,6 @@ const defaultRenderToggle = ( {
 		isDisabled={ disabled }
 	/>
 );
-
 export class Inserter extends Component {
 	constructor() {
 		super( ...arguments );
@@ -200,7 +199,7 @@ export class Inserter extends Component {
 	 */
 	renderInserterToggle( { onToggle, isOpen } ) {
 		const {
-			canViewEditorOnboarding,
+			enableEditorOnboarding,
 			disabled,
 			renderToggle = defaultRenderToggle,
 			getStylesFromColorScheme,
@@ -247,7 +246,7 @@ export class Inserter extends Component {
 		return (
 			<>
 				{ renderToggle( {
-					canViewEditorOnboarding,
+					enableEditorOnboarding,
 					onToggle: onPress,
 					isOpen,
 					disabled,
@@ -378,8 +377,7 @@ export default compose( [
 		const insertionIndexEnd = endOfRootIndex;
 
 		return {
-			canViewEditorOnboarding: getBlockEditorSettings()
-				.canViewEditorOnboarding,
+			enableEditorOnboarding: getBlockEditorSettings().editorOnboarding,
 			destinationRootClientId,
 			insertionIndexDefault: getDefaultInsertionIndex(),
 			insertionIndexBefore,

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -64,6 +64,7 @@ const defaultRenderToggle = ( {
 		isDisabled={ disabled }
 	/>
 );
+
 export class Inserter extends Component {
 	constructor() {
 		super( ...arguments );

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -18,7 +18,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val translations: Bundle,
     val isDarkMode: Boolean,
     val htmlModeEnabled: Boolean,
-    val canViewEditorOnboarding: Boolean
+    val editorOnboarding: Boolean
 ) {
 
     fun getInitialProps(bundle: Bundle?) = (bundle ?: Bundle()).apply {
@@ -47,7 +47,7 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, isAudioBlockMediaUploadEnabled)
         putBoolean(PROP_CAPABILITIES_REUSABLE_BLOCK, enableReusableBlock)
-        putBoolean(PROP_CAPABILITIES_CAN_VIEW_EDITOR_ONBOARDING, canViewEditorOnboarding)
+        putBoolean(PROP_CAPABILITIES_EDITOR_ONBOARDING, editorOnboarding)
     }
 
     companion object {
@@ -77,6 +77,6 @@ data class GutenbergProps @JvmOverloads constructor(
         const val PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR = "canEnableUnsupportedBlockEditor"
         const val PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED = "isAudioBlockMediaUploadEnabled"
         const val PROP_CAPABILITIES_REUSABLE_BLOCK = "reusableBlock"
-        const val PROP_CAPABILITIES_CAN_VIEW_EDITOR_ONBOARDING = "canViewEditorOnboarding"
+        const val PROP_CAPABILITIES_EDITOR_ONBOARDING = "editorOnboarding"
     }
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -18,7 +18,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val translations: Bundle,
     val isDarkMode: Boolean,
     val htmlModeEnabled: Boolean,
-    val editorOnboarding: Boolean
+    val enableEditorOnboarding: Boolean
 ) {
 
     fun getInitialProps(bundle: Bundle?) = (bundle ?: Bundle()).apply {
@@ -47,7 +47,7 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, isAudioBlockMediaUploadEnabled)
         putBoolean(PROP_CAPABILITIES_REUSABLE_BLOCK, enableReusableBlock)
-        putBoolean(PROP_CAPABILITIES_EDITOR_ONBOARDING, editorOnboarding)
+        putBoolean(PROP_CAPABILITIES_EDITOR_ONBOARDING, enableEditorOnboarding)
     }
 
     companion object {

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -24,7 +24,7 @@ public enum Capabilities: String {
     case canEnableUnsupportedBlockEditor
     case isAudioBlockMediaUploadEnabled
     case reusableBlock
-    case canViewEditorOnboarding
+    case editorOnboarding
 }
 
 /// Wrapper for single block data

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -33,7 +33,7 @@ public class MainActivity extends ReactActivity {
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_REUSABLE_BLOCK, false);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, true);
-                capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_CAN_VIEW_EDITOR_ONBOARDING, false);
+                capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_EDITOR_ONBOARDING, false);
                 bundle.putBundle(GutenbergProps.PROP_CAPABILITIES, capabilities);
                 return bundle;
             }

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -288,7 +288,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .mediaFilesCollectionBlock: true,
             .isAudioBlockMediaUploadEnabled: true,
             .reusableBlock: false,
-            .canViewEditorOnboarding: false
+            .editorOnboarding: false
         ]
     }
 


### PR DESCRIPTION
* **Gutenberg Mobile:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3625
* **WPAndroid:** https://github.com/wordpress-mobile/WordPress-Android/pull/14766
* **WPiOS:** https://github.com/wordpress-mobile/WordPress-iOS/pull/16574

## Description
This rename allows for clearer naming both in this project and the native apps.

## How has this been tested?
* Verified the Demo native editor project launched without crash. 
* See testing steps within sibling WPAndroid and WPiOS branches. 

## Screenshots
n/a

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
