### PR TITLE
Add duotone support to Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -90,6 +90,7 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"color": {
+			"__experimentalDuotone": "img",
 			"gradients": true,
 			"link": true
 		}


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/32972

## Description
Add duotone filters support to Media and Text block

## How has this been tested?
1. Select Media and Text Block
2. Add Image
3. Duotone filters should be available for Image

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/69596988/123410907-769dd800-d5cd-11eb-897a-f060b90b96ad.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

