### PR TITLE
[Mobile] - Revert enabling color support

### DIFF
--- a/packages/block-editor/src/components/provider/index.native.js
+++ b/packages/block-editor/src/components/provider/index.native.js
@@ -10,7 +10,6 @@ import { useEffect } from '@wordpress/element';
 import withRegistryProvider from './with-registry-provider';
 import useBlockSync from './use-block-sync';
 import { store as blockEditorStore } from '../../store';
-import { BlockRefsProvider } from './block-refs-provider';
 
 /** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
@@ -25,7 +24,7 @@ function BlockEditorProvider( props ) {
 	// Syncs the entity provider with changes in the block-editor store.
 	useBlockSync( props );
 
-	return <BlockRefsProvider>{ children }</BlockRefsProvider>;
+	return children;
 }
 
 export default withRegistryProvider( BlockEditorProvider );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -234,7 +234,7 @@ export function ColorEdit( props ) {
 		localAttributes.current = attributes;
 	}, [ attributes ] );
 
-	if ( ! hasColorSupport( blockName ) ) {
+	if ( ! hasColorSupport( blockName ) || Platform.OS !== 'web' ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Description
After merging https://github.com/WordPress/gutenberg/pull/30544 a bug was introduced with the color selection on some blocks, like showing duplicated color settings in the `Buttons` block or breaking the gradient selection. I'll disable this functionality while I work on a fix for it.

## How has this been tested?
- Open the demo app
- Add a Buttons block
- Open the settings of the block
- Only two color options should show up:
  - <img width="191" alt="Screenshot 2021-06-29 at 17 50 08" src="https://user-images.githubusercontent.com/4885740/123829190-85a0c500-d902-11eb-809d-df8f2529ebe4.png">
- Open the Background color settings
- Tap on Gradient
- **Expect** to see the colors correctly and to be able to set one for the block


## Screenshots <!-- if applicable -->
N/A

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
