### PR TITLE
Increase specificity of the NoPreview CSS rules to avoid conflicts with theme styles

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -114,10 +114,15 @@
 	width: 100%;
 }
 
-.wp-block-legacy-widget__edit-no-preview {
+.wp-block-legacy-widget__edit-no-preview.wp-block-legacy-widget__edit-no-preview.wp-block-legacy-widget__edit-no-preview {
+	&,
+	& h3,
+	& p {
+		font-family: $default-font;
+		font-size: $default-font-size;
+	}
+
 	background: $gray-100;
-	font-family: $default-font;
-	font-size: $default-font-size;
 	padding: $grid-unit-10 $grid-unit-15;
 
 	h3 {


### PR DESCRIPTION
## Description

When the `use theme styles` option is enabled, legacy widget block styles are getting overridden by the theme styles. In particular, one offending CSS rule is `.editor-styles-wrapper p`. As a result, the "preview unavailable" component ends up looking like this:

<img width="754" alt="124064990-37620200-da79-11eb-8305-4b1d60f6c0e7" src="https://user-images.githubusercontent.com/205419/124477359-3cd68980-dda4-11eb-9c0c-f77bd8ed21a5.png">

This PR tweaks the selector specificity, which makes for a final effect like this:

<img width="738" alt="Zrzut ekranu 2021-07-5 o 15 16 53" src="https://user-images.githubusercontent.com/205419/124477350-3a742f80-dda4-11eb-9178-6c65dae74971.png">

## How has this been tested?
1. Add a text widget using the legacy widgets editor, don't add any title or text
2. Enable the new widgets editor
3. Confirm that what you see looks like the latter screenshot

## Types of changes
Bug fix (non-breaking change which fixes an issue)