### PR TITLE
Fix broken the post-template-editor test.

### DIFF
--- a/packages/e2e-tests/plugins/block-templates.php
+++ b/packages/e2e-tests/plugins/block-templates.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Block Templates
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-block-templates
+ */
+
+/**
+ * Activate Block Templates.
+ */
+function enqueue_block_templates() {
+	add_theme_support( 'block-templates' );
+}
+
+add_action( 'setup_theme', 'enqueue_block_templates' );

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -9,6 +9,8 @@ import {
 	trashAllPosts,
 	openPreviewPage,
 	openDocumentSettingsSidebar,
+	activatePlugin,
+	deactivatePlugin,
 } from '@wordpress/e2e-test-utils';
 
 const openSidebarPanelWithTitle = async ( title ) => {
@@ -96,6 +98,7 @@ describe( 'Post Editor Template mode', () => {
 
 	afterAll( async () => {
 		await activateTheme( 'twentytwentyone' );
+		await deactivatePlugin( 'gutenberg-test-block-templates' );
 	} );
 
 	it( 'Allow to switch to template mode, edit the template and check the result', async () => {
@@ -143,6 +146,7 @@ describe( 'Post Editor Template mode', () => {
 	} );
 
 	it( 'Allow creating custom block templates in classic themes', async () => {
+		await activatePlugin( 'gutenberg-test-block-templates' );
 		await activateTheme( 'twentytwentyone' );
 		await createNewPost();
 		// Create a random post.

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -146,7 +146,6 @@ describe( 'Post Editor Template mode', () => {
 	} );
 
 	it( 'Allow creating custom block templates in classic themes', async () => {
-		await activatePlugin( 'gutenberg-test-block-templates' );
 		await activateTheme( 'twentytwentyone' );
 		await createNewPost();
 		// Create a random post.

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -91,7 +91,7 @@ const createNewTemplate = async ( templateName ) => {
 
 describe( 'Post Editor Template mode', () => {
 	beforeAll( async () => {
-		await activateTheme( 'tt1-blocks' );
+		await activatePlugin( 'gutenberg-test-block-templates' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );

--- a/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js
@@ -89,6 +89,7 @@ const createNewTemplate = async ( templateName ) => {
 
 describe( 'Post Editor Template mode', () => {
 	beforeAll( async () => {
+		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 	} );


### PR DESCRIPTION
## Description
related: #32744. #32858.

Post Editor Template mode test broken now. This problem is caused by the fact that "block-templates" is not enabled in the classic theme. 

I added a plugin to e2e-tests to solve this problem.

## How has this been tested?

` npm run test-e2e -- --puppeteer-interactive ./packages/e2e-tests/specs/experiments/post-editor-template-mode.test.js`


## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
