### PR TITLE
Fix: Media blocks crash on site editor.

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -130,6 +130,7 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );
+	wp_enqueue_media();
 
 	if (
 		current_theme_supports( 'wp-block-styles' ) ||


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/32949
 All media blocks were crashing on the site editor because media assets were missing.

## Testing
I opened the site editor.
I added an image block.
I verified the block does not crashes as it happens on trunk.