### PR TITLE
RNMobile: Fix broken doc link

### DIFF
--- a/packages/react-native-editor/README.md
+++ b/packages/react-native-editor/README.md
@@ -4,7 +4,7 @@ This package provides a demo application to simplify the environment setup requi
 
 ## Getting Started
 
-Please review [Getting Started for the React Native based Mobile Gutenberg](/docs/contributors/getting-started-native-mobile.md) to learn how to set up and run this demo application.
+Please review [Getting Started for the React Native based Mobile Gutenberg](/docs/contributors/code/getting-started-native-mobile.md) to learn how to set up and run this demo application.
 
 ## License
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This change just updates the link to the React Native Editor docs

## How has this been tested?

Make sure link now works.

## Types of changes

Update documentation.

## Checklist:

No checklist items are applicable to this PR.