### PR TITLE
E2E Test Utils: Add some functionality to `createUser` and `deleteUser`

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -181,7 +181,12 @@ _Parameters_
 
 -   _username_ `string`: User name.
 -   _firstName_ `string?`: First name.
--   _lastName_ `string?`: Larst name.
+-   _lastName_ `string?`: Last name.
+-   _role_ `string?`: Role.
+
+_Returns_
+
+-   `string`: Password for the newly created user account
 
 <a name="deactivatePlugin" href="#deactivatePlugin">#</a> **deactivatePlugin**
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -180,9 +180,10 @@ Create a new user account.
 _Parameters_
 
 -   _username_ `string`: User name.
--   _firstName_ `string?`: First name.
--   _lastName_ `string?`: Last name.
--   _role_ `Role?`: Role.
+-   _object_ `Object?`: Optional Settings for the new user account.
+-   _object.firstName_ `[string]`: First name.
+-   _object.lastName_ `[string]`: Last name.
+-   _object.role_ `[Role]`: Role.
 
 _Returns_
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -183,7 +183,7 @@ _Parameters_
 -   _object_ `Object?`: Optional Settings for the new user account.
 -   _object.firstName_ `[string]`: First name.
 -   _object.lastName_ `[string]`: Last name.
--   _object.role_ `[Role]`: Role.
+-   _object.role_ `[string]`: Role. Defaults to Administrator.
 
 _Returns_
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -182,7 +182,7 @@ _Parameters_
 -   _username_ `string`: User name.
 -   _firstName_ `string?`: First name.
 -   _lastName_ `string?`: Last name.
--   _role_ `string?`: Role.
+-   _role_ `Role?`: Role.
 
 _Returns_
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -187,7 +187,7 @@ _Parameters_
 
 _Returns_
 
--   `string`: Password for the newly created user account
+-   `string`: Password for the newly created user account.
 
 <a name="deactivatePlugin" href="#deactivatePlugin">#</a> **deactivatePlugin**
 

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -11,17 +11,13 @@ import { switchUserToTest } from './switch-user-to-test';
 import { visitAdminPage } from './visit-admin-page';
 
 /**
- * @typedef {'Subscriber' | 'Contributor' | 'Author' | 'Editor' | 'Administrator'} Role
- */
-
-/**
  * Create a new user account.
  *
  * @param {string}  username           User name.
  * @param {Object?} object             Optional Settings for the new user account.
  * @param {string}  [object.firstName] First name.
  * @param {string}  [object.lastName]  Last name.
- * @param {Role}    [object.role]      Role.
+ * @param {string}  [object.role]      Role. Defaults to Administrator.
  *
  * @return {string} Password for the newly created user account
  */

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -15,7 +15,7 @@ import { visitAdminPage } from './visit-admin-page';
  *
  * @param {string}  username  User name.
  * @param {string?} firstName First name.
- * @param {string?} lastName  Larst name.
+ * @param {string?} lastName  Last name.
  */
 export async function createUser( username, firstName, lastName ) {
 	await switchUserToAdmin();

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -19,7 +19,7 @@ import { visitAdminPage } from './visit-admin-page';
  * @param {string}  [object.lastName]  Last name.
  * @param {string}  [object.role]      Role. Defaults to Administrator.
  *
- * @return {string} Password for the newly created user account
+ * @return {string} Password for the newly created user account.
  */
 export async function createUser(
 	username,

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -20,7 +20,7 @@ import { visitAdminPage } from './visit-admin-page';
  * @param {string}  username  User name.
  * @param {string?} firstName First name.
  * @param {string?} lastName  Last name.
- * @param {string?} role      Role.
+ * @param {Role?}   role      Role.
  *
  * @return {string} Password for the newly created user account
  */

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -17,14 +17,18 @@ import { visitAdminPage } from './visit-admin-page';
 /**
  * Create a new user account.
  *
- * @param {string}  username  User name.
- * @param {string?} firstName First name.
- * @param {string?} lastName  Last name.
- * @param {Role?}   role      Role.
+ * @param {string}  username           User name.
+ * @param {Object?} object             Optional Settings for the new user account.
+ * @param {string}  [object.firstName] First name.
+ * @param {string}  [object.lastName]  Last name.
+ * @param {Role}    [object.role]      Role.
  *
  * @return {string} Password for the newly created user account
  */
-export async function createUser( username, firstName, lastName, role ) {
+export async function createUser(
+	username,
+	{ firstName, lastName, role } = {}
+) {
 	await switchUserToAdmin();
 	await visitAdminPage( 'user-new.php' );
 

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -11,13 +11,20 @@ import { switchUserToTest } from './switch-user-to-test';
 import { visitAdminPage } from './visit-admin-page';
 
 /**
+ * @typedef {'Subscriber' | 'Contributor' | 'Author' | 'Editor' | 'Administrator'} Role
+ */
+
+/**
  * Create a new user account.
  *
  * @param {string}  username  User name.
  * @param {string?} firstName First name.
  * @param {string?} lastName  Last name.
+ * @param {string?} role      Role.
+ *
+ * @return {string} Password for the newly created user account
  */
-export async function createUser( username, firstName, lastName ) {
+export async function createUser( username, firstName, lastName, role ) {
 	await switchUserToAdmin();
 	await visitAdminPage( 'user-new.php' );
 
@@ -29,11 +36,18 @@ export async function createUser( username, firstName, lastName ) {
 	if ( lastName ) {
 		await page.type( '#last_name', lastName );
 	}
+	if ( role ) {
+		await page.select( '#role', role );
+	}
+
 	await page.click( '#send_user_notification' );
+
+	const password = await page.$eval( `#pass1`, ( element ) => element.value );
 
 	await Promise.all( [
 		page.click( '#createusersub' ),
 		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 	] );
 	await switchUserToTest();
+	return password;
 }

--- a/packages/e2e-test-utils/src/delete-user.js
+++ b/packages/e2e-test-utils/src/delete-user.js
@@ -35,6 +35,14 @@ export async function deleteUser( username ) {
 		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 	] );
 
+	// If there's content owned by this user, delete it.
+	const deleteContentRadioButton = await page.$(
+		'input[type="radio"][name="delete_option"][value="delete"]'
+	);
+	if ( deleteContentRadioButton ) {
+		await deleteContentRadioButton.click();
+	}
+
 	// Confirm
 	await Promise.all( [
 		page.click( 'input#submit' ),

--- a/packages/e2e-tests/specs/editor/various/mentions.test.js
+++ b/packages/e2e-tests/specs/editor/various/mentions.test.js
@@ -12,7 +12,7 @@ import {
 
 describe( 'autocomplete mentions', () => {
 	beforeAll( async () => {
-		await createUser( 'testuser', 'Jane', 'Doe' );
+		await createUser( 'testuser', { firstName: 'Jane', lastName: 'Doe' } );
 	} );
 
 	beforeEach( async () => {


### PR DESCRIPTION
## Description

Spun off from #32868.

- `deleteUser`: Delete content owned by the user, if any.
- `createUser`:
  - Return password.
  - Allow setting role.
  - Use an object for optional function arguments.

## How has this been tested?
Only one e2e test affected so far (`mentions.test.js`) -- verify that it still passes.

---

The latest release of [`@wordpress/e2e-test-utils`](https://www.npmjs.com/package/@wordpress/e2e-test-utils) was on May 31, so no new Changelog entries are needed (since there already is one for `createUser` and `deleteUser`).