### PR TITLE
Fix navigation margin collapsing.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -1,6 +1,8 @@
 // This max-width is used to constrain the main editor column, it should not
 // cascade into columns.
-.wp-block-columns .wp-block {
+// We use :where to provide minimum specificity, so that intentional margins,
+// such as those of navigation menu items, override and win on specificity.
+.wp-block-columns :where(.wp-block) {
 	max-width: none;
 	margin-left: 0;
 	margin-right: 0;


### PR DESCRIPTION
## Description

Fixes #33002, but is blocked on #32659 landing first.

When the navigation block is used inside a columns block, menu items collapse like so:

<img width="821" alt="Screenshot 2021-06-28 at 08 50 49" src="https://user-images.githubusercontent.com/1204802/123593933-58afbd80-d7ef-11eb-9070-6695ebe1443f.png">

This is because navigation menu items have low specificity margins and paddings, and those paddings are overridden by some classic styles we have in place. Observe:

![issue](https://user-images.githubusercontent.com/1204802/123594207-b9d79100-d7ef-11eb-9901-15ef72d3ab81.gif)

These styles specifically:

<img width="398" alt="Screenshot 2021-06-28 at 08 52 16" src="https://user-images.githubusercontent.com/1204802/123594244-c22fcc00-d7ef-11eb-897b-6e6fdb27acce.png">

Those styles exist to unset the auto margins classic themes use to center in the main column, and since they have high specificity, they win this battle.

In #32659, `:where` is introduced to lower the specificity of the two "reset" stylesheets we have. The behavior is best demonstrated in [this codepen](https://codepen.io/joen/pen/abJVrGX), but it can be described as lowering the specificity to a "use these styles if nothing else styles it", which makes it a great tool to provide default styles or baseline styles. This PR does the same for this rule, fixing the problem:

<img width="805" alt="Screenshot 2021-06-28 at 08 59 06" src="https://user-images.githubusercontent.com/1204802/123594860-7d586500-d7f0-11eb-967e-c7fef916f2e2.png">

Note that this PR alone will only fix the issue for block themes. In order for the problem to also be fixed for classic themes, the specificity of the resets will also need to be reduced, or _they_ will take precedence. So #32659 will need to land as well. 

**Why not just increase specificity?**

This has been our go-to so far, but as more and more properties are absorbed by global styles, this strategy won't work. For global styles to be able to affect paddings and margins of blocks, those block need to have minimal specificity or the global styles won't work at all. See also #32574.


## How has this been tested?

Insert two navigation blocks, one of them inside a column. Both navigation blocks should have the same margin between them.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
