### PR TITLE
Post Template: Add stronger CSS

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -45,7 +45,6 @@
 @import "./text-columns/editor.scss";
 @import "./video/editor.scss";
 @import "./query-title/editor.scss";
-@import "./post-template/editor.scss";
 @import "./query/editor.scss";
 @import "./query-pagination/editor.scss";
 @import "./query-pagination-numbers/editor.scss";

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -1,7 +1,0 @@
-.editor-styles-wrapper {
-	ul.wp-block-post-template {
-		padding-left: 0;
-		margin-left: 0;
-		list-style: none;
-	}
-}

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -5,9 +5,11 @@
 // See: https://github.com/WordPress/gutenberg/pull/32514.
 // TODO: Remove this class when WordPress 5.9 is released.
 .wp-block-query-loop {
+	margin-left: 0;
 	max-width: 100%;
-	list-style: none;
+	list-style: none !important;
 	padding: 0;
+	padding-left: 0 !important;
 
 	li {
 		clear: both;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This strengthens the CSS for the Post Template block so that themes don't accidentally add padding or list styles to this block.

This was raised in https://core.trac.wordpress.org/ticket/53438. This solution aims to solve the problem for all themes, not just for Twenty Thirteen.

## How has this been tested?
- Switch to Twenty Thirteen
- Add a Query Loop block in the editor
- Check that there is no padding or list style on the block

## Screenshots <!-- if applicable -->
Before:
<img width="672" alt="Screenshot 2021-06-21 at 12 01 17" src="https://user-images.githubusercontent.com/275961/122752050-63ff6800-d288-11eb-8e55-0c00f0c4ca1f.png">

After:
<img width="671" alt="Screenshot 2021-06-21 at 12 00 41" src="https://user-images.githubusercontent.com/275961/122752095-6feb2a00-d288-11eb-8aef-48ded169b19d.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
