### PR TITLE
[Block Library - Categories]: Fix handling for low privileged users

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -27,7 +27,7 @@ export default function CategoriesEdit( {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 	const { categories, isRequesting } = useSelect( ( select ) => {
 		const { getEntityRecords, isResolving } = select( coreStore );
-		const query = { per_page: -1, hide_empty: true };
+		const query = { per_page: -1, hide_empty: true, context: 'view' };
 		return {
 			categories: getEntityRecords( 'taxonomy', 'category', query ),
 			isRequesting: isResolving( 'getEntityRecords', [


### PR DESCRIPTION
Currently when a user with no right permissions to edit terms has a broken experience with `Categories` block, due to the permissions check happening at the REST API.

This PR fixes that by changing the fetching of the terms with `context:view`. This block doesn't update anything so it purely readonly.