### PR TITLE
Query Loop Patterns: Use plain `div` for wrapper element

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -79,8 +79,8 @@ function register_gutenberg_patterns() {
 			'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 							<div class="wp-block-query">
 							<!-- wp:post-template -->
-							<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
-							<main class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:post-title {"isLink":true} /-->
+							<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
+							<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:post-title {"isLink":true} /-->
 							<!-- wp:post-excerpt {"wordCount":20} /-->
 							<!-- wp:post-date /--></div>
 							<!-- /wp:group -->
@@ -116,8 +116,8 @@ function register_gutenberg_patterns() {
 			'title'      => __( 'Offset', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
-							<main class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:columns -->
+			'content'    => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
+							<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:columns -->
 							<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
 							<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 							<div class="wp-block-query"><!-- wp:post-template -->
@@ -142,7 +142,7 @@ function register_gutenberg_patterns() {
 							<!-- /wp:post-template --></div>
 							<!-- /wp:query --></div>
 							<!-- /wp:column --></div>
-							<!-- /wp:columns --></main>
+							<!-- /wp:columns --></div>
 							<!-- /wp:group -->',
 		),
 		// Initial block pattern to be used with block transformations with patterns.


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/53389#comment:14 — The Offset and Grid patterns for the Query Loop block use `main` as a content wrapper on the group block, but there can be [at most one visible `main` on a page](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element). Otherwise this is an invalid HTML page, and can be confusing for screen reader navigation.

This change removes the tagName on the Offset and Grid patterns, so it defaults to a plain `div`.

To test, insert different query loops into a post and make sure it works as expected. There should be no user-facing changes.