### PR TITLE
[Block Library]: Less warnings when blocks try to render themselves.

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -137,23 +137,3 @@ function gutenberg_experimental_to_kebab_case( $string ) {
 	return strtolower( implode( '-', $matches[0] ) );
 	//phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 }
-
-
-/**
- * Returns true if the request is a non-legacy REST API request.
- *
- * Legacy REST requests should still run some extra code for backwards compatibility.
- *
- * @todo: replace this function once core WP function is available: https://core.trac.wordpress.org/ticket/42061.
- *
- * @return bool
- */
-function gutenberg_is_rest_api_request() {
-	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
-		return false;
-	}
-
-	$rest_prefix         = trailingslashit( rest_get_url_prefix() );
-	$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
-	return $is_rest_api_request;
-}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -137,3 +137,23 @@ function gutenberg_experimental_to_kebab_case( $string ) {
 	return strtolower( implode( '-', $matches[0] ) );
 	//phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 }
+
+
+/**
+ * Returns true if the request is a non-legacy REST API request.
+ *
+ * Legacy REST requests should still run some extra code for backwards compatibility.
+ *
+ * @todo: replace this function once core WP function is available: https://core.trac.wordpress.org/ticket/42061.
+ *
+ * @return bool
+ */
+function is_rest_api_request() {
+	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		return false;
+	}
+
+	$rest_prefix         = trailingslashit( rest_get_url_prefix() );
+	$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
+	return $is_rest_api_request;
+}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -148,7 +148,7 @@ function gutenberg_experimental_to_kebab_case( $string ) {
  *
  * @return bool
  */
-function is_rest_api_request() {
+function gutenberg_is_rest_api_request() {
 	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
 		return false;
 	}

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -30,21 +30,10 @@ function render_block_core_block( $attributes ) {
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 
-		if ( $is_debug ) {
-			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-				trigger_error(
-					sprintf(
-						// translators: %s is the user-provided title of the reusable block.
-						__( 'Could not render Reusable Block <strong>%s</strong>. Block cannot be rendered inside itself.' ),
-						$reusable_block->post_title
-					),
-					E_USER_WARNING
-				);
-			}
+		return $is_debug ?
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			return __( '[block rendering halted]' );
-		}
-		return;
+			__( '[block rendering halted]' ) :
+			'';
 	}
 
 	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -25,7 +25,7 @@ function render_block_core_block( $attributes ) {
 	}
 
 	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s is the user-provided title of the reusable block.

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -25,7 +25,7 @@ function render_block_core_block( $attributes ) {
 	}
 
 	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
-		if ( ! is_admin() && ! is_rest_api_request() ) {
+		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s is the user-provided title of the reusable block.

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -25,26 +25,26 @@ function render_block_core_block( $attributes ) {
 	}
 
 	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
-		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
-			trigger_error(
-				sprintf(
-					// translators: %s is the user-provided title of the reusable block.
-					__( 'Could not render Reusable Block <strong>%s</strong>. Block cannot be rendered inside itself.' ),
-					$reusable_block->post_title
-				),
-				E_USER_WARNING
-			);
-		}
-
 		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
 		// is set in `wp_debug_mode()`.
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 
-		return $is_debug ?
+		if ( $is_debug ) {
+			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+				trigger_error(
+					sprintf(
+						// translators: %s is the user-provided title of the reusable block.
+						__( 'Could not render Reusable Block <strong>%s</strong>. Block cannot be rendered inside itself.' ),
+						$reusable_block->post_title
+					),
+					E_USER_WARNING
+				);
+			}
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
+			return __( '[block rendering halted]' );
+		}
+		return;
 	}
 
 	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -23,7 +23,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$post_id = $block->context['postId'];
 
 	if ( isset( $seen_ids[ $post_id ] ) ) {
-		if ( ! is_admin() && ! is_rest_api_request() ) {
+		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s is a post ID (integer).

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -23,7 +23,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$post_id = $block->context['postId'];
 
 	if ( isset( $seen_ids[ $post_id ] ) ) {
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s is a post ID (integer).
@@ -44,7 +44,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	$seen_ids[ $post_id ] = true;
 
-	if ( ! in_the_loop() ) {
+	if ( ! in_the_loop() && have_posts() ) {
 		the_post();
 	}
 

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -28,21 +28,10 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 
-		if ( $is_debug ) {
-			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-				trigger_error(
-					sprintf(
-						// translators: %s is a post ID (integer).
-						__( 'Could not render Post Content block with post ID: <code>%s</code>. Block cannot be rendered inside itself.' ),
-						$post_id
-					),
-					E_USER_WARNING
-				);
-			}
+		return $is_debug ?
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			return __( '[block rendering halted]' );
-		}
-		return;
+			__( '[block rendering halted]' ) :
+			'';
 	}
 
 	$seen_ids[ $post_id ] = true;

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -23,23 +23,26 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$post_id = $block->context['postId'];
 
 	if ( isset( $seen_ids[ $post_id ] ) ) {
-		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
-			trigger_error(
-				sprintf(
-					// translators: %s is a post ID (integer).
-					__( 'Could not render Post Content block with post ID: <code>%s</code>. Block cannot be rendered inside itself.' ),
-					$post_id
-				),
-				E_USER_WARNING
-			);
-		}
-
+		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
+		// is set in `wp_debug_mode()`.
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
-		return $is_debug ?
+
+		if ( $is_debug ) {
+			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+				trigger_error(
+					sprintf(
+						// translators: %s is a post ID (integer).
+						__( 'Could not render Post Content block with post ID: <code>%s</code>. Block cannot be rendered inside itself.' ),
+						$post_id
+					),
+					E_USER_WARNING
+				);
+			}
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
+			return __( '[block rendering halted]' );
+		}
+		return;
 	}
 
 	$seen_ids[ $post_id ] = true;

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -73,25 +73,26 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {
-		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
-			trigger_error(
-				sprintf(
-					// translators: %s are the block attributes.
-					__( 'Could not render Template Part block with the attributes: <code>%s</code>. Block cannot be rendered inside itself.' ),
-					wp_json_encode( $attributes )
-				),
-				E_USER_WARNING
-			);
-		}
-
 		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
 		// is set in `wp_debug_mode()`.
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
-		return $is_debug ?
+
+		if ( $is_debug ) {
+			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+				trigger_error(
+					sprintf(
+						// translators: %s are the block attributes.
+						__( 'Could not render Template Part block with the attributes: <code>%s</code>. Block cannot be rendered inside itself.' ),
+						wp_json_encode( $attributes )
+					),
+					E_USER_WARNING
+				);
+			}
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			__( '[block rendering halted]' ) :
-			'';
+			return __( '[block rendering halted]' );
+		}
+		return;
 	}
 
 	// Run through the actions that are typically taken on the_content.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -73,7 +73,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {
-		if ( ! is_admin() && ! is_rest_api_request() ) {
+		if ( ! is_admin() && ! gutenberg_is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s are the block attributes.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -73,7 +73,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! is_rest_api_request() ) {
 			trigger_error(
 				sprintf(
 					// translators: %s are the block attributes.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -78,21 +78,10 @@ function render_block_core_template_part( $attributes ) {
 		$is_debug = defined( 'WP_DEBUG' ) && WP_DEBUG &&
 			defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY;
 
-		if ( $is_debug ) {
-			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-				trigger_error(
-					sprintf(
-						// translators: %s are the block attributes.
-						__( 'Could not render Template Part block with the attributes: <code>%s</code>. Block cannot be rendered inside itself.' ),
-						wp_json_encode( $attributes )
-					),
-					E_USER_WARNING
-				);
-			}
+		return $is_debug ?
 			// translators: Visible only in the front end, this warning takes the place of a faulty block.
-			return __( '[block rendering halted]' );
-		}
-		return;
+			__( '[block rendering halted]' ) :
+			'';
 	}
 
 	// Run through the actions that are typically taken on the_content.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes: https://github.com/WordPress/gutenberg/issues/32681

In https://github.com/WordPress/gutenberg/pull/31455, https://github.com/WordPress/gutenberg/pull/28405 and https://github.com/WordPress/gutenberg/pull/28456 an extra check was implemented for `Post Content`, `Template Part` and `Reusable blocks` not to render themselves and cause an infinite loop. If they do render themselves an `error` was triggered and was logged. 

While this is wrong usage of the blocks by users and should be handled by them - with exception with the nuances of `Query Loop` in some cases, the check that we had now didn't take into account if the code was run from the REST API making them log more times that it should. 


<!-- Please describe what you have changed or added -->

## Testing instructions
1. in a post add a `QueryLoop` block that contains itself in the results and add the `Post Content` block.
2. check the site logs for the produced warnings
3. test with block based themes (I tested with tt1-blocks) and classic themes



## Notes
1. While these changes make `tt1-blocks` to show no warnings at all, the warnings seem to differ per theme. Maybe some filter triggers the code?? 🤔  So in other classic blocks that I tested, some warnings are shown, but are way less.
2. In the below gifs I have made an extreme test post which contains all three cases/blocks containing themselves. That's why the volume of warnings are quite big. You can test with each case individually.


## Screenshots <!-- if applicable -->

### tt1-blocks before

https://user-images.githubusercontent.com/16275880/123632335-7c3f2c00-d820-11eb-8566-eb017c2e46b9.mov

### tt1-blocks after

https://user-images.githubusercontent.com/16275880/123632377-85c89400-d820-11eb-93ee-2df03addbc94.mov

### 2021 before

https://user-images.githubusercontent.com/16275880/123632406-90832900-d820-11eb-8bfc-c9140245dc1a.mov

### 2021 after

https://user-images.githubusercontent.com/16275880/123632454-9da01800-d820-11eb-88ce-dad42dcb13c9.mov



