### PR TITLE
Fix drag and drop indices when block list contains a style element

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -43,11 +43,6 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 	let candidateDistance;
 
 	elements.forEach( ( element, index ) => {
-		// Ensure the element is a block. It should have the `wp-block` class.
-		if ( ! element.classList.contains( 'wp-block' ) ) {
-			return;
-		}
-
 		const rect = element.getBoundingClientRect();
 		const [ distance, edge ] = getDistanceToNearestEdge(
 			position,
@@ -106,9 +101,8 @@ export default function useBlockDropZone( {
 	const throttled = useThrottle(
 		useCallback( ( event, currentTarget ) => {
 			const blockElements = Array.from( currentTarget.children ).filter(
-				( element ) => {
-					return element.nodeName !== 'STYLE';
-				}
+				// Ensure the element is a block. It should have the `wp-block` class.
+				( element ) => element.classList.contains( 'wp-block' )
 			);
 			const targetIndex = getNearestBlockIndex(
 				blockElements,

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -105,7 +105,11 @@ export default function useBlockDropZone( {
 	const onBlockDrop = useOnBlockDrop( targetRootClientId, targetBlockIndex );
 	const throttled = useThrottle(
 		useCallback( ( event, currentTarget ) => {
-			const blockElements = Array.from( currentTarget.children );
+			const blockElements = Array.from( currentTarget.children ).filter(
+				( element ) => {
+					return element.nodeName !== 'STYLE';
+				}
+			);
 			const targetIndex = getNearestBlockIndex(
 				blockElements,
 				{ x: event.clientX, y: event.clientY },

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -83,22 +83,6 @@ describe( 'getNearestBlockIndex', () => {
 		expect( result ).toBeUndefined();
 	} );
 
-	it( 'returns `undefined` if the elements do not have the `wp-block` class', () => {
-		const nonBlockElements = [
-			{ classList: createMockClassList( 'some-other-class' ) },
-		];
-		const position = { x: 0, y: 0 };
-		const orientation = 'horizontal';
-
-		const result = getNearestBlockIndex(
-			nonBlockElements,
-			position,
-			orientation
-		);
-
-		expect( result ).toBeUndefined();
-	} );
-
 	describe( 'Vertical block lists', () => {
 		const orientation = 'vertical';
 


### PR DESCRIPTION
## Description
Recently `<style>` elements started appearing block lists. This caused an issue with drag and drop, which expected only block elements in block lists. When these style elements appeared, they would result in the drop index being offset incorrectly.

This fixes by filtering style elements out of the list of elements to be considered to be blocks.

## How has this been tested?
1. Add a couple of image blocks, a group block with a paragraph in it, and a couple more image blocks (the group block creates a style element).
2. Drag the first image block over the last two image blocks
3. Note that in `trunk` the wrong drop target shows, but in this branch the correct one shows.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
