### PR TITLE
[E2E Tests]: Fix WP editor metabox test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/wp-editor-meta-box.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/wp-editor-meta-box.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`WP Editor Meta Boxes Should save the changes 1`] = `"Typing in a metabox"`;

--- a/packages/e2e-tests/specs/editor/plugins/wp-editor-meta-box.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/wp-editor-meta-box.test.js
@@ -39,6 +39,8 @@ describe( 'WP Editor Meta Boxes', () => {
 			( textarea ) => textarea.value
 		);
 
-		expect( content ).toMatchSnapshot();
+		expect( content ).toMatchInlineSnapshot(
+			`"<p>Typing in a metabox</p>"`
+		);
 	} );
 } );


### PR DESCRIPTION
## Description
* Updates WP editor metabox test spanshot to fix failing e2e test.
* Replaces `toMatchSnapshot` with `toMatchInlineSnapshot` to make tests more readable.

I did manual testing and always saw wrapping `<p>` when getting value from TinyMCE editor.

## How has this been tested?
```
npm run test-e2e -- packages/e2e-tests/specs/editor/plugins/wp-editor-meta-box.test.js
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
