### PR TITLE
Remove `gutenberg` domain from Post Template block

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -103,7 +103,7 @@ add_action( 'init', 'register_block_core_post_template' );
 function render_legacy_query_loop_block( $attributes, $content, $block ) {
 	trigger_error(
 		/* translators: %1$s: Block type */
-		sprintf( __( 'Block %1$s has been renamed to Post Template. %1$s will be supported until WordPress version 5.9.', 'gutenberg' ), $block->name ),
+		sprintf( __( 'Block %1$s has been renamed to Post Template. %1$s will be supported until WordPress version 5.9.' ), $block->name ),
 		headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 	);
 	return render_block_core_post_template( $attributes, $content, $block );


### PR DESCRIPTION
This PR just removes `gutenberg` domain left from Post Template block.