### PR TITLE
Add <CopyHandler> to WidgetAreasBlockEditorProvider

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -14,6 +14,7 @@ import {
 	BlockTools,
 	BlockSelectionClearer,
 	BlockInspector,
+	CopyHandler,
 	ObserveTyping,
 	WritingFlow,
 	BlockEditorKeyboardShortcuts,
@@ -114,15 +115,17 @@ export default function SidebarBlockEditor( {
 					isFixedToolbarActive={ isFixedToolbarActive }
 				/>
 
-				<BlockTools>
-					<BlockSelectionClearer>
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList renderAppender={ BlockAppender } />
-							</ObserveTyping>
-						</WritingFlow>
-					</BlockSelectionClearer>
-				</BlockTools>
+				<CopyHandler>
+					<BlockTools>
+						<BlockSelectionClearer>
+							<WritingFlow>
+								<ObserveTyping>
+									<BlockList renderAppender={ BlockAppender } />
+								</ObserveTyping>
+							</WritingFlow>
+						</BlockSelectionClearer>
+					</BlockTools>
+				</CopyHandler>
 
 				{ createPortal(
 					// This is a temporary hack to prevent button component inside <BlockInspector>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -120,7 +120,9 @@ export default function SidebarBlockEditor( {
 						<BlockSelectionClearer>
 							<WritingFlow>
 								<ObserveTyping>
-									<BlockList renderAppender={ BlockAppender } />
+									<BlockList
+										renderAppender={ BlockAppender }
+									/>
 								</ObserveTyping>
 							</WritingFlow>
 						</BlockSelectionClearer>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -13,6 +13,7 @@ import { useMemo } from '@wordpress/element';
 import {
 	BlockEditorProvider,
 	BlockEditorKeyboardShortcuts,
+	CopyHandler,
 } from '@wordpress/block-editor';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 
@@ -108,7 +109,7 @@ export default function WidgetAreasBlockEditorProvider( {
 					useSubRegistry={ false }
 					{ ...props }
 				>
-					{ children }
+					<CopyHandler>{ children }</CopyHandler>
 					<ReusableBlocksMenuItems rootClientId={ widgetAreaId } />
 				</BlockEditorProvider>
 			</SlotFillProvider>


### PR DESCRIPTION
## Description
This follows up on https://github.com/WordPress/gutenberg/pull/33164 where I noticed that using "cmd+c" copies blocks as text whereas clicking "copy" in the context menu copies them as blocks. This PR wraps the widgets editor in `<CopyHandler> ` which restores the functionallty of cmd+c.

## How has this been tested?

1. Go to the new widget editor
2. Add some blocks (e.g. Categories, Archives and a Legacy Widget block)
3. Select them all and press cmd+c (or ctrl+c if you're not on mac)
4. Confirm you see a message like the one below
5. Remove the blocks, save, reload the editor
6. Add a paragraph block, paste using cmd+v (or ctrl+v) and confirm your blocks got pasted as, well, blocks

<img width="263" alt="Zrzut ekranu 2021-07-2 o 14 30 58" src="https://user-images.githubusercontent.com/205419/124274915-24673480-db42-11eb-86a0-d38cfd560a99.png">

This works best with #33164 applied, otherwise you'll see some error messages like "This block is missing". They can be ignored for the purposes of testing this specific PR.

Then repeat in the customizer (where you won't see the notice but the pasting should still work).

## Types of changes
Bug fix (non-breaking change which fixes an issue)

