### PR TITLE
Fix slash command focus style.

### DIFF
--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -11,6 +11,6 @@
 	width: 100%;
 
 	&.is-selected {
-		box-shadow: 0 0 0 2px var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 }


### PR DESCRIPTION
## Description

Fixes #23718.

The focus style width variable was not used in the auto complete component, meaning it was wrong:

<img width="695" alt="Screenshot 2021-06-30 at 08 33 02" src="https://user-images.githubusercontent.com/1204802/123913288-4e6ff980-d97e-11eb-98ba-f5f7671ae287.png">

This PR makes it right:

<img width="584" alt="Screenshot 2021-06-30 at 08 34 21" src="https://user-images.githubusercontent.com/1204802/123913294-50d25380-d97e-11eb-93ef-48dffb592103.png">

I also verified that the border radius is correct compared to other elements.

## How has this been tested?

Use the slash command and verify the focus style is right.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
