### PR TITLE
Template Mode: Add busy state to template creation modal

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -27,6 +27,7 @@ import { createBlock, serialize } from '@wordpress/blocks';
 
 function PostTemplateActions() {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ isBusy, setIsBusy ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
 	const { template, supportsTemplateMode, defaultTemplate } = useSelect(
 		( select ) => {
@@ -49,13 +50,67 @@ function PostTemplateActions() {
 		},
 		[]
 	);
-	const { __unstableSwitchToTemplateMode } = useDispatch( editPostStore );
+	const {
+		__unstableCreateTemplate,
+		__unstableSwitchToTemplateMode,
+	} = useDispatch( editPostStore );
 
 	if ( ! supportsTemplateMode ) {
 		return null;
 	}
 
 	const defaultTitle = __( 'Custom Template' );
+
+	async function onCreateTemplate( event ) {
+		event.preventDefault();
+		setIsBusy( true );
+
+		const newTemplateContent =
+			defaultTemplate ??
+			serialize( [
+				createBlock(
+					'core/group',
+					{
+						tagName: 'header',
+						layout: { inherit: true },
+					},
+					[
+						createBlock( 'core/site-title' ),
+						createBlock( 'core/site-tagline' ),
+					]
+				),
+				createBlock( 'core/separator' ),
+				createBlock(
+					'core/group',
+					{
+						tagName: 'main',
+					},
+					[
+						createBlock(
+							'core/group',
+							{
+								layout: { inherit: true },
+							},
+							[ createBlock( 'core/post-title' ) ]
+						),
+						createBlock( 'core/post-content', {
+							layout: { inherit: true },
+						} ),
+					]
+				),
+			] );
+
+		await __unstableCreateTemplate( {
+			slug: 'wp-custom-template-' + kebabCase( title || defaultTitle ),
+			content: newTemplateContent,
+			title: title || defaultTitle,
+		} );
+
+		setIsBusy( false );
+		setIsModalOpen( false );
+
+		__unstableSwitchToTemplateMode( true );
+	}
 
 	return (
 		<>
@@ -82,58 +137,7 @@ function PostTemplateActions() {
 					} }
 					overlayClassName="edit-post-template__modal"
 				>
-					<form
-						onSubmit={ ( event ) => {
-							event.preventDefault();
-							const newTemplateContent =
-								defaultTemplate ??
-								serialize( [
-									createBlock(
-										'core/group',
-										{
-											tagName: 'header',
-											layout: { inherit: true },
-										},
-										[
-											createBlock( 'core/site-title' ),
-											createBlock( 'core/site-tagline' ),
-										]
-									),
-									createBlock( 'core/separator' ),
-									createBlock(
-										'core/group',
-										{
-											tagName: 'main',
-										},
-										[
-											createBlock(
-												'core/group',
-												{
-													layout: { inherit: true },
-												},
-												[
-													createBlock(
-														'core/post-title'
-													),
-												]
-											),
-											createBlock( 'core/post-content', {
-												layout: { inherit: true },
-											} ),
-										]
-									),
-								] );
-
-							__unstableSwitchToTemplateMode( {
-								slug:
-									'wp-custom-template-' +
-									kebabCase( title || defaultTitle ),
-								content: newTemplateContent,
-								title: title || defaultTitle,
-							} );
-							setIsModalOpen( false );
-						} }
-					>
+					<form onSubmit={ isBusy ? undefined : onCreateTemplate }>
 						<Flex align="flex-start" gap={ 8 }>
 							<FlexItem>
 								<TextControl
@@ -141,6 +145,7 @@ function PostTemplateActions() {
 									value={ title }
 									onChange={ setTitle }
 									placeholder={ defaultTitle }
+									disabled={ isBusy }
 									help={ __(
 										'Describe the purpose of the template, e.g. "Full Width". Custom templates can be applied to any post or page.'
 									) }
@@ -165,7 +170,12 @@ function PostTemplateActions() {
 								</Button>
 							</FlexItem>
 							<FlexItem>
-								<Button variant="primary" type="submit">
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={ isBusy }
+									aria-disabled={ isBusy }
+								>
 									{ __( 'Create' ) }
 								</Button>
 							</FlexItem>

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -479,36 +479,11 @@ export function setIsEditingTemplate( value ) {
 }
 
 /**
- * Potentially create a block based template and switches to the template mode.
+ * Switches to the template mode.
  *
- * @param {Object?} template template to create and assign before switching.
+ * @param {boolean} newTemplate Is new template.
  */
-export function* __unstableSwitchToTemplateMode( template ) {
-	if ( !! template ) {
-		const savedTemplate = yield controls.dispatch(
-			coreStore,
-			'saveEntityRecord',
-			'postType',
-			'wp_template',
-			template
-		);
-		const post = yield controls.select(
-			editorStore.name,
-			'getCurrentPost'
-		);
-
-		yield controls.dispatch(
-			coreStore,
-			'editEntityRecord',
-			'postType',
-			post.type,
-			post.id,
-			{
-				template: savedTemplate.slug,
-			}
-		);
-	}
-
+export function* __unstableSwitchToTemplateMode( newTemplate = false ) {
 	yield setIsEditingTemplate( true );
 
 	const isWelcomeGuideActive = yield controls.select(
@@ -518,7 +493,7 @@ export function* __unstableSwitchToTemplateMode( template ) {
 	);
 
 	if ( ! isWelcomeGuideActive ) {
-		const message = !! template
+		const message = newTemplate
 			? __( "Custom template created. You're in template mode now." )
 			: __(
 					'Editing template. Changes made here affect all posts and pages that use the template.'
@@ -527,4 +502,31 @@ export function* __unstableSwitchToTemplateMode( template ) {
 			type: 'snackbar',
 		} );
 	}
+}
+
+/**
+ * Create a block based template.
+ *
+ * @param {Object?} template Template to create and assign.
+ */
+export function* __unstableCreateTemplate( template ) {
+	const savedTemplate = yield controls.dispatch(
+		coreStore,
+		'saveEntityRecord',
+		'postType',
+		'wp_template',
+		template
+	);
+	const post = yield controls.select( editorStore.name, 'getCurrentPost' );
+
+	yield controls.dispatch(
+		coreStore,
+		'editEntityRecord',
+		'postType',
+		post.type,
+		post.id,
+		{
+			template: savedTemplate.slug,
+		}
+	);
 }


### PR DESCRIPTION
## Description
Adds busy state to the "Create custom template" modal — part of #32813.

While this improves UX, it's not much. 

The "Edit" template action is much faster, even when using network throttling. I think bottleneck here might be `getEditedPostTemplate()`. The selector has to re-fetch all the templates and find the new one by slug.

https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/packages/edit-post/src/editor.js#L98-L101

## How has this been tested?
1. Enable TT1 Blocks theme.
2. Create page.
3. Throttle network to 3G via DevTools.
4. Create a new template.
5. Name input filed should be disabled.
6. Create button should have a busy state.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/123904119-01415700-d981-11eb-8074-1e10100c0f7a.mp4

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
