### PR TITLE
components: Remove `@emotion/css` from Divider

### DIFF
--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -298,41 +298,44 @@ Object {
 }
 
 .emotion-15 {
-  border-color: rgba(0, 0, 0, 0.1);
-  border-width: 0 0 1px 0;
-  height: 0;
-  margin: 0;
-  width: auto;
   box-sizing: border-box;
   display: block;
   width: 100%;
   border-color: rgba(0, 0, 0, 0.1);
 }
 
-.emotion-19 {
+.emotion-16 {
+  border-color: rgba(0, 0, 0, 0.1);
+  border-width: 0 0 1px 0;
+  height: 0;
+  margin: 0;
+  width: auto;
+}
+
+.emotion-21 {
   box-sizing: border-box;
   overflow: hidden;
 }
 
-.emotion-19>img,
-.emotion-19>iframe {
+.emotion-21>img,
+.emotion-21>iframe {
   display: block;
   height: auto;
   max-width: 100%;
   width: 100%;
 }
 
-.emotion-19:first-of-type {
+.emotion-21:first-of-type {
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
 }
 
-.emotion-19:last-of-type {
+.emotion-21:last-of-type {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
 
-.emotion-22 {
+.emotion-24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -353,29 +356,29 @@ Object {
   padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-22>*+*:not(marquee) {
+.emotion-24>*+*:not(marquee) {
   margin-left: calc(4px * 2);
 }
 
-.emotion-22>* {
+.emotion-24>* {
   min-width: 0;
 }
 
-.emotion-22:first-child {
+.emotion-24:first-child {
   border-top: none;
 }
 
-.emotion-22:first-of-type {
+.emotion-24:first-of-type {
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
 }
 
-.emotion-22:last-of-type {
+.emotion-24:last-of-type {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
 
-.emotion-25 {
+.emotion-27 {
   background: transparent;
   display: block;
   margin: 0!important;
@@ -427,7 +430,7 @@ Object {
           </div>
           <hr
             aria-orientation="horizontal"
-            class="components-divider components-card__divider components-card-divider emotion-15"
+            class="components-divider components-card__divider components-card-divider emotion-15 emotion-16 emotion-17"
             data-wp-c16t="true"
             data-wp-component="CardDivider"
             role="separator"
@@ -440,7 +443,7 @@ Object {
             Card Body 3
           </div>
           <div
-            class="components-card__media components-card-media emotion-19 emotion-1 emotion-2"
+            class="components-card__media components-card-media emotion-21 emotion-1 emotion-2"
             data-wp-c16t="true"
             data-wp-component="CardMedia"
           >
@@ -450,7 +453,7 @@ Object {
             />
           </div>
           <div
-            class="components-flex components-card__footer components-card-footer emotion-22 emotion-1 emotion-2"
+            class="components-flex components-card__footer components-card-footer emotion-24 emotion-1 emotion-2"
             data-wp-c16t="true"
             data-wp-component="CardFooter"
           >
@@ -459,13 +462,13 @@ Object {
         </div>
         <div
           aria-hidden="true"
-          class="components-elevation emotion-25 emotion-1 emotion-2"
+          class="components-elevation emotion-27 emotion-1 emotion-2"
           data-wp-c16t="true"
           data-wp-component="Elevation"
         />
         <div
           aria-hidden="true"
-          class="components-elevation emotion-25 emotion-1 emotion-2"
+          class="components-elevation emotion-27 emotion-1 emotion-2"
           data-wp-c16t="true"
           data-wp-component="Elevation"
         />
@@ -576,41 +579,44 @@ Object {
 }
 
 .emotion-15 {
-  border-color: rgba(0, 0, 0, 0.1);
-  border-width: 0 0 1px 0;
-  height: 0;
-  margin: 0;
-  width: auto;
   box-sizing: border-box;
   display: block;
   width: 100%;
   border-color: rgba(0, 0, 0, 0.1);
 }
 
-.emotion-19 {
+.emotion-16 {
+  border-color: rgba(0, 0, 0, 0.1);
+  border-width: 0 0 1px 0;
+  height: 0;
+  margin: 0;
+  width: auto;
+}
+
+.emotion-21 {
   box-sizing: border-box;
   overflow: hidden;
 }
 
-.emotion-19>img,
-.emotion-19>iframe {
+.emotion-21>img,
+.emotion-21>iframe {
   display: block;
   height: auto;
   max-width: 100%;
   width: 100%;
 }
 
-.emotion-19:first-of-type {
+.emotion-21:first-of-type {
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
 }
 
-.emotion-19:last-of-type {
+.emotion-21:last-of-type {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
 
-.emotion-22 {
+.emotion-24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -631,29 +637,29 @@ Object {
   padding: calc(4px * 4) calc(4px * 6);
 }
 
-.emotion-22>*+*:not(marquee) {
+.emotion-24>*+*:not(marquee) {
   margin-left: calc(4px * 2);
 }
 
-.emotion-22>* {
+.emotion-24>* {
   min-width: 0;
 }
 
-.emotion-22:first-child {
+.emotion-24:first-child {
   border-top: none;
 }
 
-.emotion-22:first-of-type {
+.emotion-24:first-of-type {
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
 }
 
-.emotion-22:last-of-type {
+.emotion-24:last-of-type {
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
 
-.emotion-25 {
+.emotion-27 {
   background: transparent;
   display: block;
   margin: 0!important;
@@ -704,7 +710,7 @@ Object {
         </div>
         <hr
           aria-orientation="horizontal"
-          class="components-divider components-card__divider components-card-divider emotion-15"
+          class="components-divider components-card__divider components-card-divider emotion-15 emotion-16 emotion-17"
           data-wp-c16t="true"
           data-wp-component="CardDivider"
           role="separator"
@@ -717,7 +723,7 @@ Object {
           Card Body 3
         </div>
         <div
-          class="components-card__media components-card-media emotion-19 emotion-1 emotion-2"
+          class="components-card__media components-card-media emotion-21 emotion-1 emotion-2"
           data-wp-c16t="true"
           data-wp-component="CardMedia"
         >
@@ -727,7 +733,7 @@ Object {
           />
         </div>
         <div
-          class="components-flex components-card__footer components-card-footer emotion-22 emotion-1 emotion-2"
+          class="components-flex components-card__footer components-card-footer emotion-24 emotion-1 emotion-2"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -736,13 +742,13 @@ Object {
       </div>
       <div
         aria-hidden="true"
-        class="components-elevation emotion-25 emotion-1 emotion-2"
+        class="components-elevation emotion-27 emotion-1 emotion-2"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />
       <div
         aria-hidden="true"
-        class="components-elevation emotion-25 emotion-1 emotion-2"
+        class="components-elevation emotion-27 emotion-1 emotion-2"
         data-wp-c16t="true"
         data-wp-component="Elevation"
       />

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -3,8 +3,6 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import { Separator } from 'reakit';
-// eslint-disable-next-line no-restricted-imports, no-duplicate-imports
-import type { SeparatorProps } from 'reakit';
 // eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
@@ -14,23 +12,8 @@ import type { Ref } from 'react';
 import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
-import { StyledHorizontalRule } from './styles';
-import type { SpaceInput } from '../ui/utils/space';
-
-export interface DividerProps extends Omit< SeparatorProps, 'children' > {
-	/**
-	 * Adjusts all margins.
-	 */
-	margin?: SpaceInput;
-	/**
-	 * Adjusts top margins.
-	 */
-	marginTop?: SpaceInput;
-	/**
-	 * Adjusts bottom margins.
-	 */
-	marginBottom?: SpaceInput;
-}
+import { DividerView } from './styles';
+import type { DividerProps } from './types';
 
 function Divider(
 	props: PolymorphicComponentProps< DividerProps, 'hr', false >,
@@ -40,7 +23,7 @@ function Divider(
 
 	return (
 		<Separator
-			as={ StyledHorizontalRule }
+			as={ DividerView }
 			{ ...contextProps }
 			ref={ forwardedRef }
 		/>

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -1,10 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: Temporarily disable for existing usages
-// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
-// eslint-disable-next-line no-restricted-imports
-import { css, cx } from '@emotion/css';
 // eslint-disable-next-line no-restricted-imports
 import { Separator } from 'reakit';
 // eslint-disable-next-line no-restricted-imports, no-duplicate-imports
@@ -13,18 +9,12 @@ import type { SeparatorProps } from 'reakit';
 import type { Ref } from 'react';
 
 /**
- * WordPress dependencies
- */
-import { useMemo } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
-import * as styles from './styles';
-import { space } from '../ui/utils/space';
+import { StyledHorizontalRule } from './styles';
 
 export interface DividerProps extends Omit< SeparatorProps, 'children' > {
 	/**
@@ -45,50 +35,12 @@ function Divider(
 	props: PolymorphicComponentProps< DividerProps, 'hr', false >,
 	forwardedRef: Ref< any >
 ) {
-	const {
-		className,
-		margin,
-		marginBottom,
-		marginTop,
-		...otherProps
-	} = useContextSystem( props, 'Divider' );
-
-	const classes = useMemo( () => {
-		const sx: Record< string, string > = {};
-
-		if ( typeof margin !== 'undefined' ) {
-			sx.margin = css`
-				margin-bottom: ${ space( margin ) };
-				margin-top: ${ space( margin ) };
-			`;
-		} else {
-			if ( typeof marginTop !== 'undefined' ) {
-				sx.marginTop = css`
-					margin-top: ${ space( marginTop ) };
-				`;
-			}
-
-			if ( typeof marginBottom !== 'undefined' ) {
-				sx.marginBottom = css`
-					margin-bottom: ${ space( marginBottom ) };
-				`;
-			}
-		}
-
-		return cx(
-			styles.Divider,
-			sx.marginBottom,
-			sx.marginTop,
-			sx.margin,
-			className
-		);
-	}, [ className, margin, marginBottom, marginTop ] );
+	const contextProps = useContextSystem( props, 'Divider' );
 
 	return (
 		<Separator
-			as="hr"
-			{ ...otherProps }
-			className={ classes }
+			as={ StyledHorizontalRule }
+			{ ...contextProps }
 			ref={ forwardedRef }
 		/>
 	);

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -15,20 +15,21 @@ import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import { StyledHorizontalRule } from './styles';
+import type { SpaceInput } from '../ui/utils/space';
 
 export interface DividerProps extends Omit< SeparatorProps, 'children' > {
 	/**
 	 * Adjusts all margins.
 	 */
-	margin?: number;
+	margin?: SpaceInput;
 	/**
 	 * Adjusts top margins.
 	 */
-	marginTop?: number;
+	marginTop?: SpaceInput;
 	/**
 	 * Adjusts bottom margins.
 	 */
-	marginBottom?: number;
+	marginBottom?: SpaceInput;
 }
 
 function Divider(

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -13,10 +13,10 @@ import { contextConnect, useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import { DividerView } from './styles';
-import type { DividerProps } from './types';
+import type { Props } from './types';
 
 function Divider(
-	props: PolymorphicComponentProps< DividerProps, 'hr', false >,
+	props: PolymorphicComponentProps< Props, 'hr', false >,
 	forwardedRef: Ref< any >
 ) {
 	const contextProps = useContextSystem( props, 'Divider' );

--- a/packages/components/src/divider/index.ts
+++ b/packages/components/src/divider/index.ts
@@ -1,2 +1,2 @@
 export { default as Divider } from './component';
-export type { DividerProps } from './component';
+export type { DividerProps } from './types';

--- a/packages/components/src/divider/index.ts
+++ b/packages/components/src/divider/index.ts
@@ -1,2 +1,2 @@
 export { default as Divider } from './component';
-export type { DividerProps } from './types';
+export type { Props as DividerProps } from './types';

--- a/packages/components/src/divider/stories/index.js
+++ b/packages/components/src/divider/stories/index.js
@@ -13,12 +13,23 @@ export default {
 	title: 'Components (Experimental)/Divider',
 };
 
+const BlackDivider = ( props ) => (
+	<Divider { ...props } style={ { borderColor: 'black' } } />
+);
+
 export const _default = () => {
 	const props = {
-		margin: number( 'margin', undefined ),
-		marginTop: number( 'marginTop', undefined ),
-		marginBottom: number( 'marginBottom', undefined ),
+		margin: number( 'margin', 0 ),
 	};
 	// make the border color black to give higher contrast and help it appear in storybook better
-	return <Divider { ...props } style={ { borderColor: 'black' } } />;
+	return <BlackDivider { ...props } />;
+};
+
+export const splitMargins = () => {
+	const props = {
+		marginTop: number( 'marginTop', 0 ),
+		marginBottom: number( 'marginBottom', 0 ),
+	};
+
+	return <BlackDivider { ...props } />;
 };

--- a/packages/components/src/divider/stories/index.js
+++ b/packages/components/src/divider/stories/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { number } from '@storybook/addon-knobs';
+
+/**
  * Internal dependencies
  */
 import { Divider } from '..';
@@ -9,5 +14,11 @@ export default {
 };
 
 export const _default = () => {
-	return <Divider />;
+	const props = {
+		margin: number( 'margin', undefined ),
+		marginTop: number( 'marginTop', undefined ),
+		marginBottom: number( 'marginBottom', undefined ),
+	};
+	// make the border color black to give higher contrast and help it appear in storybook better
+	return <Divider { ...props } style={ { borderColor: 'black' } } />;
 };

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -1,20 +1,41 @@
 /**
  * External dependencies
  */
-// Disable reason: Temporarily disable for existing usages
-// until we remove them as part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css
-// eslint-disable-next-line no-restricted-imports
-import { css } from '@emotion/css';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 /**
  * Internal dependencies
  */
+import { space } from '../ui/utils/space';
 import CONFIG from '../utils/config-values';
 
-export const Divider = css`
+type Props = {
+	margin?: number;
+	marginTop?: number;
+	marginBottom?: number;
+};
+
+const renderMargin = ( { margin, marginTop, marginBottom }: Props ) => {
+	if ( typeof margin !== 'undefined' ) {
+		return css( {
+			marginBottom: space( margin ),
+			marginTop: space( margin ),
+		} );
+	}
+
+	return css( {
+		marginTop,
+		marginBottom,
+	} );
+};
+
+export const StyledHorizontalRule = styled.hr< Props >`
 	border-color: ${ CONFIG.colorDivider };
 	border-width: 0 0 1px 0;
 	height: 0;
 	margin: 0;
 	width: auto;
+
+	${ renderMargin }
 `;

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -12,7 +12,9 @@ import CONFIG from '../utils/config-values';
 import type { OwnProps } from './types';
 
 const renderMargin = ( { margin, marginTop, marginBottom }: OwnProps ) => {
-	if ( typeof margin !== 'undefined' ) {
+	// Disable reason: handle undefined and null in one go
+	// eslint-disable-next-line eqeqeq
+	if ( margin != null ) {
 		return css( {
 			marginBottom: space( margin ),
 			marginTop: space( margin ),

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -12,9 +12,7 @@ import CONFIG from '../utils/config-values';
 import type { OwnProps } from './types';
 
 const renderMargin = ( { margin, marginTop, marginBottom }: OwnProps ) => {
-	// Disable reason: handle undefined and null in one go
-	// eslint-disable-next-line eqeqeq
-	if ( margin != null ) {
+	if ( typeof margin !== 'undefined' ) {
 		return css( {
 			marginBottom: space( margin ),
 			marginTop: space( margin ),

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -7,16 +7,11 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import { space, SpaceInput } from '../ui/utils/space';
+import { space } from '../ui/utils/space';
 import CONFIG from '../utils/config-values';
+import type { OwnProps } from './types';
 
-type Props = {
-	margin?: SpaceInput;
-	marginTop?: SpaceInput;
-	marginBottom?: SpaceInput;
-};
-
-const renderMargin = ( { margin, marginTop, marginBottom }: Props ) => {
+const renderMargin = ( { margin, marginTop, marginBottom }: OwnProps ) => {
 	if ( typeof margin !== 'undefined' ) {
 		return css( {
 			marginBottom: space( margin ),
@@ -30,7 +25,7 @@ const renderMargin = ( { margin, marginTop, marginBottom }: Props ) => {
 	} );
 };
 
-export const StyledHorizontalRule = styled.hr< Props >`
+export const DividerView = styled.hr< OwnProps >`
 	border-color: ${ CONFIG.colorDivider };
 	border-width: 0 0 1px 0;
 	height: 0;

--- a/packages/components/src/divider/styles.ts
+++ b/packages/components/src/divider/styles.ts
@@ -7,13 +7,13 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import { space } from '../ui/utils/space';
+import { space, SpaceInput } from '../ui/utils/space';
 import CONFIG from '../utils/config-values';
 
 type Props = {
-	margin?: number;
-	marginTop?: number;
-	marginBottom?: number;
+	margin?: SpaceInput;
+	marginTop?: SpaceInput;
+	marginBottom?: SpaceInput;
 };
 
 const renderMargin = ( { margin, marginTop, marginBottom }: Props ) => {
@@ -25,8 +25,8 @@ const renderMargin = ( { margin, marginTop, marginBottom }: Props ) => {
 	}
 
 	return css( {
-		marginTop,
-		marginBottom,
+		marginTop: space( marginTop ),
+		marginBottom: space( marginBottom ),
 	} );
 };
 

--- a/packages/components/src/divider/test/__snapshots__/index.js.snap
+++ b/packages/components/src/divider/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`props should render correctly 1`] = `
 
 <hr
   aria-orientation="horizontal"
-  class="emotion-0 components-divider"
+  class="components-divider emotion-0 emotion-1"
   data-wp-c16t="true"
   data-wp-component="Divider"
   role="separator"

--- a/packages/components/src/divider/types.ts
+++ b/packages/components/src/divider/types.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { SeparatorProps } from 'reakit';
+
+/**
+ * Internal dependencies
+ */
+import type { SpaceInput } from '../ui/utils/space';
+
+export interface OwnProps {
+	/**
+	 * Adjusts all margins.
+	 */
+	margin?: SpaceInput;
+	/**
+	 * Adjusts top margins.
+	 */
+	marginTop?: SpaceInput;
+	/**
+	 * Adjusts bottom margins.
+	 */
+	marginBottom?: SpaceInput;
+}
+
+export interface DividerProps
+	extends Omit< SeparatorProps, 'children' >,
+		OwnProps {}

--- a/packages/components/src/divider/types.ts
+++ b/packages/components/src/divider/types.ts
@@ -24,6 +24,4 @@ export interface OwnProps {
 	marginBottom?: SpaceInput;
 }
 
-export interface DividerProps
-	extends Omit< SeparatorProps, 'children' >,
-		OwnProps {}
+export interface Props extends Omit< SeparatorProps, 'children' >, OwnProps {}

--- a/packages/components/src/flex/types.ts
+++ b/packages/components/src/flex/types.ts
@@ -8,6 +8,7 @@ import type { CSSProperties } from 'react';
  * Internal dependencies
  */
 import type { ResponsiveCSSValue } from '../ui/utils/types';
+import type { SpaceInput } from '../ui/utils/space';
 
 export type FlexDirection = ResponsiveCSSValue<
 	CSSProperties[ 'flexDirection' ]
@@ -39,7 +40,7 @@ export type FlexProps = {
 	 *
 	 * @default 2
 	 */
-	gap?: import('react').ReactText;
+	gap?: SpaceInput;
 	/**
 	 * Horizontally aligns content if the `direction` is `row`, or vertically aligns content if the `direction` is `column`.
 	 * In the example below, `flex-start` will align the children content to the left.

--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -12,7 +12,7 @@ import { css, cx } from '@emotion/css';
 import { useContextSystem } from '../ui/context';
 // eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
-import { space } from '../ui/utils/space';
+import { space, SpaceInput } from '../ui/utils/space';
 
 const isDefined = < T >( o: T ): o is Exclude< T, null | undefined > =>
 	typeof o !== 'undefined' && o !== null;
@@ -21,61 +21,61 @@ export interface SpacerProps {
 	/**
 	 * Adjusts all margins.
 	 */
-	margin?: number;
+	margin?: SpaceInput;
 	/**
 	 * Adjusts top and bottom margins.
 	 */
-	marginY?: number;
+	marginY?: SpaceInput;
 	/**
 	 * Adjusts left and right margins.
 	 */
-	marginX?: number;
+	marginX?: SpaceInput;
 	/**
 	 * Adjusts top margins.
 	 */
-	marginTop?: number;
+	marginTop?: SpaceInput;
 	/**
 	 * Adjusts bottom margins.
 	 *
 	 * @default 2
 	 */
-	marginBottom?: number;
+	marginBottom?: SpaceInput;
 	/**
 	 * Adjusts left margins.
 	 */
-	marginLeft?: number;
+	marginLeft?: SpaceInput;
 	/**
 	 * Adjusts right margins.
 	 */
-	marginRight?: number;
+	marginRight?: SpaceInput;
 	/**
 	 * Adjusts all padding.
 	 */
-	padding?: number;
+	padding?: SpaceInput;
 	/**
 	 * Adjusts top and bottom padding.
 	 */
-	paddingY?: number;
+	paddingY?: SpaceInput;
 	/**
 	 * Adjusts left and right padding.
 	 */
-	paddingX?: number;
+	paddingX?: SpaceInput;
 	/**
 	 * Adjusts top padding.
 	 */
-	paddingTop?: number;
+	paddingTop?: SpaceInput;
 	/**
 	 * Adjusts bottom padding.
 	 */
-	paddingBottom?: number;
+	paddingBottom?: SpaceInput;
 	/**
 	 * Adjusts left padding.
 	 */
-	paddingLeft?: number;
+	paddingLeft?: SpaceInput;
 	/**
 	 * Adjusts right padding.
 	 */
-	paddingRight?: number;
+	paddingRight?: SpaceInput;
 	/**
 	 * The children elements.
 	 */

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -1,16 +1,14 @@
 /**
- * External dependencies
+ * A real number or something parsable as a number
  */
-// eslint-disable-next-line no-restricted-imports
-import type { ReactText } from 'react';
-/**
- * Internal dependencies
- */
+export type SpaceInput = number | `${ number }`;
 
 const GRID_BASE = '4px';
 
-export function space( value: ReactText ): string {
-	return typeof value === 'number'
-		? `calc(${ GRID_BASE } * ${ value })`
-		: value;
+export function space( value?: SpaceInput ): string | undefined {
+	if ( typeof value === 'undefined' ) {
+		return undefined;
+	}
+
+	return `calc(${ GRID_BASE } * ${ value })`;
 }

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -28,7 +28,7 @@ export function space( value?: SpaceInput ): string | undefined {
 
 	const asInt = typeof value === 'number' ? value : Number( value );
 
-	// test if the input has a unit or was NaN, in which case just use that value
+	// test if the input has a unit, was NaN, or was one of the named CSS values (like `auto`), in which case just use that value
 	if (
 		CSS.supports?.( 'margin', value.toString() ) ||
 		Number.isNaN( asInt )

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -1,13 +1,19 @@
 /**
  * A real number or something parsable as a number
  */
-export type SpaceInput = number | `${ number }`;
+export type SpaceInput = number | string;
 
 const GRID_BASE = '4px';
 
 export function space( value?: SpaceInput ): string | undefined {
 	if ( typeof value === 'undefined' ) {
 		return undefined;
+	}
+
+	const asInt = typeof value === 'number' ? value : parseInt( value, 10 );
+
+	if ( Number.isNaN( asInt ) ) {
+		return value.toString();
 	}
 
 	return `calc(${ GRID_BASE } * ${ value })`;

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -10,7 +10,18 @@ export function space( value?: SpaceInput ): string | undefined {
 		return undefined;
 	}
 
-	const asInt = typeof value === 'number' ? value : Number( value );
+	// handle empty strings, if it's the number 0 this still works
+	if ( ! value ) {
+		return '0';
+	}
+
+	// test if the input has a unit, in which case just use that value
+	if ( CSS.supports( 'margin', value.toString() ) ) {
+		return value.toString();
+	}
+
+	// otherwise try to parse the value as a number if it's a string and then do the calculation
+	const asInt = typeof value === 'number' ? value : parseInt( value, 10 );
 
 	if ( Number.isNaN( asInt ) ) {
 		return value.toString();

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -16,12 +16,15 @@ export function space( value?: SpaceInput ): string | undefined {
 	}
 
 	// test if the input has a unit, in which case just use that value
-	if ( CSS.supports( 'margin', value.toString() ) ) {
+	if (
+		typeof CSS.supports === 'function' &&
+		CSS.supports( 'margin', value.toString() )
+	) {
 		return value.toString();
 	}
 
 	// otherwise try to parse the value as a number if it's a string and then do the calculation
-	const asInt = typeof value === 'number' ? value : parseInt( value, 10 );
+	const asInt = typeof value === 'number' ? value : Number( value );
 
 	if ( Number.isNaN( asInt ) ) {
 		return value.toString();

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -10,7 +10,7 @@ export function space( value?: SpaceInput ): string | undefined {
 		return undefined;
 	}
 
-	const asInt = typeof value === 'number' ? value : parseInt( value, 10 );
+	const asInt = typeof value === 'number' ? value : Number( value );
 
 	if ( Number.isNaN( asInt ) ) {
 		return value.toString();

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -11,7 +11,8 @@ const GRID_BASE = '4px';
  * When given a number or a numeric string, it will return the grid-based
  * value as a factor of GRID_BASE, defined above.
  *
- * When given a unit value, it will simply return the unit value back.
+ * When given a unit value or one of the named CSS values like `auto`,
+ * it will simply return the value back.
  *
  * @param  value A number, numeric string, or a unit value.
  */
@@ -25,18 +26,13 @@ export function space( value?: SpaceInput ): string | undefined {
 		return '0';
 	}
 
-	// test if the input has a unit, in which case just use that value
-	if (
-		typeof CSS.supports === 'function' &&
-		CSS.supports( 'margin', value.toString() )
-	) {
-		return value.toString();
-	}
-
-	// otherwise try to parse the value as a number if it's a string and then do the calculation
 	const asInt = typeof value === 'number' ? value : Number( value );
 
-	if ( Number.isNaN( asInt ) ) {
+	// test if the input has a unit or was NaN, in which case just use that value
+	if (
+		CSS.supports?.( 'margin', value.toString() ) ||
+		Number.isNaN( asInt )
+	) {
 		return value.toString();
 	}
 

--- a/packages/components/src/ui/utils/space.ts
+++ b/packages/components/src/ui/utils/space.ts
@@ -5,6 +5,16 @@ export type SpaceInput = number | string;
 
 const GRID_BASE = '4px';
 
+/**
+ * A function that handles numbers, numeric strings, and unit values.
+ *
+ * When given a number or a numeric string, it will return the grid-based
+ * value as a factor of GRID_BASE, defined above.
+ *
+ * When given a unit value, it will simply return the unit value back.
+ *
+ * @param  value A number, numeric string, or a unit value.
+ */
 export function space( value?: SpaceInput ): string | undefined {
 	if ( typeof value === 'undefined' ) {
 		return undefined;

--- a/packages/components/src/ui/utils/test/space.js
+++ b/packages/components/src/ui/utils/test/space.js
@@ -11,6 +11,7 @@ describe( 'space', () => {
 		${ '-1px' }      | ${ '-1px' }
 		${ '1em' }       | ${ '1em' }
 		${ '1notaunit' } | ${ '1notaunit' }
+		${ 'auto' }      | ${ 'auto' }
 	`( 'should return $output when given $input', ( { input, output } ) => {
 		expect( space( input ) ).toEqual( output );
 	} );

--- a/packages/components/src/ui/utils/test/space.js
+++ b/packages/components/src/ui/utils/test/space.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { space } from '../space';
+
+describe( 'space', () => {
+	it.each`
+		input            | output
+		${ 1 }           | ${ 'calc(4px * 1)' }
+		${ '1' }         | ${ 'calc(4px * 1)' }
+		${ '-1px' }      | ${ '-1px' }
+		${ '1em' }       | ${ '1em' }
+		${ '1notaunit' } | ${ '1notaunit' }
+	`( 'should return $output when given $input', ( { input, output } ) => {
+		expect( space( input ) ).toEqual( output );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Part of https://github.com/WordPress/gutenberg/issues/30503#deprecating-emotion-css

I also updated the story so that it's easier to test.

## How has this been tested?
Storybook, everything all the props etc should all work as they worked before (aside from the additional storybook knobs)

## Types of changes
Non breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
