### PR TITLE
Documentation: Remove `withState` HOC references

### DIFF
--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -16,19 +16,19 @@ Render a DateTimePicker.
 
 ```jsx
 import { DateTimePicker } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyDateTimePicker = withState( {
-	date: new Date(),
-} )( ( { date, setState } ) => {
+const MyDateTimePicker = () => {
+	const [ date, setDate ] = useState( new Date() );
+
 	return (
 		<DateTimePicker
 			currentDate={ date }
-			onChange={ ( date ) => setState( { date } ) }
+			onChange={ ( newDate ) => setDate( newDate ) }
 			is12Hour={ true }
 		/>
 	);
-} );
+}
 ```
 
 ## Props

--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -15,9 +15,9 @@ const MyDropZone = () => {
 		<div>
 			{ hasDropped ? 'Dropped!' : 'Drop something here' }
 			<DropZone
-				onFilesDrop={ () => setState( { hasDropped: true } ) }
-				onHTMLDrop={ () => setState( { hasDropped: true } ) }
-				onDrop={ () => setState( { hasDropped: true } ) }
+				onFilesDrop={ () => setHasDropped( true ) }
+				onHTMLDrop={ () => setHasDropped( true ) }
+				onDrop={ () => setHasDropped( true ) }
 			/>
 		</div>
 	);

--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -6,20 +6,22 @@
 
 ```jsx
 import { DropZone } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyDropZone = withState( {
-	hasDropped: false,
-} )( ( { hasDropped, setState } ) => (
-	<div>
-		{ hasDropped ? 'Dropped!' : 'Drop something here' }
-		<DropZone
-			onFilesDrop={ () => setState( { hasDropped: true } ) }
-			onHTMLDrop={ () => setState( { hasDropped: true } ) }
-			onDrop={ () => setState( { hasDropped: true } ) }
-		/>
-	</div>
-) );
+const MyDropZone = () => {
+	const [ hasDropped, setHasDropped ] = useState( false );
+
+	return (
+		<div>
+			{ hasDropped ? 'Dropped!' : 'Drop something here' }
+			<DropZone
+				onFilesDrop={ () => setState( { hasDropped: true } ) }
+				onHTMLDrop={ () => setState( { hasDropped: true } ) }
+				onDrop={ () => setState( { hasDropped: true } ) }
+			/>
+		</div>
+	);
+}
 ```
 
 ## Props

--- a/packages/components/src/higher-order/with-constrained-tabbing/README.md
+++ b/packages/components/src/higher-order/with-constrained-tabbing/README.md
@@ -12,15 +12,14 @@ import {
 	TextControl,
 	Button,
 } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 const ConstrainedTabbing = withConstrainedTabbing(
 	( { children } ) => children
 );
 
-const MyComponentWithConstrainedTabbing = withState( {
-	isConstrainedTabbing: false,
-} )( ( { isConstrainedTabbing, setState } ) => {
+const MyComponentWithConstrainedTabbing = () => {
+	const [ isConstrainedTabbing, setIsConstrainedTabbing ] = useState( false );
 	let form = (
 		<form>
 			<TextControl label="Input 1" onChange={ () => {} } />
@@ -32,9 +31,7 @@ const MyComponentWithConstrainedTabbing = withState( {
 	}
 
 	const toggleConstrain = () => {
-		setState( ( state ) => ( {
-			isConstrainedTabbing: ! state.isConstrainedTabbing,
-		} ) );
+		setIsConstrainedTabbing( ( state ) => ! state );
 	};
 
 	return (
@@ -46,5 +43,5 @@ const MyComponentWithConstrainedTabbing = withState( {
 			</Button>
 		</div>
 	);
-} );
+}
 ```

--- a/packages/components/src/higher-order/with-focus-return/README.md
+++ b/packages/components/src/higher-order/with-focus-return/README.md
@@ -8,7 +8,7 @@
 
 ```jsx
 import { withFocusReturn, TextControl, Button } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 const EnhancedComponent = withFocusReturn( () => (
 	<div>
@@ -17,12 +17,11 @@ const EnhancedComponent = withFocusReturn( () => (
 	</div>
 ) );
 
-const MyComponentWithFocusReturn = withState( {
-	text: '',
-} )( ( { text, setState } ) => {
+const MyComponentWithFocusReturn = () => {
+	const [ text, setText ] = useState( '' );
 	const unmount = () => {
 		document.activeElement.blur();
-		setState( { text: '' } );
+		setText( '' );
 	};
 
 	return (
@@ -30,7 +29,7 @@ const MyComponentWithFocusReturn = withState( {
 			<TextControl
 				placeholder="Type something"
 				value={ text }
-				onChange={ ( text ) => setState( { text } ) }
+				onChange={ ( value ) => setText( value ) }
 			/>
 			{ text && <EnhancedComponent /> }
 			{ text && (
@@ -40,7 +39,7 @@ const MyComponentWithFocusReturn = withState( {
 			) }
 		</div>
 	);
-} );
+}
 ```
 
 `withFocusReturn` can optionally be called as a higher-order function creator. Provided an options object, a new higher-order function is returned.

--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -55,11 +55,11 @@ Designs with a `MenuItemsChoice` option selected by default make a strong sugges
 
 ```jsx
 import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyMenuItemsChoice = withState( {
-	mode: 'visual',
-	choices: [
+const MyMenuItemsChoice = () => {
+	const [ mode, setMode ] = useState( 'visual' );
+	const choices = [
 		{
 			value: 'visual',
 			label: 'Visual editor',
@@ -68,14 +68,16 @@ const MyMenuItemsChoice = withState( {
 			value: 'text',
 			label: 'Code editor',
 		},
-	],
-} )( ( { mode, choices, setState } ) => (
-	<MenuGroup label="Editor">
-		<MenuItemsChoice
-			choices={ choices }
-			value={ mode }
-			onSelect={ ( mode ) => setState( { mode } ) }
-		/>
-	</MenuGroup>
-) );
+	];
+
+	return (
+		<MenuGroup label="Editor">
+			<MenuItemsChoice
+				choices={ choices }
+				value={ mode }
+				onSelect={ ( newMode ) => setMode( newMode ) }
+			/>
+		</MenuGroup>
+	);
+};
 ```

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -58,24 +58,24 @@ Render a user interface to select the user type using radio inputs.
 
 ```jsx
 import { RadioControl } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyRadioControl = withState( {
-	option: 'a',
-} )( ( { option, setState } ) => (
-	<RadioControl
-		label="User type"
-		help="The type of the current user"
-		selected={ option }
-		options={ [
-			{ label: 'Author', value: 'a' },
-			{ label: 'Editor', value: 'e' },
-		] }
-		onChange={ ( option ) => {
-			setState( { option } );
-		} }
-	/>
-) );
+const MyRadioControl = () => {
+	const [ option, setOption ] = useState( 'a' );
+
+	return (
+		<RadioControl
+			label="User type"
+			help="The type of the current user"
+			selected={ option }
+			options={ [
+				{ label: 'Author', value: 'a' },
+				{ label: 'Editor', value: 'e' },
+			] }
+			onChange={ ( value ) => setOption( value ) }
+		/>
+	);
+}
 ```
 
 ### Props

--- a/packages/components/src/textarea-control/README.md
+++ b/packages/components/src/textarea-control/README.md
@@ -76,19 +76,23 @@ When text input isn’t accepted, an error message can display instructions on h
 
 ### Usage
 
-    import { TextareaControl } from '@wordpress/components';
-    import { withState } from '@wordpress/compose';
+```jsx
+import { TextareaControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
-    const MyTextareaControl = withState( {
-        text: '',
-    } )( ( { text, setState } ) => (
-        <TextareaControl
-            label="Text"
-            help="Enter some text"
-            value={ text }
-            onChange={ ( text ) => setState( { text } ) }
-        />
-    ) );
+const MyTextareaControl = () => {
+	const [ text, setText ] = useState( '' );
+
+	return (
+		<TextareaControl
+			label="Text"
+			help="Enter some text"
+			value={ text }
+			onChange={ ( value ) => setText( value ) }
+		/>
+	);
+};
+```
 
 ### Props
 

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -8,44 +8,46 @@ Render a user interface to select the parent page in a hierarchy of pages:
 
 ```jsx
 import { TreeSelect } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyTreeSelect = withState( {
-	page: 'p21',
-} )( ( { page, setState } ) => (
-	<TreeSelect
-		label="Parent page"
-		noOptionLabel="No parent page"
-		onChange={ ( page ) => setState( { page } ) }
-		selectedId={ page }
-		tree={ [
-			{
-				name: 'Page 1',
-				id: 'p1',
-				children: [
-					{ name: 'Descend 1 of page 1', id: 'p11' },
-					{ name: 'Descend 2 of page 1', id: 'p12' },
-				],
-			},
-			{
-				name: 'Page 2',
-				id: 'p2',
-				children: [
-					{
-						name: 'Descend 1 of page 2',
-						id: 'p21',
-						children: [
-							{
-								name: 'Descend 1 of Descend 1 of page 2',
-								id: 'p211',
-							},
-						],
-					},
-				],
-			},
-		] }
-	/>
-) );
+const MyTreeSelect = () => {
+	const [ page, setPage ] = useState( 'p21' );
+
+	return (
+		<TreeSelect
+			label="Parent page"
+			noOptionLabel="No parent page"
+			onChange={ ( newPage ) => setPage( newPage ) }
+			selectedId={ page }
+			tree={ [
+				{
+					name: 'Page 1',
+					id: 'p1',
+					children: [
+						{ name: 'Descend 1 of page 1', id: 'p11' },
+						{ name: 'Descend 2 of page 1', id: 'p12' },
+					],
+				},
+				{
+					name: 'Page 2',
+					id: 'p2',
+					children: [
+						{
+							name: 'Descend 1 of page 2',
+							id: 'p21',
+							children: [
+								{
+									name: 'Descend 1 of Descend 1 of page 2',
+									id: 'p211',
+								},
+							],
+						},
+					],
+				},
+			] }
+		/>
+	);
+}
 ```
 
 ## Props


### PR DESCRIPTION
## Description
PR replaces the usage of recently deprecated `withState` HOC with the `useState` hook.

P.S. I'm thinking of splitting these updates into several PRs to make them easier to review. But let me know if a single PR is preferred.

## Types of changes
Documentation update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
