### PR TITLE
Remove `.min` from the File block's `viewScript`.

### DIFF
--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -51,7 +51,7 @@
 		"anchor": true,
 		"align": true
 	},
-	"viewScript": "file:./view.min.js",
+	"viewScript": "file:./view.js",
 	"editorStyle": "wp-block-file-editor",
 	"style": "wp-block-file"
 }


### PR DESCRIPTION
## Description
After WordPress/wordpress-develop#1412 was committed to Core in [[51259]](https://core.trac.wordpress.org/changeset/51259), a [notice appeared](https://core.trac.wordpress.org/ticket/53397#comment:39).

`Notice: register_block_script_handle was called <strong>incorrectly</strong>. The asset file for the "viewScript" defined in "core/file" block definition is missing. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.5.0.) in /var/www/src/wp-includes/functions.php on line 5535`

After tracking this down, it appears that this was caused by the `viewScript` file being set to `view.min.js` and not `view.js` ([full details outlined on the Trac ticket](https://core.trac.wordpress.org/ticket/53397#comment:44)).

This PR removes the `.min`, which would remove the need for Core to perform the correction before trying to check that the file exists, causing a notice.

However, if including the minified script in the `block.json` file is preferred, then Core should be updated to account for this with a more permanent fix instead.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
