### PR TITLE
Fix to remove default indent from Latest Posts and Latest Comments block in various editors

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -1,4 +1,17 @@
+
+
+// Lower specificity
+.wp-block-latest-comments {
+	// Removes left spacing in Customizer Widgets screen.
+	// Due to low specificity this will be safely overriden
+	// by default wp-block layout styles in the Post/Site editor
+	margin-left: 0;
+}
+
+// Higher specificity
 ol.wp-block-latest-comments {
+	// Remove left spacing. Higher specificity required to
+	// override default wp-block layout styles in the Post/Site editor.
 	padding-left: 0;
 }
 

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -1,15 +1,13 @@
-
-
-// Lower specificity
-.wp-block-latest-comments {
+// Lower specificity - target list element.
+ol.wp-block-latest-comments {
 	// Removes left spacing in Customizer Widgets screen.
 	// Due to low specificity this will be safely overriden
 	// by default wp-block layout styles in the Post/Site editor
 	margin-left: 0;
 }
 
-// Higher specificity
-ol.wp-block-latest-comments {
+// Higher specificity - target list via wrapper.
+.wp-block-latest-comments .wp-block-latest-comments {
 	// Remove left spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
 	padding-left: 0;

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -9,11 +9,13 @@
 	}
 	&.wp-block-latest-posts__list {
 		list-style: none;
+		padding-left: 0;
 
 		li {
 			clear: both;
 		}
 	}
+
 	&.is-grid {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Simplified fix for https://github.com/WordPress/gutenberg/issues/32718.

Essentially the aim of the PR is to remove any visual "indent" (left spacing) from _both_:

* Latest **Posts** block
* Latest **Comments** block

...when they are in their default state with "Theme Styles" preference turned _off_ in the following Editors:

* Post.
* Site.
* Widgets
* Customizer Widgets.


## How has this been tested?

* Create a load of Posts and a load of Comments - I used FakerPress Plugin for this.
* Create new Post in the Post Editor.
* Insert Latest Posts and Latest Comments - do not tweak default settings.
* Open the Editor Preferences panel and toggle off "Theme Styles" under the "Apperance" tab.
* Back in Editor you should see both blocks have no indentation (left spacing).

Repeat the above but for the following Editors:

* **Site** (don't skip this!)
* Widgets
* Customizer Widgets.

## Screenshots <!-- if applicable -->

### Before


https://user-images.githubusercontent.com/444434/123401022-4854d400-d59e-11eb-9e1a-f9d927124516.mov



### After

https://user-images.githubusercontent.com/444434/123400517-c19ff700-d59d-11eb-8b9f-e67f857db364.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
