### PR TITLE
[WIP] Button: Adopt width block support for button widths

### DIFF
--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -230,6 +230,9 @@
 			"core/button": {
 				"border": {
 					"radius": true
+				},
+				"dimensions": {
+					"width": true
 				}
 			},
 			"core/pullquote": {

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -73,6 +73,13 @@
 				"fontSize": true
 			}
 		},
+		"__experimentalDimensions": {
+			"width": "segmented",
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"width": true
+			}
+		},
 		"reusable": false,
 		"spacing": {
 			"__experimentalSkipSerialization": true,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -8,14 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
-import {
-	Button,
-	ButtonGroup,
-	PanelBody,
-	TextControl,
-	ToolbarButton,
-	Popover,
-} from '@wordpress/components';
+import { TextControl, ToolbarButton, Popover } from '@wordpress/components';
 import {
 	BlockControls,
 	InspectorControls,
@@ -30,40 +23,12 @@ import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import getWidthClassesAndStyles from './get-width-classes-and-styles';
+
 const NEW_TAB_REL = 'noreferrer noopener';
-
-function WidthPanel( { selectedWidth, setAttributes } ) {
-	function handleChange( newWidth ) {
-		// Check if we are toggling the width off
-		const width = selectedWidth === newWidth ? undefined : newWidth;
-
-		// Update attributes
-		setAttributes( { width } );
-	}
-
-	return (
-		<PanelBody title={ __( 'Width settings' ) }>
-			<ButtonGroup aria-label={ __( 'Button width' ) }>
-				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-					return (
-						<Button
-							key={ widthValue }
-							isSmall
-							variant={
-								widthValue === selectedWidth
-									? 'primary'
-									: undefined
-							}
-							onClick={ () => handleChange( widthValue ) }
-						>
-							{ widthValue }%
-						</Button>
-					);
-				} ) }
-			</ButtonGroup>
-		</PanelBody>
-	);
-}
 
 function ButtonEdit( props ) {
 	const {
@@ -75,14 +40,15 @@ function ButtonEdit( props ) {
 		mergeBlocks,
 	} = props;
 	const {
+		fontSize,
 		linkTarget,
 		placeholder,
 		rel,
 		style,
 		text,
 		url,
-		width,
 	} = attributes;
+
 	const onSetLinkRel = useCallback(
 		( value ) => {
 			setAttributes( { rel: value } );
@@ -123,9 +89,9 @@ function ButtonEdit( props ) {
 	const borderProps = useBorderProps( attributes );
 	const colorProps = useColorProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
+	const widthProps = getWidthClassesAndStyles( attributes );
 	const ref = useRef();
 	const richTextRef = useRef();
-	const blockProps = useBlockProps( { ref, onKeyDown } );
 
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
 	const isURLSet = !! url;
@@ -151,15 +117,18 @@ function ButtonEdit( props ) {
 		}
 	}, [ isSelected ] );
 
+	const blockProps = useBlockProps( {
+		ref,
+		onKeyDown,
+		className: classnames( widthProps.className, {
+			[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
+		} ),
+		style: widthProps.style,
+	} );
+
 	return (
 		<>
-			<div
-				{ ...blockProps }
-				className={ classnames( blockProps.className, {
-					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
-					[ `has-custom-font-size` ]: blockProps.style.fontSize,
-				} ) }
-			>
+			<div { ...blockProps }>
 				<RichText
 					ref={ richTextRef }
 					aria-label={ __( 'Button text' ) }
@@ -246,12 +215,6 @@ function ButtonEdit( props ) {
 					/>
 				</Popover>
 			) }
-			<InspectorControls>
-				<WidthPanel
-					selectedWidth={ width }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
 					label={ __( 'Link rel' ) }

--- a/packages/block-library/src/button/get-width-classes-and-styles.js
+++ b/packages/block-library/src/button/get-width-classes-and-styles.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+export default function getWidthProps( { style } ) {
+	const width = style?.dimensions?.width;
+	const presetWidth = [ 25, 50, 75, 100 ].find(
+		( preset ) => `${ preset }%` === width
+	);
+	const customWidth = width && ! presetWidth ? width : undefined;
+
+	const className = classnames( {
+		[ `has-custom-width` ]: width,
+		[ `wp-block-button__width-${ presetWidth }` ]: presetWidth,
+	} );
+
+	return {
+		className: className || undefined,
+		style: { width: customWidth },
+	};
+}

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -14,17 +14,13 @@ import {
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import getWidthClassesAndStyles from './get-width-classes-and-styles';
+
 export default function save( { attributes, className } ) {
-	const {
-		fontSize,
-		linkTarget,
-		rel,
-		style,
-		text,
-		title,
-		url,
-		width,
-	} = attributes;
+	const { fontSize, linkTarget, rel, style, text, title, url } = attributes;
 
 	if ( ! text ) {
 		return null;
@@ -53,13 +49,18 @@ export default function save( { attributes, className } ) {
 	// if it had already been assigned, for the sake of backward-compatibility.
 	// A title will no longer be assigned for new or updated button block links.
 
-	const wrapperClasses = classnames( className, {
-		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+	const widthProps = getWidthClassesAndStyles( attributes );
+	const wrapperClasses = classnames( className, widthProps.className, {
 		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 	} );
 
 	return (
-		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+		<div
+			{ ...useBlockProps.save( {
+				className: wrapperClasses,
+				style: widthProps.style,
+			} ) }
+		>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }


### PR DESCRIPTION
🚧  This is in progress and only intended to further discussion on the width block support and proposed width control. 🚧 

## Description

A proof of concept in switching the button block to use the [proposed width block support](https://github.com/WordPress/gutenberg/pull/32502).

### Known issues

Custom widths that do not match preset percentage widths (`25`, `50`, `75`, `100`) do not automatically take into account margin or column gap. Possible options include including `<style>` or styled component that does factor the margin/gap in.

### Next Steps

- [ ] Investigate styled component solution to factoring in margins/column gaps within buttons block
- [ ] Would the block benefit from having a toggle to turn the above adjustment on/off?
- [ ] Add a deprecation to migrate from the old `width` attribute to the block support's `style.dimensions.width` attribute


## How has this been tested?
🚧 TBA.

## Screenshots <!-- if applicable -->
<img width="1175" alt="Screen Shot 2021-06-22 at 4 13 03 pm" src="https://user-images.githubusercontent.com/60436221/122873191-ce8dd200-d374-11eb-825d-88229fa89c52.png">

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
