### PR TITLE
Fix incorrect block insertion point after blurring post title

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -16,7 +16,7 @@ function useNativeBlockEditorSettings( settings, hasTemplate ) {
 	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
 
 	const supportReusableBlock = capabilities.reusableBlock === true;
-	const { isTitleSelected, reusableBlocks } = useSelect(
+	const { reusableBlocks } = useSelect(
 		( select ) => ( {
 			reusableBlocks: supportReusableBlock
 				? select( coreStore ).getEntityRecords(
@@ -27,10 +27,13 @@ function useNativeBlockEditorSettings( settings, hasTemplate ) {
 						{ per_page: 100 }
 				  )
 				: [],
-			isTitleSelected: select( editorStore ).isPostTitleSelected(),
 		} ),
 		[ supportReusableBlock ]
 	);
+
+	const { isTitleSelected } = useSelect( ( select ) => ( {
+		isTitleSelected: select( editorStore ).isPostTitleSelected(),
+	} ) );
 
 	return useMemo(
 		() => ( {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [**] Fix incorrect block insertion point after blurring the post title field. [#32831]
 
 ## 1.55.0
 -   [*] Gallery block - Fix gallery images caption text formatting [#32351]


### PR DESCRIPTION
* **Gutenberg Mobile:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3640

## Description
Fixes #32154. Selecting the title selection status within the same `useSelect` for reusable blocks caused the title selection status to become stale, due to the dependency array for the `useSelect` hook. The staleness caused the block insertion point to show up in the incorrect location after blurring the title text input.

## How has this been tested?

I attempted to add automated tests for this but ran into issues asserting the order of the elements. The primary issue was that our current tree structure does not have queryable attributes on the relevant elements, with no easy fix obvious to me. Additionally, React Native Testing Library's lack of support for [traversing upwards the tree](https://github.com/callstack/react-native-testing-library/issues/520) or [snapshotting a subset of a rendered tree](https://github.com/callstack/react-native-testing-library/issues/536) inhibited alternative methods. 

The following was manually tested: 

1. Launch the Demo editor. 
2. Focus the first block. 
3. Tap the + button to add a block. 
4. **ℹ️ Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the selected block. 
5. Focus the title for the post. 
6. Tap the + button to add a block. 
7. **ℹ️ Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the title. 
2. Focus the first block. 
3. Tap the + button to add a block. 
4. **ℹ️ Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the selected block. 

## Screenshots <!-- if applicable -->

<details><summary>Before</summary>

https://user-images.githubusercontent.com/438664/122610436-4098ab00-d045-11eb-9a0b-bd26f33f26b7.mov

</details>

<details><summary>After</summary>

https://user-images.githubusercontent.com/438664/122610449-47272280-d045-11eb-8805-e4c3bbadd6e0.mov

</details>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
