### PR TITLE
Pattern Directory: Merge Core locale, caching updates

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -210,18 +210,29 @@ function load_remote_patterns() {
 		return;
 	}
 
-	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
-	$core_keyword_id = 11; // 11 is the ID for "core".
-	$request->set_param( 'keyword', $core_keyword_id );
-	$response = rest_do_request( $request );
-	if ( $response->is_error() ) {
-		return;
-	}
-	$patterns = $response->get_data();
+	/**
+	 * Filter to disable remote block patterns.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param bool $should_load_remote
+	 */
+	$should_load_remote = apply_filters( 'should_load_remote_block_patterns', true );
 
-	foreach ( $patterns as $settings ) {
-		$pattern_name = 'core/' . sanitize_title( $settings['title'] );
-		register_block_pattern( $pattern_name, (array) $settings );
+	if ( $should_load_remote ) {
+		$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+		$core_keyword_id = 11; // 11 is the ID for "core".
+		$request->set_param( 'keyword', $core_keyword_id );
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return;
+		}
+		$patterns = $response->get_data();
+
+		foreach ( $patterns as $settings ) {
+			$pattern_name = 'core/' . sanitize_title( $settings['title'] );
+			register_block_pattern( $pattern_name, (array) $settings );
+		}
 	}
 }
 

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -200,25 +200,24 @@ function remove_core_patterns() {
 }
 
 /**
- * Import patterns from wordpress.org/patterns.
+ * Register Core's official patterns from wordpress.org/patterns.
+ *
+ * @since 5.8.0
  */
 function load_remote_patterns() {
 	// This is the core function that provides the same feature.
 	if ( function_exists( '_load_remote_block_patterns' ) ) {
 		return;
 	}
-	$patterns = get_transient( 'gutenberg_remote_block_patterns' );
-	if ( ! $patterns ) {
-		$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
-		$core_keyword_id = 11; // 11 is the ID for "core".
-		$request->set_param( 'keyword', $core_keyword_id );
-		$response = rest_do_request( $request );
-		if ( $response->is_error() ) {
-			return;
-		}
-		$patterns = $response->get_data();
-		set_transient( 'gutenberg_remote_block_patterns', $patterns, HOUR_IN_SECONDS );
+
+	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+	$core_keyword_id = 11; // 11 is the ID for "core".
+	$request->set_param( 'keyword', $core_keyword_id );
+	$response = rest_do_request( $request );
+	if ( $response->is_error() ) {
+		return;
 	}
+	$patterns = $response->get_data();
 
 	foreach ( $patterns as $settings ) {
 		$pattern_name = 'core/' . sanitize_title( $settings['title'] );

--- a/lib/class-wp-rest-pattern-directory-controller.php
+++ b/lib/class-wp-rest-pattern-directory-controller.php
@@ -85,7 +85,22 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$query_args  = array();
+		/*
+		 * Include an unmodified `$wp_version`, so the API can craft a response that's tailored to
+		 * it. Some plugins modify the version in a misguided attempt to improve security by
+		 * obscuring the version, which can cause invalid requests.
+		 */
+		require ABSPATH . WPINC . '/version.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$gutenberg_data = get_plugin_data( dirname( __DIR__ ) . '/gutenberg.php', false );
+
+		$query_args = array(
+			'locale'            => get_user_locale(),
+			'wp-version'        => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
+			'gutenberg-version' => $gutenberg_data['Version'],
+		);
+
 		$category_id = $request['category'];
 		$keyword_id  = $request['keyword'];
 		$search_term = $request['search'];

--- a/lib/class-wp-rest-pattern-directory-controller.php
+++ b/lib/class-wp-rest-pattern-directory-controller.php
@@ -117,38 +117,73 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 			$query_args['search'] = $search_term;
 		}
 
-		$api_url = add_query_arg(
-			array_map( 'rawurlencode', $query_args ),
-			'http://api.wordpress.org/patterns/1.0/'
-		);
+		/*
+		 * Include a hash of the query args, so that different requests are stored in
+		 * separate caches.
+		 *
+		 * MD5 is chosen for its speed, low-collision rate, universal availability, and to stay
+		 * under the character limit for `_site_transient_timeout_{...}` keys.
+		 *
+		 * @link https://stackoverflow.com/questions/3665247/fastest-hash-for-non-cryptographic-uses
+		 */
+		$transient_key = 'wp_remote_block_patterns_' . md5( implode( '-', $query_args ) );
 
-		if ( wp_http_supports( array( 'ssl' ) ) ) {
-			$api_url = set_url_scheme( $api_url, 'https' );
-		}
+		/*
+		 * Use network-wide transient to improve performance. The locale is the only site
+		 * configuration that affects the response, and it's included in the transient key.
+		 */
+		$raw_patterns = get_site_transient( $transient_key );
 
-		$wporg_response = wp_remote_get( $api_url );
-		$raw_patterns   = json_decode( wp_remote_retrieve_body( $wporg_response ) );
-
-		if ( is_wp_error( $wporg_response ) ) {
-			$wporg_response->add_data( array( 'status' => 500 ) );
-
-			return $wporg_response;
-		}
-
-		// Make sure w.org returned valid data.
-		if ( ! is_array( $raw_patterns ) ) {
-			return new WP_Error(
-				'pattern_api_failed',
-				sprintf(
-				/* translators: %s: Support forums URL. */
-					__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.', 'gutenberg' ),
-					__( 'https://wordpress.org/support/forums/', 'gutenberg' )
-				),
-				array(
-					'status'   => 500,
-					'response' => wp_remote_retrieve_body( $wporg_response ),
-				)
+		if ( ! $raw_patterns ) {
+			$api_url = add_query_arg(
+				array_map( 'rawurlencode', $query_args ),
+				'http://api.wordpress.org/patterns/1.0/'
 			);
+
+			if ( wp_http_supports( array( 'ssl' ) ) ) {
+				$api_url = set_url_scheme( $api_url, 'https' );
+			}
+
+			/*
+			 * Default to a short TTL, to mitigate cache stampedes on high-traffic sites.
+			 * This assumes that most errors will be short-lived, e.g., packet loss that causes the
+			 * first request to fail, but a follow-up one will succeed. The value should be high
+			 * enough to avoid stampedes, but low enough to not interfere with users manually
+			 * re-trying a failed request.
+			 */
+			$cache_ttl      = 5;
+			$wporg_response = wp_remote_get( $api_url );
+			$raw_patterns   = json_decode( wp_remote_retrieve_body( $wporg_response ) );
+
+			if ( is_wp_error( $wporg_response ) ) {
+				$raw_patterns = $wporg_response;
+
+			} elseif ( ! is_array( $raw_patterns ) ) {
+				// HTTP request succeeded, but response data is invalid.
+				$raw_patterns = new WP_Error(
+					'pattern_api_failed',
+					sprintf(
+					/* translators: %s: Support forums URL. */
+						__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.', 'gutenberg' ),
+						__( 'https://wordpress.org/support/forums/', 'gutenberg' )
+					),
+					array(
+						'response' => wp_remote_retrieve_body( $wporg_response ),
+					)
+				);
+
+			} else {
+				// Response has valid data.
+				$cache_ttl = HOUR_IN_SECONDS;
+			}
+
+			set_site_transient( $transient_key, $raw_patterns, $cache_ttl );
+		}
+
+		if ( is_wp_error( $raw_patterns ) ) {
+			$raw_patterns->add_data( array( 'status' => 500 ) );
+
+			return $raw_patterns;
 		}
 
 		$response = array();

--- a/phpunit/class-wp-rest-pattern-directory-controller-test.php
+++ b/phpunit/class-wp-rest-pattern-directory-controller-test.php
@@ -292,6 +292,46 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		$this->assertWPError( $response->as_error() );
 	}
 
+	/**
+	 * @covers WP_REST_Pattern_Directory_Controller::get_items
+	 *
+	 * @since 5.8.0
+	 */
+	public function test_get_items_prepare_filter() {
+		wp_set_current_user( self::$contributor_id );
+		self::mock_successful_response( 'browse-all', true );
+
+		// Test that filter changes uncached values.
+		add_filter(
+			'rest_prepare_block_pattern',
+			function() {
+				return 'initial value';
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+		$response = rest_do_request( $request );
+		$patterns = $response->get_data();
+
+		$this->assertSame( 'initial value', $patterns[0] );
+
+		// Test that filter changes cached values (the previous request primed the cache).
+		add_filter(
+			'rest_prepare_block_pattern',
+			function() {
+				return 'modified the cache';
+			},
+			11
+		);
+
+		// Test that the filter works against cached values.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+		$response = rest_do_request( $request );
+		$patterns = $response->get_data();
+
+		$this->assertSame( 'modified the cache', $patterns[0] );
+	}
+
 	public function test_get_item() {
 		$this->markTestSkipped( 'Controller does not have get_item route.' );
 	}

--- a/phpunit/class-wp-rest-pattern-directory-controller-test.php
+++ b/phpunit/class-wp-rest-pattern-directory-controller-test.php
@@ -11,8 +11,9 @@
  * @group pattern-directory
  */
 class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_Testcase {
+
 	/**
-	 * Administrator user id.
+	 * Contributor user id.
 	 *
 	 * @since 5.8.0
 	 *
@@ -62,12 +63,9 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_register_routes() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		$routes = rest_get_server()->get_routes();
 
-		$this->assertArrayHasKey( '/__experimental/pattern-directory/patterns', $routes );
+		$this->assertArrayHasKey( '/wp/v2/pattern-directory/patterns', $routes );
 	}
 
 	/**
@@ -76,10 +74,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_context_param() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
-		$request  = new WP_REST_Request( 'OPTIONS', '/__experimental/pattern-directory/patterns' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/pattern-directory/patterns' );
 		$response = rest_get_server()->dispatch( $request );
 		$patterns = $response->get_data();
 
@@ -93,13 +88,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'browse-all', true );
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
 
@@ -116,13 +108,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_by_category() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'browse-category', true );
 
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'category' => 2 ) );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
@@ -144,13 +133,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_by_keyword() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'browse-keyword', true );
 
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'keyword' => 11 ) );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
@@ -172,14 +158,11 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_search() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'search', true );
 
 		$search_term = 'button';
-		$request     = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request     = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'search' => $search_term ) );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
@@ -203,13 +186,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_wdotorg_unavailable() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::prevent_requests_to_host( 'api.wordpress.org' );
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$response = rest_do_request( $request );
 
 		$this->assertErrorResponse( 'patterns_api_failed', $response, 500 );
@@ -221,10 +201,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_logged_out() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'search' => 'button' ) );
 		$response = rest_do_request( $request );
 
@@ -237,13 +214,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_no_results() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'browse-all', false );
 
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'category' => PHP_INT_MAX ) );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
@@ -258,13 +232,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_search_no_results() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'search', false );
 
-		$request = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request->set_query_params( array( 'search' => '0c4549ee68f24eaaed46a49dc983ecde' ) );
 		$response = rest_do_request( $request );
 		$patterns = $response->get_data();
@@ -279,13 +250,10 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @since 5.8.0
 	 */
 	public function test_get_items_invalid_response_data() {
-		$this->markTestSkipped(
-			'The test is failing with latest WordPress core.'
-		);
 		wp_set_current_user( self::$contributor_id );
 		self::mock_successful_response( 'invalid-data', true );
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/pattern-directory/patterns' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$response = rest_do_request( $request );
 
 		$this->assertSame( 500, $response->status );
@@ -390,26 +358,28 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	 * @return string
 	 */
 	private static function get_raw_response( $action ) {
+		$fixtures_dir = __DIR__ . '/fixtures/rest-api/pattern-directory';
+
 		switch ( $action ) {
 			default:
 			case 'browse-all':
 				// Response from https://api.wordpress.org/patterns/1.0/.
-				$response = file_get_contents( __DIR__ . '/fixtures/rest-api/pattern-directory/browse-all.json' );
+				$response = file_get_contents( $fixtures_dir . '/browse-all.json' );
 				break;
 
 			case 'browse-category':
 				// Response from https://api.wordpress.org/patterns/1.0/?pattern-categories=2.
-				$response = file_get_contents( __DIR__ . '/fixtures/rest-api/pattern-directory/browse-category-2.json' );
+				$response = file_get_contents( $fixtures_dir . '/browse-category-2.json' );
 				break;
 
 			case 'browse-keyword':
 				// Response from https://api.wordpress.org/patterns/1.0/?pattern-keywords=11.
-				$response = file_get_contents( __DIR__ . '/fixtures/rest-api/pattern-directory/browse-keyword-11.json' );
+				$response = file_get_contents( $fixtures_dir . '/browse-keyword-11.json' );
 				break;
 
 			case 'search':
 				// Response from https://api.wordpress.org/patterns/1.0/?search=button.
-				$response = file_get_contents( __DIR__ . '/fixtures/rest-api/pattern-directory/search-button.json' );
+				$response = file_get_contents( $fixtures_dir . '/search-button.json' );
 				break;
 
 			case 'invalid-data':


### PR DESCRIPTION
## Description

Merges https://core.trac.wordpress.org/changeset/51206 and https://core.trac.wordpress.org/changeset/51208, so the bundled versions of Core files are up to date with Core `5.8-beta4`

Fixes #32754

## How has this been tested?

- [x] Unit tests pass
- [x] Manual testing works

Manual testing:
1. downgrade to wp 5.7 branch so the changesets above don't exist in core
1. point `api.wordpress.org` to a w.org sandbox via `/etc/hosts/` (if applicable)
1. clear the locale transients
1. refresh the editor to trigger a request
2. view the request on the sandbox and see that the payload contains the locale. alternatively, you could observe the request w/ something like Burp Suite, the `pre_http_request` filter, etc.
3.  refresh again and observed that no request is made, because the results from the previous one were cached
4. change locales and refreshe again, and see a new request on the sandbox, and a new transient created locally.




## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
