### PR TITLE
data: Add types to redux-store/metadata/selectors

### DIFF
--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -21,7 +21,7 @@ type Action =
 			typeof import('./actions').invalidateResolutionForStoreSelector
 	  >;
 
-type State = EquivalentKeyMap< unknown[] | unknown, boolean >;
+export type State = EquivalentKeyMap< unknown[] | unknown, boolean >;
 
 /**
  * Reducer function returning next state for selector resolution of

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -3,22 +3,24 @@
  */
 import { get } from 'lodash';
 
+/** @typedef {Record<string, import('./reducer').State>} State */
+
 /**
  * Returns the raw `isResolving` value for a given selector name,
  * and arguments set. May be undefined if the selector has never been resolved
  * or not resolved for the given set of arguments, otherwise true or false for
  * resolution started and completed respectively.
  *
- * @param {Object} state        Data state.
- * @param {string} selectorName Selector name.
- * @param {Array}  args         Arguments passed to selector.
+ * @param {State}     state        Data state.
+ * @param {string}    selectorName Selector name.
+ * @param {unknown[]} args         Arguments passed to selector.
  *
- * @return {?boolean} isResolving value.
+ * @return {boolean | undefined} isResolving value.
  */
 export function getIsResolving( state, selectorName, args ) {
 	const map = get( state, [ selectorName ] );
 	if ( ! map ) {
-		return;
+		return undefined;
 	}
 
 	return map.get( args );
@@ -28,9 +30,9 @@ export function getIsResolving( state, selectorName, args ) {
  * Returns true if resolution has already been triggered for a given
  * selector name, and arguments set.
  *
- * @param {Object} state        Data state.
- * @param {string} selectorName Selector name.
- * @param {?Array} args         Arguments passed to selector (default `[]`).
+ * @param {State}     state        Data state.
+ * @param {string}    selectorName Selector name.
+ * @param {unknown[]} [args]       Arguments passed to selector (default `[]`).
  *
  * @return {boolean} Whether resolution has been triggered.
  */
@@ -42,9 +44,9 @@ export function hasStartedResolution( state, selectorName, args = [] ) {
  * Returns true if resolution has completed for a given selector
  * name, and arguments set.
  *
- * @param {Object} state        Data state.
- * @param {string} selectorName Selector name.
- * @param {?Array} args         Arguments passed to selector.
+ * @param {State}     state        Data state.
+ * @param {string}    selectorName Selector name.
+ * @param {unknown[]} [args]       Arguments passed to selector.
  *
  * @return {boolean} Whether resolution has completed.
  */
@@ -56,9 +58,9 @@ export function hasFinishedResolution( state, selectorName, args = [] ) {
  * Returns true if resolution has been triggered but has not yet completed for
  * a given selector name, and arguments set.
  *
- * @param {Object} state        Data state.
- * @param {string} selectorName Selector name.
- * @param {?Array} args         Arguments passed to selector.
+ * @param {State}     state        Data state.
+ * @param {string}    selectorName Selector name.
+ * @param {unknown[]} [args]       Arguments passed to selector.
  *
  * @return {boolean} Whether resolution is in progress.
  */
@@ -69,9 +71,9 @@ export function isResolving( state, selectorName, args = [] ) {
 /**
  * Returns the list of the cached resolvers.
  *
- * @param {Object} state Data state.
+ * @param {State} state Data state.
  *
- * @return {Object} Resolvers mapped by args and selectorName.
+ * @return {State} Resolvers mapped by args and selectorName.
  */
 export function getCachedResolvers( state ) {
 	return state;

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -15,9 +15,6 @@
 		// { "path": "../redux-routine" }
 	],
 	"include": [
-		"src/redux-store/metadata/actions.js",
-		"src/redux-store/metadata/equivalent-key-map.d.ts",
-		"src/redux-store/metadata/reducer.ts",
-		"src/redux-store/metadata/utils.js"
+		"src/redux-store/metadata/**/*",
 	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds types to the rest of `redux-store/metadata/selectors` which finishes `redux-store/metadata`.

Part of #18838

## How has this been tested?
Type checks pass.

## Types of changes
Only one runtime change is to explicitly `return undefined` instead of just `return;`. This isn't _really_ a runtime change 🤷 

Otherwise it's only updates to the JSDocs.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
