### PR TITLE
[Regression]: Fix breadcrumbs html structure and React warnings

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -65,27 +65,28 @@ function BlockBreadcrumb( { rootLabelText } ) {
 					</Button>
 				) }
 				{ ! hasSelection && rootLabel }
-			</li>
-			<Icon
-				icon={ chevronRightSmall }
-				className="block-editor-block-breadcrumb__separator"
-			/>
-			{ parents.map( ( parentClientId ) => (
-				<>
-					<li key={ parentClientId }>
-						<Button
-							className="block-editor-block-breadcrumb__button"
-							variant="tertiary"
-							onClick={ () => selectBlock( parentClientId ) }
-						>
-							<BlockTitle clientId={ parentClientId } />
-						</Button>
-					</li>
+				{ !! clientId && (
 					<Icon
 						icon={ chevronRightSmall }
 						className="block-editor-block-breadcrumb__separator"
 					/>
-				</>
+				) }
+			</li>
+
+			{ parents.map( ( parentClientId ) => (
+				<li key={ parentClientId }>
+					<Button
+						className="block-editor-block-breadcrumb__button"
+						variant="tertiary"
+						onClick={ () => selectBlock( parentClientId ) }
+					>
+						<BlockTitle clientId={ parentClientId } />
+					</Button>
+					<Icon
+						icon={ chevronRightSmall }
+						className="block-editor-block-breadcrumb__separator"
+					/>
+				</li>
 			) ) }
 			{ !! clientId && (
 				<li

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -4,19 +4,19 @@
 	margin: 0;
 
 	li {
-		display: inline-block;
+		display: inline-flex;
 		margin: 0;
-	}
 
-	.block-editor-block-breadcrumb__separator {
-		fill: currentColor;
-		margin-left: -$grid-unit-05;
-		margin-right: -$grid-unit-05;
+		.block-editor-block-breadcrumb__separator {
+			fill: currentColor;
+			margin-left: -$grid-unit-05;
+			margin-right: -$grid-unit-05;
 
-		// Flip for RTL.
-		transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the chevron right for LTR and left for RTL.
+			// Flip for RTL.
+			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the chevron right for LTR and left for RTL.
+		}
 
-		&:last-child {
+		&:last-child .block-editor-block-breadcrumb__separator {
 			display: none;
 		}
 	}

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -12,19 +12,5 @@ exports[`BlockBreadcrumb should render correctly 1`] = `
   >
     Document
   </li>
-  <svg
-    aria-hidden="true"
-    class="block-editor-block-breadcrumb__separator"
-    focusable="false"
-    height="24"
-    role="img"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M10.8622 8.04053L14.2805 12.0286L10.8622 16.0167L9.72327 15.0405L12.3049 12.0286L9.72327 9.01672L10.8622 8.04053Z"
-    />
-  </svg>
 </ul>
 `;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

There was a small regression introduced here: https://github.com/WordPress/gutenberg/pull/33042

As[ per this comment](https://github.com/WordPress/gutenberg/pull/33042#issuecomment-872441841)
>A couple of things that need to be fixed:
>1. Having `svg` elements inside of a `ul` [is invalid html](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul). The `Icon` needs to go inside the `li` and change styles accordingly.
>2. When we loop React elements each element must have a unique key. With this change you have added a segment `<>` which causes `Warning: Each child in a list should have a unique "key" prop.`. You can check this by opening the dev tools and just click in a block. Having the Icon inside the `li` which had from before a unique `key`, will resolve this as well.
<!-- Please describe what you have changed or added -->

## Testing instructions
1. Verify that no breadcrumb related React warning are triggered.
2. Verify that the styling is exactly the same with the current in trunk.
3. Check by selecting nested blocks and top level breadcrumb item
4. Verify proper block navigation from breadcrumb

## Before and after video

At first I show the tab with the code in trunk and then (when I change and reload the tab) I show with the code from this branch. 


https://user-images.githubusercontent.com/16275880/124238778-a6933100-db21-11eb-8645-1036c9a20d7b.mov



