### PR TITLE
Cancel left margin when full width block appender used at root level of layout

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -33,6 +33,12 @@
 	}
 }
 
+// Cancel left margin when appender is used at the root level of a list of blocks.
+// This happens on the Widgets screen where the full width appender is used.
+.block-editor-block-list__block .block-editor-block-list__layout > .block-list-appender {
+	margin-left: 0;
+}
+
 // For vertical flex containers, a 100% width ensures correct alignment.
 .is-vertical .block-list-appender {
 	width: $icon-size;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR ensures that when a full width block appended is used at the root level of the block list then it doesn't have any left margin applied to it.

It looks like[ we've been tinkering with the block appended margins quite a bit](https://github.com/WordPress/gutenberg/commits/trunk/packages/block-editor/src/components/block-list-appender/style.scss) so it's obviously a thorny area.

This fixes https://github.com/WordPress/gutenberg/issues/33085

## How has this been tested?

I don't have a high degree of confidence in the test scenarios I'll need to run through but here's a start:

* Activate TT1.
* Go to Appearance -> Widgets
* Look at the block list appender - check there is no additional left margin.
* Also check full width appender that is used in the Group block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
