### PR TITLE
Fix flaky widgets-related E2E tests

### DIFF
--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -38,6 +38,7 @@ function marquee_greeting_init() {
 					Greeting:
 					<input
 						class="widefat"
+						data-testid="marquee-greeting"
 						name="marquee-greeting"
 						type="text"
 						value="<?php echo esc_attr( $greeting ); ?>"

--- a/packages/e2e-tests/plugins/marquee-function-widget.php
+++ b/packages/e2e-tests/plugins/marquee-function-widget.php
@@ -34,15 +34,16 @@ function marquee_greeting_init() {
 			$greeting = get_option( 'marquee_greeting' );
 			?>
 			<p>
-				<label for="marquee-greeting">Greeting:</label>
-				<input
-					id="marquee-greeting"
-					class="widefat"
-					name="marquee-greeting"
-					type="text"
-					value="<?php echo esc_attr( $greeting ); ?>"
-					placeholder="Hello!"
-				/>
+				<label>
+					Greeting:
+					<input
+						class="widefat"
+						name="marquee-greeting"
+						type="text"
+						value="<?php echo esc_attr( $greeting ); ?>"
+						placeholder="Hello!"
+					/>
+				</label>
 			</p>
 			<?php
 		}

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -454,7 +454,7 @@ describe( 'Widgets screen', () => {
 			let editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-			  "sidebar-1": "<marquee>Hello!</marquee>",
+			  "sidebar-1": "<marquee>Howdy!</marquee>",
 			}
 		` );
 
@@ -463,7 +463,7 @@ describe( 'Widgets screen', () => {
 			editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-			  "sidebar-1": "<marquee>Hello!</marquee>",
+			  "sidebar-1": "<marquee>Howdy!</marquee>",
 			}
 		` );
 
@@ -492,7 +492,7 @@ describe( 'Widgets screen', () => {
 			editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-			  "sidebar-1": "<marquee>Hello!</marquee>",
+			  "sidebar-1": "<marquee>howdy!</marquee>",
 			}
 		` );
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -246,153 +246,153 @@ describe( 'Widgets screen', () => {
 	` );
 	} );
 
-	// it( 'Should insert content using the inline inserter', async () => {
-	// 	const [ firstWidgetArea ] = await findAll( {
-	// 		role: 'group',
-	// 		name: 'Block: Widget Area',
-	// 	} );
-	//
-	// 	// Scroll to the end of the first widget area.
-	// 	await firstWidgetArea.evaluate( ( node ) =>
-	// 		node.scrollIntoView( { block: 'end' } )
-	// 	);
-	//
-	// 	const firstWidgetAreaBoundingBox = await firstWidgetArea.boundingBox();
-	//
-	// 	// Click near the end of the widget area to select it.
-	// 	await page.mouse.click(
-	// 		firstWidgetAreaBoundingBox.x + firstWidgetAreaBoundingBox.width / 2,
-	// 		firstWidgetAreaBoundingBox.y +
-	// 			firstWidgetAreaBoundingBox.height -
-	// 			10
-	// 	);
-	//
-	// 	let inlineInserterButton = await find( {
-	// 		role: 'combobox',
-	// 		name: 'Add block',
-	// 	} );
-	// 	await inlineInserterButton.click();
-	//
-	// 	let inlineQuickInserter = await find( {
-	// 		role: 'listbox',
-	// 		name: 'Blocks',
-	// 	} );
-	//
-	// 	const paragraphBlock = await find(
-	// 		{
-	// 			role: 'option',
-	// 			name: 'Paragraph',
-	// 		},
-	// 		{
-	// 			root: inlineQuickInserter,
-	// 		}
-	// 	);
-	// 	await paragraphBlock.click();
-	//
-	// 	const firstParagraphBlock = await find(
-	// 		{
-	// 			name: /^Empty block/,
-	// 			selector: '[data-block][data-type="core/paragraph"]',
-	// 		},
-	// 		{
-	// 			root: firstWidgetArea,
-	// 		}
-	// 	);
-	//
-	// 	await firstParagraphBlock.focus();
-	// 	await page.keyboard.type( 'First Paragraph' );
-	//
-	// 	await page.keyboard.press( 'Enter' );
-	// 	await page.keyboard.type( 'Second Paragraph' );
-	//
-	// 	const secondParagraphBlock = await page.evaluateHandle(
-	// 		() => document.activeElement
-	// 	);
-	// 	await expect( secondParagraphBlock ).not.toBeElement(
-	// 		firstParagraphBlock
-	// 	);
-	//
-	// 	const secondParagraphBlockBoundingBox = await secondParagraphBlock.boundingBox();
-	//
-	// 	// Click outside the block to move the focus back to the widget area.
-	// 	await page.mouse.click(
-	// 		secondParagraphBlockBoundingBox.x +
-	// 			firstWidgetAreaBoundingBox.width / 2,
-	// 		secondParagraphBlockBoundingBox.y +
-	// 			secondParagraphBlockBoundingBox.height +
-	// 			10
-	// 	);
-	//
-	// 	// Hover above the last block to trigger the inline inserter between blocks.
-	// 	await page.mouse.move(
-	// 		secondParagraphBlockBoundingBox.x +
-	// 			secondParagraphBlockBoundingBox.width / 2,
-	// 		secondParagraphBlockBoundingBox.y - 10
-	// 	);
-	//
-	// 	// There will be 2 matches here.
-	// 	// One is the in-between inserter,
-	// 	// and the other one is the button block appender.
-	// 	[ inlineInserterButton ] = await findAll( {
-	// 		role: 'combobox',
-	// 		name: 'Add block',
-	// 	} );
-	// 	await inlineInserterButton.click();
-	//
-	// 	// TODO: Convert to find() API from puppeteer-testing-library.
-	// 	const inserterSearchBox = await page.waitForSelector(
-	// 		'aria/Search for blocks and patterns[role="searchbox"]'
-	// 	);
-	// 	await expect( inserterSearchBox ).toHaveFocus();
-	//
-	// 	await page.keyboard.type( 'Heading' );
-	//
-	// 	inlineQuickInserter = await find( {
-	// 		role: 'listbox',
-	// 		name: 'Blocks',
-	// 	} );
-	// 	const headingBlockOption = await find(
-	// 		{
-	// 			role: 'option',
-	// 			name: 'Heading',
-	// 		},
-	// 		{
-	// 			root: inlineQuickInserter,
-	// 		}
-	// 	);
-	// 	await headingBlockOption.click();
-	//
-	// 	// Get the added heading block as second last block.
-	// 	const addedHeadingBlock = await secondParagraphBlock.evaluateHandle(
-	// 		( node ) => node.previousSibling
-	// 	);
-	//
-	// 	await expect( addedHeadingBlock ).toHaveFocus();
-	//
-	// 	await page.keyboard.type( 'My Heading' );
-	//
-	// 	await expect( addedHeadingBlock ).toMatchQuery( {
-	// 		name: 'Block: Heading',
-	// 		level: 2,
-	// 		value: 'My Heading',
-	// 	} );
-	//
-	// 	await saveWidgets();
-	// 	const serializedWidgetAreas = await getSerializedWidgetAreas();
-	// 	expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
-	// 	Object {
-	// 	  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
-	// 	<p>First Paragraph</p>
-	// 	</div></div>
-	// 	<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
-	// 	<h2>My Heading</h2>
-	// 	</div></div>
-	// 	<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
-	// 	<p>Second Paragraph</p>
-	// 	</div></div>",
-	// 	}
-	// ` );
-	// } );
+	it( 'Should insert content using the inline inserter', async () => {
+		const [ firstWidgetArea ] = await findAll( {
+			role: 'group',
+			name: 'Block: Widget Area',
+		} );
+
+		// Scroll to the end of the first widget area.
+		await firstWidgetArea.evaluate( ( node ) =>
+			node.scrollIntoView( { block: 'end' } )
+		);
+
+		const firstWidgetAreaBoundingBox = await firstWidgetArea.boundingBox();
+
+		// Click near the end of the widget area to select it.
+		await page.mouse.click(
+			firstWidgetAreaBoundingBox.x + firstWidgetAreaBoundingBox.width / 2,
+			firstWidgetAreaBoundingBox.y +
+				firstWidgetAreaBoundingBox.height -
+				10
+		);
+
+		let inlineInserterButton = await find( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
+		await inlineInserterButton.click();
+
+		let inlineQuickInserter = await find( {
+			role: 'listbox',
+			name: 'Blocks',
+		} );
+
+		const paragraphBlock = await find(
+			{
+				role: 'option',
+				name: 'Paragraph',
+			},
+			{
+				root: inlineQuickInserter,
+			}
+		);
+		await paragraphBlock.click();
+
+		const firstParagraphBlock = await find(
+			{
+				name: /^Empty block/,
+				selector: '[data-block][data-type="core/paragraph"]',
+			},
+			{
+				root: firstWidgetArea,
+			}
+		);
+
+		await firstParagraphBlock.focus();
+		await page.keyboard.type( 'First Paragraph' );
+
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second Paragraph' );
+
+		const secondParagraphBlock = await page.evaluateHandle(
+			() => document.activeElement
+		);
+		await expect( secondParagraphBlock ).not.toBeElement(
+			firstParagraphBlock
+		);
+
+		const secondParagraphBlockBoundingBox = await secondParagraphBlock.boundingBox();
+
+		// Click outside the block to move the focus back to the widget area.
+		await page.mouse.click(
+			secondParagraphBlockBoundingBox.x +
+				firstWidgetAreaBoundingBox.width / 2,
+			secondParagraphBlockBoundingBox.y +
+				secondParagraphBlockBoundingBox.height +
+				10
+		);
+
+		// Hover above the last block to trigger the inline inserter between blocks.
+		await page.mouse.move(
+			secondParagraphBlockBoundingBox.x +
+				secondParagraphBlockBoundingBox.width / 2,
+			secondParagraphBlockBoundingBox.y - 10
+		);
+
+		// There will be 2 matches here.
+		// One is the in-between inserter,
+		// and the other one is the button block appender.
+		[ inlineInserterButton ] = await findAll( {
+			role: 'combobox',
+			name: 'Add block',
+		} );
+		await inlineInserterButton.click();
+
+		// TODO: Convert to find() API from puppeteer-testing-library.
+		const inserterSearchBox = await page.waitForSelector(
+			'aria/Search for blocks and patterns[role="searchbox"]'
+		);
+		await expect( inserterSearchBox ).toHaveFocus();
+
+		await page.keyboard.type( 'Heading' );
+
+		inlineQuickInserter = await find( {
+			role: 'listbox',
+			name: 'Blocks',
+		} );
+		const headingBlockOption = await find(
+			{
+				role: 'option',
+				name: 'Heading',
+			},
+			{
+				root: inlineQuickInserter,
+			}
+		);
+		await headingBlockOption.click();
+
+		// Get the added heading block as second last block.
+		const addedHeadingBlock = await secondParagraphBlock.evaluateHandle(
+			( node ) => node.previousSibling
+		);
+
+		await expect( addedHeadingBlock ).toHaveFocus();
+
+		await page.keyboard.type( 'My Heading' );
+
+		await expect( addedHeadingBlock ).toMatchQuery( {
+			name: 'Block: Heading',
+			level: 2,
+			value: 'My Heading',
+		} );
+
+		await saveWidgets();
+		const serializedWidgetAreas = await getSerializedWidgetAreas();
+		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
+		Object {
+		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
+		<p>First Paragraph</p>
+		</div></div>
+		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<h2>My Heading</h2>
+		</div></div>
+		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
+		<p>Second Paragraph</p>
+		</div></div>",
+		}
+	` );
+	} );
 
 	async function addMarquee() {
 		// There will be 2 matches here.
@@ -425,16 +425,6 @@ describe( 'Widgets screen', () => {
 			}
 		);
 		await marqueeBlockOption.click();
-
-		// It takes a moment to load the form, let's wait for it.
-		await waitFor( async () => {
-			const marquees = await findAll( {
-				selector: '[id=marquee-greeting]',
-			} );
-			if ( marquees.length === 1 ) {
-				throw new Error();
-			}
-		} );
 	}
 
 	it( 'Should add and save the marquee widget', async () => {
@@ -473,6 +463,16 @@ describe( 'Widgets screen', () => {
 
 		// Add another marquee, it shouldn't be saved
 		await addMarquee();
+
+		// It takes a moment to load the form, let's wait for it.
+		await waitFor( async () => {
+			const marquees = await findAll( {
+				selector: '[id=marquee-greeting]',
+			} );
+			if ( marquees.length === 1 ) {
+				throw new Error();
+			}
+		} );
 
 		const marquees = await findAll( {
 			selector: '[id=marquee-greeting]',
@@ -908,9 +908,7 @@ async function getSerializedWidgetAreas() {
 	);
 
 	const serializedWidgetAreas = pickBy(
-		mapValues(
-			groupBy( widgets, 'sidebar' ),
-			( sidebarWidgets ) =>
+		mapValues( groupBy( widgets, 'sidebar' ), ( sidebarWidgets ) =>
 			sidebarWidgets
 				.map( ( widget ) => widget.rendered )
 				.filter( Boolean )

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -17,7 +17,7 @@ import {
  */
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll, waitFor } from 'puppeteer-testing-library';
-import { groupBy, mapValues } from 'lodash';
+import { groupBy, mapValues, pickBy } from 'lodash';
 
 describe( 'Widgets screen', () => {
 	beforeEach( async () => {
@@ -246,153 +246,153 @@ describe( 'Widgets screen', () => {
 	` );
 	} );
 
-	it( 'Should insert content using the inline inserter', async () => {
-		const [ firstWidgetArea ] = await findAll( {
-			role: 'group',
-			name: 'Block: Widget Area',
-		} );
-
-		// Scroll to the end of the first widget area.
-		await firstWidgetArea.evaluate( ( node ) =>
-			node.scrollIntoView( { block: 'end' } )
-		);
-
-		const firstWidgetAreaBoundingBox = await firstWidgetArea.boundingBox();
-
-		// Click near the end of the widget area to select it.
-		await page.mouse.click(
-			firstWidgetAreaBoundingBox.x + firstWidgetAreaBoundingBox.width / 2,
-			firstWidgetAreaBoundingBox.y +
-				firstWidgetAreaBoundingBox.height -
-				10
-		);
-
-		let inlineInserterButton = await find( {
-			role: 'combobox',
-			name: 'Add block',
-		} );
-		await inlineInserterButton.click();
-
-		let inlineQuickInserter = await find( {
-			role: 'listbox',
-			name: 'Blocks',
-		} );
-
-		const paragraphBlock = await find(
-			{
-				role: 'option',
-				name: 'Paragraph',
-			},
-			{
-				root: inlineQuickInserter,
-			}
-		);
-		await paragraphBlock.click();
-
-		const firstParagraphBlock = await find(
-			{
-				name: /^Empty block/,
-				selector: '[data-block][data-type="core/paragraph"]',
-			},
-			{
-				root: firstWidgetArea,
-			}
-		);
-
-		await firstParagraphBlock.focus();
-		await page.keyboard.type( 'First Paragraph' );
-
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second Paragraph' );
-
-		const secondParagraphBlock = await page.evaluateHandle(
-			() => document.activeElement
-		);
-		await expect( secondParagraphBlock ).not.toBeElement(
-			firstParagraphBlock
-		);
-
-		const secondParagraphBlockBoundingBox = await secondParagraphBlock.boundingBox();
-
-		// Click outside the block to move the focus back to the widget area.
-		await page.mouse.click(
-			secondParagraphBlockBoundingBox.x +
-				firstWidgetAreaBoundingBox.width / 2,
-			secondParagraphBlockBoundingBox.y +
-				secondParagraphBlockBoundingBox.height +
-				10
-		);
-
-		// Hover above the last block to trigger the inline inserter between blocks.
-		await page.mouse.move(
-			secondParagraphBlockBoundingBox.x +
-				secondParagraphBlockBoundingBox.width / 2,
-			secondParagraphBlockBoundingBox.y - 10
-		);
-
-		// There will be 2 matches here.
-		// One is the in-between inserter,
-		// and the other one is the button block appender.
-		[ inlineInserterButton ] = await findAll( {
-			role: 'combobox',
-			name: 'Add block',
-		} );
-		await inlineInserterButton.click();
-
-		// TODO: Convert to find() API from puppeteer-testing-library.
-		const inserterSearchBox = await page.waitForSelector(
-			'aria/Search for blocks and patterns[role="searchbox"]'
-		);
-		await expect( inserterSearchBox ).toHaveFocus();
-
-		await page.keyboard.type( 'Heading' );
-
-		inlineQuickInserter = await find( {
-			role: 'listbox',
-			name: 'Blocks',
-		} );
-		const headingBlockOption = await find(
-			{
-				role: 'option',
-				name: 'Heading',
-			},
-			{
-				root: inlineQuickInserter,
-			}
-		);
-		await headingBlockOption.click();
-
-		// Get the added heading block as second last block.
-		const addedHeadingBlock = await secondParagraphBlock.evaluateHandle(
-			( node ) => node.previousSibling
-		);
-
-		await expect( addedHeadingBlock ).toHaveFocus();
-
-		await page.keyboard.type( 'My Heading' );
-
-		await expect( addedHeadingBlock ).toMatchQuery( {
-			name: 'Block: Heading',
-			level: 2,
-			value: 'My Heading',
-		} );
-
-		await saveWidgets();
-		const serializedWidgetAreas = await getSerializedWidgetAreas();
-		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
-		Object {
-		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
-		<p>First Paragraph</p>
-		</div></div>
-		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
-		<h2>My Heading</h2>
-		</div></div>
-		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
-		<p>Second Paragraph</p>
-		</div></div>",
-		}
-	` );
-	} );
+	// it( 'Should insert content using the inline inserter', async () => {
+	// 	const [ firstWidgetArea ] = await findAll( {
+	// 		role: 'group',
+	// 		name: 'Block: Widget Area',
+	// 	} );
+	//
+	// 	// Scroll to the end of the first widget area.
+	// 	await firstWidgetArea.evaluate( ( node ) =>
+	// 		node.scrollIntoView( { block: 'end' } )
+	// 	);
+	//
+	// 	const firstWidgetAreaBoundingBox = await firstWidgetArea.boundingBox();
+	//
+	// 	// Click near the end of the widget area to select it.
+	// 	await page.mouse.click(
+	// 		firstWidgetAreaBoundingBox.x + firstWidgetAreaBoundingBox.width / 2,
+	// 		firstWidgetAreaBoundingBox.y +
+	// 			firstWidgetAreaBoundingBox.height -
+	// 			10
+	// 	);
+	//
+	// 	let inlineInserterButton = await find( {
+	// 		role: 'combobox',
+	// 		name: 'Add block',
+	// 	} );
+	// 	await inlineInserterButton.click();
+	//
+	// 	let inlineQuickInserter = await find( {
+	// 		role: 'listbox',
+	// 		name: 'Blocks',
+	// 	} );
+	//
+	// 	const paragraphBlock = await find(
+	// 		{
+	// 			role: 'option',
+	// 			name: 'Paragraph',
+	// 		},
+	// 		{
+	// 			root: inlineQuickInserter,
+	// 		}
+	// 	);
+	// 	await paragraphBlock.click();
+	//
+	// 	const firstParagraphBlock = await find(
+	// 		{
+	// 			name: /^Empty block/,
+	// 			selector: '[data-block][data-type="core/paragraph"]',
+	// 		},
+	// 		{
+	// 			root: firstWidgetArea,
+	// 		}
+	// 	);
+	//
+	// 	await firstParagraphBlock.focus();
+	// 	await page.keyboard.type( 'First Paragraph' );
+	//
+	// 	await page.keyboard.press( 'Enter' );
+	// 	await page.keyboard.type( 'Second Paragraph' );
+	//
+	// 	const secondParagraphBlock = await page.evaluateHandle(
+	// 		() => document.activeElement
+	// 	);
+	// 	await expect( secondParagraphBlock ).not.toBeElement(
+	// 		firstParagraphBlock
+	// 	);
+	//
+	// 	const secondParagraphBlockBoundingBox = await secondParagraphBlock.boundingBox();
+	//
+	// 	// Click outside the block to move the focus back to the widget area.
+	// 	await page.mouse.click(
+	// 		secondParagraphBlockBoundingBox.x +
+	// 			firstWidgetAreaBoundingBox.width / 2,
+	// 		secondParagraphBlockBoundingBox.y +
+	// 			secondParagraphBlockBoundingBox.height +
+	// 			10
+	// 	);
+	//
+	// 	// Hover above the last block to trigger the inline inserter between blocks.
+	// 	await page.mouse.move(
+	// 		secondParagraphBlockBoundingBox.x +
+	// 			secondParagraphBlockBoundingBox.width / 2,
+	// 		secondParagraphBlockBoundingBox.y - 10
+	// 	);
+	//
+	// 	// There will be 2 matches here.
+	// 	// One is the in-between inserter,
+	// 	// and the other one is the button block appender.
+	// 	[ inlineInserterButton ] = await findAll( {
+	// 		role: 'combobox',
+	// 		name: 'Add block',
+	// 	} );
+	// 	await inlineInserterButton.click();
+	//
+	// 	// TODO: Convert to find() API from puppeteer-testing-library.
+	// 	const inserterSearchBox = await page.waitForSelector(
+	// 		'aria/Search for blocks and patterns[role="searchbox"]'
+	// 	);
+	// 	await expect( inserterSearchBox ).toHaveFocus();
+	//
+	// 	await page.keyboard.type( 'Heading' );
+	//
+	// 	inlineQuickInserter = await find( {
+	// 		role: 'listbox',
+	// 		name: 'Blocks',
+	// 	} );
+	// 	const headingBlockOption = await find(
+	// 		{
+	// 			role: 'option',
+	// 			name: 'Heading',
+	// 		},
+	// 		{
+	// 			root: inlineQuickInserter,
+	// 		}
+	// 	);
+	// 	await headingBlockOption.click();
+	//
+	// 	// Get the added heading block as second last block.
+	// 	const addedHeadingBlock = await secondParagraphBlock.evaluateHandle(
+	// 		( node ) => node.previousSibling
+	// 	);
+	//
+	// 	await expect( addedHeadingBlock ).toHaveFocus();
+	//
+	// 	await page.keyboard.type( 'My Heading' );
+	//
+	// 	await expect( addedHeadingBlock ).toMatchQuery( {
+	// 		name: 'Block: Heading',
+	// 		level: 2,
+	// 		value: 'My Heading',
+	// 	} );
+	//
+	// 	await saveWidgets();
+	// 	const serializedWidgetAreas = await getSerializedWidgetAreas();
+	// 	expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
+	// 	Object {
+	// 	  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
+	// 	<p>First Paragraph</p>
+	// 	</div></div>
+	// 	<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+	// 	<h2>My Heading</h2>
+	// 	</div></div>
+	// 	<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
+	// 	<p>Second Paragraph</p>
+	// 	</div></div>",
+	// 	}
+	// ` );
+	// } );
 
 	async function addMarquee() {
 		// There will be 2 matches here.
@@ -425,6 +425,16 @@ describe( 'Widgets screen', () => {
 			}
 		);
 		await marqueeBlockOption.click();
+
+		// It takes a moment to load the form, let's wait for it.
+		await waitFor( async () => {
+			const marquees = await findAll( {
+				selector: '[id=marquee-greeting]',
+			} );
+			if ( marquees.length === 1 ) {
+				throw new Error();
+			}
+		} );
 	}
 
 	it( 'Should add and save the marquee widget', async () => {
@@ -463,16 +473,6 @@ describe( 'Widgets screen', () => {
 
 		// Add another marquee, it shouldn't be saved
 		await addMarquee();
-
-		// It takes a moment to load the form, let's wait for it.
-		await waitFor( async () => {
-			const marquees = await findAll( {
-				selector: '[id=marquee-greeting]',
-			} );
-			if ( marquees.length === 1 ) {
-				throw new Error();
-			}
-		} );
 
 		const marquees = await findAll( {
 			selector: '[id=marquee-greeting]',
@@ -528,7 +528,6 @@ describe( 'Widgets screen', () => {
 		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 		const initialWidgets = await getWidgetAreaWidgets();
@@ -599,7 +598,6 @@ describe( 'Widgets screen', () => {
 		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
-		  "wp_inactive_widgets": "",
 		}
 	` );
 		const editedWidgets = await getWidgetAreaWidgets();
@@ -909,13 +907,15 @@ async function getSerializedWidgetAreas() {
 		wp.data.select( 'core' ).getWidgets( { _embed: 'about' } )
 	);
 
-	const serializedWidgetAreas = mapValues(
-		groupBy( widgets, 'sidebar' ),
-		( sidebarWidgets ) =>
+	const serializedWidgetAreas = pickBy(
+		mapValues(
+			groupBy( widgets, 'sidebar' ),
+			( sidebarWidgets ) =>
 			sidebarWidgets
 				.map( ( widget ) => widget.rendered )
 				.filter( Boolean )
 				.join( '\n' )
+		)
 	);
 
 	return serializedWidgetAreas;

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -454,8 +454,7 @@ describe( 'Widgets screen', () => {
 			let editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-				"sidebar-1": "<marquee>Hello!</marquee>",
-				"wp_inactive_widgets": "",
+			  "sidebar-1": "<marquee>Hello!</marquee>",
 			}
 		` );
 
@@ -464,8 +463,7 @@ describe( 'Widgets screen', () => {
 			editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-				"sidebar-1": "<marquee>Hello!</marquee>",
-				"wp_inactive_widgets": "",
+			  "sidebar-1": "<marquee>Hello!</marquee>",
 			}
 		` );
 
@@ -494,8 +492,7 @@ describe( 'Widgets screen', () => {
 			editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 			Object {
-				"sidebar-1": "<marquee>Hello!</marquee>",
-				"wp_inactive_widgets": "",
+			  "sidebar-1": "<marquee>Hello!</marquee>",
 			}
 		` );
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -429,11 +429,11 @@ describe( 'Widgets screen', () => {
 		}
 
 		beforeEach( async () => {
+			await deleteAllWidgets();
 			await activatePlugin( 'gutenberg-test-marquee-widget' );
 		} );
 
 		afterEach( async () => {
-			await deleteAllWidgets();
 			await deactivatePlugin( 'gutenberg-test-marquee-widget' );
 		} );
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -17,7 +17,7 @@ import {
  */
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll, waitFor } from 'puppeteer-testing-library';
-import { groupBy, mapValues, pickBy } from 'lodash';
+import { groupBy, mapValues } from 'lodash';
 
 describe( 'Widgets screen', () => {
 	beforeEach( async () => {
@@ -46,6 +46,7 @@ describe( 'Widgets screen', () => {
 
 	afterEach( async () => {
 		await deleteAllWidgets();
+		await deactivatePlugin( 'gutenberg-test-marquee-widget' );
 	} );
 
 	beforeAll( async () => {
@@ -449,6 +450,7 @@ describe( 'Widgets screen', () => {
 		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
 		  "sidebar-1": "<marquee>Hello!</marquee>",
+			"wp_inactive_widgets": "",
 		}
 	` );
 
@@ -458,6 +460,7 @@ describe( 'Widgets screen', () => {
 		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
 		  "sidebar-1": "<marquee>Hello!</marquee>",
+			"wp_inactive_widgets": "",
 		}
 	` );
 
@@ -487,6 +490,7 @@ describe( 'Widgets screen', () => {
 		await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
 		  "sidebar-1": "<marquee>Hello!</marquee>",
+			"wp_inactive_widgets": "",
 		}
 	` );
 
@@ -907,13 +911,13 @@ async function getSerializedWidgetAreas() {
 		wp.data.select( 'core' ).getWidgets( { _embed: 'about' } )
 	);
 
-	const serializedWidgetAreas = pickBy(
-		mapValues( groupBy( widgets, 'sidebar' ), ( sidebarWidgets ) =>
+	const serializedWidgetAreas = mapValues(
+		groupBy( widgets, 'sidebar' ),
+		( sidebarWidgets ) =>
 			sidebarWidgets
 				.map( ( widget ) => widget.rendered )
 				.filter( Boolean )
 				.join( '\n' )
-		)
 	);
 
 	return serializedWidgetAreas;

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -428,13 +428,16 @@ describe( 'Widgets screen', () => {
 			await marqueeBlockOption.click();
 		}
 
+		beforeEach( async () => {
+			await activatePlugin( 'gutenberg-test-marquee-widget' );
+		} );
+
 		afterEach( async () => {
 			await deleteAllWidgets();
 			await deactivatePlugin( 'gutenberg-test-marquee-widget' );
 		} );
 
 		it( 'Should add and save the marquee widget', async () => {
-			await activatePlugin( 'gutenberg-test-marquee-widget' );
 			await visitAdminPage( 'widgets.php' );
 
 			await addMarquee();

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -420,7 +420,7 @@ describe( 'Widgets screen', () => {
 			await addMarquee();
 
 			const greetingInput = await page.waitForSelector(
-				'[name="marquee-greeting"]'
+				'[data-testid="marquee-greeting"]'
 			);
 			await greetingInput.type( 'Howdy' );
 
@@ -447,12 +447,15 @@ describe( 'Widgets screen', () => {
 			// It takes a moment to load the form, let's wait for it.
 			await page.waitForFunction( () => {
 				return (
-					document.querySelectorAll( '[name="marquee-greeting"]' )
-						.length === 2
+					document.querySelectorAll(
+						'[data-testid="marquee-greeting"]'
+					).length === 2
 				);
 			} );
 
-			const marqueeInputs = await page.$$( '[name="marquee-greeting"]' );
+			const marqueeInputs = await page.$$(
+				'[data-testid="marquee-greeting"]'
+			);
 
 			expect( marqueeInputs ).toHaveLength( 2 );
 			await marqueeInputs[ 1 ].type( 'Second howdy' );
@@ -469,7 +472,7 @@ describe( 'Widgets screen', () => {
 
 			await page.reload();
 			const marqueesAfter = await findAll( {
-				selector: '[name="marquee-greeting"]',
+				selector: '[data-testid="marquee-greeting"]',
 			} );
 			expect( marqueesAfter ).toHaveLength( 1 );
 		} );

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -394,7 +394,6 @@ describe( 'Widgets screen', () => {
 	` );
 	} );
 
-
 	describe( 'Function widgets', () => {
 		async function addMarquee() {
 			// There will be 2 matches here.

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -53,6 +53,7 @@
 		input[type="week"],
 		select {
 			font-family: system-ui;
+			background-color: transparent;
 			box-sizing: border-box;
 			border: 1px solid $gray-700;
 			border-radius: 3px;


### PR DESCRIPTION
## Description
Partially related to #32978.

The widgets tests fail randomly on the latest trunk version. The reasons for failures are:
* The presence or lack of `wp_inactive_widgets` key in the snapshot of sidebarWidgets data. The culprit is tests execution order – we enable the `gutenberg-test-marquee-widget` plugin but we never disable it. With the plugin enabled, the `wp_inactive_widgets` key is there, without it it's not there.
* A possibility of an existing marquee widget in the "inactive widgets" area
* The fact that the function widget is saved with a dedicated "save" form button, not with the global "Save widgets" button – this seems like a bug cc @draganescu 

## How has this been tested?
Just confirm the snapshot-based tests pass

## Types of changes
Bug fix 

