### PR TITLE
components: Add useCx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13932,6 +13932,7 @@
 				"@emotion/css": "^11.1.3",
 				"@emotion/react": "^11.1.5",
 				"@emotion/styled": "^11.3.0",
+				"@emotion/utils": "1.0.0",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/date": "file:packages/date",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,6 +34,7 @@
 		"@emotion/css": "^11.1.3",
 		"@emotion/react": "^11.1.5",
 		"@emotion/styled": "^11.3.0",
+		"@emotion/utils": "1.0.0",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/date": "file:../date",

--- a/packages/components/src/utils/hooks/index.js
+++ b/packages/components/src/utils/hooks/index.js
@@ -2,3 +2,4 @@ export { default as useControlledState } from './use-controlled-state';
 export { default as useJumpStep } from './use-jump-step';
 export { default as useUpdateEffect } from './use-update-effect';
 export { useControlledValue } from './use-controlled-value';
+export { useCx } from './use-cx';

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { useCx } from '..';
+import StyleProvider from '../../../style-provider';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, createPortal } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+export default {
+	title: 'Components (Experimental)/useCx',
+};
+
+const IFrame = ( { children } ) => {
+	const [ iframeDocument, setIframeDocument ] = useState();
+
+	const handleRef = ( node ) => {
+		if ( ! node ) {
+			return null;
+		}
+
+		function setIfReady() {
+			const { contentDocument } = node;
+			const { readyState } = contentDocument;
+
+			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
+				return false;
+			}
+
+			setIframeDocument( contentDocument );
+		}
+
+		if ( setIfReady() ) {
+			return;
+		}
+
+		node.addEventListener( 'load', () => {
+			// iframe isn't immediately ready in Firefox
+			setIfReady();
+		} );
+	};
+
+	return (
+		<iframe ref={ handleRef } title="use-cx-test-frame">
+			{ iframeDocument &&
+				createPortal(
+					<StyleProvider document={ iframeDocument }>
+						{ children }
+					</StyleProvider>,
+					iframeDocument.body
+				) }
+		</iframe>
+	);
+};
+
+const Example = ( { args, children } ) => {
+	const cx = useCx();
+	const classes = cx( ...args );
+	return <span className={ classes }>{ children }</span>;
+};
+
+export const _default = () => {
+	const redText = css`
+		color: red;
+	`;
+	return (
+		<IFrame>
+			<Example args={ [ redText ] }>
+				This text is inside an iframe and is red!
+			</Example>
+		</IFrame>
+	);
+};

--- a/packages/components/src/utils/hooks/test/use-cx.js
+++ b/packages/components/src/utils/hooks/test/use-cx.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import { cx as innerCx } from '@emotion/css';
+import { insertStyles } from '@emotion/utils';
+import { render } from '@testing-library/react';
+import { css, CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+
+/**
+ * Internal dependencies
+ */
+import { useCx } from '..';
+
+jest.mock( '@emotion/css', () => ( {
+	cx: jest.fn(),
+} ) );
+
+jest.mock( '@emotion/utils', () => ( {
+	insertStyles: jest.fn(),
+} ) );
+
+function Example( { args } ) {
+	const cx = useCx();
+
+	return <div className={ cx( ...args ) } />;
+}
+
+describe( 'useCx', () => {
+	it( 'should call cx with the built style name and pass serialized styles to insertStyles', () => {
+		const serializedStyle = css`
+			color: red;
+		`;
+		const className = 'component-example';
+		const object = {
+			'component-example-focused': true,
+		};
+
+		const key = 'test-cache-key';
+
+		const container = document.createElement( 'head' );
+
+		const cache = createCache( { container, key } );
+
+		render(
+			<CacheProvider value={ cache }>
+				<Example args={ [ className, serializedStyle, object ] } />
+			</CacheProvider>
+		);
+
+		expect( innerCx ).toHaveBeenCalledWith(
+			className,
+			`${ key }-${ serializedStyle.name }`,
+			object
+		);
+
+		expect( insertStyles ).toHaveBeenCalledWith(
+			cache,
+			serializedStyle,
+			false
+		);
+	} );
+} );

--- a/packages/components/src/utils/hooks/use-cx.ts
+++ b/packages/components/src/utils/hooks/use-cx.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { Context } from 'react';
+import { CacheProvider, EmotionCache } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/serialize';
+import { insertStyles } from '@emotion/utils';
+// eslint-disable-next-line no-restricted-imports
+import { cx as innerCx, ClassNamesArg } from '@emotion/css';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext, useCallback } from '@wordpress/element';
+
+// @ts-ignore Private property
+const EmotionCacheContext: Context< EmotionCache > = CacheProvider._context;
+
+const useEmotionCacheContext = () => useContext( EmotionCacheContext );
+
+const isSerializedStyles = ( o: any ): o is SerializedStyles =>
+	[ 'name', 'styles' ].every( ( p ) => typeof o[ p ] !== 'undefined' );
+
+export const useCx = () => {
+	const cache = useEmotionCacheContext();
+
+	const cx = useCallback(
+		( ...classNames: ( ClassNamesArg | SerializedStyles )[] ) => {
+			return innerCx(
+				...classNames.map( ( arg ) => {
+					if ( isSerializedStyles( arg ) ) {
+						insertStyles( cache, arg, false );
+						return `${ cache.key }-${ arg.name }`;
+					}
+					return arg;
+				} )
+			);
+		},
+		[ cache ]
+	);
+
+	return cx;
+};

--- a/packages/components/src/utils/hooks/use-cx.ts
+++ b/packages/components/src/utils/hooks/use-cx.ts
@@ -22,6 +22,27 @@ const useEmotionCacheContext = () => useContext( EmotionCacheContext );
 const isSerializedStyles = ( o: any ): o is SerializedStyles =>
 	[ 'name', 'styles' ].every( ( p ) => typeof o[ p ] !== 'undefined' );
 
+/**
+ * Retrieve a `cx` function that knows how to handle `SerializedStyles`
+ * returned by the `@emotion/react` `css` function in addition to what
+ * `cx` normally knows how to handle. It also hooks into the Emotion
+ * Cache, allowing `css` calls to work inside iframes.
+ *
+ * @example
+ * import { css } from '@emotion/react';
+ *
+ * const styles = css`
+ * 	color: red
+ * `;
+ *
+ * function RedText( { className, ...props } ) {
+ * 	const cx = useCx();
+ *
+ * 	const classes = cx(styles, className);
+ *
+ * 	return <span className={classes} {...props} />;
+ * }
+ */
 export const useCx = () => {
 	const cache = useEmotionCacheContext();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a `useCx` hook which creates a `cx` function that is able to take in `SerializedStyles` returned by the `css` function from `@emotion/react`. It also attaches these to the current EmotionCache meaning that it will work with iframes.

## How has this been tested?
Unit tests and storybook.

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
