### PR TITLE
Auto-enable the template editor for themes with theme.json only

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -189,4 +189,14 @@ function register_site_icon_url( $response ) {
 add_filter( 'rest_index', 'register_site_icon_url' );
 
 add_theme_support( 'widgets-block-editor' );
-add_theme_support( 'block-templates' );
+
+/**
+ * Enable the block templates (editor mode) for themes with theme.json.
+ */
+function gutenberg_enable_block_templates() {
+	if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		add_theme_support( 'block-templates' );
+	}
+}
+
+add_action( 'setup_theme', 'gutenberg_enable_block_templates' );


### PR DESCRIPTION
Per feedback and discussions in the 5.8 leads channel, we're making the template editor opt-in for classic themes and opt-out for themes with theme.json and FSE themes.

To test this PR, you should have WP 5.7 or prior as, this flag is enabled in Core trunk and the effect of this PR won't be noticeable.

 - Test that by default classic themes have template editor disabled.
 - Test that if you add a "theme.json" file to a classic themes, the template editor is enabled.