### PR TITLE
Iframed editor: add jQuery integration e2e test

### DIFF
--- a/packages/e2e-tests/plugins/iframed-block.php
+++ b/packages/e2e-tests/plugins/iframed-block.php
@@ -8,6 +8,13 @@
  */
 
 add_action(
+	'setup_theme',
+	function() {
+		add_theme_support( 'block-templates' );
+	}
+);
+
+add_action(
 	'init',
 	function() {
 		wp_register_script(

--- a/packages/e2e-tests/plugins/iframed-block.php
+++ b/packages/e2e-tests/plugins/iframed-block.php
@@ -7,24 +7,33 @@
  * @package gutenberg-test-iframed-block
  */
 
-add_action( 'init', function() {
-    wp_register_script(
-        'iframed-block-jquery-test',
-        plugin_dir_url( __FILE__ ) . 'iframed-block/jquery.test.js',
-        array( 'jquery' ),
-        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/jquery.test.js' )
-    );
-    wp_register_script(
-        'iframed-block-editor',
-        plugin_dir_url( __FILE__ ) . 'iframed-block/editor.js',
-        array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'iframed-block-jquery-test' ),
-        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/editor.js' )
-    );
-	wp_register_script(
-        'iframed-block-script',
-        plugin_dir_url( __FILE__ ) . 'iframed-block/script.js',
-        array( 'iframed-block-jquery-test' ),
-        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/script.js' )
-    );
-	register_block_type_from_metadata( __DIR__ . '/iframed-block' );
-} );
+add_action(
+	'init',
+	function() {
+		wp_register_script(
+			'iframed-block-jquery-test',
+			plugin_dir_url( __FILE__ ) . 'iframed-block/jquery.test.js',
+			array( 'jquery' ),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/jquery.test.js' )
+		);
+		wp_register_script(
+			'iframed-block-editor',
+			plugin_dir_url( __FILE__ ) . 'iframed-block/editor.js',
+			array(
+				'wp-blocks',
+				'wp-block-editor',
+				'wp-element',
+				'wp-compose',
+				'iframed-block-jquery-test',
+			),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/editor.js' )
+		);
+		wp_register_script(
+			'iframed-block-script',
+			plugin_dir_url( __FILE__ ) . 'iframed-block/script.js',
+			array( 'iframed-block-jquery-test' ),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/script.js' )
+		);
+		register_block_type_from_metadata( __DIR__ . '/iframed-block' );
+	}
+);

--- a/packages/e2e-tests/plugins/iframed-block.php
+++ b/packages/e2e-tests/plugins/iframed-block.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed Block
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-block
+ */
+
+add_action( 'init', function() {
+    wp_register_script(
+        'iframed-block-jquery-test',
+        plugin_dir_url( __FILE__ ) . 'iframed-block/jquery.test.js',
+        array( 'jquery' ),
+        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/jquery.test.js' )
+    );
+    wp_register_script(
+        'iframed-block-editor',
+        plugin_dir_url( __FILE__ ) . 'iframed-block/editor.js',
+        array( 'wp-blocks', 'wp-block-editor', 'wp-element', 'iframed-block-jquery-test' ),
+        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/editor.js' )
+    );
+	wp_register_script(
+        'iframed-block-script',
+        plugin_dir_url( __FILE__ ) . 'iframed-block/script.js',
+        array( 'iframed-block-jquery-test' ),
+        filemtime( plugin_dir_path( __FILE__ ) . 'iframed-block/script.js' )
+    );
+	register_block_type_from_metadata( __DIR__ . '/iframed-block' );
+} );

--- a/packages/e2e-tests/plugins/iframed-block/block.json
+++ b/packages/e2e-tests/plugins/iframed-block/block.json
@@ -1,0 +1,16 @@
+{
+	"apiVersion": 2,
+	"name": "test/iframed-block",
+	"title": "Iframed Block",
+	"category": "text",
+	"icon": "smiley",
+	"description": "",
+	"supports": {
+		"html": false
+	},
+	"textdomain": "iframed-block",
+	"editorScript": "iframed-block-editor",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css",
+	"script": "iframed-block-script"
+}

--- a/packages/e2e-tests/plugins/iframed-block/editor.css
+++ b/packages/e2e-tests/plugins/iframed-block/editor.css
@@ -1,0 +1,6 @@
+/**
+ * The following styles get applied inside the editor only.
+ */
+.wp-block-test-iframed-block {
+	border: 1px dotted #f00;
+}

--- a/packages/e2e-tests/plugins/iframed-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-block/editor.js
@@ -1,18 +1,18 @@
-( ( { wp: { element, blocks, blockEditor }, jQuery: $ } ) => {
-	const { createElement: el, useEffect, useRef } = element;
+( ( { wp: { element, blocks, blockEditor, compose }, jQuery: $ } ) => {
+	const { createElement: el } = element;
 	const { registerBlockType } = blocks;
 	const { useBlockProps } = blockEditor;
+	const { useRefEffect } = compose;
 
 	registerBlockType( 'test/iframed-block', {
-        edit: function Edit() {
-            const ref = useRef();
-            useEffect( () => {
-                $( ref.current ).test();
-            } );
-            return el( 'p', useBlockProps( { ref } ), 'Iframed Block (edit)' );
-        },
-        save: function Save() {
-            return el( 'p', useBlockProps.save(), 'Iframed Block (saved)' );
-        },
+		edit: function Edit() {
+			const ref = useRefEffect( ( node ) => {
+				$( node ).test();
+			}, [] );
+			return el( 'p', useBlockProps( { ref } ), 'Iframed Block (edit)' );
+		},
+		save: function Save() {
+			return el( 'p', useBlockProps.save(), 'Iframed Block (saved)' );
+		},
 	} );
 } )( window );

--- a/packages/e2e-tests/plugins/iframed-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-block/editor.js
@@ -1,0 +1,18 @@
+( ( { wp: { element, blocks, blockEditor }, jQuery: $ } ) => {
+	const { createElement: el, useEffect, useRef } = element;
+	const { registerBlockType } = blocks;
+	const { useBlockProps } = blockEditor;
+
+	registerBlockType( 'test/iframed-block', {
+        edit: function Edit() {
+            const ref = useRef();
+            useEffect( () => {
+                $( ref.current ).test();
+            } );
+            return el( 'p', useBlockProps( { ref } ), 'Iframed Block (edit)' );
+        },
+        save: function Save() {
+            return el( 'p', useBlockProps.save(), 'Iframed Block (saved)' );
+        },
+	} );
+} )( window );

--- a/packages/e2e-tests/plugins/iframed-block/jquery.test.js
+++ b/packages/e2e-tests/plugins/iframed-block/jquery.test.js
@@ -1,0 +1,7 @@
+( ( $ ) => {
+	$.fn.test = function() {
+		return this.each( function() {
+			$( this ).text( 'Iframed Block (set with jQuery)' );
+		} );
+	};
+} )( window.jQuery );

--- a/packages/e2e-tests/plugins/iframed-block/script.js
+++ b/packages/e2e-tests/plugins/iframed-block/script.js
@@ -1,0 +1,7 @@
+( ( win ) => {
+	const { jQuery: $ } = win;
+    win.addEventListener( 'DOMContentLoaded', () => {
+        $( '.wp-block-test-iframed-block' ).test();
+    } );
+} )( window );
+

--- a/packages/e2e-tests/plugins/iframed-block/script.js
+++ b/packages/e2e-tests/plugins/iframed-block/script.js
@@ -1,7 +1,7 @@
 ( ( win ) => {
 	const { jQuery: $ } = win;
-    win.addEventListener( 'DOMContentLoaded', () => {
-        $( '.wp-block-test-iframed-block' ).test();
-    } );
+	win.addEventListener( 'DOMContentLoaded', () => {
+		$( '.wp-block-test-iframed-block' ).test();
+	} );
 } )( window );
 

--- a/packages/e2e-tests/plugins/iframed-block/style.css
+++ b/packages/e2e-tests/plugins/iframed-block/style.css
@@ -1,0 +1,9 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ */
+.wp-block-test-iframed-block {
+	background-color: #21759b;
+	color: #fff;
+	padding: 2px;
+}

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-block.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-block.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`changing image size should load script and dependencies in iframe 1`] = `
+"<!-- wp:test/iframed-block -->
+<p class=\\"wp-block-test-iframed-block\\">Iframed Block (saved)</p>
+<!-- /wp:test/iframed-block -->"
+`;

--- a/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+	getEditedPostContent,
+	openDocumentSettingsSidebar,
+	clickButton,
+	canvas,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'changing image size', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-iframed-block' );
+		await createNewPost( { postType: 'page' } );
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-iframed-block' );
+	} );
+
+	it( 'should load script and dependencies in iframe', async () => {
+		await insertBlock( 'Iframed Block' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		const text = await page.evaluate( () => {
+			return document.querySelector( '.wp-block-test-iframed-block' )
+				.innerText;
+		} );
+
+		expect( text ).toBe( 'Iframed Block (set with jQuery)' );
+
+		await openDocumentSettingsSidebar();
+		await clickButton( 'Page' );
+		await clickButton( 'Template' );
+		await clickButton( 'New' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'Iframed Test' );
+		await clickButton( 'Create' );
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+
+		const iframedText = await canvas().evaluate( () => {
+			return document.querySelector( '.wp-block-test-iframed-block' )
+				.innerText;
+		} );
+
+		// Expect the script to load in the iframe, which replaces the block
+		// text.
+		expect( iframedText ).toBe( 'Iframed Block (set with jQuery)' );
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
@@ -27,6 +27,7 @@ describe( 'changing image size', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
+		await page.waitForSelector( '.wp-block-test-iframed-block' );
 		const text = await page.evaluate( () => {
 			return document.querySelector( '.wp-block-test-iframed-block' )
 				.innerText;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Tests a block that uses jQuery to initialise something in the editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
