### PR TITLE
Button block border: fix block validation issue for numeric border radius

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -202,6 +202,12 @@ function ButtonEdit( props ) {
 	const ref = useRef();
 	const blockProps = useBlockProps( { ref } );
 
+	// For backwards compatibility support number based radius.
+	const borderStyle =
+		typeof style?.border?.radius === 'number' && style?.border?.radius
+			? { borderRadius: style.border.radius }
+			: { ...borderProps.style };
+
 	return (
 		<>
 			<div
@@ -229,7 +235,7 @@ function ButtonEdit( props ) {
 						}
 					) }
 					style={ {
-						...borderProps.style,
+						...borderStyle,
 						...colorProps.style,
 					} }
 					onSplit={ ( value ) =>

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -29,6 +29,7 @@ export default function save( { attributes, className } ) {
 		return null;
 	}
 
+	const borderRadius = style?.border?.radius;
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
 	const buttonClasses = classnames(
@@ -38,11 +39,18 @@ export default function save( { attributes, className } ) {
 		{
 			// For backwards compatibility add style that isn't provided via
 			// block support.
-			'no-border-radius': style?.border?.radius === 0,
+			'no-border-radius': borderRadius === 0,
 		}
 	);
+
+	// For backwards compatibility support number based radius.
+	const borderStyle =
+		typeof borderRadius === 'number' && borderRadius
+			? { borderRadius: style.border.radius }
+			: { ...borderProps.style };
+
 	const buttonStyle = {
-		...borderProps.style,
+		...borderStyle,
 		...colorProps.style,
 	};
 

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.html
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.html
@@ -1,0 +1,3 @@
+<!-- wp:button {"style":{"border":{"radius":1}},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" style="border-radius:1px">Where We Are</a></div>
+<!-- /wp:button -->

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.json
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.json
@@ -1,0 +1,18 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"text": "Where We Are",
+			"className": "is-style-outline",
+			"style": {
+				"border": {
+					"radius": 1
+				}
+			}
+		},
+		"innerBlocks": [],
+		"originalContent": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link\" style=\"border-radius:1px\">Where We Are</a></div>"
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.parsed.json
@@ -1,0 +1,18 @@
+[
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"style": {
+				"border": {
+					"radius": 1
+				}
+			},
+			"className": "is-style-outline"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link\" style=\"border-radius:1px\">Where We Are</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link\" style=\"border-radius:1px\">Where We Are</a></div>\n"
+		]
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__numeric.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:button {"className":"is-style-outline","style":{"border":{"radius":1}}} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" style="border-radius:1px">Where We Are</a></div>
+<!-- /wp:button -->


### PR DESCRIPTION
Following on from #33017, it looks like we might have missed a particular case of the button block where the radius is set numerically. This resulted in the following block pattern throwing a block validation error:

![image](https://user-images.githubusercontent.com/14988353/123968861-fb885780-d9fa-11eb-8054-dde32b0d1e09.png)

![image](https://user-images.githubusercontent.com/14988353/123970624-a0effb00-d9fc-11eb-9c97-b4f29117576e.png)

```html
<!-- wp:buttons {"contentJustification":"center"} -->
<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"style":{"border":{"radius":0}}} -->
<div class="wp-block-button"><a class="wp-block-button__link no-border-radius">Our Work</a></div>
<!-- /wp:button -->

<!-- wp:button {"style":{"border":{"radius":1}},"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" style="border-radius:1px">Where We Are</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following on from #33017, add back in a condition to use the numeric border radius attribute if present, otherwise use the border props styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. From the code editor view, insert the above pattern.
2. Switch back to the visual editor and check that there are no validation errors and that the pattern is rendering correctly
3. Add the following pattern from #33017 in the code editor view and ensure it renders correctly without block validation errors:

```html
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"width":50,"style":{"border":{"radius":{"topLeft":"89px","topRight":"86px","bottomLeft":"14px","bottomRight":"14px"}}}} -->
<div class="wp-block-button has-custom-width wp-block-button__width-50"><a class="wp-block-button__link" style="border-top-left-radius:89px;border-top-right-radius:86px;border-bottom-left-radius:14px;border-bottom-right-radius:14px">Test</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

## Screenshots <!-- if applicable -->

After this change, the above should render correctly, e.g.

| Previously broken pattern | Block from #33017 |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/123969836-ebbd4300-d9fb-11eb-8405-d7c9d10914e7.png) | ![image](https://user-images.githubusercontent.com/14988353/123970154-3a6add00-d9fc-11eb-95c4-2110f20ebcea.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
