### PR TITLE
Try: Safari 13 fix round 2.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -17,6 +17,11 @@
 	line-height: initial;
 	color: initial;
 
+	// Many themes with white backgrounds load editor styles but fail to also provide
+	// an explicit white background color, assuming a white editing canvas.
+	// So to match browser defaults, we provide a white default here as well.
+	background: #fff;
+
 	// For full-wide blocks, we compensate for the base padding.
 	// These margins should match the padding value above.
 	.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -119,7 +119,7 @@ export default function VisualEditor( { styles } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
-		minHeight: '100%',
+		height: '100%',
 		width: '100%',
 		margin: 0,
 		display: 'flex',

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -61,9 +61,7 @@
 
 .edit-post-visual-editor__content-area {
 	width: 100%;
-	// If this is set to height: 100%; it breaks in Safari 13, which calculates the height relatively to the incorrect flex container.
-	// By setting it as a min-height instead, it appears to work in all cases.
-	min-height: 100%;
+	height: 100%;
 	position: relative;
 	display: flex;
 }


### PR DESCRIPTION
## Description

In #32581 I pushed a fix targetting an older flexbox interpretation by Safari 13. In my testing, that worked. But a followup suggests it wasn't enough, or that a new issue emerged.

This PR fixes that. I tested using Browserstack and reproduced by adding more content than was visible in the viewport:

<img width="1940" alt="Screenshot 2021-06-17 at 12 14 05" src="https://user-images.githubusercontent.com/1204802/122379390-1e306000-cf67-11eb-8ff9-ae4bdea88f20.png">

In this GIF I demonstrate what adding `height: 100%;` back does to fix it. I'm not entirely sure why it worked before without the height, but it appears to be neded now.

![test](https://user-images.githubusercontent.com/1204802/122379748-6d769080-cf67-11eb-90ea-f48e2b9ba901.gif)

## To test

Ideally test in browserstack, or a Safari 13 instance. Test an old theme, like TwentyNineteen. Test with no content on the page, test with a lot of content in the page, and verify you don't see any dark gray backgrounds.

Also test in modern browsers and verify no regressions there either.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
