### PR TITLE
Widget screens: set html block as freeform content handler

### DIFF
--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -11,6 +11,7 @@ import {
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
 } from '@wordpress/widgets';
+import { setFreeformContentHandlerName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -48,6 +49,12 @@ export function initialize( editorName, blockEditorSettings ) {
 		} );
 	}
 	registerLegacyWidgetVariations( blockEditorSettings );
+
+	// As we are unregistering `core/freeform` to avoid the Classic block, we must
+	// replace it with something as the default freeform content handler. Failure to
+	// do this will result in errors in the default block parser.
+	// see: https://github.com/WordPress/gutenberg/issues/33097
+	setFreeformContentHandlerName( 'core/html' );
 
 	const SidebarControl = getSidebarControl( blockEditorSettings );
 

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -4,6 +4,7 @@
 import {
 	registerBlockType,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
+	setFreeformContentHandlerName,
 } from '@wordpress/blocks';
 import { render } from '@wordpress/element';
 import {
@@ -63,6 +64,11 @@ export function initialize( id, settings ) {
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
 		fetchLinkSuggestions( search, searchOptions, settings );
 
+	// As we are unregistering `core/freeform` to avoid the Classic block, we must
+	// replace it with something as the default freeform content handler. Failure to
+	// do this will result in errors in the default block parser.
+	// see: https://github.com/WordPress/gutenberg/issues/33097
+	setFreeformContentHandlerName( 'core/html' );
 	render(
 		<Layout blockEditorSettings={ settings } />,
 		document.getElementById( id )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR addresses a problem in the widgets screens whereby copy/pasting blocks would result in "missing" blocks being inserted into the editor canvas.

We do this by registering the `core/html` block as the default freeform content block to replace the default `core/freeform` block which we have de-registered for the Widgets screens to avoid allowing access to the Classic block interface.

## Explanation - why does this happen?

These missing blocks were generated by _whitespace_ (inc. new lines) in between block definitions. For example:

```
<!-- wp:archives /-->

<!-- wp:categories /-->

<!-- wp:legacy-widget {"idBase":"meta","instance":{"encoded":"YToxOntzOjU6InRpdGxlIjtzOjExOiJMZWdhY3kgTWV0YSI7fQ==","hash":"78ef891e534480bca0e373c0723a3559","raw":{"title":"Legacy Meta"}}} /-->
```

The whitespace was being converted into the `core/missing` block due to [the `core/freeform` block being _de-registered_ in the Widgets editors](https://github.com/WordPress/gutenberg/blob/80465ea0ef7f804e515bb1b0137a31890bd7baaf/packages/edit-widgets/src/index.js#L32-L36). As the `core/freeform` block is set as the default freeform content handler this causes a bug.

The reason for this was that the default block parser utilises the registered free form content handler to handle any random content (HTML) in between block definitions (including whitespace). As the free form content handler was de-registered the parser was falling back to the `core/missing` block - thus the errors on paste.

For full info and context please see comments in https://github.com/WordPress/gutenberg/issues/33097. 

Also related: I have a proposal in https://github.com/WordPress/gutenberg/pull/33136 to have the parser ignore and not try to create a freeform block for any content that is purely whitespace that it finds in between block definitions during parse.

Fixes https://github.com/WordPress/gutenberg/issues/33097

## How has this been tested?

* Open Widgets Editor (either standalone Widgets screen or Customizer).
* Add Categories, Archives and a Legacy Widget block.
* Select all blocks.
* Copy all blocks.
* Remove all blocks.
* Save.
* Reload.
* Add a paragraph block.
* Paste in your blocks that you copied previously.
* You should see the blocks pasted in exactly as they were when you copied them.
* You should see **no** `core/missing` blocks.

## Screenshots <!-- if applicable -->



https://user-images.githubusercontent.com/444434/124263938-d34c4600-db2b-11eb-99a4-3f1950526ae9.mov



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
