### PR TITLE
Site Logo Block: update Site Logo block UI and option syncing

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -199,7 +199,7 @@ add_filter( 'rest_index', 'register_site_icon_url' );
  * @return WP_REST_Response
  */
 function register_site_logo_to_rest_index( $response ) {
-	$site_logo_id                = get_theme_mod( 'custom_logo' );
+	$site_logo_id                = get_option( 'site_logo' );
 	$response->data['site_logo'] = $site_logo_id;
 	if ( $site_logo_id ) {
 		$response->add_link(

--- a/lib/init.php
+++ b/lib/init.php
@@ -199,7 +199,7 @@ add_filter( 'rest_index', 'register_site_icon_url' );
  * @return WP_REST_Response
  */
 function register_site_logo_to_rest_index( $response ) {
-	$site_logo_id                = get_option( 'site_logo' );
+	$site_logo_id                = get_theme_mod( 'custom_logo' );
 	$response->data['site_logo'] = $site_logo_id;
 	if ( $site_logo_id ) {
 		$response->add_link(

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -280,7 +280,7 @@ export default function LogoEdit( {
 			} );
 		const _isRequestingMediaItem =
 			_siteLogoId &&
-			select( coreStore ).isResolving( 'getEntityRecord', [
+			! select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
 				'root',
 				'media',
 				_siteLogoId,
@@ -345,9 +345,7 @@ export default function LogoEdit( {
 
 	const label = __( 'Site Logo' );
 	let logoImage;
-	const isLoading =
-		siteLogoId === undefined ||
-		( siteLogoId && ! logoUrl && isRequestingMediaItem );
+	const isLoading = siteLogoId === undefined || isRequestingMediaItem;
 	if ( isLoading ) {
 		logoImage = <Spinner />;
 	}
@@ -381,7 +379,13 @@ export default function LogoEdit( {
 					className="site-logo_placeholder"
 					icon={ icon }
 					label={ label }
-				/>
+				>
+					{ isLoading && (
+						<span className="components-placeholder__preview">
+							<Spinner />
+						</span>
+					) }
+				</Placeholder>
 			) }
 			{ ! logoUrl && canUserEdit && (
 				<MediaPlaceholder

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -17,7 +17,7 @@ import {
 	ResizableBox,
 	Spinner,
 	ToggleControl,
-	Icon,
+	Placeholder,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import {
@@ -257,37 +257,46 @@ export default function LogoEdit( {
 	const [ error, setError ] = useState();
 	const ref = useRef();
 
-	const { siteLogoId, canUserEdit, url, mediaItemData } = useSelect(
-		( select ) => {
-			const { canUser, getEntityRecord, getEditedEntityRecord } = select(
-				coreStore
-			);
-			const siteSettings = getEditedEntityRecord( 'root', 'site' );
-			const siteData = getEntityRecord( 'root', '__unstableBase' );
-			const _siteLogo = siteSettings?.site_logo;
-			const _readOnlyLogo = siteData?.site_logo;
-			const _canUserEdit = canUser( 'update', 'settings' );
-			const _siteLogoId = _siteLogo || _readOnlyLogo;
-			const mediaItem =
-				_siteLogoId &&
-				select( coreStore ).getEntityRecord(
-					'root',
-					'media',
-					_siteLogoId,
-					{ context: 'view' }
-				);
-			return {
-				siteLogoId: _siteLogoId,
-				canUserEdit: _canUserEdit,
-				url: siteData?.url,
-				mediaItemData: mediaItem && {
-					url: mediaItem.source_url,
-					alt: mediaItem.alt_text,
-				},
-			};
-		},
-		[]
-	);
+	const {
+		siteLogoId,
+		canUserEdit,
+		url,
+		mediaItemData,
+		isRequestingMediaItem,
+	} = useSelect( ( select ) => {
+		const { canUser, getEntityRecord, getEditedEntityRecord } = select(
+			coreStore
+		);
+		const siteSettings = getEditedEntityRecord( 'root', 'site' );
+		const siteData = getEntityRecord( 'root', '__unstableBase' );
+		const _siteLogo = siteSettings?.site_logo;
+		const _readOnlyLogo = siteData?.site_logo;
+		const _canUserEdit = canUser( 'update', 'settings' );
+		const _siteLogoId = _siteLogo || _readOnlyLogo;
+		const mediaItem =
+			_siteLogoId &&
+			select( coreStore ).getEntityRecord( 'root', 'media', _siteLogoId, {
+				context: 'view',
+			} );
+		const _isRequestingMediaItem =
+			_siteLogoId &&
+			select( coreStore ).isResolving( 'getEntityRecord', [
+				'root',
+				'media',
+				_siteLogoId,
+				{ context: 'view' },
+			] );
+		return {
+			siteLogoId: _siteLogoId,
+			canUserEdit: _canUserEdit,
+			url: siteData?.url,
+			mediaItemData: mediaItem && {
+				url: mediaItem.source_url,
+				alt: mediaItem.alt_text,
+			},
+			isRequestingMediaItem: _isRequestingMediaItem,
+		};
+	}, [] );
 
 	const { editEntityRecord } = useDispatch( coreStore );
 	const setLogo = ( newValue ) =>
@@ -336,7 +345,9 @@ export default function LogoEdit( {
 
 	const label = __( 'Site Logo' );
 	let logoImage;
-	const isLoading = siteLogoId === undefined || ( siteLogoId && ! logoUrl );
+	const isLoading =
+		siteLogoId === undefined ||
+		( siteLogoId && ! logoUrl && isRequestingMediaItem );
 	if ( isLoading ) {
 		logoImage = <Spinner />;
 	}
@@ -366,10 +377,11 @@ export default function LogoEdit( {
 			{ controls }
 			{ !! logoUrl && logoImage }
 			{ ! logoUrl && ! canUserEdit && (
-				<div className="site-logo_placeholder">
-					<Icon icon={ icon } />
-					<p> { __( 'Site Logo' ) }</p>
-				</div>
+				<Placeholder
+					className="site-logo_placeholder"
+					icon={ icon }
+					label={ label }
+				/>
 			) }
 			{ ! logoUrl && canUserEdit && (
 				<MediaPlaceholder

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -43,16 +43,19 @@
 
 	// Placeholder improvements.
 	.components-placeholder {
+		justify-content: flex-start;
 		min-height: auto;
 		height: 120px;
-		padding: $grid-unit-10;
+		padding: $grid-unit-15;
 
 		// Massage the label.
 		.components-placeholder__label {
+			margin-top: $grid-unit-15;
 			white-space: nowrap;
 		}
 
-		.components-placeholder__label .block-editor-block-icon {
+		.components-placeholder__label .block-editor-block-icon,
+		.components-placeholder__label > svg {
 			margin-right: $grid-unit-05;
 		}
 
@@ -77,26 +80,6 @@
 		// Hide drag and drop text.
 		.components-drop-zone__content-text {
 			display: none;
-		}
-	}
-}
-.editor-styles-wrapper {
-	.site-logo_placeholder {
-		display: flex;
-		flex-direction: row;
-		align-items: flex-start;
-		border-radius: $radius-block-ui;
-		background-color: $white;
-		box-shadow: inset 0 0 0 $border-width $gray-900;
-		padding: $grid-unit-15;
-		svg {
-			margin-right: $grid-unit-15;
-		}
-		p {
-			font-family: $default-font;
-			font-size: $default-font-size;
-			margin: 0;
-			line-height: initial;
 		}
 	}
 }

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -157,6 +157,6 @@ function _delete_site_logo_on_remove_theme_mods() {
 function _delete_site_logo_on_remove_custom_logo_on_setup_theme() {
 	$theme = get_option( 'stylesheet' );
 	add_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10, 2 );
-	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods', 10, 0 );
+	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 }
 add_action( 'setup_theme', '_delete_site_logo_on_remove_custom_logo_on_setup_theme', 11 );


### PR DESCRIPTION
## Description

Updates for the Site Logo block, including some important bug fixes to prevent

- The site_logo from being deleted when switching themes or saving theme_mods with a theme that doesn't support `custom-logo`.
- The Site Logo block from being stuck in a perpetual loading state when the logo image doesn't exist.

### Ensure `site_logo` isn't deleted unintentionally

The change in #32370 introduced a problem where the `site_logo` would be deleted when switching to a theme without any theme mods settings in the database, because the `update_option_theme_mods_$theme` hook would run with a default set of theme mods that didn't include a custom_logo, and then delete the site logo.

This change restores the use of the `pre_set_theme_mod_custom_logo` hook, and uses a different set of hooks to make sure the site_logo is deleted as needed by `remove_theme_mod` or `remove_theme_mods`. This should allow the change to pass Core unit tests.

### Fix loading bug when image does not exist

Previously, if the logo attachment ID points to a non-existent image, the block would perpetually show a loading state. This adds a check to ensure the loading state only shows when requesting the attachment information.

| **Before** | **After** |
| - | - |
| <img width="122" alt="image" src="https://user-images.githubusercontent.com/1699996/124316835-d4856f00-db3b-11eb-9842-935c2b2d182c.png"> | <img width="122" alt="image" src="https://user-images.githubusercontent.com/1699996/124316960-04cd0d80-db3c-11eb-81f7-02452e72631d.png"> |

### Improves the placeholder

In the editor, a placeholder is shown for the block when there's no image and before we know the user can edit the logo settings. Use the `<Placeholder>` component, rather than a plain `<div>`, and update styles so that the UI transitions are smoother.

| **Before** | **After** |
| - | - |
| <img width="122" alt="Screen Shot 2021-07-02 at 12 26 12" src="https://user-images.githubusercontent.com/1699996/124313045-f11ea880-db35-11eb-9a28-528f12b256f9.png"> |  <img width="122" alt="Screen Shot 2021-07-02 at 12 46 07" src="https://user-images.githubusercontent.com/1699996/124319868-7f982780-db40-11eb-9e8e-02fcab15b8d0.png"> |
| <img width="130" src="https://user-images.githubusercontent.com/1699996/124313887-25469900-db37-11eb-87d9-f7ad4abb51dd.gif" /> | <img width="130" src="https://user-images.githubusercontent.com/1699996/124313910-2bd51080-db37-11eb-97e2-688494d76079.gif" /> |

### Remove the site_logo -> custom_logo hooks

`site_logo` (when set) is always used for displaying the logo (with `get_custom_logo()`), so I'm not aware of a specific need to keep the `custom_logo` theme_mod in sync. Also, the current implementation is incomplete: it needs additional hooks for `add_option` and `delete_option`. Combined with having both the Core and Gutenberg versions of the block code, all of this adds considerable complexity that can make it very hard to track what's happening when updates are made.

Because of this, I propose removing `_sync_site_logo_to_custom_logo`, for now. If we ever have a specific use case (e.g. we need to delete the `custom_logo` setting when the logo is deleted from the block), we could add back exactly what we need, at that time.

## How has this been tested?

- Load the updated block in the editor, and see the updates to the loading state
- Add an image to the block and save the logo
- See that the logo shows on the site, both in the block and as the theme logo
- Update the logo from the Customizer, and check that the logo is updated
- Remove the logo from the Customizer, and check that the logo is removed
- After setting a logo, switch themes to another theme that supports a logo, and see that the existing logo is displayed by the new theme.
- Call `remove_theme_mod( 'custom_logo' )` (or `wp theme mod remove custom_logo` via cli) and see that `site_logo` is removed and the theme no longer displays a logo. Check the same for `remove_theme_mods()`.

**IMPORTANT:** The filters registered on `setup_theme` are difficult to test because of #33177. The `_delete_site_logo_on_...` functions in Gutenberg will not execute b/c the `setup_theme` action has already happened when the action is added.

To test these changes you can

- Copy the filter updates from this branch into `wp-includes/blocks/site-logo.php` in your development environment, or
- Manually update `setup_theme` hook to `init` in `site-logo/index.php` for the purposes of testing.

Make sure you disable the similar code that's running in Core (`wp-includes/blocks/site-logo.php`) to test this change in isolation.

## Types of changes

Refinements and bug fixes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
