### PR TITLE
Add width: 100% to components-base-control inside wp-block-legacy-widget

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -155,6 +155,9 @@
 }
 
 .wp-block-legacy-widget {
+	.components-base-control {
+		width: 100%;
+	}
 	.components-select-control__input {
 		padding: 0;
 		font-family: system-ui;


### PR DESCRIPTION
## Description

Solves https://github.com/WordPress/gutenberg/issues/33124

The truncation problem is caused by the `max-width: calc( 100% 10px );` CSS rule on `.components-flex-item` combined with the fact that `components-base-control` doesn't have any width set:

<img width="1181" alt="Zrzut ekranu 2021-07-1 o 17 32 04" src="https://user-images.githubusercontent.com/205419/124152245-a8161800-da93-11eb-844d-8afd2c052862.png">

At the moment there is no way of adding a class name to that components-base-control div, so I added a special rule to legacy widget's stylesheet. I used `width: 100%` so the consequence is that the select box is now full-width. I think that's okay, and we could always make it smaller by adding width: auto to `.components-input-control__container`

<img width="678" alt="Zrzut ekranu 2021-07-1 o 17 37 06" src="https://user-images.githubusercontent.com/205419/124152237-a51b2780-da93-11eb-8b90-60b72a2a3a95.png">

## Test plan:

1. Insert a Legacy Widget block
2. The "Select a legacy widget to display" text should not be truncated.