### PR TITLE
Fix collapsing appender when paragraph disabled.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -40,6 +40,7 @@
 			background-color: $gray-900;
 			color: $white;
 			border-radius: $radius-block-ui;
+			flex: 1 0 auto;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #32891, with context in https://github.com/WordPress/gutenberg/pull/28219#discussion_r656230139.

If you have the Paragraph block disabled, whether manually or through a custom post type, the plus button collapses to this:

<img width="650" alt="Screenshot 2021-06-22 at 15 57 43" src="https://user-images.githubusercontent.com/1204802/122938295-eb290a80-d372-11eb-8a43-2844ff42e5c0.png">

The SVG has zero width:

<img width="799" alt="Screenshot 2021-06-22 at 15 57 48" src="https://user-images.githubusercontent.com/1204802/122938303-ee23fb00-d372-11eb-8850-e267c8f2c805.png">

This PR sets flex-shrink to zero, causing it to not collapse:

<img width="453" alt="Screenshot 2021-06-22 at 15 56 39" src="https://user-images.githubusercontent.com/1204802/122938331-f54b0900-d372-11eb-9a41-92dfce4d4897.png">

It would be nice to revisit this particular appender and offer a bigger one, such as what's seen in the group block. We might even revisit that appender component entirely and provide an ability to select it, like so:

<img width="1427" alt="Screenshot 2021-06-22 at 15 57 25" src="https://user-images.githubusercontent.com/1204802/122938459-0e53ba00-d373-11eb-8e4e-29f734f41d4b.png">

But that's a bigger undertaking, and this being a very small change can serve as a hotfix.

## How has this been tested?

Add a custom post type that disables the paragraph, or just disable the paragraph in your preferences:

<img width="751" alt="Screenshot 2021-06-22 at 15 51 42" src="https://user-images.githubusercontent.com/1204802/122938531-2297b700-d373-11eb-8770-27c77cc5655a.png">

Create a new empty post, and you should see a black plus button.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
