### PR TITLE
Rename .interface-interface-skeleton__body z-index to .interface-interface-skeleton__content

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,7 +32,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
-	".interface-interface-skeleton__body": 20,
+	".interface-interface-skeleton__content": 20,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -87,7 +87,7 @@ html.interface-interface-skeleton__html-container {
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.
 	// See https://github.com/WordPress/gutenberg/issues/32631
-	z-index: z-index(".interface-interface-skeleton__body");
+	z-index: z-index(".interface-interface-skeleton__content");
 
 }
 


### PR DESCRIPTION
I got excited and merged https://github.com/WordPress/gutenberg/pull/32732 without reading @gwwar's suggestion to rename this variable 🙂