### PR TITLE
Try: Small chevron icon for breadcrumb separators.

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -4,6 +4,7 @@
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { chevronRightSmall, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,9 +15,9 @@ import { store as blockEditorStore } from '../../store';
 /**
  * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
  *
- * @param  {Object}   props               Component props.
- * @param  {string}   props.rootLabelText Translated label for the root element of the breadcrumb trail.
- * @return {WPElement}                    Block Breadcrumb.
+ * @param {Object} props               Component props.
+ * @param {string} props.rootLabelText Translated label for the root element of the breadcrumb trail.
+ * @return {WPElement}                 Block Breadcrumb.
  */
 function BlockBreadcrumb( { rootLabelText } ) {
 	const { selectBlock, clearSelectedBlock } = useDispatch( blockEditorStore );
@@ -65,16 +66,26 @@ function BlockBreadcrumb( { rootLabelText } ) {
 				) }
 				{ ! hasSelection && rootLabel }
 			</li>
+			<Icon
+				icon={ chevronRightSmall }
+				className="block-editor-block-breadcrumb__separator"
+			/>
 			{ parents.map( ( parentClientId ) => (
-				<li key={ parentClientId }>
-					<Button
-						className="block-editor-block-breadcrumb__button"
-						variant="tertiary"
-						onClick={ () => selectBlock( parentClientId ) }
-					>
-						<BlockTitle clientId={ parentClientId } />
-					</Button>
-				</li>
+				<>
+					<li key={ parentClientId }>
+						<Button
+							className="block-editor-block-breadcrumb__button"
+							variant="tertiary"
+							onClick={ () => selectBlock( parentClientId ) }
+						>
+							<BlockTitle clientId={ parentClientId } />
+						</Button>
+					</li>
+					<Icon
+						icon={ chevronRightSmall }
+						className="block-editor-block-breadcrumb__separator"
+					/>
+				</>
 			) ) }
 			{ !! clientId && (
 				<li

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -6,9 +6,18 @@
 	li {
 		display: inline-block;
 		margin: 0;
+	}
 
-		&:not(:last-child)::after {
-			content: "\2192" #{'/*rtl:"\2190"*/'}; // This becomes → for LTR and ← for RTL.
+	.block-editor-block-breadcrumb__separator {
+		fill: currentColor;
+		margin-left: -$grid-unit-05;
+		margin-right: -$grid-unit-05;
+
+		// Flip for RTL.
+		transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the chevron right for LTR and left for RTL.
+
+		&:last-child {
+			display: none;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -12,5 +12,19 @@ exports[`BlockBreadcrumb should render correctly 1`] = `
   >
     Document
   </li>
+  <svg
+    aria-hidden="true"
+    class="block-editor-block-breadcrumb__separator"
+    focusable="false"
+    height="24"
+    role="img"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.8622 8.04053L14.2805 12.0286L10.8622 16.0167L9.72327 15.0405L12.3049 12.0286L9.72327 9.01672L10.8622 8.04053Z"
+    />
+  </svg>
 </ul>
 `;


### PR DESCRIPTION
## Description

The breadcrumb bar uses → for the separators, like so:

<img width="463" alt="Screenshot 2021-06-28 at 16 59 45" src="https://user-images.githubusercontent.com/1204802/123658926-74888300-d832-11eb-9f95-d19fb13c12da.png">

This PR replaces them with chevrons, for just a little bit more DNA shared with the list view:

<img width="343" alt="Screenshot 2021-06-28 at 17 01 58" src="https://user-images.githubusercontent.com/1204802/123659059-96820580-d832-11eb-8d77-6fee977bb7d2.png">

Like so:

<img width="504" alt="Screenshot 2021-06-28 at 16 57 25" src="https://user-images.githubusercontent.com/1204802/123659096-9eda4080-d832-11eb-90fd-50849912c498.png">

Here it is in action:

![chevrons](https://user-images.githubusercontent.com/1204802/123659115-a1d53100-d832-11eb-911a-1d13dffd878d.gif)

The RTL fix has been ported as well:

<img width="412" alt="Screenshot 2021-06-28 at 16 56 44" src="https://user-images.githubusercontent.com/1204802/123659152-ab5e9900-d832-11eb-9cb7-6366bbd6638f.png">

## How has this been tested?

Test a document with lots of nesting, observe the chevron in the breadcrumb bar. Test also RTL languages.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
