### PR TITLE
components: Restrict imports of @emotion/css

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,11 @@ module.exports = {
 						message:
 							'`puppeteer-testing-library` is still experimental.',
 					},
+					{
+						name: '@emotion/css',
+						message:
+							'Please use `@emotion/react` and `@emotion/styled` in order to maintain iframe support',
+					},
 				],
 			},
 		],

--- a/packages/components/src/base-field/hook.js
+++ b/packages/components/src/base-field/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/base-field/styles.js
+++ b/packages/components/src/base-field/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card-body/hook.js
+++ b/packages/components/src/card/card-body/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card-divider/hook.js
+++ b/packages/components/src/card/card-divider/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card-footer/hook.js
+++ b/packages/components/src/card/card-footer/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card-header/hook.js
+++ b/packages/components/src/card/card-header/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card-media/hook.js
+++ b/packages/components/src/card/card-media/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card/component.js
+++ b/packages/components/src/card/card/component.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/card/hook.js
+++ b/packages/components/src/card/card/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/card/styles.js
+++ b/packages/components/src/card/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import { Separator } from 'reakit';

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/elevation/hook.js
+++ b/packages/components/src/elevation/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 import { isNil } from 'lodash';
 

--- a/packages/components/src/elevation/styles.js
+++ b/packages/components/src/elevation/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 export const Elevation = css`

--- a/packages/components/src/flex/flex-item/hook.js
+++ b/packages/components/src/flex/flex-item/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/flex/flex/hook.js
+++ b/packages/components/src/flex/flex/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/flex/styles.js
+++ b/packages/components/src/flex/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 export const Flex = css`

--- a/packages/components/src/grid/hook.js
+++ b/packages/components/src/grid/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/scrollable/hook.js
+++ b/packages/components/src/scrollable/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/scrollable/styles.js
+++ b/packages/components/src/scrollable/styles.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
+
 /**
  * Internal dependencies
  */

--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/surface/hook.js
+++ b/packages/components/src/surface/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/surface/styles.js
+++ b/packages/components/src/surface/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/text/hook.js
+++ b/packages/components/src/text/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 import { isPlainObject } from 'lodash';
 

--- a/packages/components/src/text/styles.js
+++ b/packages/components/src/text/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/truncate/hook.js
+++ b/packages/components/src/truncate/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/truncate/styles.js
+++ b/packages/components/src/truncate/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 export const Truncate = css`

--- a/packages/components/src/ui/context/use-context-system.js
+++ b/packages/components/src/ui/context/use-context-system.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/control-group/hook.js
+++ b/packages/components/src/ui/control-group/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/control-group/styles.js
+++ b/packages/components/src/ui/control-group/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 export const first = css`

--- a/packages/components/src/ui/control-label/hook.js
+++ b/packages/components/src/ui/control-label/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/control-label/styles.js
+++ b/packages/components/src/ui/control-label/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/form-group/form-group-styles.js
+++ b/packages/components/src/ui/form-group/form-group-styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 export const FormGroup = css`

--- a/packages/components/src/ui/form-group/use-form-group.js
+++ b/packages/components/src/ui/form-group/use-form-group.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/item-group/styles.ts
+++ b/packages/components/src/ui/item-group/styles.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/item-group/use-item-group.ts
+++ b/packages/components/src/ui/item-group/use-item-group.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/item-group/use-item.ts
+++ b/packages/components/src/ui/item-group/use-item.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/popover/content.js
+++ b/packages/components/src/ui/popover/content.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import { Popover as ReakitPopover } from 'reakit';

--- a/packages/components/src/ui/popover/styles.js
+++ b/packages/components/src/ui/popover/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/tooltip/content.js
+++ b/packages/components/src/ui/tooltip/content.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import { Tooltip as ReakitTooltip } from 'reakit';

--- a/packages/components/src/ui/tooltip/styles.js
+++ b/packages/components/src/ui/tooltip/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 

--- a/packages/components/src/ui/utils/get-high-dpi.ts
+++ b/packages/components/src/ui/utils/get-high-dpi.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, CSSInterpolation } from '@emotion/css';
 
 export function getHighDpi(

--- a/packages/components/src/ui/visually-hidden/hook.js
+++ b/packages/components/src/ui/visually-hidden/hook.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { cx } from '@emotion/css';
 
 /**

--- a/packages/components/src/ui/visually-hidden/styles.js
+++ b/packages/components/src/ui/visually-hidden/styles.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /**

--- a/packages/components/src/utils/browsers.js
+++ b/packages/components/src/utils/browsers.js
@@ -1,11 +1,14 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 
 /* eslint-disable jsdoc/no-undefined-types */
 /**
- * @param {TemplateStringsArray}                     strings
+ * @param {TemplateStringsArray}                                      strings
  * @param {import('@emotion/css/create-instance').CSSInterpolation[]} interpolations
  */
 export function firefoxOnly( strings, ...interpolations ) {
@@ -19,7 +22,7 @@ export function firefoxOnly( strings, ...interpolations ) {
 }
 
 /**
- * @param {TemplateStringsArray}                     strings
+ * @param {TemplateStringsArray}                                      strings
  * @param {import('@emotion/css/create-instance').CSSInterpolation[]} interpolations
  */
 export function safariOnly( strings, ...interpolations ) {

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css, cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import type { Ref, ReactNode } from 'react';

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+// Disable reason: Temporarily disable for existing usages
+// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
+// eslint-disable-next-line no-restricted-imports
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css.

The first step in removing `@emotion/css` and replacing it with `@emotion/styled` and `@emotion/react`.

## How has this been tested?
ESLint errors should appear for `@emotion/css`. The existing errors should all be disabled (with a comment explaining that the import will be removed as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css)

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
