### PR TITLE
[RNMobile] Handle floating keyboard case

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
+++ b/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
@@ -38,6 +38,12 @@ class KeyboardAvoidingView extends Component {
 			return 0;
 		}
 
+		const windowWidth = Dimensions.get( 'window' ).width;
+		const isFloatingKeyboard = keyboardFrame.width !== windowWidth;
+		if ( isFloatingKeyboard ) {
+			return 0;
+		}
+
 		const windowHeight = Dimensions.get( 'window' ).height;
 		const keyboardY =
 			keyboardFrame.screenY - this.props.keyboardVerticalOffset;

--- a/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
+++ b/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
@@ -19,6 +19,7 @@ import { useResizeObserver } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import useIsFloatingKeyboard from '../utils/use-is-floating-keyboard';
 import styles from './styles.scss';
 
 const AnimatedKeyboardAvoidingView = Animated.createAnimatedComponent(
@@ -37,6 +38,7 @@ export const KeyboardAvoidingView = ( {
 	const [ isKeyboardOpen, setIsKeyboardOpen ] = useState( false );
 	const [ safeAreaBottomInset, setSafeAreaBottomInset ] = useState( 0 );
 	const { height = 0 } = sizes || {};
+	const floatingKeyboard = useIsFloatingKeyboard();
 
 	const animatedHeight = useRef( new Animated.Value( MIN_HEIGHT ) ).current;
 
@@ -101,6 +103,7 @@ export const KeyboardAvoidingView = ( {
 	return (
 		<AnimatedKeyboardAvoidingView
 			{ ...otherProps }
+			enabled={ ! floatingKeyboard }
 			behavior="padding"
 			keyboardVerticalOffset={ keyboardVerticalOffset }
 			style={

--- a/packages/components/src/mobile/utils/use-is-floating-keyboard.native.js
+++ b/packages/components/src/mobile/utils/use-is-floating-keyboard.native.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { Keyboard, Dimensions } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+export default function useIsFloatingKeyboard() {
+	const windowWidth = Dimensions.get( 'window' ).width;
+
+	const [ floating, setFloating ] = useState( false );
+
+	useEffect( () => {
+		const onKeyboardWillChangeFrame = ( event ) => {
+			setFloating( event.endCoordinates.width !== windowWidth );
+		};
+
+		Keyboard.addListener(
+			'keyboardWillChangeFrame',
+			onKeyboardWillChangeFrame
+		);
+		return () => {
+			Keyboard.removeListener(
+				'keyboardWillChangeFrame',
+				onKeyboardWillChangeFrame
+			);
+		};
+	}, [ windowWidth ] );
+
+	return floating;
+}

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,8 +12,8 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 ## 1.55.2
+-   [*] Handle floating keyboard case - Fix issue with the block selector on iPad. [#33089]
 -   [**] Fix incorrect block insertion point after blurring the post title field. [#32831]
-
 -   [*] Tweaks to the badge component's styling, including change of background color and reduced padding. [#32865]
 
 ## 1.55.1


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3687

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Some UI elements like the toolbar and the bottom sheet take into account the keyboard height for calculating their layouts. On iOS, the keyboard can be switched to a floating mode which is affecting the layout calculations for those elements and the user experience.

This PR introduces a hook that determines if the keyboard is in floating mode and updates the layout calculations for the following elements:
- `BottomSheet`
- `KeyboardAvoidingView`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**NOTE:** This can only be tested on iPad devices.

1. Open the app on an iPad device.
2. Tap on the post's title or any text block like the Paragraph block to display the keyboard.
3. Long press on the keyboard button located at the lower right corner and tap on "Floating" ([here](https://support.apple.com/en-us/HT210758) are the official instructions for switching on/off the floating mode).
4. Observe that the toolbar is located at the bottom.
5. Move the floating keyboard around the screen.
6. Observe that the elements are not being affected by the previous action.
7. Tap on the ➕ button to display the inserter menu.
8. Observe that the menu displays its content properly.
9. Disable the floating keyboard by dragging it to the bottom area.
10. Observe that the toolbar and the inserter menu are displayed properly.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/123938766-b121bf00-d997-11eb-834d-e131c2a374e9.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
