### PR TITLE
wp-env: Show `--help` when no subcommand is passed.

### DIFF
--- a/packages/env/bin/wp-env
+++ b/packages/env/bin/wp-env
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
 'use strict';
-require( '../lib/cli' )().parse( process.argv.slice( 2 ) );
+const command = process.argv.slice( 2 );
+require( '../lib/cli' )().parse( command.length ? command : [ '--help' ] );


### PR DESCRIPTION

## Description

`$ wp-env` does not show anything.

I think it is better to show help when no subcommand is passed, like npm or wp-cli.

## How has this been tested?

Run `npm run wp-env`. And check if it shows the same as `npm run wp-env -- -help`.

## Types of changes

New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
