### PR TITLE
Inline link card: Style updates to better match original design

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -51,7 +51,7 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-error {
-	margin: -$grid-unit-20/2 $grid-unit-20 $grid-unit-20; // Negative margin to bring the error a bit closer to the button.
+	margin: -$grid-unit-20 * 0.5 $grid-unit-20 $grid-unit-20; // Negative margin to bring the error a bit closer to the button.
 }
 
 .block-editor-link-control__search-actions {
@@ -68,8 +68,8 @@ $preview-image-height: 140px;
 	 *  - Horizontally, pad to the minimum of: default input padding, or the
 	 *    equivalent of the vertical padding.
 	 */
-	top: $grid-unit-20 + $border-width + ( ( 40px - $button-size ) / 2 );
-	right: $grid-unit-20 + $border-width + min($grid-unit-10, ( 40px - $button-size ) / 2);
+	top: $grid-unit-20 + $border-width + ( ( 40px - $button-size ) * 0.5 );
+	right: $grid-unit-20 + $border-width + min($grid-unit-10, (40px - $button-size ) * 0.5);
 }
 
 .components-button .block-editor-link-control__search-submit .has-icon {
@@ -168,12 +168,6 @@ $preview-image-height: 140px;
 		align-items: flex-start;
 		margin-right: $grid-unit-10;
 		overflow: hidden;
-
-		// Force text to wrap to improve UX when encountering long lines
-		// of text, particular those with no spaces.
-		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
-		white-space: pre-wrap;
-		word-wrap: break-word;
 		white-space: nowrap;
 		line-height: 1.5;
 	}
@@ -190,10 +184,12 @@ $preview-image-height: 140px;
 	.block-editor-link-control__search-item-icon {
 		position: relative;
 		margin-right: $grid-unit-10;
-		width: $grid-unit-40;
 		height: $grid-unit-40;
-		padding: 7px;
 		background: $gray-100;
+		display: flex;
+		flex: 0 0 $grid-unit-40;
+		justify-content: center;
+		align-items: center;
 
 		svg {
 			padding: 0;
@@ -203,6 +199,7 @@ $preview-image-height: 140px;
 		img {
 			max-width: none;
 			width: 18px;
+			height: 18px;
 		}
 	}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -38,10 +38,10 @@ $preview-image-height: 140px;
 		width: calc(100% - #{$grid-unit-20*2});
 		display: block;
 		padding: 11px $grid-unit-20;
-		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
+		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // Width of reset and submit buttons.
 		margin: $grid-unit-20;
 		position: relative;
-		border: 1px solid $gray-300;
+		border: $border-width solid $gray-300;
 		border-radius: $radius-block-ui;
 	}
 
@@ -51,7 +51,7 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-error {
-	margin: -$grid-unit-20*0.5 $grid-unit-20 $grid-unit-20; // negative margin to bring the error a bit closer to the button
+	margin: -$grid-unit-20/2 $grid-unit-20 $grid-unit-20; // Negative margin to bring the error a bit closer to the button.
 }
 
 .block-editor-link-control__search-actions {
@@ -68,24 +68,24 @@ $preview-image-height: 140px;
 	 *  - Horizontally, pad to the minimum of: default input padding, or the
 	 *    equivalent of the vertical padding.
 	 */
-	top: $grid-unit-20 + 1px + ( ( 40px - $button-size ) * 0.5 );
-	right: $grid-unit-20 + 1px + min($grid-unit-10, ( 40px - $button-size ) * 0.5);
+	top: $grid-unit-20 + $border-width + ( ( 40px - $button-size ) / 2 );
+	right: $grid-unit-20 + $border-width + min($grid-unit-10, ( 40px - $button-size ) / 2);
 }
 
 .components-button .block-editor-link-control__search-submit .has-icon {
-	margin: -1px;
+	margin: -$border-width;
 }
 
 .block-editor-link-control__search-results-wrapper {
 	position: relative;
-	margin-top: -$grid-unit-20 + 1px;
+	margin-top: -$grid-unit-20 + $border-width;
 
 	&::before,
 	&::after {
 		content: "";
 		position: absolute;
-		left: -1px;
-		right: $grid-unit-20; // avoid overlaying scrollbars
+		left: -$border-width;
+		right: $grid-unit-20; // Avoid overlaying scrollbars.
 		display: block;
 		pointer-events: none;
 		z-index: 100;
@@ -114,7 +114,7 @@ $preview-image-height: 140px;
 	margin: 0;
 	padding: $grid-unit-20*0.5 $grid-unit-20 $grid-unit-20*0.5;
 	max-height: 200px;
-	overflow-y: auto; // allow results list to scroll
+	overflow-y: auto; // Allow results list to scroll.
 
 	&.is-loading {
 		opacity: 0.2;
@@ -154,7 +154,7 @@ $preview-image-height: 140px;
 	}
 
 	&.is-current {
-		flex-direction: column; // allow for stacking.
+		flex-direction: column; // Allow for stacking.
 		background: transparent;
 		border: 0;
 		width: 100%;
@@ -174,25 +174,26 @@ $preview-image-height: 140px;
 		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
 		white-space: pre-wrap;
 		word-wrap: break-word;
+		white-space: nowrap;
+		line-height: 1.5;
 	}
 
 	&.is-preview .block-editor-link-control__search-item-header {
 		display: flex;
-		flex: 1; // fill available space.
+		flex: 1; // Fill available space.
 	}
 
 	.block-editor-link-control__search-item-details {
-		overflow: hidden; // clip to force text ellipsis.
+		overflow: hidden; // Clip to force text ellipsis.
 	}
 
 	.block-editor-link-control__search-item-icon {
 		position: relative;
-		top: 0.2em;
 		margin-right: $grid-unit-10;
-		width: 32px;
-		height: 32px;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
 		padding: 7px;
-		background: $gray-0;
+		background: $gray-100;
 
 		svg {
 			padding: 0;
@@ -200,7 +201,8 @@ $preview-image-height: 140px;
 		}
 
 		img {
-			width: 16px; // favicons often have a source of 32px
+			max-width: none;
+			width: 18px;
 		}
 	}
 
@@ -219,8 +221,7 @@ $preview-image-height: 140px;
 
 	.block-editor-link-control__search-item-title {
 		display: block;
-		margin-top: 0.2em;
-		font-size: 1.1em;
+		font-size: $default-font-size;
 		font-weight: 500;
 		position: relative;
 
@@ -235,32 +236,32 @@ $preview-image-height: 140px;
 		}
 
 		svg {
-			display: none; // specifically requested to be removed visually as well.
+			display: none; // Specifically requested to be removed visually as well.
 		}
 	}
 
 	.block-editor-link-control__search-item-info {
 		display: block;
 		color: $gray-700;
-		font-size: 0.9em;
-		line-height: 1.3;
+		font-size: $helptext-font-size;
+		line-height: inherit;
 	}
 
 	.block-editor-link-control__search-item-type {
 		display: block;
-		padding: 3px 8px;
+		padding: 3px $grid-unit-10;
 		margin-left: auto;
-		font-size: 0.9em;
+		font-size: $default-font-size;
 		background-color: $gray-100;
-		border-radius: 2px;
+		border-radius: $radius-block-ui;
 	}
 
 	.block-editor-link-control__search-item-description {
-		padding-top: 12px;
+		padding-top: $grid-unit-15;
 		margin: 0;
 
 		&.is-placeholder {
-			margin-top: 12px;
+			margin-top: $grid-unit-15;
 			padding-top: 0;
 			height: 28px;
 			display: flex;
@@ -271,16 +272,16 @@ $preview-image-height: 140px;
 			&::after {
 				display: block;
 				content: "";
-				height: 0.7em;
+				height: $grid-unit-10;
 				width: 100%;
 				background-color: $gray-100;
-				border-radius: 3px;
+				border-radius: $radius-block-ui + $border-width;
 			}
 		}
 
 		.components-text {
-			font-size: 0.9em;
-			line-height: 1.3em;
+			font-size: $default-font-size;
+			line-height: inherit;
 		}
 	}
 
@@ -289,22 +290,22 @@ $preview-image-height: 140px;
 		width: 100%;
 		background-color: $gray-100;
 		justify-content: center;
-		height: $preview-image-height; // limit height
-		max-height: $preview-image-height; // limit height
+		height: $preview-image-height; // Limit height.
+		max-height: $preview-image-height; // Limit height.
 		overflow: hidden;
-		border-radius: 2px;
-		margin-top: 12px;
+		border-radius: $radius-block-ui;
+		margin-top: $grid-unit-15;
 
 		&.is-placeholder {
 			background-color: $gray-100;
-			border-radius: 3px;
+			border-radius: $radius-block-ui + $border-width;
 		}
 
 		img {
-			display: block; // remove unwanted space below image
+			display: block; // Remove unwanted space below image.
 			max-width: 100%;
-			height: $preview-image-height; // limit height
-			max-height: $preview-image-height; // limit height
+			height: $preview-image-height; // Limit height.
+			max-height: $preview-image-height; // Limit height.
 		}
 	}
 }
@@ -312,11 +313,13 @@ $preview-image-height: 140px;
 .block-editor-link-control__search-item-top {
 	display: flex;
 	flex-direction: row;
-	width: 100%; // clip.
+	width: 100%; // Clip.
 }
 
 .block-editor-link-control__search-item-bottom {
 	transition: opacity 1.5s;
+	@include reduce-motion("transition");
+	min-height: 100px;
 	width: 100%;
 }
 
@@ -327,14 +330,16 @@ $preview-image-height: 140px;
 		&::before,
 		&::after {
 			animation: loadingpulse 1s linear infinite;
-			animation-delay: 0.5s; // avoid animating for fast network responses
+			animation-delay: 0.5s; // Avoid animating for fast network responses.
+			@include reduce-motion("animation");
 		}
 
 	}
 
 	.block-editor-link-control__search-item-image {
 		animation: loadingpulse 1s linear infinite;
-		animation-delay: 0.5s; // avoid animating for fast network responses
+		animation-delay: 0.5s; // Avoid animating for fast network responses.
+		@include reduce-motion("animation");
 	}
 
 	.block-editor-link-control__search-item-icon {
@@ -354,13 +359,14 @@ $preview-image-height: 140px;
 			bottom: 0;
 			border-radius: 100%;
 			animation: loadingpulse 1s linear infinite;
-			animation-delay: 0.5s; // avoid animating for fast network responses
+			animation-delay: 0.5s; // Avoid animating for fast network responses.
+			@include reduce-motion("animation");
 		}
 	}
 }
 
 .block-editor-link-control__loading {
-	margin: $grid-unit-20; // when only loading control is shown it requires it's own spacing.
+	margin: $grid-unit-20; // When only loading control is shown it requires it's own spacing.
 	display: flex;
 	align-items: center;
 
@@ -375,7 +381,7 @@ $preview-image-height: 140px;
 	padding: $grid-unit-15 $grid-unit-20;
 
 	// Create fake border. We cannot use border because the button has a border
-	// radius applied to it
+	// radius applied to it.
 	&::before {
 		content: "";
 		position: absolute;
@@ -451,6 +457,6 @@ $preview-image-height: 140px;
 }
 
 .block-editor-link-control__search-item-action {
-	margin-left: auto; // push to far right hand side
+	margin-left: auto; // Push to far right hand side.
 	flex-shrink: 0;
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -189,11 +189,15 @@ $preview-image-height: 140px;
 		position: relative;
 		top: 0.2em;
 		margin-right: $grid-unit-10;
-		max-height: 24px;
-		flex-shrink: 0;
-		width: 24px;
-		display: flex;
-		justify-content: center;
+		width: 32px;
+		height: 32px;
+		padding: 7px;
+		background: $gray-0;
+
+		svg {
+			padding: 0;
+			background: none;
+		}
 
 		img {
 			width: 16px; // favicons often have a source of 32px
@@ -215,7 +219,8 @@ $preview-image-height: 140px;
 
 	.block-editor-link-control__search-item-title {
 		display: block;
-		margin-bottom: 0.2em;
+		margin-top: 0.2em;
+		font-size: 1.1em;
 		font-weight: 500;
 		position: relative;
 
@@ -275,6 +280,7 @@ $preview-image-height: 140px;
 
 		.components-text {
 			font-size: 0.9em;
+			line-height: 1.3em;
 		}
 	}
 


### PR DESCRIPTION
Before: 
<img width="375" alt="Screen Shot 2021-06-23 at 3 04 43 PM" src="https://user-images.githubusercontent.com/5835847/123174059-66062a00-d434-11eb-9584-2ada81875d61.png">

After: 
<img width="380" alt="Screen Shot 2021-06-23 at 2 55 48 PM" src="https://user-images.githubusercontent.com/5835847/123173979-48d15b80-d434-11eb-8fbe-911138e425d0.png">

- site icon visually spans height of name+URL rows
- increase line height between name and URL, make URL larger
- increase line height of description
- align “open in new tab” toggle with the left content side.