### PR TITLE
Testing: Fix failing PHPUnit test caused by changes in WP core

### DIFF
--- a/phpunit/class-block-editor-test.php
+++ b/phpunit/class-block-editor-test.php
@@ -163,7 +163,7 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		$settings = gutenberg_get_default_block_editor_settings();
 
 		$this->assertCount( 17, $settings );
-		$this->assertTrue( $settings['__unstableEnableFullSiteEditingBlocks'] );
+		$this->assertFalse( $settings['__unstableEnableFullSiteEditingBlocks'] );
 		$this->assertFalse( $settings['alignWide'] );
 		$this->assertInternalType( 'array', $settings['allowedMimeTypes'] );
 		$this->assertTrue( $settings['allowedBlockTypes'] );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I'm seeing PHPUnit test failures in `trunk` and in my of one rebased branches:

<img width="1130" alt="Screen Shot 2021-06-22 at 14 18 47" src="https://user-images.githubusercontent.com/699132/122923304-de9db580-d364-11eb-99dc-7aa5715fc0d5.png">

It is most likely related to the changes in WP core to the template editor and the condition when it is enabled.