### PR TITLE
Automated Testing: Disable remote patterns in tests

### DIFF
--- a/packages/e2e-tests/mu-plugins/disable-remote-patterns.php
+++ b/packages/e2e-tests/mu-plugins/disable-remote-patterns.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Disable Remote Patterns
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-disable-remote-patterns
+ */
+
+add_filter( 'should_load_remote_block_patterns', '__return_false' );


### PR DESCRIPTION
## Description
Adds new "mu-plugin" to disable loading remote patterns loading in tests.

Fixes #33126

## How has this been tested?
1. Symlink new "disable-remote-patterns.php" mu-plugin to your local mu-plugins directory.
2. Remote patterns shouldn't be loaded in the editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
