### PR TITLE
Fix glitchy block focus style when multiselecting blocks.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -74,7 +74,7 @@
 	&.is-navigate-mode .block-editor-block-list__block.is-selected::after,
 	& .is-block-moving-mode.block-editor-block-list__block.has-child-selected {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		outline: var(--wp-admin-border-width-focus) solid transparent;
+		outline: 2px solid transparent;
 	}
 
 	& .is-block-moving-mode.block-editor-block-list__block.is-selected {


### PR DESCRIPTION
## Description

On 2x/retina displays, when you select multiple blocks, the focus style can occasionally be cropped:

<img width="413" alt="Screenshot 2021-06-23 at 15 12 26" src="https://user-images.githubusercontent.com/1204802/123102840-be89f700-d435-11eb-8ec7-0df23d0ab596.png">

This PR fixes that:

<img width="459" alt="Screenshot 2021-06-23 at 15 13 37" src="https://user-images.githubusercontent.com/1204802/123102874-c6499b80-d435-11eb-9555-252b77a4e07d.png">

I believe this issue has come and gone a couple of times, but it's been easy to reproduce lately, and this seems to fix it.

## How has this been tested?

Insert a bunch of blocks and select them. The focus style should be consistent all the way around the block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
