### PR TITLE
Implement basic in memory cache for rich link previews data

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
@@ -5,6 +5,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs, prependHTTP } from '@wordpress/url';
 
 /**
+ * A simple in-memory cache for requests.
+ * This avoids repeat HTTP requests which may be beneficial
+ * for those wishing to preserve low-bandwidth.
+ */
+const CACHE = new Map();
+
+/**
  * @typedef WPRemoteUrlData
  *
  * @property {string} title contents of the remote URL's `<title>` tag.
@@ -38,10 +45,17 @@ const fetchRemoteUrlData = async ( url, options = {} ) => {
 		url: prependHTTP( url ),
 	};
 
-	return apiFetch( {
+	if ( CACHE.has( url ) ) {
+		return CACHE.get( url );
+	}
+
+	const response = apiFetch( {
 		path: addQueryArgs( endpoint, args ),
 		...options,
 	} );
+
+	CACHE.set( url, response );
+	return response;
 };
 
 export default fetchRemoteUrlData;

--- a/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
@@ -52,9 +52,11 @@ const fetchRemoteUrlData = async ( url, options = {} ) => {
 	const response = apiFetch( {
 		path: addQueryArgs( endpoint, args ),
 		...options,
+	} ).then( ( res ) => {
+		CACHE.set( url, res );
+		return res;
 	} );
 
-	CACHE.set( url, response );
 	return response;
 };
 

--- a/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-remote-url-data.js
@@ -49,15 +49,13 @@ const fetchRemoteUrlData = async ( url, options = {} ) => {
 		return CACHE.get( url );
 	}
 
-	const response = apiFetch( {
+	return apiFetch( {
 		path: addQueryArgs( endpoint, args ),
 		...options,
 	} ).then( ( res ) => {
 		CACHE.set( url, res );
 		return res;
 	} );
-
-	return response;
 };
 
 export default fetchRemoteUrlData;

--- a/packages/core-data/src/fetch/test/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-remote-url-data.js
@@ -5,13 +5,13 @@ import fetchRemoteUrlData from '../__experimental-fetch-remote-url-data';
 /**
  * WordPress dependencies
  */
-import triggerFetch from '@wordpress/api-fetch';
+import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
 describe( 'fetchRemoteUrlData', () => {
 	afterEach( () => {
-		triggerFetch.mockReset();
+		apiFetch.mockReset();
 	} );
 
 	describe( 'return value settles as expected', () => {
@@ -23,19 +23,17 @@ describe( 'fetchRemoteUrlData', () => {
 				description:
 					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 			};
-			triggerFetch.mockReturnValueOnce( Promise.resolve( data ) );
+			apiFetch.mockReturnValueOnce( Promise.resolve( data ) );
 
 			await expect(
 				fetchRemoteUrlData( 'https://www.wordpress.org' )
 			).resolves.toEqual( data );
 
-			expect( triggerFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toBeCalledTimes( 1 );
 		} );
 
 		it( 'rejects with error upon fetch failure', async () => {
-			triggerFetch.mockReturnValueOnce(
-				Promise.reject( 'fetch failed' )
-			);
+			apiFetch.mockReturnValueOnce( Promise.reject( 'fetch failed' ) );
 
 			await expect(
 				fetchRemoteUrlData( 'https://www.wordpress.org/1' )
@@ -45,15 +43,15 @@ describe( 'fetchRemoteUrlData', () => {
 
 	describe( 'interaction with underlying fetch API', () => {
 		it( 'passes options argument through to fetch API', async () => {
-			triggerFetch.mockReturnValueOnce( Promise.resolve() );
+			apiFetch.mockReturnValueOnce( Promise.resolve() );
 
 			await fetchRemoteUrlData( 'https://www.wordpress.org/2', {
 				method: 'POST',
 			} );
 
-			expect( triggerFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toBeCalledTimes( 1 );
 
-			const argsPassedToFetchApi = triggerFetch.mock.calls[ 0 ][ 0 ];
+			const argsPassedToFetchApi = apiFetch.mock.calls[ 0 ][ 0 ];
 
 			expect( argsPassedToFetchApi ).toEqual(
 				expect.objectContaining( {
@@ -73,16 +71,16 @@ describe( 'fetchRemoteUrlData', () => {
 				description:
 					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 			};
-			triggerFetch.mockReturnValueOnce( Promise.resolve( data ) );
+			apiFetch.mockReturnValueOnce( Promise.resolve( data ) );
 
 			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
 				data
 			);
-			expect( triggerFetch ).toBeCalledTimes( 1 );
+			expect( apiFetch ).toBeCalledTimes( 1 );
 
 			// Allow us to reassert on calls without it being polluted by first fetch
 			// but retains the mock implementation from earlier.
-			triggerFetch.mockClear();
+			apiFetch.mockClear();
 
 			// Fetch the same URL again...should be cached.
 			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
@@ -90,7 +88,7 @@ describe( 'fetchRemoteUrlData', () => {
 			);
 
 			// Should now be in cache so no need to refetch from API.
-			expect( triggerFetch ).toBeCalledTimes( 0 );
+			expect( apiFetch ).toBeCalledTimes( 0 );
 		} );
 
 		it( 'does not cache failed requests', async () => {
@@ -103,7 +101,7 @@ describe( 'fetchRemoteUrlData', () => {
 					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 			};
 
-			triggerFetch
+			apiFetch
 				.mockReturnValueOnce( Promise.reject( 'fetch failed' ) )
 				.mockReturnValueOnce( Promise.resolve( data ) );
 
@@ -117,7 +115,7 @@ describe( 'fetchRemoteUrlData', () => {
 				data
 			);
 
-			expect( triggerFetch ).toBeCalledTimes( 2 );
+			expect( apiFetch ).toBeCalledTimes( 2 );
 		} );
 	} );
 } );

--- a/packages/core-data/src/fetch/test/__experimental-fetch-remote-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-remote-url-data.js
@@ -1,0 +1,123 @@
+/**
+ * Internal dependencies
+ */
+import fetchRemoteUrlData from '../__experimental-fetch-remote-url-data';
+/**
+ * WordPress dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
+
+describe( 'fetchRemoteUrlData', () => {
+	afterEach( () => {
+		triggerFetch.mockReset();
+	} );
+
+	describe( 'return value settles as expected', () => {
+		it( 'resolves with response data upon fetch success', async () => {
+			const data = {
+				title: 'Lorem ipsum dolor',
+				icon: '',
+				image: '',
+				description:
+					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+			};
+			triggerFetch.mockReturnValueOnce( Promise.resolve( data ) );
+
+			await expect(
+				fetchRemoteUrlData( 'https://www.wordpress.org' )
+			).resolves.toEqual( data );
+
+			expect( triggerFetch ).toBeCalledTimes( 1 );
+		} );
+
+		it( 'rejects with error upon fetch failure', async () => {
+			triggerFetch.mockReturnValueOnce(
+				Promise.reject( 'fetch failed' )
+			);
+
+			await expect(
+				fetchRemoteUrlData( 'https://www.wordpress.org/1' )
+			).rejects.toEqual( 'fetch failed' );
+		} );
+	} );
+
+	describe( 'interaction with underlying fetch API', () => {
+		it( 'passes options argument through to fetch API', async () => {
+			triggerFetch.mockReturnValueOnce( Promise.resolve() );
+
+			await fetchRemoteUrlData( 'https://www.wordpress.org/2', {
+				method: 'POST',
+			} );
+
+			expect( triggerFetch ).toBeCalledTimes( 1 );
+
+			const argsPassedToFetchApi = triggerFetch.mock.calls[ 0 ][ 0 ];
+
+			expect( argsPassedToFetchApi ).toEqual(
+				expect.objectContaining( {
+					method: 'POST',
+				} )
+			);
+		} );
+	} );
+
+	describe( 'client side caching', () => {
+		it( 'caches repeat requests to same url', async () => {
+			const targetUrl = 'https://www.wordpress.org/3';
+			const data = {
+				title: 'Lorem ipsum dolor',
+				icon: '',
+				image: '',
+				description:
+					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+			};
+			triggerFetch.mockReturnValueOnce( Promise.resolve( data ) );
+
+			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
+				data
+			);
+			expect( triggerFetch ).toBeCalledTimes( 1 );
+
+			// Allow us to reassert on calls without it being polluted by first fetch
+			// but retains the mock implementation from earlier.
+			triggerFetch.mockClear();
+
+			// Fetch the same URL again...should be cached.
+			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
+				data
+			);
+
+			// Should now be in cache so no need to refetch from API.
+			expect( triggerFetch ).toBeCalledTimes( 0 );
+		} );
+
+		it( 'does not cache failed requests', async () => {
+			const targetUrl = 'https://www.wordpress.org/4';
+			const data = {
+				title: 'Lorem ipsum dolor',
+				icon: '',
+				image: '',
+				description:
+					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+			};
+
+			triggerFetch
+				.mockReturnValueOnce( Promise.reject( 'fetch failed' ) )
+				.mockReturnValueOnce( Promise.resolve( data ) );
+
+			await expect( fetchRemoteUrlData( targetUrl ) ).rejects.toEqual(
+				'fetch failed'
+			);
+
+			// Cache should not store the previous failed fetch and should retry
+			// with a new fetch.
+			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
+				data
+			);
+
+			expect( triggerFetch ).toBeCalledTimes( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently, each time you preview an external URL an HTTP request is made to the REST API for that data. For some people this could be additional bandwidth that they don't want to expend.

To avoid this, this PR implements a very simple in-memory (only) cache on a per-URL basis.

If the URL has been previewed before for the same request then the same data-set will be returned from the local cache.

As this dataset is cached at a block editor settings level we don't loose the information between mounting/unmounting of the `<LinkControl>` component.

I'm not feeling great about burdening the block editor settings with yet more rich preview related code so any suggestions or improvements are most welcome.


Fixes https://github.com/WordPress/gutenberg/issues/32554

## How has this been tested?

* Create a post.
* Create some links to a mixture of URLs both internal and external.
* OPen up Network panel.
* Click on a link. See HTTP request to REST API for data.
* Click away and then click back to the same link. You should not see another HTTP request but you should still see the rich preview.
* For internal links you should continue to see no rich preview and everything should be "as was". 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
