### PR TITLE
Safari: see if compositing layer size is more reasonable when position fixed divs are not inserted into content

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -12,12 +12,6 @@ import { useRef } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../../store';
 
-/**
- * Useful for positioning an element within the viewport so focussing the
- * element does not scroll the page.
- */
-const PREVENT_SCROLL_ON_FOCUS = { position: 'fixed' };
-
 function isFormElement( element ) {
 	const { tagName } = element;
 	return (
@@ -75,7 +69,6 @@ export default function useTabNav() {
 			ref={ focusCaptureBeforeRef }
 			tabIndex={ focusCaptureTabIndex }
 			onFocus={ onFocusCapture }
-			style={ PREVENT_SCROLL_ON_FOCUS }
 		/>
 	);
 
@@ -84,7 +77,6 @@ export default function useTabNav() {
 			ref={ focusCaptureAfterRef }
 			tabIndex={ focusCaptureTabIndex }
 			onFocus={ onFocusCapture }
-			style={ PREVENT_SCROLL_ON_FOCUS }
 		/>
 	);
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -163,7 +163,6 @@ export default function useTabNav() {
 				target === focusCaptureBeforeRef.current ||
 				target === focusCaptureAfterRef.current
 			) {
-				event.stopPropagation();
 				event.preventDefault();
 				target.focus( { preventScroll: true } );
 			}

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -146,6 +146,15 @@ export default function useTabNav() {
 			if ( event.keyCode !== TAB ) {
 				return;
 			}
+
+			if ( event.target?.getAttribute( 'role' ) === 'region' ) {
+				return;
+			}
+
+			if ( container.current === event.target ) {
+				return;
+			}
+
 			const isShift = event.shiftKey;
 			const direction = isShift ? 'findPrevious' : 'findNext';
 			const target = focus.tabbable[ direction ]( event.target );

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -123,7 +123,11 @@ export default function useTabNav() {
 			// doesn't refocus this block and so it allows default behaviour
 			// (moving focus to the next tabbable element).
 			noCapture.current = true;
-			next.current.focus();
+
+			// Focusing the focus capture element, which is located above and
+			// below the editor, should not scroll the page all the way up or
+			// down.
+			next.current.focus( { preventScroll: true } );
 		}
 
 		function onFocusOut( event ) {


### PR DESCRIPTION
### Background 

In Safari, when we scroll we can notice a few things happening in some cases during scroll:

- Text flickering on the cover block
- ~Background colors that bleed from `.edit-post-layout .interface-interface-skeleton__content`. This appears as a flash of gray, and is normally used as a background color when previewing in tablet or mobile mode from the preview dropdown.~ Fixed by https://github.com/WordPress/gutenberg/pull/32747


https://user-images.githubusercontent.com/1270189/122598641-f2be7b80-d021-11eb-81c9-a59d909d115d.mp4

#### Changes In this PR

In this branch we experiment with keeping a large compositing layer a more reasonable size. This appears to get rid of the flickering text.

| Layer size in trunk | Layer size in Branch |
|-----|-----|
| <img width="1360" alt="Screen Shot 2021-06-23 at 10 53 11 AM" src="https://user-images.githubusercontent.com/1270189/123147500-fa13c980-d413-11eb-9ec3-a28749917bfc.png"> | <img width="1324" alt="Screen Shot 2021-06-23 at 10 51 49 AM" src="https://user-images.githubusercontent.com/1270189/123147523-00a24100-d414-11eb-8e2f-4c1e9e9fedc8.png"> |

#### Potential Memory Savings:

Memory use is going to depend on post content plus browser window size, but we should see roughly around a 30% reduction ✨ 

Here's a quick example of a very large window, the post content isn't that long but contains two galleries:

| trunk ~150-170MB | branch ~ 110 - 120MB |
|-----|-----|
| <img width="2304" alt="Screen Shot 2021-06-23 at 2 27 45 PM" src="https://user-images.githubusercontent.com/1270189/123170855-df4f4e00-d42f-11eb-922a-cafe7d97059c.png"> | <img width="2304" alt="Screen Shot 2021-06-23 at 2 29 21 PM" src="https://user-images.githubusercontent.com/1270189/123170881-e7a78900-d42f-11eb-8a7f-b35262f32f78.png"> |

#### With position:fixed rule removed from useTabNav:

https://user-images.githubusercontent.com/1270189/123135142-4f48de80-d406-11eb-8197-b981b61b5ccb.mp4

## Testing Instructions
- Create a post with enough content to scroll in the editor. Try adding a few images with captions in addition to a paragraph.
- In Safari try focusing on an image. The caption text should not flicker on scroll or when block option menus are open
- In Chrome, Safari, and FF verify that when tabbing from the editor pane no scroll occurs
- Do a shift-tab back. We shouldn't see the editor post-content pane scroll when this happens

### Isolated Test Case

**As a general note, these Safari graphical glitches are dependant on one's GPU memory and how large of viewport folks are trying to power**. It's a lot easier for example to see these errors when viewing this on a monitor (in a high resolution) with an older machine.

One other thing I noticed in Gutenberg was that one of the layers are much bigger in size than expected. Ideally it should be about the size of the scrollable pane if we didn't explicitly set some compositing reasons.

<img width="1543" alt="122439481-89226c80-cf50-11eb-9f16-7a74bb6e80bb" src="https://user-images.githubusercontent.com/1270189/122599455-4087b380-d023-11eb-8255-814764f3f78a.png">

So in this [test case](https://gist.github.com/gwwar/4d674b0ef9618fd0a5df0e25db969b19#file-scrollingbasecase-2-html) I tried to isolate why one of the compositing layers is so large. I traced it down to ```<div tabindex="0" style="position: fixed;"></div>``` being inserted. This is added by the writing flow component https://github.com/WordPress/gutenberg/blob/28fcd95831d47c3ce56d35ca4338def006d1d381/packages/block-editor/src/components/writing-flow/use-tab-nav.js#L73-L89

Here's another [isolated test case](https://gist.github.com/gwwar/4d674b0ef9618fd0a5df0e25db969b19#file-scrollingbasecase-2-html) for that. 

As a side note, changes here also reduces memory usage. **With the scrollable browser pane at ~1584px x 588px with the test case, there around a 50MB difference in memory usage.**

https://user-images.githubusercontent.com/1270189/122599397-2a79f300-d023-11eb-9474-c4e2373315bd.mp4

### Other useful Debugging Notes:

- `--webkit-overflow-scrolling:touch` **is added by default** in Safari when there’s a scroll area, such as (overflow:scroll or overflow:auto)
- We cannot unset `--webkit-overflow-scrolling` 😭. (This is shown as an invalid property in dev tools, but will still show up as a compositing reason in the layers tab).
- `--webkit-overflow-scrolling:touch` is a compositing reason. It creates a new layer to be sent off to the GPU to render. This is fine, but when this layer gets too large(and likely hits GPU memory limits, we see glitches like flicking text and incorrect ordering of elements.
- With the same content and code, we can trigger or not trigger these glitches based on how large the compositing layer is. For example by resizing the browser window smaller, or [changing the font size](https://github.com/WordPress/gutenberg/pull/32747#issuecomment-862741600).
