### PR TITLE
Allow left/right/center alignments when a layout is defined

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -34,7 +34,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
-					? [ 'wide', 'full' ]
+					? [ 'wide', 'full', 'left', 'center', 'right' ]
 					: [ 'left', 'center', 'right' ];
 			return {
 				type: 'default',

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -51,7 +51,7 @@ function EditableContent( { layout, context = {} } ) {
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
-					? [ 'wide', 'full' ]
+					? [ 'wide', 'full', 'left', 'center', 'right' ]
 					: [ 'left', 'center', 'right' ];
 			return {
 				type: 'default',

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -49,7 +49,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
-					? [ 'wide', 'full' ]
+					? [ 'wide', 'full', 'left', 'center', 'right' ]
 					: [ 'left', 'center', 'right' ];
 			return {
 				type: 'default',

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -29,7 +29,7 @@ export default function TemplatePartInnerBlocks( {
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
-					? [ 'wide', 'full' ]
+					? [ 'wide', 'full', 'left', 'center', 'right' ]
 					: [ 'left', 'center', 'right' ];
 			return {
 				type: 'default',

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -178,7 +178,7 @@ export default function VisualEditor( { styles } ) {
 		if ( themeSupportsLayout ) {
 			const alignments =
 				contentSize || wideSize
-					? [ 'wide', 'full' ]
+					? [ 'wide', 'full', 'left', 'center', 'right' ]
 					: [ 'left', 'center', 'right' ];
 			return {
 				type: 'default',


### PR DESCRIPTION
closes #30568 

When we introduced the layout config, we made the decision to remove left/right alignments from containers with a defined layout, the idea was that we can't left/right align inside the "content size" area, so to avoid confusing users, we shouldn't propose these options.

Apparently, removing these is even more confusing and some themes do expect float alignments to work like that (left/right align at the edge of the container), so we're bringing these in this PR

**Testing instructions**

Please help test this with several themes. It requires a theme with theme.json though.

 - Add a container block with a layout define (inherit or custom both work)
 - See that you can align left/right blocks inside that container and that they show properly in both editor and frontend.