### PR TITLE
Revert "Prepublish Panel: Disable the Publish and Cancel buttons while saving"

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -147,7 +147,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const buttonProps = {
-			'aria-disabled': isButtonDisabled,
+			'aria-disabled': isButtonDisabled && ! hasNonPostEntityChanges,
 			className: 'editor-post-publish-button',
 			isBusy: ! isAutoSaving && isSaving && isPublished,
 			variant: 'primary',

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -25,22 +25,6 @@ describe( 'PostPublishButton', () => {
 			);
 		} );
 
-		it( 'should be true if post is currently saving, even if there are non-post entity changes', () => {
-			// This normally means that we're still saving those changes.
-			const wrapper = shallow(
-				<PostPublishButton
-					hasNonPostEntityChanges
-					isPublishable
-					isSaveable
-					isSaving
-				/>
-			);
-
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
-			);
-		} );
-
 		it( 'should be true if forceIsSaving is true', () => {
 			const wrapper = shallow(
 				<PostPublishButton isPublishable isSaveable forceIsSaving />
@@ -106,20 +90,6 @@ describe( 'PostPublishButton', () => {
 		it( 'should be false if post is publishave and saveable', () => {
 			const wrapper = shallow(
 				<PostPublishButton isPublishable isSaveable />
-			);
-
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				false
-			);
-		} );
-
-		it( 'should be false if there are non-post entity changes', () => {
-			const wrapper = shallow(
-				<PostPublishButton
-					hasNonPostEntityChanges
-					isPublishable
-					isSaveable
-				/>
 			);
 
 			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -97,11 +97,7 @@ export class PostPublishPanel extends Component {
 								/>
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">
-								<Button
-									disabled={ isSaving }
-									onClick={ onClose }
-									variant="secondary"
-								>
+								<Button onClick={ onClose } variant="secondary">
 									{ __( 'Cancel' ) }
 								</Button>
 							</div>

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -135,7 +135,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
-        disabled={false}
         variant="secondary"
       >
         Cancel
@@ -176,7 +175,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
-        disabled={true}
         variant="secondary"
       >
         Cancel


### PR DESCRIPTION
Reverts WordPress/gutenberg#32889

Fixes https://github.com/WordPress/gutenberg/issues/33072. See https://github.com/WordPress/gutenberg/issues/33072#issuecomment-871669601 for more details.