### PR TITLE
Customize Widgets: Fix block toolbar deselection when clicking scrollbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -16,11 +16,6 @@
 	transition: border-color 0.1s linear, box-shadow 0.1s linear;
 	@include reduce-motion("transition");
 
-	// Allow overflow on desktop.
-	@include break-small() {
-		overflow: inherit;
-	}
-
 	// Borders around toolbar segments.
 	.components-toolbar-group,
 	.components-toolbar {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -16,6 +16,10 @@
 	transition: border-color 0.1s linear, box-shadow 0.1s linear;
 	@include reduce-motion("transition");
 
+	@include break-small() {
+		overflow: inherit;
+	}
+
 	// Borders around toolbar segments.
 	.components-toolbar-group,
 	.components-toolbar {

--- a/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
+++ b/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
@@ -52,8 +52,8 @@ export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
 				}
 			}
 
-			// Handle focusing in the same document.
-			function handleFocus( event ) {
+			// Handle mouse down in the same document.
+			function handleMouseDown( event ) {
 				handleClearSelectedBlock( event.target );
 			}
 			// Handle focusing outside the current document, like to iframes.
@@ -61,11 +61,14 @@ export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
 				handleClearSelectedBlock( ownerDocument.activeElement );
 			}
 
-			ownerDocument.addEventListener( 'focusin', handleFocus );
+			ownerDocument.addEventListener( 'mousedown', handleMouseDown );
 			ownerWindow.addEventListener( 'blur', handleBlur );
 
 			return () => {
-				ownerDocument.removeEventListener( 'focusin', handleFocus );
+				ownerDocument.removeEventListener(
+					'mousedown',
+					handleMouseDown
+				);
 				ownerWindow.removeEventListener( 'blur', handleBlur );
 			};
 		}


### PR DESCRIPTION
## Description
Fixes https://core.trac.wordpress.org/ticket/53400

With scrollbars set to show 'always' in Mac OS, trying to drag the scrollbar on the top block toolbar resulted in a block deselection.

This PR also fixes the vertical scrollbar that shows sometimes in the top toolbar mode

## How has this been tested?
1. In Mac OS general preferences, set toolbars to always show.
2. Go to customize widgets and enable top toolbar mode
3. Add a paragraph
4. Try dragging the horizontal scrollbar on the block toolbar


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
