### PR TITLE
[DO NOT MERGE] Debug stale useSelect value

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -88,7 +88,12 @@ const renderQueue = createQueue();
  *
  * @return {Function}  A custom react hook.
  */
-export default function useSelect( _mapSelect, deps ) {
+export default function useSelect( _mapSelect, deps, { debug } = {} ) {
+	function debugLog( ...args ) {
+		if ( debug ) {
+			console.log( ...args );
+		}
+	}
 	const isWithoutMapping = typeof _mapSelect !== 'function';
 
 	if ( isWithoutMapping ) {
@@ -194,6 +199,7 @@ export default function useSelect( _mapSelect, deps ) {
 						return;
 					}
 					latestMapOutput.current = newMapOutput;
+					debugLog( '> useSelect: UPDATE', latestMapOutput.current );
 				} catch ( error ) {
 					latestMapOutputError.current = error;
 				}
@@ -229,5 +235,6 @@ export default function useSelect( _mapSelect, deps ) {
 		};
 	}, [ registry, trapSelect, depsChangedFlag, isWithoutMapping ] );
 
+	debugLog( '> useSelect: RETURN', mapOutput );
 	return isWithoutMapping ? registry.select( _mapSelect ) : mapOutput;
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -16,24 +16,29 @@ function useNativeBlockEditorSettings( settings, hasTemplate ) {
 	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
 
 	const supportReusableBlock = capabilities.reusableBlock === true;
-	const { reusableBlocks } = useSelect(
-		( select ) => ( {
-			reusableBlocks: supportReusableBlock
-				? select( coreStore ).getEntityRecords(
-						'postType',
-						'wp_block',
-						// Unbounded queries are not supported on native so as a workaround, we set per_page with the maximum value that native version can handle.
-						// Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
-						{ per_page: 100 }
-				  )
-				: [],
-		} ),
-		[ supportReusableBlock ]
+	const { reusableBlocks, isTitleSelected } = useSelect(
+		( select ) => {
+			console.log( '> INSIDE useSelect', {
+				isTitleSelected: select( editorStore ).isPostTitleSelected(),
+			} );
+			return {
+				reusableBlocks: supportReusableBlock
+					? select( coreStore ).getEntityRecords(
+							'postType',
+							'wp_block',
+							// Unbounded queries are not supported on native so as a workaround, we set per_page with the maximum value that native version can handle.
+							// Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
+							{ per_page: 100 }
+					  )
+					: [],
+				isTitleSelected: select( editorStore ).isPostTitleSelected(),
+			};
+		},
+		[ supportReusableBlock ],
+		{ debug: true }
 	);
 
-	const { isTitleSelected } = useSelect( ( select ) => ( {
-		isTitleSelected: select( editorStore ).isPostTitleSelected(),
-	} ) );
+	console.log( '> OUTSIDE useSelect', { isTitleSelected } );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## Description
⚠️ This PR should not be merged. ⚠️ 

This PR is further debugging of #32154. A fix was applied in #32831, but it shouldn't be necessary as the [dependency array should only memoize `mapSelect` itself](https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/packages/data/src/components/use-select/index.js#L41-L43), not the return value of `useSelect`. I have been unable to identify what is causing the stale value from `useSelect`. 

The `isPostTitleSelected` value appears to update _within_ `useSelect`, but the return value appears stale. When `mapSelect` has not changed, the update state is [assigned to `latestMapOutput.current`](https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/packages/data/src/components/use-select/index.js#L196), but that value is not returned in the [next `forceRender`](https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/packages/data/src/components/use-select/index.js#L200). A stale value appears to be [returned from `useSelect`](https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/packages/data/src/components/use-select/index.js#L232). 

Changing `forceRender()` to `setTimeout(forceRender, 0)` fixes the issue, showcasing the value is temporarily stale. 

## How has this been tested?
This PR is for debugging purposes and has not been tested. 

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/438664/123883406-948d7480-d90e-11eb-943f-b3a9adafcd73.mov


## Types of changes
Temporary debugging PR. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
