### PR TITLE
Improve image caret e2e-test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -115,7 +115,7 @@ describe( 'Image', () => {
 		const fileName = await upload( '.wp-block-image input[type="file"]' );
 		await waitForImage( fileName );
 		await page.keyboard.type( '1' );
-		await insertBlock( 'Paragraph' );
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '2' );
 


### PR DESCRIPTION

## Description

This PR aims to improve the image e2e test that checks the scenario

1. Add caption
2. Add paragraph block
3. Backspace in paragraph returns to caption

The change switches from using inserter to insert block to simply pressing
enter which default adds a paragraph block, without having to invole the
inserter, search, and the additional time involved which is not the use cae
being testing.

Local tests runs show saving ~5 seconds on normal test run and
>10 seconds when using THROTTLE_CPU=4 SLOW_NETWORK=true


## How has this been tested?

Run test and confirm works as expected:

`npm run test-e2e packages/e2e-tests/specs/editor/blocks/image.test.js`

You can also simulate a slower connection which I was able to fail locally before the change, and passes after this change:

`THROTTLE_CPU=4 SLOW_NETWORK=true npm run test-e2e packages/e2e-tests/specs/editor/blocks/image.test.js`

If you want to watch what puppeteer is doing use `--puppeteer-interactive`

`npm run test-e2e -- --puppeteer-interactive packages/e2e-tests/specs/editor/blocks/image.test.js`


## Types of changes

Switches insertBlock to pressing enter in e2e test.

