### PR TITLE
Refactor the user autocompleter to avoid apiFetch and rely on the data module

### DIFF
--- a/packages/editor/src/components/autocompleters/test/user.js
+++ b/packages/editor/src/components/autocompleters/test/user.js
@@ -1,34 +1,31 @@
 /**
  * Internal dependencies
  */
-import userCompleter from '../user';
+import { getUserLabel } from '../user';
 
 describe( 'user', () => {
-	describe( 'getOptionLabel', () => {
+	describe( 'getUserLabel', () => {
 		it( 'should return user details fragment', () => {
 			const user = {
 				name: 'Smithers Jones',
 				slug: 'userSlug',
 				avatar_urls: { 24: 'http://my.avatar' },
 			};
-			const userLabel = userCompleter.getOptionLabel( user );
-			expect( userLabel[ 0 ] ).toEqual(
-				<img
-					key="avatar"
-					className="editor-autocompleters__user-avatar"
-					alt=""
-					src="http://my.avatar"
-				/>
-			);
-			expect( userLabel[ 1 ] ).toEqual(
-				<span key="name" className="editor-autocompleters__user-name">
-					Smithers Jones
-				</span>
-			);
-			expect( userLabel[ 2 ] ).toEqual(
-				<span key="slug" className="editor-autocompleters__user-slug">
-					userSlug
-				</span>
+			const userLabel = getUserLabel( user );
+			expect( userLabel ).toEqual(
+				<>
+					<img
+						className="editor-autocompleters__user-avatar"
+						alt=""
+						src="http://my.avatar"
+					/>
+					<span className="editor-autocompleters__user-name">
+						Smithers Jones
+					</span>
+					<span className="editor-autocompleters__user-slug">
+						userSlug
+					</span>
+				</>
 			);
 		} );
 		it( 'should return user details fragment without default avatar dashicon if avatar_urls array not set', () => {
@@ -36,19 +33,17 @@ describe( 'user', () => {
 				name: 'Smithers Jones',
 				slug: 'userSlug',
 			};
-			const userLabel = userCompleter.getOptionLabel( user );
-			expect( userLabel[ 0 ] ).toEqual(
-				<span className="editor-autocompleters__no-avatar"></span>
-			);
-			expect( userLabel[ 1 ] ).toEqual(
-				<span key="name" className="editor-autocompleters__user-name">
-					Smithers Jones
-				</span>
-			);
-			expect( userLabel[ 2 ] ).toEqual(
-				<span key="slug" className="editor-autocompleters__user-slug">
-					userSlug
-				</span>
+			const userLabel = getUserLabel( user );
+			expect( userLabel ).toEqual(
+				<>
+					<span className="editor-autocompleters__no-avatar"></span>
+					<span className="editor-autocompleters__user-name">
+						Smithers Jones
+					</span>
+					<span className="editor-autocompleters__user-slug">
+						userSlug
+					</span>
+				</>
 			);
 		} );
 	} );


### PR DESCRIPTION
Now that we can rely on the data module to make "view" context requests, we can start removing the adhoc usage of apiFetch across the codebase, making our packages more WP agnostic.

This PR does so for the user auto-completer.

**Testing instructions**

 - Create multiple users
 - Check that the user autocomplete (type `@username`) works as expected
 - Check with different roles.