### PR TITLE
Second batch of package updates for WordPress 5.8 beta 3

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -138,7 +138,7 @@ function gutenberg_menu_order( $menu_order ) {
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	return ( is_callable( 'get_current_screen' ) && 'toplevel_page_gutenberg-edit-site' === get_current_screen()->base )
+	return ( is_callable( 'get_current_screen' ) && get_current_screen() && 'toplevel_page_gutenberg-edit-site' === get_current_screen()->base )
 		? true
 		: $is_block_editor_screen;
 }

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -64,7 +64,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
+	if ( is_callable( 'get_current_screen' ) && get_current_screen() && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
 		return true;
 	}
 

--- a/lib/widgets-api.php
+++ b/lib/widgets-api.php
@@ -217,6 +217,32 @@ if ( ! function_exists( 'gutenberg_get_widget_instance' ) ) {
 	}
 }
 
+if ( ! function_exists( 'gutenberg_get_widget_key' ) ) {
+	/**
+	 * Returns the registered key for the given widget type.
+	 *
+	 * Belongs in WP_Widget_Factory when merged to Core.
+	 *
+	 * Can be removed when minimum WordPress version is 5.8.
+	 *
+	 * @since 10.3.0
+	 *
+	 * @param string $id_base Widget type ID.
+	 * @return string
+	 */
+	function gutenberg_get_widget_key( $id_base ) {
+		global $wp_widget_factory;
+
+		foreach ( $wp_widget_factory->widgets as $key => $widget_object ) {
+			if ( $widget_object->id_base === $id_base ) {
+				return $key;
+			}
+		}
+
+		return '';
+	}
+}
+
 if ( ! function_exists( 'gutenberg_get_widget_object' ) ) {
 	/**
 	 * Returns the registered WP_Widget object for the given widget type.
@@ -233,12 +259,11 @@ if ( ! function_exists( 'gutenberg_get_widget_object' ) ) {
 	function gutenberg_get_widget_object( $id_base ) {
 		global $wp_widget_factory;
 
-		foreach ( $wp_widget_factory->widgets as $widget_object ) {
-			if ( $widget_object->id_base === $id_base ) {
-				return $widget_object;
-			}
+		$key = gutenberg_get_widget_key( $id_base );
+		if ( ! $key ) {
+			return null;
 		}
 
-		return null;
+		return $wp_widget_factory->widgets[ $key ];
 	}
 }

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -126,7 +126,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
+	if ( is_callable( 'get_current_screen' ) && get_current_screen() && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
 		return true;
 	}
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,6 +32,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
+	".interface-interface-skeleton__body": 20,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,7 +32,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
-	".interface-interface-skeleton__body": 20,
+	".interface-interface-skeleton__content": 20,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -87,7 +87,7 @@ html.interface-interface-skeleton__html-container {
 	// On Safari iOS on smaller viewports lack of a z-index causes the background
 	// to "bleed" through the header.
 	// See https://github.com/WordPress/gutenberg/issues/32631
-	z-index: z-index(".interface-interface-skeleton__body");
+	z-index: z-index(".interface-interface-skeleton__content");
 
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -82,8 +82,12 @@ html.interface-interface-skeleton__html-container {
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	// Beyond the medium breakpoint, we allow the sidebar.
 	// The sidebar should scroll independently, so enable scroll here also.
-
 	overflow: auto;
+
+	// On Safari iOS on smaller viewports lack of a z-index causes the background
+	// to "bleed" through the header.
+	// See https://github.com/WordPress/gutenberg/issues/32631
+	z-index: z-index(".interface-interface-skeleton__body");
 
 }
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -13,8 +13,8 @@ import {
 	BlockIcon,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { ToolbarButton, Spinner, Placeholder } from '@wordpress/components';
-import { brush as brushIcon, update as updateIcon } from '@wordpress/icons';
+import { Spinner, Placeholder } from '@wordpress/components';
+import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -94,23 +94,14 @@ function NotEmpty( {
 } ) {
 	const [ hasPreview, setHasPreview ] = useState( null );
 
-	const {
-		widgetType,
-		hasResolvedWidgetType,
-		isWidgetTypeHidden,
-		isNavigationMode,
-	} = useSelect(
+	const { widgetType, hasResolvedWidgetType, isNavigationMode } = useSelect(
 		( select ) => {
 			const widgetTypeId = id ?? idBase;
-			const hiddenIds =
-				select( blockEditorStore ).getSettings()
-					?.widgetTypesToHideFromLegacyWidgetBlock ?? [];
 			return {
 				widgetType: select( coreStore ).getWidgetType( widgetTypeId ),
 				hasResolvedWidgetType: select(
 					coreStore
 				).hasFinishedResolution( 'getWidgetType', [ widgetTypeId ] ),
-				isWidgetTypeHidden: hiddenIds.includes( widgetTypeId ),
 				isNavigationMode: select( blockEditorStore ).isNavigationMode(),
 			};
 		},
@@ -144,22 +135,6 @@ function NotEmpty( {
 
 	return (
 		<>
-			{ ! isWidgetTypeHidden && (
-				<BlockControls group="block">
-					<ToolbarButton
-						label={ __( 'Change widget' ) }
-						icon={ updateIcon }
-						onClick={ () =>
-							setAttributes( {
-								id: null,
-								idBase: null,
-								instance: null,
-							} )
-						}
-					/>
-				</BlockControls>
-			) }
-
 			{ idBase === 'text' && (
 				<BlockControls group="other">
 					<ConvertToBlocksButton

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -114,7 +114,7 @@ function handle_legacy_widget_preview_iframe() {
 	exit;
 }
 
-// Ensure handle_legacy_widget_preview_iframe() is called after Core's
-// register_block_core_legacy_widget() (priority = 10) and after Gutenberg's
-// register_block_core_legacy_widget() (priority = 20).
-add_action( 'init', 'handle_legacy_widget_preview_iframe', 21 );
+// Use admin_init instead of init to ensure get_current_screen function is already available.
+// This isn't strictly required, but enables better compatibility with existing plugins.
+// See: https://github.com/WordPress/gutenberg/issues/32624.
+add_action( 'admin_init', 'handle_legacy_widget_preview_iframe', 20 );

--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -24,13 +24,14 @@ function render_block_core_legacy_widget( $attributes ) {
 		return '';
 	}
 
-	if ( method_exists( $wp_widget_factory, 'get_widget_object' ) ) {
-		$widget_object = $wp_widget_factory->get_widget_object( $attributes['idBase'] );
+	$id_base = $attributes['idBase'];
+	if ( method_exists( $wp_widget_factory, 'get_widget_key' ) ) {
+		$widget_key = $wp_widget_factory->get_widget_key( $id_base );
 	} else {
-		$widget_object = gutenberg_get_widget_object( $attributes['idBase'] );
+		$widget_key = gutenberg_get_widget_key( $id_base );
 	}
 
-	if ( ! $widget_object ) {
+	if ( ! $widget_key ) {
 		return '';
 	}
 
@@ -45,7 +46,7 @@ function render_block_core_legacy_widget( $attributes ) {
 	}
 
 	ob_start();
-	the_widget( get_class( $widget_object ), $instance );
+	the_widget( $widget_key, $instance );
 	return ob_get_clean();
 }
 

--- a/packages/widgets/src/blocks/legacy-widget/transforms.js
+++ b/packages/widgets/src/blocks/legacy-widget/transforms.js
@@ -14,7 +14,7 @@ const legacyWidgetTransforms = [
 	},
 	{
 		block: 'core/html',
-		widget: 'html',
+		widget: 'custom_html',
 		transform: ( { content } ) => ( {
 			content,
 		} ),


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/32848.

Widgets Editor:

- Widget preivew not working if widget registered via a instance #32781
- Remove the widget switcher block toolbar button #32733
- Legacy custom html widget should have option to transform to custom html block #32862
- Wire handle_legacy_widget_preview_iframe to admin_init_hook #32854
- Set explicit z-index on interface body to ensure it’s pinned under interface header #32732
- Rename .interface-interface-skeleton__body z-index to .interface-interface-skeleton__content #32869