### PR TITLE
Block Inserter: Prevent page scroll when searching a block

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,6 +16,10 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__content {
+	position: relative;
+}
+
 .block-editor-inserter__popover.is-quick {
 	.components-popover__content {
 		border: none;
@@ -194,7 +198,6 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__panel-title button {
 	margin: 0 $grid-unit-15 0 0;
 	color: $gray-700;
-	position: relative;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -194,6 +194,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__panel-title button {
 	margin: 0 $grid-unit-15 0 0;
 	color: $gray-700;
+	position: relative;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;


### PR DESCRIPTION
## Description
Prevent page scroll when searching in the block inserter.

Fixes #33011

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
