### PR TITLE
[WIP] Unit Control: Allow custom values with more specificity than step value

### DIFF
--- a/packages/components/src/utils/math.js
+++ b/packages/components/src/utils/math.js
@@ -56,7 +56,7 @@ export function subtract( ...args ) {
  *
  * @return {number} The number of decimal places.
  */
-function getPrecision( value ) {
+export function getPrecision( value ) {
 	const split = ( value + '' ).split( '.' );
 	return split[ 1 ] !== undefined ? split[ 1 ].length : 0;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following on from comments in #32481, this PR is an attempt to allow the user to enter values into a UnitControl field with greater specificity than the step value allows.

For example, if the step value for `em` units is `0.01` by default then even though dragging the values will do so in increments of `0.01`, a user should be able to manually enter `1.123em` without it being rounded to `1.12`. Or at least, that's the premise behind this PR!

At the moment, this PR doesn't quite work right — we're grabbing the real value from within the `unitControlStateReducer` and setting the step value accordingly. This seems to work okay once the UnitControl component re-renders, however because we're using a ref, updating its value doesn't trigger a re-render. And unfortunately, we can't swap this out for a `setState` call instead, because this function is called within a child component, and we can't trigger a render on a parent component during the render of a child component.

So, at the moment, we have a situation where this PR kind of works the _second_ time that a user goes to commit their value, at which point the UnitControl component is re-rendered and passes down the correct `step` value.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Add a Group block to a post, and attempt to enter a value with more specificity than `0.01em`, e.g. try `1.123em`.
* After a couple of goes, this should allow you to enter a more specific value manually, however it's currently a bit unreliable.

## Screenshots <!-- if applicable -->

Note in this screenshot that the first time we enter the more specific value it gets rounded to `2.23` (when enter is pressed), but the second time, the more specific value is preserved `2.234`:

![unit-control-specific-value](https://user-images.githubusercontent.com/14988353/124224611-58922380-db49-11eb-83c0-972244af3f31.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
