### PR TITLE
useNavigateRegions: Don't remove click event if there's no element

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -53,7 +53,7 @@ export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
 		ref.current.addEventListener( 'click', onClick );
 
 		return () => {
-			ref.current.removeEventListener( 'click', onClick );
+			ref.current?.removeEventListener( 'click', onClick );
 		};
 	}, [ setIsFocusingRegions ] );
 


### PR DESCRIPTION
## Description
Currently, when visiting Site Editor, there's `Uncaught TypeError` in the console. This PR tried to fix that.

P.S. I'm not very familiar with `useMergeRefs`, but based on docs this effect logic looks like a good candidate for `useRefEffect`.

## How has this been tested?
1. Activate block theme - TT1 Block or similar.
2. Go to Site Editor.
3. Following errors shouldn't be visible in the console:
```
Uncaught TypeError: Cannot read property 'removeEventListener' of null
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-06-18 at 16 16 21](https://user-images.githubusercontent.com/240569/122585902-0d6a1200-d06d-11eb-8368-30ce300065e9.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
