### PR TITLE
Image Block: Improve "can switch to cover" check

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -87,7 +87,6 @@ export default function Image( {
 } ) {
 	const captionRef = useRef();
 	const prevUrl = usePrevious( url );
-	const { getBlock } = useSelect( blockEditorStore );
 	const { image, multiImageSelection } = useSelect(
 		( select ) => {
 			const { getMedia } = select( coreStore );
@@ -109,6 +108,7 @@ export default function Image( {
 	);
 	const {
 		canInsertCover,
+		getBlock,
 		imageEditing,
 		imageSizes,
 		maxWidth,
@@ -116,12 +116,18 @@ export default function Image( {
 	} = useSelect(
 		( select ) => {
 			const {
-				canInsertBlockType,
+				getBlock: _getBlock,
 				getBlockRootClientId,
+				getBlockTransformItems,
 				getSettings,
 			} = select( blockEditorStore );
 
+			const block = _getBlock( clientId );
 			const rootClientId = getBlockRootClientId( clientId );
+			const transformations = getBlockTransformItems(
+				[ block ],
+				rootClientId
+			);
 			const settings = pick( getSettings(), [
 				'imageEditing',
 				'imageSizes',
@@ -131,10 +137,12 @@ export default function Image( {
 
 			return {
 				...settings,
-				canInsertCover: canInsertBlockType(
-					'core/cover',
-					rootClientId
-				),
+				getBlock: _getBlock,
+				canInsertCover:
+					transformations?.length &&
+					!! transformations.find(
+						( { name } ) => name === 'core/cover'
+					),
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
## Description
Removes custom `checkBlockExists` method and replaces it with a custom check that uses possible block transformations.

This fixes the issue when the "Add text over image" button is still displayed, even if the Cover block settings are filtered to disable inserter or transformations.

New check should cover scenarios when:
* Cover block is unregistered.
* Cover block is hidden using Preferences > Blocks modal.
* Parent block doesn't have Cover in the allowed blocks list.
* Cover block has `supports.inserter` set to `false`.
* Transformation settings for the Cover block are filtered by a plugin.

Fixes #32520.

## How has this been tested?
1. Create a post.
2. Insert Image block and select image.
3. Disable Cover block from the Preferences > Blocks modal section.
4. "Add text over image" toolbar item shouldn't be visible.

**Disable inserted for the Cover block:**
```php
add_filter( 'block_type_metadata', function( $metadata ) {
	if ( $metadata['name'] !== 'core/cover' ) {
		return $metadata;
	}

	$metadata['supports']['inserter'] = false;

	return $metadata;
} );
```

**Disabled transformations:**
```js
function disableCoverTransformations( settings, name ) {
	if ( name !== 'core/cover' ) {
		return settings;
	}

	settings.transforms = {
		from: [],
		to: [],
	};

	return settings
}

wp.hooks.addFilter(
	'blocks.registerBlockType',
	'mamaduka/disable-cover-transform',
	disableCoverTransformations
);
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
