### PR TITLE
Disable Android e2e tests while we investigate foundational breakage

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
     test:
         runs-on: macos-latest
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        # The false value below disables the test while we investigate a
+        # foundational error causing failures
+        if: ${{ false && github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -1,9 +1,10 @@
 name: React Native E2E Tests (Android)
 
+# Triggers disabled while we investigate a foundational error is causing all runs
+# to fail
 on:
-    pull_request:
     push:
-        branches: [trunk]
+        branches: []
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -1,10 +1,9 @@
 name: React Native E2E Tests (Android)
 
-# Triggers disabled while we investigate a foundational error is causing all runs
-# to fail
 on:
+    pull_request:
     push:
-        branches: []
+        branches: [trunk]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: macos-latest
         # The false value below disables the test while we investigate a
         # foundational error causing failures
-        if: ${{ false && github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        if: ${{ false && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]


### PR DESCRIPTION
## Description
A `adb: no devices/emulators found` error is occurring and cause every run to fail. We intend to temporarily disable this job while we investigate the cause to avoid causing disruptions or confusion for contributors.

## How has this been tested?
Verify all CI checks succeed.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Tooling change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
