### PR TITLE
Columns: Update columns to allow full height stretch when vertically aligned

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -103,6 +103,8 @@
 
 .wp-block-column {
 	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
 
 	// Prevent the columns from growing wider than their distributed sizes.
 	min-width: 0;
@@ -115,15 +117,15 @@
 	* Individual Column Alignment
 	*/
 	&.is-vertically-aligned-top {
-		align-self: flex-start;
+		justify-content: flex-start;
 	}
 
 	&.is-vertically-aligned-center {
-		align-self: center;
+		justify-content: center;
 	}
 
 	&.is-vertically-aligned-bottom {
-		align-self: flex-end;
+		justify-content: flex-end;
 	}
 
 	&.is-vertically-aligned-top,

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -113,6 +113,10 @@
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
 
+	> .wp-block[data-align="right"] {
+		margin-left: auto;
+	}
+
 	/**
 	* Individual Column Alignment
 	*/

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -103,8 +103,6 @@
 
 .wp-block-column {
 	flex-grow: 1;
-	display: flex;
-	flex-direction: column;
 
 	// Prevent the columns from growing wider than their distributed sizes.
 	min-width: 0;
@@ -112,6 +110,12 @@
 	// Prevent long unbroken words from overflowing.
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
+
+	// Only apply display flex for vertically aligned columns.
+	&[class*="is-vertically-aligned-"] {
+		display: flex;
+		flex-direction: column;
+	}
 
 	// Columns need flex layout to achieve full height column when vertically
 	// aligned with a background color. This means normal float alignments for

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -113,8 +113,30 @@
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
 
+	// Columns need flex layout to achieve full height column when vertically
+	// aligned with a background color. This means normal float alignments for
+	// immediate children will not work properly. Allowing them to stretch full
+	// width then floating their contents gives reasonable compromise.
+	> .wp-block[data-align="left"] {
+		height: auto;
+
+		> * {
+			float: left;
+		}
+	}
+
 	> .wp-block[data-align="right"] {
-		margin-left: auto;
+		height: auto;
+
+		> * {
+			float: right;
+		}
+	}
+
+	// Flex column layout requires this tweak so that inserter button is
+	// positioned correctly.
+	> .block-list-appender {
+		width: 100%;
 	}
 
 	/**

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -164,3 +164,10 @@
 		width: 100%;
 	}
 }
+
+// Once blocks are nested within columns that are vertically aligned, if they
+// are then aligned themselves full, wide etc they get auto margins effectively
+// shrinking their width.
+html :where(.wp-block-column[class*="is-vertically-aligned"] > .wp-block) {
+	width: 100%;
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/32907

## Description

- Allows column blocks to stretch to the full height when aligned vertically so background colors appear as expected.

#### Notes

The ability to set a background color on individual columns was recently added. Prior to then columns simply set `align-self` styles to achieve the vertical alignment.

This PR changes columns to be `display: flex;` and vertically align their children within them in line with the column's vertical alignment selection. This is working with multiple inner blocks or nested columns. 

## How has this been tested?
Manually.

1. Checkout this PR, create a new post and add a columns block, choosing the 50/50 split
2. Within the first column insert a tall image or block of content.
3. Select the second column, set a background color and add some short content
4. Try out the different vertical alignment options for the second column
5. Save post and confirm display is correct on the frontend
6. Switch themes and reconfirm display is correct

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="676" alt="Screen Shot 2021-06-23 at 5 45 35 pm" src="https://user-images.githubusercontent.com/60436221/123057066-e5065d00-d44a-11eb-9c31-1e247d94bdcc.png"> | ![vertical-align-column-fix](https://user-images.githubusercontent.com/60436221/123057113-f0f21f00-d44a-11eb-9f5c-f35a7ba38d62.gif) |

## Types of changes
Bug fix / enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
