### PR TITLE
Experiment: try Theme JSON API to control block orientation

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -44,8 +44,6 @@ const LAYOUT = {
 	alignments: [],
 };
 
-const DEFAULT_ORIENTATION = 'vertical';
-
 function Navigation( {
 	selectedBlockHasDescendants,
 	attributes,
@@ -66,8 +64,6 @@ function Navigation( {
 		false
 	);
 
-	const possibleOrientation = attributes.orientation || DEFAULT_ORIENTATION;
-
 	const allowedOrientations = Object.entries(
 		useSetting( 'layout.orientations' )
 	).reduce( ( allowed, curr ) => {
@@ -77,9 +73,24 @@ function Navigation( {
 		return allowed;
 	}, [] );
 
+	let defaultOrientation;
+
+	if ( allowedOrientations.includes( 'vertical' ) ) {
+		defaultOrientation = 'vertical';
+	} else if (
+		! allowedOrientations.includes( 'vertical' ) &&
+		allowedOrientations.includes( 'horizontal' )
+	) {
+		defaultOrientation = 'horizontal';
+	} else {
+		defaultOrientation = 'vertical';
+	}
+
+	const possibleOrientation = attributes.orientation || defaultOrientation;
+
 	const blockOrientation = allowedOrientations.includes( possibleOrientation )
 		? possibleOrientation
-		: DEFAULT_ORIENTATION;
+		: defaultOrientation;
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -44,6 +44,8 @@ const LAYOUT = {
 	alignments: [],
 };
 
+const DEFAULT_ORIENTATION = 'vertical';
+
 function Navigation( {
 	selectedBlockHasDescendants,
 	attributes,
@@ -64,13 +66,20 @@ function Navigation( {
 		false
 	);
 
-	const possibleOrientation = attributes.orientation || 'horizontal';
+	const possibleOrientation = attributes.orientation || DEFAULT_ORIENTATION;
 
-	const allowedOrientations = useSetting( 'layout.orientations' );
+	const allowedOrientations = Object.entries(
+		useSetting( 'layout.orientations' )
+	).reduce( ( allowed, curr ) => {
+		if ( true === curr[ 1 ] ) {
+			allowed.push( curr[ 0 ] );
+		}
+		return allowed;
+	}, [] );
 
 	const blockOrientation = allowedOrientations.includes( possibleOrientation )
 		? possibleOrientation
-		: 'vertical';
+		: DEFAULT_ORIENTATION;
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -44,6 +44,9 @@ const LAYOUT = {
 	alignments: [],
 };
 
+const ORIENTATION_VERTICAL = 'vertical';
+const ORIENTATION_HORIZONTAL = 'horizontal';
+
 function Navigation( {
 	selectedBlockHasDescendants,
 	attributes,
@@ -64,26 +67,29 @@ function Navigation( {
 		false
 	);
 
-	const allowedOrientations = Object.entries(
-		useSetting( 'layout.orientations' )
-	).reduce( ( allowed, curr ) => {
-		if ( true === curr[ 1 ] ) {
-			allowed.push( curr[ 0 ] );
-		}
-		return allowed;
-	}, [] );
+	const orientationSettings = useSetting( 'layout.orientations' ) || {};
+
+	const allowedOrientations = Object.entries( orientationSettings ).reduce(
+		( allowed, curr ) => {
+			if ( true === curr[ 1 ] ) {
+				allowed.push( curr[ 0 ] );
+			}
+			return allowed;
+		},
+		[]
+	);
 
 	let defaultOrientation;
 
-	if ( allowedOrientations.includes( 'vertical' ) ) {
-		defaultOrientation = 'vertical';
+	if ( allowedOrientations.includes( ORIENTATION_VERTICAL ) ) {
+		defaultOrientation = ORIENTATION_VERTICAL;
 	} else if (
-		! allowedOrientations.includes( 'vertical' ) &&
-		allowedOrientations.includes( 'horizontal' )
+		! allowedOrientations.includes( ORIENTATION_VERTICAL ) &&
+		allowedOrientations.includes( ORIENTATION_HORIZONTAL )
 	) {
-		defaultOrientation = 'horizontal';
+		defaultOrientation = ORIENTATION_HORIZONTAL;
 	} else {
-		defaultOrientation = 'vertical';
+		defaultOrientation = ORIENTATION_VERTICAL;
 	}
 
 	const possibleOrientation = attributes.orientation || defaultOrientation;
@@ -97,7 +103,7 @@ function Navigation( {
 	const blockProps = useBlockProps( {
 		className: classnames( className, {
 			[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-			'is-vertical': blockOrientation === 'vertical',
+			'is-vertical': blockOrientation === ORIENTATION_VERTICAL,
 			'is-responsive': attributes.isResponsive,
 		} ),
 	} );
@@ -149,7 +155,7 @@ function Navigation( {
 	}
 
 	const justifyAllowedControls =
-		blockOrientation === 'vertical'
+		blockOrientation === ORIENTATION_VERTICAL
 			? [ 'left', 'center', 'right' ]
 			: [ 'left', 'center', 'right', 'space-between' ];
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -15,6 +15,7 @@ import {
 	BlockControls,
 	useBlockProps,
 	store as blockEditorStore,
+	useSetting,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
@@ -63,12 +64,20 @@ function Navigation( {
 		false
 	);
 
+	const possibleOrientation = attributes.orientation || 'horizontal';
+
+	const allowedOrientations = useSetting( 'layout.orientations' );
+
+	const blockOrientation = allowedOrientations.includes( possibleOrientation )
+		? possibleOrientation
+		: 'vertical';
+
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const blockProps = useBlockProps( {
 		className: classnames( className, {
 			[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-			'is-vertical': attributes.orientation === 'vertical',
+			'is-vertical': blockOrientation === 'vertical',
 			'is-responsive': attributes.isResponsive,
 		} ),
 	} );
@@ -85,7 +94,7 @@ function Navigation( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			orientation: attributes.orientation || 'horizontal',
+			orientation: blockOrientation,
 			renderAppender:
 				( isImmediateParentOfSelectedBlock &&
 					! selectedBlockHasDescendants ) ||
@@ -120,7 +129,7 @@ function Navigation( {
 	}
 
 	const justifyAllowedControls =
-		attributes.orientation === 'vertical'
+		blockOrientation === 'vertical'
 			? [ 'left', 'center', 'right' ]
 			: [ 'left', 'center', 'right', 'space-between' ];
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is a _experimental_ PoC PR to see if it's possible/suitable to utilise the Theme JSON API to control a block's `orientation` via a Theme JSON setting.

This is part of a wider exploration to see if it's appropriate to use Theme JSON as a mechanism to control block features.

See https://github.com/WordPress/gutenberg/issues/30007#issuecomment-869778331 for context.

## Questions

There is much to think about here.

* Is the setting key in the right place?
* ~Is using an open array the best option or should you have to pick from predefined options (eg: `vertical: true`, `horizontal: true`...etc).~ I think it's better to have limited options.
* How do we define the fallback orientation for a block and what if that fallback isn't enabled in the Theme JSON. Relates to question above.
* How could we utilise this feature in the Nav Editor to switch the Nav Block into "simple" mode?
* Which other blocks could benefit from this approach?

## How has this been tested?

* Use a block based theme.

#### Site Level Orientation
* Edit the `theme.json` file in your theme to have the following key under the _top level_ `settings.layout.orientation`:
```json
{
    "settings": {
        "layout": {
            "contentSize": "610px",
            "wideSize": "1240px",
            "orientations": {
                "vertical": true,
                "horizontal": false
            }
        }
    }
}
```
* Create a new Post.
* Insert Nav Block.
* Notice how it is forced into `vertical` mode because you allowed that in the Theme JSON.
* Try using other values.

#### Block Level Orienation

Now let's try making this setting apply to the Nav Block _only_. 

* Remove the previous changes to `theme.json`.
* Create a new entry under `settings.blocks.core/navigation` - it should look like this although be aware you may have other settings already present so you will need to be VERY careful about where you place this code otherwise it won't work:

```json
{

    "settings": {
        "blocks": {
            "core/navigation": {
                "layout": {
                    "orientations": {
                        "vertical": true,
                        "horizontal": false
                    }
                }
            }
        }
    }
}
```
* Create a new Post.
* Insert Nav Block.
* Notice how it is forced into `vertical` mode because you allowed that in the Theme JSON.
* Try using other values.


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
