### PR TITLE
components: Remove `@emotion/css` from ZStack

### DIFF
--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -1,10 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: Temporarily disable for existing usages
-// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
-// eslint-disable-next-line no-restricted-imports
-import { css, cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import type { Ref, ReactNode } from 'react';
 
@@ -20,9 +16,7 @@ import { getValidChildren } from '../ui/utils/get-valid-children';
 import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
-import { View } from '../view';
-import * as styles from './styles';
-const { ZStackView } = styles;
+import { ZStackView, ZStackChild } from './styles';
 
 export interface ZStackProps {
 	/**
@@ -69,27 +63,17 @@ function ZStack(
 		const zIndex = isReversed ? childrenLastIndex - index : index;
 		const offsetAmount = offset * index;
 
-		const classes = cx(
-			isLayered ? styles.positionAbsolute : styles.positionRelative,
-			css( {
-				...( isLayered
-					? { marginLeft: offsetAmount }
-					: { right: offsetAmount * -1 } ),
-			} )
-		);
-
 		const key = isValidElement( child ) ? child.key : index;
 
 		return (
-			<View
-				className={ classes }
+			<ZStackChild
+				isLayered={ isLayered }
+				offsetAmount={ offsetAmount }
+				zIndex={ zIndex }
 				key={ key }
-				style={ {
-					zIndex,
-				} }
 			>
 				{ child }
-			</View>
+			</ZStackChild>
 		);
 	} );
 

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -16,7 +16,7 @@ import { getValidChildren } from '../ui/utils/get-valid-children';
 import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
-import { ZStackView, ZStackChild } from './styles';
+import { ZStackView, ZStackChildView } from './styles';
 
 export interface ZStackProps {
 	/**
@@ -66,14 +66,14 @@ function ZStack(
 		const key = isValidElement( child ) ? child.key : index;
 
 		return (
-			<ZStackChild
+			<ZStackChildView
 				isLayered={ isLayered }
 				offsetAmount={ offsetAmount }
 				zIndex={ zIndex }
 				key={ key }
 			>
 				{ child }
-			</ZStackChild>
+			</ZStackChildView>
 		);
 	} );
 

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -9,7 +9,7 @@ export const ZStackView = styled.div`
 	position: relative;
 `;
 
-export const ZStackChild = styled.div< {
+export const ZStackChildView = styled.div< {
 	isLayered: boolean;
 	offsetAmount: number;
 	zIndex: number;

--- a/packages/components/src/z-stack/styles.ts
+++ b/packages/components/src/z-stack/styles.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-// Disable reason: Temporarily disable for existing usages
-// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
-// eslint-disable-next-line no-restricted-imports
-import { css } from '@emotion/css';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const ZStackView = styled.div`
@@ -12,10 +9,26 @@ export const ZStackView = styled.div`
 	position: relative;
 `;
 
-export const positionAbsolute = css`
+export const ZStackChild = styled.div< {
+	isLayered: boolean;
+	offsetAmount: number;
+	zIndex: number;
+} >`
+	${ ( { isLayered, offsetAmount } ) =>
+		isLayered
+			? css( { marginLeft: offsetAmount } )
+			: css( { right: offsetAmount * -1 } ) }
+
+	${ ( { isLayered } ) =>
+		isLayered ? positionAbsolute : positionRelative }
+
+	${ ( { zIndex } ) => css( { zIndex } ) }
+`;
+
+const positionAbsolute = css`
 	position: absolute;
 `;
 
-export const positionRelative = css`
+const positionRelative = css`
 	position: relative;
 `;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css

## How has this been tested?
Storybook, everything all the props etc should all work as they worked before.

## Types of changes
Non breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
