### PR TITLE
Correct the case of navigation __unstableLocation

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -43,7 +43,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"__unstable__location": {
+		"__unstableLocation": {
 			"type": "string"
 		}
 	},

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -102,7 +102,7 @@ function render_classic_location_menu( $location, $attributes ) {
 	}
 
 	$block_attributes = $attributes;
-	unset( $block_attributes['__unstable__location'] );
+	unset( $block_attributes['__unstableLocation'] );
 
 	return wp_nav_menu(
 		array(
@@ -164,8 +164,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $block->inner_blocks ) ) {
-		if ( array_key_exists( '__unstable__location', $attributes ) ) {
-			$location                 = $attributes['__unstable__location'];
+		if ( array_key_exists( '__unstableLocation', $attributes ) ) {
+			$location                 = $attributes['__unstableLocation'];
 			$maybe_classic_navigation = render_classic_location_menu( $location, $attributes );
 			if ( $maybe_classic_navigation ) {
 				return $maybe_classic_navigation;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -107,7 +107,6 @@ function render_classic_location_menu( $location, $attributes ) {
 	return wp_nav_menu(
 		array(
 			'theme_location'   => $location,
-			'block_attributes' => $block_attributes,
 			'container'        => '',
 			'items_wrap'       => '%3$s',
 			'fallback_cb'      => false,


### PR DESCRIPTION
I did not pay attention when reviewing and #32491 got merged with a wrong casing for the new `__unstableLocation` attribute. This PR fixes that.