### PR TITLE
ServerSideRender: Update documentation for placeholder props

### DIFF
--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -67,24 +67,34 @@ E.g: `{ post_id: 12 }`.
 
 ### EmptyResponsePlaceholder
 
-This is a [render prop](https://reactjs.org/docs/render-props.html). When the api response is empty, the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+The component is rendered when the API response is empty. The component will receive the value of the API response, and all props passed into `ServerSideRenderer`.
 
--   Type: `WPElement`
+-   Type: `Component`
 -   Required: No
 
 ### ErrorResponsePlaceholder
 
-This is a [render prop](https://reactjs.org/docs/render-props.html). When the api response is an error, the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+The component is rendered when the API response is an error. The component will receive the value of the API response, and all props passed into `ServerSideRenderer`.
 
--   Type: `WPElement`
+-   Type: `Component`
 -   Required: No
 
 ### LoadingResponsePlaceholder
 
-This is a [render prop](https://reactjs.org/docs/render-props.html). While the request is being processed (loading state), the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+The component is rendered while the API request is being processed (loading state). The component will receive the value of the API response, and all props passed into `ServerSideRenderer`.
 
--   Type: `WPElement`
+-   Type: `Component`
 -   Required: No
+
+#### Example usage
+
+```jsx
+const MyServerSideRender = () => (
+	<ServerSideRender
+		LoadingResponsePlaceholder={ MyAmazingPlaceholder }
+	/>
+);
+```
 
 ## Usage
 


### PR DESCRIPTION
## Description
Updates documentation for `EmptyResponsePlaceholder`, `ErrorResponsePlaceholder` and `LoadingResponsePlaceholder`. Also adds basic usage example.

Similar to #29925
> It's best to pass a component to renderAppender, as is done in most core blocks. Passing a callback function will cause React to treat this as a new function component on every render causing reconciliation issues.

## Types of changes
Documentation
