### PR TITLE
Add a label for screen reader in categories block

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -28,7 +28,7 @@ function render_block_core_categories( $attributes ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
 		$args['show_option_none'] = __( 'Select Category' );
-		$wrapper_markup           = '<div %1$s>%2$s</div>';
+		$wrapper_markup           = '<div %1$s><label class="screen-reader-text" for="' . $id . '">' . __( 'Categories' ) . '</label>%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );
 		$type                     = 'dropdown';
 


### PR DESCRIPTION
## Description
Add a label for screen reader when rendering a category block in dropdown mode.
Fixes this issue https://core.trac.wordpress.org/ticket/53510

## How has this been tested?
Tested in WP5.7.2 with Gutenberg 10.9.
Environment :
- Mac OS 11.3.1
- PHP 7.4.12
I tested manually and it seems to work fine.
I ran the tests suite locally but I experienced some trouble both with the trunk branch and my new one, but the errors doesn't seems related to this fix.

## Types of changes
Changes have been made in `package/block-library/src/categories/index.php` modifying the dropdown attributes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] I've tested my changes with keyboard and screen readers.