### PR TITLE
Block Library: Ensure there is no direct import from core/editor store

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -22,7 +22,6 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { renderToString, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -61,7 +60,10 @@ export default function TableOfContentsEdit( {
 			listBlockExists: !! select( blocksStore ).getBlockType(
 				'core/list'
 			),
-			postContent: select( editorStore ).getEditedPostContent(),
+			// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+			// Blocks can be loaded into a *non-post* block editor.
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			postContent: select( 'core/editor' ).getEditedPostContent(),
 		} ),
 		[]
 	);

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -6,7 +6,6 @@ import { SelectControl, TextControl } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 
 export function TemplatePartAdvancedControls( {
 	tagName,
@@ -30,8 +29,11 @@ export function TemplatePartAdvancedControls( {
 	);
 
 	const { areaOptions } = useSelect( ( select ) => {
+		// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+		// Blocks can be loaded into a *non-post* block editor.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const definedAreas = select(
-			editorStore
+			'core/editor'
 		).__experimentalGetDefaultTemplatePartAreas();
 		return {
 			areaOptions: definedAreas.map( ( { label, area: _area } ) => ( {

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -89,7 +88,10 @@ export default function TemplatePartEdit( {
 				  )
 				: false;
 
-			const defaultWrapperElement = select( editorStore )
+			// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+			// Blocks can be loaded into a *non-post* block editor.
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			const defaultWrapperElement = select( 'core/editor' )
 				.__experimentalGetDefaultTemplatePartAreas()
 				.find( ( { area: value } ) => value === _area )?.area_tag;
 

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -12,7 +12,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Placeholder, Dropdown, Button } from '@wordpress/components';
 import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -36,8 +35,11 @@ export default function TemplatePartPlaceholder( {
 
 	const { areaIcon, areaLabel } = useSelect(
 		( select ) => {
+			// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+			// Blocks can be loaded into a *non-post* block editor.
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
 			const definedAreas = select(
-				editorStore
+				'core/editor'
 			).__experimentalGetDefaultTemplatePartAreas();
 
 			const selectedArea = find( definedAreas, { area } );

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -21,7 +21,7 @@ import {
 import { useAsyncList } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
+
 /**
  * Internal dependencies
  */
@@ -307,8 +307,11 @@ export default function TemplatePartPreviews( {
 				) !== templatePartId
 		);
 
+		// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+		// Blocks can be loaded into a *non-post* block editor.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const definedAreas = select(
-			editorStore
+			'core/editor'
 		).__experimentalGetDefaultTemplatePartAreas();
 		const _labelsByArea = {};
 		definedAreas.forEach( ( item ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Addressed ESLInt rule violation for the missing import for `@wordpress/editor` in `@wordpress/block-library`. 

@noisysocks removed `@wordpress/editor` as a dependency from `@wordpress/block-library` in https://github.com/WordPress/gutenberg/pull/32801. It was discovered as an issue by @youknowriad in #32848.

We want to keep the hard rule about dependencies as proposed by @noisysocks so this PR copies the workaround used. A proper fix is going to be discussed in https://github.com/WordPress/gutenberg/issues/32842.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
