### PR TITLE
Add an API to define the default template used for the template mode

### DIFF
--- a/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/post-editor-template-mode.test.js.snap
@@ -1,19 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Post Editor Template mode Allow creating custom block templates in classic themes 1`] = `
-"<h1 class=\\"wp-block-site-title\\"><a href=\\"http://localhost:8889\\" rel=\\"home\\">gutenberg</a></h1>
+"<a class=\\"skip-link screen-reader-text\\" href=\\"#wp--skip-link--target\\">Skip to content</a>
+<header class=\\"wp-block-group\\"><h1 class=\\"wp-block-site-title\\"><a href=\\"http://localhost:8889\\" rel=\\"home\\">gutenberg</a></h1>
 
-<p class=\\"wp-block-site-tagline\\">Just another WordPress site</p>
+<p class=\\"wp-block-site-tagline\\">Just another WordPress site</p></header>
+
 
 
 <hr class=\\"wp-block-separator\\">
 
 
-<h2 class=\\"wp-block-post-title\\">Another FSE Post</h2>
+
+<main class=\\"wp-block-group\\" id=\\"wp--skip-link--target\\">
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><div class=\\"wp-block-group__inner-container\\"><div class=\\"wp-block-group__inner-container\\"><h2 class=\\"wp-block-post-title\\">Another FSE Post</h2></div></div></div></div>
+
 
 <div class=\\"entry-content wp-block-post-content\\">
 <p>Hello World</p>
-</div>
+</div></main>
+
 
 
 <p>Just a random paragraph added to the template</p>

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -87,13 +87,40 @@ function PostTemplateActions() {
 							const newTemplateContent =
 								defaultTemplate ??
 								serialize( [
-									createBlock( 'core/site-title' ),
-									createBlock( 'core/site-tagline' ),
+									createBlock(
+										'core/group',
+										{
+											tagName: 'header',
+											layout: { inherit: true },
+										},
+										[
+											createBlock( 'core/site-title' ),
+											createBlock( 'core/site-tagline' ),
+										]
+									),
 									createBlock( 'core/separator' ),
-									createBlock( 'core/post-title' ),
-									createBlock( 'core/post-content', {
-										layout: { inherit: true },
-									} ),
+									createBlock(
+										'core/group',
+										{
+											tagName: 'main',
+										},
+										[
+											createBlock(
+												'core/group',
+												{
+													layout: { inherit: true },
+												},
+												[
+													createBlock(
+														'core/post-title'
+													),
+												]
+											),
+											createBlock( 'core/post-content', {
+												layout: { inherit: true },
+											} ),
+										]
+									),
 								] );
 
 							__unstableSwitchToTemplateMode( {


### PR DESCRIPTION
closes #32752 

We got some feedback that it would be great to have the possibility to define a default template to be used for the template mode for themes. This PR solves that by using a new editor setting:

you can do this:

```php
add_filter( 'block_editor_settings_all', function( $settings ) {
    $settings['defaultBlockTemplate'] = "<!-- wp:paragraph -->
<p>This is a random template</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph -->";

	return $settings;
});
```

or use a file

```php
add_filter( 'block_editor_settings_all', function( $settings ) {
    $settings['defaultBlockTemplate'] = file_get_contents( get_theme_file_path( 'block-template-default.html' ) );
    return $settings;
});
```