### PR TITLE
components: Allow for non-polymorphic components

### DIFF
--- a/packages/components/src/card/card-divider/component.js
+++ b/packages/components/src/card/card-divider/component.js
@@ -6,8 +6,8 @@ import { Divider } from '../../divider';
 import { useCardDivider } from './hook';
 
 /**
- * @param {import('../../ui/context').PolymorphicComponentProps<import('../../divider').DividerProps, 'hr'>} props
- * @param {import('react').Ref<any>}                                                                         forwardedRef
+ * @param {import('../../ui/context').PolymorphicComponentProps<import('../../divider').DividerProps, 'hr', false>} props
+ * @param {import('react').Ref<any>}                                                                                forwardedRef
  */
 function CardDivider( props, forwardedRef ) {
 	const dividerProps = useCardDivider( props );

--- a/packages/components/src/card/card-divider/hook.js
+++ b/packages/components/src/card/card-divider/hook.js
@@ -15,7 +15,7 @@ import { useContextSystem } from '../../ui/context';
 import * as styles from '../styles';
 
 /**
- * @param {import('../../ui/context').PolymorphicComponentProps<import('../../divider').DividerProps, 'hr'>} props
+ * @param {import('../../ui/context').PolymorphicComponentProps<import('../../divider').DividerProps, 'hr', false>} props
  */
 export function useCardDivider( props ) {
 	const { className, ...otherProps } = useContextSystem(

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -39,7 +39,7 @@ export interface DividerProps extends Omit< SeparatorProps, 'children' > {
 }
 
 function Divider(
-	props: PolymorphicComponentProps< DividerProps, 'hr' >,
+	props: PolymorphicComponentProps< DividerProps, 'hr', false >,
 	forwardedRef: Ref< any >
 ) {
 	const {

--- a/packages/components/src/ui/context/context-connect.js
+++ b/packages/components/src/ui/context/context-connect.js
@@ -24,12 +24,12 @@ import { getStyledClassNameFromKey } from './get-styled-class-name-from-key';
  * The hope is that we can improve render performance by removing functional
  * component wrappers.
  *
- * @template {import('./polymorphic-component').PolymorphicComponentProps<{}, any>} P
+ * @template {import('./polymorphic-component').PolymorphicComponentProps<{}, any, any>} P
  * @param {(props: P, ref: import('react').Ref<any>) => JSX.Element | null} Component            The component to register into the Context system.
  * @param {string}                                                          namespace            The namespace to register the component under.
  * @param {Object}                                                          options
  * @param {boolean}                                                         [options.memo=false]
- * @return {import('./polymorphic-component').PolymorphicComponent<import('./polymorphic-component').ElementTypeFromPolymorphicComponentProps<P>, import('./polymorphic-component').PropsFromPolymorphicComponentProps<P>>} The connected PolymorphicComponent
+ * @return {import('./polymorphic-component').PolymorphicComponentFromProps<P>} The connected PolymorphicComponent
  */
 export function contextConnect( Component, namespace, options = {} ) {
 	/* eslint-enable jsdoc/valid-types */

--- a/packages/components/src/ui/context/polymorphic-component.ts
+++ b/packages/components/src/ui/context/polymorphic-component.ts
@@ -11,24 +11,38 @@ import type * as React from 'react';
  * by `ComponentPropsWithRef`. The context is that components should require the `children`
  * prop explicitely when needed (see https://github.com/WordPress/gutenberg/pull/31817).
  */
-export type PolymorphicComponentProps< P, T extends React.ElementType > = P &
-	Omit< React.ComponentPropsWithRef< T >, 'as' | keyof P | 'children' > & {
-		as?: T | keyof JSX.IntrinsicElements;
-	};
+export type PolymorphicComponentProps<
+	P,
+	T extends React.ElementType,
+	IsPolymorphic extends boolean = true
+> = P &
+	Omit< React.ComponentPropsWithRef< T >, 'as' | keyof P | 'children' > &
+	( IsPolymorphic extends true
+		? {
+				as?: T | keyof JSX.IntrinsicElements;
+		  }
+		: { as?: never } );
 
-export type ElementTypeFromPolymorphicComponentProps<
-	P
-> = P extends PolymorphicComponentProps< unknown, infer T > ? T : never;
-
-export type PropsFromPolymorphicComponentProps<
-	P
-> = P extends PolymorphicComponentProps< infer PP, any > ? PP : never;
-
-export type PolymorphicComponent< T extends React.ElementType, O > = {
+export type PolymorphicComponent<
+	T extends React.ElementType,
+	O,
+	IsPolymorphic extends boolean
+> = {
 	< TT extends React.ElementType >(
-		props: PolymorphicComponentProps< O, TT > & { as: TT }
+		props: PolymorphicComponentProps<
+			O,
+			TT,
+			IsPolymorphic extends true ? true : false
+		> &
+			( IsPolymorphic extends true ? { as: TT } : { as: never } )
 	): JSX.Element | null;
-	( props: PolymorphicComponentProps< O, T > ): JSX.Element | null;
+	(
+		props: PolymorphicComponentProps<
+			O,
+			T,
+			IsPolymorphic extends true ? true : false
+		>
+	): JSX.Element | null;
 	displayName?: string;
 	/**
 	 * A CSS selector used to fake component interpolation in styled components
@@ -40,3 +54,9 @@ export type PolymorphicComponent< T extends React.ElementType, O > = {
 	 */
 	selector: `.${ string }`;
 };
+
+export type PolymorphicComponentFromProps<
+	Props
+> = Props extends PolymorphicComponentProps< infer P, infer T, infer I >
+	? PolymorphicComponent< T, P, I >
+	: never;

--- a/packages/components/src/ui/context/polymorphic-component.ts
+++ b/packages/components/src/ui/context/polymorphic-component.ts
@@ -29,19 +29,11 @@ export type PolymorphicComponent<
 	IsPolymorphic extends boolean
 > = {
 	< TT extends React.ElementType >(
-		props: PolymorphicComponentProps<
-			O,
-			TT,
-			IsPolymorphic extends true ? true : false
-		> &
+		props: PolymorphicComponentProps< O, TT, IsPolymorphic > &
 			( IsPolymorphic extends true ? { as: TT } : { as: never } )
 	): JSX.Element | null;
 	(
-		props: PolymorphicComponentProps<
-			O,
-			T,
-			IsPolymorphic extends true ? true : false
-		>
+		props: PolymorphicComponentProps< O, T, IsPolymorphic >
 	): JSX.Element | null;
 	displayName?: string;
 	/**

--- a/packages/components/src/ui/popover/content.js
+++ b/packages/components/src/ui/popover/content.js
@@ -60,4 +60,9 @@ function PopoverContent( props, forwardedRef ) {
 	);
 }
 
-export default contextConnect( PopoverContent, 'PopoverContent' );
+const ConnectedPopoverContent = contextConnect(
+	PopoverContent,
+	'PopoverContent'
+);
+
+export default ConnectedPopoverContent;

--- a/packages/components/src/ui/utils/create-component.tsx
+++ b/packages/components/src/ui/utils/create-component.tsx
@@ -11,16 +11,14 @@ import type { As } from 'reakit-utils/types';
 import { contextConnect } from '../context';
 // eslint-disable-next-line no-duplicate-imports
 import type {
-	PolymorphicComponent,
-	PropsFromPolymorphicComponentProps,
-	ElementTypeFromPolymorphicComponentProps,
 	PolymorphicComponentProps,
+	PolymorphicComponentFromProps,
 } from '../context';
 import { View } from '../../view';
 
 interface Options<
 	A extends As,
-	P extends PolymorphicComponentProps< {}, A >
+	P extends PolymorphicComponentProps< {}, A, any >
 > {
 	as: A;
 	name: string;
@@ -40,16 +38,13 @@ interface Options<
  */
 export const createComponent = <
 	A extends As,
-	P extends PolymorphicComponentProps< {}, A >
+	P extends PolymorphicComponentProps< {}, A, any >
 >( {
 	as,
 	name,
 	useHook,
 	memo = false,
-}: Options< A, P > ): PolymorphicComponent<
-	ElementTypeFromPolymorphicComponentProps< P >,
-	PropsFromPolymorphicComponentProps< P >
-> => {
+}: Options< A, P > ): PolymorphicComponentFromProps< P > => {
 	function Component( props: P, forwardedRef: Ref< any > ) {
 		const otherProps = useHook( props );
 

--- a/packages/components/src/view/component.js
+++ b/packages/components/src/view/component.js
@@ -20,7 +20,7 @@ import styled from '@emotion/styled';
  * }
  * ```
  *
- * @type {import('../ui/context').PolymorphicComponent<'div', { children?: import('react').ReactNode }>}
+ * @type {import('../ui/context').PolymorphicComponent<'div', { children?: import('react').ReactNode }, true>}
  */
 // @ts-ignore
 const View = styled.div``;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Simplifies some type extraction and also adds non-polymorphism.

We should probably rename all this stuff to just like "WordPressComponent" or something like that.

## How has this been tested?
Type checks pass! Also you should be able to use the `Divider` and not assign an `as` prop to it, TypeScript should error telling you that you cannot assign anything to `never`.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
