### PR TITLE
Build Workflow: Avoid double zip for plugin files

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -179,9 +179,7 @@ jobs:
               run: ./bin/build-plugin-zip.sh
               env:
                   NO_CHECKS: 'true'
-
-            - name: Unzip Gutenberg plugin files
-              run: unzip gutenberg.zip -d gutenberg
+                  NO_ZIP: 'true'
 
             - name: Upload artifact
               uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -180,11 +180,14 @@ jobs:
               env:
                   NO_CHECKS: 'true'
 
+            - name: Unzip Gutenberg plugin files
+              run: unzip gutenberg.zip -d gutenberg
+
             - name: Upload artifact
               uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
               with:
-                  name: gutenberg-plugin
-                  path: ./gutenberg.zip
+                  name: gutenberg
+                  path: gutenberg/
 
             - name: Build release notes draft
               if: ${{ needs.bump-version.outputs.new_version }}
@@ -266,10 +269,13 @@ jobs:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
               run: echo ::set-output name=version::$(echo $VERSION | cut -d / -f 3 | sed 's/-rc./ RC/' )
 
-            - name: Download Plugin Zip Artifact
+            - name: Download Plugin Artifact Files
               uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8
               with:
-                  name: gutenberg-plugin
+                  name: gutenberg
+
+            - name: Create Plugin Zip
+              run: zip -r gutenberg.zip *
 
             - name: Download Release Notes Artifact
               uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -182,7 +182,7 @@ jobs:
                   NO_ZIP: 'true'
 
             - name: Upload artifact
-              uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
+              uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
               with:
                   name: gutenberg
                   path: gutenberg/
@@ -205,7 +205,7 @@ jobs:
 
             - name: Upload release notes artifact
               if: ${{ needs.bump-version.outputs.new_version }}
-              uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
+              uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
               with:
                   name: release-notes
                   path: ./release-notes.txt
@@ -268,7 +268,7 @@ jobs:
               run: echo ::set-output name=version::$(echo $VERSION | cut -d / -f 3 | sed 's/-rc./ RC/' )
 
             - name: Download Plugin Artifact Files
-              uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8
+              uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2.1.0
               with:
                   name: gutenberg
 
@@ -276,7 +276,7 @@ jobs:
               run: zip -r gutenberg.zip *
 
             - name: Download Release Notes Artifact
-              uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843 # v2.0.8
+              uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2.1.0
               with:
                   name: release-notes
 

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -120,10 +120,9 @@ build_files=$(
 	build/widgets/blocks/*/block.json \
 )
 
-
-# Generate the plugin zip file.
-status "Creating archive... 🎁"
-zip -r gutenberg.zip \
+# Copy plugin files to gutenberg/ and retain folder structure.
+mkdir gutenberg/
+rsync -Rav \
 	gutenberg.php \
 	lib \
 	packages/block-serialization-default-parser/*.php \
@@ -132,7 +131,17 @@ zip -r gutenberg.zip \
 	$build_files \
 	readme.txt \
 	changelog.txt \
-	README.md
+	README.md \
+	gutenberg/
+
+if [ -z "$NO_ZIP" ]; then
+	# Generate the plugin zip file.
+	status "Creating archive... 🎁"
+	cd gutenberg/
+	zip -r ../gutenberg.zip *
+	cd ..
+	rm -rf gutenberg/
+fi
 
 # Reset `gutenberg.php`.
 git checkout gutenberg.php


### PR DESCRIPTION
## Description

When uploading files as an artifact to a GHA workflow, GH automatically creates a zip file that includes the files. If the artifact file in question is a zip file itself (such as `gutenberg.zip`), this results in a double zip (in this case: `gutenberg-plugin.zip`, which includes `gutenberg.zip`). This is a frequent source of confusion. 

This PR fixes this issue by uploading the collection of Gutenberg plugin files that are normally included in `gutenberg.zip`, and by relying on GHA to create the zip.

The downside is that any GH job that _downloads_ the artifact will get that collection of files. For our release-draft-creation step, this means that it'll have to "manually" create the zip asset (to be attached to the release draft) itself.

## How has this been tested?

TBD