### PR TITLE
Fix legacy widget height overflow

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -22,7 +22,12 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			// or it will grow to an unexpected large height in Safari if it's hidden initially.
 			if ( isLoaded ) {
 				function setHeight() {
-					iframe.style.height = `${ iframe.contentDocument.body.offsetHeight }px`;
+					// Pick the maximum of these two values to account for margin collapsing.
+					const height = Math.max(
+						iframe.contentDocument.documentElement.offsetHeight,
+						iframe.contentDocument.body.offsetHeight
+					);
+					iframe.style.height = `${ height }px`;
 				}
 
 				const {
@@ -95,10 +100,18 @@ export default function Preview( { idBase, instance, isVisible } ) {
 							},
 						} ) }
 						onLoad={ ( event ) => {
-							// To hide the scrollbars of the preview frame,
-							// it can't be scrolled anyway.
-							event.target.contentDocument.body.style.overflow =
-								'hidden';
+							// To hide the scrollbars of the preview frame for some edge cases,
+							// such as negative margins in the Gallery Legacy Widget.
+							// It can't be scrolled anyway.
+							// TODO: Ideally, this should be fixed in core.
+							try {
+								event.target.contentDocument.body.style.overflow =
+									'hidden';
+							} catch {
+								// There might be permission error when trying to access cross-origin iframes.
+								// As a progressive enhancement, simply ignore the errors here.
+							}
+
 							setIsLoaded( true );
 						} }
 						height={ 100 }

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -17,7 +17,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 
 	// Resize the iframe on either the load event, or when the iframe becomes visible.
 	const ref = useRefEffect( ( iframe ) => {
-		function onChange() {
+		function setHeight() {
 			iframe.style.height = `${ iframe.contentDocument.documentElement.offsetHeight }px`;
 		}
 
@@ -28,7 +28,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 		const intersectionObserver = new IntersectionObserver(
 			( [ entry ] ) => {
 				if ( entry.isIntersecting ) {
-					onChange();
+					setHeight();
 				}
 			},
 			{
@@ -37,11 +37,11 @@ export default function Preview( { idBase, instance, isVisible } ) {
 		);
 		intersectionObserver.observe( iframe );
 
-		iframe.addEventListener( 'load', onChange );
+		iframe.addEventListener( 'load', setHeight );
 
 		return () => {
 			intersectionObserver.disconnect();
-			iframe.removeEventListener( 'load', onChange );
+			iframe.removeEventListener( 'load', setHeight );
 		};
 	}, [] );
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -22,7 +22,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			// or it will grow to an unexpected large height in Safari if it's hidden initially.
 			if ( isLoaded ) {
 				function setHeight() {
-					iframe.style.height = `${ iframe.contentDocument.documentElement.offsetHeight }px`;
+					iframe.style.height = `${ iframe.contentDocument.body.offsetHeight }px`;
 				}
 
 				const {
@@ -94,7 +94,13 @@ export default function Preview( { idBase, instance, isVisible } ) {
 								instance,
 							},
 						} ) }
-						onLoad={ () => setIsLoaded( true ) }
+						onLoad={ ( event ) => {
+							// To hide the scrollbars of the preview frame,
+							// it can't be scrolled anyway.
+							event.target.contentDocument.body.style.overflow =
+								'hidden';
+							setIsLoaded( true );
+						} }
 						height={ 100 }
 					/>
 				</Disabled>

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -21,6 +21,9 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			// Only set height if the iframe is loaded,
 			// or it will grow to an unexpected large height in Safari if it's hidden initially.
 			if ( isLoaded ) {
+				// If the preview frame has another origin then this won't work.
+				// One possible solution is to add custom script to call `postMessage` in the preview frame.
+				// Or, better yet, we migrate away from iframe.
 				function setHeight() {
 					// Pick the maximum of these two values to account for margin collapsing.
 					const height = Math.max(
@@ -104,13 +107,8 @@ export default function Preview( { idBase, instance, isVisible } ) {
 							// such as negative margins in the Gallery Legacy Widget.
 							// It can't be scrolled anyway.
 							// TODO: Ideally, this should be fixed in core.
-							try {
-								event.target.contentDocument.body.style.overflow =
-									'hidden';
-							} catch {
-								// There might be permission error when trying to access cross-origin iframes.
-								// As a progressive enhancement, simply ignore the errors here.
-							}
+							event.target.contentDocument.body.style.overflow =
+								'hidden';
 
 							setIsLoaded( true );
 						} }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #33115. Fix #33123.

Fix legacy widget height overflow. I also refactored the code a bit to make it simpler.

The margins are a bit high, Most of them are coming from the preview. We'll need to add some custom styling in the preview frame to remove the margins. It probably will have to be done in core though.

Please note that I don't think this is the optimal solution. I believe we should migrate away from iframes in the future, so probably don't worth much time trying to fix every edge case here.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Go to Appearance -> Widgets
2. Try to add some legacy widgets
3. Verify that there're no scrollbars in the preview mode.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/124411802-cc1d7600-dd7f-11eb-81f6-a5208f1563bc.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
