### PR TITLE
Add list layout options to Latest Comments block

### DIFF
--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -24,6 +24,10 @@
 		"displayExcerpt": {
 			"type": "boolean",
 			"default": true
+		},
+		"commentLayout": {
+			"type": "string",
+			"default": "list"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -1,15 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	BlockControls,
+} from '@wordpress/block-editor';
 import {
 	Disabled,
 	PanelBody,
 	RangeControl,
 	ToggleControl,
+	ToolbarDropdownMenu,
+	ToolbarGroup,
 } from '@wordpress/components';
+
 import ServerSideRender from '@wordpress/server-side-render';
 import { __ } from '@wordpress/i18n';
+import { list, formatListNumbered } from '@wordpress/icons';
 
 /**
  * Minimum number of comments a user can show using this block.
@@ -30,10 +38,48 @@ export default function LatestComments( { attributes, setAttributes } ) {
 		displayAvatar,
 		displayDate,
 		displayExcerpt,
+		commentLayout,
 	} = attributes;
+
+	function applyLayout( layout ) {
+		return () =>
+			setAttributes( {
+				commentLayout: layout,
+			} );
+	}
+
+	const layoutControls = [
+		{
+			layout: 'list',
+			icon: list,
+			title: __( 'List' ),
+			onClick: applyLayout( 'list' ),
+			isActive: commentLayout === 'list',
+		},
+		{
+			layout: 'numbered-list',
+			icon: formatListNumbered,
+			title: __( 'Numbered List' ),
+			onClick: applyLayout( 'numbered-list' ),
+			isActive: commentLayout === 'numbered-list',
+		},
+	];
+
+	const activeCommentLayoutIcon =
+		layoutControls.find( ( layout ) => layout.layout === commentLayout )
+			?.icon || 'list';
 
 	return (
 		<div { ...useBlockProps() }>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={ activeCommentLayoutIcon }
+						label={ __( 'Layout' ) }
+						controls={ layoutControls }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Latest comments settings' ) }>
 					<ToggleControl

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -129,6 +129,15 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	if ( empty( $comments ) ) {
 		$classnames[] = 'no-comments';
 	}
+
+	if ( $attributes['commentLayout'] !== 'numbered-list' ) {
+		$classnames[] = 'has-no-numbering';
+	}
+
+	if ( $attributes['commentLayout'] === 'numbered-list' ) {
+		$classnames[] = 'has-numbering';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 
 	return ! empty( $comments ) ? sprintf(

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -1,15 +1,21 @@
 ol.wp-block-latest-comments {
-	padding-left: 0;
+	&.has-numbering {
+		padding-left: revert;
+		list-style: revert;
+	}
+
+	&.has-no-numbering {
+		padding-left: 0;
+		list-style: none;
+	}
 }
 
 .wp-block-latest-comments__comment {
 	line-height: 1.1;
-	list-style: none;
 	margin-bottom: 1em;
 
 	.has-avatars & {
 		min-height: 2.25em;
-		list-style: none;
 
 		.wp-block-latest-comments__comment-meta,
 		.wp-block-latest-comments__comment-excerpt {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Building on work in https://github.com/WordPress/gutenberg/pull/32806, this PR adds the ability to switch between two layouts for the Latest Comments block:

1. List - no bullets/numbering.
2. Numbered List - displays the default numbering of the ordered list.

It's likely we'll need a deprecation for this one as we're adding new attributes. I could be wrong though...

Related https://github.com/WordPress/gutenberg/issues/32718.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* On this branch - add a load of comments. I used FakerPress to automate this.
* Add Latest Comments block.
* See default layout "as was" with no bullets.
* See new "Layout" toolbar item added to Block Toolbar.
* Select "Numbered List" from the Layout options.
* See numbers displayed indented.
* Toggle "Show Avatars" and check that numbers still show up (previously having avatars "on" removed list styling).
* Switch back to standard list and check everything still looks good.
* Check front end output.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/123273978-0292ff80-d4fb-11eb-848b-76a8307070ac.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
