### PR TITLE
Try: Refactor appender margin.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -33,7 +33,10 @@
 		margin-left: $grid-unit-10;
 	}
 
-	// Cancel any left margin if the black plus is the only child.
+	// Cancel any left margin if the black plus sits alone in the container.
+	// `first-of-type` is used instead of `first-child` as the element is not always the only
+	// element in the "empty" container. For example the empty navigation block state has a
+	// zero-width placeholder state that is meant to help correctly size the dimensions.
 	&:first-of-type .block-list-appender__toggle {
 		margin-left: 0;
 	}

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -10,26 +10,31 @@
 		max-width: none;
 	}
 
-	// Add a little left margin when used horizontally.
-	// The right margin should be set to auto, so as to not shift layout in flex containers.
-	margin: 0 auto 0 $grid-unit-10;
-
-	// ... unless it's the only child.
-	&:first-child {
-		margin-left: 0;
-	}
-
 	.block-editor-default-block-appender {
 		margin: $grid-unit-10 0;
 	}
 
-	// Animate appearance.
+	// Add an explicit left margin of zero and auto right margin
+	// to work in horizontal flex containers.
+	margin: 0 auto 0 0;
+
+	// Black square plus appender.
 	.block-list-appender__toggle {
 		padding: 0;
+
+		// Animate appearance.
 		opacity: 1;
 		transform: scale(1);
 		transition: all 0.1s ease;
 		@include reduce-motion("transition");
+
+		// The black square button should have a little left margin in horizontal containers.
+		margin-left: $grid-unit-10;
+	}
+
+	// Cancel any left margin if the black plus is the only child.
+	&:first-of-type .block-list-appender__toggle {
+		margin-left: 0;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -14,8 +14,9 @@
 		margin: $grid-unit-10 0;
 	}
 
-	// Add an explicit left margin of zero and auto right margin
-	// to work in horizontal flex containers.
+	// Add an explicit left margin of zero and auto right margin to work in horizontal
+	// flex containers. Without it, a "space-between"-like effect from two auto margins
+	// will cause the black plus to sit in the center of what space is left.
 	margin: 0 auto 0 0;
 
 	// Black square plus appender.


### PR DESCRIPTION
## Description

Fixes #33085. Alternative to #33087. 

As detailed in https://github.com/WordPress/gutenberg/pull/33087#issuecomment-871227848, there's a small explicit left margin on the black appender plus, and an intentional right auto margin, so as to work inside flex containers:

<img width="718" alt="Screenshot 2021-06-30 at 11 03 12" src="https://user-images.githubusercontent.com/1204802/123933600-d19b4a80-d992-11eb-984c-fd5118824f0c.png">

It _has_ to have an explicit left margin that isn't "auto", in order to work inside flex containers:

<img width="733" alt="Screenshot 2021-06-30 at 11 03 52" src="https://user-images.githubusercontent.com/1204802/123933730-eed01900-d992-11eb-82f3-83c40aec32e5.png">

The problem as reported is that this left margin is applied also to the big white square plus, the "button" appender, and it shouldn't be.

This PR tries to move the margin from the general block appender itself (both black and white), to the specific button type inside (either black or white), thus solving the problem.

<img width="836" alt="Screenshot 2021-06-30 at 11 18 37" src="https://user-images.githubusercontent.com/1204802/123939122-1675b000-d998-11eb-8ce8-40343f515ef6.png">

<img width="837" alt="Screenshot 2021-06-30 at 11 39 28" src="https://user-images.githubusercontent.com/1204802/123939131-183f7380-d998-11eb-9b2a-a52032e7cab7.png">

<img width="813" alt="Screenshot 2021-06-30 at 11 39 44" src="https://user-images.githubusercontent.com/1204802/123939138-1a093700-d998-11eb-8414-cf525aecdc8a.png">

<img width="825" alt="Screenshot 2021-06-30 at 11 39 53" src="https://user-images.githubusercontent.com/1204802/123939150-1c6b9100-d998-11eb-9424-778ed12af65f.png">

## How has this been tested?

- Test that there's no extra left margin on the big white plus button in the widgets page.

But it's also important to test this doesn't regress any of the other appenders in any of the contexts.

- The white plus appender is also used in groups and columns and other places, and should never have margin.
- The black plus should have left margin when there are multiple horizontal blocks like social links, buttons, or navigation items.
- The black plus should not have left margin if it's the only block inside such a horizontal container.
- It seems prudent to also test that the black plus looks correct in any other context where used, such as nesting containers and otherwise.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
