### PR TITLE
Fix legacy widget edit style bleed

### DIFF
--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -35,7 +35,7 @@ function useDarkThemeBodyClassName( styles ) {
 				// DOM, so calculate the background color by creating a fake
 				// wrapper.
 				const tempCanvas = ownerDocument.createElement( 'div' );
-				tempCanvas.classList.add( EDITOR_STYLES_SELECTOR );
+				tempCanvas.classList.add( 'editor-styles-wrapper' );
 				body.appendChild( tempCanvas );
 
 				backgroundColor = defaultView

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -21,6 +21,10 @@
 	.block-list-appender.wp-block {
 		width: initial;
 	}
+	// Override theme custom widths for blocks.
+	.editor-styles-wrapper .wp-block.wp-block.wp-block.wp-block.wp-block {
+		max-width: 100%;
+	}
 }
 
 // Add some spacing above the inner blocks so that the block toolbar doesn't

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -12,7 +12,7 @@
 		margin: 0 0 $grid-unit-15 0;
 	}
 
-	.widget-inside {
+	.widget-inside.widget-inside {
 		border: none;
 		box-shadow: none;
 		display: block;
@@ -59,6 +59,12 @@
 	.widget.open {
 		z-index: 0;
 	}
+}
+
+// Make sure edit form text and no preview warning are always visible.
+.wp-block-legacy-widget__edit-form.wp-block-legacy-widget__edit-form,
+.wp-block-legacy-widget__edit-no-preview.wp-block-legacy-widget__edit-no-preview {
+	color: $black;
 }
 
 .wp-block-legacy-widget__edit-preview,

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -25,6 +25,34 @@
 		label + .widefat {
 			margin-top: $grid-unit-15;
 		}
+
+		// Override theme style bleed.
+		label,
+		input,
+		a {
+			color: $black;
+		}
+		select {
+			font-family: system-ui;
+			-webkit-appearance: revert;
+			color: revert;
+			border: revert;
+			border-radius: revert;
+			background: revert;
+			box-shadow: revert;
+			text-shadow: revert;
+			outline: revert;
+			cursor: revert;
+			transform: revert;
+			font-size: revert;
+			line-height: revert;
+			padding: revert;
+			margin: revert;
+			min-height: revert;
+			max-width: revert;
+			vertical-align: revert;
+			font-weight: revert;
+		}
 	}
 
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #32849. 

Legacy widget edit forms were inheriting some theme styles, this PR adds some CSS to override them.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. With Twenty Twenty One theme enabled, set a dark background in Customize > Colors & Dark Mode.
2. In the Widgets editor, add a Legacy Widget, choose a widget option (Meta or Navigation will do) and check that all labels and fields are visible in the edit form.

## Screenshots <!-- if applicable -->

<img width="695" alt="Screen Shot 2021-06-22 at 11 22 15 am" src="https://user-images.githubusercontent.com/8096000/122848061-29f79a00-d34c-11eb-9f30-985e7a250bbf.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
