### PR TITLE
Add conditions to ensure hidden/inactive "Publish" button is a toggle or a publish button depending on context.

### DIFF
--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -61,9 +61,9 @@ export function PostPublishButtonOrToggle( {
 		( isPending && ! hasPublishAction && ! isSmallerThanMediumViewport )
 	) {
 		component = IS_BUTTON;
-	} else if ( isSmallerThanMediumViewport ) {
+	} else if ( isSmallerThanMediumViewport && ! isPublishSidebarOpened ) {
 		component = IS_TOGGLE;
-	} else if ( isPublishSidebarEnabled ) {
+	} else if ( isPublishSidebarEnabled && ! isPublishSidebarOpened ) {
 		component = IS_TOGGLE;
 	} else {
 		component = IS_BUTTON;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

When you come to publish a post an actions panel appears with a "Publish" button:

![Screen Capture on 2021-06-21 at 15-56-48](https://user-images.githubusercontent.com/444434/122783268-51e1f180-d2a9-11eb-91b0-8ec6cba309ad.gif)


In https://github.com/WordPress/gutenberg/pull/32732 I discovered that there is actually a hidden "Publish" button stacked 
_underneath_ the actions panel.

https://user-images.githubusercontent.com/444434/122783396-7047ed00-d2a9-11eb-9fb9-3ef083fe1bf3.mp4

In actual fact this button is the button which is used to "toggle" the actions panel ("Publish sidebar") open. However once it toggles the action panel AFAIK this button is then intended not to be exposed in the UI because it is _always_ obscured (via `z-index`) by the interface skeleton's "actions" panel which contains the "Publish" sidebar we're all used to interacting with. It is also not accessible via keyboard because focus is trapped within the actions panel.

Nonetheless the case that this button exists and that is a little odd that it doesn't function as you'd expect. I believe once the button has been clicked and the actions panel is toggled then it should become a "Publish" button able to publish the post. Indeed this is what the component tries to do:

https://github.com/WordPress/gutenberg/blob/b332c75bd291b3bd2087b7a0d50ab172a5803970/packages/edit-post/src/components/header/post-publish-button-or-toggle.js#L58-L81

In the code above the value of `isToggle` being passed to `<PostPublishButton />` determines whether the button functions as a toggle or as a publish button.

I believe we should either:

* Fix the logic in the button so that it only acts as a toggle button if the actions panel is _not_ open - that's what this PR does. **OR...**
* Make the button `disabled` once the actions panel has been toggled.

This might seem like an edge case but as shown here https://github.com/WordPress/gutenberg/pull/32732#issuecomment-863241689 it's simple to introduce a change which exposes this hidden UI and it can cause a lot of confusion to both humans and the e2e tests.

Better to just remove or fix it.

I could be wrong here but didn't want to leave this odd feature/bug unresolved...



## How has this been tested?

### On trunk
* Create Post with content.
* Open inspector and set `.interface-interface-skeleton__body` to have `z-index: 10`.
* Now try to publish the post. Notice that you cannot this is because the normal publish button in the actions button is hidden underneath the header. The publish button you are clicking simply toggles the actions panel and nothing more.

### On this PR branch
* Create Post with content.
* Open inspector and set `.interface-interface-skeleton__body` to have `z-index: 10`.
* Now try to publish the post. On your first click the sidebar will be toggled. On the second it will publish the post.


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
