### PR TITLE
[Widgets editor] Replace the "technical" error notice a more user-friendly one

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import { useRef, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 /**
@@ -56,12 +56,16 @@ export default function Form( {
 			},
 			onChangeHasPreview,
 			onError( error ) {
+				window.console.error( error );
 				createNotice(
 					'error',
-					error?.message ??
+					sprintf(
+						/* translators: %s: the name of the affected block. */
 						__(
-							'An error occured while fetching or updating the widget.'
-						)
+							'The "%s" block was affected by errors and may not function properly. Check the developer tools for more details.'
+						),
+						idBase || id
+					)
 				);
 			},
 		} );


### PR DESCRIPTION
## Description
I believe that, besides its technical aspects, [Trac #53437](https://core.trac.wordpress.org/ticket/53437) is largely a communication problem. We need to somehow tell the user that the error happened, but saying wp.editor.initialize is not a function or dropping any other error message isn't very helpful to the user.

We could just disable the affected widgets, but we still need to communicate it, it’s just the wording would be more like "The following blocks (...) have been disabled".

Two things this PR is missing are:
- Collapsing multiple error messages into a single one mentioning multiple blocks (`Blocks 'text' and  'plugin/cool-editor' were affected...`) – 
- A button like "Close and don't show this message again" – this could be a new feature of the @wordpress/notices package

Before – a cryptic message and no stack trace:

<img width="1419" alt="Zrzut ekranu 2021-07-2 o 13 21 18" src="https://user-images.githubusercontent.com/205419/124267527-a94d5080-db38-11eb-8590-6230de8abaf4.png">

After – an informative message + a relevant stack trace logged in the console:

<img width="1415" alt="Zrzut ekranu 2021-07-2 o 13 20 44" src="https://user-images.githubusercontent.com/205419/124267549-b1a58b80-db38-11eb-8df7-3a5780d8edaf.png">

## How has this been tested?

1. Use the latest WordPress 5.8 RC
2. Activate TwentyTwenty theme
3. Install the SiteOrigin Widgets Bundle plugin
4. Install the Classic Widgets plugin
5. Activate the Classic Widgets plugin
6. Go to Appearance > Widgets
7. Add a text widget and put content in it
8. Deactivate the Classic Widgets plugin
9. Go to Appearance > Widgets
10. Focus the text widget
11. Confirm the error message looks like on the screenshot above

## Types of changes
Bug fix