### PR TITLE
Fix: missing link color on style properties to css var mapping.

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -71,6 +71,7 @@ export const PRESET_METADATA = [
 ];
 
 const STYLE_PROPERTIES_TO_CSS_VAR_INFIX = {
+	linkColor: 'color',
 	backgroundColor: 'color',
 	background: 'gradient',
 };


### PR DESCRIPTION
Fixes missing linkColor on STYLE_PROPERTIES_TO_CSS_VAR_INFIX constant that allows to mapping style properties to the CSS variable that could be used on them.
This makes sure after https://github.com/WordPress/gutenberg/pull/33149 is merged CSS variables for link color are used like they are in other presets.
