### PR TITLE
Template part e2e fix: try and force waiting for button xpath

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -100,10 +100,13 @@ describe( 'Multi-entity save flow', () => {
 
 			// Add a template part and edit it.
 			await insertBlock( 'Template Part' );
+
+			await page.waitForXPath( createNewButtonSelector );
 			const [ createNewButton ] = await page.$x(
 				createNewButtonSelector
 			);
 			await createNewButton.click();
+
 			await page.waitForSelector( activatedTemplatePartSelector );
 			await page.click( '.block-editor-button-block-appender' );
 			await page.click( '.editor-block-list-item-paragraph' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This e2e test keeps failing

```
FAIL specs/experiments/multi-entity-saving.test.js (46.989 s)
  ● Multi-entity save flow › Post Editor › Save flow should work as expected.
    TimeoutError: waiting for selector `*[data-type="core/template-part"].block-editor-block-list__layout` failed: timeout 30000ms exceeded
      105 | 			);
      106 | 			await createNewButton.click();
    > 107 | 			await page.waitForSelector( activatedTemplatePartSelector );
```

Looking at the failure artifacts it looks like we've clicked the wrong button and activated the "Choose existing" button.

This is because `*[data-type="core/template-part"].block-editor-block-list__layout` will only exist once we've click the `New template part` button.

![Save flow should work as expected  2021-07-02T10-56-38](https://user-images.githubusercontent.com/444434/124282738-11089900-db43-11eb-8fc0-755da3c0ab20.jpg)

The test selects the "New template part" button by xpath and that resolves to a DOM node with class variant `primary`. However the button variant is set to change to `tertiary` as soon as the "Choose existing" button is rendered. I wonder if this causes the test to click the wrong button?

This PR tries to force waiting for the xpath before clicking. We'll see...


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
