### PR TITLE
Disable "FSE" blocks in Widgets Editor

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -22,7 +22,7 @@ import './filters';
 
 const { wp } = window;
 
-const DISABLED_BLOCKS = [ 'core/more', 'core/freeform' ];
+const DISABLED_BLOCKS = [ 'core/more', 'core/block', 'core/freeform' ];
 const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 
 /**

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -22,6 +22,9 @@ import './filters';
 
 const { wp } = window;
 
+const DISABLED_BLOCKS = [ 'core/more', 'core/freeform' ];
+const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
+
 /**
  * Initializes the widgets block editor in the customizer.
  *
@@ -29,13 +32,20 @@ const { wp } = window;
  * @param {Object} blockEditorSettings Block editor settings.
  */
 export function initialize( editorName, blockEditorSettings ) {
-	const coreBlocks = __experimentalGetCoreBlocks().filter(
-		( block ) => ! [ 'core/more', 'core/freeform' ].includes( block.name )
-	);
+	const coreBlocks = __experimentalGetCoreBlocks().filter( ( block ) => {
+		return ! (
+			DISABLED_BLOCKS.includes( block.name ) ||
+			block.name.startsWith( 'core/post' ) ||
+			block.name.startsWith( 'core/query' ) ||
+			block.name.startsWith( 'core/site' )
+		);
+	} );
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks();
+		__experimentalRegisterExperimentalCoreBlocks( {
+			enableFSEBlocks: ENABLE_EXPERIMENTAL_FSE_BLOCKS,
+		} );
 	}
 	registerLegacyWidgetVariations( blockEditorSettings );
 

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -24,6 +24,7 @@ import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 import { store as editWidgetsStore } from '../../store';
+import { ALLOW_REUSABLE_BLOCKS } from '../../constants';
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
@@ -43,10 +44,9 @@ export default function WidgetAreasBlockEditorProvider( {
 			),
 			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
 			widgets: select( editWidgetsStore ).getWidgets(),
-			reusableBlocks: select( coreStore ).getEntityRecords(
-				'postType',
-				'wp_block'
-			),
+			reusableBlocks: ALLOW_REUSABLE_BLOCKS
+				? select( coreStore ).getEntityRecords( 'postType', 'wp_block' )
+				: [],
 			isFixedToolbarActive: select(
 				editWidgetsStore
 			).__unstableIsFeatureActive( 'fixedToolbar' ),

--- a/packages/edit-widgets/src/constants.js
+++ b/packages/edit-widgets/src/constants.js
@@ -1,0 +1,1 @@
+export const ALLOW_REUSABLE_BLOCKS = false;

--- a/packages/edit-widgets/src/constants.js
+++ b/packages/edit-widgets/src/constants.js
@@ -1,1 +1,2 @@
 export const ALLOW_REUSABLE_BLOCKS = false;
+export const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -28,7 +28,7 @@ import { ALLOW_REUSABLE_BLOCKS } from './constants';
 
 const DISABLED_BLOCKS = [
 	'core/more',
-    'core/freeform',
+	'core/freeform',
 	...( ! ALLOW_REUSABLE_BLOCKS && [ 'core/block' ] ),
 ];
 const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -26,6 +26,7 @@ import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
 
 const DISABLED_BLOCKS = [ 'core/more', 'core/freeform' ];
+const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 
 /**
  * Initializes the block editor in the widgets screen.
@@ -37,15 +38,18 @@ export function initialize( id, settings ) {
 	const coreBlocks = __experimentalGetCoreBlocks().filter( ( block ) => {
 		return ! (
 			DISABLED_BLOCKS.includes( block.name ) ||
-			block.name.startsWith( 'core/post-' ) ||
-			block.name.startsWith( 'core/query' )
+			block.name.startsWith( 'core/post' ) ||
+			block.name.startsWith( 'core/query' ) ||
+			block.name.startsWith( 'core/site' )
 		);
 	} );
 
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks();
+		__experimentalRegisterExperimentalCoreBlocks( {
+			enableFSEBlocks: ENABLE_EXPERIMENTAL_FSE_BLOCKS,
+		} );
 	}
 	registerLegacyWidgetVariations( settings );
 	registerBlock( widgetArea );

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -24,14 +24,16 @@ import './store';
 import './filters';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
-import { ALLOW_REUSABLE_BLOCKS } from './constants';
+import {
+	ALLOW_REUSABLE_BLOCKS,
+	ENABLE_EXPERIMENTAL_FSE_BLOCKS,
+} from './constants';
 
-const DISABLED_BLOCKS = [
+const disabledBlocks = [
 	'core/more',
 	'core/freeform',
 	...( ! ALLOW_REUSABLE_BLOCKS && [ 'core/block' ] ),
 ];
-const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 
 /**
  * Initializes the block editor in the widgets screen.
@@ -42,7 +44,7 @@ const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 export function initialize( id, settings ) {
 	const coreBlocks = __experimentalGetCoreBlocks().filter( ( block ) => {
 		return ! (
-			DISABLED_BLOCKS.includes( block.name ) ||
+			disabledBlocks.includes( block.name ) ||
 			block.name.startsWith( 'core/post' ) ||
 			block.name.startsWith( 'core/query' ) ||
 			block.name.startsWith( 'core/site' )

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -25,6 +25,8 @@ import './filters';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
 
+const DISABLED_BLOCKS = [ 'core/more', 'core/freeform' ];
+
 /**
  * Initializes the block editor in the widgets screen.
  *
@@ -32,9 +34,14 @@ import Layout from './components/layout';
  * @param {Object} settings Block editor settings.
  */
 export function initialize( id, settings ) {
-	const coreBlocks = __experimentalGetCoreBlocks().filter(
-		( block ) => ! [ 'core/more', 'core/freeform' ].includes( block.name )
-	);
+	const coreBlocks = __experimentalGetCoreBlocks().filter( ( block ) => {
+		return ! (
+			DISABLED_BLOCKS.includes( block.name ) ||
+			block.name.startsWith( 'core/post-' ) ||
+			block.name.startsWith( 'core/query' )
+		);
+	} );
+
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -25,7 +25,7 @@ import './filters';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
 
-const DISABLED_BLOCKS = [ 'core/more', 'core/freeform' ];
+const DISABLED_BLOCKS = [ 'core/more', 'core/freeform', 'core/block' ];
 const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 
 /**

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -24,8 +24,13 @@ import './store';
 import './filters';
 import * as widgetArea from './blocks/widget-area';
 import Layout from './components/layout';
+import { ALLOW_REUSABLE_BLOCKS } from './constants';
 
-const DISABLED_BLOCKS = [ 'core/more', 'core/freeform', 'core/block' ];
+const DISABLED_BLOCKS = [
+	'core/more',
+    'core/freeform',
+	...( ! ALLOW_REUSABLE_BLOCKS && [ 'core/block' ] ),
+];
 const ENABLE_EXPERIMENTAL_FSE_BLOCKS = false;
 
 /**
@@ -55,6 +60,7 @@ export function initialize( id, settings ) {
 	registerBlock( widgetArea );
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
 		fetchLinkSuggestions( search, searchOptions, settings );
+
 	render(
 		<Layout blockEditorSettings={ settings } />,
 		document.getElementById( id )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently FSE blocks don't play well with the Widgets Editor because the required entities aren't there. Moreover, we'd need to support the multi-saving flows/UI from the Site Editor in order to support these blocks.

For 5.8 we could consider disabling all "FSE" blocks. This PR does just that.

It doesn't mean we go with this approach, but this PR allows it to be an option.

Fixes https://github.com/WordPress/gutenberg/issues/32756

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
