### PR TITLE
Workflows: Re-enable manually triggered workflows on forks

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -145,7 +145,12 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: always()
+        if: |
+            always() && (
+              github.event_name == 'pull_request' ||
+              github.event_name == 'workflow_dispatch' ||
+              github.repository == 'WordPress/gutenberg'
+            )
 
         steps:
             - name: Checkout code

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -21,6 +21,7 @@ jobs:
     compute-stable-branches:
         name: Compute current and next stable release branches
         runs-on: ubuntu-latest
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         outputs:
             current_stable_branch: ${{ steps.get_branches.outputs.current_stable_branch }}
             next_stable_branch: ${{ steps.get_branches.outputs.next_stable_branch }}

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -46,7 +46,6 @@ jobs:
         runs-on: ubuntu-latest
         needs: compute-stable-branches
         if: |
-            github.repository == 'WordPress/gutenberg' &&
             github.event_name == 'workflow_dispatch' && (
               (
                 github.ref == 'refs/heads/trunk' ||
@@ -146,7 +145,7 @@ jobs:
         name: Build Release Artifact
         runs-on: ubuntu-latest
         needs: bump-version
-        if: ${{ ( github.repository == 'WordPress/gutenberg' && always() ) || ( github.event_name == 'pull_request' && always() ) }}
+        if: always()
 
         steps:
             - name: Checkout code
@@ -204,7 +203,6 @@ jobs:
         name: Create Release Draft and Attach Asset
         needs: [bump-version, build]
         runs-on: ubuntu-latest
-        if: ${{ github.repository == 'WordPress/gutenberg' }}
 
         steps:
             - name: Set Release Version


### PR DESCRIPTION
## Description

Re-enable manually triggered workflows on forks, to allow for better testability of changes to those workflows.

See https://github.com/WordPress/gutenberg/pull/32114#issuecomment-864013314 for background.

## How has this been tested?

Fork GB, and try to trigger release creation on your fork (using this branch). It's what I did to test https://github.com/WordPress/gutenberg/pull/32560, so see the links to GHA workflows on my fork under the "How has this been tested?" section of that PR 😬 