### PR TITLE
Generate classes and custom properties for global styles in the same way the post editor does

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -757,7 +757,7 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
 				$declarations[] = array(
-					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenbeng_experimental_to_kebab_case( $slug ),
+					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),
 					'value' => $value,
 				);
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -723,7 +723,7 @@ class WP_Theme_JSON_Gutenberg {
 						array(
 							array(
 								'name'  => $class['property_name'],
-								'value' => 'var(--wp--preset--' . $preset['css_var_infix'] . "--" . gutenberg_experimental_to_kebab_case( $slug ) . ") !important",
+								'value' => 'var(--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ) . ') !important',
 							),
 						)
 					);

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -723,7 +723,7 @@ class WP_Theme_JSON_Gutenberg {
 						array(
 							array(
 								'name'  => $class['property_name'],
-								'value' => 'var(--wp--preset--' . $preset['css_var_infix'] . "--$slug) !important",
+								'value' => 'var(--wp--preset--' . $preset['css_var_infix'] . "--" . gutenberg_experimental_to_kebab_case( $slug ) . ") !important",
 							),
 						)
 					);
@@ -757,7 +757,7 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
 				$declarations[] = array(
-					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $slug,
+					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenbeng_experimental_to_kebab_case( $slug ),
 					'value' => $value,
 				);
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -719,7 +719,7 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $preset['classes'] as $class ) {
 				foreach ( $preset_by_slug as $slug => $value ) {
 					$stylesheet .= self::to_ruleset(
-						self::append_to_selector( $selector, '.has-' . $slug . '-' . $class['class_suffix'] ),
+						self::append_to_selector( $selector, '.has-' . gutenberg_experimental_to_kebab_case( $slug ) . '-' . $class['class_suffix'] ),
 						array(
 							array(
 								'name'  => $class['property_name'],

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -63,3 +63,30 @@ function gutenberg_experimental_set( &$array, $path, $value = null ) {
 	}
 	$array[ $path[ $i ] ] = $value;
 }
+
+/**
+ * This function is trying to replicate what
+ * lodash's kebabCase (JS library) does in the client.
+ *
+ * The reason for that is that we do some processing
+ * in both the client and the server (e.g.: we generate
+ * preset classes from preset slugs) that needs to
+ * behave the same.
+ *
+ * Due to backward compatibility we need to keep the
+ * client's library as it is, hence, we have to
+ * make the server behave like the client.
+ *
+ * @param string $string The string to kebab-case.
+ *
+ * @return string kebab-cased-string.
+ */
+function gutenberg_experimental_to_kebab_case( $string ) {
+	$regexp = '#'.implode('|', [
+		'[a-z]?[A-Z]+',
+		'[A-Z]?[a-z]+',
+		'\d+',
+	]).'#';
+	preg_match_all( $regexp, $string, $matches );
+	return implode( '-', $matches[0] );
+}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -68,25 +68,72 @@ function gutenberg_experimental_set( &$array, $path, $value = null ) {
  * This function is trying to replicate what
  * lodash's kebabCase (JS library) does in the client.
  *
- * The reason for that is that we do some processing
+ * The reason we need this function is that we do some processing
  * in both the client and the server (e.g.: we generate
  * preset classes from preset slugs) that needs to
- * behave the same.
+ * create the same output.
  *
- * Due to backward compatibility we need to keep the
- * client's library as it is, hence, we have to
- * make the server behave like the client.
+ * We can't remove or update the client's library due to backward compatibility
+ * (some of the output of lodash's kebabCaseare saved in the post content).
+ * We have to make the server behave like the client.
+ *
+ * @link https://github.com/lodash/lodash/blob/4.17/dist/lodash.js#L14369
+ * @link https://github.com/lodash/lodash/blob/4.17/dist/lodash.js#L278
+ * @link https://github.com/lodash-php/lodash-php/blob/master/src/String/kebabCase.php
+ * @link https://github.com/lodash-php/lodash-php/blob/master/src/internal/unicodeWords.php
  *
  * @param string $string The string to kebab-case.
  *
  * @return string kebab-cased-string.
  */
 function gutenberg_experimental_to_kebab_case( $string ) {
-	$regexp = '#'.implode('|', [
-		'[a-z]?[A-Z]+',
-		'[A-Z]?[a-z]+',
-		'\d+',
-	]).'#';
-	preg_match_all( $regexp, $string, $matches );
-	return implode( '-', $matches[0] );
+	//phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	// ignore the camelCase names for variables so the names are the same as lodash
+	// so comparing and porting new changes is easier.
+
+	/*
+	 * Some notable things we've removed compared to the lodash version are:
+	 *
+	 * - non-alphanumeric characters: rsAstralRange, rsEmoji, etc
+	 * - the groups that processed the apostrophe, as it's removed before passing the string to preg_match: rsApos, rsOptContrLower, and rsOptContrUpper
+	 *
+	 */
+
+	/** Used to compose unicode character classes. */
+	$rsLowerRange       = 'a-z\\xdf-\\xf6\\xf8-\\xff';
+	$rsNonCharRange     = '\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf';
+	$rsPunctuationRange = '\\x{2000}-\\x{206f}';
+	$rsSpaceRange       = ' \\t\\x0b\\f\\xa0\\x{feff}\\n\\r\\x{2028}\\x{2029}\\x{1680}\\x{180e}\\x{2000}\\x{2001}\\x{2002}\\x{2003}\\x{2004}\\x{2005}\\x{2006}\\x{2007}\\x{2008}\\x{2009}\\x{200a}\\x{202f}\\x{205f}\\x{3000}';
+	$rsUpperRange       = 'A-Z\\xc0-\\xd6\\xd8-\\xde';
+	$rsBreakRange       = $rsNonCharRange . $rsPunctuationRange . $rsSpaceRange;
+
+	/** Used to compose unicode capture groups. */
+	$rsBreak  = '[' . $rsBreakRange . ']';
+	$rsDigits = '\\d+'; // The last lodash version in GitHub uses a single digit here and expands it when in use.
+	$rsLower  = '[' . $rsLowerRange . ']';
+	$rsMisc   = '[^' . $rsBreakRange . $rsDigits . $rsLowerRange . $rsUpperRange . ']';
+	$rsUpper  = '[' . $rsUpperRange . ']';
+
+	/** Used to compose unicode regexes. */
+	$rsMiscLower = '(?:' . $rsLower . '|' . $rsMisc . ')';
+	$rsMiscUpper = '(?:' . $rsUpper . '|' . $rsMisc . ')';
+	$rsOrdLower  = '\\d*(?:1st|2nd|3rd|(?![123])\\dth)(?=\\b|[A-Z_])';
+	$rsOrdUpper  = '\\d*(?:1ST|2ND|3RD|(?![123])\\dTH)(?=\\b|[a-z_])';
+
+	$regexp = '/' . implode(
+		'|',
+		array(
+			$rsUpper . '?' . $rsLower . '+' . '(?=' . implode( '|', array( $rsBreak, $rsUpper, '$' ) ) . ')',
+			$rsMiscUpper . '+' . '(?=' . implode( '|', array( $rsBreak, $rsUpper . $rsMiscLower, '$' ) ) . ')',
+			$rsUpper . '?' . $rsMiscLower . '+',
+			$rsUpper . '+',
+			$rsOrdUpper,
+			$rsOrdLower,
+			$rsDigits,
+		)
+	) . '/u';
+
+	preg_match_all( $regexp, str_replace( "'", '', $string ), $matches );
+	return strtolower( implode( '-', $matches[0] ) );
+	//phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 }

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -57,7 +57,9 @@ function getPresetsDeclarations( blockPresets = {} ) {
 				if ( presetByOrigin[ origin ] ) {
 					presetByOrigin[ origin ].forEach( ( value ) => {
 						declarations.push(
-							`--wp--preset--${ cssVarInfix }--${ value.slug }: ${ value[ valueKey ] }`
+							`--wp--preset--${ cssVarInfix }--${ kebabCase(
+								value.slug
+							) }: ${ value[ valueKey ] }`
 						);
 					} );
 				}
@@ -93,7 +95,9 @@ function getPresetsClasses( blockSelector, blockPresets = {} ) {
 								slug
 							) }-${ classSuffix }`;
 							const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
-							const value = `var(--wp--preset--${ cssVarInfix }--${ slug })`;
+							const value = `var(--wp--preset--${ cssVarInfix }--${ kebabCase(
+								slug
+							) })`;
 							declarations += `${ selectorToUse }{${ propertyName }: ${ value } !important;}`;
 						} );
 					} );

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -89,7 +89,9 @@ function getPresetsClasses( blockSelector, blockPresets = {} ) {
 				if ( presetByOrigin[ origin ] ) {
 					presetByOrigin[ origin ].forEach( ( { slug } ) => {
 						classes.forEach( ( { classSuffix, propertyName } ) => {
-							const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
+							const classSelectorToUse = `.has-${ kebabCase(
+								slug
+							) }-${ classSuffix }`;
 							const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
 							const value = `var(--wp--preset--${ cssVarInfix }--${ slug })`;
 							declarations += `${ selectorToUse }{${ propertyName }: ${ value } !important;}`;

--- a/phpunit/class-gutenberg-utils-test.php
+++ b/phpunit/class-gutenberg-utils-test.php
@@ -124,8 +124,29 @@ class Gutenberg_Utils_Test extends WP_UnitTestCase {
 
 	public function test_gutenberg_experimental_to_kebab_case() {
 		$this->assertEquals( 'white', gutenberg_experimental_to_kebab_case( 'white' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white+black' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white:black' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white*black' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white.black' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white black' ) );
+		$this->assertEquals( 'white-black', gutenberg_experimental_to_kebab_case( 'white	black' ) );
+		$this->assertEquals( 'white-to-black', gutenberg_experimental_to_kebab_case( 'white-to-black' ) );
 		$this->assertEquals( 'white-2-white', gutenberg_experimental_to_kebab_case( 'white2white' ) );
 		$this->assertEquals( 'white-2nd', gutenberg_experimental_to_kebab_case( 'white2nd' ) );
+		$this->assertEquals( 'white-2-ndcolor', gutenberg_experimental_to_kebab_case( 'white2ndcolor' ) );
+		$this->assertEquals( 'white-2nd-color', gutenberg_experimental_to_kebab_case( 'white2ndColor' ) );
+		$this->assertEquals( 'white-2nd-color', gutenberg_experimental_to_kebab_case( 'white2nd_color' ) );
+		$this->assertEquals( 'white-23-color', gutenberg_experimental_to_kebab_case( 'white23color' ) );
+		$this->assertEquals( 'white-23', gutenberg_experimental_to_kebab_case( 'white23' ) );
+		$this->assertEquals( '23-color', gutenberg_experimental_to_kebab_case( '23color' ) );
+		$this->assertEquals( 'white-4th', gutenberg_experimental_to_kebab_case( 'white4th' ) );
+		$this->assertEquals( 'font-2-xl', gutenberg_experimental_to_kebab_case( 'font2xl' ) );
 		$this->assertEquals( 'white-to-white', gutenberg_experimental_to_kebab_case( 'whiteToWhite' ) );
+		$this->assertEquals( 'white-t-owhite', gutenberg_experimental_to_kebab_case( 'whiteTOwhite' ) );
+		$this->assertEquals( 'whit-eto-white', gutenberg_experimental_to_kebab_case( 'WHITEtoWHITE' ) );
+		$this->assertEquals( '42', gutenberg_experimental_to_kebab_case( 42 ) );
+		$this->assertEquals( 'ive-done', gutenberg_experimental_to_kebab_case( "i've done" ) );
+		$this->assertEquals( 'ffffff', gutenberg_experimental_to_kebab_case( '#ffffff' ) );
+		$this->assertEquals( 'ffffff', gutenberg_experimental_to_kebab_case( '$ffffff' ) );
 	}
 }

--- a/phpunit/class-gutenberg-utils-test.php
+++ b/phpunit/class-gutenberg-utils-test.php
@@ -121,4 +121,11 @@ class Gutenberg_Utils_Test extends WP_UnitTestCase {
 			array( 'a' => 2 )
 		);
 	}
+
+	public function test_gutenberg_experimental_to_kebab_case() {
+		$this->assertEquals( 'white', gutenberg_experimental_to_kebab_case( 'white' ) );
+		$this->assertEquals( 'white-2-white', gutenberg_experimental_to_kebab_case( 'white2white' ) );
+		$this->assertEquals( 'white-2nd', gutenberg_experimental_to_kebab_case( 'white2nd' ) );
+		$this->assertEquals( 'white-to-white', gutenberg_experimental_to_kebab_case( 'whiteToWhite' ) );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/32347

We generate CSS classes for presets in a few places -post editor, site editor, server- and we need them to behave all the same. This PR explores porting lodash's `kebabCase` to the server. It's also applied to the names of the CSS Custom Properties for coherence.

## Background

This is the second take to fix https://github.com/WordPress/gutenberg/issues/32347 We first tried to remove lodash's `kebabCase` function in the client at https://github.com/WordPress/gutenberg/pull/32352 but that caused some issues and had to revert the original PR at https://github.com/WordPress/gutenberg/pull/32742

## How to test

In the front end:

- Install and activate the TT1-blocks theme.
- Modify the slugs of some presets (e.g.: `settings.color.palette`) in its `theme.json` to contain edge cases (see [this table](https://github.com/WordPress/gutenberg/issues/32347) and the tests at [class-gutenberg-utils-test.php](https://github.com/WordPress/gutenberg/pull/32766/files#diff-d8cdcf4e9cd388491123407e06c9c6255e5cef261d0df658a99afcbef8fdb4c2R125) for inspiration). For example, set a slug to `black23white`.
- Load the front-end and verify the classes in the `global-styles-inline-css` style tag are generated properly as well as the CSS Custom Properties. Following the example above, you should find the `--wp--preset--color--black-23-white` var and the classes `has-black-23-white-color`, etc.

In the site editor:

- Install and activate the TT1-blocks theme.
- Modify the slugs of some presets (e.g.: `settings.color.palette`) in its `theme.json` to contain edge cases (see [this table](https://github.com/WordPress/gutenberg/issues/32347) and the tests at [class-gutenberg-utils-test.php](https://github.com/WordPress/gutenberg/pull/32766/files#diff-d8cdcf4e9cd388491123407e06c9c6255e5cef261d0df658a99afcbef8fdb4c2R125) for inspiration). For example, set a slug to `black23white`.
- Go to the site editor and search for that class. You should find it in one unnamed embedded style tag. Following the example above you should find the `--wp--preset--color--black-23-white` var and the classes `has-black-23-white-color`, etc.
