### PR TITLE
data: Add types to redux-store metadata reducer

### DIFF
--- a/packages/data/src/redux-store/metadata/equivalent-key-map.d.ts
+++ b/packages/data/src/redux-store/metadata/equivalent-key-map.d.ts
@@ -1,0 +1,4 @@
+declare module 'equivalent-key-map' {
+	class EquivalentKeyMap< K, V > extends Map< K, V > {}
+	export = EquivalentKeyMap;
+}

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -21,66 +21,55 @@ type Action =
 			typeof import('./actions').invalidateResolutionForStoreSelector
 	  >;
 
+type State = EquivalentKeyMap< unknown[] | unknown, boolean >;
+
 /**
  * Reducer function returning next state for selector resolution of
  * subkeys, object form:
  *
  *  selectorName -> EquivalentKeyMap<Array,boolean>
  */
-const subKeysIsResolved: Reducer<
-	Record< string, EquivalentKeyMap< unknown[] | unknown, boolean > >,
+const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
+	State,
 	Action
-> = onSubKey< EquivalentKeyMap< unknown[] | unknown, boolean >, Action >(
-	'selectorName'
-)(
-	(
-		state = new EquivalentKeyMap< unknown[] | unknown, boolean >(),
-		action: Action
-	) => {
-		switch ( action.type ) {
-			case 'START_RESOLUTION':
-			case 'FINISH_RESOLUTION': {
-				const isStarting = action.type === 'START_RESOLUTION';
-				const nextState = new EquivalentKeyMap( state );
-				nextState.set( action.args, isStarting );
-				return nextState;
-			}
-			case 'START_RESOLUTIONS':
-			case 'FINISH_RESOLUTIONS': {
-				const isStarting = action.type === 'START_RESOLUTIONS';
-				const nextState = new EquivalentKeyMap( state );
-				for ( const resolutionArgs of action.args ) {
-					nextState.set( resolutionArgs, isStarting );
-				}
-				return nextState;
-			}
-			case 'INVALIDATE_RESOLUTION': {
-				const nextState = new EquivalentKeyMap( state );
-				nextState.delete( action.args );
-				return nextState;
-			}
+>( 'selectorName' )( ( state = new EquivalentKeyMap(), action: Action ) => {
+	switch ( action.type ) {
+		case 'START_RESOLUTION':
+		case 'FINISH_RESOLUTION': {
+			const isStarting = action.type === 'START_RESOLUTION';
+			const nextState = new EquivalentKeyMap( state );
+			nextState.set( action.args, isStarting );
+			return nextState;
 		}
-		return state;
+		case 'START_RESOLUTIONS':
+		case 'FINISH_RESOLUTIONS': {
+			const isStarting = action.type === 'START_RESOLUTIONS';
+			const nextState = new EquivalentKeyMap( state );
+			for ( const resolutionArgs of action.args ) {
+				nextState.set( resolutionArgs, isStarting );
+			}
+			return nextState;
+		}
+		case 'INVALIDATE_RESOLUTION': {
+			const nextState = new EquivalentKeyMap( state );
+			nextState.delete( action.args );
+			return nextState;
+		}
 	}
-);
+	return state;
+} );
 
 /**
  * Reducer function returning next state for selector resolution, object form:
  *
  *   selectorName -> EquivalentKeyMap<Array, boolean>
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param  state  Current state.
+ * @param  action Dispatched action.
  *
- * @return {Object} Next state.
+ * @return Next state.
  */
-const isResolved = (
-	state: Record<
-		string,
-		EquivalentKeyMap< unknown[] | unknown, boolean >
-	> = {},
-	action: Action
-) => {
+const isResolved = ( state: Record< string, State > = {}, action: Action ) => {
 	switch ( action.type ) {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return {};

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -3,25 +3,40 @@
  */
 import { omit, has } from 'lodash';
 import EquivalentKeyMap from 'equivalent-key-map';
+import type { Reducer } from 'redux';
 
 /**
  * Internal dependencies
  */
 import { onSubKey } from './utils';
 
+type Action =
+	| ReturnType< typeof import('./actions').startResolution >
+	| ReturnType< typeof import('./actions').finishResolution >
+	| ReturnType< typeof import('./actions').startResolutions >
+	| ReturnType< typeof import('./actions').finishResolutions >
+	| ReturnType< typeof import('./actions').invalidateResolution >
+	| ReturnType< typeof import('./actions').invalidateResolutionForStore >
+	| ReturnType<
+			typeof import('./actions').invalidateResolutionForStoreSelector
+	  >;
+
 /**
  * Reducer function returning next state for selector resolution of
  * subkeys, object form:
  *
  *  selectorName -> EquivalentKeyMap<Array,boolean>
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Next state.
  */
-const subKeysIsResolved = onSubKey( 'selectorName' )(
-	( state = new EquivalentKeyMap(), action ) => {
+const subKeysIsResolved: Reducer<
+	Record< string, EquivalentKeyMap< unknown[] | unknown, boolean > >,
+	Action
+> = onSubKey< EquivalentKeyMap< unknown[] | unknown, boolean >, Action >(
+	'selectorName'
+)(
+	(
+		state = new EquivalentKeyMap< unknown[] | unknown, boolean >(),
+		action: Action
+	) => {
 		switch ( action.type ) {
 			case 'START_RESOLUTION':
 			case 'FINISH_RESOLUTION': {
@@ -59,7 +74,13 @@ const subKeysIsResolved = onSubKey( 'selectorName' )(
  *
  * @return {Object} Next state.
  */
-const isResolved = ( state = {}, action ) => {
+const isResolved = (
+	state: Record<
+		string,
+		EquivalentKeyMap< unknown[] | unknown, boolean >
+	> = {},
+	action: Action
+) => {
 	switch ( action.type ) {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return {};

--- a/packages/data/src/redux-store/metadata/utils.js
+++ b/packages/data/src/redux-store/metadata/utils.js
@@ -2,16 +2,22 @@
  * Higher-order reducer creator which creates a combined reducer object, keyed
  * by a property on the action object.
  *
+ * @template {any} TState
+ * @template {import('redux').AnyAction} TAction
+ *
  * @param {string} actionProperty Action property by which to key object.
  *
- * @return {Function} Higher-order reducer.
+ * @return {(reducer: import('redux').Reducer<TState, TAction>) => import('redux').Reducer<Record<string, TState>, TAction>} Higher-order reducer.
  */
 export const onSubKey = ( actionProperty ) => ( reducer ) => (
-	state = {},
+	/* eslint-disable jsdoc/no-undefined-types */
+	state = /** @type {Record<string, TState>} */ ( {} ),
 	action
 ) => {
 	// Retrieve subkey from action. Do not track if undefined; useful for cases
 	// where reducer is scoped by action shape.
+	/** @type {keyof state} */
+	/* eslint-enable jsdoc/no-undefined-types */
 	const key = action[ actionProperty ];
 	if ( key === undefined ) {
 		return state;

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -15,6 +15,9 @@
 		// { "path": "../redux-routine" }
 	],
 	"include": [
-		"src/redux-store/metadata/actions.js"
+		"src/redux-store/metadata/actions.js",
+		"src/redux-store/metadata/equivalent-key-map.d.ts",
+		"src/redux-store/metadata/reducer.ts",
+		"src/redux-store/metadata/utils.js"
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to `data/redux-store/metadata/reducer`. I had to convert it to TypeScript to be able to call the `subKey` function with type parameters.

Part of #18838

## How has this been tested?
No runtime changes so as long as the type checks pass we're good.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
