### PR TITLE
Adjust legacy widget form styles to match editor.

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -22,36 +22,32 @@
 			font-size: $default-font-size;
 		}
 
-		label + .widefat {
-			margin-top: $grid-unit-15;
-		}
-
 		// Override theme style bleed.
 		label,
 		input,
 		a {
+			font-family: system-ui;
+			font-weight: normal;
 			color: $black;
 		}
+		input[type="text"],
 		select {
 			font-family: system-ui;
-			-webkit-appearance: revert;
-			color: revert;
-			border: revert;
-			border-radius: revert;
-			background: revert;
-			box-shadow: revert;
-			text-shadow: revert;
-			outline: revert;
-			cursor: revert;
-			transform: revert;
-			font-size: revert;
-			line-height: revert;
-			padding: revert;
-			margin: revert;
-			min-height: revert;
-			max-width: revert;
-			vertical-align: revert;
-			font-weight: revert;
+			background: transparent;
+			box-sizing: border-box;
+			border: 1px solid $gray-700;
+			border-radius: 3px;
+			box-shadow: none;
+			color: $black;
+			display: block;
+			margin: 0;
+			width: 100%;
+			font-size: $default-font-size;
+			font-weight: normal;
+			height: 30px;
+			line-height: 1;
+			min-height: 30px;
+			padding-left: $grid-unit-05;
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #32955 by adding styles for legacy widget form fields that match the editor defaults (as much as possible given we don't control the markup of third party widget forms.)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Activate Twenty Twenty theme, install Web Stories plugin.
In Widgets editor, add Web Stories legacy widget and check that form fields look reasonably consistent with editor styles.

## Screenshots <!-- if applicable -->

<img width="680" alt="Screen Shot 2021-06-25 at 1 54 12 pm" src="https://user-images.githubusercontent.com/8096000/123367177-da6bd500-d5bc-11eb-8b1e-5b6f2eda2fd2.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
