### PR TITLE
components: Add isValueNumeric util

### DIFF
--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { isValueNumeric } from '../values';
+
+describe( 'isValueNumeric', () => {
+	it.each( [
+		'999',
+		'99.33',
+		0.0003,
+		2222,
+		'22,222,222',
+		-888,
+		new Number(),
+	] )( 'should return `true` for numeric values %s', ( x ) => {
+		expect( isValueNumeric( x ) ).toBe( true );
+	} );
+
+	it.each( [ null, , 'Stringy', {}, [] ] )(
+		'should return `false` for non-numeric value %s',
+		( x ) => {
+			expect( isValueNumeric( x ) ).toBe( false );
+		}
+	);
+} );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -27,6 +27,13 @@ function scopeTestToFullICU( testCallback ) {
 }
 
 describe( 'isValueNumeric', () => {
+	scopeTestToFullICU( () => {
+		it( 'should handle space separated numbers for various locales', () => {
+			expect( isValueNumeric( '1 000.1', 'en-US' ) ).toBe( true );
+			expect( isValueNumeric( '1 000.1', 'pt-BR' ) ).toBe( true );
+		} );
+	} );
+
 	it.each( [
 		'999',
 		'99.33',

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -84,13 +84,17 @@ describe( 'isValueNumeric', () => {
 			expect( isValueNumeric( '1.000,1', 'ar' ) ).toBe( true );
 			expect( isValueNumeric( '1.000,1', 'fa' ) ).toBe( true );
 			expect( isValueNumeric( '1.000,1', 'ur' ) ).toBe( true );
+			expect( isValueNumeric( '1.000,1', 'ckb' ) ).toBe( true );
+			expect( isValueNumeric( '1.000,1', 'ps' ) ).toBe( true );
 			expect( isValueNumeric( '1.000,a', 'ar' ) ).toBe( false );
 		} );
 
 		it( 'should handle arabic locales with eastern arabic numerals', () => {
 			expect( isValueNumeric( '١٬٠٠٠٫١', 'ar' ) ).toBe( true );
-			expect( isValueNumeric( '١٬٠٠٠٫١', 'fa' ) ).toBe( true );
+			expect( isValueNumeric( '۴۵۶٫۱', 'fa' ) ).toBe( true );
 			expect( isValueNumeric( '١٬٠٠٠٫١', 'ur' ) ).toBe( true );
+			expect( isValueNumeric( '١٬٠٠٠٫١', 'ckb' ) ).toBe( true );
+			expect( isValueNumeric( '١٬٠٠٠٫١', 'ps' ) ).toBe( true );
 			expect( isValueNumeric( '١٬٠٠٠٫a', 'ar' ) ).toBe( false );
 		} );
 	} );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -79,5 +79,17 @@ describe( 'isValueNumeric', () => {
 				expect( isValueNumeric( x, 'pt-BR' ) ).toBe( false );
 			}
 		);
+
+		it( 'should handle arabic locales with western arabic numerals', () => {
+			expect( isValueNumeric( '1.000,1', 'ar' ) ).toBe( true );
+			expect( isValueNumeric( '1.000,1', 'fa' ) ).toBe( true );
+			expect( isValueNumeric( '1.000,a', 'ar' ) ).toBe( false );
+		} );
+
+		it( 'should handle arabic locales with eastern arabic numerals', () => {
+			expect( isValueNumeric( '١٬٠٠٠٫١', 'ar' ) ).toBe( true );
+			expect( isValueNumeric( '١٬٠٠٠٫١', 'fa' ) ).toBe( true );
+			expect( isValueNumeric( '١٬٠٠٠٫a', 'ar' ) ).toBe( false );
+		} );
 	} );
 } );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -12,14 +12,39 @@ describe( 'isValueNumeric', () => {
 		'22,222,222',
 		-888,
 		new Number(),
-	] )( 'should return `true` for numeric values %s', ( x ) => {
-		expect( isValueNumeric( x ) ).toBe( true );
-	} );
+	] )(
+		'should return `true` for numeric values %s for locale with comma delimiter',
+		( x ) => {
+			expect( isValueNumeric( x, 'en-US' ) ).toBe( true );
+		}
+	);
 
 	it.each( [ null, , 'Stringy', {}, [] ] )(
-		'should return `false` for non-numeric value %s',
+		'should return `false` for non-numeric value %s for locale with comma delimiter',
 		( x ) => {
-			expect( isValueNumeric( x ) ).toBe( false );
+			expect( isValueNumeric( x, 'en-US' ) ).toBe( false );
+		}
+	);
+
+	it.each( [
+		'999',
+		'99,33',
+		0.0003,
+		2222,
+		'22.222.222',
+		-888,
+		new Number(),
+	] )(
+		'should return `true` for numeric values %s for locale with period delimiter',
+		( x ) => {
+			expect( isValueNumeric( x, 'pt-BR' ) ).toBe( true );
+		}
+	);
+
+	it.each( [ null, , 'Stringy', {}, [] ] )(
+		'should return `false` for non-numeric value %s for locale with period delimiter',
+		( x ) => {
+			expect( isValueNumeric( x, 'pt-BR' ) ).toBe( false );
 		}
 	);
 } );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -83,12 +83,14 @@ describe( 'isValueNumeric', () => {
 		it( 'should handle arabic locales with western arabic numerals', () => {
 			expect( isValueNumeric( '1.000,1', 'ar' ) ).toBe( true );
 			expect( isValueNumeric( '1.000,1', 'fa' ) ).toBe( true );
+			expect( isValueNumeric( '1.000,1', 'ur' ) ).toBe( true );
 			expect( isValueNumeric( '1.000,a', 'ar' ) ).toBe( false );
 		} );
 
 		it( 'should handle arabic locales with eastern arabic numerals', () => {
 			expect( isValueNumeric( '١٬٠٠٠٫١', 'ar' ) ).toBe( true );
 			expect( isValueNumeric( '١٬٠٠٠٫١', 'fa' ) ).toBe( true );
+			expect( isValueNumeric( '١٬٠٠٠٫١', 'ur' ) ).toBe( true );
 			expect( isValueNumeric( '١٬٠٠٠٫a', 'ar' ) ).toBe( false );
 		} );
 	} );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -27,11 +27,8 @@ function scopeTestToFullICU( testCallback ) {
 }
 
 describe( 'isValueNumeric', () => {
-	scopeTestToFullICU( () => {
-		it( 'should handle space separated numbers for various locales', () => {
-			expect( isValueNumeric( '1 000.1', 'en-US' ) ).toBe( true );
-			expect( isValueNumeric( '1 000.1', 'pt-BR' ) ).toBe( true );
-		} );
+	it( 'should handle space separated numbers for locales with period decimal delimiters', () => {
+		expect( isValueNumeric( '1 000.1', 'en-US' ) ).toBe( true );
 	} );
 
 	it.each( [
@@ -57,6 +54,10 @@ describe( 'isValueNumeric', () => {
 	);
 
 	scopeTestToFullICU( () => {
+		it( 'should handle space separated numbers for locales with comma decimal delimiters', () => {
+			expect( isValueNumeric( '1 000,1', 'pt-BR' ) ).toBe( true );
+		} );
+
 		it.each( [
 			'999',
 			'99,33',

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -3,6 +3,29 @@
  */
 import { isValueNumeric } from '../values';
 
+/**
+ * This works because Node 12 ships with `small-icu` instead of `full-icu`
+ * meaning it only supports the `en-US` locale. If we test for support of the
+ * `pt-BR` locale, we can detect when we're running in a "full-icu" environment
+ * i.e., either Node 14+ or previous versions built with the `full-icu` option.
+ *
+ * Furthermore, this is safe to run in a `jsdom` test environment because, as the
+ * issue linked below describes, `jsdom` does not implement the Intl object, instead
+ * relying on the relevant Node implementation.
+ *
+ * @see https://nodejs.org/docs/latest-v12.x/api/intl.html#intl_options_for_building_node_js
+ * @see https://nodejs.org/docs/latest-v14.x/api/intl.html#intl_options_for_building_node_js
+ * @see https://github.com/jsdom/jsdom/issues/1626
+ *
+ * @todo Remove when Node 12 is deprecated
+ * @param {() => void} testCallback
+ */
+function scopeTestToFullICU( testCallback ) {
+	if ( Intl.NumberFormat.supportedLocalesOf( 'pt-BR' ).length === 1 ) {
+		testCallback();
+	}
+}
+
 describe( 'isValueNumeric', () => {
 	it.each( [
 		'999',
@@ -26,25 +49,27 @@ describe( 'isValueNumeric', () => {
 		}
 	);
 
-	it.only.each( [
-		// '999',
-		// '99,33',
-		// 0.0003,
-		// 2222,
-		'22.222.222',
-		// -888,
-		// new Number(),
-	] )(
-		'should return `true` for numeric values %s for locale with period delimiter',
-		( x ) => {
-			expect( isValueNumeric( x, 'pt-BR' ) ).toBe( true );
-		}
-	);
+	scopeTestToFullICU( () => {
+		it.each( [
+			'999',
+			'99,33',
+			0.0003,
+			2222,
+			'22.222.222',
+			-888,
+			new Number(),
+		] )(
+			'should return `true` for numeric values %s for locale with period delimiter',
+			( x ) => {
+				expect( isValueNumeric( x, 'pt-BR' ) ).toBe( true );
+			}
+		);
 
-	it.each( [ null, , 'Stringy', {}, [] ] )(
-		'should return `false` for non-numeric value %s for locale with period delimiter',
-		( x ) => {
-			expect( isValueNumeric( x, 'pt-BR' ) ).toBe( false );
-		}
-	);
+		it.each( [ null, , 'Stringy', {}, [] ] )(
+			'should return `false` for non-numeric value %s for locale with period delimiter',
+			( x ) => {
+				expect( isValueNumeric( x, 'pt-BR' ) ).toBe( false );
+			}
+		);
+	} );
 } );

--- a/packages/components/src/utils/test/values.js
+++ b/packages/components/src/utils/test/values.js
@@ -26,14 +26,14 @@ describe( 'isValueNumeric', () => {
 		}
 	);
 
-	it.each( [
-		'999',
-		'99,33',
-		0.0003,
-		2222,
+	it.only.each( [
+		// '999',
+		// '99,33',
+		// 0.0003,
+		// 2222,
 		'22.222.222',
-		-888,
-		new Number(),
+		// -888,
+		// new Number(),
 	] )(
 		'should return `true` for numeric values %s for locale with period delimiter',
 		( x ) => {

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -58,6 +58,10 @@ const getDelimiterAndDecimalRegex = ( locale ) => {
 // https://en.wikipedia.org/wiki/Decimal_separator#Current_standards
 const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
 
+const ARABIC_NUMERAL_LOCALES = [ 'ar', 'fa' ];
+
+const EASTERN_ARABIC_NUMBERS = /([۰-۹]|[٠-٩])/g;
+
 /**
  * Checks to see if a value is a numeric value (`number` or `string`).
  *
@@ -68,7 +72,19 @@ const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
  * @param {string} [locale]
  * @return {boolean} Whether value is numeric.
  */
-export function isValueNumeric( value, locale ) {
+export function isValueNumeric( value, locale = window.navigator.language ) {
+	if ( ARABIC_NUMERAL_LOCALES.some( ( l ) => locale.startsWith( l ) ) ) {
+		locale = 'en-GB';
+		if ( EASTERN_ARABIC_NUMBERS.test( value ) ) {
+			value = value
+				.replace( /([۰-۹]|[٠-٩])/g, ( /** @type {string} */ d ) =>
+					'٠١٢٣٤٥٦٧٨٩'.indexOf( d )
+				)
+				.replace( /٬/g, ',' )
+				.replace( /٫/g, '.' );
+		}
+	}
+
 	const [ delimiterRegexp, decimalRegexp ] = getDelimiterAndDecimalRegex(
 		locale
 	);

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -55,6 +55,9 @@ const getDelimiterAndDecimalRegex = ( locale ) => {
 	];
 };
 
+// https://en.wikipedia.org/wiki/Decimal_separator#Current_standards
+const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
+
 /**
  * Checks to see if a value is a numeric value (`number` or `string`).
  *
@@ -68,7 +71,10 @@ export function isValueNumeric( value, locale ) {
 	);
 	const valueToCheck =
 		typeof value === 'string'
-			? value.replace( delimiterRegexp, '' ).replace( decimalRegexp, '.' )
+			? value
+					.replace( delimiterRegexp, '' )
+					.replace( decimalRegexp, '.' )
+					.replace( INTERNATIONAL_THOUSANDS_DELIMITER, '' )
 			: value;
 	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
 }

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -41,17 +41,35 @@ export function getDefinedValue( values = [], fallbackValue ) {
 	return values.find( isValueDefined ) ?? fallbackValue;
 }
 
-/* eslint-disable jsdoc/valid-types */
+/**
+ * @param {string} [locale]
+ * @return {[RegExp, RegExp]} The delimiter and decimal regexp
+ */
+const getDelimiterAndDecimalRegex = ( locale ) => {
+	const formatted = Intl.NumberFormat( locale ).format( 1000.1 );
+	const delimiter = formatted[ 1 ];
+	const decimal = formatted[ formatted.length - 2 ];
+	return [
+		new RegExp( `\\${ delimiter }`, 'g' ),
+		new RegExp( `\\${ decimal }`, 'g' ),
+	];
+};
+
 /**
  * Checks to see if a value is a numeric value (`number` or `string`).
  *
- * @param {any} value
- *
+ * @param {any}    value
+ * @param {string} [locale]
  * @return {boolean} Whether value is numeric.
  */
-export function isValueNumeric( value ) {
-	/* eslint-enable jsdoc/valid-types */
+export function isValueNumeric( value, locale ) {
+	const [ delimiterRegexp, decimalRegexp ] = getDelimiterAndDecimalRegex(
+		locale
+	);
 	const valueToCheck =
-		typeof value === 'string' ? value.replace( /,/g, '' ) : value;
+		typeof value === 'string'
+			? value.replace( delimiterRegexp, '' ).replace( decimalRegexp, '.' )
+			: value;
+
 	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
 }

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -58,7 +58,7 @@ const getDelimiterAndDecimalRegex = ( locale ) => {
 // https://en.wikipedia.org/wiki/Decimal_separator#Current_standards
 const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
 
-const ARABIC_NUMERAL_LOCALES = [ 'ar', 'fa' ];
+const ARABIC_NUMERAL_LOCALES = [ 'ar', 'fa', 'ur' ];
 
 const EASTERN_ARABIC_NUMBERS = /([۰-۹]|[٠-٩])/g;
 

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -47,7 +47,7 @@ export function getDefinedValue( values = [], fallbackValue ) {
  *
  * @param {any} value
  *
- * @return {value is number | `${number}`} Whether value is numeric.
+ * @return {boolean} Whether value is numeric.
  */
 export function isValueNumeric( value ) {
 	/* eslint-enable jsdoc/valid-types */

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -66,11 +66,9 @@ export function isValueNumeric( value, locale ) {
 	const [ delimiterRegexp, decimalRegexp ] = getDelimiterAndDecimalRegex(
 		locale
 	);
-	console.log( delimiterRegexp, decimalRegexp );
 	const valueToCheck =
 		typeof value === 'string'
 			? value.replace( delimiterRegexp, '' ).replace( decimalRegexp, '.' )
 			: value;
-	console.log( valueToCheck );
 	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
 }

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -61,6 +61,9 @@ const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
 /**
  * Checks to see if a value is a numeric value (`number` or `string`).
  *
+ * Intentionally ignores whether the thousands delimiters are only
+ * in the thousands marks.
+ *
  * @param {any}    value
  * @param {string} [locale]
  * @return {boolean} Whether value is numeric.

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -66,10 +66,11 @@ export function isValueNumeric( value, locale ) {
 	const [ delimiterRegexp, decimalRegexp ] = getDelimiterAndDecimalRegex(
 		locale
 	);
+	console.log( delimiterRegexp, decimalRegexp );
 	const valueToCheck =
 		typeof value === 'string'
 			? value.replace( delimiterRegexp, '' ).replace( decimalRegexp, '.' )
 			: value;
-
+	console.log( valueToCheck );
 	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
 }

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -58,7 +58,7 @@ const getDelimiterAndDecimalRegex = ( locale ) => {
 // https://en.wikipedia.org/wiki/Decimal_separator#Current_standards
 const INTERNATIONAL_THOUSANDS_DELIMITER = / /g;
 
-const ARABIC_NUMERAL_LOCALES = [ 'ar', 'fa', 'ur' ];
+const ARABIC_NUMERAL_LOCALES = [ 'ar', 'fa', 'ur', 'ckb', 'ps' ];
 
 const EASTERN_ARABIC_NUMBERS = /([۰-۹]|[٠-٩])/g;
 
@@ -77,8 +77,11 @@ export function isValueNumeric( value, locale = window.navigator.language ) {
 		locale = 'en-GB';
 		if ( EASTERN_ARABIC_NUMBERS.test( value ) ) {
 			value = value
-				.replace( /([۰-۹]|[٠-٩])/g, ( /** @type {string} */ d ) =>
+				.replace( /[٠-٩]/g, ( /** @type {string} */ d ) =>
 					'٠١٢٣٤٥٦٧٨٩'.indexOf( d )
+				)
+				.replace( /[۰-۹]/g, ( /** @type {string} */ d ) =>
+					'۰۱۲۳۴۵۶۷۸۹'.indexOf( d )
 				)
 				.replace( /٬/g, ',' )
 				.replace( /٫/g, '.' );

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -40,3 +40,18 @@ export function isValueEmpty( value ) {
 export function getDefinedValue( values = [], fallbackValue ) {
 	return values.find( isValueDefined ) ?? fallbackValue;
 }
+
+/* eslint-disable jsdoc/valid-types */
+/**
+ * Checks to see if a value is a numeric value (`number` or `string`).
+ *
+ * @param {any} value
+ *
+ * @return {value is number | `${number}`} Whether value is numeric.
+ */
+export function isValueNumeric( value ) {
+	/* eslint-enable jsdoc/valid-types */
+	const valueToCheck =
+		typeof value === 'string' ? value.replace( /,/g, '' ) : value;
+	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a new `isValueNumeric` utility required by `TextInput`.

Does this need to also take in a locale?

## How has this been tested?
Unit tests pass

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
