### PR TITLE
Box Control: Rename VerticalHorizontalInputControls to AxialInputControls

### DIFF
--- a/packages/components/src/box-control/axial-input-controls.js
+++ b/packages/components/src/box-control/axial-input-controls.js
@@ -7,7 +7,7 @@ import { Layout } from './styles/box-control-styles';
 
 const groupedSides = [ 'vertical', 'horizontal' ];
 
-export default function VerticalHorizontalInputControls( {
+export default function AxialInputControls( {
 	onChange,
 	onFocus,
 	onHoverOn,

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -17,7 +17,7 @@ import Button from '../button';
 import { FlexItem, FlexBlock } from '../flex';
 import AllInputControl from './all-input-control';
 import InputControls from './input-controls';
-import VerticalHorizontalInputControls from './vertical-horizontal-input-controls';
+import AxialInputControls from './axial-input-controls';
 import BoxControlIcon from './icon';
 import { Text } from '../text';
 import LinkedButton from './linked-button';
@@ -157,9 +157,7 @@ export default function BoxControl( {
 				) }
 				{ ! isLinked && splitOnAxis && (
 					<FlexBlock>
-						<VerticalHorizontalInputControls
-							{ ...inputControlProps }
-						/>
+						<AxialInputControls { ...inputControlProps } />
 					</FlexBlock>
 				) }
 				{ ! hasOneSide && (

--- a/packages/components/src/box-control/stories/index.js
+++ b/packages/components/src/box-control/stories/index.js
@@ -87,11 +87,11 @@ export const singleSide = () => {
 	);
 };
 
-export const verticalHorizontalControls = () => {
+export const axialControls = () => {
 	return <DemoExample splitOnAxis={ true } />;
 };
 
-export const verticalHorizontalControlsWithSingleSide = () => {
+export const axialControlsWithSingleSide = () => {
 	return (
 		<DemoExample
 			sides={ [ 'horizontal' ] }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Following on from #32610 and based on a suggestion from @mtias, rename the `VerticalHorizontalInputControls` component to `AxialInputControls`. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested for regressions based on the steps in #32610:

1. Check out this PR, and start up Storybook with `npm run storybook:dev`
2. Open up Storybook in your browser and navigate to http://localhost:50240/?path=/story/components-boxcontrol--axial-controls to test out this variation of the BoxControl
3. To test out on a block within the block editor, switch the default value of splitOnAxis to true on this line: https://github.com/wordpress/gutenberg/blob/f1f0cd7adceeecce546641dafdb2a1d0844f2bb2/packages/components/src/box-control/index.js#L57
4. To run the JS tests locally, use `npm run test-unit -- packages/components/src/box-control/test/ `

## Screenshots <!-- if applicable -->

Renamed component in Storybook:

![image](https://user-images.githubusercontent.com/14988353/123568007-c4515500-d806-11eb-93c0-d84392e7cdf1.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Non-breaking code quality update.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
