### PR TITLE
[RNMobile] Upgrade react-native-modal and other warning fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14599,6 +14599,17 @@
 				"react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#83c4e7c16b704c7706339341b22434b29f0b27d6",
 				"react-native-url-polyfill": "^1.1.2",
 				"react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#e74bb901f37f86a8842232468b43c9cbaedb6aa4"
+			},
+			"dependencies": {
+				"react-native-modal": {
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-11.10.0.tgz",
+					"integrity": "sha512-syRYDJYSh16bR37R5EKU9T/wC+5bEOfF17IUqf5URdhbEDd+hxyMInC++l45E8oI+MtdOaEp9yAws5xDqk8dnA==",
+					"requires": {
+						"prop-types": "^15.6.2",
+						"react-native-animatable": "1.3.3"
+					}
+				}
 			}
 		},
 		"@wordpress/readable-js-assets-webpack-plugin": {
@@ -50368,15 +50379,6 @@
 		"react-native-linear-gradient": {
 			"version": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7",
 			"from": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7"
-		},
-		"react-native-modal": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-6.5.0.tgz",
-			"integrity": "sha512-ewchdETAGd32xLGLK93NETEGkRcePtN7ZwjmLSQnNW1Zd0SRUYE8NqftjamPyfKvK0i2DZjX4YAghGZTqaRUbA==",
-			"requires": {
-				"prop-types": "^15.6.1",
-				"react-native-animatable": "^1.2.4"
-			}
 		},
 		"react-native-prompt-android": {
 			"version": "git+https://github.com/wordpress-mobile/react-native-prompt-android.git#6406b77d0162262c868bcbbaa0766bfafbf43742",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50370,12 +50370,12 @@
 			"from": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7"
 		},
 		"react-native-modal": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-6.5.0.tgz",
-			"integrity": "sha512-ewchdETAGd32xLGLK93NETEGkRcePtN7ZwjmLSQnNW1Zd0SRUYE8NqftjamPyfKvK0i2DZjX4YAghGZTqaRUbA==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-11.10.0.tgz",
+			"integrity": "sha512-syRYDJYSh16bR37R5EKU9T/wC+5bEOfF17IUqf5URdhbEDd+hxyMInC++l45E8oI+MtdOaEp9yAws5xDqk8dnA==",
 			"requires": {
-				"prop-types": "^15.6.1",
-				"react-native-animatable": "^1.2.4"
+				"prop-types": "^15.6.2",
+				"react-native-animatable": "1.3.3"
 			}
 		},
 		"react-native-prompt-android": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14599,17 +14599,6 @@
 				"react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#83c4e7c16b704c7706339341b22434b29f0b27d6",
 				"react-native-url-polyfill": "^1.1.2",
 				"react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#e74bb901f37f86a8842232468b43c9cbaedb6aa4"
-			},
-			"dependencies": {
-				"react-native-modal": {
-					"version": "11.10.0",
-					"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-11.10.0.tgz",
-					"integrity": "sha512-syRYDJYSh16bR37R5EKU9T/wC+5bEOfF17IUqf5URdhbEDd+hxyMInC++l45E8oI+MtdOaEp9yAws5xDqk8dnA==",
-					"requires": {
-						"prop-types": "^15.6.2",
-						"react-native-animatable": "1.3.3"
-					}
-				}
 			}
 		},
 		"@wordpress/readable-js-assets-webpack-plugin": {
@@ -50379,6 +50368,15 @@
 		"react-native-linear-gradient": {
 			"version": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7",
 			"from": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7"
+		},
+		"react-native-modal": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-6.5.0.tgz",
+			"integrity": "sha512-ewchdETAGd32xLGLK93NETEGkRcePtN7ZwjmLSQnNW1Zd0SRUYE8NqftjamPyfKvK0i2DZjX4YAghGZTqaRUbA==",
+			"requires": {
+				"prop-types": "^15.6.1",
+				"react-native-animatable": "^1.2.4"
+			}
 		},
 		"react-native-prompt-android": {
 			"version": "git+https://github.com/wordpress-mobile/react-native-prompt-android.git#6406b77d0162262c868bcbbaa0766bfafbf43742",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14589,7 +14589,7 @@
 				"react-native-hsv-color-picker": "git+https://github.com/wordpress-mobile/react-native-hsv-color-picker.git#dfe4d06595fefc9b4d48ce0ced029076c80dab74",
 				"react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#6febe4faf7ff51579087bac105f62be8e4c4015d",
 				"react-native-linear-gradient": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7",
-				"react-native-modal": "^6.5.0",
+				"react-native-modal": "^11.10.0",
 				"react-native-prompt-android": "git+https://github.com/wordpress-mobile/react-native-prompt-android.git#6406b77d0162262c868bcbbaa0766bfafbf43742",
 				"react-native-reanimated": "git+https://github.com/wordpress-mobile/react-native-reanimated.git#047ae6064e2bcfdaeb1f25d1d38157359ba96cb6",
 				"react-native-safe-area": "^0.5.0",

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -6,7 +6,7 @@ import { Animated, Easing, View, Platform } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { ToolbarButton, Toolbar } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -83,7 +83,7 @@ const FloatingToolbar = ( {
 				pointerEvents={ showFloatingToolbar ? 'auto' : 'none' }
 			>
 				{ showNavUpButton && (
-					<Toolbar passedStyle={ styles.toolbar }>
+					<ToolbarGroup passedStyle={ styles.toolbar }>
 						<ToolbarButton
 							title={ __( 'Navigate Up' ) }
 							onClick={
@@ -93,7 +93,7 @@ const FloatingToolbar = ( {
 							icon={ <NavigateUpSVG isRTL={ isRTL } /> }
 						/>
 						<View style={ styles.pipe } />
-					</Toolbar>
+					</ToolbarGroup>
 				) }
 				<BlockSelectionButton
 					clientId={ blockSelectionButtonClientId }

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -83,7 +83,10 @@ const FloatingToolbar = ( {
 				pointerEvents={ showFloatingToolbar ? 'auto' : 'none' }
 			>
 				{ showNavUpButton && (
-					<Toolbar passedStyle={ styles.toolbar }>
+					<Toolbar
+						label={ __( 'Options' ) }
+						passedStyle={ styles.toolbar }
+					>
 						<ToolbarButton
 							title={ __( 'Navigate Up' ) }
 							onClick={

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -83,10 +83,7 @@ const FloatingToolbar = ( {
 				pointerEvents={ showFloatingToolbar ? 'auto' : 'none' }
 			>
 				{ showNavUpButton && (
-					<Toolbar
-						label={ __( 'Options' ) }
-						passedStyle={ styles.toolbar }
-					>
+					<Toolbar passedStyle={ styles.toolbar }>
 						<ToolbarButton
 							title={ __( 'Navigate Up' ) }
 							onClick={

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -171,7 +171,7 @@ export class Inserter extends Component {
 	}
 
 	onInserterToggledAnnouncement( isOpen ) {
-		AccessibilityInfo.fetch().done( ( isEnabled ) => {
+		AccessibilityInfo.isScreenReaderEnabled().done( ( isEnabled ) => {
 			if ( isEnabled ) {
 				const isIOS = Platform.OS === 'ios';
 				const announcement = isOpen

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -23,7 +23,7 @@ export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 		return null;
 	}
 	return (
-		<Toolbar>
+		<Toolbar label={ __( 'Options' ) }>
 			<ToolbarButton
 				title={ __( 'Ungroup' ) }
 				icon={ UngroupIcon }

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -23,7 +23,7 @@ export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 		return null;
 	}
 	return (
-		<Toolbar label={ __( 'Options' ) }>
+		<Toolbar>
 			<ToolbarButton
 				title={ __( 'Ungroup' ) }
 				icon={ UngroupIcon }

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
-import { Toolbar, ToolbarButton } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -23,13 +23,13 @@ export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 		return null;
 	}
 	return (
-		<Toolbar>
+		<ToolbarGroup>
 			<ToolbarButton
 				title={ __( 'Ungroup' ) }
 				icon={ UngroupIcon }
 				onClick={ onConvertFromGroup }
 			/>
-		</Toolbar>
+		</ToolbarGroup>
 	);
 }
 

--- a/packages/components/src/focal-point-picker/index.native.js
+++ b/packages/components/src/focal-point-picker/index.native.js
@@ -92,10 +92,10 @@ function FocalPointPicker( props ) {
 					pan.extractOffset(); // Set offset to current value
 				},
 				// Move cursor to match delta drag
-				onPanResponderMove: Animated.event( [
-					null,
-					{ dx: pan.x, dy: pan.y },
-				] ),
+				onPanResponderMove: Animated.event(
+					[ null, { dx: pan.x, dy: pan.y } ],
+					{ useNativeDriver: false }
+				),
 				onPanResponderRelease: ( event ) => {
 					shouldEnableBottomSheetScroll( true );
 					pan.flattenOffset(); // Flatten offset into value

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -495,7 +495,7 @@ class BottomSheet extends Component {
 				backdropOpacity={ 0.2 }
 				onBackdropPress={ this.onCloseBottomSheet }
 				onBackButtonPress={ this.onHardwareButtonPress }
-				onSwipe={ this.onCloseBottomSheet }
+				onSwipeComplete={ this.onCloseBottomSheet }
 				onDismiss={ Platform.OS === 'ios' ? this.onDismiss : undefined }
 				onModalHide={
 					Platform.OS === 'android' ? this.onDismiss : undefined

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -16,7 +16,7 @@ import {
 	BlockToolbar,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Toolbar, ToolbarButton } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import {
 	keyboardClose,
 	undo as undoIcon,
@@ -94,7 +94,7 @@ function HeaderToolbar( {
 				<BlockToolbar />
 			</ScrollView>
 			{ showKeyboardHideButton && (
-				<Toolbar passedStyle={ styles.keyboardHideContainer }>
+				<ToolbarGroup passedStyle={ styles.keyboardHideContainer }>
 					<ToolbarButton
 						title={ __( 'Hide keyboard' ) }
 						icon={ keyboardClose }
@@ -103,7 +103,7 @@ function HeaderToolbar( {
 							hint: __( 'Tap to hide the keyboard' ),
 						} }
 					/>
-				</Toolbar>
+				</ToolbarGroup>
 			) }
 		</View>
 	);

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -94,10 +94,7 @@ function HeaderToolbar( {
 				<BlockToolbar />
 			</ScrollView>
 			{ showKeyboardHideButton && (
-				<Toolbar
-					label={ __( 'Options' ) }
-					passedStyle={ styles.keyboardHideContainer }
-				>
+				<Toolbar passedStyle={ styles.keyboardHideContainer }>
 					<ToolbarButton
 						title={ __( 'Hide keyboard' ) }
 						icon={ keyboardClose }

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -94,7 +94,10 @@ function HeaderToolbar( {
 				<BlockToolbar />
 			</ScrollView>
 			{ showKeyboardHideButton && (
-				<Toolbar passedStyle={ styles.keyboardHideContainer }>
+				<Toolbar
+					label={ __( 'Options' ) }
+					passedStyle={ styles.keyboardHideContainer }
+				>
 					<ToolbarButton
 						title={ __( 'Hide keyboard' ) }
 						icon={ keyboardClose }

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -24,7 +24,7 @@ export default class VisualEditor extends Component {
 		};
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		this.keyboardDidShow = Keyboard.addListener(
 			'keyboardDidShow',
 			this.keyboardDidShow

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -457,7 +457,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: b2d297a15cf094d1947df4f0519779bb3a7f2392
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 420ad7ff87adc491b45199891c72ea531fa4926e
+  FBReactNativeSpec: c59a3cde8d0336ac8239c33e89e70a0daa170d2b
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Gutenberg: 829c1db189c6f47728327bb1503026f42698cdb6
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
@@ -475,9 +475,9 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 03edb8dcc2d3f43e55aa67ea13b61b6723bbf047
   react-native-keyboard-aware-scroll-view: 6cb84879bf07e4cc1caed18b11fb928e142adac6
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: e471852c5ed67eea4b10c5d9d43c1cebae3b231d
+  react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
   react-native-slider: 2e42dc91e7ab8b35a9c7f2eb3532729a41d0dbe2
-  react-native-video: e5dd0649534076cd6d09a0db51c617fa668d534a
+  react-native-video: b8767f54061e475ddd38c22375f46f4d93e5fdfd
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -491,7 +491,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
   ReactNativeDarkMode: 6d807bc8373b872472c8541fc3341817d979a6fb
-  RNCMaskedView: dfeba59697c44d36abec79c062aeb1ea343d610d
+  RNCMaskedView: 66caacf33c86eaa7d22b43178dd998257d5c2e4d
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -457,7 +457,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: b2d297a15cf094d1947df4f0519779bb3a7f2392
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: c59a3cde8d0336ac8239c33e89e70a0daa170d2b
+  FBReactNativeSpec: 420ad7ff87adc491b45199891c72ea531fa4926e
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Gutenberg: 829c1db189c6f47728327bb1503026f42698cdb6
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
@@ -475,9 +475,9 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 03edb8dcc2d3f43e55aa67ea13b61b6723bbf047
   react-native-keyboard-aware-scroll-view: 6cb84879bf07e4cc1caed18b11fb928e142adac6
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
+  react-native-safe-area-context: e471852c5ed67eea4b10c5d9d43c1cebae3b231d
   react-native-slider: 2e42dc91e7ab8b35a9c7f2eb3532729a41d0dbe2
-  react-native-video: b8767f54061e475ddd38c22375f46f4d93e5fdfd
+  react-native-video: e5dd0649534076cd6d09a0db51c617fa668d534a
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -491,7 +491,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
   ReactNativeDarkMode: 6d807bc8373b872472c8541fc3341817d979a6fb
-  RNCMaskedView: 66caacf33c86eaa7d22b43178dd998257d5c2e4d
+  RNCMaskedView: dfeba59697c44d36abec79c062aeb1ea343d610d
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -62,7 +62,7 @@
 		"react-native-hsv-color-picker": "git+https://github.com/wordpress-mobile/react-native-hsv-color-picker#dfe4d06595fefc9b4d48ce0ced029076c80dab74",
 		"react-native-keyboard-aware-scroll-view": "git+https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git#6febe4faf7ff51579087bac105f62be8e4c4015d",
 		"react-native-linear-gradient": "git+https://github.com/wordpress-mobile/react-native-linear-gradient.git#deafc7a7b3dcfdc2a2d8327b5727cb393f1cabf7",
-		"react-native-modal": "^6.5.0",
+		"react-native-modal": "^11.10.0",
 		"react-native-prompt-android": "git+https://github.com/wordpress-mobile/react-native-prompt-android.git#6406b77d0162262c868bcbbaa0766bfafbf43742",
 		"react-native-reanimated": "git+https://github.com/wordpress-mobile/react-native-reanimated.git#047ae6064e2bcfdaeb1f25d1d38157359ba96cb6",
 		"react-native-safe-area": "^0.5.0",

--- a/patches/metro+0.64.0.patch
+++ b/patches/metro+0.64.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js b/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+index 5f32fc5..2b80fda 100644
+--- a/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
++++ b/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+@@ -346,7 +346,7 @@ class UnableToResolveError extends Error {
+     try {
+       file = fs.readFileSync(this.originModulePath, "utf8");
+     } catch (error) {
+-      if (error.code === "ENOENT") {
++      if (error.code === "ENOENT" || error.code === 'EISDIR') {
+         // We're probably dealing with a virtualised file system where
+         // `this.originModulePath` doesn't actually exist on disk.
+         // We can't show a code frame, but there's no need to let this I/O


### PR DESCRIPTION
Bumping the `react-native-modal` version we use to fix the "Animated.event now requires a second argument for options" log caused by using a fairly old version of the lib.

Took the opportunity to fix more warnings too, see the "Changes" list below.

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3630

## How has this been tested?
* Run the demo app and the various bottom-sheet based UIs should work (e.g. the block picker, the block settings sheet)
* The warning logs should stop happening

## Types of changes
* Upgrading a library to fix the logs mentioning an function signature mispatch. No actual breakage was noticed.
* Updating some code sites that use deprecated functions

## Changes

1. Update `react-native-modal` to remove the "Animated.event now requires a second argument for options" message in the logs when the app starts.
2. Stop using deprecated `Modal.onSwipe` and start using `Modal.onSwipeComplete` as [per the message](https://github.com/react-native-modal/react-native-modal/blob/b580105f4b2b4e1163bed1228f241b16ea17dacb/src/modal.tsx#L268-L272).
3. Stop using deprecated `AccessibilityInfo.fetch` and start using `AccessibilityInfo.isScreenReaderEnabled` as [per this note](https://github.com/facebook/react-native/blob/v0.64.0/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js#L94-L99).
4. Replaced deprecated `componentWillUnmount` with `componentDidMount1`. Ensured that the [original fix](https://github.com/WordPress/gutenberg/pull/28352) still works.
5. The nested `react-native-editor/Podfile.lock` got updated when I ran `npm run core ios` in gutenberg-mobile, not sure if the changes there are warranted 🤔 
6. Replaced some uses of label-less `Toolbar` instances as that format is deprecated. Used `ToolbarGroup` instead, as recommended by the doc. Seems to work fine, while [my attempt to add labels](https://github.com/WordPress/gutenberg/pull/32772/commits/d6cf2f8f098b61a71c2dfb0718f2f6a032ecf25c) actually led to the keyboard dismiss button to get misplaced.
7. Metro [patch](https://github.com/WordPress/gutenberg/pull/32772/commits/170e4dcefa880f2acaf62a936a862a7926d4c65f) to make a warning go away. The same fix is already applied to Metro but RN doesn't have that Metro version yet. See [upstream PR here](https://github.com/facebook/metro/pull/567).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
