### PR TITLE
Fix drag and drop indicator above first block and RTL drop indicators

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -94,11 +94,7 @@ function BlockListAppender( {
 			// Prevent the block from being selected when the appender is
 			// clicked.
 			onFocus={ stopPropagation }
-			className={ classnames(
-				'block-list-appender',
-				'wp-block',
-				className
-			) }
+			className={ classnames( 'block-list-appender', className ) }
 		>
 			{ appender }
 		</TagName>

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -156,8 +156,8 @@ function InsertionPointPopover( {
 		if ( isRTL() ) {
 			return {
 				top: previousRect ? previousRect.top : nextRect.top,
-				left: nextRect ? nextRect.left : previousRect.right,
-				right: previousRect ? previousRect.right : nextRect.left,
+				left: previousRect ? previousRect.left : nextRect.right,
+				right: nextRect ? nextRect.right : previousRect.left,
 				bottom: previousRect ? previousRect.bottom : nextRect.bottom,
 				ownerDocument,
 			};

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -79,24 +79,33 @@ function InsertionPointPopover( {
 	}, [] );
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );
+
 	const style = useMemo( () => {
-		if ( ! previousElement ) {
+		if ( ! previousElement && ! nextElement ) {
 			return {};
 		}
-		const previousRect = previousElement.getBoundingClientRect();
+
+		const previousRect = previousElement
+			? previousElement.getBoundingClientRect()
+			: null;
 		const nextRect = nextElement
 			? nextElement.getBoundingClientRect()
 			: null;
 
 		if ( orientation === 'vertical' ) {
 			return {
-				width: previousElement.offsetWidth,
-				height: nextRect ? nextRect.top - previousRect.bottom : 0,
+				width: previousElement
+					? previousElement.offsetWidth
+					: nextElement.offsetWidth,
+				height:
+					nextRect && previousRect
+						? nextRect.top - previousRect.bottom
+						: 0,
 			};
 		}
 
 		let width = 0;
-		if ( nextElement ) {
+		if ( previousRect && nextRect ) {
 			width = isRTL()
 				? previousRect.left - nextRect.right
 				: nextRect.left - previousRect.right;
@@ -104,31 +113,41 @@ function InsertionPointPopover( {
 
 		return {
 			width,
-			height: previousElement.offsetHeight,
+			height: previousElement
+				? previousElement.offsetHeight
+				: nextElement.offsetHeight,
 		};
 	}, [ previousElement, nextElement ] );
 
 	const getAnchorRect = useCallback( () => {
-		const { ownerDocument } = previousElement;
-		const previousRect = previousElement.getBoundingClientRect();
+		if ( ! previousElement && ! nextElement ) {
+			return {};
+		}
+
+		const { ownerDocument } = previousElement || nextElement;
+
+		const previousRect = previousElement
+			? previousElement.getBoundingClientRect()
+			: null;
 		const nextRect = nextElement
 			? nextElement.getBoundingClientRect()
 			: null;
+
 		if ( orientation === 'vertical' ) {
 			if ( isRTL() ) {
 				return {
-					top: previousRect.bottom,
-					left: previousRect.right,
-					right: previousRect.left,
+					top: previousRect ? previousRect.bottom : nextRect.top,
+					left: previousRect ? previousRect.right : nextRect.right,
+					right: previousRect ? previousRect.left : nextRect.left,
 					bottom: nextRect ? nextRect.top : previousRect.bottom,
 					ownerDocument,
 				};
 			}
 
 			return {
-				top: previousRect.bottom,
-				left: previousRect.left,
-				right: previousRect.right,
+				top: previousRect ? previousRect.bottom : nextRect.top,
+				left: previousRect ? previousRect.left : nextRect.left,
+				right: previousRect ? previousRect.right : nextRect.right,
 				bottom: nextRect ? nextRect.top : previousRect.bottom,
 				ownerDocument,
 			};
@@ -136,28 +155,24 @@ function InsertionPointPopover( {
 
 		if ( isRTL() ) {
 			return {
-				top: previousRect.top,
-				left: nextRect ? nextRect.right : previousRect.left,
-				right: previousRect.left,
-				bottom: previousRect.bottom,
+				top: previousRect ? previousRect.top : nextRect.top,
+				left: nextRect ? nextRect.left : previousRect.right,
+				right: previousRect ? previousRect.right : nextRect.left,
+				bottom: previousRect ? previousRect.bottom : nextRect.bottom,
 				ownerDocument,
 			};
 		}
 
 		return {
-			top: previousRect.top,
-			left: previousRect.right,
+			top: previousRect ? previousRect.top : nextRect.top,
+			left: previousRect ? previousRect.right : nextRect.left,
 			right: nextRect ? nextRect.left : previousRect.right,
-			bottom: previousRect.bottom,
+			bottom: previousRect ? previousRect.bottom : nextRect.bottom,
 			ownerDocument,
 		};
 	}, [ previousElement, nextElement ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
-
-	if ( ! previousElement ) {
-		return null;
-	}
 
 	const className = classnames(
 		'block-editor-block-list__insertion-point',
@@ -178,10 +193,10 @@ function InsertionPointPopover( {
 		}
 	}
 
-	// Only show the inserter when there's a `nextElement` (a block after the
-	// insertion point). At the end of the block list the trailing appender
-	// should serve the purpose of inserting blocks.
-	const showInsertionPointInserter = nextElement && isInserterShown;
+	// Only show the in-between inserter between blocks, so when there's a
+	// previous and a next element.
+	const showInsertionPointInserter =
+		previousElement && nextElement && isInserterShown;
 
 	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	// While ideally it would be enough to capture the

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -110,9 +110,7 @@ export default function useBlockDropZone( {
 		useCallback( ( event, currentTarget ) => {
 			const blockElements = Array.from( currentTarget.children ).filter(
 				// Ensure the element is a block. It should have the `wp-block` class.
-				( element ) =>
-					element.classList.contains( 'wp-block' ) &&
-					! element.classList.contains( 'block-list-appender' )
+				( element ) => element.classList.contains( 'wp-block' )
 			);
 			const targetIndex = getNearestBlockIndex(
 				blockElements,


### PR DESCRIPTION
## Description
The drag and drop indicator before the first block hasn't been working (I think since the insertion point component was used for the drop indicator).

This PR fixes that. While working on it and testing my changes, I noticed a few issues with drag and drop for RTL languages, so I've fixed those too.

## How has this been tested?
Dropping to the ends of block lists still requires some precision (the cursor must be within the block list element), so be aware of that when testing.

### LTR (vertical block list)
1. Add some blocks
2. Try dragging a block from the end to the start
3. The drop indicator should show before the first block

### LTR (horizontal block list)
1. Add a button block and some buttons blocks within that.
2. Drag a block from the end to the start
3. The drop indicator should show before the first block (it can be hard to see, but it is there)

### RTL (vertical block list)
Prerequisite, Install the RTL Tester plugin, switch to RTL, and change this function to return `true` - https://github.com/WordPress/gutenberg/blob/trunk/packages/i18n/src/create-i18n.js#L400.
1. Add some blocks
2. Try dragging a block from the end to the start
3. The drop indicator should show before the first block

### RTL (horizontal block list)
Prerequisite, Install the RTL Tester plugin, switch to RTL, and change this function to return `true` - https://github.com/WordPress/gutenberg/blob/trunk/packages/i18n/src/create-i18n.js#L400.
1. Add a button block and some buttons blocks within that.
2. Drag a block from the end to the start
3. The drop indicator should show before the first block (it can be hard to see, but it is there)

Also worth testing the in-between inserter and the indicator when hovering a block in the main block library, which all use the same InsertionPoint component.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
