### PR TITLE
Pass block attributes with rendering with location

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -94,7 +94,7 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * @param  string $location The location of the classic menu to display.
  * @return string|false HTML markup of a generated Navigation Block or false if no location is specified.
  */
-function gutenberg_render_menu_from_location( $location ) {
+function gutenberg_render_menu_from_location( $location, $attributes ) {
 	if ( empty( $location ) ) {
 		return false;
 	}
@@ -104,6 +104,7 @@ function gutenberg_render_menu_from_location( $location ) {
 			'theme_location' => $location,
 			'container'      => '',
 			'items_wrap'     => '%3$s',
+			'block_attributes' => $attributes,
 			'fallback_cb'    => false,
 			'echo'           => false,
 		)
@@ -154,7 +155,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( empty( $block->inner_blocks ) ) {
 		if ( array_key_exists( '__unstableLocation', $attributes ) ) {
 			$location                 = $attributes['__unstableLocation'];
-			$maybe_classic_navigation = gutenberg_render_menu_from_location( $location );
+			$maybe_classic_navigation = gutenberg_render_menu_from_location( $location, $attributes );
 			if ( $maybe_classic_navigation ) {
 				return $maybe_classic_navigation;
 			}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -102,12 +102,12 @@ function gutenberg_render_menu_from_location( $location, $attributes ) {
 
 	return wp_nav_menu(
 		array(
-			'theme_location' => $location,
-			'container'      => '',
-			'items_wrap'     => '%3$s',
+			'theme_location'   => $location,
+			'container'        => '',
+			'items_wrap'       => '%3$s',
 			'block_attributes' => $attributes,
-			'fallback_cb'    => false,
-			'echo'           => false,
+			'fallback_cb'      => false,
+			'echo'             => false,
 		)
 	);
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -92,6 +92,7 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * If no location was provided as a block attribute then false is returned.
  *
  * @param  string $location The location of the classic menu to display.
+ * @param  object $attributes The block attributes.
  * @return string|false HTML markup of a generated Navigation Block or false if no location is specified.
  */
 function gutenberg_render_menu_from_location( $location, $attributes ) {


### PR DESCRIPTION
## Description
When the Navigation block is rendering via the __unstableLocation attribute the attributes are now passed to the rendering function. The [rendering function was already expecting 'block_attribute'](https://github.com/WordPress/gutenberg/pull/31911/files) this change just passes it along.

This fixes a theme issue for Quadrat (or any theme that uses _unstableLocation and also expects mobile styling which is achived by setting the isResponsive attribute).

## How has this been tested?
Activate Quadrat (or any theme that uses both `__unstableLocation` and `isResponsive` attributes).
Observe that the responsive (mobile) styling works as expected.


## Types of changes
Bug fix 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
