### PR TITLE
Add ability to toggle bullets on and off for Latest Posts Block via new "Layout" option.

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -18,6 +18,7 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarGroup,
+	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -437,34 +438,55 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			? latestPosts.slice( 0, postsToShow )
 			: latestPosts;
 
+	function applyOrUnset( layout ) {
+		return () =>
+			setAttributes( {
+				postLayout: postLayout === layout ? undefined : layout,
+			} );
+	}
+
 	const layoutControls = [
 		{
+			layout: 'list',
 			icon: list,
 			title: __( 'List view' ),
-			onClick: () => setAttributes( { postLayout: 'list' } ),
+			onClick: applyOrUnset( 'list' ),
 			isActive: postLayout === 'list',
 		},
 		{
+			layout: 'bullet-list',
 			icon: formatListBullets,
 			title: __( 'Bullet List view' ),
-			onClick: () => setAttributes( { postLayout: 'bullet-list' } ),
+			onClick: applyOrUnset( 'bullet-list' ),
 			isActive: postLayout === 'bullet-list',
 		},
 		{
+			layout: 'grid',
 			icon: grid,
 			title: __( 'Grid view' ),
-			onClick: () => setAttributes( { postLayout: 'grid' } ),
+			onClick: applyOrUnset( 'grid' ),
 			isActive: postLayout === 'grid',
 		},
 	];
 
 	const dateFormat = __experimentalGetSettings().formats.date;
 
+	const activePostLayoutIcon =
+		layoutControls.filter( ( layout ) => layout.layout === postLayout )[ 0 ]
+			?.icon || 'list';
+
 	return (
 		<div>
 			{ inspectorControls }
 			<BlockControls>
-				<ToolbarGroup controls={ layoutControls } />
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={ activePostLayoutIcon }
+						label={ __( 'Layout' ) }
+						toggleProps={ __( 'Change layout' ) }
+						controls={ layoutControls }
+					/>
+				</ToolbarGroup>
 			</BlockControls>
 			<ul { ...blockProps }>
 				{ displayPosts.map( ( post, i ) => {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -438,7 +438,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			? latestPosts.slice( 0, postsToShow )
 			: latestPosts;
 
-	function applyOrUnset( layout ) {
+	function applyOrUnsetLayout( layout ) {
 		return () =>
 			setAttributes( {
 				postLayout: postLayout === layout ? undefined : layout,
@@ -449,22 +449,22 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		{
 			layout: 'list',
 			icon: list,
-			title: __( 'List view' ),
-			onClick: applyOrUnset( 'list' ),
+			title: __( 'List' ),
+			onClick: applyOrUnsetLayout( 'list' ),
 			isActive: postLayout === 'list',
 		},
 		{
 			layout: 'bullet-list',
 			icon: formatListBullets,
-			title: __( 'Bullet List view' ),
-			onClick: applyOrUnset( 'bullet-list' ),
+			title: __( 'Bulleted List' ),
+			onClick: applyOrUnsetLayout( 'bullet-list' ),
 			isActive: postLayout === 'bullet-list',
 		},
 		{
 			layout: 'grid',
 			icon: grid,
-			title: __( 'Grid view' ),
-			onClick: applyOrUnset( 'grid' ),
+			title: __( 'Grid' ),
+			onClick: applyOrUnsetLayout( 'grid' ),
 			isActive: postLayout === 'grid',
 		},
 	];

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -412,7 +412,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			'has-dates': displayPostDate,
 			'has-author': displayAuthor,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
-			'has-no-bullets': 'list' === postLayout,
+			'has-no-bullets': 'bullet-list' !== postLayout,
 			'has-bullets': 'bullet-list' === postLayout,
 		} ),
 	} );

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -32,7 +32,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { pin, list, grid } from '@wordpress/icons';
+import { pin, list, formatListBullets, grid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -411,6 +411,8 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			'has-dates': displayPostDate,
 			'has-author': displayAuthor,
 			[ `columns-${ columns }` ]: postLayout === 'grid',
+			'has-no-bullets': 'list' === postLayout,
+			'has-bullets': 'bullet-list' === postLayout,
 		} ),
 	} );
 
@@ -441,6 +443,12 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			title: __( 'List view' ),
 			onClick: () => setAttributes( { postLayout: 'list' } ),
 			isActive: postLayout === 'list',
+		},
+		{
+			icon: formatListBullets,
+			title: __( 'Bullet List view' ),
+			onClick: () => setAttributes( { postLayout: 'bullet-list' } ),
+			isActive: postLayout === 'bullet-list',
 		},
 		{
 			icon: grid,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -438,10 +438,10 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			? latestPosts.slice( 0, postsToShow )
 			: latestPosts;
 
-	function applyOrUnsetLayout( layout ) {
+	function applyLayout( layout ) {
 		return () =>
 			setAttributes( {
-				postLayout: postLayout === layout ? undefined : layout,
+				postLayout: layout,
 			} );
 	}
 
@@ -450,21 +450,21 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			layout: 'list',
 			icon: list,
 			title: __( 'List' ),
-			onClick: applyOrUnsetLayout( 'list' ),
+			onClick: applyLayout( 'list' ),
 			isActive: postLayout === 'list',
 		},
 		{
 			layout: 'bullet-list',
 			icon: formatListBullets,
 			title: __( 'Bulleted List' ),
-			onClick: applyOrUnsetLayout( 'bullet-list' ),
+			onClick: applyLayout( 'bullet-list' ),
 			isActive: postLayout === 'bullet-list',
 		},
 		{
 			layout: 'grid',
 			icon: grid,
 			title: __( 'Grid' ),
-			onClick: applyOrUnsetLayout( 'grid' ),
+			onClick: applyLayout( 'grid' ),
 			isActive: postLayout === 'grid',
 		},
 	];
@@ -472,7 +472,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const dateFormat = __experimentalGetSettings().formats.date;
 
 	const activePostLayoutIcon =
-		layoutControls.filter( ( layout ) => layout.layout === postLayout )[ 0 ]
+		layoutControls.find( ( layout ) => layout.layout === postLayout )
 			?.icon || 'list';
 
 	return (

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -483,7 +483,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					<ToolbarDropdownMenu
 						icon={ activePostLayoutIcon }
 						label={ __( 'Layout' ) }
-						toggleProps={ __( 'Change layout' ) }
 						controls={ layoutControls }
 					/>
 				</ToolbarGroup>

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -8,7 +8,10 @@
 		margin-left: 2em;
 	}
 	&.wp-block-latest-posts__list {
-		list-style: none;
+
+		&.has-no-bullets {
+			list-style: none;
+		}
 
 		li {
 			clear: both;

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -9,6 +9,12 @@
 	}
 	&.wp-block-latest-posts__list {
 
+		// Ensure bullets are visible even if block is "full-width"
+		// or "wide" alignment.
+		&.has-bullets {
+			padding-left: revert;
+		}
+
 		&.has-no-bullets {
 			list-style: none;
 		}

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -13,6 +13,7 @@
 		// or "wide" alignment.
 		&.has-bullets {
 			padding-left: revert;
+			list-style: initial; // needed in case Theme Styles are disabled.
 		}
 
 		&.has-no-bullets {

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -17,6 +17,7 @@
 
 		&.has-no-bullets {
 			list-style: none;
+			padding-left: 0; // needed in case Theme Styles are disabled.
 		}
 
 		li {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Related https://github.com/WordPress/gutenberg/issues/32718.

This PR allows a user to ~turn bullet points on and off for the block~ to decide between between the following block layouts:

* list
* **bullet-list (new!)**
* grid

This is in response to designer guidance from @critterverse in https://github.com/WordPress/gutenberg/pull/32806#issuecomment-866064458.

~We will need to replicate this for Latest Comments - probably in the separate PR.~

See also  https://github.com/WordPress/gutenberg/pull/32959 for the Latest Comments block.

## How has this been tested?

1. Create Latest Posts Block.
2. Click on the `Layout` item in the Block Toolbar.
3. Select a layout to see different layouts, one of which is now "Bulleted List".

Also check we don't need a deprecation:

1. Switch to `trunk`.
2. Build Plugin.
3. Create new Post and add Latest Posts Block.
4. Change some settings - especially the Layout setting in the Block Toolbar.
5. Save
6. Switch to this PR.
7. Build Plugin.
8. Open DevTools Console and Reload Post.
9. Select Latest Posts Block. 
10. Check there are no warnings shown in console.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/123126162-111ce080-d441-11eb-8547-db32491cf99a.mov




## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
