### PR TITLE
E2E Test Utils: Add getCurrentUser(), and use it for user switching

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 -   Added `createUser` and `deleteUser` - Create and delete a user account, respectively.
+-   Added `getCurrentUser` - Determine the currently logged in user. Changed `switchUserToAdmin` and `switchUserToTest` to use it.
 
 ## 5.3.0 (2021-05-31)
 

--- a/packages/e2e-test-utils/src/get-current-user.js
+++ b/packages/e2e-test-utils/src/get-current-user.js
@@ -1,7 +1,7 @@
 /**
- * Performs log in with specified username and password.
+ * Get the username of the user that's currently logged into WordPress (if any).
  *
- * @return {string} username The user that's currently logged into WordPress (if any).
+ * @return {string?} username The user that's currently logged into WordPress (if any).
  */
 export async function getCurrentUser() {
 	const cookies = await page.cookies();

--- a/packages/e2e-test-utils/src/get-current-user.js
+++ b/packages/e2e-test-utils/src/get-current-user.js
@@ -1,0 +1,16 @@
+/**
+ * Performs log in with specified username and password.
+ *
+ * @return {string} username The user that's currently logged into WordPress (if any).
+ */
+export async function getCurrentUser() {
+	const cookies = await page.cookies();
+	const cookie = cookies.find(
+		( c ) => !! c?.name?.startsWith( 'wordpress_logged_in_' )
+	);
+
+	if ( ! cookie?.value ) {
+		return;
+	}
+	return decodeURIComponent( cookie.value ).split( '|' )[ 0 ];
+}

--- a/packages/e2e-test-utils/src/switch-user-to-admin.js
+++ b/packages/e2e-test-utils/src/switch-user-to-admin.js
@@ -1,15 +1,16 @@
 /**
  * Internal dependencies
  */
+import { getCurrentUser } from './get-current-user';
 import { loginUser } from './login-user';
-import { WP_USERNAME, WP_ADMIN_USER } from './shared/config';
+import { WP_ADMIN_USER } from './shared/config';
 
 /**
  * Switches the current user to the admin user (if the user
  * running the test is not already the admin user).
  */
 export async function switchUserToAdmin() {
-	if ( WP_USERNAME === WP_ADMIN_USER.username ) {
+	if ( ( await getCurrentUser() ) === WP_ADMIN_USER.username ) {
 		return;
 	}
 	await loginUser( WP_ADMIN_USER.username, WP_ADMIN_USER.password );

--- a/packages/e2e-test-utils/src/switch-user-to-test.js
+++ b/packages/e2e-test-utils/src/switch-user-to-test.js
@@ -1,15 +1,16 @@
 /**
  * Internal dependencies
  */
+import { getCurrentUser } from './get-current-user';
 import { loginUser } from './login-user';
-import { WP_USERNAME, WP_ADMIN_USER } from './shared/config';
+import { WP_USERNAME } from './shared/config';
 
 /**
  * Switches the current user to whichever user we should be
  * running the tests as (if we're not already that user).
  */
 export async function switchUserToTest() {
-	if ( WP_USERNAME === WP_ADMIN_USER.username ) {
+	if ( ( await getCurrentUser() ) === WP_USERNAME ) {
 		return;
 	}
 	await loginUser();


### PR DESCRIPTION
## Description

Spun off from #32868.

A lot of our E2E test utils use `switchUserToAdmin()` and `switchUserToUser()`. Typically, `switchUserToAdmin()` is used at the beginning to be able to change a site-wide setting in wp-admin; and `switchUserToUser()` is used at the end to switch back to 'normal' test privileges.

The credentials used for `switchUserToAdmin()` are statically stored here: https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/packages/e2e-test-utils/src/shared/config.js#L1-L4.

The credentials for `switchUserToUser()` are informed by the `WP_USERNAME` and `WP_PASSWORD` env vars, which in turn can be set through [the `--wordpress-username` and `--wordpress-password` args for the e2e test command](https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/packages/scripts/scripts/test-e2e.js#L68-L72), as [documented here](https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/docs/contributors/code/testing-overview.md#using-alternate-enviornment).

If those args/env vars aren't set, we fall back to the admin credentials: https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/packages/e2e-test-utils/src/shared/config.js#L6-L10

Due to the implementation of `switchUserToAdmin()` and `switchUserToUser()`, this means that in the default case (with no custom username/password combination set), both functions are pretty much no-ops, as they both bail early in that case:

https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/packages/e2e-test-utils/src/switch-user-to-admin.js#L11-L16

https://github.com/WordPress/gutenberg/blob/37d6024ed0993615d1af6f5af78494a98602710b/packages/e2e-test-utils/src/switch-user-to-test.js#L11-L16

---

This means that those functions cannot scale to a scenario where we want to use a different user programmatically, i.e. as part of an e2e test, rather than statically setting a different user for _all_ tests. One example for such a scenario would be #32868 -- or really _any_ e2e test where we'd like to use a user with lesser-than-admin privileges.

For this reason, I'd like to change the checks in `switchUserToAdmin()` (and, for symmetry reasons, in `switchUserToUser()`), to compare the _currently logged-in user_ to the admin or custom user, respectively.

(This means that for a scenario like #32868, we still won't be able to use `switchUserToUser()`, as that just falls back to the custom user set via e2e tests args or env vars; but it's easy enough to use `loginUser()` directly).

Note that `switchUserToAdmin()` and `switchUserToUser()` are present in a lot of our e2e test utils, so performance is crucial: we want to continue to bail early if the admin is already logged in, and we want to do it quickly.

## Alternatives considered

### Evaluate `.display-name` (in the masterbar, top right)

Downside: Returns the display name, not the username

### Add a test plugin that injects the username as a global JS var

Downside: Requires a plugin to be active, which can present a bit of a catch-22: e2e test setup needs to log in as admin (via `switchUserToAdmin()`) -- but `switchUserToAdmin()` determines whether to log in based on the global var provided by the plugin.

## How has this been tested?
Run the e2e tests locally (`npm run test-e2e`), or observe them in CI on this PR.
