### PR TITLE
Add a "separator" attribute to post-terms block

### DIFF
--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -13,7 +13,8 @@
 			"type": "string"
 		},
 		"separator": {
-			"type": "string"
+			"type": "string",
+			"default": ", "
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -11,6 +11,9 @@
 		},
 		"textAlign": {
 			"type": "string"
+		},
+		"separator": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -28,5 +28,6 @@
 			"lineHeight": true,
 			"fontSize": true
 		}
-	}
+	},
+	"style": "wp-block-post-terms"
 }

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -107,7 +107,7 @@ export default function PostTermsEdit( {
 						.reduce( ( prev, curr ) => (
 							<>
 								{ prev }
-								<span className="wp-block-post-terms__sep">
+								<span className="wp-block-post-terms__separator">
 									{ separator || ' ' }
 								</span>
 								{ curr }

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -8,11 +8,12 @@ import classnames from 'classnames';
  */
 import {
 	AlignmentToolbar,
+	InspectorAdvancedControls,
 	BlockControls,
 	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Spinner } from '@wordpress/components';
+import { Spinner, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
@@ -27,7 +28,7 @@ export default function PostTermsEdit( {
 	context,
 	setAttributes,
 } ) {
-	const { term, textAlign } = attributes;
+	const { term, textAlign, separator } = attributes;
 	const { postId, postType } = context;
 
 	const selectedTerm = useSelect(
@@ -78,6 +79,17 @@ export default function PostTermsEdit( {
 					} }
 				/>
 			</BlockControls>
+			<InspectorAdvancedControls>
+				<TextControl
+					autoComplete="off"
+					label={ __( 'Separator' ) }
+					value={ separator || '' }
+					onChange={ ( nextValue ) => {
+						setAttributes( { separator: nextValue } );
+					} }
+					help={ __( 'Enter character(s) used to separate terms.' ) }
+				/>
+			</InspectorAdvancedControls>
 			<div { ...blockProps }>
 				{ isLoading && <Spinner /> }
 				{ ! isLoading &&
@@ -92,7 +104,15 @@ export default function PostTermsEdit( {
 								{ postTerm.name }
 							</a>
 						) )
-						.reduce( ( prev, curr ) => [ prev, ' | ', curr ] ) }
+						.reduce( ( prev, curr ) => (
+							<>
+								{ prev }
+								<span className="wp-block-post-terms__sep">
+									{ separator || ' ' }
+								</span>
+								{ curr }
+							</>
+						) ) }
 				{ ! isLoading &&
 					! hasPostTerms &&
 					( selectedTerm?.labels?.no_terms ||

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -23,10 +23,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	}
 
 	$post_terms = get_the_terms( $block->context['postId'], $attributes['term'] );
-	if ( is_wp_error( $post_terms ) ) {
-		return '';
-	}
-	if ( empty( $post_terms ) ) {
+	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
 		return '';
 	}
 
@@ -35,21 +32,16 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
-	$terms_links = '';
-	foreach ( $post_terms as $term ) {
-		$terms_links .= sprintf(
-			'<a href="%1$s">%2$s</a> | ',
-			get_term_link( $term->term_id ),
-			esc_html( $term->name )
-		);
-	}
-	$terms_links        = trim( $terms_links, ' | ' );
+	$separator = empty( $attributes['separator'] ) ? ' | ' : $attributes['separator'];
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
-	return sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		$terms_links
+	return get_the_term_list(
+		$block->context['postId'],
+		$attributes['term'],
+		"<div $wrapper_attributes>",
+		$separator,
+		'</div>'
 	);
 }
 

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -40,7 +40,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$block->context['postId'],
 		$attributes['term'],
 		"<div $wrapper_attributes>",
-		'<span class="wp-block-post-terms__sep">' . $separator . '</span>',
+		'<span class="wp-block-post-terms__separator">' . $separator . '</span>',
 		'</div>'
 	);
 }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -40,7 +40,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$block->context['postId'],
 		$attributes['term'],
 		"<div $wrapper_attributes>",
-		$separator,
+		'<span class="wp-block-post-terms__sep">' . $separator . '</span>',
 		'</div>'
 	);
 }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
-	$separator = empty( $attributes['separator'] ) ? ', ' : $attributes['separator'];
+	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
-	$separator = empty( $attributes['separator'] ) ? ' | ' : $attributes['separator'];
+	$separator = empty( $attributes['separator'] ) ? ', ' : $attributes['separator'];
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -1,0 +1,3 @@
+.wp-block-post-terms__separator {
+    white-space: pre-wrap;
+}

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -1,3 +1,3 @@
 .wp-block-post-terms__separator {
-    white-space: pre-wrap;
+	white-space: pre-wrap;
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -31,6 +31,7 @@
 @import "./post-comments/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-excerpt/style.scss";
+@import "./post-terms/style.scss";
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";

--- a/packages/e2e-tests/fixtures/blocks/core__post-terms.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-terms.json
@@ -3,7 +3,9 @@
 		"clientId": "_clientId_0",
 		"name": "core/post-terms",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"separator": ", "
+		},
 		"innerBlocks": [],
 		"originalContent": ""
 	}


### PR DESCRIPTION
## Description

Fixes #31710
Adds a "Separator" attribute to post-terms. The control is exposed in the "Advanced" section of the post-categories and post-tags blocks.

## How has this been tested?
* Tested adding a separator like `, ` and confirmed that it works both in the editor and the frontend
* Tested previously saved blocks and confirmed nothing breaks

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
