### PR TITLE
Remove "is-dark-theme" rules from mixins.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -266,21 +266,6 @@
 	&:-ms-input-placeholder {
 		color: $dark-gray-placeholder;
 	}
-
-	.is-dark-theme & {
-		&::-webkit-input-placeholder {
-			color: $light-gray-placeholder;
-		}
-
-		&::-moz-placeholder {
-			opacity: 1; // Necessary because Firefox reduces this from 1.
-			color: $light-gray-placeholder;
-		}
-
-		&:-ms-input-placeholder {
-			color: $light-gray-placeholder;
-		}
-	}
 }
 
 @mixin checkbox-control {


### PR DESCRIPTION
## Description

Fixes https://core.trac.wordpress.org/ticket/53525.

If you choose a dark background in a theme (you can customize twentytwentyone to have a black backgrond and white text), the block editor will detect the theme to be "dark", and apply an `is-dark-theme` class to the body. 

That class is meant only for block UI inside, such as white focus styles on dark backgrounds instead of dark blue focus styles. In this case it was also applied to form controls like text inputs, colorizing the placeholder. This was almost certainly just a copy/paste error, since we _do_ need the placeholder colors customized for text inputs in the canvas:

<img width="646" alt="Screenshot 2021-06-29 at 09 03 54" src="https://user-images.githubusercontent.com/1204802/123752314-f4593080-d8b8-11eb-9c12-0dd2b2fc2efb.png">

The problem was this affected inputs elsewhere, like search:

<img width="1270" alt="Screenshot 2021-06-29 at 08 57 23" src="https://user-images.githubusercontent.com/1204802/123752343-fb803e80-d8b8-11eb-91c7-3516970f857a.png">

☝️ Notice how there is white text that says "Search" in the inserter. 

This PR fixes it:

<img width="1270" alt="Screenshot 2021-06-29 at 09 00 45" src="https://user-images.githubusercontent.com/1204802/123752415-0c30b480-d8b9-11eb-8bcb-0bac2c425229.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
