### PR TITLE
Add custom classes to archive dropdown

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -40,6 +40,10 @@ function render_block_core_archives( $attributes ) {
 
 		$archives = wp_get_archives( $dropdown_args );
 
+		$classnames = esc_attr( $class );
+
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':
 				$label = __( 'Select Year' );
@@ -65,8 +69,8 @@ function render_block_core_archives( $attributes ) {
 	<option value="">' . $label . '</option>' . $archives . '</select>';
 
 		return sprintf(
-			'<div class="%1$s">%2$s</div>',
-			esc_attr( $class ),
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
 			$block_content
 		);
 	}


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/32870

## Description
Add custom classes to archive dropdown

## How has this been tested?
1. Go to Appearance > Widgets
2. Add a monthly archive block
3. Format as a dropdown
4. Add some custom classes in the advanced section
5. Update the widgets
6. The custom classes should be there in the front end and in the editor.

## Screenshots

![image](https://user-images.githubusercontent.com/69596988/123324758-d310e100-d554-11eb-942c-0a665eb9aca6.png)



## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

