### PR TITLE
Avoid flash of background color when scrolling in safari

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -85,7 +85,3 @@
 		bottom: 0;
 	}
 }
-
-.edit-post-layout .interface-interface-skeleton__content {
-	background-color: $gray-800;
-}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -3,6 +3,11 @@
 	display: flex;
 	flex-flow: column;
 
+	// Gray preview overlay (desktop/tablet/mobile) is intentionally not set on an element with scrolling content like
+	// interface-interface-skeleton__content. This causes graphical glitches (flashes of the background color)
+	// when scrolling in Safari due to incorrect ordering of large compositing layers (GPU acceleration).
+	background-color: $gray-800;
+
 	// The button element easily inherits styles that are meant for the editor style.
 	// These rules enhance the specificity to reduce that inheritance.
 	// This is duplicated in edit-site.


### PR DESCRIPTION
In Safari when we scroll we can see a flash of background color that's set on `.edit-post-layout .interface-interface-skeleton__content`. **I set it to pink in the before video to make this more apparent**. This background color is intended to be used while in device preview/template mode.

**Changes in this PR move this background color rule to a different div that is not a compositing layer**. It looks like there may be a Safari browser bug around ordering (or general slowness) with mixing hardware accelerated elements and non-accelerated elements.

**This fix targets the background flashing behavior only in Safari**. There's a separate exploratory PR to remove the text flashing issues in https://github.com/WordPress/gutenberg/pull/32824

#### Extra Debugging Notes:
* --webkit-overflow-scrolling:touch is added by default in Safari when there’s a scroll area, such as (overflow:scroll or overflow:auto)
* We cannot unset --webkit-overflow-scrolling 😭. (This is shown as an invalid property in dev tools, but will still show up as a compositing reason in the layers tab).
* --webkit-overflow-scrolling:touch is a compositing reason. It creates a new layer to be sent off to the GPU to render. This is fine, but when this layer gets too large(and likely hits GPU memory limits, we see glitches like incorrect ordering of elements.)
* With the same content and code, we can trigger or not trigger these glitches based on how large the compositing layer is. For example by resizing the browser window smaller, or [changing the font size](https://github.com/WordPress/gutenberg/pull/32747#issuecomment-862741600).

Before:

https://user-images.githubusercontent.com/1270189/122275769-ed81f500-ce98-11eb-9534-edc6b4417b54.mp4

After:

https://user-images.githubusercontent.com/1270189/123001520-ac408800-d365-11eb-9dbd-7658ea41a571.mp4

### Testing Instructions
- In trunk+Safari verify that the grey/black flashing appears when scrolling. It's easier to trigger this with a post with gallery content.
- In this branch verify that the flashing no longer occurs. No regressions when modifying templates or previewing with tablet or mobile.