### PR TITLE
Fix block parser to ignore whitespace between block grammar

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -300,13 +300,22 @@ class WP_Block_Parser {
 				 */
 				if ( 0 === $stack_depth ) {
 					if ( isset( $leading_html_start ) ) {
-						$this->output[] = (array) $this->freeform(
-							substr(
-								$this->document,
-								$leading_html_start,
-								$start_offset - $leading_html_start
-							)
+						$html_soup = substr(
+							$this->document,
+							$leading_html_start,
+							$start_offset - $leading_html_start
 						);
+
+						if ( trim( $html_soup ) ) {
+
+							$this->output[] = (array) $this->freeform(
+								substr(
+									$this->document,
+									$leading_html_start,
+									$start_offset - $leading_html_start
+								)
+							);
+						}
 					}
 
 					$this->output[] = (array) new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() );
@@ -492,7 +501,13 @@ class WP_Block_Parser {
 			return;
 		}
 
-		$this->output[] = (array) $this->freeform( substr( $this->document, $this->offset, $length ) );
+		$candidate_freeform = substr( $this->document, $this->offset, $length );
+
+		if ( ! trim( $candidate_freeform ) ) {
+			return;
+		}
+
+		$this->output[] = (array) $this->freeform( $candidate_freeform );
 	}
 
 	/**

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -306,8 +306,7 @@ class WP_Block_Parser {
 							$start_offset - $leading_html_start
 						);
 
-						if ( trim( $html_soup ) ) {
-
+						if ( ! empty( trim( $html_soup ) ) ) {
 							$this->output[] = (array) $this->freeform(
 								substr(
 									$this->document,
@@ -503,7 +502,7 @@ class WP_Block_Parser {
 
 		$candidate_freeform = substr( $this->document, $this->offset, $length );
 
-		if ( ! trim( $candidate_freeform ) ) {
+		if ( empty( trim( $candidate_freeform ) ) ) {
 			return;
 		}
 

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -202,14 +202,23 @@ function proceed() {
 			// in the top-level of the document
 			if ( 0 === stackDepth ) {
 				if ( null !== leadingHtmlStart ) {
-					output.push(
-						Freeform(
-							document.substr(
-								leadingHtmlStart,
-								startOffset - leadingHtmlStart
-							)
-						)
+					const htmlSoup = document.substr(
+						leadingHtmlStart,
+						startOffset - leadingHtmlStart
 					);
+					// If there is some non-whitespace content between
+					// blocks then create a freeform block to contain it.
+					// Otherwise ignore as whitespace.
+					if ( htmlSoup.trim() ) {
+						output.push(
+							Freeform(
+								document.substr(
+									leadingHtmlStart,
+									startOffset - leadingHtmlStart
+								)
+							)
+						);
+					}
 				}
 				output.push( Block( blockName, attrs, [], '', [] ) );
 				offset = startOffset + tokenLength;

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -378,7 +378,7 @@ function addFreeform( rawLength ) {
 		return;
 	}
 
-	output.push( Freeform( document.substr( offset, length ) ) );
+	output.push( Freeform( candidateFreeform ) );
 }
 
 function addInnerBlock( block, tokenStart, tokenLength, lastOffset ) {

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -206,10 +206,11 @@ function proceed() {
 						leadingHtmlStart,
 						startOffset - leadingHtmlStart
 					);
+
 					// If there is some non-whitespace content between
 					// blocks then create a freeform block to contain it.
 					// Otherwise ignore as whitespace.
-					if ( htmlSoup.trim() ) {
+					if ( htmlSoup?.trim()?.length ) {
 						output.push(
 							Freeform(
 								document.substr(
@@ -221,6 +222,7 @@ function proceed() {
 					}
 				}
 				output.push( Block( blockName, attrs, [], '', [] ) );
+
 				offset = startOffset + tokenLength;
 				return true;
 			}
@@ -367,6 +369,12 @@ function addFreeform( rawLength ) {
 	const length = rawLength ? rawLength : document.length - offset;
 
 	if ( 0 === length ) {
+		return;
+	}
+
+	const candidateFreeform = document.substr( offset, length );
+
+	if ( ! candidateFreeform?.trim()?.length ) {
 		return;
 	}
 

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -223,6 +223,22 @@ export const jsTester = ( parse ) => () => {
 				] )
 			) );
 
+		test( 'should ignore HTML soup that is empty whitespace', () =>
+			[
+				`<!-- wp:archives /-->
+				<!-- wp:categories /-->
+				`,
+			].forEach( ( input ) =>
+				expect( parse( input ) ).toEqual( [
+					expect.objectContaining( {
+						blockName: 'core/archives',
+					} ),
+					expect.objectContaining( {
+						blockName: 'core/categories',
+					} ),
+				] )
+			) );
+
 		test( 'should grab HTML soup after blocks', () =>
 			[
 				'<!-- wp:block /--><p>Break me</p>',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

⚠️ **I do not have a high degree of confidence in this change as it's a pretty fundamental part of the codebase. However, hopefully it acts as a starting point for a more resilient fix.**

-----------

Fixes https://github.com/WordPress/gutenberg/issues/33097.

If you paste the following into the Widgets Editor 

```
<!-- wp:archives /-->
<!-- wp:categories /-->
<!-- wp:legacy-widget {"idBase":"meta","instance":{"encoded":"YToxOntzOjU6InRpdGxlIjtzOjExOiJMZWdhY3kgTWV0YSI7fQ==","hash":"78ef891e534480bca0e373c0723a3559","raw":{"title":"Legacy Meta"}}} /-->
```

...you will get some `wp:null` blocks inserted into your post. These will be marked as `undefined` blocks. 

It looks as though the default block parser is treating newline characters as something to be made into a `core/freeform` block. However, in Widgets Editor `core/freeform` has been disabled in order to remove the usage of the Classic block and so we end up with a `core/missing` block as a fallback. 

Nonetheless, it is completely valid that HTML in between block grammar should be converted into a freeform block, but we should not do this for empty whitespace.

This PR fixes this by checking whether the parsed "HTML" between blocks contains more than just whitespace. ONly then will it create a freeform block to represent it.

As a result, if you paste in the test data above it will not result in `wp:null` blocks being created.



## How has this been tested?

* Open Widgets Editor
* Create `core/paragraph` block.
* Paste in the following:
```
<!-- wp:archives /-->
<!-- wp:categories /-->
<!-- wp:legacy-widget {"idBase":"meta","instance":{"encoded":"YToxOntzOjU6InRpdGxlIjtzOjExOiJMZWdhY3kgTWV0YSI7fQ==","hash":"78ef891e534480bca0e373c0723a3559","raw":{"title":"Legacy Meta"}}} /-->
```
* See only Archives, Categories and Legacy widget blocks created.
* Do not see any "missing block" messages.


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
