### PR TITLE
Block API: Improve how blocks assets are versioned

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -261,7 +261,7 @@ Sometimes a block could have aliases that help users discover it while searching
 { "version": "1.0.3" }
 ```
 
-The current version number of the block, such as 1.0 or 1.0.3. It's similar to how plugins are versioned. This field might be used with block assets to control cache invalidation.
+The current version number of the block, such as 1.0 or 1.0.3. It's similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the current version of WordPress is used instead.
 
 ### Text Domain
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -14,6 +14,7 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 	"icon": "star",
 	"description": "Shows warning, error or success notices…",
 	"keywords": [ "alert", "message" ],
+	"version": "1.0.3",
 	"textdomain": "my-plugin",
 	"attributes": {
 		"message": {
@@ -247,6 +248,20 @@ This is a short description for your block, which can be translated with our tra
 ```
 
 Sometimes a block could have aliases that help users discover it while searching. For example, an image block could also want to be discovered by photo. You can do so by providing an array of unlimited terms (which are translated).
+
+### Version
+
+-   Type: `string`
+-   Optional
+-   Localized: No
+-   Property: `version`
+-   Since: `5.8.0`
+
+```json
+{ "version": "1.0.3" }
+```
+
+The current version number of the block, such as 1.0 or 1.0.3. It's similar to how plugins are versioned. This field might be used with block assets to control cache invalidation.
 
 ### Text Domain
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -261,7 +261,7 @@ Sometimes a block could have aliases that help users discover it while searching
 { "version": "1.0.3" }
 ```
 
-The current version number of the block, such as 1.0 or 1.0.3. It's similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the current version of WordPress is used instead.
+The current version number of the block, such as 1.0 or 1.0.3. It's similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the installed version of WordPress is used instead.
 
 ### Text Domain
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Plugin scaffolded with the `esnext` template requires WordPress 5.8 now ([#33252](https://github.com/WordPress/gutenberg/pull/33252).
 -   Block scaffolded with the `esnext` template is now registered from `block.json` with the `register_block_type` helper ([#33252](https://github.com/WordPress/gutenberg/pull/33252)).
+-   Add support for the new `version` field in the `block.json` metadata file ([#33075](https://github.com/WordPress/gutenberg/pull/33075)).
 
 ## 2.3.0 (2021-04-29)
 

--- a/packages/create-block/lib/init-block-json.js
+++ b/packages/create-block/lib/init-block-json.js
@@ -15,6 +15,7 @@ module.exports = async ( {
 	slug,
 	namespace,
 	title,
+	version,
 	description,
 	category,
 	attributes,
@@ -35,6 +36,7 @@ module.exports = async ( {
 				{
 					apiVersion,
 					name: namespace + '/' + slug,
+					version,
 					title,
 					category,
 					icon: dashicon,


### PR DESCRIPTION
## Description
There is currently no standardized way for a consistent version for block assets to be supplied to WordPress. For scripts registered server side, one can be provided within the `.asset.php` file, but there is no equivalent for styles.

Developers often times resort to using `filemtime()`, which is not ideal for performance reasons, and the browser/proxy cache can be purged frequently with certain deployment setups.

Ideally, there should be a single version for all script and style assets belonging to a block when `SCRIPT_DEBUG` is not set to `true`.

`version` should be a recognized, and eventually required, top-level field within `block.json`. Block developers should be encouraged to define a version that matches their plugin's version, or one specific to the individual block when bundling multiple blocks in a single plugin (to prevent invalidating caches when a specific block in a group is not changed).

In WordPress 5.8, non-Core blocks are currently set to fallback to the current version of WordPress when `version` is not defined in the metadata. This change was made in order to eliminate the need for `filemtime()` in production environments with the plan to publish a dev note and performing outreach to encourage developers to add this field prior to their next update.

Other context:
- [Trac-53149](https://core.trac.wordpress.org/ticket/53149)
- [Trac-53507](https://core.trac.wordpress.org/ticket/53507)

## How has this been tested?

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
