### PR TITLE
Navigation Overlay: Improve handling of open overlay.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -443,6 +443,13 @@ $color-control-label-height: 20px;
 	}
 }
 
+// The iframe makes these rules a lot simpler.
+body.editor-styles-wrapper .wp-block-navigation__responsive-container.is-menu-open {
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+}
 
 // Without this, the block cannot be selected, nor does the right container get focus.
 // @todo: this is disruptive. Ideally we can retire a few of the containers,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -385,21 +385,64 @@ $color-control-label-height: 20px;
 }
 
 // Emulate the fullscreen editing inside the editor.
+// Most of this can be removed when the iframe lands.
+
+// When not fullscreen.
 .wp-block-navigation__responsive-container.is-menu-open {
 	position: fixed;
+	top: $admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
-	// Handle top position.
-	// For now, the editing of menu items in the mobile view only happens <600px.
-	// That means we only have to consider the big adminbar height (<783px).
-	// And in that view we also know that the toolbar is stacked.
-	body.admin-bar & {
+	@include break-medium() {
+		top: $admin-bar-height + $header-height + $border-width;
+	}
+
+	// Navigation sidebar rules.
+	@include break-medium() {
+		left: $admin-sidebar-width-collapsed;
+	}
+	@include break-large() {
+		left: $admin-sidebar-width;
+	}
+}
+
+.has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
+	@include break-medium() {
+		top: $admin-bar-height + $header-height + $block-toolbar-height + $border-width;
+	}
+}
+
+.is-mobile-preview .wp-block-navigation__responsive-container.is-menu-open,
+.is-tablet-preview .wp-block-navigation__responsive-container.is-menu-open {
+	top: $admin-bar-height + $header-height + $block-toolbar-height + $border-width;
+}
+
+.is-sidebar-opened .wp-block-navigation__responsive-container.is-menu-open {
+	right: $sidebar-width;
+}
+
+// When fullscreen.
+.is-fullscreen-mode {
+	.wp-block-navigation__responsive-container.is-menu-open {
+		left: 0; // Unset the value from non fullscreen mode.
 		top: $admin-bar-height-big + $header-height + $block-toolbar-height + $border-width;
 
 		@include break-medium() {
 			top: $header-height + $border-width;
 		}
 	}
+
+	.has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
+		@include break-medium() {
+			top: $header-height + $block-toolbar-height + $border-width;
+		}
+	}
+
+	.is-mobile-preview .wp-block-navigation__responsive-container.is-menu-open,
+	.is-tablet-preview .wp-block-navigation__responsive-container.is-menu-open {
+		top: $header-height + $block-toolbar-height + $border-width;
+	}
 }
+
 
 // Without this, the block cannot be selected, nor does the right container get focus.
 // @todo: this is disruptive. Ideally we can retire a few of the containers,

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -137,6 +137,7 @@ export default function VisualEditor( { styles } ) {
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
 	const defaultLayout = useSetting( 'layout' );
 	const { contentSize, wideSize } = defaultLayout || {};
+	const previewMode = 'is-' + deviceType.toLowerCase() + '-preview';
 
 	let animatedStyles = isTemplateMode
 		? templateModeStyles
@@ -219,6 +220,7 @@ export default function VisualEditor( { styles } ) {
 					<motion.div
 						animate={ animatedStyles }
 						initial={ desktopCanvasStyles }
+						className={ previewMode }
 					>
 						<MaybeIframe
 							isTemplateMode={ isTemplateMode }


### PR DESCRIPTION
## Description

The navigation overlay menu, the one you get when you enable "Responsive menu" on the navigation block, can be opened inside the editor. When that happens, you see the full overlay just like you do on the frontend.

However where `position: fixed;` for the fullscreen menu is fine on the frontend because it literally needs to cover everything, when inside the editor, we still need to see the UI, like the top toolbar, the sidebar, etc. And we can't use `position: absolute;` because there are some ancestors setting `position: relative;`, breaking that. 

This PR adds:

- CSS classes to the viewport container, `is-mobile-preview` and `is-tablet-preview` and `is-desktop-preview`.
- Leverages those classes, and existing classes, to provide positioning rules so that the overlay menu never covers anything.

![now](https://user-images.githubusercontent.com/1204802/122916733-83b49000-d35d-11eb-9cbd-7a997c8c8012.gif)

I suspect the device preview classes are useful in other contexts, but let me know if you'd prefer me to find another way to handle this.

![now](https://user-images.githubusercontent.com/1204802/122916836-9dee6e00-d35d-11eb-82aa-a8be9213a6aa.gif)

A silver lining is: all of this positioning stuff can be removed when this lands in an iframe, including making the preview accept the device preview sizings.

## How has this been tested?

Insert a navigation menu with some menu items. Enable responsive menu. Add a background color so you can more easily see the overlay. Now scale the viewport small so the burger menu becomes visible. Then click the burger menu and resize back.

Now try combinations of device preview, top toolbar, fullscreen, and breakpoints.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
