### PR TITLE
Prepublish Panel: Disable the Publish and Cancel buttons while saving

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -147,7 +147,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const buttonProps = {
-			'aria-disabled': isButtonDisabled && ! hasNonPostEntityChanges,
+			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
 			isBusy: ! isAutoSaving && isSaving && isPublished,
 			variant: 'primary',

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -25,6 +25,22 @@ describe( 'PostPublishButton', () => {
 			);
 		} );
 
+		it( 'should be true if post is currently saving, even if there are non-post entity changes', () => {
+			// This normally means that we're still saving those changes.
+			const wrapper = shallow(
+				<PostPublishButton
+					hasNonPostEntityChanges
+					isPublishable
+					isSaveable
+					isSaving
+				/>
+			);
+
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
+				true
+			);
+		} );
+
 		it( 'should be true if forceIsSaving is true', () => {
 			const wrapper = shallow(
 				<PostPublishButton isPublishable isSaveable forceIsSaving />
@@ -90,6 +106,20 @@ describe( 'PostPublishButton', () => {
 		it( 'should be false if post is publishave and saveable', () => {
 			const wrapper = shallow(
 				<PostPublishButton isPublishable isSaveable />
+			);
+
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should be false if there are non-post entity changes', () => {
+			const wrapper = shallow(
+				<PostPublishButton
+					hasNonPostEntityChanges
+					isPublishable
+					isSaveable
+				/>
 			);
 
 			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -94,10 +94,15 @@ export class PostPublishPanel extends Component {
 									onSubmit={ this.onSubmit }
 									forceIsDirty={ forceIsDirty }
 									forceIsSaving={ forceIsSaving }
+									isSaving={ isSaving }
 								/>
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">
-								<Button onClick={ onClose } variant="secondary">
+								<Button
+									disabled={ isSaving }
+									onClick={ onClose }
+									variant="secondary"
+								>
 									{ __( 'Cancel' ) }
 								</Button>
 							</div>

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -94,7 +94,6 @@ export class PostPublishPanel extends Component {
 									onSubmit={ this.onSubmit }
 									forceIsDirty={ forceIsDirty }
 									forceIsSaving={ forceIsSaving }
-									isSaving={ isSaving }
 								/>
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -128,7 +128,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
     >
       <WithSelect(WithDispatch(PostPublishButton))
         focusOnMount={true}
-        isSaving={false}
         onSubmit={[Function]}
       />
     </div>
@@ -170,7 +169,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
     >
       <WithSelect(WithDispatch(PostPublishButton))
         focusOnMount={true}
-        isSaving={true}
         onSubmit={[Function]}
       />
     </div>

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -128,6 +128,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
     >
       <WithSelect(WithDispatch(PostPublishButton))
         focusOnMount={true}
+        isSaving={false}
         onSubmit={[Function]}
       />
     </div>
@@ -135,6 +136,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
+        disabled={false}
         variant="secondary"
       >
         Cancel
@@ -168,6 +170,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
     >
       <WithSelect(WithDispatch(PostPublishButton))
         focusOnMount={true}
+        isSaving={true}
         onSubmit={[Function]}
       />
     </div>
@@ -175,6 +178,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
+        disabled={true}
         variant="secondary"
       >
         Cancel


### PR DESCRIPTION
## Description
Found while working on #32868; see the conversation starting at https://github.com/WordPress/gutenberg/pull/32868#discussion_r655903289 for more background.

Currently, when editing a post in such a way that a "multi-entity save" is required (i.e. updates to things that aren't just limited to the post content (and other post attributes), but e.g. site title and the like), the user is prompted with a panel to save those changes prior to publishing the post.

Once they're done saving, they're presented with the regular pre-publish panel, including the familiar 'Publish' and 'Cancel' buttons. Actually, those buttons are visible even before the rest of the pre-publish panel is: The panel might still show a spinner that indicates that entities are being saved, but the buttons are already present -- and clickable.

This has turned out to be a problem in e2e tests, where the headless browser is quick enough to press one of those buttons, even though entities haven't been saved yet. However, it's of course possible that a user might also be quick enough (e.g. if behind a slow network connection).

In order to ensure that entities are really saved/updated prior to allowing the user to click the 'Publish' or 'Cancel' button, ~this PR makes them `disabled` while `isSaving` is `true`.~ _Edit: Nope, see https://github.com/WordPress/gutenberg/pull/32889#issuecomment-867182739._

Note that there are quite a number of conditions around `isSaving` (and an extra `forceIsSaving` prop 😅 ) in `PostPublishButton`, so it'd be great if someone more familiar with those could review this PR 😄 

## How has this been tested?
- Throttle your network connection.
- Create a new post.
- Add a 'Site Title' block.
- Edit the site title in the block to some new value.
- The 'Publish' button in the top right corner should now show a little dot, indicating that entities need saving.
- Click the 'Publish' button. This will open the entity saving panel.
- Click 'Save'.
- Note that the panel now shows a spinner. Furthermore, note that the 'Publish' and 'Cancel' buttons are already visible. On `trunk`, they will be enabled; on this PR, they will be disabled.
- On `trunk`, try clicking 'Cancel' while the spinner is still there. Reload the page (and discard any changes), and observe that the site title hasn't been changed. 

## Screenshots

Before:

![save](https://user-images.githubusercontent.com/96308/122920620-e3149f00-d361-11eb-951b-1b154b2a0d9e.jpg)

After:

![saveEntities](https://user-images.githubusercontent.com/96308/123254180-a2965c00-d4ee-11eb-912b-9209c68709be.jpg)
