### PR TITLE
Widgets: Add regression e2e tests for non-multi widgets

### DIFF
--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -40,7 +40,7 @@ function marquee_greeting_init() {
 					class="widefat"
 					name="marquee-greeting"
 					type="text"
-					value="<?php echo esc_attr( $greeting ) ?>"
+					value="<?php echo esc_attr( $greeting ); ?>"
 					placeholder="Hello!"
 				/>
 			</p>

--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Marquee Widget
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-marquee-widget
+ */
+
+// Add a non-WP_Widget marquee widget
+function marquee_greeting_init() {
+	wp_register_sidebar_widget(
+		'marquee_greeting',
+		'Marquee Greeting',
+		function() {
+			$greeting = get_option( 'marquee_greeting', 'Hello!' );
+			printf( '<marquee>%s</marquee>', esc_html( $greeting ) );
+		}
+	);
+
+	wp_register_widget_control(
+		'marquee_greeting',
+		'Marquee Greeting',
+		function() {
+			if ( isset( $_POST['marquee-greeting'] ) ) {
+				update_option(
+					'marquee_greeting',
+					sanitize_text_field( $_POST['marquee-greeting'] )
+				);
+			}
+
+			$greeting = get_option( 'marquee_greeting' );
+			?>
+			<p>
+				<label for="marquee-greeting">Greeting:</label>
+				<input
+					id="marquee-greeting"
+					class="widefat"
+					name="marquee-greeting"
+					type="text"
+					value="<?= esc_attr( $greeting ) ?>"
+					placeholder="Hello!"
+				/>
+			</p>
+			<?php
+		}
+	);
+}
+add_action( 'init', 'marquee_greeting_init' );

--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -7,7 +7,9 @@
  * @package gutenberg-test-marquee-widget
  */
 
-// Add a non-WP_Widget marquee widget
+/**
+ * Add a non-WP_Widget marquee widget.
+ */
 function marquee_greeting_init() {
 	wp_register_sidebar_widget(
 		'marquee_greeting',
@@ -38,7 +40,7 @@ function marquee_greeting_init() {
 					class="widefat"
 					name="marquee-greeting"
 					type="text"
-					value="<?= esc_attr( $greeting ) ?>"
+					value="<?php echo esc_attr( $greeting ) ?>"
 					placeholder="Hello!"
 				/>
 			</p>

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -16,7 +16,7 @@ import {
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { find, findAll } from 'puppeteer-testing-library';
+import { find, findAll, waitFor } from 'puppeteer-testing-library';
 import { groupBy, mapValues } from 'lodash';
 
 describe( 'Widgets screen', () => {
@@ -242,6 +242,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\"><p><div style=\\"width: 580px;\\" class=\\"wp-video\\"><!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->
 		<video class=\\"wp-video-shortcode\\" id=\\"video-0-1\\" width=\\"580\\" height=\\"326\\" preload=\\"metadata\\" controls=\\"controls\\"><source type=\\"video/mp4\\" src=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4?_=1\\" /><a href=\\"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\\">http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4</a></video></div></p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -390,8 +391,112 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
+	} );
+
+	async function addMarquee() {
+		// There will be 2 matches here.
+		// One is the in-between inserter,
+		// and the other one is the button block appender.
+		const [ inlineInserterButton ] = await findAll( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
+		await inlineInserterButton.click();
+
+		// TODO: Convert to find() API from puppeteer-testing-library.
+		const inserterSearchBox = await page.waitForSelector(
+			'aria/Search for blocks and patterns[role="searchbox"]'
+		);
+		await expect( inserterSearchBox ).toHaveFocus();
+
+		await page.keyboard.type( 'Marquee' );
+
+		const inlineQuickInserter = await find( {
+			role: 'listbox',
+			name: 'Blocks',
+		} );
+		const marqueeBlockOption = await find(
+			{
+				role: 'option',
+			},
+			{
+				root: inlineQuickInserter,
+			}
+		);
+		await marqueeBlockOption.click();
+	}
+
+	it( 'Should add and save the marquee widget', async () => {
+		await activatePlugin( 'gutenberg-test-marquee-widget' );
+		await visitAdminPage( 'widgets.php' );
+
+		await addMarquee();
+
+		await find( {
+			selector: '[data-block][data-type="core/legacy-widget"]',
+		} );
+
+		const greetingsInput = await find( {
+			selector: '#marquee-greeting',
+		} );
+		await greetingsInput.click();
+		await page.keyboard.type( 'Howdy' );
+
+		await saveWidgets();
+
+		let editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		await page.reload();
+
+		editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		// Add another marquee, it shouldn't be saved
+		await addMarquee();
+
+		// It takes a moment to load the form, let's wait for it.
+		await waitFor( async () => {
+			const marquees = await findAll( {
+				selector: '[id=marquee-greeting]',
+			} );
+			if ( marquees.length === 1 ) {
+				throw new Error();
+			}
+		} );
+
+		const marquees = await findAll( {
+			selector: '[id=marquee-greeting]',
+		} );
+
+		expect( marquees ).toHaveLength( 2 );
+		await marquees[ 1 ].click();
+		await page.keyboard.type( 'Second howdy' );
+
+		await saveWidgets();
+		editedSerializedWidgetAreas = await getSerializedWidgetAreas();
+		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<marquee>Hello!</marquee>",
+		}
+	` );
+
+		await page.reload();
+		const marqueesAfter = await findAll( {
+			selector: '[id=marquee-greeting]',
+		} );
+		expect( marqueesAfter ).toHaveLength( 1 );
 	} );
 
 	// Disable reason: We temporary skip this test until we can figure out why it fails sometimes.
@@ -423,6 +528,7 @@ describe( 'Widgets screen', () => {
 		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 		const initialWidgets = await getWidgetAreaWidgets();
@@ -493,6 +599,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 		const editedWidgets = await getWidgetAreaWidgets();
@@ -626,6 +733,7 @@ describe( 'Widgets screen', () => {
 			<input type=\\"submit\\" class=\\"search-submit\\" value=\\"Search\\" />
 		</form>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -694,6 +802,7 @@ describe( 'Widgets screen', () => {
 		  "sidebar-2": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );
@@ -750,6 +859,7 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
+		  "wp_inactive_widgets": "",
 		}
 	` );
 	} );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/32978 which adds E2E tests.

They won't pass until the `wp-env` environment that GitHub Actions contains https://github.com/WordPress/WordPress/commit/7131a90b0ac08f924b65d7ac8e9c656ded53ce9c.

Props to @adamziel for writing the tests.