### PR TITLE
Improve insertion point and drag-n-drop in the widgets screen

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -59,7 +59,7 @@ function useInsertionPoint( {
 			let _destinationRootClientId = rootClientId;
 			let _destinationIndex;
 
-			if ( insertionIndex ) {
+			if ( insertionIndex !== undefined ) {
 				// Insert into a specific index.
 				_destinationIndex = insertionIndex;
 			} else if ( clientId ) {

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -69,16 +69,17 @@ export default function WidgetAreaEdit( {
 					// unmounted when the panel is collapsed. Unmounting legacy
 					// widgets may have unintended consequences (e.g.  TinyMCE
 					// not being properly reinitialized)
-					<DisclosureContent visible={ opened }>
-						<div className="editor-styles-wrapper">
-							<EntityProvider
-								kind="root"
-								type="postType"
-								id={ `widget-area-${ id }` }
-							>
-								<WidgetAreaInnerBlocks />
-							</EntityProvider>
-						</div>
+					<DisclosureContent
+						className="widget-area-panel-body-content"
+						visible={ opened }
+					>
+						<EntityProvider
+							kind="root"
+							type="postType"
+							id={ `widget-area-${ id }` }
+						>
+							<WidgetAreaInnerBlocks />
+						</EntityProvider>
 					</DisclosureContent>
 				) }
 			</PanelBody>

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -15,6 +15,7 @@ import {
  */
 import WidgetAreaInnerBlocks from './inner-blocks';
 import { store as editWidgetsStore } from '../../../store';
+import useIsDraggingWithin from './use-is-dragging-within';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
@@ -116,52 +117,4 @@ const useIsDragging = ( elementRef ) => {
 	}, [] );
 
 	return isDragging;
-};
-
-/**
- * A React hook to determine if it's dragging within the target element.
- *
- * @param {RefObject<HTMLElement>} elementRef The target elementRef object.
- *
- * @return {boolean} Is dragging within the target element.
- */
-const useIsDraggingWithin = ( elementRef ) => {
-	const [ isDraggingWithin, setIsDraggingWithin ] = useState( false );
-
-	useEffect( () => {
-		const { ownerDocument } = elementRef.current;
-
-		function handleDragStart( event ) {
-			// Check the first time when the dragging starts.
-			handleDragEnter( event );
-		}
-
-		// Set to false whenever the user cancel the drag event by either releasing the mouse or press Escape.
-		function handleDragEnd() {
-			setIsDraggingWithin( false );
-		}
-
-		function handleDragEnter( event ) {
-			// Check if the current target is inside the item element.
-			if ( elementRef.current.contains( event.target ) ) {
-				setIsDraggingWithin( true );
-			} else {
-				setIsDraggingWithin( false );
-			}
-		}
-
-		// Bind these events to the document to catch all drag events.
-		// Ideally, we can also use `event.relatedTarget`, but sadly that doesn't work in Safari.
-		ownerDocument.addEventListener( 'dragstart', handleDragStart );
-		ownerDocument.addEventListener( 'dragend', handleDragEnd );
-		ownerDocument.addEventListener( 'dragenter', handleDragEnter );
-
-		return () => {
-			ownerDocument.removeEventListener( 'dragstart', handleDragStart );
-			ownerDocument.removeEventListener( 'dragend', handleDragEnd );
-			ownerDocument.removeEventListener( 'dragenter', handleDragEnter );
-		};
-	}, [] );
-
-	return isDraggingWithin;
 };

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -70,7 +70,7 @@ export default function WidgetAreaEdit( {
 					// widgets may have unintended consequences (e.g.  TinyMCE
 					// not being properly reinitialized)
 					<DisclosureContent
-						className="widget-area-panel-body-content"
+						className="wp-block-widget-area__panel-body-content"
 						visible={ opened }
 					>
 						<EntityProvider

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -1,8 +1,16 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEntityBlockEditor } from '@wordpress/core-data';
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	__experimentalUseInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 
 /**
@@ -17,25 +25,29 @@ export default function WidgetAreaInnerBlocks() {
 	);
 	const innerBlocksRef = useRef();
 	const isDraggingWithinInnerBlocks = useIsDraggingWithin( innerBlocksRef );
-	const shouldHighlightDropZone =
-		blocks.length === 0 && isDraggingWithinInnerBlocks;
+	const shouldHighlightDropZone = isDraggingWithinInnerBlocks;
+	// Using the experimental hook so that we can control the className of the element.
+	const innerBlocksProps = __experimentalUseInnerBlocksProps(
+		{ ref: innerBlocksRef },
+		{
+			value: blocks,
+			onInput,
+			onChange,
+			templateLock: false,
+			renderAppender: InnerBlocks.ButtonBlockAppender,
+		}
+	);
 
 	return (
 		<div
-			className={
-				shouldHighlightDropZone
-					? 'edit-widgets-highlight-drop-zone'
-					: undefined
-			}
+			className={ classnames(
+				'widget-area-inner-blocks block-editor-inner-blocks editor-styles-wrapper',
+				{
+					'widget-area-highlight-drop-zone': shouldHighlightDropZone,
+				}
+			) }
 		>
-			<InnerBlocks
-				ref={ innerBlocksRef }
-				value={ blocks }
-				onInput={ onInput }
-				onChange={ onChange }
-				templateLock={ false }
-				renderAppender={ InnerBlocks.ButtonBlockAppender }
-			/>
+			<div { ...innerBlocksProps } />
 		</div>
 	);
 }

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -3,19 +3,39 @@
  */
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useIsDraggingWithin from './use-is-dragging-within';
 
 export default function WidgetAreaInnerBlocks() {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'root',
 		'postType'
 	);
+	const innerBlocksRef = useRef();
+	const isDraggingWithinInnerBlocks = useIsDraggingWithin( innerBlocksRef );
+	const shouldHighlightDropZone =
+		blocks.length === 0 && isDraggingWithinInnerBlocks;
+
 	return (
-		<InnerBlocks
-			value={ blocks }
-			onInput={ onInput }
-			onChange={ onChange }
-			templateLock={ false }
-			renderAppender={ InnerBlocks.ButtonBlockAppender }
-		/>
+		<div
+			className={
+				shouldHighlightDropZone
+					? 'edit-widgets-highlight-drop-zone'
+					: undefined
+			}
+		>
+			<InnerBlocks
+				ref={ innerBlocksRef }
+				value={ blocks }
+				onInput={ onInput }
+				onChange={ onChange }
+				templateLock={ false }
+				renderAppender={ InnerBlocks.ButtonBlockAppender }
+			/>
+		</div>
 	);
 }

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -41,9 +41,9 @@ export default function WidgetAreaInnerBlocks() {
 	return (
 		<div
 			className={ classnames(
-				'widget-area-inner-blocks block-editor-inner-blocks editor-styles-wrapper',
+				'wp-block-widget-area__inner-blocks block-editor-inner-blocks editor-styles-wrapper',
 				{
-					'widget-area-highlight-drop-zone': shouldHighlightDropZone,
+					'wp-block-widget-area__highlight-drop-zone': shouldHighlightDropZone,
 				}
 			) }
 		>

--- a/packages/edit-widgets/src/blocks/widget-area/edit/use-is-dragging-within.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/use-is-dragging-within.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/** @typedef {import('@wordpress/element').RefObject} RefObject */
+
+/**
+ * A React hook to determine if it's dragging within the target element.
+ *
+ * @param {RefObject<HTMLElement>} elementRef The target elementRef object.
+ *
+ * @return {boolean} Is dragging within the target element.
+ */
+const useIsDraggingWithin = ( elementRef ) => {
+	const [ isDraggingWithin, setIsDraggingWithin ] = useState( false );
+
+	useEffect( () => {
+		const { ownerDocument } = elementRef.current;
+
+		function handleDragStart( event ) {
+			// Check the first time when the dragging starts.
+			handleDragEnter( event );
+		}
+
+		// Set to false whenever the user cancel the drag event by either releasing the mouse or press Escape.
+		function handleDragEnd() {
+			setIsDraggingWithin( false );
+		}
+
+		function handleDragEnter( event ) {
+			// Check if the current target is inside the item element.
+			if ( elementRef.current.contains( event.target ) ) {
+				setIsDraggingWithin( true );
+			} else {
+				setIsDraggingWithin( false );
+			}
+		}
+
+		// Bind these events to the document to catch all drag events.
+		// Ideally, we can also use `event.relatedTarget`, but sadly that doesn't work in Safari.
+		ownerDocument.addEventListener( 'dragstart', handleDragStart );
+		ownerDocument.addEventListener( 'dragend', handleDragEnd );
+		ownerDocument.addEventListener( 'dragenter', handleDragEnter );
+
+		return () => {
+			ownerDocument.removeEventListener( 'dragstart', handleDragStart );
+			ownerDocument.removeEventListener( 'dragend', handleDragEnd );
+			ownerDocument.removeEventListener( 'dragenter', handleDragEnter );
+		};
+	}, [] );
+
+	return isDraggingWithin;
+};
+
+export default useIsDraggingWithin;

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -60,7 +60,7 @@ $panel-title-height: 48px;
 }
 
 .widget-area-highlight-drop-zone {
-	outline: --wp-admin-border-width-focus solid var(--wp-admin-theme-color);
+	outline: var(--wp-admin-border-width-focus) solid var(--wp-admin-theme-color);
 }
 
 // Prevent "dragenter" event from firing when dragging onto the title component.

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -1,3 +1,5 @@
+$panel-title-height: 48px;
+
 .wp-block[data-type="core/widget-area"] {
 	max-width: $widget-area-width;
 	margin-left: auto;
@@ -6,16 +8,22 @@
 	.components-panel__body > .components-panel__body-title {
 		font-family: $default-font;
 		margin: 0;
+		height: $panel-title-height;
+		// Create a stacking context and make sure it's higher is than the content.
+		// Since the inner blocks will be stretched to cover the whole panel,
+		// we still want the title to be interactive.
+		position: relative;
+		z-index: 1;
+		background: $white;
+		// z-index should be enough to create a new stacking context,
+		// unfortunately, Safari needs this to stop it from flickering while dragging.
+		// The reason behind that is still unknown, probably a bug in the browser.
+		transform: translateZ(0);
 
 		// Remove default hover background in panel title. See #25752.
 		&:hover {
-			background: inherit;
+			background: $white;
 		}
-	}
-
-	.components-panel__body .editor-styles-wrapper {
-		margin: 0;
-		padding: $grid-unit-20;
 	}
 
 	.block-list-appender.wp-block {
@@ -29,19 +37,33 @@
 
 	.components-panel__body.is-opened {
 		padding: 0;
-
-		> div > .editor-styles-wrapper > .block-editor-inner-blocks > .block-editor-block-list__layout {
-			// Ensure the widget area block lists have a minimum height so that it doesn't
-			// collapse to zero height when it has no blocks. When that happens the block
-			// can't be used as a drop target.
-			min-height: $grid-unit-40;
-			// Add some spacing above the inner blocks so that the block toolbar doesn't
-			// overlap the panel header.
-			padding: $grid-unit-30 $grid-unit-20 $grid-unit-20;
-		}
 	}
 }
 
-.edit-widgets-highlight-drop-zone {
-	outline: 2px dashed var(--wp-admin-theme-color);
+.blocks-widgets-container .widget-area-inner-blocks.editor-styles-wrapper {
+	margin: 0;
+	padding: 0;
+
+	> .block-editor-block-list__layout {
+		// Stretch the inner-blocks container to cover the entire panel,
+		// so that dragging onto anywhere in it works.
+		margin-top: -$panel-title-height;
+		// Add some spacing above the inner blocks so that the block toolbar doesn't
+		// overlap the panel header.
+		padding: ($panel-title-height + $grid-unit-30) $grid-unit-20 $grid-unit-20;
+
+		// Ensure the widget area block lists have a minimum height so that it doesn't
+		// collapse to zero height when it has no blocks. When that happens the block
+		// can't be used as a drop target.
+		min-height: $grid-unit-40;
+	}
+}
+
+.widget-area-highlight-drop-zone {
+	outline: --wp-admin-border-width-focus solid var(--wp-admin-theme-color);
+}
+
+// Prevent "dragenter" event from firing when dragging onto the title component.
+body.is-dragging-components-draggable .wp-block[data-type="core/widget-area"] .components-panel__body > .components-panel__body-title {
+	pointer-events: none;
 }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -21,22 +21,27 @@
 	.block-list-appender.wp-block {
 		width: initial;
 	}
+
 	// Override theme custom widths for blocks.
 	.editor-styles-wrapper .wp-block.wp-block.wp-block.wp-block.wp-block {
 		max-width: 100%;
+	}
+
+	.components-panel__body.is-opened {
+		padding: 0;
+
+		> div > .editor-styles-wrapper > .block-editor-inner-blocks > .block-editor-block-list__layout {
+			// Ensure the widget area block lists have a minimum height so that it doesn't
+			// collapse to zero height when it has no blocks. When that happens the block
+			// can't be used as a drop target.
+			min-height: $grid-unit-40;
+			// Add some spacing above the inner blocks so that the block toolbar doesn't
+			// overlap the panel header.
+			padding: $grid-unit-30 $grid-unit-20 $grid-unit-20;
+		}
 	}
 }
 
 .edit-widgets-highlight-drop-zone {
 	outline: 2px dashed var(--wp-admin-theme-color);
-}
-
-.wp-block-widget-area > .components-panel__body > div > .editor-styles-wrapper > .block-editor-inner-blocks > .block-editor-block-list__layout {
-	// Ensure the widget area block lists have a minimum height so that it doesn't
-	// collapse to zero height when it has no blocks. When that happens the block
-	// can't be used as a drop target.
-	min-height: $grid-unit-40;
-	// Add some spacing above the inner blocks so that the block toolbar doesn't
-	// overlap the panel header.
-	margin-top: $grid-unit-30;
 }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -27,15 +27,16 @@
 	}
 }
 
-// Add some spacing above the inner blocks so that the block toolbar doesn't
-// overlap the panel header.
-.wp-block-widget-area > .components-panel__body > div > .editor-styles-wrapper > .block-editor-inner-blocks {
-	padding-top: $grid-unit-30;
+.edit-widgets-highlight-drop-zone {
+	outline: 2px dashed var(--wp-admin-theme-color);
+}
 
+.wp-block-widget-area > .components-panel__body > div > .editor-styles-wrapper > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	// Ensure the widget area block lists have a minimum height so that it doesn't
 	// collapse to zero height when it has no blocks. When that happens the block
 	// can't be used as a drop target.
-	> .block-editor-block-list__layout {
-		min-height: $grid-unit-40;
-	}
+	min-height: $grid-unit-40;
+	// Add some spacing above the inner blocks so that the block toolbar doesn't
+	// overlap the panel header.
+	margin-top: $grid-unit-30;
 }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -65,5 +65,8 @@ $panel-title-height: 48px;
 
 // Prevent "dragenter" event from firing when dragging onto the title component.
 body.is-dragging-components-draggable .wp-block[data-type="core/widget-area"] .components-panel__body > .components-panel__body-title {
-	pointer-events: none;
+	&,
+	* {
+		pointer-events: none;
+	}
 }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -5,7 +5,7 @@
 
 	.components-panel__body > .components-panel__body-title {
 		font-family: $default-font;
-		margin-bottom: 0;
+		margin: 0;
 
 		// Remove default hover background in panel title. See #25752.
 		&:hover {
@@ -14,7 +14,7 @@
 	}
 
 	.components-panel__body .editor-styles-wrapper {
-		margin: 0 (-$grid-unit-20) (-$grid-unit-20) (-$grid-unit-20);
+		margin: 0;
 		padding: $grid-unit-20;
 	}
 

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -40,7 +40,7 @@ $panel-title-height: 48px;
 	}
 }
 
-.blocks-widgets-container .widget-area-inner-blocks.editor-styles-wrapper {
+.blocks-widgets-container .wp-block-widget-area__inner-blocks.editor-styles-wrapper {
 	margin: 0;
 	padding: 0;
 
@@ -59,7 +59,7 @@ $panel-title-height: 48px;
 	}
 }
 
-.widget-area-highlight-drop-zone {
+.wp-block-widget-area__highlight-drop-zone {
 	outline: var(--wp-admin-border-width-focus) solid var(--wp-admin-theme-color);
 }
 

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -43,7 +43,10 @@ export default function WidgetAreasBlockEditorContent( {
 				<BlockSelectionClearer>
 					<WritingFlow>
 						<ObserveTyping>
-							<BlockList className="edit-widgets-main-block-list" />
+							<BlockList
+								className="edit-widgets-main-block-list"
+								renderAppender={ false }
+							/>
 						</ObserveTyping>
 					</WritingFlow>
 				</BlockSelectionClearer>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -43,10 +43,7 @@ export default function WidgetAreasBlockEditorContent( {
 				<BlockSelectionClearer>
 					<WritingFlow>
 						<ObserveTyping>
-							<BlockList
-								className="edit-widgets-main-block-list"
-								renderAppender={ false }
-							/>
+							<BlockList className="edit-widgets-main-block-list" />
 						</ObserveTyping>
 					</WritingFlow>
 				</BlockSelectionClearer>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #32652, fix #32931.

Expand the size of Widget Area's `InnerBlocks` to the entire panel, so that dropping anywhere on that panel works. The trick is to use some hacky negative `margin-top` and `padding-top` combo to achieve the effects. We also have to elevate the z-index of the title element so that clicking on it still works. However, we don't want `dragenter` and `dragleave` events being triggered when dragging blocks onto the title element, hence we set `pointer-events: none` to the title element while dragging.

The widget area now shows a ring outline when a block is dragging upon it, to compensate that the blue line indicator is still kind of buggy and not easy to fix at the time (#32880).

c.c. @critterverse for design reviews ♥️ 🙇‍♂️ !

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Appearance -> Widgets
2. Try to drag a block to another widget area.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/123249395-7cd37c00-d51b-11eb-90b7-f16842547e22.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

