### PR TITLE
Widgets: Fix creating and editing non-multi widgets

### DIFF
--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -40,7 +40,7 @@ function marquee_greeting_init() {
 					class="widefat"
 					name="marquee-greeting"
 					type="text"
-					value="<?php echo esc_attr( $greeting ) ?>"
+					value="<?php echo esc_attr( $greeting ); ?>"
 					placeholder="Hello!"
 				/>
 			</p>

--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Marquee Widget
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-marquee-widget
+ */
+
+// Add a non-WP_Widget marquee widget
+function marquee_greeting_init() {
+	wp_register_sidebar_widget(
+		'marquee_greeting',
+		'Marquee Greeting',
+		function() {
+			$greeting = get_option( 'marquee_greeting', 'Hello!' );
+			printf( '<marquee>%s</marquee>', esc_html( $greeting ) );
+		}
+	);
+
+	wp_register_widget_control(
+		'marquee_greeting',
+		'Marquee Greeting',
+		function() {
+			if ( isset( $_POST['marquee-greeting'] ) ) {
+				update_option(
+					'marquee_greeting',
+					sanitize_text_field( $_POST['marquee-greeting'] )
+				);
+			}
+
+			$greeting = get_option( 'marquee_greeting' );
+			?>
+			<p>
+				<label for="marquee-greeting">Greeting:</label>
+				<input
+					id="marquee-greeting"
+					class="widefat"
+					name="marquee-greeting"
+					type="text"
+					value="<?= esc_attr( $greeting ) ?>"
+					placeholder="Hello!"
+				/>
+			</p>
+			<?php
+		}
+	);
+}
+add_action( 'init', 'marquee_greeting_init' );

--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -7,7 +7,9 @@
  * @package gutenberg-test-marquee-widget
  */
 
-// Add a non-WP_Widget marquee widget
+/**
+ * Add a non-WP_Widget marquee widget.
+ */
 function marquee_greeting_init() {
 	wp_register_sidebar_widget(
 		'marquee_greeting',
@@ -38,7 +40,7 @@ function marquee_greeting_init() {
 					class="widefat"
 					name="marquee-greeting"
 					type="text"
-					value="<?= esc_attr( $greeting ) ?>"
+					value="<?php echo esc_attr( $greeting ) ?>"
 					placeholder="Hello!"
 				/>
 			</p>

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -16,7 +16,7 @@ import {
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll } from 'puppeteer-testing-library';
+import { find, findAll, waitFor } from 'puppeteer-testing-library';
 import { groupBy, mapValues } from 'lodash';
 
 describe( 'Widgets screen', () => {
@@ -242,6 +242,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\"><p><div style=\\"width: 580px;\\" class=\\"wp-video\\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->
 		<video class=\\"wp-video-shortcode\\" id=\\"video-0-1\\" width=\\"580\\" height=\\"326\\" preload=\\"metadata\\" controls=\\"controls\\"><source type=\\"video/mp4\\" src=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4?_=1\\" /><a href=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\\">http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4</a></video></div></p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -390,8 +391,112 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
+	} );
+
+	async function addMarquee() {
+		// There will be 2 matches here.
+		// One is the in-between inserter,
+		// and the other one is the button block appender.
+		const [ inlineInserterButton ] = await findAll( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
+		await inlineInserterButton.click();
+
+		// TODO: Convert to find() API from puppeteer-testing-library.
+		const inserterSearchBox = await page.waitForSelector(
+			'aria/Search for blocks and patterns[role="searchbox"]'
+		);
+		await expect( inserterSearchBox ).toHaveFocus();
+
+		await page.keyboard.type( 'Marquee' );
+
+		const inlineQuickInserter = await find( {
+			role: 'listbox',
+			name: 'Blocks',
+		} );
+		const marqueeBlockOption = await find(
+			{
+				role: 'option',
+			},
+			{
+				root: inlineQuickInserter,
+			}
+		);
+		await marqueeBlockOption.click();
+	}
+
+	it( 'Should add and save the marquee widget', async () => {
+		await activatePlugin( 'gutenberg-test-marquee-widget' );
+		await visitAdminPage( 'widgets.php' );
+
+		await addMarquee();
+
+		await find( {
+			selector: '[data-block][data-type="core/legacy-widget"]',
+		} );
+
+		const greetingsInput = await find( {
+			selector: '#marquee-greeting',
+		} );
+		await greetingsInput.click();
+		await page.keyboard.type( 'Howdy' );
+
+		await saveWidgets();
+
+		let editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		await page.reload();
+
+		editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		// Add another marquee, it shouldn't be saved
+		await addMarquee();
+
+		// It takes a moment to load the form, let's wait for it.
+		await waitFor( async () => {
+			const marquees = await findAll( {
+				selector: '[id=marquee-greeting]',
+			} );
+			if ( marquees.length === 1 ) {
+				throw new Error();
+			}
+		} );
+
+		const marquees = await findAll( {
+			selector: '[id=marquee-greeting]',
+		} );
+
+		expect( marquees ).toHaveLength( 2 );
+		await marquees[ 1 ].click();
+		await page.keyboard.type( 'Second howdy' );
+
+		await saveWidgets();
+		editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		await page.reload();
+		const marqueesAfter = await findAll( {
+			selector: '[id=marquee-greeting]',
+		} );
+		expect( marqueesAfter ).toHaveLength( 1 );
 	} );
 
 	// Disable reason: We temporary skip this test until we can figure out why it fails sometimes.
@@ -423,6 +528,7 @@ describe( 'Widgets screen', () => {
 		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 		const initialWidgets = await getWidgetAreaWidgets();
@@ -493,6 +599,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 		const editedWidgets = await getWidgetAreaWidgets();
@@ -626,6 +733,7 @@ describe( 'Widgets screen', () => {
 			<input type=\\"submit\\" class=\\"search-submit\\" value=\\"Search\\" />
 		</form>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -694,6 +802,7 @@ describe( 'Widgets screen', () => {
 		  "sidebar-2": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -750,6 +859,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -242,7 +242,6 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\"><p><div style=\\"width: 580px;\\" class=\\"wp-video\\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->
 		<video class=\\"wp-video-shortcode\\" id=\\"video-0-1\\" width=\\"580\\" height=\\"326\\" preload=\\"metadata\\" controls=\\"controls\\"><source type=\\"video/mp4\\" src=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4?_=1\\" /><a href=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\\">http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4</a></video></div></p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -391,7 +390,6 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -497,6 +495,8 @@ describe( 'Widgets screen', () => {
 			selector: '[id=marquee-greeting]',
 		} );
 		expect( marqueesAfter ).toHaveLength( 1 );
+
+		await deactivatePlugin( 'gutenberg-test-marquee-widget' );
 	} );
 
 	// Disable reason: We temporary skip this test until we can figure out why it fails sometimes.
@@ -733,7 +733,6 @@ describe( 'Widgets screen', () => {
 			<input type=\\"submit\\" class=\\"search-submit\\" value=\\"Search\\" />
 		</form>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -802,7 +801,6 @@ describe( 'Widgets screen', () => {
 		  "sidebar-2": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -859,7 +857,6 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -148,13 +148,15 @@ export function* saveWidgetArea( widgetAreaId ) {
 		const widgetId = getWidgetIdFromBlock( block );
 		const oldWidget = widgets[ widgetId ];
 		const widget = transformBlockToWidget( block, oldWidget );
+
 		// We'll replace the null widgetId after save, but we track it here
 		// since order is important.
 		sidebarWidgetsIds.push( widgetId );
 
-		// We need to check for the id in the widget object here, because a deleted
-		// and restored widget won't have this id.
-		if ( widget.id ) {
+		// Check oldWidget as widgetId might refer to an ID which has been
+		// deleted, e.g. if a deleted block is restored via undo after saving.
+		if ( oldWidget ) {
+			// Update an existing widget.
 			yield dispatch(
 				'core',
 				'editEntityRecord',
@@ -184,6 +186,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 				saveEditedEntityRecord( 'root', 'widget', widgetId )
 			);
 		} else {
+			// Create a new widget.
 			batchTasks.push( ( { saveEntityRecord } ) =>
 				saveEntityRecord( 'root', 'widget', {
 					...widget,

--- a/packages/widgets/src/blocks/legacy-widget/edit/control.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/control.js
@@ -52,7 +52,10 @@ export default class Control {
 		// a fake but unique number.
 		this.number = ++lastNumber;
 
-		this.handleFormChange = debounce( this.saveForm.bind( this ), 200 );
+		this.handleFormChange = debounce(
+			this.handleFormChange.bind( this ),
+			200
+		);
 		this.handleFormSubmit = this.handleFormSubmit.bind( this );
 
 		this.initDOM();
@@ -211,6 +214,18 @@ export default class Control {
 			}
 		} catch ( error ) {
 			this.onError( error );
+		}
+	}
+
+	/**
+	 * Perform a save when a multi widget's form is changed. Non-multi widgets
+	 * are saved manually.
+	 *
+	 * @access private
+	 */
+	handleFormChange() {
+		if ( this.idBase ) {
+			this.saveForm();
 		}
 	}
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -131,7 +131,8 @@ function NotEmpty( {
 		);
 	}
 
-	const mode = isNavigationMode || ! isSelected ? 'preview' : 'edit';
+	const mode =
+		idBase && ( isNavigationMode || ! isSelected ) ? 'preview' : 'edit';
 
 	return (
 		<>


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/32960.
Requires https://github.com/WordPress/wordpress-develop/pull/1433.

Addresses a few different bugs affecting non-`WP_Widget` widgets, like the [Marquee Greeting widget](https://gist.github.com/adamziel/526436b4cc9bc82a7221c77e00137ae1).

It's still altogether really awkward (e.g. if you add two non-`WP_Widget` widgets then only one will be saved, and if you delete a non-`WP_Widget` widget then it will move to Inactive Widgets after a refresh) but this is a rare type of widget and it's better than what's in `trunk`.

- Fixes 'record is undefined' error when saving a non-`WP_Widget` widget.
- Fixes Legacy Widget block's form refreshing while you type in the input field of a non-`WP_Widget` widget.
- Fixes the Legacy Widget block so that it **always** shows the form for non-`WP_Widget` widgets. (These kinds of widgets don't support previewing.)

## How has this been tested?

1. Check out https://github.com/WordPress/wordpress-develop/pull/1433.
1. Add the [marquee widget](https://gist.github.com/adamziel/526436b4cc9bc82a7221c77e00137ae1) to your WP installation
2. Go to the widgets editor and add marquee.
3. Try to save the form.

## Video

https://user-images.githubusercontent.com/612155/123381238-ced7d880-d5d3-11eb-8da2-53eee3fa50f2.mp4

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->