### PR TITLE
Add 'area' key to function doc for `gutenberg_get_block_templates`

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -291,6 +291,7 @@ function _gutenberg_build_template_result_from_post( $post ) {
  *
  *     @type array  $slug__in List of slugs to include.
  *     @type int    $wp_id Post ID of customized template.
+ *     @type string $area A 'wp_template_part_area' taxonomy value to filter by.
  * }
  * @param array $template_type wp_template or wp_template_part.
  *

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -291,7 +291,7 @@ function _gutenberg_build_template_result_from_post( $post ) {
  *
  *     @type array  $slug__in List of slugs to include.
  *     @type int    $wp_id Post ID of customized template.
- *     @type string $area A 'wp_template_part_area' taxonomy value to filter by.
+ *     @type string $area A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
  * }
  * @param array $template_type wp_template or wp_template_part.
  *

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -290,8 +290,8 @@ function _gutenberg_build_template_result_from_post( $post ) {
  *     Optional. Arguments to retrieve templates.
  *
  *     @type array  $slug__in List of slugs to include.
- *     @type int    $wp_id Post ID of customized template.
- *     @type string $area A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
+ *     @type int    $wp_id    Post ID of customized template.
+ *     @type string $area     A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
  * }
  * @param array $template_type wp_template or wp_template_part.
  *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Adds the `area` key for the `query` param to the docblock for `gutenberg_get_block_templates` function.  I forgot to add this previously in https://github.com/WordPress/gutenberg/pull/28410

