### PR TITLE
Skip the "Should add and save the marquee widget" e2e test

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -427,7 +427,7 @@ describe( 'Widgets screen', () => {
 		await marqueeBlockOption.click();
 	}
 
-	it( 'Should add and save the marquee widget', async () => {
+	it.skip( 'Should add and save the marquee widget', async () => {
 		await activatePlugin( 'gutenberg-test-marquee-widget' );
 		await visitAdminPage( 'widgets.php' );
 


### PR DESCRIPTION
An alternative to https://github.com/WordPress/gutenberg/pull/33066 where we temporarily skip the faulty test for the purposes of RC release.