### PR TITLE
Remove the __unstableLocation attribute prior to rendering

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -155,8 +155,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	if ( empty( $block->inner_blocks ) ) {
 		if ( array_key_exists( '__unstableLocation', $attributes ) ) {
-			$location                 = $attributes['__unstableLocation'];
-			$maybe_classic_navigation = gutenberg_render_menu_from_location( $location, $attributes );
+			$location                         = $attributes['__unstableLocation'];
+			$attributes['__unstableLocation'] = null;
+			$maybe_classic_navigation         = gutenberg_render_menu_from_location( $location, $attributes );
 			if ( $maybe_classic_navigation ) {
 				return $maybe_classic_navigation;
 			}


### PR DESCRIPTION

## Description

Remove the __unstableLocation attribute before passing the attributes to
the menu renderer to avoid an infinate loop if no menu is assigned to
the location.

## How has this been tested?
Activate a theme that uses the Navigation block and an __unstableLocation attribute.  Don't assign a menu to that location and attempt to render the site (any page that renders the menu block).  

Note that before the fix WordPress runs out of memory (assuming due to an infinite loop).

With the fix the page renders as expected.

## Types of changes
A simple bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
