### PR TITLE
[RNMobile] Mock switch component to address a warning when running tests

### DIFF
--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -178,3 +178,14 @@ jest.mock(
 		} ) ),
 	} )
 );
+
+// Silences the warning: dispatchCommand was called with a ref that isn't a native
+// component. Use React.forwardRef to get access to the underlying native component.
+// This is a known bug of react-native-testing-library package:
+// https://github.com/callstack/react-native-testing-library/issues/329#issuecomment-737307473
+jest.mock( 'react-native/Libraries/Components/Switch/Switch', () => {
+	const jestMockComponent = require( 'react-native/jest/mockComponent' );
+	return jestMockComponent(
+		'react-native/Libraries/Components/Switch/Switch'
+	);
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I noticed when running the unit and integration tests that we're getting the following warning on some of the tests:
```
dispatchCommand was called with a ref that isn't a native component. Use React.forwardRef to get access to the underlying native component
```

I found out that this is a known bug and I applied a workaround posted in [the issue](https://github.com/callstack/react-native-testing-library/issues/329#issuecomment-737307473).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Run command: `npm run native test`
2. Observe that the mentioned warning is not logged

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
