### PR TITLE
Search: Update search block to handle per corner border radii

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -75,6 +75,14 @@ export default function SearchEdit( {
 
 	const borderRadius = style?.border?.radius;
 	const borderProps = useBorderProps( attributes );
+
+	// Check for old deprecated numerical border radius. Done as a separate
+	// check so that a borderRadius style won't overwrite the longhand
+	// per-corner styles.
+	if ( typeof borderRadius === 'number' ) {
+		borderProps.style.borderRadius = `${ borderRadius }px`;
+	}
+
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -321,8 +321,13 @@ export default function SearchEdit( {
 		</>
 	);
 
+	const padBorderRadius = ( radius ) =>
+		radius ? `calc(${ radius } + ${ DEFAULT_INNER_PADDING })` : undefined;
+
 	const getWrapperStyles = () => {
-		if ( 'button-inside' === buttonPosition && borderRadius ) {
+		const isNonZeroBorderRadius = parseInt( borderRadius, 10 ) !== 0;
+
+		if ( 'button-inside' === buttonPosition && isNonZeroBorderRadius ) {
 			// We have button inside wrapper and a border radius value to apply.
 			// Add default padding so we don't get "fat" corners.
 			//
@@ -338,10 +343,10 @@ export default function SearchEdit( {
 				} = borderRadius;
 
 				return {
-					borderTopLeftRadius: `calc(${ topLeft } + ${ DEFAULT_INNER_PADDING })`,
-					borderTopRightRadius: `calc(${ topRight } + ${ DEFAULT_INNER_PADDING })`,
-					borderBottomLeftRadius: `calc(${ bottomLeft } + ${ DEFAULT_INNER_PADDING })`,
-					borderBottomRightRadius: `calc(${ bottomRight } + ${ DEFAULT_INNER_PADDING })`,
+					borderTopLeftRadius: padBorderRadius( topLeft ),
+					borderTopRightRadius: padBorderRadius( topRight ),
+					borderBottomLeftRadius: padBorderRadius( bottomLeft ),
+					borderBottomRightRadius: padBorderRadius( bottomRight ),
 				};
 			}
 

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -11,6 +11,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
+	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/block-editor';
 import {
@@ -73,6 +74,7 @@ export default function SearchEdit( {
 	} = attributes;
 
 	const borderRadius = style?.border?.radius;
+	const borderProps = useBorderProps( attributes );
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 
@@ -133,7 +135,7 @@ export default function SearchEdit( {
 		return (
 			<input
 				className="wp-block-search__input"
-				style={ { borderRadius } }
+				style={ borderProps.style }
 				aria-label={ __( 'Optional placeholder text' ) }
 				// We hide the placeholder field's placeholder when there is a value. This
 				// stops screen readers from reading the placeholder field's placeholder
@@ -156,14 +158,14 @@ export default function SearchEdit( {
 					<Button
 						icon={ search }
 						className="wp-block-search__button"
-						style={ { borderRadius } }
+						style={ borderProps.style }
 					/>
 				) }
 
 				{ ! buttonUseIcon && (
 					<RichText
 						className="wp-block-search__button"
-						style={ { borderRadius } }
+						style={ borderProps.style }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
@@ -320,12 +322,32 @@ export default function SearchEdit( {
 	);
 
 	const getWrapperStyles = () => {
-		if ( 'button-inside' === buttonPosition && style?.border?.radius ) {
+		if ( 'button-inside' === buttonPosition && borderRadius ) {
 			// We have button inside wrapper and a border radius value to apply.
 			// Add default padding so we don't get "fat" corners.
 			//
-			// CSS calc() is used here to support non-pixel units. The inline
-			// style using calc() will only apply if both values have units.
+			// CSS calc() is used here to support non-pixel units.
+
+			if ( typeof borderRadius === 'object' ) {
+				// Individual corner border radii present.
+				const {
+					topLeft,
+					topRight,
+					bottomLeft,
+					bottomRight,
+				} = borderRadius;
+
+				return {
+					borderTopLeftRadius: `calc(${ topLeft } + ${ DEFAULT_INNER_PADDING })`,
+					borderTopRightRadius: `calc(${ topRight } + ${ DEFAULT_INNER_PADDING })`,
+					borderBottomLeftRadius: `calc(${ bottomLeft } + ${ DEFAULT_INNER_PADDING })`,
+					borderBottomRightRadius: `calc(${ bottomRight } + ${ DEFAULT_INNER_PADDING })`,
+				};
+			}
+
+			// The inline style using calc() will only apply if both values
+			// supplied to calc() have units. Deprecated block's may have
+			// unitless integer.
 			const radius = Number.isInteger( borderRadius )
 				? `${ borderRadius }px`
 				: borderRadius;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -158,6 +158,31 @@ function classnames_for_block_core_search( $attributes ) {
 }
 
 /**
+ * Generates a border radius inline style for the wrapper element. It will
+ * adjust the supplied radius value to account for the default padding, making
+ * it visually consistent with the border radii applied to inner elements.
+ * `calc()` is used to support non-pixel CSS units.
+ *
+ * @param string $css_property The CSS property for the inline style.
+ * @param string $value        The border radius value to apply to the property.
+ *
+ * @return string A border radius inline style.
+ */
+function get_wrapper_radius_style( $css_property, $value ) {
+	$default_padding = '4px';
+
+	// Adjust border radius value for outer wrapper to make it
+	// visually consistent with those applied ot inner elements.
+	// calc() is used to support non-pixel CSS units.
+	return sprintf(
+		'%s: calc(%s + %s);',
+		$css_property,
+		esc_attr( $value ),
+		$default_padding
+	);
+}
+
+/**
  * Builds an array of inline styles for the search block.
  *
  * The result will contain one entry for shared styles such as those for the
@@ -189,24 +214,31 @@ function styles_for_block_core_search( $attributes ) {
 
 	if ( $has_border_radius ) {
 		// Shared style for button and input radius values.
-		$border_radius   = $attributes['style']['border']['radius'];
-		$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
-		$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
+		$border_radius = $attributes['style']['border']['radius'];
 
-		// Apply wrapper border radius if button placed inside.
-		$button_inside = ! empty( $attributes['buttonPosition'] ) &&
-			'button-inside' === $attributes['buttonPosition'];
+		if ( is_array( $border_radius ) ) {
+			// Add shared styles for individual border radii for input & button.
+			$shared_styles[] = sprintf( 'border-top-left-radius: %s;', esc_attr( $border_radius['topLeft'] ) );
+			$shared_styles[] = sprintf( 'border-top-right-radius: %s;', esc_attr( $border_radius['topRight'] ) );
+			$shared_styles[] = sprintf( 'border-bottom-left-radius: %s;', esc_attr( $border_radius['bottomLeft'] ) );
+			$shared_styles[] = sprintf( 'border-bottom-right-radius: %s;', esc_attr( $border_radius['bottomRight'] ) );
 
-		if ( $button_inside ) {
-			// We adjust the border radius value for the outer wrapper element
-			// to make it visually consistent with the radius applied to inner
-			// elements. calc() is used to support non-pixel CSS units.
-			$default_padding  = '4px';
-			$wrapper_styles[] = sprintf(
-				'border-radius: calc(%s + %s);',
-				esc_attr( $border_radius ),
-				esc_attr( $default_padding )
-			);
+			// Add adjusted border radius styles for the wrapper element.
+			$wrapper_styles[] = get_wrapper_radius_style( 'border-top-left-radius', $border_radius['topLeft'] );
+			$wrapper_styles[] = get_wrapper_radius_style( 'border-top-right-radius', $border_radius['topRight'] );
+			$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-left-radius', $border_radius['bottomLeft'] );
+			$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-right-radius', $border_radius['bottomRight'] );
+		} else {
+			$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
+			$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
+
+			// Apply wrapper border radius if button placed inside.
+			$button_inside = ! empty( $attributes['buttonPosition'] ) &&
+				'button-inside' === $attributes['buttonPosition'];
+
+			if ( $button_inside ) {
+				$wrapper_styles[] = get_wrapper_radius_style( 'border-radius', $border_radius );
+			}
 		}
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -213,8 +213,9 @@ function styles_for_block_core_search( $attributes ) {
 	$has_border_radius = ! empty( $attributes['style']['border']['radius'] );
 
 	if ( $has_border_radius ) {
-		// Shared style for button and input radius values.
 		$border_radius = $attributes['style']['border']['radius'];
+		$button_inside = ! empty( $attributes['buttonPosition'] ) &&
+			'button-inside' === $attributes['buttonPosition'];
 
 		if ( is_array( $border_radius ) ) {
 			// Add shared styles for individual border radii for input & button.
@@ -224,17 +225,15 @@ function styles_for_block_core_search( $attributes ) {
 			$shared_styles[] = sprintf( 'border-bottom-right-radius: %s;', esc_attr( $border_radius['bottomRight'] ) );
 
 			// Add adjusted border radius styles for the wrapper element.
-			$wrapper_styles[] = get_wrapper_radius_style( 'border-top-left-radius', $border_radius['topLeft'] );
-			$wrapper_styles[] = get_wrapper_radius_style( 'border-top-right-radius', $border_radius['topRight'] );
-			$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-left-radius', $border_radius['bottomLeft'] );
-			$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-right-radius', $border_radius['bottomRight'] );
+			if ( $button_inside ) {
+				$wrapper_styles[] = get_wrapper_radius_style( 'border-top-left-radius', $border_radius['topLeft'] );
+				$wrapper_styles[] = get_wrapper_radius_style( 'border-top-right-radius', $border_radius['topRight'] );
+				$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-left-radius', $border_radius['bottomLeft'] );
+				$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-right-radius', $border_radius['bottomRight'] );
+			}
 		} else {
 			$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
 			$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
-
-			// Apply wrapper border radius if button placed inside.
-			$button_inside = ! empty( $attributes['buttonPosition'] ) &&
-				'button-inside' === $attributes['buttonPosition'];
 
 			if ( $button_inside ) {
 				$wrapper_styles[] = get_wrapper_radius_style( 'border-radius', $border_radius );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -201,14 +201,18 @@ function styles_for_block_core_search( $attributes ) {
 					$name = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $key ) );
 
 					// Add shared styles for individual border radii for input & button.
-					$shared_styles[] = sprintf( 'border-%s-radius: %s;', $name, esc_attr( $value ) );
+					$shared_styles[] = sprintf(
+						'border-%s-radius: %s;',
+						esc_attr( $name ),
+						esc_attr( $value )
+					);
 
 					// Add adjusted border radius styles for the wrapper element
 					// if button is positioned inside.
 					if ( $button_inside && intval( $value ) !== 0 ) {
 						$wrapper_styles[] = sprintf(
 							'border-%s-radius: calc(%s + %s);',
-							$name,
+							esc_attr( $name ),
 							esc_attr( $value ),
 							$default_padding
 						);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -168,7 +168,7 @@ function classnames_for_block_core_search( $attributes ) {
  *
  * @return string A border radius inline style.
  */
-function get_wrapper_radius_style( $css_property, $value ) {
+function wrapper_radius_style_for_block_core_search( $css_property, $value ) {
 	$default_padding = '4px';
 
 	// Adjust border radius value for outer wrapper to make it
@@ -226,17 +226,17 @@ function styles_for_block_core_search( $attributes ) {
 
 			// Add adjusted border radius styles for the wrapper element.
 			if ( $button_inside ) {
-				$wrapper_styles[] = get_wrapper_radius_style( 'border-top-left-radius', $border_radius['topLeft'] );
-				$wrapper_styles[] = get_wrapper_radius_style( 'border-top-right-radius', $border_radius['topRight'] );
-				$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-left-radius', $border_radius['bottomLeft'] );
-				$wrapper_styles[] = get_wrapper_radius_style( 'border-bottom-right-radius', $border_radius['bottomRight'] );
+				$wrapper_styles[] = wrapper_radius_style_for_block_core_search( 'border-top-left-radius', $border_radius['topLeft'] );
+				$wrapper_styles[] = wrapper_radius_style_for_block_core_search( 'border-top-right-radius', $border_radius['topRight'] );
+				$wrapper_styles[] = wrapper_radius_style_for_block_core_search( 'border-bottom-left-radius', $border_radius['bottomLeft'] );
+				$wrapper_styles[] = wrapper_radius_style_for_block_core_search( 'border-bottom-right-radius', $border_radius['bottomRight'] );
 			}
 		} else {
 			$border_radius   = is_numeric( $border_radius ) ? $border_radius . 'px' : $border_radius;
 			$shared_styles[] = sprintf( 'border-radius: %s;', esc_attr( $border_radius ) );
 
 			if ( $button_inside ) {
-				$wrapper_styles[] = get_wrapper_radius_style( 'border-radius', $border_radius );
+				$wrapper_styles[] = wrapper_radius_style_for_block_core_search( 'border-radius', $border_radius );
 			}
 		}
 	}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/31585 & https://github.com/WordPress/gutenberg/pull/33017

## Description
Updates the Search block's ad hoc application of border radius block support styles to handle individual border radii for each corner.

The border radii are still applied in a 1:1 fashion to the corners of the input and button when the button is positioned inside. A possible future iteration might be to change this so the input gets left corner values only and button gets right corner values.

## How has this been tested?
Manually.

1. Create a new post, add a search block and set a border radius on it before saving.
2. Checkout this PR branch and build
3. Reload the post and confirm no block validation errors
4. Load the post on the frontend ensuring it still displays correctly
5. Back in the editor, adjust the border radius for the search block and ensure it updates appropriately
6. Save the post and refresh the frontend confirming the border radii are appropriate.
7. Switch back to the block editor and paste in the snippet below to set individual corner border radii and one block using deprecated numerical border radius value.
8. Confirm the search blocks display individual corners or the old numerical value correctly, save and refresh the frontend checking there as well

```html
<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside"} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside","style":{"border":{"radius":50}}} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside","style":{"border":{"radius":"10px"}}} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","style":{"border":{"radius":{"topLeft":null,"topRight":"10px","bottomLeft":null,"bottomRight":null}}}} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside","style":{"border":{"radius":{"topLeft":"45px","topRight":"45px","bottomLeft":"10px","bottomRight":"30px"}}}} /-->
```

## Screenshots <!-- if applicable -->
<img width="668" alt="Screen Shot 2021-06-28 at 6 07 49 pm" src="https://user-images.githubusercontent.com/60436221/123602936-aa326980-d83c-11eb-8f25-d989fcab3842.png">

## Types of changes
Bug fix.
(Prevents issue with per-corner border radius block support that will occur when UI PR update lands)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
