### PR TITLE
Block Library: Improve view script integration to account for WordPress Core

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -165,37 +165,15 @@ add_action( 'init', 'gutenberg_reregister_core_block_types' );
  * @return void
  */
 function gutenberg_register_core_block_assets( $block_name ) {
+	if ( ! wp_should_load_separate_core_block_assets() ) {
+		return;
+	}
+
 	$block_name = str_replace( 'core/', '', $block_name );
 
 	// When in production, use the plugin's version as the default asset version;
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? GUTENBERG_VERSION : time();
-	$script_suffix   = '.min.js';
-
-	$view_script_path = "build/block-library/blocks/$block_name/view$script_suffix";
-	if ( file_exists( gutenberg_dir_path() . $view_script_path ) ) {
-		$view_script_handle = "wp-block-{$block_name}-view";
-		wp_deregister_script( $view_script_handle );
-
-		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
-		$view_asset_file          = substr( $view_script_path, 0, -( strlen( $script_suffix ) ) ) . '.asset.php';
-		$view_asset               = file_exists( gutenberg_dir_path() . $view_asset_file )
-			? require( gutenberg_dir_path() . $view_asset_file )
-			: null;
-		$view_script_dependencies = isset( $view_asset['dependencies'] ) ? $view_asset['dependencies'] : array();
-		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : $default_version;
-
-		wp_register_script(
-			$view_script_handle,
-			gutenberg_url( $view_script_path ),
-			$view_script_dependencies,
-			$view_script_version
-		);
-	}
-
-	if ( ! wp_should_load_separate_core_block_assets() ) {
-		return;
-	}
 
 	$style_path        = "build/block-library/blocks/$block_name/style.css";
 	$editor_style_path = "build/block-library/blocks/$block_name/style-editor.css";

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -242,7 +242,7 @@ function gutenberg_register_packages_scripts( $scripts ) {
 		// For example, `…/build/a11y/index.min.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );
 
-		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
+		// Replace extension with `.asset.php` to find the generated dependencies file.
 		$asset_file   = substr( $path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
 		$asset        = file_exists( $asset_file )
 			? require( $asset_file )

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -236,15 +236,14 @@ function gutenberg_register_packages_scripts( $scripts ) {
 	// When in production, use the plugin's version as the default asset version;
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? GUTENBERG_VERSION : time();
-	$suffix          = '.min.js';
 
-	foreach ( glob( gutenberg_dir_path() . "build/*/index$suffix" ) as $path ) {
+	foreach ( glob( gutenberg_dir_path() . 'build/*/index.min.js' ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.
 		// For example, `…/build/a11y/index.min.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );
 
 		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
-		$asset_file   = substr( $path, 0, -( strlen( $suffix ) ) ) . '.asset.php';
+		$asset_file   = substr( $path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
 		$asset        = file_exists( $asset_file )
 			? require( $asset_file )
 			: null;

--- a/lib/compat/wordpress-5.8/blocks.php
+++ b/lib/compat/wordpress-5.8/blocks.php
@@ -34,7 +34,7 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 		wp_deregister_script( $view_script_handle );
 
 		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
-		$view_asset_file          = substr( $view_script_path, 0, -( strlen( '.min.js' ) ) ) . '.asset.php';
+		$view_asset_file          = substr( $view_script_path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
 		$view_asset               = file_exists( $view_asset_file ) ? require( $view_asset_file ) : null;
 		$view_script_dependencies = isset( $view_asset['dependencies'] ) ? $view_asset['dependencies'] : array();
 		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : false;

--- a/lib/compat/wordpress-5.8/blocks.php
+++ b/lib/compat/wordpress-5.8/blocks.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Blocks.
+ *
+ * @package Gutenberg
+ * @subpackage Editor
+ * @since 11.0.0
+ */
+
+/**
+ * Registers view scripts for core blocks if handling is missing in WordPress core.
+ *
+ * This is a temporary solution until the Gutenberg plugin sets
+ * the required WordPress version to 5.8.
+ *
+ * @param array $settings Array of determined settings for registering a block type.
+ * @param array $metadata Metadata provided for registering a block type.
+ *
+ * @return array Array of settings for registering a block type.
+ */
+function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
+	if (
+		! isset( $metadata['viewScript'] ) ||
+		! empty( $settings['view_script'] ) ||
+		! isset( $metadata['file'] ) ||
+		strpos( $metadata['file'], gutenberg_dir_path() ) !== 0
+	) {
+		return $settings;
+	}
+
+	$view_script_path = realpath( dirname( $metadata['file'] ) . '/' . remove_block_asset_path_prefix( $metadata['viewScript'] ) );
+	if ( file_exists( $view_script_path ) ) {
+		$view_script_handle = str_replace( 'core/', 'wp-block-', $metadata['name'] ) . '-view';
+		wp_deregister_script( $view_script_handle );
+
+		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
+		$view_asset_file          = substr( $view_script_path, 0, -( strlen( '.min.js' ) ) ) . '.asset.php';
+		$view_asset               = file_exists( $view_asset_file ) ? require( $view_asset_file ) : null;
+		$view_script_dependencies = isset( $view_asset['dependencies'] ) ? $view_asset['dependencies'] : array();
+		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : false;
+
+		$result = wp_register_script(
+			$view_script_handle,
+			gutenberg_url( str_replace( gutenberg_dir_path(), '', $view_script_path ) ),
+			$view_script_dependencies,
+			$view_script_version,
+			true
+		);
+		if ( $result ) {
+			$settings['view_script'] = $view_script_handle;
+		}
+	}
+
+	return $settings;
+}
+
+add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_script', 10, 2 );

--- a/lib/compat/wordpress-5.8/index.php
+++ b/lib/compat/wordpress-5.8/index.php
@@ -12,6 +12,7 @@ if ( ! class_exists( 'WP_Block_Editor_Context' ) ) {
 }
 
 require_once __DIR__ . '/block-editor.php';
+require_once __DIR__ . '/blocks.php';
 
 if ( ! function_exists( 'build_query_vars_from_query_block' ) ) {
 	/**

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -51,6 +51,7 @@
 		"anchor": true,
 		"align": true
 	},
+	"viewScript": "file:./view.min.js",
 	"editorStyle": "wp-block-file-editor",
 	"style": "wp-block-file"
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -70,6 +70,7 @@
 		},
 		"color": true
 	},
+	"viewScript": "file:./view.min.js",
 	"editorStyle": "wp-block-navigation-editor",
 	"style": "wp-block-navigation"
 }

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -179,7 +179,7 @@ class DependencyExtractionWebpackPlugin {
 				}
 
 				const assetFilename = buildFilename.replace(
-					/(\.min)?\.js$/i,
+					/\.js$/i,
 					'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' )
 				);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #32814.
Required for https://github.com/WordPress/wordpress-develop/pull/1412.

We are trying a solution that integrates easier with WordPress core. The idea is to introduce `viewScript` in the `block.json` file and shim handling for WordPress 5.7 with `block_type_metadata_settings` hook for WordPress core blocks.

This solution won't work with WP 5.6 but we will phase it out in 2-3 plugin releases anyway when WP 5.8 is out. So I think it's a good compromise.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I tested with the Navigation block and its "Enable responsive menu" option enabled in the sidebar menu.

<img width="436" alt="Screen Shot 2021-06-21 at 12 45 44" src="https://user-images.githubusercontent.com/699132/122750305-9e6c0380-d28e-11eb-98d1-258241c2ca73.png">

Once you insert the block, enable the option. It has to be tested on the front end on small viewports.

It should be tested also with the File block and embed previews for PDF files.

## Screenshots <!-- if applicable -->

<img width="856" alt="Screen Shot 2021-06-21 at 12 42 55" src="https://user-images.githubusercontent.com/699132/122750055-5947d180-d28e-11eb-9d47-44a13ecf6fb1.png">
<img width="561" alt="Screen Shot 2021-06-21 at 12 43 09" src="https://user-images.githubusercontent.com/699132/122750057-5a78fe80-d28e-11eb-97a9-b6896cd04c42.png">

<img width="567" alt="Screen Shot 2021-06-21 at 12 43 15" src="https://user-images.githubusercontent.com/699132/122750058-5b119500-d28e-11eb-9d8d-49f1a7080d2f.png">

Script handles should be also printed at the end of the HTML source when visiting the published post:

<img width="491" alt="Screen Shot 2021-06-25 at 10 49 19" src="https://user-images.githubusercontent.com/699132/123397805-23169480-d5a3-11eb-9449-752802847a71.png">


## Types of changes

Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
