### PR TITLE
Refactor saveEntityRecord from redux-rungen to async thunks

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -702,7 +702,7 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor or a promise.
 
 ### undo
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -702,7 +702,7 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor or a promise.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### undo
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -236,7 +236,7 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor or a promise.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### undo
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -236,7 +236,7 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor or a promise.
 
 ### undo
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -358,8 +358,7 @@ export function __unstableCreateUndoLevel() {
  * @param {boolean}  [options.isAutosave=false] Whether this is an autosave.
  * @param {Function} [options.__unstableFetch]  Internal use only. Function to
  *                                              call instead of `apiFetch()`.
- *                                              Must return a control
- *                                              descriptor or a promise.
+ *                                              Must return a promise.
  */
 export const saveEntityRecord = (
 	kind,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -647,11 +647,10 @@ export function* __experimentalBatch( requests ) {
  * @param {Object} recordId ID of the record.
  * @param {Object} options  Saving options.
  */
-export function* saveEditedEntityRecord( kind, name, recordId, options ) {
+export const saveEditedEntityRecord = ( kind, name, recordId, options ) =>
+ async ( { select, dispatch } ) => {
 	if (
-		! ( yield controls.select(
-			STORE_NAME,
-			'hasEditsForEntityRecord',
+		! ( select.hasEditsForEntityRecord(
 			kind,
 			name,
 			recordId
@@ -659,15 +658,13 @@ export function* saveEditedEntityRecord( kind, name, recordId, options ) {
 	) {
 		return;
 	}
-	const edits = yield controls.select(
-		STORE_NAME,
-		'getEntityRecordNonTransientEdits',
+	const edits = select.getEntityRecordNonTransientEdits(
 		kind,
 		name,
 		recordId
 	);
 	const record = { id: recordId, ...edits };
-	return yield* saveEntityRecord( kind, name, record, options );
+	return await dispatch( saveEntityRecord( kind, name, record, options ) );
 }
 
 /**
@@ -679,17 +676,15 @@ export function* saveEditedEntityRecord( kind, name, recordId, options ) {
  * @param {Array}  itemsToSave List of entity properties to save.
  * @param {Object} options     Saving options.
  */
-export function* __experimentalSaveSpecifiedEntityEdits(
+export const __experimentalSaveSpecifiedEntityEdits = (
 	kind,
 	name,
 	recordId,
 	itemsToSave,
 	options
-) {
+) => async ( { select, dispatch } ) => {
 	if (
-		! ( yield controls.select(
-			STORE_NAME,
-			'hasEditsForEntityRecord',
+		! ( select.hasEditsForEntityRecord(
 			kind,
 			name,
 			recordId
@@ -697,9 +692,7 @@ export function* __experimentalSaveSpecifiedEntityEdits(
 	) {
 		return;
 	}
-	const edits = yield controls.select(
-		STORE_NAME,
-		'getEntityRecordNonTransientEdits',
+	const edits = select.getEntityRecordNonTransientEdits(
 		kind,
 		name,
 		recordId
@@ -710,7 +703,7 @@ export function* __experimentalSaveSpecifiedEntityEdits(
 			editsToSave[ edit ] = edits[ edit ];
 		}
 	}
-	return yield* saveEntityRecord( kind, name, editsToSave, options );
+	return await dispatch( saveEntityRecord( kind, name, editsToSave, options ) );
 }
 
 /**

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -403,7 +403,7 @@ export const saveEntityRecord = (
 			}
 		}
 
-		dispatch( {
+		await dispatch( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind,
 			name,
@@ -417,8 +417,6 @@ export const saveEntityRecord = (
 				recordId ? '/' + recordId : ''
 			}`;
 			const persistedRecord = select.getRawEntityRecord(
-				STORE_NAME,
-				'getRawEntityRecord',
 				kind,
 				name,
 				recordId
@@ -432,8 +430,6 @@ export const saveEntityRecord = (
 				const currentUser = select.getCurrentUser();
 				const currentUserId = currentUser ? currentUser.id : undefined;
 				const autosavePost = select.getAutosave(
-					STORE_NAME,
-					'getAutosave',
 					persistedRecord.type,
 					persistedRecord.id,
 					currentUserId

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -662,7 +662,7 @@ export const saveEditedEntityRecord = (
 		recordId
 	);
 	const record = { id: recordId, ...edits };
-	return await dispatch( saveEntityRecord( kind, name, record, options ) );
+	return await dispatch.saveEntityRecord( kind, name, record, options );
 };
 
 /**

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -695,9 +695,7 @@ export const __experimentalSaveSpecifiedEntityEdits = (
 			editsToSave[ edit ] = edits[ edit ];
 		}
 	}
-	return await dispatch(
-		saveEntityRecord( kind, name, editsToSave, options )
-	);
+	return await dispatch.saveEntityRecord( kind, name, editsToSave, options );
 };
 
 /**

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -535,11 +535,7 @@ export const saveEntityRecord = (
 					method: recordId ? 'PUT' : 'POST',
 					data: edits,
 				};
-				if ( __unstableFetch ) {
-					updatedRecord = await __unstableFetch( options );
-				} else {
-					updatedRecord = await triggerFetch( options );
-				}
+				updatedRecord = await __unstableFetch( options );
 				await dispatch.receiveEntityRecords(
 					kind,
 					name,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -359,13 +359,13 @@ export function __unstableCreateUndoLevel() {
  * @param {Function} [options.__unstableFetch]  Internal use only. Function to
  *                                              call instead of `apiFetch()`.
  *                                              Must return a control
- *                                              descriptor.
+ *                                              descriptor or a promise.
  */
 export const saveEntityRecord = (
 	kind,
 	name,
 	record,
-	{ isAutosave = false, __unstableFetch = null } = {}
+	{ isAutosave = false, __unstableFetch = triggerFetch } = {}
 ) => async ( { select, dispatch } ) => {
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
@@ -461,11 +461,8 @@ export const saveEntityRecord = (
 					method: 'POST',
 					data,
 				};
-				if ( __unstableFetch ) {
-					updatedRecord = await __unstableFetch( options );
-				} else {
-					updatedRecord = await triggerFetch( options );
-				}
+				updatedRecord = await __unstableFetch( options );
+
 				// An autosave may be processed by the server as a regular save
 				// when its update is requested by the author and the post had
 				// draft or auto-draft status.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -647,15 +647,13 @@ export function* __experimentalBatch( requests ) {
  * @param {Object} recordId ID of the record.
  * @param {Object} options  Saving options.
  */
-export const saveEditedEntityRecord = ( kind, name, recordId, options ) =>
- async ( { select, dispatch } ) => {
-	if (
-		! ( select.hasEditsForEntityRecord(
-			kind,
-			name,
-			recordId
-		) )
-	) {
+export const saveEditedEntityRecord = (
+	kind,
+	name,
+	recordId,
+	options
+) => async ( { select, dispatch } ) => {
+	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 		return;
 	}
 	const edits = select.getEntityRecordNonTransientEdits(
@@ -665,7 +663,7 @@ export const saveEditedEntityRecord = ( kind, name, recordId, options ) =>
 	);
 	const record = { id: recordId, ...edits };
 	return await dispatch( saveEntityRecord( kind, name, record, options ) );
-}
+};
 
 /**
  * Action triggered to save only specified properties for the entity.
@@ -683,13 +681,7 @@ export const __experimentalSaveSpecifiedEntityEdits = (
 	itemsToSave,
 	options
 ) => async ( { select, dispatch } ) => {
-	if (
-		! ( select.hasEditsForEntityRecord(
-			kind,
-			name,
-			recordId
-		) )
-	) {
+	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 		return;
 	}
 	const edits = select.getEntityRecordNonTransientEdits(
@@ -703,8 +695,10 @@ export const __experimentalSaveSpecifiedEntityEdits = (
 			editsToSave[ edit ] = edits[ edit ];
 		}
 	}
-	return await dispatch( saveEntityRecord( kind, name, editsToSave, options ) );
-}
+	return await dispatch(
+		saveEntityRecord( kind, name, editsToSave, options )
+	);
+};
 
 /**
  * Returns an action object used in signalling that Upload permissions have been received.

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -63,6 +63,7 @@ const storeConfig = {
 	actions: { ...actions, ...entityActions, ...locksActions },
 	selectors: { ...selectors, ...entitySelectors, ...locksSelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
+	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -13,7 +13,6 @@ import {
 	editEntityRecord,
 	saveEntityRecord,
 	deleteEntityRecord,
-	// receiveEntityRecords,
 	receiveUserPermission,
 	receiveAutosaves,
 	receiveCurrentUser,

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -8,9 +8,9 @@ import { controls } from '@wordpress/data';
  */
 import {
 	editEntityRecord,
-	saveEntityRecord,
+	// saveEntityRecord,
 	deleteEntityRecord,
-	receiveEntityRecords,
+	// receiveEntityRecords,
 	receiveUserPermission,
 	receiveAutosaves,
 	receiveCurrentUser,
@@ -105,150 +105,150 @@ describe( 'deleteEntityRecord', () => {
 	} );
 } );
 
-describe( 'saveEntityRecord', () => {
-	it( 'triggers a POST request for a new record', async () => {
-		const post = { title: 'new post' };
-		const entities = [
-			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
-		];
-		const fulfillment = saveEntityRecord( 'postType', 'post', post );
-		// Trigger generator
-		fulfillment.next();
-
-		// Provide entities and acquire lock
-		expect( fulfillment.next( entities ).value.type ).toBe(
-			'MOCKED_ACQUIRE_LOCK'
-		);
-
-		// Trigger apiFetch
-		expect( fulfillment.next().value.type ).toEqual(
-			'SAVE_ENTITY_RECORD_START'
-		);
-
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		const { value: apiFetchAction } = fulfillment.next( {} );
-		expect( apiFetchAction.request ).toEqual( {
-			path: '/wp/v2/posts',
-			method: 'POST',
-			data: post,
-		} );
-		// Provide response and trigger action
-		const updatedRecord = { ...post, id: 10 };
-		const { value: received } = fulfillment.next( updatedRecord );
-		expect( received ).toEqual(
-			receiveEntityRecords(
-				'postType',
-				'post',
-				updatedRecord,
-				undefined,
-				true,
-				{ title: 'new post' }
-			)
-		);
-		expect( fulfillment.next().value.type ).toBe(
-			'SAVE_ENTITY_RECORD_FINISH'
-		);
-		// Release lock
-		expect( fulfillment.next().value.type ).toEqual(
-			'MOCKED_RELEASE_LOCK'
-		);
-
-		expect( fulfillment.next().value ).toBe( updatedRecord );
-	} );
-
-	it( 'triggers a PUT request for an existing record', async () => {
-		const post = { id: 10, title: 'new post' };
-		const entities = [
-			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
-		];
-		const fulfillment = saveEntityRecord( 'postType', 'post', post );
-		// Trigger generator
-		fulfillment.next();
-
-		// Provide entities and acquire lock
-		expect( fulfillment.next( entities ).value.type ).toBe(
-			'MOCKED_ACQUIRE_LOCK'
-		);
-
-		// Trigger apiFetch
-		expect( fulfillment.next().value.type ).toEqual(
-			'SAVE_ENTITY_RECORD_START'
-		);
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		const { value: apiFetchAction } = fulfillment.next( {} );
-		expect( apiFetchAction.request ).toEqual( {
-			path: '/wp/v2/posts/10',
-			method: 'PUT',
-			data: post,
-		} );
-		// Provide response and trigger action
-		const { value: received } = fulfillment.next( post );
-		expect( received ).toEqual(
-			receiveEntityRecords( 'postType', 'post', post, undefined, true, {
-				title: 'new post',
-				id: 10,
-			} )
-		);
-		expect( fulfillment.next().value.type ).toBe(
-			'SAVE_ENTITY_RECORD_FINISH'
-		);
-		// Release lock
-		expect( fulfillment.next().value.type ).toEqual(
-			'MOCKED_RELEASE_LOCK'
-		);
-	} );
-
-	it( 'triggers a PUT request for an existing record with a custom key', async () => {
-		const postType = { slug: 'page', title: 'Pages' };
-		const entities = [
-			{
-				name: 'postType',
-				kind: 'root',
-				baseURL: '/wp/v2/types',
-				key: 'slug',
-			},
-		];
-		const fulfillment = saveEntityRecord( 'root', 'postType', postType );
-		// Trigger generator
-		fulfillment.next();
-
-		// Provide entities and acquire lock
-		expect( fulfillment.next( entities ).value.type ).toBe(
-			'MOCKED_ACQUIRE_LOCK'
-		);
-
-		// Trigger apiFetch
-		expect( fulfillment.next().value.type ).toEqual(
-			'SAVE_ENTITY_RECORD_START'
-		);
-		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		const { value: apiFetchAction } = fulfillment.next( {} );
-		expect( apiFetchAction.request ).toEqual( {
-			path: '/wp/v2/types/page',
-			method: 'PUT',
-			data: postType,
-		} );
-		// Provide response and trigger action
-		const { value: received } = fulfillment.next( postType );
-		expect( received ).toEqual(
-			receiveEntityRecords(
-				'root',
-				'postType',
-				postType,
-				undefined,
-				true,
-				{ slug: 'page', title: 'Pages' }
-			)
-		);
-		expect( fulfillment.next().value.type ).toBe(
-			'SAVE_ENTITY_RECORD_FINISH'
-		);
-		// Release lock
-		expect( fulfillment.next().value.type ).toEqual(
-			'MOCKED_RELEASE_LOCK'
-		);
-	} );
-} );
+// describe( 'saveEntityRecord', () => {
+// 	it( 'triggers a POST request for a new record', async () => {
+// 		const post = { title: 'new post' };
+// 		const entities = [
+// 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
+// 		];
+// 		const fulfillment = saveEntityRecord( 'postType', 'post', post );
+// 		// Trigger generator
+// 		fulfillment.next();
+//
+// 		// Provide entities and acquire lock
+// 		expect( fulfillment.next( entities ).value.type ).toBe(
+// 			'MOCKED_ACQUIRE_LOCK'
+// 		);
+//
+// 		// Trigger apiFetch
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'SAVE_ENTITY_RECORD_START'
+// 		);
+//
+// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
+// 		const { value: apiFetchAction } = fulfillment.next( {} );
+// 		expect( apiFetchAction.request ).toEqual( {
+// 			path: '/wp/v2/posts',
+// 			method: 'POST',
+// 			data: post,
+// 		} );
+// 		// Provide response and trigger action
+// 		const updatedRecord = { ...post, id: 10 };
+// 		const { value: received } = fulfillment.next( updatedRecord );
+// 		expect( received ).toEqual(
+// 			receiveEntityRecords(
+// 				'postType',
+// 				'post',
+// 				updatedRecord,
+// 				undefined,
+// 				true,
+// 				{ title: 'new post' }
+// 			)
+// 		);
+// 		expect( fulfillment.next().value.type ).toBe(
+// 			'SAVE_ENTITY_RECORD_FINISH'
+// 		);
+// 		// Release lock
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'MOCKED_RELEASE_LOCK'
+// 		);
+//
+// 		expect( fulfillment.next().value ).toBe( updatedRecord );
+// 	} );
+//
+// 	it( 'triggers a PUT request for an existing record', async () => {
+// 		const post = { id: 10, title: 'new post' };
+// 		const entities = [
+// 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
+// 		];
+// 		const fulfillment = saveEntityRecord( 'postType', 'post', post );
+// 		// Trigger generator
+// 		fulfillment.next();
+//
+// 		// Provide entities and acquire lock
+// 		expect( fulfillment.next( entities ).value.type ).toBe(
+// 			'MOCKED_ACQUIRE_LOCK'
+// 		);
+//
+// 		// Trigger apiFetch
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'SAVE_ENTITY_RECORD_START'
+// 		);
+// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
+// 		const { value: apiFetchAction } = fulfillment.next( {} );
+// 		expect( apiFetchAction.request ).toEqual( {
+// 			path: '/wp/v2/posts/10',
+// 			method: 'PUT',
+// 			data: post,
+// 		} );
+// 		// Provide response and trigger action
+// 		const { value: received } = fulfillment.next( post );
+// 		expect( received ).toEqual(
+// 			receiveEntityRecords( 'postType', 'post', post, undefined, true, {
+// 				title: 'new post',
+// 				id: 10,
+// 			} )
+// 		);
+// 		expect( fulfillment.next().value.type ).toBe(
+// 			'SAVE_ENTITY_RECORD_FINISH'
+// 		);
+// 		// Release lock
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'MOCKED_RELEASE_LOCK'
+// 		);
+// 	} );
+//
+// 	it( 'triggers a PUT request for an existing record with a custom key', async () => {
+// 		const postType = { slug: 'page', title: 'Pages' };
+// 		const entities = [
+// 			{
+// 				name: 'postType',
+// 				kind: 'root',
+// 				baseURL: '/wp/v2/types',
+// 				key: 'slug',
+// 			},
+// 		];
+// 		const fulfillment = saveEntityRecord( 'root', 'postType', postType );
+// 		// Trigger generator
+// 		fulfillment.next();
+//
+// 		// Provide entities and acquire lock
+// 		expect( fulfillment.next( entities ).value.type ).toBe(
+// 			'MOCKED_ACQUIRE_LOCK'
+// 		);
+//
+// 		// Trigger apiFetch
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'SAVE_ENTITY_RECORD_START'
+// 		);
+// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
+// 		const { value: apiFetchAction } = fulfillment.next( {} );
+// 		expect( apiFetchAction.request ).toEqual( {
+// 			path: '/wp/v2/types/page',
+// 			method: 'PUT',
+// 			data: postType,
+// 		} );
+// 		// Provide response and trigger action
+// 		const { value: received } = fulfillment.next( postType );
+// 		expect( received ).toEqual(
+// 			receiveEntityRecords(
+// 				'root',
+// 				'postType',
+// 				postType,
+// 				undefined,
+// 				true,
+// 				{ slug: 'page', title: 'Pages' }
+// 			)
+// 		);
+// 		expect( fulfillment.next().value.type ).toBe(
+// 			'SAVE_ENTITY_RECORD_FINISH'
+// 		);
+// 		// Release lock
+// 		expect( fulfillment.next().value.type ).toEqual(
+// 			'MOCKED_RELEASE_LOCK'
+// 		);
+// 	} );
+// } );
 
 describe( 'receiveUserPermission', () => {
 	it( 'builds an action object', () => {

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -2,13 +2,16 @@
  * WordPress dependencies
  */
 import { controls } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
 
 /**
  * Internal dependencies
  */
 import {
 	editEntityRecord,
-	// saveEntityRecord,
+	saveEntityRecord,
 	deleteEntityRecord,
 	// receiveEntityRecords,
 	receiveUserPermission,
@@ -105,150 +108,236 @@ describe( 'deleteEntityRecord', () => {
 	} );
 } );
 
-// describe( 'saveEntityRecord', () => {
-// 	it( 'triggers a POST request for a new record', async () => {
-// 		const post = { title: 'new post' };
-// 		const entities = [
-// 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
-// 		];
-// 		const fulfillment = saveEntityRecord( 'postType', 'post', post );
-// 		// Trigger generator
-// 		fulfillment.next();
-//
-// 		// Provide entities and acquire lock
-// 		expect( fulfillment.next( entities ).value.type ).toBe(
-// 			'MOCKED_ACQUIRE_LOCK'
-// 		);
-//
-// 		// Trigger apiFetch
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'SAVE_ENTITY_RECORD_START'
-// 		);
-//
-// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-// 		const { value: apiFetchAction } = fulfillment.next( {} );
-// 		expect( apiFetchAction.request ).toEqual( {
-// 			path: '/wp/v2/posts',
-// 			method: 'POST',
-// 			data: post,
-// 		} );
-// 		// Provide response and trigger action
-// 		const updatedRecord = { ...post, id: 10 };
-// 		const { value: received } = fulfillment.next( updatedRecord );
-// 		expect( received ).toEqual(
-// 			receiveEntityRecords(
-// 				'postType',
-// 				'post',
-// 				updatedRecord,
-// 				undefined,
-// 				true,
-// 				{ title: 'new post' }
-// 			)
-// 		);
-// 		expect( fulfillment.next().value.type ).toBe(
-// 			'SAVE_ENTITY_RECORD_FINISH'
-// 		);
-// 		// Release lock
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'MOCKED_RELEASE_LOCK'
-// 		);
-//
-// 		expect( fulfillment.next().value ).toBe( updatedRecord );
-// 	} );
-//
-// 	it( 'triggers a PUT request for an existing record', async () => {
-// 		const post = { id: 10, title: 'new post' };
-// 		const entities = [
-// 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
-// 		];
-// 		const fulfillment = saveEntityRecord( 'postType', 'post', post );
-// 		// Trigger generator
-// 		fulfillment.next();
-//
-// 		// Provide entities and acquire lock
-// 		expect( fulfillment.next( entities ).value.type ).toBe(
-// 			'MOCKED_ACQUIRE_LOCK'
-// 		);
-//
-// 		// Trigger apiFetch
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'SAVE_ENTITY_RECORD_START'
-// 		);
-// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-// 		const { value: apiFetchAction } = fulfillment.next( {} );
-// 		expect( apiFetchAction.request ).toEqual( {
-// 			path: '/wp/v2/posts/10',
-// 			method: 'PUT',
-// 			data: post,
-// 		} );
-// 		// Provide response and trigger action
-// 		const { value: received } = fulfillment.next( post );
-// 		expect( received ).toEqual(
-// 			receiveEntityRecords( 'postType', 'post', post, undefined, true, {
-// 				title: 'new post',
-// 				id: 10,
-// 			} )
-// 		);
-// 		expect( fulfillment.next().value.type ).toBe(
-// 			'SAVE_ENTITY_RECORD_FINISH'
-// 		);
-// 		// Release lock
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'MOCKED_RELEASE_LOCK'
-// 		);
-// 	} );
-//
-// 	it( 'triggers a PUT request for an existing record with a custom key', async () => {
-// 		const postType = { slug: 'page', title: 'Pages' };
-// 		const entities = [
-// 			{
-// 				name: 'postType',
-// 				kind: 'root',
-// 				baseURL: '/wp/v2/types',
-// 				key: 'slug',
-// 			},
-// 		];
-// 		const fulfillment = saveEntityRecord( 'root', 'postType', postType );
-// 		// Trigger generator
-// 		fulfillment.next();
-//
-// 		// Provide entities and acquire lock
-// 		expect( fulfillment.next( entities ).value.type ).toBe(
-// 			'MOCKED_ACQUIRE_LOCK'
-// 		);
-//
-// 		// Trigger apiFetch
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'SAVE_ENTITY_RECORD_START'
-// 		);
-// 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-// 		const { value: apiFetchAction } = fulfillment.next( {} );
-// 		expect( apiFetchAction.request ).toEqual( {
-// 			path: '/wp/v2/types/page',
-// 			method: 'PUT',
-// 			data: postType,
-// 		} );
-// 		// Provide response and trigger action
-// 		const { value: received } = fulfillment.next( postType );
-// 		expect( received ).toEqual(
-// 			receiveEntityRecords(
-// 				'root',
-// 				'postType',
-// 				postType,
-// 				undefined,
-// 				true,
-// 				{ slug: 'page', title: 'Pages' }
-// 			)
-// 		);
-// 		expect( fulfillment.next().value.type ).toBe(
-// 			'SAVE_ENTITY_RECORD_FINISH'
-// 		);
-// 		// Release lock
-// 		expect( fulfillment.next().value.type ).toEqual(
-// 			'MOCKED_RELEASE_LOCK'
-// 		);
-// 	} );
-// } );
+describe( 'saveEntityRecord', () => {
+	beforeEach( async () => {
+		apiFetch.mockReset();
+		jest.useFakeTimers();
+	} );
+
+	it( 'triggers a POST request for a new record', async () => {
+		const post = { title: 'new post' };
+		const entities = [
+			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
+		];
+		const select = {
+			getRawEntityRecord: () => post,
+		};
+
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
+
+		// Provide response
+		const updatedRecord = { ...post, id: 10 };
+		apiFetch.mockImplementation( () => {
+			return updatedRecord;
+		} );
+
+		const result = await saveEntityRecord(
+			'postType',
+			'post',
+			post
+		)( { select, dispatch } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts',
+			method: 'POST',
+			data: post,
+		} );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 5 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_START',
+			kind: 'postType',
+			name: 'post',
+			recordId: undefined,
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_ACQUIRE_LOCK',
+			},
+		] );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_FINISH',
+			kind: 'postType',
+			name: 'post',
+			recordId: undefined,
+			error: undefined,
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_RELEASE_LOCK',
+			},
+		] );
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			updatedRecord,
+			undefined,
+			true,
+			post
+		);
+
+		expect( result ).toBe( updatedRecord );
+	} );
+
+	it( 'triggers a PUT request for an existing record', async () => {
+		const post = { id: 10, title: 'new post' };
+		const entities = [
+			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
+		];
+		const select = {
+			getRawEntityRecord: () => post,
+		};
+
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
+
+		// Provide response
+		const updatedRecord = { ...post, id: 10 };
+		apiFetch.mockImplementation( () => {
+			return updatedRecord;
+		} );
+
+		const result = await saveEntityRecord(
+			'postType',
+			'post',
+			post
+		)( { select, dispatch } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: post,
+		} );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 5 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_START',
+			kind: 'postType',
+			name: 'post',
+			recordId: 10,
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_ACQUIRE_LOCK',
+			},
+		] );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_FINISH',
+			kind: 'postType',
+			name: 'post',
+			recordId: 10,
+			error: undefined,
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_RELEASE_LOCK',
+			},
+		] );
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			updatedRecord,
+			undefined,
+			true,
+			post
+		);
+
+		expect( result ).toBe( updatedRecord );
+	} );
+
+	it( 'triggers a PUT request for an existing record with a custom key', async () => {
+		const postType = { slug: 'page', title: 'Pages' };
+		const entities = [
+			{
+				name: 'postType',
+				kind: 'root',
+				baseURL: '/wp/v2/types',
+				key: 'slug',
+			},
+		];
+		const select = {
+			getRawEntityRecord: () => ( {} ),
+		};
+
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
+
+		// Provide response
+		apiFetch.mockImplementation( () => postType );
+
+		const result = await saveEntityRecord(
+			'root',
+			'postType',
+			postType
+		)( { select, dispatch } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/types/page',
+			method: 'PUT',
+			data: postType,
+		} );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 5 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_START',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'page',
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_ACQUIRE_LOCK',
+			},
+		] );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'SAVE_ENTITY_RECORD_FINISH',
+			kind: 'root',
+			name: 'postType',
+			recordId: 'page',
+			error: undefined,
+			isAutosave: false,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_RELEASE_LOCK',
+			},
+		] );
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'root',
+			'postType',
+			postType,
+			undefined,
+			true,
+			{ slug: 'page', title: 'Pages' }
+		);
+
+		expect( result ).toBe( postType );
+	} );
+} );
 
 describe( 'receiveUserPermission', () => {
 	it( 'builds an action object', () => {

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -213,6 +213,11 @@ describe( 'saveEntityRecord', () => {
 				slug: 'post-1',
 				newField: 'a',
 			} );
+
+		// Wait a few ticks – without rungen we have less control over the flow of things.
+		// @TODO: A better solution
+		await runPendingPromises();
+		await runPendingPromises();
 		await runPendingPromises();
 
 		// There should ONLY be a single hanging API call (PUT) by this point.

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -1,14 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { controls } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { STORE_NAME } from '../name';
-
-/**
  * Higher-order function which invokes the given resolver only if it has not
  * already been resolved with the arguments passed to the enhanced function.
  *
@@ -20,21 +10,13 @@ import { STORE_NAME } from '../name';
  *
  * @return {Function} Enhanced resolver.
  */
-const ifNotResolved = ( resolver, selectorName ) =>
-	/**
-	 * @param {...any} args Original resolver arguments.
-	 */
-	function* resolveIfNotResolved( ...args ) {
-		const hasStartedResolution = yield controls.select(
-			STORE_NAME,
-			'hasStartedResolution',
-			selectorName,
-			args
-		);
-
-		if ( ! hasStartedResolution ) {
-			yield* resolver( ...args );
-		}
-	};
+const ifNotResolved = ( resolver, selectorName ) => ( ...args ) => ( {
+	select,
+	dispatch,
+} ) => {
+	if ( ! select.hasStartedResolution( selectorName, args ) ) {
+		dispatch( resolver( ...args ) );
+	}
+};
 
 export default ifNotResolved;

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -10,12 +10,12 @@
  *
  * @return {Function} Enhanced resolver.
  */
-const ifNotResolved = ( resolver, selectorName ) => ( ...args ) => ( {
+const ifNotResolved = ( resolver, selectorName ) => ( ...args ) => async ( {
 	select,
 	dispatch,
 } ) => {
 	if ( ! select.hasStartedResolution( selectorName, args ) ) {
-		dispatch( resolver( ...args ) );
+		await dispatch( resolver( ...args ) );
 	}
 };
 

--- a/packages/core-data/src/utils/test/if-not-resolved.js
+++ b/packages/core-data/src/utils/test/if-not-resolved.js
@@ -54,4 +54,23 @@ describe( 'ifNotResolved', () => {
 
 		expect( originalResolver ).toHaveBeenCalledTimes( 0 );
 	} );
+
+	it( 'returns a promise when the resolver was not already resolved', async () => {
+		const select = { hasStartedResolution: () => false };
+		let thunkRetval;
+		const dispatch = jest.fn( ( thunk ) => {
+			thunkRetval = thunk();
+			return thunkRetval;
+		} );
+
+		const originalResolver = jest.fn( () => () =>
+			Promise.resolve( 'success!' )
+		);
+
+		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
+		const result = resolver()( { select, dispatch } );
+
+		await expect( result ).resolves.toBe( undefined );
+		await expect( thunkRetval ).resolves.toBe( 'success!' );
+	} );
 } );

--- a/packages/core-data/src/utils/test/if-not-resolved.js
+++ b/packages/core-data/src/utils/test/if-not-resolved.js
@@ -27,48 +27,30 @@ describe( 'ifNotResolved', () => {
 		expect( resolver ).toBeInstanceOf( Function );
 	} );
 
-	it( 'triggers original resolver if not already resolved', () => {
-		controls.select.mockImplementation( ( _storeKey, selectorName ) => ( {
-			_nextValue:
-				selectorName === 'hasStartedResolution' ? false : undefined,
-		} ) );
+	it( 'triggers original resolver if not already resolved', async () => {
+		const select = { hasStartedResolution: () => false };
+		const dispatch = () => {};
 
 		const originalResolver = jest
 			.fn()
-			.mockImplementation( function* () {} );
+			.mockImplementation( async function () {} );
 
 		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
-
-		const runResolver = resolver();
-
-		let next, nextValue;
-		do {
-			next = runResolver.next( nextValue );
-			nextValue = next.value?._nextValue;
-		} while ( ! next.done );
+		await resolver()( { select, dispatch } );
 
 		expect( originalResolver ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'does not trigger original resolver if already resolved', () => {
-		controls.select.mockImplementation( ( _storeKey, selectorName ) => ( {
-			_nextValue:
-				selectorName === 'hasStartedResolution' ? true : undefined,
-		} ) );
+	it( 'does not trigger original resolver if already resolved', async () => {
+		const select = { hasStartedResolution: () => true };
+		const dispatch = () => {};
 
 		const originalResolver = jest
 			.fn()
-			.mockImplementation( function* () {} );
+			.mockImplementation( async function () {} );
 
 		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
-
-		const runResolver = resolver();
-
-		let next, nextValue;
-		do {
-			next = runResolver.next( nextValue );
-			nextValue = next.value?._nextValue;
-		} while ( ! next.done );
+		await resolver()( { select, dispatch } );
 
 		expect( originalResolver ).toHaveBeenCalledTimes( 0 );
 	} );


### PR DESCRIPTION
Builds on top of the thunks support added in #27276 and refactors just the parts of core-data required to make the `saveEntityRecord` work (this PR is a minimal viable subset of #28389).

**Test plan:**

So you ask how to test this PR? The impact surface is pretty big. For sure confirm all the tests are green – that is a good indicator of the overall health. You may want to play with the Gutenberg too:
* Create a new post and save it, confirm the preview works
* Add a `blog title` block, edit it, save the post and related entities
* Play the widgets editor, add new widgets, update the existing ones
* Anything else that comes to your mind
 