### PR TITLE
Fix switcher focus style.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -82,10 +82,6 @@
 			width: $button-size-small !important;
 			margin: 0 !important;
 		}
-
-		&:focus::before {
-			right: $grid-unit-05 !important;
-		}
 	}
 
 	// Match the parent selector button.
@@ -157,10 +153,6 @@
 		.block-editor-block-icon {
 			width: 0 !important;
 			height: 0 !important;
-		}
-
-		&:focus::before {
-			right: $grid-unit-05 !important;
 		}
 	}
 

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -72,12 +72,12 @@
 		}
 
 		// Ensure the icon buttons remain square.
-		&.has-icon {
+		// This needs specificity.
+		&.has-icon.has-icon {
 			// Reduce the default padding when a button only has an icon.
-			padding-left: $grid-unit-10;
-			padding-right: $grid-unit-10;
+			padding-left: $grid-unit-15;
+			padding-right: $grid-unit-15;
 			min-width: $block-toolbar-height;
-			justify-content: center;
 		}
 
 		// @todo: We should extract the tabs styles to the tabs component itself


### PR DESCRIPTION
## Description

The focus style of the switcher is off:

<img width="440" alt="Screenshot 2021-06-28 at 13 30 46" src="https://user-images.githubusercontent.com/1204802/123629844-10a39180-d815-11eb-8c4d-1e24d12a8c59.png">

This PR fixes it:

<img width="526" alt="Screenshot 2021-06-28 at 13 29 51" src="https://user-images.githubusercontent.com/1204802/123629852-139e8200-d815-11eb-8a93-2eb27f5a5e00.png">

As I look at the code here, the refactor from the old block toolbar style to the new plus recent feature additions have built up the complexity a fair bit. Now that we don't have to support IE11 anymore, I think there's an opportunity to refactor this whole component to be vastly simpler. We'd need to remove some fragments and revisit a few extensibility points and CSS classes, so I'd love someone to pair up with on this — of you're interested, let me know.

## How has this been tested?

Insert a block, focus the switcher. The focus style should be square.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
