### PR TITLE
Improve high contrast mode rendering of icon buttons.

### DIFF
--- a/packages/block-editor/src/components/block-icon/style.scss
+++ b/packages/block-editor/src/components/block-icon/style.scss
@@ -8,6 +8,12 @@
 	&.has-colors {
 		svg {
 			fill: currentColor;
+
+			// Optimizate for high contrast modes.
+			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
+			@media (forced-colors: active) {
+				fill: CanvasText;
+			}
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -332,6 +332,12 @@
 	svg {
 		fill: currentColor;
 		outline: none;
+
+		// Optimizate for high contrast modes.
+		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
+		@media (forced-colors: active) {
+			fill: CanvasText;
+		}
 	}
 
 	// Fixes a Safari+VoiceOver bug, where the screen reader text is announced not respecting the source order.

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -49,8 +49,13 @@
 	> svg,
 	.dashicon,
 	.block-editor-block-icon {
-		fill: currentColor;
 		margin-right: 1ch;
+		fill: currentColor;
+		// Optimizate for high contrast modes.
+		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
+		@media (forced-colors: active) {
+			fill: CanvasText;
+		}
 	}
 
 	// Don't take up space if the label is empty.


### PR DESCRIPTION
## Description

Followup to #33022. Windows has, for a while, had a "high contrast mode", which drastically increases contrast of the operating system and webpages. This has included replacing background images and colors with a canvas color, replacing any and all text colors with a yellow text color, links with white, doing the same for borders and outlines. Notably, box-shadows are removed entirely, whereas even transparent outlines are made opaque, which we have leveraged across focus styles to ensure highly legible focus styles for high contrast modes. 

It appears that as Microsoft has moved from Trident-based Edge to Chromium-based Edge, the particular rendering heuristic has also changed how it renders SVGs, essentially classifying them as decorative and therefore not changing the colors:

![icon colors before](https://user-images.githubusercontent.com/1204802/123774693-f4176000-d8cd-11eb-9aa2-79c4c845c9e3.png)

The good news is, [there are new tools and HTML standardized mechanisms for handling high contrast mode(s)](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/), which makes it easy to address:

![icon colors after](https://user-images.githubusercontent.com/1204802/123774783-0d201100-d8ce-11eb-8f27-8a041576b912.png)

In the case of this PR, I've simply applied `CanvasText` color to any SVG we use for icon buttons.

## How has this been tested?

If you're a Windows user:

- Upgrade to Chromium based Edge
- Search for "High Contrast" in the start menu, and turn it on
- Observe that icon buttons are visible (yellow on black) in the block editor

If you're not a Windows user, this one is a bit trickier. One way to do it is this:

- Download [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
- Download [a Windows 10 + Edge virtual machine for Virtualbox](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
- Start VirtualBox and import the VM — the OS password is `Passw0rd!`, because of course it is.
- Install Chromium based Edge in your VM.
- Search for "High Contrast" in the start menu, and turn it on
- Open http://gutenberg.run and test this PR.
- Observe that icon buttons are visible (yellow on black) in the block editor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
