### PR TITLE
Post Template Block: Add alignfull rules

### DIFF
--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -3,5 +3,22 @@
 		padding-left: 0;
 		margin-left: 0;
 		list-style: none;
+
+		[data-align="full"] &,
+		.alignfull & {
+			max-width: none;
+			width: auto;
+		}
 	}
+
+	// We need to nest this below .editor-styles-wrapper so it has enough specificity to override the padding-left: 0 above.
+	[data-align="full"],
+	.alignfull {
+		ul.wp-block-post-template {
+			max-width: none;
+			padding: 0 1em;
+			width: auto;
+		}
+	}
+
 }

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -40,6 +40,7 @@
 		}
 	}
 
+	[data-align="full"] &,
 	.alignfull & {
 		padding: 0 1em;
 	}

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -39,4 +39,8 @@
 			}
 		}
 	}
+
+	.alignfull & {
+		padding: 0 1em;
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When the Post Template block has "full width" alignment, it sits right against the container (usually the window), which makes for a poor reading experience. This PR adds 1em padding to the left and right of the block so it is easier to read. It also removes the width constraints on the block in the editor, so the editor matches the front end.

This was raised in https://core.trac.wordpress.org/ticket/53398

## How has this been tested?
Tested in TT1 with Post Template blocks in both grid and list view.

## Screenshots <!-- if applicable -->
Before
<img width="1440" alt="Screenshot 2021-06-22 at 11 52 06" src="https://user-images.githubusercontent.com/275961/122912491-4dbcdf00-d350-11eb-9bdc-6fc5791f867e.png">
<img width="1440" alt="Screenshot 2021-06-22 at 11 51 46" src="https://user-images.githubusercontent.com/275961/122912502-501f3900-d350-11eb-8a14-44e7de64e409.png">

After
<img width="1439" alt="Screenshot 2021-06-22 at 11 49 26" src="https://user-images.githubusercontent.com/275961/122912261-0afb0700-d350-11eb-8ab2-bd012bde7bf1.png">
<img width="1440" alt="Screenshot 2021-06-22 at 11 49 18" src="https://user-images.githubusercontent.com/275961/122912265-0c2c3400-d350-11eb-8cb1-003e3234c415.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
