### PR TITLE
Include Legacy Widget block files in the plugin build

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -116,6 +116,8 @@ build_files=$(
 	build/block-library/blocks/*/*.css \
 	build/block-library/blocks/*/*.js \
 	build/edit-widgets/blocks/*/block.json \
+	build/widgets/blocks/*.php \
+	build/widgets/blocks/*/block.json \
 )
 
 


### PR DESCRIPTION
## Description
Updates plugin ZIP creation to include the Legacy Widget block files.

Fixes #32785.
Fixes #32795.

## How has this been tested?
1. Run `bin/build-plugin-zip.sh` in plugin directory.
2. Make sure the `widgets` package has a block directory with structure:

```
blocks/
  legecy-widget/block.json
  legacy-widget.php
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
