### PR TITLE
Mobile - Disable Slash inserter E2E

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
@@ -25,7 +25,9 @@ async function assertSlashInserterPresent( checkIsVisible ) {
 	}
 }
 
-describe( 'Gutenberg Editor Slash Inserter tests', () => {
+// Due to flakiness, disabling until its more stable
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip( 'Gutenberg Editor Slash Inserter tests', () => {
 	it( 'should show the menu after typing /', async () => {
 		await editorPage.addNewBlock( blockNames.paragraph );
 		const paragraphBlockElement = await editorPage.getBlockAtPosition(

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-slash-inserter-@canary.test.js
@@ -26,6 +26,7 @@ async function assertSlashInserterPresent( checkIsVisible ) {
 }
 
 // Due to flakiness, disabling until its more stable
+// https://github.com/wordpress-mobile/gutenberg-mobile/issues/3699
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip( 'Gutenberg Editor Slash Inserter tests', () => {
 	it( 'should show the menu after typing /', async () => {


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3698

## Description
Disables the Slash inserter E2E tests while we improve them to be more stable.

## How has this been tested?
Check the test is skipped in [this PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3698).

## Screenshots
N/A

## Types of changes
Disables E2E test

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
