### PR TITLE
[Block Library - Query Loop]: Set default block variations not to inherit from global query

### DIFF
--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -14,6 +14,24 @@ import {
 	imageDateTitle,
 } from './icons';
 
+const QUERY_DEFAULT_ATTRIBUTES = {
+	query: {
+		perPage: 3,
+		pages: 0,
+		offset: 0,
+		postType: 'post',
+		categoryIds: [],
+		tagIds: [],
+		order: 'desc',
+		orderBy: 'date',
+		author: '',
+		search: '',
+		exclude: [],
+		sticky: '',
+		inherit: false,
+	},
+};
+
 const variations = [
 	{
 		name: 'posts-list',
@@ -44,6 +62,7 @@ const variations = [
 		name: 'title-date',
 		title: __( 'Title & Date' ),
 		icon: titleDate,
+		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -57,6 +76,7 @@ const variations = [
 		name: 'title-excerpt',
 		title: __( 'Title & Excerpt' ),
 		icon: titleExcerpt,
+		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -70,6 +90,7 @@ const variations = [
 		name: 'title-date-excerpt',
 		title: __( 'Title, Date, & Excerpt' ),
 		icon: titleDateExcerpt,
+		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
 		innerBlocks: [
 			[
 				'core/post-template',
@@ -87,6 +108,7 @@ const variations = [
 		name: 'image-date-title',
 		title: __( 'Image, Date, & Title' ),
 		icon: imageDateTitle,
+		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
 		innerBlocks: [
 			[
 				'core/post-template',


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR just adds as a default argument of `inherit` to `false` for the default `Query Loop` variations. Since we have this default value in current available patterns and the block will be exposed in post/page editors  for 5.8, this setting makes more sense for now. An issue for dynamic calculating and setting this value is here:https://github.com/WordPress/gutenberg/issues/30369

## Testing instructions
1. Add `Query Loop` block in a page
2. Verify that choosing any pattern works properly as before
3. Then insert the `Query Loop` block and click `Start blank`
4. Check all four default variations that set the `inherit` value to `false` and allow you to customize the query properties, and of course that they work properly as before.

## Before


https://user-images.githubusercontent.com/16275880/124255093-743dff80-db32-11eb-95d5-1e23ceab6519.mov



## After

https://user-images.githubusercontent.com/16275880/124254716-01cd1f80-db32-11eb-9a8f-a5d01a69eb69.mov


