### PR TITLE
[RNMobile] Fix `wp.data.select` deprecation warning

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -115,8 +115,8 @@ export default compose( [
 			getBlockRootClientId,
 			getBlockSelectionEnd,
 			hasInserterItems,
-			getEditorSettings,
-		} = select( editorStore );
+		} = select( blockEditorStore );
+		const { getEditorSettings } = select( editorStore );
 		return {
 			hasRedo: select( editorStore ).hasEditorRedo(),
 			hasUndo: select( editorStore ).hasEditorUndo(),


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3661

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When opening a post/page, the app is giving the following warnings related to the use of deprecated selectors:
```
wp.data.select( 'core/editor' ).getBlockSelectionEnd` is deprecated since version 5.3. Please use `wp.data.select( 'core/block-editor' ).getBlockSelectionEnd` instead. 
```
```
wp.data.select( 'core/editor' ).getBlockRootClientId` is deprecated since version 5.3. Please use `wp.data.select( 'core/block-editor' ).getBlockRootClientId` instead.
```
```
wp.data.select( 'core/editor' ).hasInserterItems` is deprecated since version 5.3. Please use `wp.data.select( 'core/block-editor' ).hasInserterItems` instead.
```

This PR addresses this issue by using the block editor store in the mentioned selectors located in the header toolbar component.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Use a debug build of the app that connects to the Metro server
2. Open a post/page
3. Observe that these warnings are not logged in the console

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
