### PR TITLE
Fix dependency extraction webpack v5 deprecation

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -215,8 +215,7 @@ class DependencyExtractionWebpackPlugin {
 
 			// Add source and file into compilation for webpack to output.
 			compilation.assets[ assetFilename ] = new RawSource( assetString );
-			if ( isWebpack4 ) runtimeChunk.files.push( assetFilename );
-			else runtimeChunk.files.add( assetFilename );
+			runtimeChunk.files[ isWebpack4 ? 'push' : 'add' ]( assetFilename );
 		}
 
 		if ( combineAssets ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -7,6 +7,7 @@ const webpack = require( 'webpack' );
 // In webpack 5 there is a `webpack.sources` field but for webpack 4 we have to fallback to the `webpack-sources` package.
 const { RawSource } = webpack.sources || require( 'webpack-sources' );
 const json2php = require( 'json2php' );
+const isWebpack4 = webpack.version.startsWith( '4.' );
 
 /**
  * Internal dependencies
@@ -41,7 +42,9 @@ class DependencyExtractionWebpackPlugin {
 		// Offload externalization work to the ExternalsPlugin.
 		this.externalsPlugin = new webpack.ExternalsPlugin(
 			'window',
-			this.externalizeWpDeps.bind( this )
+			isWebpack4
+				? this.externalizeWpDeps.bind( this )
+				: this.externalizeWpDepsV5.bind( this )
 		);
 	}
 
@@ -68,6 +71,10 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		return callback();
+	}
+
+	externalizeWpDepsV5( { context, request }, callback ) {
+		return this.externalizeWpDeps( context, request, callback );
 	}
 
 	mapRequestToDependency( request ) {
@@ -104,116 +111,139 @@ class DependencyExtractionWebpackPlugin {
 	apply( compiler ) {
 		this.externalsPlugin.apply( compiler );
 
-		compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
-			const {
-				combineAssets,
-				combinedOutputFile,
-				injectPolyfill,
-				outputFormat,
-			} = this.options;
-
-			const combinedAssetsData = {};
-
-			// Process each entry point independently.
-			for ( const [
-				entrypointName,
-				entrypoint,
-			] of compilation.entrypoints.entries() ) {
-				const entrypointExternalizedWpDeps = new Set();
-				if ( injectPolyfill ) {
-					entrypointExternalizedWpDeps.add( 'wp-polyfill' );
+		if ( isWebpack4 ) {
+			compiler.hooks.emit.tap( this.constructor.name, ( compilation ) =>
+				this.addAssets( compilation, compiler )
+			);
+		} else {
+			compiler.hooks.thisCompilation.tap(
+				this.constructor.name,
+				( compilation ) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: this.constructor.name,
+							stage:
+								webpack.Compilation
+									.PROCESS_ASSETS_STAGE_ADDITIONAL,
+						},
+						() => this.addAssets( compilation, compiler )
+					);
 				}
+			);
+		}
+	}
 
-				const processModule = ( { userRequest } ) => {
-					if ( this.externalizedDeps.has( userRequest ) ) {
-						const scriptDependency = this.mapRequestToDependency(
-							userRequest
-						);
-						entrypointExternalizedWpDeps.add( scriptDependency );
-					}
-				};
+	addAssets( compilation, compiler ) {
+		const {
+			combineAssets,
+			combinedOutputFile,
+			injectPolyfill,
+			outputFormat,
+		} = this.options;
 
-				// Search for externalized modules in all chunks.
-				for ( const chunk of entrypoint.chunks ) {
-					for ( const chunkModule of chunk.modulesIterable ) {
-						processModule( chunkModule );
-						// loop through submodules of ConcatenatedModule
-						if ( chunkModule.modules ) {
-							for ( const concatModule of chunkModule.modules ) {
-								processModule( concatModule );
-							}
+		const combinedAssetsData = {};
+
+		// Process each entry point independently.
+		for ( const [
+			entrypointName,
+			entrypoint,
+		] of compilation.entrypoints.entries() ) {
+			const entrypointExternalizedWpDeps = new Set();
+			if ( injectPolyfill ) {
+				entrypointExternalizedWpDeps.add( 'wp-polyfill' );
+			}
+
+			const processModule = ( { userRequest } ) => {
+				if ( this.externalizedDeps.has( userRequest ) ) {
+					const scriptDependency = this.mapRequestToDependency(
+						userRequest
+					);
+					entrypointExternalizedWpDeps.add( scriptDependency );
+				}
+			};
+
+			// Search for externalized modules in all chunks.
+			for ( const chunk of entrypoint.chunks ) {
+				const modulesIterable = isWebpack4
+					? chunk.modulesIterable
+					: compilation.chunkGraph.getChunkModules( chunk );
+				for ( const chunkModule of modulesIterable ) {
+					processModule( chunkModule );
+					// loop through submodules of ConcatenatedModule
+					if ( chunkModule.modules ) {
+						for ( const concatModule of chunkModule.modules ) {
+							processModule( concatModule );
 						}
 					}
 				}
+			}
 
-				const runtimeChunk = entrypoint.getRuntimeChunk();
+			const runtimeChunk = entrypoint.getRuntimeChunk();
 
-				const assetData = {
-					// Get a sorted array so we can produce a stable, stringified representation.
+			const assetData = {
+				// Get a sorted array so we can produce a stable, stringified representation.
 					dependencies: Array.from(
 						entrypointExternalizedWpDeps
 					).sort(),
-					version: runtimeChunk.hash,
-				};
+				version: runtimeChunk.hash,
+			};
 
-				const assetString = this.stringify( assetData );
+			const assetString = this.stringify( assetData );
 
-				// Determine a filename for the asset file.
-				const [ filename, query ] = entrypointName.split( '?', 2 );
-				const buildFilename = compilation.getPath(
-					compiler.options.output.filename,
-					{
-						chunk: runtimeChunk,
-						filename,
-						query,
-						basename: basename( filename ),
-						contentHash: createHash( 'md4' )
-							.update( assetString )
-							.digest( 'hex' ),
-					}
-				);
-
-				if ( combineAssets ) {
-					combinedAssetsData[ buildFilename ] = assetData;
-					continue;
+			// Determine a filename for the asset file.
+			const [ filename, query ] = entrypointName.split( '?', 2 );
+			const buildFilename = compilation.getPath(
+				compiler.options.output.filename,
+				{
+					chunk: runtimeChunk,
+					filename,
+					query,
+					basename: basename( filename ),
+					contentHash: createHash( 'md4' )
+						.update( assetString )
+						.digest( 'hex' ),
 				}
-
-				const assetFilename = buildFilename.replace(
-					/\.js$/i,
-					'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' )
-				);
-
-				// Add source and file into compilation for webpack to output.
-				compilation.assets[ assetFilename ] = new RawSource(
-					assetString
-				);
-				runtimeChunk.files.push( assetFilename );
-			}
+			);
 
 			if ( combineAssets ) {
-				// Assert the `string` type for output path.
-				// The type indicates the option may be `undefined`.
-				// However, at this point in compilation, webpack has filled the options in if
-				// they were not provided.
+				combinedAssetsData[ buildFilename ] = assetData;
+				continue;
+			}
+
+			const assetFilename = buildFilename.replace(
+				/\.js$/i,
+				'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' )
+			);
+
+			// Add source and file into compilation for webpack to output.
+			compilation.assets[ assetFilename ] = new RawSource( assetString );
+			if ( isWebpack4 ) runtimeChunk.files.push( assetFilename );
+			else runtimeChunk.files.add( assetFilename );
+		}
+
+		if ( combineAssets ) {
+			// Assert the `string` type for output path.
+			// The type indicates the option may be `undefined`.
+			// However, at this point in compilation, webpack has filled the options in if
+			// they were not provided.
 				const outputFolder = /** @type {{path:string}} */ ( compiler
 					.options.output ).path;
 
-				const assetsFilePath = path.resolve(
-					outputFolder,
-					combinedOutputFile ||
-						'assets.' + ( outputFormat === 'php' ? 'php' : 'json' )
-				);
-				const assetsFilename = path.relative(
-					outputFolder,
-					assetsFilePath
-				);
+			const assetsFilePath = path.resolve(
+				outputFolder,
+				combinedOutputFile ||
+					'assets.' + ( outputFormat === 'php' ? 'php' : 'json' )
+			);
+			const assetsFilename = path.relative(
+				outputFolder,
+				assetsFilePath
+			);
 
-				// Add source into compilation for webpack to output.
-				compilation.assets[ assetsFilename ] = new RawSource(
-					this.stringify( combinedAssetsData )
-				);
-			}
-		} );
+			// Add source into compilation for webpack to output.
+			compilation.assets[ assetsFilename ] = new RawSource(
+				this.stringify( combinedAssetsData )
+			);
+		}
 	}
 }
 

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -182,9 +182,7 @@ class DependencyExtractionWebpackPlugin {
 
 			const assetData = {
 				// Get a sorted array so we can produce a stable, stringified representation.
-					dependencies: Array.from(
-						entrypointExternalizedWpDeps
-					).sort(),
+				dependencies: Array.from( entrypointExternalizedWpDeps ).sort(),
 				version: runtimeChunk.hash,
 			};
 
@@ -226,8 +224,8 @@ class DependencyExtractionWebpackPlugin {
 			// The type indicates the option may be `undefined`.
 			// However, at this point in compilation, webpack has filled the options in if
 			// they were not provided.
-				const outputFolder = /** @type {{path:string}} */ ( compiler
-					.options.output ).path;
+			const outputFolder = /** @type {{path:string}} */ ( compiler.options
+				.output ).path;
 
 			const assetsFilePath = path.resolve(
 				outputFolder,

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -123,7 +123,7 @@ class DependencyExtractionWebpackPlugin {
 						{
 							name: this.constructor.name,
 							stage:
-								webpack.Compilation
+								compiler.webpack.Compilation
 									.PROCESS_ASSETS_STAGE_ADDITIONAL,
 						},
 						() => this.addAssets( compilation, compiler )


### PR DESCRIPTION
## Description
Get rid of webpack v5 deprecation, supporting also v4. Using conditionals checks to implement solutions for both versions
This should fix #27984. And allow other projects using this package to update to v5 safely.
## How has this been tested?
Appreciate a hand here to properly test it. I checked the following cases:
- Tests runs without issues.
- Used it in WC Pay with both v4 and v5 without issues.

## Types of changes
**Bug fix** -  The support for webpack v5 is now completed, fixing all warnings about deprecation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
