### PR TITLE
Fix: Logic error on site editor useSetting.

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -104,7 +104,7 @@ export function useSetting( path, blockName = '' ) {
 	const topLevelPath = `__experimentalFeatures.${ path }`;
 	const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ path }`;
 	const result = get( settings, blockPath ) ?? get( settings, topLevelPath );
-	if ( PATHS_WITH_MERGE[ path ] ) {
+	if ( result && PATHS_WITH_MERGE[ path ] ) {
 		return result.user ?? result.theme ?? result.core;
 	}
 	return result;


### PR DESCRIPTION
Fixes a logic error on site editor useSetting that in certain cases causes a crash.
