### PR TITLE
added conditional class to block-switcher.js to target reusable and c…

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -149,7 +149,11 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 							<>
 								<BlockIcon
 									icon={ icon }
-									className="block-editor-block-switcher__toggle"
+									className={
+										isReusable || isTemplate
+											? 'block-editor-block-switcher__toggle-with-text'
+											: 'block-editor-block-switcher__toggle'
+									}
 									showColors
 								/>
 								{ ( isReusable || isTemplate ) && (

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -21,7 +21,7 @@
 }
 
 .block-editor-block-switcher__toggle-text {
-	margin-left: $grid-unit-10;
+	margin-right: $grid-unit-10;
 
 	// Account for double label when show-text-buttons is set.
 	.show-icon-labels & {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -79,6 +79,10 @@
 		.block-editor-block-icon {
 			width: $button-size-small !important;
 			margin: 0 !important;
+
+			&.block-editor-block-switcher__toggle-with-text {
+				width: $grid-unit-50 !important;
+			}
 		}
 
 		&:focus::before {


### PR DESCRIPTION
…ustom block icons in the toolbar

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes #32599

## How has this been tested?
Using npm run test

## Screenshots <!-- if applicable -->

## Types of changes
conditional class render block-switcher.js and new css for those icons.  I'm not sure the reusable block icon is being stretched.  I think the file is displaying properly.  Perhaps the file is stretched?  Not 100% confident on that.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
