### PR TITLE
ESLint Plugin: Use Jest related rules only when the package is installed

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^34.1.0` to requiring `^36.0.8` ([#34338](https://github.com/WordPress/gutenberg/pull/34338)).
 
+### Bug Fix
+
+-   Use Jest related rules only when the `jest` package is installed ([#33120](https://github.com/WordPress/gutenberg/pull/33120)).
+
 ## 9.1.2 (2021-09-09)
 
 ### Bug Fix

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -1,4 +1,9 @@
-module.exports = {
+/**
+ * Internal dependencies
+ */
+const { isPackageInstalled } = require( '../utils' );
+
+const config = {
 	parser: 'babel-eslint',
 	extends: [
 		require.resolve( './jsx-a11y.js' ),
@@ -27,7 +32,10 @@ module.exports = {
 		'import/default': 'warn',
 		'import/named': 'warn',
 	},
-	overrides: [
+};
+
+if ( isPackageInstalled( 'jest' ) ) {
+	config.overrides = [
 		{
 			// Unit test files and their helpers only.
 			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
@@ -38,5 +46,7 @@ module.exports = {
 			files: [ '**/specs/**/*.js', '**/?(*.)spec.js' ],
 			extends: [ require.resolve( './test-e2e.js' ) ],
 		},
-	],
-};
+	];
+}
+
+module.exports = config;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -45,6 +45,7 @@
 		"eslint-plugin-react": "^7.22.0",
 		"eslint-plugin-react-hooks": "^4.2.0",
 		"globals": "^12.0.0",
+		"jest": "26.6.3",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"requireindex": "^1.2.0"
 	},

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -45,7 +45,6 @@
 		"eslint-plugin-react": "^7.22.0",
 		"eslint-plugin-react-hooks": "^4.2.0",
 		"globals": "^12.0.0",
-		"jest": "26.6.3",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"requireindex": "^1.2.0"
 	},


### PR DESCRIPTION
## Description

Using `@wordpress/eslint-plugin` on its own produces an error:

```
Error: Error while loading rule 'jest/no-deprecated-functions': Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly
```

## How has this been tested?

1. Create a new project with the following `package.json`

```json
{
	"name": "test-repo",
	"version": "1.0.0",
	"devDependencies": {
		"@woocommerce/eslint-plugin": "^1.2.0",
	}
}
```
2. Create a `test.js` file with some violations

```js
import { prettier } from 'prettier';

const arr = [ 1, 1, 2, 3, 3 ];
```
3. `npm install`
4. `./node_modules/.bin/eslint test.js`. This fails and you should see the error. It can be fixed by installing Jest.

## Types of changes

Dependency declaration for `@wordpress/eslint-plugin`

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
