### PR TITLE
[Block Library - Site Logo]: Add permissions handling

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -199,9 +199,17 @@ add_filter( 'rest_index', 'register_site_icon_url' );
  * @return WP_REST_Response
  */
 function register_site_logo_to_rest_index( $response ) {
-	$data              = $response->data;
-	$data['site_logo'] = get_theme_mod( 'custom_logo' );
-	$response->set_data( $data );
+	$site_logo_id                = get_theme_mod( 'custom_logo' );
+	$response->data['site_logo'] = $site_logo_id;
+	if ( $site_logo_id ) {
+		$response->add_link(
+			'https://api.w.org/featuredmedia',
+			rest_url( 'wp/v2/media/' . $site_logo_id ),
+			array(
+				'embeddable' => true,
+			)
+		);
+	}
 	return $response;
 }
 

--- a/lib/init.php
+++ b/lib/init.php
@@ -188,6 +188,30 @@ function register_site_icon_url( $response ) {
 
 add_filter( 'rest_index', 'register_site_icon_url' );
 
+/**
+ * Exposes the site logo to the Gutenberg editor through the WordPress REST
+ * API. This is used for fetching this information when user has no rights
+ * to update settings.
+ *
+ * @since 10.9
+ *
+ * @param WP_REST_Response $response Response data served by the WordPress REST index endpoint.
+ * @return WP_REST_Response
+ */
+function register_site_logo_to_rest_index( $response ) {
+	$data              = $response->data;
+	$logo_id           = get_theme_mod( 'custom_logo' );
+	$data['site_logo'] = array(
+		'id'  => $logo_id,
+		'url' => wp_get_attachment_image_url( $logo_id, 'full' ),
+		'alt' => get_post_meta( $logo_id, '_wp_attachment_image_alt', true ),
+	);
+	$response->set_data( $data );
+	return $response;
+}
+
+add_filter( 'rest_index', 'register_site_logo_to_rest_index' );
+
 add_theme_support( 'widgets-block-editor' );
 
 /**

--- a/lib/init.php
+++ b/lib/init.php
@@ -200,12 +200,7 @@ add_filter( 'rest_index', 'register_site_icon_url' );
  */
 function register_site_logo_to_rest_index( $response ) {
 	$data              = $response->data;
-	$logo_id           = get_theme_mod( 'custom_logo' );
-	$data['site_logo'] = array(
-		'id'  => $logo_id,
-		'url' => wp_get_attachment_image_url( $logo_id, 'full' ),
-		'alt' => get_post_meta( $logo_id, '_wp_attachment_image_alt', true ),
-	);
+	$data['site_logo'] = get_theme_mod( 'custom_logo' );
 	$response->set_data( $data );
 	return $response;
 }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -267,13 +267,15 @@ export default function LogoEdit( {
 			const _siteLogo = siteSettings?.site_logo;
 			const _readOnlyLogo = siteData?.site_logo;
 			const _canUserEdit = canUser( 'update', 'settings' );
-			const _siteLogoId = _canUserEdit ? _siteLogo : _readOnlyLogo;
-			const mediaItem = select( coreStore ).getEntityRecord(
-				'root',
-				'media',
-				_siteLogoId,
-				{ context: 'view' }
-			);
+			const _siteLogoId = _siteLogo || _readOnlyLogo;
+			const mediaItem =
+				_siteLogoId &&
+				select( coreStore ).getEntityRecord(
+					'root',
+					'media',
+					_siteLogoId,
+					{ context: 'view' }
+				);
 			return {
 				siteLogoId: _siteLogoId,
 				canUserEdit: _canUserEdit,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -268,12 +268,11 @@ export default function LogoEdit( {
 			const _readOnlyLogo = siteData?.site_logo;
 			const _canUserEdit = canUser( 'update', 'settings' );
 			const _siteLogoId = _canUserEdit ? _siteLogo : _readOnlyLogo;
-			const query = _canUserEdit ? {} : { context: 'view' };
 			const mediaItem = select( coreStore ).getEntityRecord(
 				'root',
 				'media',
 				_siteLogoId,
-				query
+				{ context: 'view' }
 			);
 			return {
 				siteLogoId: _siteLogoId,

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -80,3 +80,22 @@
 		}
 	}
 }
+.editor-styles-wrapper {
+	.site-logo_placeholder {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		border-radius: $radius-block-ui;
+		background-color: $white;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		padding: $grid-unit-15;
+		svg {
+			margin-right: $grid-unit-15;
+		}
+		p {
+			font-family: $default-font;
+			font-size: $default-font-size;
+			margin: 0;
+		}
+	}
+}

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -96,6 +96,7 @@
 			font-family: $default-font;
 			font-size: $default-font-size;
 			margin: 0;
+			line-height: initial;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of: #26573

Currently when a user with no right permissions to edit `Site Logo` has a broken experience due to the permissions check happening at the REST API.

This PR fixes that by checking the rights and adding a readonly view for those users.



## Testing instructions
- With an admin user insert `Site Logo` and observe that everything works as before.
- With a user whose role hasn't the right permissions(like author, editor, etc...), insert the block and observe that are readonly, but can be moved and their block attributes can be changed (ex.image width).
- Also test the case when the value of this block is empty, where the admin can still edit, but the other users see a placeholder text. While this is not ideal, currently it shows just a `Spinner`.

## Notes

- Should we add a `remove` option in a follow up for this block? Is there any other way to remove it, like in Customizer or something? I couldn't find a way..
- Since Site Logo works as a theme_mod, you can check the empty logo case by changing to another theme that you haven't set one.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
