### PR TITLE
Skip failing image caption caret test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -110,7 +110,7 @@ describe( 'Image', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 	} );
 
-	it( 'should place caret at end of caption after merging empty paragraph', async () => {
+	it.skip( 'should place caret at end of caption after merging empty paragraph', async () => {
 		await insertBlock( 'Image' );
 		const fileName = await upload( '.wp-block-image input[type="file"]' );
 		await waitForImage( fileName );


### PR DESCRIPTION
## Description
Skip this test because it's failing lots. There was an attempt at a solution and some discussion on the problem in https://github.com/WordPress/gutenberg/pull/32832, but haven't yet found a solution.