### PR TITLE
Widget Editor: hide legacy widget form on deselection

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -104,8 +104,12 @@ export default function Form( {
 				>
 					<div
 						ref={ ref }
-						className="wp-block-legacy-widget__edit-form"
-						hidden={ ! isVisible }
+						className={ classnames(
+							'wp-block-legacy-widget__edit-form',
+							{
+								'is-hidden': ! isVisible,
+							}
+						) }
 					></div>
 				</Popover>
 			</div>
@@ -115,8 +119,9 @@ export default function Form( {
 	return (
 		<div
 			ref={ ref }
-			className="wp-block-legacy-widget__edit-form"
-			hidden={ ! isVisible }
+			className={ classnames( 'wp-block-legacy-widget__edit-form', {
+				'is-hidden': ! isVisible,
+			} ) }
 		>
 			<h3 className="wp-block-legacy-widget__edit-form-title">
 				{ title }

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -80,6 +80,7 @@
 	}
 }
 
+.wp-block-legacy-widget__edit-form.is-hidden,
 .wp-block-legacy-widget__edit-preview.is-offscreen {
 	left: -9999px;
 	position: absolute;


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/33000
## Description
 
The form element was using the `hidden` attribute to hide the form on deselection. For some reason, the hidden property was not working as reported in https://github.com/WordPress/gutenberg/issues/33000 
A better way to hide the form would be to use custom classes. Here, I am using `is-hidden` class to hide the form

## How has this been tested?
1. Add a legacy widget block
2. Deselect it 
3. The form should not be visible on deselection

## Screenshots 
![legacy widget block](https://user-images.githubusercontent.com/69596988/123506946-7e6c8380-d684-11eb-9a4b-eb9507ea6aa1.gif)


## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
