### PR TITLE
Widget Editor: Fix allow adding same image twice

### DIFF
--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -116,7 +116,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 	const widgetsBlocks = post.blocks.filter( ( block ) => {
 		const { id } = block.attributes;
 
-		if ( block.name === 'core/legacy-widget' && block.attributes?.id ) {
+		if ( block.name === 'core/legacy-widget' && id ) {
 			if ( usedReferenceWidgets.includes( id ) ) {
 				return false;
 			}

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -108,7 +108,22 @@ export function* saveWidgetArea( widgetAreaId ) {
 		( { sidebar } ) => sidebar === widgetAreaId
 	);
 
-	const widgetsBlocks = post.blocks;
+	// Remove all duplicate reference widget instances for legacy widgets.
+	// Why? We filter out the widgets with duplicate IDs to prevent adding more than one instance of a widget
+	// implemented using a function. WordPress doesn't support having more than one instance of these, if you try to
+	// save multiple instances of these in different sidebars you will run into undefined behaviors.
+	const usedReferenceWidgets = [];
+	const widgetsBlocks = post.blocks.filter( ( block ) => {
+		const { id } = block.attributes;
+
+		if ( block.name === 'core/legacy-widget' && block.attributes?.id ) {
+			if ( usedReferenceWidgets.includes( id ) ) {
+				return false;
+			}
+			usedReferenceWidgets.push( id );
+		}
+		return true;
+	} );
 
 	// Determine which widgets have been deleted. We can tell if a widget is
 	// deleted and not just moved to a different area by looking to see if

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -108,17 +108,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 		( { sidebar } ) => sidebar === widgetAreaId
 	);
 
-	// Remove all duplicate reference widget instances
-	const usedReferenceWidgets = [];
-	const widgetsBlocks = post.blocks.filter( ( { attributes: { id } } ) => {
-		if ( id ) {
-			if ( usedReferenceWidgets.includes( id ) ) {
-				return false;
-			}
-			usedReferenceWidgets.push( id );
-		}
-		return true;
-	} );
+	const widgetsBlocks = post.blocks;
 
 	// Determine which widgets have been deleted. We can tell if a widget is
 	// deleted and not just moved to a different area by looking to see if


### PR DESCRIPTION

## Description
Fixes https://github.com/WordPress/gutenberg/issues/32901

Adding same image twice in the widgets editor only saves one block. This PR fixes that.

This was happening because while saving/updating the blocks in the widget editor, duplicate widget instances were filtered. Whereas when multiple blocks (cover block/image block) use the same image, the `id` attribute of the blocks becomes identical and only the first block was saved.

## How has this been tested?
1. Go to widget editor.
2. Insert an image block with an image.
3. Insert a new image block with the same image.
4. Click save
5. Reload the page and both the blocks should be saved.

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
