### PR TITLE
Global Styles: Try a simple navigation

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-v2/index.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/index.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalNavigation as Navigation } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { GLOBAL_STYLES_VIEWS, VIEW_ROOT } from './navigation/constants';
+import GlobalStylesNavigation from './navigation';
+import GlobalStylesCurrentView from './navigation/view';
+
+export default function GlobalStylesV2() {
+	return (
+		<GlobalStylesNavigation>
+			<GlobalStylesView />
+		</GlobalStylesNavigation>
+	);
+}
+
+function GlobalStylesView() {
+	return (
+		<Navigation data={ GLOBAL_STYLES_VIEWS } initial={ VIEW_ROOT }>
+			<GlobalStylesCurrentView />
+		</Navigation>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/constants.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/constants.js
@@ -1,0 +1,15 @@
+export const VIEW_ROOT = 'root';
+export const VIEW_COLORS = 'colors';
+export const VIEW_COLORS_PALETTE = 'colors-palette';
+export const VIEW_COLORS_ELEMENT = 'colors-element';
+export const VIEW_TYPOGRAPHY = 'typography';
+export const VIEW_TYPOGRAPHY_ELEMENT = 'typography-element';
+
+export const GLOBAL_STYLES_VIEWS = [
+	{ title: 'Global Styles', slug: VIEW_ROOT },
+	{ title: 'Colors', slug: VIEW_COLORS },
+	{ title: 'Colors Palette', slug: VIEW_COLORS_PALETTE },
+	{ title: 'Colors Element', slug: VIEW_COLORS_ELEMENT },
+	{ title: 'Typography', slug: VIEW_TYPOGRAPHY },
+	{ title: 'Typography Element', slug: VIEW_TYPOGRAPHY_ELEMENT },
+];

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/context.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/context.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_ROOT } from './constants';
+
+export const GlobalStylesNavigationContext = createContext( {
+	currentView: VIEW_ROOT,
+	setCurrentView: () => {},
+} );
+
+export const useGlobalStylesNavigationContext = () =>
+	useContext( GlobalStylesNavigationContext );

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/index.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_ROOT } from './constants';
+import { GlobalStylesNavigationContext } from './context';
+
+export default function GlobalStylesNavigation( { children } ) {
+	const [ currentView, setCurrentView ] = useState( VIEW_ROOT );
+
+	return (
+		<GlobalStylesNavigationContext.Provider
+			value={ { currentView, setCurrentView } }
+		>
+			{ children }
+		</GlobalStylesNavigationContext.Provider>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/view.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/navigation/view.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import {
+	VIEW_COLORS,
+	VIEW_COLORS_ELEMENT,
+	VIEW_COLORS_PALETTE,
+	VIEW_ROOT,
+	VIEW_TYPOGRAPHY,
+	VIEW_TYPOGRAPHY_ELEMENT,
+} from './constants';
+import { useGlobalStylesNavigationContext } from './context';
+import GlobalStylesViewColors from '../views/colors';
+import GlobalStylesViewColorsElement from '../views/colors-element';
+import GlobalStylesViewColorsPalette from '../views/colors-palette';
+import GlobalStylesViewRoot from '../views/root';
+import GlobalStylesViewTypography from '../views/typography';
+import GlobalStylesViewTypographyElement from '../views/typography-element';
+
+const allViews = {
+	[ VIEW_ROOT ]: GlobalStylesViewRoot,
+	[ VIEW_COLORS ]: GlobalStylesViewColors,
+	[ VIEW_COLORS_ELEMENT ]: GlobalStylesViewColorsElement,
+	[ VIEW_COLORS_PALETTE ]: GlobalStylesViewColorsPalette,
+	[ VIEW_TYPOGRAPHY ]: GlobalStylesViewTypography,
+	[ VIEW_TYPOGRAPHY_ELEMENT ]: GlobalStylesViewTypographyElement,
+};
+
+export default function GlobalStylesCurrentView() {
+	const { currentView } = useGlobalStylesNavigationContext();
+	const CurrentView = allViews[ currentView ] ?? null;
+
+	return (
+		<div style={ { padding: '20px 0' } }>
+			<CurrentView />
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/stories/index.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/stories/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import GlobalStylesV2 from '../';
+
+export default { title: 'Edit Site (Experimental) /Global Styles v2' };
+
+export const _default = () => {
+	return <GlobalStylesV2 />;
+};

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors-element.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors-element.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewColorsElement() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToColors = () => setCurrentView( 'colors' );
+	const navigateToColorsPalette = () => setCurrentView( 'colors-palette' );
+
+	return (
+		<>
+			<h3>Colors Element view</h3>
+			<button onClick={ navigateToColors }>
+				&lt; Back to Colors view
+			</button>
+			<button onClick={ navigateToColorsPalette }>
+				Go to Colors Palette view &gt;
+			</button>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors-palette.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors-palette.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewColorsPalette() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToColorsElement = () => setCurrentView( 'colors-element' );
+
+	return (
+		<>
+			<h3>Colors Palette view</h3>
+			<button onClick={ navigateToColorsElement }>
+				&lt; Back to Colors Element view
+			</button>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/colors.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewColors() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToColorsElement = () => setCurrentView( 'colors-element' );
+	const navigateToRoot = () => setCurrentView( 'root' );
+
+	return (
+		<>
+			<h3>Colors view</h3>
+			<button onClick={ navigateToRoot }>&lt; Back to Root view</button>
+			<button onClick={ navigateToColorsElement }>
+				Go to Colors Element view &gt;
+			</button>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/root.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/root.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewRoot() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToColors = () => setCurrentView( 'colors' );
+	const navigateToTypography = () => setCurrentView( 'typography' );
+
+	return (
+		<>
+			<h3>Root (main) view</h3>
+			<button onClick={ navigateToColors }>Go to Colors view &gt;</button>
+			<button onClick={ navigateToTypography }>
+				Go to Typography view &gt;
+			</button>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/typography-element.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/typography-element.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewTypographyElement() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToTypography = () => setCurrentView( 'typography' );
+
+	return (
+		<>
+			<h3>Typography Element view</h3>
+			<button onClick={ navigateToTypography }>
+				&lt; Back to Typography view
+			</button>
+		</>
+	);
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-v2/views/typography.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-v2/views/typography.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesNavigationContext } from '../navigation/context';
+
+export default function GlobalStylesViewTypography() {
+	const { setCurrentView } = useGlobalStylesNavigationContext();
+
+	const navigateToTypographyElement = () =>
+		setCurrentView( 'typography-element' );
+	const navigateToRoot = () => setCurrentView( 'root' );
+
+	return (
+		<>
+			<h3>Typography view</h3>
+			<button onClick={ navigateToRoot }>&lt; Back to Root view</button>
+			<button onClick={ navigateToTypographyElement }>
+				Go to Typography Element view &gt;
+			</button>
+		</>
+	);
+}

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -8,6 +8,7 @@ const stories = [
 	'../packages/block-editor/src/**/stories/*.js',
 	'../packages/components/src/**/stories/*.js',
 	'../packages/icons/src/**/stories/*.js',
+	'../packages/edit-site/src/**/stories/*.js',
 ].filter( Boolean );
 
 const customEnvVariables = {};


### PR DESCRIPTION
## Description

One of the bigger blockers for moving #32923 forward (moving global styles v2 from g2 to Gutenberg) is the navigation/router logic. There's a lot to discuss there when it comes to how functional and "routery" we want it to be, whether we need advanced routing (with react router or so), URL persistence, history management, a dedicated data store, animations, transitions, etc. However, to me, none of that is a blocker for the initial implementation and all of those could be incrementally added to the project. 

So what we really need to move the project forward is a simple navigation system that's responsible for holding all the views (I'm adopting that term [as per this discussion](https://github.com/WordPress/gutenberg/pull/32923#discussion_r657084553)), maintaining and presenting the current view and allowing navigation between all the views. That's all we need in order to make progress for now, and all the rest could be considered a feature and/or eye candy. If we land this, it will help unblock much of #32923 and allow us to actually get much closer to a working prototype.

So this PR sets the stage with a very simple navigation system that's based on the existing `Navigation` component base and uses the Context API. We're introducing the views that are introduced in #32923 as simple empty placeholder components with some navigational items inside them, which we're currently using just for demonstration. Since that's not imported anywhere, we can use that stage and further build the Global Styles v2 prototype on top of it.

## How has this been tested?
This is manually testable through a new Storybook story:

* Checkout this branch
* Run `npm run storybook:dev`
* Navigate to the "Edit Site (experimental)" > "Global Styles v2" > "Default" story.
* Play with the navigation buttons and verify you can navigate as expected.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
