### PR TITLE
RNMobile: Fix column wrapping

### DIFF
--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -6,6 +6,7 @@
 
 .horizontalContentContainer {
 	flex-direction: row;
+	flex-wrap: wrap;
 	justify-content: flex-start;
 	align-items: stretch;
 	overflow: visible;


### PR DESCRIPTION
This Pr adds back the flex-wrap attribute needed for columns to work as expected.

## Description

The change was introduced in https://github.com/WordPress/gutenberg/pull/29118/files#diff-9c3ccb89737b8491cb71efe149c7d3a2204c374f7bb916097a5c6e01ecc65622L9

Specific commit https://github.com/WordPress/gutenberg/commit/ef1774ee592520df3f5ae3684f550799bd701c84

## How has this been tested?
On Mobile editor. Load up this PR. 
Add the columns block. Notice it works as expected.

## Screenshots <!-- if applicable -->
Before:

https://user-images.githubusercontent.com/115071/122609954-af6d0880-d033-11eb-8a02-4b4044cd86d2.mov


After: 

https://user-images.githubusercontent.com/115071/122609965-b562e980-d033-11eb-931b-3d1d14d5b08b.mov






## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
