### PR TITLE
[Regression - Button]: Add deprecation for `style.border.radius` `number`

### DIFF
--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -18,8 +18,18 @@ import { compose } from '@wordpress/compose';
 
 const migrateBorderRadius = ( attributes ) => {
 	const { borderRadius, ...newAttributes } = attributes;
-
-	if ( ! borderRadius && borderRadius !== 0 ) {
+	// We have to check old property `borderRadius` and if
+	// `styles.border.radius` is a `number`
+	const oldBorderRadius = [
+		borderRadius,
+		newAttributes.style?.border?.radius,
+	].find( ( possibleBorderRadius ) => {
+		return (
+			typeof possibleBorderRadius === 'number' &&
+			possibleBorderRadius !== 0
+		);
+	} );
+	if ( ! oldBorderRadius ) {
 		return newAttributes;
 	}
 
@@ -27,7 +37,10 @@ const migrateBorderRadius = ( attributes ) => {
 		...newAttributes,
 		style: {
 			...newAttributes.style,
-			border: { radius: `${ borderRadius }px` },
+			border: {
+				...newAttributes.style?.border,
+				radius: `${ oldBorderRadius }px`,
+			},
 		},
 	};
 };
@@ -100,6 +113,112 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		supports: {
+			anchor: true,
+			align: true,
+			alignWide: false,
+			color: {
+				__experimentalSkipSerialization: true,
+				gradients: true,
+			},
+			typography: {
+				fontSize: true,
+				__experimentalFontFamily: true,
+			},
+			reusable: false,
+			__experimentalSelector: '.wp-block-button__link',
+		},
+		attributes: {
+			...blockAttributes,
+			linkTarget: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'a',
+				attribute: 'target',
+			},
+			rel: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'a',
+				attribute: 'rel',
+			},
+			placeholder: {
+				type: 'string',
+			},
+			backgroundColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			gradient: {
+				type: 'string',
+			},
+			width: {
+				type: 'number',
+			},
+		},
+		isEligible( { style } ) {
+			return typeof style?.border?.radius === 'number';
+		},
+		save( { attributes, className } ) {
+			const {
+				fontSize,
+				linkTarget,
+				rel,
+				style,
+				text,
+				title,
+				url,
+				width,
+			} = attributes;
+
+			if ( ! text ) {
+				return null;
+			}
+
+			const borderRadius = style?.border?.radius;
+			const colorProps = getColorClassesAndStyles( attributes );
+			const buttonClasses = classnames(
+				'wp-block-button__link',
+				colorProps.className,
+				{
+					'no-border-radius': style?.border?.radius === 0,
+				}
+			);
+			const buttonStyle = {
+				borderRadius: borderRadius ? borderRadius : undefined,
+				...colorProps.style,
+			};
+
+			// The use of a `title` attribute here is soft-deprecated, but still applied
+			// if it had already been assigned, for the sake of backward-compatibility.
+			// A title will no longer be assigned for new or updated button block links.
+
+			const wrapperClasses = classnames( className, {
+				[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+				[ `has-custom-font-size` ]:
+					fontSize || style?.typography?.fontSize,
+			} );
+
+			return (
+				<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+					<RichText.Content
+						tagName="a"
+						className={ buttonClasses }
+						href={ url }
+						title={ title }
+						style={ buttonStyle }
+						value={ text }
+						target={ linkTarget }
+						rel={ rel }
+					/>
+				</div>
+			);
+		},
+		migrate: migrateBorderRadius,
+	},
 	{
 		supports: {
 			anchor: true,

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.html
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.html
@@ -1,0 +1,3 @@
+<!-- wp:button {"style":{"border":{"radius":10},"color":{"text":"#1b9b6c"}},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color" style="color:#1b9b6c;border-radius:10px;">Where We Are</a></div>
+<!-- /wp:button -->

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.json
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.json
@@ -1,0 +1,21 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"text": "Where We Are",
+			"className": "is-style-outline",
+			"style": {
+				"border": {
+					"radius": "10px"
+				},
+				"color": {
+					"text": "#1b9b6c"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"originalContent": "<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color\" style=\"color:#1b9b6c;border-radius:10px;\">Where We Are</a></div>"
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.parsed.json
@@ -1,0 +1,21 @@
+[
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"style": {
+				"border": {
+					"radius": 10
+				},
+				"color": {
+					"text": "#1b9b6c"
+				}
+			},
+			"className": "is-style-outline"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color\" style=\"color:#1b9b6c;border-radius:10px;\">Where We Are</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color\" style=\"color:#1b9b6c;border-radius:10px;\">Where We Are</a></div>\n"
+		]
+	}
+]

--- a/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__button__border_radius__deprecated-2.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:button {"className":"is-style-outline","style":{"border":{"radius":"10px"},"color":{"text":"#1b9b6c"}}} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color" style="border-radius:10px;color:#1b9b6c">Where We Are</a></div>
+<!-- /wp:button -->


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes: https://github.com/WordPress/pattern-directory/issues/245

Regression from: https://github.com/WordPress/gutenberg/pull/33017


The above PR(33017) added support for longhand border radius styles for each corner. This resulted in leaving the existing case of a button block with a number value at `border.style.color` unhandled from deprecations, therefore causing errors.

[It was discussed ](https://wordpress.slack.com/archives/C02QB2JS7/p1625050079137700?thread_ts=1625031663.134000&cid=C02QB2JS7)in `core-editor` slack, after noticing that a core pattern was causing errors and made all tests fail, as they don't expect `console` messages.

While this PR fixes the regression, we need to handle in another PR the removal of the remote patterns from the tests, as we cannot let the repo's CI depend on something external.

<!-- Please describe what you have changed or added -->

## Testing instructions
1. In code view in a page add the following markup which contains `style.border.radius` as a number (that was the core pattern)
```
<!-- wp:buttons {"contentJustification":"center"} -->
<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"style":{"border":{"radius":0}}} -->
<div class="wp-block-button"><a class="wp-block-button__link no-border-radius">Our Work</a></div>
<!-- /wp:button -->
<!-- wp:button {"style":{"border":{"radius":1}},"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link" style="border-radius:1px">Where We Are</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
2. Observe that in trunk it errors and in this branch is converted fine.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
