### PR TITLE
components: Stop modifying the parent context and correctly memoize it

### DIFF
--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -10,10 +10,11 @@ import {
 	createContext,
 	useContext,
 	useRef,
-	useState,
+	useEffect,
+	useMemo,
 	memo,
 } from '@wordpress/element';
-import { useIsomorphicLayoutEffect } from '@wordpress/compose';
+import warn from '@wordpress/warning';
 
 export const ComponentsContext = createContext(
 	/** @type {Record<string, any>} */ ( {} )
@@ -21,7 +22,26 @@ export const ComponentsContext = createContext(
 export const useComponentsContext = () => useContext( ComponentsContext );
 
 /**
+ * Runs an effect only on update (i.e., ignores the first render)
+ *
+ * @param {import('react').EffectCallback} effect
+ * @param {import('react').DependencyList} deps
+ */
+function useUpdateEffect( effect, deps ) {
+	const mounted = useRef( false );
+	useEffect( () => {
+		if ( mounted.current ) {
+			return effect();
+		}
+		mounted.current = true;
+		return undefined;
+	}, deps );
+}
+
+/**
  * Consolidates incoming ContextSystem values with a (potential) parent ContextSystem value.
+ *
+ * Note: This function will warn if it detects an un-memoized `value`
  *
  * @param {Object}              props
  * @param {Record<string, any>} props.value
@@ -29,36 +49,32 @@ export const useComponentsContext = () => useContext( ComponentsContext );
  */
 function useContextSystemBridge( { value } ) {
 	const parentContext = useComponentsContext();
-	const parentContextRef = useRef( parentContext );
-	const valueRef = useRef( merge( cloneDeep( parentContext ), value ) );
 
-	const [ config, setConfig ] = useState( valueRef.current );
+	const valueRef = useRef( value );
 
-	useIsomorphicLayoutEffect( () => {
-		let hasChange = false;
-
-		if ( ! isEqual( value, valueRef.current ) ) {
-			valueRef.current = value;
-			hasChange = true;
+	useUpdateEffect( () => {
+		if (
+			// objects are equivalent
+			isEqual( valueRef.current, value ) &&
+			// but not the same reference
+			valueRef.current !== value
+		) {
+			warn( `Please memoize your context: ${ JSON.stringify( value ) }` );
 		}
+	}, [ parentContext, value ] );
 
-		if ( ! isEqual( parentContext, parentContextRef.current ) ) {
-			valueRef.current = merge(
-				cloneDeep( parentContext ),
-				valueRef.current
-			);
-			parentContextRef.current = parentContext;
-			hasChange = true;
-		}
-
-		if ( hasChange ) {
-			setConfig( ( prev ) => ( { ...prev, ...valueRef.current } ) );
-		}
-	}, [ value, parentContext ] );
+	// parent context will always be memoized or the default value (which will not change)
+	// so this memoization will prevent `merge` and `cloneDeep` from rerunning unless
+	// the referneces to value change. The `useUpdateEffect` above will ensure that we are
+	// correctly warning when the `value` isn't being properly memoized. All of that to say
+	// that this should be super safe to assume that `useMemo` will only run on actual
+	// changes to the two dependencies, therefore saving us calls to `merge` and `cloneDeep`!
+	const config = useMemo( () => {
+		return merge( cloneDeep( parentContext ), value );
+	}, [ parentContext, value ] );
 
 	return config;
 }
-
 /**
  * A Provider component that can modify props for connected components within
  * the Context system.

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -75,6 +75,7 @@ function useContextSystemBridge( { value } ) {
 
 	return config;
 }
+
 /**
  * A Provider component that can modify props for connected components within
  * the Context system.

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, merge } from 'lodash';
+import { isEqual, merge, cloneDeep } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,7 @@ export const useComponentsContext = () => useContext( ComponentsContext );
 function useContextSystemBridge( { value } ) {
 	const parentContext = useComponentsContext();
 	const parentContextRef = useRef( parentContext );
-	const valueRef = useRef( merge( parentContext, value ) );
+	const valueRef = useRef( merge( cloneDeep( parentContext ), value ) );
 
 	const [ config, setConfig ] = useState( valueRef.current );
 
@@ -43,7 +43,10 @@ function useContextSystemBridge( { value } ) {
 		}
 
 		if ( ! isEqual( parentContext, parentContextRef.current ) ) {
-			valueRef.current = merge( parentContext, valueRef.current );
+			valueRef.current = merge(
+				cloneDeep( parentContext ),
+				valueRef.current
+			);
 			parentContextRef.current = parentContext;
 			hasChange = true;
 		}

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -63,9 +63,15 @@ function useContextSystemBridge( { value } ) {
 		}
 	}, [ value ] );
 
-	// parent context will always be memoized or the default value (which will not change)
+	// `parentContext` will always be memoized (i.e., the result of this hook itself)
+	// or the default value from when the `ComponentsContext` was originally
+	// initialized (which will never change, it's a static variable)
 	// so this memoization will prevent `merge` and `cloneDeep` from rerunning unless
-	// the referneces to value change. The `useUpdateEffect` above will ensure that we are
+	// the references to `value` change OR the `parentContext` has an actual material change
+	// (because again, it's guaranteed to be memoized or a static reference to the empty object
+	// so we know that the only changes for `parentContext` are material ones... i.e., why we
+	// don't have to warn in the `useUpdateEffect` hook above for `parentContext` and we only
+	// need to bother with the `value`). The `useUpdateEffect` above will ensure that we are
 	// correctly warning when the `value` isn't being properly memoized. All of that to say
 	// that this should be super safe to assume that `useMemo` will only run on actual
 	// changes to the two dependencies, therefore saving us calls to `merge` and `cloneDeep`!

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -61,7 +61,7 @@ function useContextSystemBridge( { value } ) {
 		) {
 			warn( `Please memoize your context: ${ JSON.stringify( value ) }` );
 		}
-	}, [ parentContext, value ] );
+	}, [ value ] );
 
 	// parent context will always be memoized or the default value (which will not change)
 	// so this memoization will prevent `merge` and `cloneDeep` from rerunning unless


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This fixes a bug in the `ContextSystemProvider` where the parent context was being modified by the `merge` function which is not a pure function (hello lodash 😱). By cloning the parent context we ensure that it will not be modified and therefore spread throughout the app.

To test this apply this patch to https://github.com/WordPress/gutenberg/pull/32743 and ensure that you can no longer reproduce the bug described by @ciampo.

Note: if this becomes a performance concern we can always switch to using the `deepmerge` package which exports a pure function. It's very fast and very small dependency. May be worth it if we find this to be a perf issue.

## How has this been tested?
Apply the patch to the PR described above.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
