### PR TITLE
Add E2E test to demonstrate the broken "select all" behavior

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -79,7 +79,11 @@ exports[`Multi-block selection should gradually multi-select 1`] = `
 
 <!-- wp:paragraph -->
 <p>2</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>1</li></ul>
+<!-- /wp:list --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -633,6 +633,10 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
+		// Add a list
+		await page.keyboard.type( '/list' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
 
 		// Confirm correct setup: two columns with two paragraphs in the first.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -633,6 +633,8 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+
 		// Add a list
 		await page.keyboard.type( '/list' );
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
DO NOT MERGE! This is just an addition to https://github.com/WordPress/gutenberg/pull/33167