### PR TITLE
Navigation: Update the unstable location attribute

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -43,7 +43,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"__unstable__location": {
+		"__unstableLocation": {
 			"type": "string"
 		}
 	},

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -102,12 +102,11 @@ function render_classic_location_menu( $location, $attributes ) {
 	}
 
 	$block_attributes = $attributes;
-	unset( $block_attributes['__unstable__location'] );
+	unset( $block_attributes['__unstableLocation'] );
 
 	return wp_nav_menu(
 		array(
 			'theme_location'   => $location,
-			'block_attributes' => $block_attributes,
 			'container'        => '',
 			'items_wrap'       => '%3$s',
 			'fallback_cb'      => false,
@@ -164,8 +163,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $block->inner_blocks ) ) {
-		if ( array_key_exists( '__unstable__location', $attributes ) ) {
-			$location                 = $attributes['__unstable__location'];
+		if ( array_key_exists( '__unstableLocation', $attributes ) ) {
+			$location                 = $attributes['__unstableLocation'];
 			$maybe_classic_navigation = render_classic_location_menu( $location, $attributes );
 			if ( $maybe_classic_navigation ) {
 				return $maybe_classic_navigation;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This implements a couple of changes suggested in https://github.com/WordPress/gutenberg/pull/32491

## How has this been tested?
I used this PR for Quadrat: https://github.com/Automattic/themes/pull/4070

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
