### PR TITLE
[Block Library - Site Title, Site Tagline] - Readonly view when user has no the right permissions

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -36,6 +36,8 @@
 @import "./separator/editor.scss";
 @import "./shortcode/editor.scss";
 @import "./site-logo/editor.scss";
+@import "./site-tagline/editor.scss";
+@import "./site-title/editor.scss";
 @import "./social-link/editor.scss";
 @import "./social-links/editor.scss";
 @import "./spacer/editor.scss";

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -27,5 +27,6 @@
 			"__experimentalTextTransform": true,
 			"__experimentalLetterSpacing": true
 		}
-	}
+	},
+	"editorStyle": "wp-block-site-tagline-editor"
 }

--- a/packages/block-library/src/site-tagline/editor.scss
+++ b/packages/block-library/src/site-tagline/editor.scss
@@ -1,0 +1,4 @@
+.wp-block-site-tagline__placeholder {
+	padding: 1em 0;
+	border: 1px dashed;
+}

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -13,13 +13,17 @@
  * @return string The render.
  */
 function render_block_core_site_tagline( $attributes ) {
+	$site_tagline = get_bloginfo( 'description' );
+	if ( ! $site_tagline ) {
+		return;
+	}
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(
 		'<p %1$s>%2$s</p>',
 		$wrapper_attributes,
-		get_bloginfo( 'description' )
+		$site_tagline
 	);
 }
 

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -35,5 +35,6 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true
 		}
-	}
+	},
+	"editorStyle": "wp-block-site-title-editor"
 }

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -51,7 +51,7 @@ export default function SiteTitleEdit( {
 				tagName="a"
 				aria-label={ __( 'Site title text' ) }
 				placeholder={ __( 'Write site title…' ) }
-				value={ title }
+				value={ title || readOnlyTitle }
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -1,0 +1,4 @@
+.wp-block-site-title__placeholder {
+	padding: 1em 0;
+	border: 1px dashed;
+}

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -13,6 +13,11 @@
  * @return string The render.
  */
 function render_block_core_site_title( $attributes ) {
+	$site_title = get_bloginfo( 'name' );
+	if ( ! $site_title ) {
+		return;
+	}
+
 	$tag_name         = 'h1';
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
@@ -20,7 +25,7 @@ function render_block_core_site_title( $attributes ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
 
-	$link               = sprintf( '<a href="%1$s" rel="home">%2$s</a>', get_bloginfo( 'url' ), get_bloginfo( 'name' ) );
+	$link               = sprintf( '<a href="%1$s" rel="home">%2$s</a>', get_bloginfo( 'url' ), $site_title );
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -178,12 +178,21 @@ describe( 'Multi-entity save flow', () => {
 			await insertBlock( 'Site Title' );
 			// Ensure title is retrieved before typing.
 			await page.waitForXPath( '//a[contains(text(), "gutenberg")]' );
+			const editableSiteTitleSelector =
+				'.wp-block-site-title a[contenteditable="true"]';
+			await page.waitForSelector( editableSiteTitleSelector );
+			await page.focus( editableSiteTitleSelector );
 			await page.keyboard.type( '...' );
+
 			await insertBlock( 'Site Tagline' );
 			// Ensure tagline is retrieved before typing.
 			await page.waitForXPath(
 				'//p[contains(text(), "Just another WordPress site")]'
 			);
+			const editableSiteTagLineSelector =
+				'.wp-block-site-tagline[contenteditable="true"]';
+			await page.waitForSelector( editableSiteTagLineSelector );
+			await page.focus( editableSiteTagLineSelector );
 			await page.keyboard.type( '...' );
 
 			await clickButton( 'Publish' );


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of: https://github.com/WordPress/gutenberg/issues/26573

Currently when a user with no right permissions to edit `Site Title` and `Site Tagline` has a broken experience for these blocks due to the permissions check happening at the REST API.

This PR fixes that by checking the rights and adding a `readonly` view for these blocks, for those users.

In addition I have added a check to both blocks to bail early and print nothing in the front-end, if the respective values are `empty`.


## Testing instructions
1. With an `admin` user insert these two blocks and observe that everything works as expected.
2. With a user whose role hasn't the right permissions(like `author`, `editor`, etc...), insert the blocks and observe that are `readonly`, but can be moved and their block attributes can be changed (ex. `text align`).
3. Also test the case when the value of these blocks is `empty`, where the `admin` can still edit, but the other users see a `placeholder text`, so they can still apply changes for when/if a value is set.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
