### PR TITLE
Block Settings Menu: Don't render 'Move to' if there is only one block.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -156,10 +156,9 @@ export function BlockSettingsDropdown( {
 										</MenuItem>
 									</>
 								) }
-								{ ! isLocked && (
+								{ ! isLocked && ! onlyBlock && (
 									<MenuItem
 										onClick={ flow( onClose, onMoveTo ) }
-										disabled={ onlyBlock }
 									>
 										{ __( 'Move to' ) }
 									</MenuItem>


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
In the Block Settings Menu, instead of disabling, don't render "Move to" when there is only one block.

This is a follow-up for consideration from #33135 and [this comment from @mtias](https://github.com/WordPress/gutenberg/pull/33135#issuecomment-872541191).

Other items in the Block Settings Dropdown [aren't displayed when they aren't actionable](https://github.com/WordPress/gutenberg/blob/8a520e93ca5755f0c4dd9a031ac3da8c683e5c95/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js#L125).

Assuming there are no a11y concerns, I like the idea of further reducing noise and interface elements when possible.

See: #33029, #33135

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Using `wp-env`:
- Check to confirm "Move to" is disabled with one block
- Add another block
- Check to confirm "Move to" is enabled and functions
- Remove one block
- Check to confirm "Move to" is disabled again.

Also tested with `npm run test`.

## Screenshots <!-- if applicable -->
The current/before behavior can be seen in the video at the top of #33135.

Proposed Change:

https://user-images.githubusercontent.com/1034160/124237939-0a821d80-db53-11eb-9b4e-b11bd5473f06.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
