### PR TITLE
Unit control Utils: update JS Docs and add basic test coverage

### DIFF
--- a/packages/components/src/unit-control/test/utils.js
+++ b/packages/components/src/unit-control/test/utils.js
@@ -11,6 +11,7 @@ describe( 'UnitControl utils', () => {
 				availableUnits: [ 'em', 'px' ],
 				units: cssUnits,
 			} );
+
 			expect( units ).toEqual( [ { value: 'px' } ] );
 		} );
 
@@ -21,6 +22,7 @@ describe( 'UnitControl utils', () => {
 				defaultValues: { '%': 10, px: 10 },
 				units: cssUnits,
 			} );
+
 			expect( units ).toEqual( [
 				{ value: 'px', default: 10 },
 				{ value: '%', default: 10 },
@@ -34,6 +36,7 @@ describe( 'UnitControl utils', () => {
 				defaultValues: { '%': 10, px: 10 },
 				units: cssUnits,
 			} );
+
 			expect( units ).toBe( false );
 		} );
 	} );
@@ -42,6 +45,7 @@ describe( 'UnitControl utils', () => {
 		it( 'should return filtered units array', () => {
 			const preferredUnits = [ '%', 'px' ];
 			const availableUnits = [ { value: 'px' }, { value: 'em' } ];
+
 			expect(
 				filterUnitsWithSettings( preferredUnits, availableUnits )
 			).toEqual( [ { value: 'px' } ] );
@@ -50,6 +54,7 @@ describe( 'UnitControl utils', () => {
 		it( 'should return empty array where preferred units match no available css unit', () => {
 			const preferredUnits = [ '%', 'px' ];
 			const availableUnits = [ { value: 'em' } ];
+
 			expect(
 				filterUnitsWithSettings( preferredUnits, availableUnits )
 			).toEqual( [] );

--- a/packages/components/src/unit-control/test/utils.js
+++ b/packages/components/src/unit-control/test/utils.js
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { filterUnitsWithSettings, useCustomUnits } from '../utils';
+
+describe( 'UnitControl utils', () => {
+	describe( 'useCustomUnits', () => {
+		it( 'should return filtered css units', () => {
+			const cssUnits = [ { value: 'px' }, { value: '%' } ];
+			const units = useCustomUnits( {
+				availableUnits: [ 'em', 'px' ],
+				units: cssUnits,
+			} );
+			expect( units ).toEqual( [ { value: 'px' } ] );
+		} );
+
+		it( 'should add default values to available units', () => {
+			const cssUnits = [ { value: 'px' }, { value: '%' } ];
+			const units = useCustomUnits( {
+				availableUnits: [ '%', 'px' ],
+				defaultValues: { '%': 10, px: 10 },
+				units: cssUnits,
+			} );
+			expect( units ).toEqual( [
+				{ value: 'px', default: 10 },
+				{ value: '%', default: 10 },
+			] );
+		} );
+
+		it( 'should return `false` where availableUnits match no preferred css units', () => {
+			const cssUnits = [ { value: 'em' }, { value: 'vh' } ];
+			const units = useCustomUnits( {
+				availableUnits: [ '%', 'px' ],
+				defaultValues: { '%': 10, px: 10 },
+				units: cssUnits,
+			} );
+			expect( units ).toBe( false );
+		} );
+	} );
+
+	describe( 'filterUnitsWithSettings', () => {
+		it( 'should return filtered units array', () => {
+			const preferredUnits = [ '%', 'px' ];
+			const availableUnits = [ { value: 'px' }, { value: 'em' } ];
+			expect(
+				filterUnitsWithSettings( preferredUnits, availableUnits )
+			).toEqual( [ { value: 'px' } ] );
+		} );
+
+		it( 'should return empty array where preferred units match no available css unit', () => {
+			const preferredUnits = [ '%', 'px' ];
+			const availableUnits = [ { value: 'em' } ];
+			expect(
+				filterUnitsWithSettings( preferredUnits, availableUnits )
+			).toEqual( [] );
+		} );
+	} );
+} );

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -249,7 +249,7 @@ export function parseA11yLabelForUnit( unit ) {
  *
  * @return {Array} Filtered units based on settings.
  */
-function filterUnitsWithSettings( settings = [], units = [] ) {
+export function filterUnitsWithSettings( settings = [], units = [] ) {
 	return units.filter( ( unit ) => {
 		return settings.includes( unit.value );
 	} );
@@ -260,12 +260,12 @@ function filterUnitsWithSettings( settings = [], units = [] ) {
  * TODO: ideally this hook shouldn't be needed
  * https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823
  *
- * @param {Object} args                An object containing units, settingPath & defaultUnits.
- * @param {Object} args.units          Collection of available units.
- * @param {string} args.availableUnits The setting path. Defaults to 'spacing.units'.
- * @param {Object} args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
+ * @param {Object} args                                  An object containing units, settingPath & defaultUnits.
+ * @param {Array<Object>|undefined} args.units           Collection of available units.
+ * @param {Array<string>|undefined} args.availableUnits  The setting path. Defaults to 'spacing.units'.
+ * @param {Object|undefined}        args.defaultValues   Collection of default values for defined units. Example: { px: '350', em: '15' }.
  *
- * @return {Array} Filtered units based on settings.
+ * @return {Array|boolean} Filtered units based on settings.
  */
 export const useCustomUnits = ( { units, availableUnits, defaultValues } ) => {
 	units = units || ALL_CSS_UNITS;


### PR DESCRIPTION
## Description
The JS Docs defining the argument property types for `useCustomUnits()` did not match examples of usage, where some properties were `undefined`.

Examples:

[font-size-picker/index.js](https://github.com/WordPress/gutenberg/blob/9df736c678b2e8ef00c355e6cc9fb8092fe25484/packages/components/src/font-size-picker/index.js#L80)

```js
	const units = useCustomUnits( {
		availableUnits: [ 'px', 'em', 'rem' ],
	} );
```

This was causing Type warnings.


This commit updates the param and return types to reflect current usage and adds some basic test coverage.

The types in the JS Doc describing objects are still not super specific, but this PR aims only to remove the warning for now.

## How has this been tested?

`npm run test-unit packages/components/src/unit-control/test/utils.js`

## Screenshots <!-- if applicable -->

## Types of changes

No code changes. We're only updating documentation and adding unit tests.
