### PR TITLE
Replace FullscreenMode from Class components to functional components.

### DIFF
--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -1,51 +1,48 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
-export class FullscreenMode extends Component {
-	componentDidMount() {
-		this.isSticky = false;
-		this.sync();
+export const FullscreenMode = ( { isActive } ) => {
+	const [ isSticky, setIsSticky ] = useState( false );
 
+	// componentDidMount
+	useEffect( () => {
 		// `is-fullscreen-mode` is set in PHP as a body class by Gutenberg, and this causes
 		// `sticky-menu` to be applied by WordPress and prevents the admin menu being scrolled
 		// even if `is-fullscreen-mode` is then removed. Let's remove `sticky-menu` here as
 		// a consequence of the FullscreenMode setup
 		if ( document.body.classList.contains( 'sticky-menu' ) ) {
-			this.isSticky = true;
+			setIsSticky( true );
 			document.body.classList.remove( 'sticky-menu' );
 		}
-	}
+	}, [ setIsSticky ] );
 
-	componentWillUnmount() {
-		if ( this.isSticky ) {
-			document.body.classList.add( 'sticky-menu' );
-		}
+	// componentWillUnmount
+	useEffect( () => {
+		return () => {
+			if ( isSticky ) {
+				document.body.classList.add( 'sticky-menu' );
+			}
+		};
+	}, [ isSticky ] );
 
-		if ( this.props.isActive ) {
-			document.body.classList.remove( 'is-fullscreen-mode' );
-		}
-	}
+	useEffect( () => {
+		return () => {
+			if ( isActive ) {
+				document.body.classList.remove( 'is-fullscreen-mode' );
+			}
+		};
+	}, [ isActive ] );
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.isActive !== prevProps.isActive ) {
-			this.sync();
-		}
-	}
-
-	sync() {
-		const { isActive } = this.props;
+	// componentDidUpdate
+	useEffect( () => {
 		if ( isActive ) {
 			document.body.classList.add( 'is-fullscreen-mode' );
 		} else {
 			document.body.classList.remove( 'is-fullscreen-mode' );
 		}
-	}
+	}, [ isActive ] );
 
-	render() {
-		return null;
-	}
-}
-
-export default FullscreenMode;
+	return null;
+};

--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -3,7 +3,7 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 
-export const FullscreenMode = ( { isActive } ) => {
+const FullscreenMode = ( { isActive } ) => {
 	const [ isSticky, setIsSticky ] = useState( false );
 
 	// componentDidMount
@@ -46,3 +46,4 @@ export const FullscreenMode = ( { isActive } ) => {
 
 	return null;
 };
+export default FullscreenMode;

--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -15,15 +15,13 @@ const FullscreenMode = ( { isActive } ) => {
 			isSticky.current = true;
 			document.body.classList.remove( 'sticky-menu' );
 		}
-	}, [] );
 
-	useEffect( () => {
 		return () => {
 			if ( isSticky.current ) {
 				document.body.classList.add( 'sticky-menu' );
 			}
 		};
-	}, [ isSticky ] );
+	}, [] );
 
 	useEffect( () => {
 		if ( isActive ) {

--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -1,47 +1,42 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 const FullscreenMode = ( { isActive } ) => {
-	const [ isSticky, setIsSticky ] = useState( false );
+	const isSticky = useRef( false );
 
-	// componentDidMount
 	useEffect( () => {
 		// `is-fullscreen-mode` is set in PHP as a body class by Gutenberg, and this causes
 		// `sticky-menu` to be applied by WordPress and prevents the admin menu being scrolled
 		// even if `is-fullscreen-mode` is then removed. Let's remove `sticky-menu` here as
 		// a consequence of the FullscreenMode setup
 		if ( document.body.classList.contains( 'sticky-menu' ) ) {
-			setIsSticky( true );
+			isSticky.current = true;
 			document.body.classList.remove( 'sticky-menu' );
 		}
-	}, [ setIsSticky ] );
+	}, [] );
 
-	// componentWillUnmount
 	useEffect( () => {
 		return () => {
-			if ( isSticky ) {
+			if ( isSticky.current ) {
 				document.body.classList.add( 'sticky-menu' );
 			}
 		};
 	}, [ isSticky ] );
 
 	useEffect( () => {
-		return () => {
-			if ( isActive ) {
-				document.body.classList.remove( 'is-fullscreen-mode' );
-			}
-		};
-	}, [ isActive ] );
-
-	// componentDidUpdate
-	useEffect( () => {
 		if ( isActive ) {
 			document.body.classList.add( 'is-fullscreen-mode' );
 		} else {
 			document.body.classList.remove( 'is-fullscreen-mode' );
 		}
+
+		return () => {
+			if ( isActive ) {
+				document.body.classList.remove( 'is-fullscreen-mode' );
+			}
+		};
 	}, [ isActive ] );
 
 	return null;

--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -1,23 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 const FullscreenMode = ( { isActive } ) => {
-	const isSticky = useRef( false );
-
 	useEffect( () => {
+		let isSticky = false;
 		// `is-fullscreen-mode` is set in PHP as a body class by Gutenberg, and this causes
 		// `sticky-menu` to be applied by WordPress and prevents the admin menu being scrolled
 		// even if `is-fullscreen-mode` is then removed. Let's remove `sticky-menu` here as
 		// a consequence of the FullscreenMode setup
 		if ( document.body.classList.contains( 'sticky-menu' ) ) {
-			isSticky.current = true;
+			isSticky = true;
 			document.body.classList.remove( 'sticky-menu' );
 		}
 
 		return () => {
-			if ( isSticky.current ) {
+			if ( isSticky ) {
 				document.body.classList.add( 'sticky-menu' );
 			}
 		};

--- a/packages/interface/src/components/fullscreen-mode/test/index.js
+++ b/packages/interface/src/components/fullscreen-mode/test/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
-
+import { act, create } from 'react-test-renderer';
 /**
  * Internal dependencies
  */
@@ -10,16 +9,18 @@ import { FullscreenMode } from '..';
 
 describe( 'FullscreenMode', () => {
 	it( 'fullscreen mode to be added to document body when active', () => {
-		shallow( <FullscreenMode isActive={ true } /> );
-
+		act( () => {
+			create( <FullscreenMode isActive={ true } /> );
+		} );
 		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
 			true
 		);
 	} );
 
 	it( 'fullscreen mode not to be added to document body when active', () => {
-		shallow( <FullscreenMode isActive={ false } /> );
-
+		act( () => {
+			create( <FullscreenMode isActive={ false } /> );
+		} );
 		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
 			false
 		);
@@ -27,9 +28,9 @@ describe( 'FullscreenMode', () => {
 
 	it( 'sticky-menu to be removed from the body class if present', () => {
 		document.body.classList.add( 'sticky-menu' );
-
-		shallow( <FullscreenMode isActive={ false } /> );
-
+		act( () => {
+			create( <FullscreenMode isActive={ false } /> );
+		} );
 		expect( document.body.classList.contains( 'sticky-menu' ) ).toBe(
 			false
 		);
@@ -37,10 +38,13 @@ describe( 'FullscreenMode', () => {
 
 	it( 'sticky-menu to be restored when component unmounted and originally present', () => {
 		document.body.classList.add( 'sticky-menu' );
-
-		const mode = shallow( <FullscreenMode isActive={ false } /> );
-		mode.unmount();
-
+		let mode;
+		act( () => {
+			mode = create( <FullscreenMode isActive={ false } /> );
+		} );
+		act( () => {
+			mode.unmount();
+		} );
 		expect( document.body.classList.contains( 'sticky-menu' ) ).toBe(
 			true
 		);
@@ -51,15 +55,18 @@ describe( 'FullscreenMode', () => {
 		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
 			false
 		);
-
-		const mode = shallow( <FullscreenMode isActive /> );
-
+		let mode;
+		act( () => {
+			mode = create( <FullscreenMode isActive /> );
+		} );
 		// present after mounting with `isActive`
 		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
 			true
 		);
 
-		mode.unmount();
+		act( () => {
+			mode.unmount();
+		} );
 
 		// removed after unmounting
 		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(

--- a/packages/interface/src/components/fullscreen-mode/test/index.js
+++ b/packages/interface/src/components/fullscreen-mode/test/index.js
@@ -5,7 +5,7 @@ import { act, create } from 'react-test-renderer';
 /**
  * Internal dependencies
  */
-import { FullscreenMode } from '..';
+import FullscreenMode from '..';
 
 describe( 'FullscreenMode', () => {
 	it( 'fullscreen mode to be added to document body when active', () => {


### PR DESCRIPTION
Related #22890

Replace FullscreenMode from Class components to functional components.

I changed test code because `useEffect` does not seem to be executed when the component is rendered with `shallow`.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. `npm run test-unit`

and

1. Click "options" icon in editor.
2. Click "Fullscreen mode".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
