### PR TITLE
Revert mistaken push to trunk

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -698,7 +698,7 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
  *
  * @return array Filtered editor settings.
  */
-function gutenberg_extend_block_editor_settings_with_block_theme_flag( $settings ) {
+function gutenberg_extend_block_editor_settings_with_fse_theme_flag( $settings ) {
 	$settings['supportsTemplateMode'] = gutenberg_supports_block_templates();
 
 	// Enable the new layout options for themes with a theme.json file.
@@ -708,9 +708,9 @@ function gutenberg_extend_block_editor_settings_with_block_theme_flag( $settings
 }
 // This can be removed when plugin support requires WordPress 5.8.0+.
 if ( function_exists( 'get_block_editor_settings' ) ) {
-	add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_settings_with_block_theme_flag' );
+	add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_settings_with_fse_theme_flag' );
 } else {
-	add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_settings_with_block_theme_flag' );
+	add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_settings_with_fse_theme_flag' );
 }
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -47,7 +47,7 @@ if ( ! function_exists( 'wp_should_load_separate_core_block_assets' ) ) {
 add_filter(
 	'separate_core_block_assets',
 	function( $load_separate_styles ) {
-		if ( function_exists( 'gutenberg_is_block_theme' ) && gutenberg_is_block_theme() ) {
+		if ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) {
 			return true;
 		}
 		return $load_separate_styles;

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -24,7 +24,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$settings['imageDefaultSize']                      = in_array( $image_default_size, $image_sizes, true ) ? $image_default_size : 'large';
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
-	if ( gutenberg_is_block_theme() ) {
+	if ( gutenberg_is_fse_theme() ) {
 		$settings['defaultTemplatePartAreas'] = gutenberg_get_allowed_template_part_areas();
 	}
 

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -10,7 +10,7 @@
  *
  * @return boolean Whether the current theme is an FSE theme or not.
  */
-function gutenberg_is_block_theme() {
+function gutenberg_is_fse_theme() {
 	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
 }
 
@@ -20,14 +20,14 @@ function gutenberg_is_block_theme() {
  * @return boolean Whether the current theme is FSE-enabled or not.
  */
 function gutenberg_supports_block_templates() {
-	return gutenberg_is_block_theme() || current_theme_supports( 'block-templates' );
+	return gutenberg_is_fse_theme() || current_theme_supports( 'block-templates' );
 }
 
 /**
  * Show a notice when a Full Site Editing theme is used.
  */
 function gutenberg_full_site_editing_notice() {
-	if ( ! gutenberg_is_block_theme() ) {
+	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
 	?>
@@ -42,7 +42,7 @@ add_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
  * Removes legacy pages from FSE themes.
  */
 function gutenberg_remove_legacy_pages() {
-	if ( ! gutenberg_is_block_theme() ) {
+	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
 
@@ -74,7 +74,7 @@ add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 function gutenberg_adminbar_items( $wp_admin_bar ) {
 
 	// Early exit if not an FSE theme.
-	if ( ! gutenberg_is_block_theme() ) {
+	if ( ! gutenberg_is_fse_theme() ) {
 		return;
 	}
 
@@ -110,7 +110,7 @@ add_filter( 'menu_order', 'gutenberg_menu_order' );
  * @param array $menu_order Menu Order.
  */
 function gutenberg_menu_order( $menu_order ) {
-	if ( ! gutenberg_is_block_theme() ) {
+	if ( ! gutenberg_is_fse_theme() ) {
 		return $menu_order;
 	}
 

--- a/lib/init.php
+++ b/lib/init.php
@@ -94,7 +94,7 @@ add_action( 'admin_menu', 'gutenberg_menu', 9 );
  * @since 9.4.0
  */
 function gutenberg_site_editor_menu() {
-	if ( gutenberg_is_block_theme() ) {
+	if ( gutenberg_is_fse_theme() ) {
 		add_menu_page(
 			__( 'Site Editor (beta)', 'gutenberg' ),
 			sprintf(

--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -22,7 +22,7 @@ function _gutenberg_migrate_database() {
 
 	if ( _GUTENBERG_VERSION_MIGRATION !== $gutenberg_installed_version ) {
 		if ( version_compare( $gutenberg_installed_version, '9.8.0', '<' ) ) {
-			_gutenberg_migrate_remove_wp_template_drafts();
+			_gutenberg_migrate_remove_fse_drafts();
 		}
 
 		update_option( 'gutenberg_version_migration', _GUTENBERG_VERSION_MIGRATION );
@@ -35,7 +35,7 @@ function _gutenberg_migrate_database() {
  * @access private
  * @internal
  */
-function _gutenberg_migrate_remove_wp_template_drafts() {
+function _gutenberg_migrate_remove_fse_drafts() {
 	// Delete auto-draft templates and template parts.
 	$delete_query = new WP_QUERY(
 		array(
@@ -59,7 +59,7 @@ function _gutenberg_migrate_remove_wp_template_drafts() {
 	delete_option( 'gutenberg_last_synchronize_theme_template-part_checks' );
 }
 
-// Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_wp_template_drafts) must happen
+// Deletion of the `_wp_file_based` term (in _gutenberg_migrate_remove_fse_drafts) must happen
 // after its taxonomy (`wp_theme`) is registered. This happens in `gutenberg_register_wp_theme_taxonomy`,
 // which is hooked into `init` (default priority, i.e. 10).
 add_action( 'init', '_gutenberg_migrate_database', 20 );


### PR DESCRIPTION
## Description
Commits https://github.com/WordPress/gutenberg/commit/3ca3f72dc0713f0c21d22c3893fb61f6824bf3b5 & https://github.com/WordPress/gutenberg/commit/6a6f48721ff8ad4836959db17b0df0a59b388fc8 were pushed to `trunk` by mistake instead of creating a branch and going through a review.

This PR reverts them so they can be submitted in a normal PR and reviewed properly.