### PR TITLE
Enable rich previews for internal links

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -28,9 +28,9 @@ export default function LinkPreview( {
 	hasRichPreviews = false,
 } ) {
 	// Avoid fetching if rich previews are not desired.
-	const maybeRemoteURL = hasRichPreviews ? value?.url : null;
+	const useRichPreviews = hasRichPreviews ? value?.url : null;
 
-	const { richData, isFetching } = useRichUrlData( maybeRemoteURL );
+	const { richData, isFetching } = useRichUrlData( useRichPreviews );
 
 	// Rich data may be an empty object so test for that.
 	const hasRichData = richData && Object.keys( richData ).length;

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -28,9 +28,9 @@ export default function LinkPreview( {
 	hasRichPreviews = false,
 } ) {
 	// Avoid fetching if rich previews are not desired.
-	const useRichPreviews = hasRichPreviews ? value?.url : null;
+	const showRichPreviews = hasRichPreviews ? value?.url : null;
 
-	const { richData, isFetching } = useRichUrlData( useRichPreviews );
+	const { richData, isFetching } = useRichUrlData( showRichPreviews );
 
 	// Rich data may be an empty object so test for that.
 	const hasRichData = richData && Object.keys( richData ).length;

--- a/packages/core-data/src/fetch/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-url-data.js
@@ -52,9 +52,7 @@ const fetchUrlData = async ( url, options = {} ) => {
 	};
 
 	if ( ! isURL( url ) ) {
-		return Promise.reject(
-			new TypeError( `${ url } is not a valid URL.` )
-		);
+		return Promise.reject( `${ url } is not a valid URL.` );
 	}
 
 	// Test for "http" based URL as it is possible for valid
@@ -67,7 +65,7 @@ const fetchUrlData = async ( url, options = {} ) => {
 		! /^https?:\/\/[^\/\s]/i.test( url )
 	) {
 		return Promise.reject(
-			new TypeError( `${ url } does not have a valid protocol.` )
+			`${ url } does not have a valid protocol. URLs must be "http" based`
 		);
 	}
 

--- a/packages/core-data/src/fetch/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-url-data.js
@@ -26,19 +26,19 @@ const CACHE = new Map();
  * @param {Object?} options any options to pass to the underlying fetch.
  * @example
  * ```js
- * import { __experimentalFetchRemoteUrlData as fetchRemoteUrlData } from '@wordpress/core-data';
+ * import { __experimentalFetchUrlData as fetchUrlData } from '@wordpress/core-data';
  *
  * //...
  *
  * export function initialize( id, settings ) {
  *
- * settings.__experimentalFetchRemoteUrlData = (
+ * settings.__experimentalFetchUrlData = (
  * url
- * ) => fetchRemoteUrlData( url );
+ * ) => fetchUrlData( url );
  * ```
  * @return {Promise< WPRemoteUrlData[] >} Remote URL data.
  */
-const fetchRemoteUrlData = async ( url, options = {} ) => {
+const fetchUrlData = async ( url, options = {} ) => {
 	const endpoint = '/__experimental/url-details';
 
 	const args = {
@@ -58,4 +58,4 @@ const fetchRemoteUrlData = async ( url, options = {} ) => {
 	} );
 };
 
-export default fetchRemoteUrlData;
+export default fetchUrlData;

--- a/packages/core-data/src/fetch/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-url-data.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs, prependHTTP } from '@wordpress/url';
+import {
+	addQueryArgs,
+	prependHTTP,
+	isURL,
+	getProtocol,
+	isValidProtocol,
+} from '@wordpress/url';
 
 /**
  * A simple in-memory cache for requests.
@@ -44,6 +50,26 @@ const fetchUrlData = async ( url, options = {} ) => {
 	const args = {
 		url: prependHTTP( url ),
 	};
+
+	if ( ! isURL( url ) ) {
+		return Promise.reject(
+			new TypeError( `${ url } is not a valid URL.` )
+		);
+	}
+
+	// Test for "http" based URL as it is possible for valid
+	// yet unusable URLs such as `tel:123456` to be passed.
+	const protocol = getProtocol( url );
+
+	if (
+		! isValidProtocol( protocol ) ||
+		! protocol.startsWith( 'http' ) ||
+		! /^https?:\/\/[^\/\s]/i.test( url )
+	) {
+		return Promise.reject(
+			new TypeError( `${ url } does not have a valid protocol.` )
+		);
+	}
 
 	if ( CACHE.has( url ) ) {
 		return CACHE.get( url );

--- a/packages/core-data/src/fetch/index.js
+++ b/packages/core-data/src/fetch/index.js
@@ -1,2 +1,2 @@
 export { default as __experimentalFetchLinkSuggestions } from './__experimental-fetch-link-suggestions';
-export { default as __experimentalFetchRemoteUrlData } from './__experimental-fetch-remote-url-data';
+export { default as __experimentalFetchUrlData } from './__experimental-fetch-url-data';

--- a/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import fetchRemoteUrlData from '../__experimental-fetch-remote-url-data';
+import fetchUrlData from '../__experimental-fetch-url-data';
 /**
  * WordPress dependencies
  */
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
-describe( 'fetchRemoteUrlData', () => {
+describe( 'fetchUrlData', () => {
 	afterEach( () => {
 		apiFetch.mockReset();
 	} );
@@ -26,7 +26,7 @@ describe( 'fetchRemoteUrlData', () => {
 			apiFetch.mockReturnValueOnce( Promise.resolve( data ) );
 
 			await expect(
-				fetchRemoteUrlData( 'https://www.wordpress.org' )
+				fetchUrlData( 'https://www.wordpress.org' )
 			).resolves.toEqual( data );
 
 			expect( apiFetch ).toBeCalledTimes( 1 );
@@ -36,7 +36,7 @@ describe( 'fetchRemoteUrlData', () => {
 			apiFetch.mockReturnValueOnce( Promise.reject( 'fetch failed' ) );
 
 			await expect(
-				fetchRemoteUrlData( 'https://www.wordpress.org/1' )
+				fetchUrlData( 'https://www.wordpress.org/1' )
 			).rejects.toEqual( 'fetch failed' );
 		} );
 	} );
@@ -45,7 +45,7 @@ describe( 'fetchRemoteUrlData', () => {
 		it( 'passes options argument through to fetch API', async () => {
 			apiFetch.mockReturnValueOnce( Promise.resolve() );
 
-			await fetchRemoteUrlData( 'https://www.wordpress.org/2', {
+			await fetchUrlData( 'https://www.wordpress.org/2', {
 				method: 'POST',
 			} );
 
@@ -73,9 +73,7 @@ describe( 'fetchRemoteUrlData', () => {
 			};
 			apiFetch.mockReturnValueOnce( Promise.resolve( data ) );
 
-			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
-				data
-			);
+			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
 			expect( apiFetch ).toBeCalledTimes( 1 );
 
 			// Allow us to reassert on calls without it being polluted by first fetch
@@ -83,9 +81,7 @@ describe( 'fetchRemoteUrlData', () => {
 			apiFetch.mockClear();
 
 			// Fetch the same URL again...should be cached.
-			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
-				data
-			);
+			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
 
 			// Should now be in cache so no need to refetch from API.
 			expect( apiFetch ).toBeCalledTimes( 0 );
@@ -105,15 +101,13 @@ describe( 'fetchRemoteUrlData', () => {
 				.mockReturnValueOnce( Promise.reject( 'fetch failed' ) )
 				.mockReturnValueOnce( Promise.resolve( data ) );
 
-			await expect( fetchRemoteUrlData( targetUrl ) ).rejects.toEqual(
+			await expect( fetchUrlData( targetUrl ) ).rejects.toEqual(
 				'fetch failed'
 			);
 
 			// Cache should not store the previous failed fetch and should retry
 			// with a new fetch.
-			await expect( fetchRemoteUrlData( targetUrl ) ).resolves.toEqual(
-				data
-			);
+			await expect( fetchUrlData( targetUrl ) ).resolves.toEqual( data );
 
 			expect( apiFetch ).toBeCalledTimes( 2 );
 		} );

--- a/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
@@ -112,4 +112,36 @@ describe( 'fetchUrlData', () => {
 			expect( apiFetch ).toBeCalledTimes( 2 );
 		} );
 	} );
+
+	describe( 'URL validation', () => {
+		it.each( [ '#internal-link' ] )(
+			'errors when an invalid URL is passed',
+			async ( targetUrl ) => {
+				expect( apiFetch ).toBeCalledTimes( 0 );
+
+				await expect( fetchUrlData( targetUrl ) ).rejects.toEqual(
+					expect.stringContaining(
+						`${ targetUrl } is not a valid URL.`
+					)
+				);
+			}
+		);
+		it.each( [
+			'tel:123456',
+			'ftp://something',
+			'mailto:example@wordpress.org',
+			'file:somefilehere',
+		] )(
+			'errors when a non-http protocol (%s) is passed as part of URL',
+			async ( targetUrl ) => {
+				expect( apiFetch ).toBeCalledTimes( 0 );
+
+				await expect( fetchUrlData( targetUrl ) ).rejects.toEqual(
+					expect.stringContaining(
+						`${ targetUrl } does not have a valid protocol.`
+					)
+				);
+			}
+		);
+	} );
 } );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -11,7 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
-	__experimentalFetchRemoteUrlData as fetchRemoteUrlData,
+	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import {
 	getAuthority,
@@ -119,7 +119,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			}
 
 			// If external then attempt fetch of data.
-			return fetchRemoteUrlData( url, fetchOptions );
+			return fetchUrlData( url, fetchOptions );
 		},
 		[ baseUrl, hasResolvedLocalSiteData ]
 	);

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -6,27 +6,19 @@ import { pick, defaultTo } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Platform, useMemo, useCallback } from '@wordpress/element';
+import { Platform, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
-import {
-	getAuthority,
-	isURL,
-	getProtocol,
-	isValidProtocol,
-} from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
-
-const EMPTY_DATA = {};
 
 /**
  * React hook used to compute the block editor settings to use for the post editor.
@@ -41,8 +33,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		reusableBlocks,
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
-		baseUrl,
-		hasResolvedLocalSiteData,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
@@ -75,54 +65,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	}, [] );
 
 	const { undo } = useDispatch( editorStore );
-
-	// Temporary home - should this live in `core-data`?
-	const fetchRichUrlData = useCallback(
-		function ( url, fetchOptions = {} ) {
-			if ( ! isURL( url ) ) {
-				return Promise.reject(
-					new TypeError( `${ url } is not a valid URL.` )
-				);
-			}
-
-			// Test for "http" based URL as it is possible for valid
-			// yet unusable URLs such as `tel:123456` to be passed.
-			const protocol = getProtocol( url );
-
-			if (
-				! isValidProtocol( protocol ) ||
-				! protocol.startsWith( 'http' ) ||
-				! /^https?:\/\/[^\/\s]/i.test( url )
-			) {
-				return Promise.reject(
-					new TypeError( `${ url } does not have a valid protocol.` )
-				);
-			}
-
-			// If the baseUrl is still resolving then return
-			// empty data for this request.
-			if ( ! hasResolvedLocalSiteData ) {
-				return Promise.resolve( EMPTY_DATA );
-			}
-
-			// More accurate test for internal URLs to avoid edge cases
-			// such as baseURL being included as part of a query string
-			// on the target url.
-			const baseUrlAuthority = getAuthority( baseUrl );
-			const urlAuthority = getAuthority( url );
-
-			const isInternal = urlAuthority === baseUrlAuthority;
-
-			// Don't handle internal URLs (yet...).
-			if ( isInternal ) {
-				return Promise.resolve( EMPTY_DATA );
-			}
-
-			// If external then attempt fetch of data.
-			return fetchUrlData( url, fetchOptions );
-		},
-		[ baseUrl, hasResolvedLocalSiteData ]
-	);
 
 	return useMemo(
 		() => ( {
@@ -170,7 +112,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
-			__experimentalFetchRichUrlData: fetchRichUrlData,
+			__experimentalFetchRichUrlData: fetchUrlData,
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR enables rich previews in the link UI for _internal_ links. Currently we have a "middleman" method which short-circuits any attempts to fetch rich previews for internal URLs. However based on discussion in https://github.com/WordPress/gutenberg/issues/32689 this is not needed as the only thing that originally made me think those requests did not work was the `wp-env` environment setup.

Closes https://github.com/WordPress/gutenberg/issues/32689

## How has this been tested?

### Testing environment

⚠️ **Please do not use `wp-env` to test this PR.**

The best way to test this is on a site that is accessible to the internet or has a local hosts file mapping to ensure traffic can be routed to it. I recommend MAMP or Local by Flywheel (which is now free!). 

If you attempt to test this using the default `wp-env` setup on `localhost:8888` then **it will not work**. That's _not_ a failure of the code, it's just a facet of the way WP ENV and Docker work.

Aside: you _could_ use ngrok if using `wp-env` but it's fairly "involved".

### Awareness of caching

Also when testing this be aware that there are x2 caches involved:

* Local in memory cache - will cache a request for a rich preview until you refresh the page.
* Server side transient cache - will cache a request for a given URL for 1hr. You can turn this off by [shortcutting this conditional](https://github.com/WordPress/gutenberg/blob/a125447b6383e0a186e3614fdd886c61f2651a1c/lib/class-wp-rest-url-details-controller.php#L123) to make testing easier.

### Testing Steps

* Install the Gutenberg Plugin generated by Github action for this PR. You can [follow these steps](https://make.wordpress.org/design/2021/03/03/testing-a-gutenberg-pull-request-pr/) to guide you.
* Ensure your site is **accessible to the internet**.
* Go to the Customizer and set a `Site Icon` under `Site Identity`.
* Create and publish a few Posts/Pages - make sure you assign a featured image and add a title, excerpt and some post content. I used FakerPress Plugin to do this for me.
* Create a _fresh_ Post with some text.
* Create a link to one of the Posts you previously created.
* Click away from the link to close the link UI.
* Click on the same link again to open the rich preview.
* You should see a rich preview of that URL even though it is internal. By default you should see:
   - correct page title
   - correct site icon

**Note**: unfortunately out of the box WP doesn't set a meta description or a reference to the canonical image for the page so we cannot reliably retrieve these items to display in the rich preview. @hellofromtonya any idea why this is? Why don't we set these by default?

###  Bonus: testing even richer previews!

In order to prove this feature _does_ work if the correct meta data is made available in the page HTML, you can install a SEO Plugin to set these items for you.

* Try installing ~Yoast SEO~ (don't install Yoast as they [overide the inline link UI](https://github.com/Yoast/wordpress-seo/blob/13c4be0b65b5d7efd7bc87ff211dc063f9879465/packages/js/src/inline-links/inline.js#L259-L264) so they won't get rich previews) **The SEO Framework** Plugin.
* Remember the notes above regarding caches. You will probably want to disable these at this point to ensure you are seeing the latest data rather than a cache.
* Retry the above and see the new previews with more metadata including:
   - image of the page
   - description of the page.


## Screenshots <!-- if applicable -->

### Out of the box (no SEO Plugin)

https://user-images.githubusercontent.com/444434/127491380-e40c7ef8-cfb4-4641-aa23-d1bc8fa7baa4.mov

### With SEO Plugin 


https://user-images.githubusercontent.com/444434/127491423-e8a3639c-a8f4-46db-9c64-938793e0d1c4.mp4





## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
