### PR TITLE
[Block Library - Categories]: Fix crash when trying to access categories on insertion

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -150,7 +150,7 @@ export default function CategoriesEdit( {
 					<Spinner />
 				</Placeholder>
 			) }
-			{ ! isRequesting && categories.length === 0 && (
+			{ ! isRequesting && categories?.length === 0 && (
 				<p>
 					{ __(
 						'Your site does not have any posts, so there is nothing to display here at the moment.'
@@ -158,7 +158,7 @@ export default function CategoriesEdit( {
 				</p>
 			) }
 			{ ! isRequesting &&
-				categories.length > 0 &&
+				categories?.length > 0 &&
 				( displayAsDropdown
 					? renderCategoryDropdown()
 					: renderCategoryList() ) }


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently when trying to insert `Categories` block in a post where the same block doesn't exist, therefore the request happens for the first time, It can lead sometimes to have the `isRequesting` value to `false` and the `categories` to `null` at the first render. This PR adds optional chaining where needed, so we can avoid the block crash.


https://user-images.githubusercontent.com/16275880/123430275-abf7f500-d5d0-11eb-9484-0843c9eca554.mov

