### PR TITLE
Wire handle_legacy_widget_preview_iframe to admin_init_hook 

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -138,7 +138,7 @@ function gutenberg_menu_order( $menu_order ) {
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	return ( is_callable( 'get_current_screen' ) && 'toplevel_page_gutenberg-edit-site' === get_current_screen()->base )
+	return ( is_callable( 'get_current_screen' ) && get_current_screen() && 'toplevel_page_gutenberg-edit-site' === get_current_screen()->base )
 		? true
 		: $is_block_editor_screen;
 }

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -64,7 +64,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
+	if ( is_callable( 'get_current_screen' ) && get_current_screen() && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
 		return true;
 	}
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -81,7 +81,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
+	if ( is_callable( 'get_current_screen' ) && get_current_screen() && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
 		return true;
 	}
 

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -114,7 +114,7 @@ function handle_legacy_widget_preview_iframe() {
 	exit;
 }
 
-// Ensure handle_legacy_widget_preview_iframe() is called after Core's
-// register_block_core_legacy_widget() (priority = 10) and after Gutenberg's
-// register_block_core_legacy_widget() (priority = 20).
-add_action( 'init', 'handle_legacy_widget_preview_iframe', 21 );
+// Use admin_init instead of init to ensure get_current_screen function is already available.
+// This isn't strictly required, but enables better compatibility with existing plugins.
+// See: https://github.com/WordPress/gutenberg/issues/32624
+add_action( 'admin_init', 'handle_legacy_widget_preview_iframe', 20 );

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -116,5 +116,5 @@ function handle_legacy_widget_preview_iframe() {
 
 // Use admin_init instead of init to ensure get_current_screen function is already available.
 // This isn't strictly required, but enables better compatibility with existing plugins.
-// See: https://github.com/WordPress/gutenberg/issues/32624
+// See: https://github.com/WordPress/gutenberg/issues/32624.
 add_action( 'admin_init', 'handle_legacy_widget_preview_iframe', 20 );


### PR DESCRIPTION
## Description

Problem: https://github.com/WordPress/gutenberg/issues/32624

> When there's an error happening while block editor is loaded + debug log is enabled, we're displaying the error in each instance of legacy widgets.

This PR solves the issue by hooking into `admin_init` instead of `init`. This alone wasn't enough as multiple other hooks assumed that `get_current_screen()` returned an object while in this case it's NULL, so I added an additional guard there. I considered actually assigning something to the current_screen, but concluded that it may bring unintended side-effects and decided against it.

## How has this been tested?
1. Enable debug log, set WP_DEBUG_DISPLAY to true
1. Install Imagify and Yoast
1. Make sure there are some legacy widgets
1. Go to the Widgets section
1. See errors present in each widget section

## Screenshots
<img width="722" alt="Zrzut ekranu 2021-06-21 o 17 22 38" src="https://user-images.githubusercontent.com/205419/122787117-4c8aa400-d2b5-11eb-8a2d-b8fbc256b5a4.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

