### PR TITLE
Fix slash inserter for widgets screen

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -25,6 +25,7 @@ export function useInBetweenInserter() {
 		isBlockInsertionPointVisible,
 		isMultiSelecting,
 		getSelectedBlockClientIds,
+		getTemplateLock,
 	} = useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
@@ -66,6 +67,11 @@ export function useInBetweenInserter() {
 						? event.target
 						: event.target.closest( '[data-block]' );
 					rootClientId = blockElement.getAttribute( 'data-block' );
+				}
+
+				// Don't set the insertion point if the template is locked.
+				if ( getTemplateLock( rootClientId ) ) {
+					return;
 				}
 
 				const orientation =

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1215,17 +1215,7 @@ export function getBlockInsertionPoint( state ) {
  * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	const insertionPoint = state.insertionPoint;
-
-	if ( ! state.insertionPoint ) {
-		return false;
-	}
-
-	if ( getTemplateLock( state, insertionPoint.rootClientId ) ) {
-		return false;
-	}
-
-	return true;
+	return state.insertionPoint !== null;
 }
 
 /**

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2255,43 +2255,12 @@ describe( 'selectors', () => {
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
 		} );
 
-		it( 'should return false if the rootClientId has a truthy template lock', () => {
-			const state = {
-				insertionPoint: {
-					rootClientId: 'testClientId',
-					index: 5,
-				},
-				blockListSettings: {
-					testClientId: {
-						templateLock: 'all',
-					},
-				},
-			};
-
-			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
-		} );
-
-		it( 'should return false if the rootClientId is undefined, and the settings has a template lock', () => {
-			const state = {
-				insertionPoint: {
-					rootClientId: undefined,
-					index: 5,
-				},
-				settings: {
-					templateLock: 'all',
-				},
-			};
-
-			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
-		} );
-
 		it( 'should return true if assigned insertion point', () => {
 			const state = {
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 5,
 				},
-				settings: {},
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );


### PR DESCRIPTION
## Description
Fixes #33099

#32576 caused a bug in the widget screen where the slash inserter would often not work.

To fix it, this PR follows the advice in https://github.com/WordPress/gutenberg/pull/32576/files#r649890607, and avoids setting the `insertionPoint` state in the first place in a template locked block list.

The cause of the problem is that after #32576, the insertion point state would get set for the root template-locked block list in the widget editor, but never cleared. It wouldn't be cleared because the code that unsets it uses a selector that returned `false` after #32576 to check if it should be cleared:
https://github.com/WordPress/gutenberg/blob/f077bbe351a830b54a8b450692a425ceab29b604/packages/block-editor/src/components/block-list/use-in-between-inserter.js#L53-L55

Whenever inserting blocks using the slash inserter, the `insertionPoint` state that was stuck in the store would be used as a basis of populating the slash inserter, but because that state considers the block list to be template locked, no blocks are allowed, therefore causing the slash inserter to not appear.

## How has this been tested?
1. Open the widget editor
2. Remove all blocks in the first widget area and save.
3. Reload the editor
4. Insert a paragraph and try using the slash inserter
5. It should work

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
