### PR TITLE
Fix Post Template Editor e2e test - Templates tab missing

### DIFF
--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -12,6 +12,11 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 const openSidebarPanelWithTitle = async ( title ) => {
+	await page.evaluate( () =>
+		wp.data
+			.dispatch( 'core/edit-post' )
+			.toggleEditorPanelEnabled( 'template' )
+	);
 	const panel = await page.waitForXPath(
 		`//div[contains(@aria-label,"Editor settings")]//button[contains(text(),"${ title }")]`
 	);

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -9,7 +9,6 @@ import {
 	trashAllPosts,
 	openPreviewPage,
 	openDocumentSettingsSidebar,
-	closeDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 const openSidebarPanelWithTitle = async ( title ) => {
@@ -61,8 +60,6 @@ const createNewTemplate = async ( templateName ) => {
 	await disableTemplateWelcomeGuide();
 
 	// Create a new custom template.
-	await openDocumentSettingsSidebar();
-	await closeDocumentSettingsSidebar();
 	await openDocumentSettingsSidebar();
 	await openSidebarPanelWithTitle( 'Template' );
 	const newTemplateXPath =

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -13,7 +13,7 @@ import {
 
 const openSidebarPanelWithTitle = async ( title ) => {
 	const panel = await page.waitForXPath(
-		`//div[contains(@class,"edit-post-sidebar")]//button[@class="components-button components-panel__body-toggle"][contains(text(),"${ title }")]`
+		`//div[contains(@aria-label,"Editor settings")]//button[contains(text(),"${ title }")]`
 	);
 	await panel.click();
 };

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -9,6 +9,7 @@ import {
 	trashAllPosts,
 	openPreviewPage,
 	openDocumentSettingsSidebar,
+	closeDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 const openSidebarPanelWithTitle = async ( title ) => {
@@ -60,6 +61,8 @@ const createNewTemplate = async ( templateName ) => {
 	await disableTemplateWelcomeGuide();
 
 	// Create a new custom template.
+	await openDocumentSettingsSidebar();
+	await closeDocumentSettingsSidebar();
 	await openDocumentSettingsSidebar();
 	await openSidebarPanelWithTitle( 'Template' );
 	const newTemplateXPath =


### PR DESCRIPTION
Avoid relying on developer APIs such as classnames to select things.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The PR attempts to resolve the current failures on `End-to-End Tests / Admin - 4 (pull_request)` around the Post Editor Template mode.

* `Post Editor Template mode › Allow creating custom block templates in classic themes`
* `Post Editor Template mode › Allow to switch to template mode, edit the template and check the result`

Currently, tests are failing because the e2e test tries to select an element using two classnames...

https://github.com/WordPress/gutenberg/blob/aefdcfe329db0d5b6d0442e35316cfecd914bde0/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js#L15-L17

...one of which `components-panel__body-toggle` no longer exists:

<img width="1280" alt="Screen Shot 2021-06-22 at 12 44 51" src="https://user-images.githubusercontent.com/444434/122919365-0e928c00-d358-11eb-8105-6c6e802d760c.png">

This PR utilises user-perceivable means of selecting the correct button without relying on developer focused APIs such as classnames. Over reliance on such developer focused APIs makes test extremely brittle because classnames might be an API of a lower level component which might change at any point.



## How has this been tested?
Run

`npm run test-e2e:watch packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js`

or

`npm run test-e2e:watch -- --puppeteer-interactive packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js`

Check they pass correctly.


## Screenshots <!-- if applicable -->

Here's a broken test from https://github.com/WordPress/gutenberg/pull/32761

<img width="943" alt="Screen Shot 2021-06-22 at 12 50 59" src="https://user-images.githubusercontent.com/444434/122919761-852f8980-d358-11eb-8927-9f0626d5af7f.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

