### PR TITLE
Cover against non existing styles

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -134,6 +134,12 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			'__experimentalNoWrapper' => true,
 		);
 
+		// Make sure the styles array exists.
+		// In some contexts, like the navigation editor, it doesn't.
+		if ( ! isset( $settings['styles'] ) ) {
+			$settings['styles'] = array();
+		}
+
 		// Reset existing global styles.
 		foreach ( $settings['styles'] as $key => $style ) {
 			if ( isset( $style['__unstableType'] ) && 'globalStyles' === $style['__unstableType'] ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/32377/files#r662092611

The navigation editor doesn't have 'styles' as part of its settings, but still calls the `gutenberg_experimental_global_styles_settings` function.
