### PR TITLE
Add missing period in block descriptions.

### DIFF
--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Comment Author' ),
-	description: __( 'Post Comment Author' ),
+	description: __( 'Post Comment Author.' ),
 	icon,
 	edit,
 	parent: [ 'core/post-comment' ],

--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Comment Content' ),
-	description: __( 'Post Comment Content' ),
+	description: __( 'Post Comment Content.' ),
 	icon,
 	edit,
 	parent: [ 'core/post-comment' ],

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Comment Date' ),
-	description: __( 'Post Comment Date' ),
+	description: __( 'Post Comment Date.' ),
 	icon,
 	edit,
 	parent: [ 'core/post-comment' ],

--- a/packages/block-library/src/post-comment/index.js
+++ b/packages/block-library/src/post-comment/index.js
@@ -16,7 +16,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Comment' ),
-	description: __( 'Post Comment' ),
+	description: __( 'Post Comment.' ),
 	icon,
 	edit,
 	save,

--- a/packages/block-library/src/post-hierarchical-terms/index.js
+++ b/packages/block-library/src/post-hierarchical-terms/index.js
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Post Hierarchical Terms' ),
+	title: __( 'Post Hierarchical Terms.' ),
 	variations,
 	edit,
 };

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Site Logo' ),
-	description: __( 'Show a site logo' ),
+	description: __( 'Show a site logo.' ),
 	icon,
 	supports: {
 		align: true,


### PR DESCRIPTION
## Description
In the few recent blocks added in last versions of the block editor, some block descriptions were missing a final period. This pull request fix this small consistency issue.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
