### PR TITLE
Fix apparent overflow in Customizer caused by widgets editor

### DIFF
--- a/packages/customize-widgets/src/controls/style.scss
+++ b/packages/customize-widgets/src/controls/style.scss
@@ -1,9 +1,11 @@
 // Additional ids and class names are used in the selector for
 // added specificity.
 #customize-theme-controls .customize-pane-child.customize-widgets__sidebar-section {
-	// Override the default 'overflow' to allow the
-	// editor toolbars to be sticky.
-	overflow: unset;
+	// Override the `overflow` to allow the editor toolbars to be sticky.
+	// Applied with `.open` to keep overflow hidden in outer customize panes.
+	&.open {
+		overflow: unset;
+	}
 
 	// Make the entire sidebar background white.
 	min-height: 100%;


### PR DESCRIPTION
A simple styling change to fix #32437 

## How has this been tested?
Manually, trying to reproduce the linked issue.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
