### PR TITLE
Fix unintended search http request in <LinkControl>

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -19,8 +19,8 @@ import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
 
 // Must be a function as otherwise URLInput will default
-// to the fetchLinkSuggestions passed in block editor settings.
-// This will cause an unintended http request.
+// to the fetchLinkSuggestions passed in block editor settings
+// which will cause an unintended http request.
 const noopSearchHandler = () => Promise.resolve( [] );
 
 const LinkControlSearchInput = forwardRef(

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -18,7 +18,11 @@ import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
 
-const noopSearchHandler = Promise.resolve( [] );
+// Must be a function as otherwise URLInput will default
+// to the fetchLinkSuggestions passed in block editor settings.
+// This will cause an unintended http request.
+const noopSearchHandler = () => Promise.resolve( [] );
+
 const LinkControlSearchInput = forwardRef(
 	(
 		{
@@ -50,6 +54,7 @@ const LinkControlSearchInput = forwardRef(
 			withCreateSuggestion,
 			withURLSuggestion
 		);
+
 		const searchHandler = showSuggestions
 			? fetchSuggestions || genericSearchHandler
 			: noopSearchHandler;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -371,6 +371,31 @@ describe( 'Searching for a link', () => {
 		expect( mockFetchSuggestionsFirstArg ).toEqual( 'Hello' );
 	} );
 
+	it( 'should not call search handler when showSuggestions is false', async () => {
+		act( () => {
+			render( <LinkControl showSuggestions={ false } />, container );
+		} );
+
+		// Search Input UI
+		const searchInput = getURLInput();
+
+		// Simulate searching for a term
+		act( () => {
+			Simulate.change( searchInput, {
+				target: { value: 'anything' },
+			} );
+		} );
+
+		const searchResultElements = getSearchResults();
+
+		// fetchFauxEntitySuggestions resolves on next "tick" of event loop
+		await eventLoopTick();
+
+		// TODO: select these by aria relationship to autocomplete rather than arbitrary selector.
+		expect( searchResultElements ).toHaveLength( 0 );
+		expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
+	} );
+
 	it.each( [
 		[ 'couldbeurlorentitysearchterm' ],
 		[ 'ThisCouldAlsoBeAValidURL' ],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When `showSuggestions` prop is passed to `<LinkControl>` the consumer should expect that the component will not make any HTTP requests for search suggestions. 

At first glance this appears to be the case, but if we observe the Network tab we can see that in fact due to an error in the logic within the component, the default search handler attached to the block editor settings is invoked.

This PR fixes things so that if `showSuggestions` is `false` then the default "noop" handler is invoked and no HTTP is made.

This issue is what is currently causing flaky e2e tests in the Image block.



## How has this been tested?


To manually test:

#### On Trunk

* Create an Image block.
* Upload an image.
* Open Network tab and clear it out.
* Click `Replace` on the Image block.
* Then click `Edit` button that appears.
* You should see a HTTP request is made to the `search` endpoint in the Network tab. 

#### On this PR

* Create an Image block.
* Upload an image.
* Open Network tab and clear it out.
* Click `Replace` on the Image block.
* Then click `Edit` button that appears.
* You should see no HTTP is trigger in the Network tab.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
