### PR TITLE
RN: fix heading anchor control

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -79,13 +79,15 @@ export const withInspectorControl = createHigherOrderComponent(
 									'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
 								) }
 
-								{ isWeb && <ExternalLink
-									href={
-										'https://wordpress.org/support/article/page-jumps/'
-									}
-								>
-									{ __( 'Learn more about anchors' ) }
-								</ExternalLink> }
+								{ isWeb && (
+									<ExternalLink
+										href={
+											'https://wordpress.org/support/article/page-jumps/'
+										}
+									>
+										{ __( 'Learn more about anchors' ) }
+									</ExternalLink>
+								) }
 							</>
 						}
 						value={ props.attributes.anchor || '' }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -79,13 +79,13 @@ export const withInspectorControl = createHigherOrderComponent(
 									'Enter a word or two — without spaces — to make a unique web address just for this block, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
 								) }
 
-								<ExternalLink
+								{ isWeb && <ExternalLink
 									href={
 										'https://wordpress.org/support/article/page-jumps/'
 									}
 								>
 									{ __( 'Learn more about anchors' ) }
-								</ExternalLink>
+								</ExternalLink> }
 							</>
 						}
 						value={ props.attributes.anchor || '' }


### PR DESCRIPTION
## Description
This Pr tries to fix the way the anchor setting looks in the mobile app. 

I am not sure if this is the right fix. Should we remove the whole text on mobile? 
cc: @iamthomasbishop 


## How has this been tested?
1. Add the Header block. 
2. Open the block settings.
3. Notice the anchor setting. Does it look as expected? 

## Screenshots <!-- if applicable -->
Before:
<img width="404" alt="Screen Shot 2021-06-30 at 9 51 54 PM" src="https://user-images.githubusercontent.com/115071/124068554-9713cb00-d9ef-11eb-9f9e-2b26fe58b88b.png">

After:
<img width="395" alt="Screen Shot 2021-06-30 at 9 51 34 PM" src="https://user-images.githubusercontent.com/115071/124068586-a09d3300-d9ef-11eb-8f85-f272f1774f96.png">

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
