### PR TITLE
Fix "Select all" behavior in the editor

### DIFF
--- a/packages/dom/src/dom/is-entirely-selected.js
+++ b/packages/dom/src/dom/is-entirely-selected.js
@@ -48,15 +48,37 @@ export default function isEntirelySelected( element ) {
 
 	const lastChild = element.lastChild;
 	assertIsDefined( lastChild, 'lastChild' );
-	const lastChildContentLength =
-		lastChild.nodeType === lastChild.TEXT_NODE
-			? /** @type {Text} */ ( lastChild ).data.length
-			: lastChild.childNodes.length;
+	const endContainerContentLength =
+		endContainer.nodeType === endContainer.TEXT_NODE
+			? /** @type {Text} */ ( endContainer ).data.length
+			: endContainer.childNodes.length;
 
 	return (
-		startContainer === element.firstChild &&
-		endContainer === element.lastChild &&
+		isDeepChild( startContainer, element, 'firstChild' ) &&
+		isDeepChild( endContainer, element, 'lastChild' ) &&
 		startOffset === 0 &&
-		endOffset === lastChildContentLength
+		endOffset === endContainerContentLength
 	);
+}
+
+/**
+ * Check whether the contents of the element have been entirely selected.
+ * Returns true if there is no possibility of selection.
+ *
+ * @param {HTMLElement|Node} query The element to check.
+ * @param {HTMLElement} container The container that we suspect "query" may be a first or last child of.
+ * @param {"firstChild"|"lastChild"} propName "firstChild" or "lastChild"
+ *
+ * @return {boolean} True if query is a deep first/last child of container, false otherwise.
+ */
+function isDeepChild( query, container, propName ) {
+	/** @type {HTMLElement | ChildNode | null} */
+	let candidate = container;
+	do {
+		if ( query === candidate ) {
+			return true;
+		}
+		candidate = candidate[ propName ];
+	} while ( candidate );
+	return false;
 }

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import {
-	isEntirelySelected,
 	isHorizontalEdge,
 	placeCaretAtHorizontalEdge,
 	isTextField,
@@ -24,73 +23,6 @@ describe( 'DOM', () => {
 
 	afterEach( () => {
 		parent.remove();
-	} );
-
-	describe( 'isEntirelySelected', () => {
-		describe( 'input', () => {
-			let input;
-
-			beforeEach( () => {
-				input = document.createElement( 'input' );
-				parent.appendChild( input );
-				input.value = 'value';
-				input.focus();
-			} );
-
-			it( 'should return true when the entire content of an input is selected', () => {
-				input.selectionStart = 0;
-				input.selectionEnd = 5;
-				expect( isEntirelySelected( input ) ).toBe( true );
-			} );
-			it( 'should return false when less than the entire content of an input is selected', () => {
-				input.selectionStart = 0;
-				input.selectionEnd = 4;
-				expect( isEntirelySelected( input ) ).toBe( false );
-			} );
-		} );
-
-		it( 'should return true when the entire content of a contenteditable span is selected', () => {
-			const span = document.createElement( 'span' );
-			parent.appendChild( span );
-			span.innerText = 'value';
-			span.contentEditable = true;
-			span.focus();
-			span.selectionStart = 0;
-			span.selectionEnd = 5;
-			expect( isEntirelySelected( span ) ).toBe( true );
-		} );
-
-		describe( 'ul', () => {
-			let ul;
-			let li;
-
-			beforeEach( () => {
-				ul = document.createElement( 'ul' );
-				parent.appendChild( ul );
-				ul.contentEditable = true;
-
-				li = document.createElement( 'li' );
-				ul.appendChild( li );
-				li.innerText = 'value';
-				li.focus();
-			} );
-
-			it( 'should return true when the entire content of a <li> is selected within a contenteditable <ul>', () => {
-				li.selectionStart = 0;
-				li.selectionEnd = 5;
-				expect( isEntirelySelected( ul ) ).toBe( true );
-			} );
-			it( 'should return true when less than the entire content of a <li> is selected within a contenteditable <ul> (1)', () => {
-				li.selectionStart = 0;
-				li.selectionEnd = 2;
-				expect( isEntirelySelected( ul ) ).toBe( false );
-			} );
-			// it( 'should return true when less than the entire content of a <li> is selected within a contenteditable <ul> (2)', () => {
-			// 	li.selectionStart = 1;
-			// 	li.selectionEnd = 5;
-			// 	expect( isEntirelySelected( ul ) ).toBe( false );
-			// } );
-		} );
 	} );
 
 	describe( 'isHorizontalEdge', () => {

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	isEntirelySelected,
 	isHorizontalEdge,
 	placeCaretAtHorizontalEdge,
 	isTextField,
@@ -23,6 +24,73 @@ describe( 'DOM', () => {
 
 	afterEach( () => {
 		parent.remove();
+	} );
+
+	describe( 'isEntirelySelected', () => {
+		describe( 'input', () => {
+			let input;
+
+			beforeEach( () => {
+				input = document.createElement( 'input' );
+				parent.appendChild( input );
+				input.value = 'value';
+				input.focus();
+			} );
+
+			it( 'should return true when the entire content of an input is selected', () => {
+				input.selectionStart = 0;
+				input.selectionEnd = 5;
+				expect( isEntirelySelected( input ) ).toBe( true );
+			} );
+			it( 'should return false when less than the entire content of an input is selected', () => {
+				input.selectionStart = 0;
+				input.selectionEnd = 4;
+				expect( isEntirelySelected( input ) ).toBe( false );
+			} );
+		} );
+
+		it( 'should return true when the entire content of a contenteditable span is selected', () => {
+			const span = document.createElement( 'span' );
+			parent.appendChild( span );
+			span.innerText = 'value';
+			span.contentEditable = true;
+			span.focus();
+			span.selectionStart = 0;
+			span.selectionEnd = 5;
+			expect( isEntirelySelected( span ) ).toBe( true );
+		} );
+
+		describe( 'ul', () => {
+			let ul;
+			let li;
+
+			beforeEach( () => {
+				ul = document.createElement( 'ul' );
+				parent.appendChild( ul );
+				ul.contentEditable = true;
+
+				li = document.createElement( 'li' );
+				ul.appendChild( li );
+				li.innerText = 'value';
+				li.focus();
+			} );
+
+			it( 'should return true when the entire content of a <li> is selected within a contenteditable <ul>', () => {
+				li.selectionStart = 0;
+				li.selectionEnd = 5;
+				expect( isEntirelySelected( ul ) ).toBe( true );
+			} );
+			it( 'should return true when less than the entire content of a <li> is selected within a contenteditable <ul> (1)', () => {
+				li.selectionStart = 0;
+				li.selectionEnd = 2;
+				expect( isEntirelySelected( ul ) ).toBe( false );
+			} );
+			// it( 'should return true when less than the entire content of a <li> is selected within a contenteditable <ul> (2)', () => {
+			// 	li.selectionStart = 1;
+			// 	li.selectionEnd = 5;
+			// 	expect( isEntirelySelected( ul ) ).toBe( false );
+			// } );
+		} );
 	} );
 
 	describe( 'isHorizontalEdge', () => {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -79,11 +79,7 @@ exports[`Multi-block selection should gradually multi-select 1`] = `
 
 <!-- wp:paragraph -->
 <p>2</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:list -->
-<ul><li>1</li></ul>
-<!-- /wp:list --></div>
+<!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
@@ -96,6 +92,20 @@ exports[`Multi-block selection should gradually multi-select 2`] = `
 "<!-- wp:columns -->
 <div class=\\"wp-block-columns\\"></div>
 <!-- /wp:columns -->"
+`;
+
+exports[`Multi-block selection should multi-select from within the list block 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>1</li></ul>
+<!-- /wp:list -->"
 `;
 
 exports[`Multi-block selection should not multi select single block 1`] = `

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -99,10 +99,6 @@ exports[`Multi-block selection should multi-select from within the list block 1`
 <p>1</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->
-
 <!-- wp:list -->
 <ul><li>1</li></ul>
 <!-- /wp:list -->"

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -79,7 +79,11 @@ exports[`Multi-block selection should gradually multi-select 1`] = `
 
 <!-- wp:paragraph -->
 <p>2</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>1</li></ul>
+<!-- /wp:list --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -633,6 +633,10 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
+		// Add a list
+		await page.keyboard.type( '/list' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
 
 		// Confirm correct setup: two columns with two paragraphs in the first.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -661,14 +661,12 @@ describe( 'Multi-block selection', () => {
 		// Select a paragraph.
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'Enter' );
 		// Add a list
 		await page.keyboard.type( '/list' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );
 
-		// Confirm correct setup: two columns with two paragraphs in the first.
+		// Confirm correct setup: a paragraph and a list
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		await pressKeyWithModifier( 'primary', 'a' );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -633,6 +633,7 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
 		// Add a list
 		await page.keyboard.type( '/list' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -633,11 +633,6 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'Enter' );
-		// Add a list
-		await page.keyboard.type( '/list' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '1' );
 
 		// Confirm correct setup: two columns with two paragraphs in the first.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -659,5 +654,28 @@ describe( 'Multi-block selection', () => {
 
 		// Expect both columns to be deleted.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should multi-select from within the list block', async () => {
+		await clickBlockAppender();
+		// Select a paragraph.
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		// Add a list
+		await page.keyboard.type( '/list' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+
+		// Confirm correct setup: two columns with two paragraphs in the first.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+
+		await page.waitForSelector(
+			'[data-type="core/paragraph"].is-multi-selected'
+		);
 	} );
 } );


### PR DESCRIPTION
## Description

When my cursor in in a block like "list" and I press cmd+a twice, the selection doesn't expand to all blocks anymore:

<img width="544" alt="Zrzut ekranu 2021-07-2 o 15 10 05" src="https://user-images.githubusercontent.com/205419/124279326-a86feb00-db47-11eb-9b16-d7ba6402de1d.png">

The issue is caused by `isEntirelySelected` only checking the selection container against block's `firstChild` – which in this case is `li`. The actual selection is pinned to the text note inside of that `li`. This PR explores resolving that using a deep comparison instead of a shallow comparison.

The issue is reproducible across all editors (posts, pages, widgets etc.)

## How has this been tested?
By interacting with the editor, unfortunately. I wanted to cover this with unit tests, but jsdom doesn't support contentEditable very well: https://github.com/jsdom/jsdom/issues/1670

This means that the only way to test it is by adding some E2E tests. That's fine with me, but since that's cumbersome I'd rather get some comments on the approach first.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
