### PR TITLE
Try: Vertical heading levels menu

### DIFF
--- a/packages/block-library/src/heading/editor.scss
+++ b/packages/block-library/src/heading/editor.scss
@@ -1,20 +1,8 @@
 // Remove padding in heading level control popover since the toolbar buttons already have padding.
 .block-library-heading-level-dropdown .components-popover__content {
-	// TODO: Find a less hardcoded way of doing this. `max-content` works on
-	// Chromium, but it results in a scrollbar on Safari, and isn't supported
-	// at all in IE11.
-	min-width: 230px;
+	min-width: auto;
 
 	> div {
 		padding: 0;
-	}
-}
-
-// The dropdown already has a border, so we can remove the one on the heading
-// level toolbar.
-.block-library-heading-level-toolbar {
-	border: none;
-	.components-toolbar-group {
-		flex-wrap: nowrap;
 	}
 }

--- a/packages/block-library/src/heading/heading-level-dropdown.js
+++ b/packages/block-library/src/heading/heading-level-dropdown.js
@@ -1,14 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	Dropdown,
-	Toolbar,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { ToolbarDropdownMenu } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { DOWN } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -19,7 +13,6 @@ const HEADING_LEVELS = [ 1, 2, 3, 4, 5, 6 ];
 
 const POPOVER_PROPS = {
 	className: 'block-library-heading-level-dropdown',
-	isAlternate: true,
 };
 
 /** @typedef {import('@wordpress/element').WPComponent} WPComponent */
@@ -43,58 +36,33 @@ const POPOVER_PROPS = {
  */
 export default function HeadingLevelDropdown( { selectedLevel, onChange } ) {
 	return (
-		<Dropdown
+		<ToolbarDropdownMenu
 			popoverProps={ POPOVER_PROPS }
-			renderToggle={ ( { onToggle, isOpen } ) => {
-				const openOnArrowDown = ( event ) => {
-					if ( ! isOpen && event.keyCode === DOWN ) {
-						event.preventDefault();
-						onToggle();
-					}
-				};
+			icon={ <HeadingLevelIcon level={ selectedLevel } /> }
+			label={ __( 'Change heading level' ) }
+			controls={ HEADING_LEVELS.map( ( targetLevel ) => {
+				{
+					const isActive = targetLevel === selectedLevel;
 
-				return (
-					<ToolbarButton
-						aria-expanded={ isOpen }
-						aria-haspopup="true"
-						icon={ <HeadingLevelIcon level={ selectedLevel } /> }
-						label={ __( 'Change heading level' ) }
-						onClick={ onToggle }
-						onKeyDown={ openOnArrowDown }
-						showTooltip
-					/>
-				);
-			} }
-			renderContent={ () => (
-				<Toolbar
-					className="block-library-heading-level-toolbar"
-					label={ __( 'Change heading level' ) }
-				>
-					<ToolbarGroup
-						isCollapsed={ false }
-						controls={ HEADING_LEVELS.map( ( targetLevel ) => {
-							const isActive = targetLevel === selectedLevel;
-							return {
-								icon: (
-									<HeadingLevelIcon
-										level={ targetLevel }
-										isPressed={ isActive }
-									/>
-								),
-								title: sprintf(
-									// translators: %s: heading level e.g: "1", "2", "3"
-									__( 'Heading %d' ),
-									targetLevel
-								),
-								isActive,
-								onClick() {
-									onChange( targetLevel );
-								},
-							};
-						} ) }
-					/>
-				</Toolbar>
-			) }
+					return {
+						icon: (
+							<HeadingLevelIcon
+								level={ targetLevel }
+								isPressed={ isActive }
+							/>
+						),
+						label: sprintf(
+							// translators: %s: heading level e.g: "1", "2", "3"
+							__( 'Heading %d' ),
+							targetLevel
+						),
+						isActive,
+						onClick() {
+							onChange( targetLevel );
+						},
+					};
+				}
+			} ) }
 		/>
 	);
 }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -173,9 +173,11 @@ function DropdownMenu( {
 												indexOfSet > 0 &&
 												indexOfControl === 0,
 											'is-active': control.isActive,
+											'is-icon-only': ! control.title,
 										}
 									) }
 									icon={ control.icon }
+									label={ control.label }
 									aria-checked={
 										control.role === 'menuitemcheckbox' ||
 										control.role === 'menuitemradio'

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -44,6 +44,11 @@
 			width: $button-size-small;
 			height: $button-size-small;
 		}
+
+		// If menu items are icon-only, make them stretch only to the icon size.
+		&.is-icon-only {
+			width: auto;
+		}
 	}
 
 	.components-menu-item__button,


### PR DESCRIPTION
## Description

Responding to [this feedback](https://github.com/WordPress/gutenberg/pull/32483#issuecomment-866756480), a vertical heading level dropdown solves a couple of problems:

- It does not require a min-width to contain the items
- It opens downwards, and shows up to match
- It shows the hierarchy

GIF:

![subheading](https://user-images.githubusercontent.com/1204802/123101728-a1085d80-d434-11eb-80fa-a29852ef82dd.gif)

The missing piece here is to make the arrow keys function to move up/downwards. I could use some help there: from reading the documentation, supplying an `orientation` prop should do the work, and it does apply the correct `aria-orientation` to the container. 

My best guess it that the `ToolbarGroup` component was never thought of as able to be vertical, and is locked to horizontal somewhere. So a fix might need to either allow that, or move to a Dropdown component instead.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
