### PR TITLE
Safari 13, another try

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -119,7 +119,6 @@ export default function VisualEditor( { styles } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
-		minHeight: '100%',
 		width: '100%',
 		margin: 0,
 		display: 'flex',


### PR DESCRIPTION
See #32767 for the bulk.

The difference in this one is that it removes both height and min-height values, and in one session testing TT1 fixed both the issue of very little content and very much content for me.

It's a curious issue, and worth testing in at least a few themes with both lots and little content.