### PR TITLE
[E2E] Add regression E2E test for the Paragraph to List copy and paste failure

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -539,4 +539,26 @@ describe( 'List', () => {
 		);
 		expect( content ).toMatchSnapshot();
 	} );
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/33078
+	it( 'pasting from paragraph blocks work', async () => {
+		const text = 'Copy and paste me, pretty please!';
+
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( text );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		await page.keyboard.press( 'Enter' );
+		await insertBlock( 'List' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		const content = await page.$eval(
+			'.wp-block-list',
+			( el ) => el.innerHTML
+		);
+
+		expect( content ).toMatch( text );
+	} );
 } );


### PR DESCRIPTION
## Description

Adds regression test to cover https://github.com/WordPress/gutenberg/issues/33078. 

For now this is very specific to the paragraph -> list copy and paste scenario (see issue above). If we learn more about the root of the issue in https://github.com/WordPress/gutenberg/issues/33078, we might add more scenarios or perhaps test it at a lower level (?), and or move it somewhere else (I'm open to suggestions!). For now, this should be enough to catch the issue though. Note that at the time of this writing, `trunk` still doesn't have a fix for it, so it's expected that this test is failing. 

## How has this been tested?

* Ran the test. It's currently failing as pasting from `Paragraph` -> `List` doesn't work (it copies and pastes by sending the actual key combos, refer to the test). I manually tested the positive scenario by pasting from some other source, and it passed.

To run the test, run `npm install`, make sure to `unset PUPPETEER_SKIP_DOWNLOAD` just in case and:
* Without debugger support, from the gutenberg root dir: `npx wp-scripts test-e2e --config packages/e2e-tests/jest.config.js packages/e2e-tests/specs/editor/blocks/list.test.js`
* With debugger supprot: npx wp-scripts test-e2e --config packages/e2e-tests/jest.config.js packages/e2e-tests/specs/editor/blocks/list.test.js -- --puppeteer-devtools`

## Screenshots <!-- if applicable -->

## Types of changes

New regression E2E test.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/33073

