### PR TITLE
Try: Polish labels and consolidate options in preferences.

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -120,7 +120,7 @@ export default function PreferencesModal() {
 							<EnableFeature
 								featureName="showIconLabels"
 								help={ __(
-									'Shows text instead of icons in toolbar.'
+									'Shows text instead of icons in the toolbar.'
 								) }
 								label={ __( 'Display button labels' ) }
 							/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -81,7 +81,10 @@ export default function PreferencesModal() {
 					<>
 						{ isLargeViewport && (
 							<Section
-								title={ __( 'Choose your own experience' ) }
+								title={ __( 'Publishing' ) }
+								description={ __(
+									'Change options related to publishing.'
+								) }
 							>
 								<EnablePublishSidebarOption
 									help={ __(
@@ -94,7 +97,12 @@ export default function PreferencesModal() {
 							</Section>
 						) }
 
-						<Section title={ __( 'Decide what to focus on' ) }>
+						<Section
+							title={ __( 'Appearance' ) }
+							description={ __(
+								'Customize options related to the block editor interface and editing flow.'
+							) }
+						>
 							<EnableFeature
 								featureName="reducedUI"
 								help={ __(
@@ -108,6 +116,20 @@ export default function PreferencesModal() {
 									'Highlights the current block and fades other content.'
 								) }
 								label={ __( 'Spotlight mode' ) }
+							/>
+							<EnableFeature
+								featureName="showIconLabels"
+								help={ __(
+									'Shows text instead of icons in toolbar.'
+								) }
+								label={ __( 'Display button labels' ) }
+							/>
+							<EnableFeature
+								featureName="themeStyles"
+								help={ __(
+									'Make the editor look like your theme.'
+								) }
+								label={ __( 'Use theme styles' ) }
 							/>
 							{ showBlockBreadcrumbsOption && (
 								<EnableFeature
@@ -123,35 +145,14 @@ export default function PreferencesModal() {
 				),
 			},
 			{
-				name: 'appearance',
-				tabLabel: __( 'Appearance' ),
-				content: (
-					<Section title={ __( 'Choose the way it looks' ) }>
-						<EnableFeature
-							featureName="showIconLabels"
-							help={ __(
-								'Shows text instead of icons in toolbar.'
-							) }
-							label={ __( 'Display button labels' ) }
-						/>
-						<EnableFeature
-							featureName="themeStyles"
-							help={ __(
-								'Make the editor look like your theme.'
-							) }
-							label={ __( 'Use theme styles' ) }
-						/>
-					</Section>
-				),
-			},
-			{
 				name: 'blocks',
 				tabLabel: __( 'Blocks' ),
 				content: (
 					<>
 						<Section
-							title={ __(
-								'Choose how you interact with blocks'
+							title={ __( 'Block interactions' ) }
+							description={ __(
+								'Customize how you interact with blocks in the block library and editing canvas.'
 							) }
 						>
 							<EnableFeature

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -119,9 +119,7 @@ export default function PreferencesModal() {
 							/>
 							<EnableFeature
 								featureName="showIconLabels"
-								help={ __(
-									'Shows text instead of icons in the toolbar.'
-								) }
+								help={ __( 'Shows text instead of icons.' ) }
 								label={ __( 'Display button labels' ) }
 							/>
 							<EnableFeature

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -112,7 +112,7 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         >
           <WithSelect(WithDispatch(BaseOption))
             featureName="showIconLabels"
-            help="Shows text instead of icons in toolbar."
+            help="Shows text instead of icons in the toolbar."
             label="Display button labels"
           />
           <WithSelect(WithDispatch(BaseOption))

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -18,10 +18,6 @@ exports[`PreferencesModal should match snapshot when the modal is active large v
           "title": "General",
         },
         Object {
-          "name": "appearance",
-          "title": "Appearance",
-        },
-        Object {
           "name": "blocks",
           "title": "Blocks",
         },
@@ -57,11 +53,6 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         title="General"
       />
       <NavigationItem
-        key="appearance"
-        navigateToMenu="appearance"
-        title="Appearance"
-      />
-      <NavigationItem
         key="blocks"
         navigateToMenu="blocks"
         title="Blocks"
@@ -80,7 +71,8 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
     >
       <NavigationItem>
         <Section
-          title="Decide what to focus on"
+          description="Customize options related to the block editor interface and editing flow."
+          title="Appearance"
         >
           <WithSelect(WithDispatch(BaseOption))
             featureName="reducedUI"
@@ -93,24 +85,6 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             label="Spotlight mode"
           />
           <WithSelect(WithDispatch(BaseOption))
-            featureName="showBlockBreadcrumbs"
-            help="Shows block breadcrumbs at the bottom of the editor."
-            label="Display block breadcrumbs"
-          />
-        </Section>
-      </NavigationItem>
-    </NavigationMenu>
-    <NavigationMenu
-      key="appearance-menu"
-      menu="appearance"
-      parentMenu="preferences-menu"
-      title="Appearance"
-    >
-      <NavigationItem>
-        <Section
-          title="Choose the way it looks"
-        >
-          <WithSelect(WithDispatch(BaseOption))
             featureName="showIconLabels"
             help="Shows text instead of icons."
             label="Display button labels"
@@ -119,6 +93,11 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             featureName="themeStyles"
             help="Make the editor look like your theme."
             label="Use theme styles"
+          />
+          <WithSelect(WithDispatch(BaseOption))
+            featureName="showBlockBreadcrumbs"
+            help="Shows block breadcrumbs at the bottom of the editor."
+            label="Display block breadcrumbs"
           />
         </Section>
       </NavigationItem>
@@ -131,7 +110,8 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
     >
       <NavigationItem>
         <Section
-          title="Choose how you interact with blocks"
+          description="Customize how you interact with blocks in the block library and editing canvas."
+          title="Block interactions"
         >
           <WithSelect(WithDispatch(BaseOption))
             featureName="mostUsedBlocks"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -112,7 +112,7 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         >
           <WithSelect(WithDispatch(BaseOption))
             featureName="showIconLabels"
-            help="Shows text instead of icons in the toolbar."
+            help="Shows text instead of icons."
             label="Display button labels"
           />
           <WithSelect(WithDispatch(BaseOption))


### PR DESCRIPTION
Followup to https://github.com/WordPress/gutenberg/pull/32922#issuecomment-867066725.

## Description

In this PR I've taken a stab at consolidating options in the Preferences dialog, as well as simplify the titles and add descriptive text instead. 

_I'm marking this one as a draft and in progress, as I expect to tweak the copy and particulars based on feedback._

Before:

<img width="829" alt="Screenshot 2021-07-01 at 13 11 54" src="https://user-images.githubusercontent.com/1204802/124116802-a76b8a80-da6f-11eb-91b6-4f260f89e8bd.png">

After:

<img width="803" alt="Screenshot 2021-07-01 at 13 18 31" src="https://user-images.githubusercontent.com/1204802/124116811-aaff1180-da6f-11eb-82ca-2bc942a292b7.png">

Notice how I've merged options from "Appearance" into the "General" section, as all of those options are conceptually related. I'm also not sure it's useful to have an entire section dedicated to just two options — "Display button labels" and "Use theme styles". While it's possible we'll have more options in the future, it doesn't seem that useful to optimize for that until we get there.

Before:

<img width="815" alt="Screenshot 2021-07-01 at 13 20 01" src="https://user-images.githubusercontent.com/1204802/124117132-0af5b800-da70-11eb-9f33-1f9b10746acb.png">

After:

<img width="817" alt="Screenshot 2021-07-01 at 13 20 41" src="https://user-images.githubusercontent.com/1204802/124117149-0f21d580-da70-11eb-9a1f-38dbda4f7da7.png">

Let me know your thoughts.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
