### PR TITLE
components: Add normalizeArrowKey

### DIFF
--- a/packages/components/src/utils/keyboard.js
+++ b/packages/components/src/utils/keyboard.js
@@ -1,0 +1,18 @@
+/**
+ * Normalizes the 'key' property of a KeyboardEvent in IE/Edge
+ *
+ * Source:
+ * https://github.com/downshift-js/downshift/blob/a71005bd879d05d7dcb892d1e0dc5c6ca74e9d39/src/utils.js#L279
+ *
+ * @param {import('react').KeyboardEvent} event A keyboardEvent object
+ *
+ * @return {string} The keyboard key
+ */
+export function normalizeArrowKey( event ) {
+	const { key, keyCode } = event;
+
+	if ( keyCode >= 37 && keyCode <= 40 && key.indexOf( 'Arrow' ) !== 0 ) {
+		return `Arrow${ key }`;
+	}
+	return key;
+}

--- a/packages/components/src/utils/keyboard.js
+++ b/packages/components/src/utils/keyboard.js
@@ -1,4 +1,14 @@
 /**
+ * WordPress dependencies
+ */
+import { RIGHT, UP, DOWN, LEFT } from '@wordpress/keycodes';
+
+/**
+ * @type {number[]}
+ */
+const arrowKeys = [ RIGHT, UP, DOWN, LEFT ];
+
+/**
  * Normalizes the 'key' property of a KeyboardEvent in IE/Edge
  *
  * Source:
@@ -11,7 +21,7 @@
 export function normalizeArrowKey( event ) {
 	const { key, keyCode } = event;
 
-	if ( keyCode >= 37 && keyCode <= 40 && key.indexOf( 'Arrow' ) !== 0 ) {
+	if ( arrowKeys.includes( keyCode ) && key.indexOf( 'Arrow' ) !== 0 ) {
 		return `Arrow${ key }`;
 	}
 	return key;

--- a/packages/components/src/utils/test/keyboard.js
+++ b/packages/components/src/utils/test/keyboard.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { RIGHT, SPACE } from '@wordpress/keycodes';
+import { RIGHT, UP, DOWN, LEFT, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -9,21 +9,26 @@ import { RIGHT, SPACE } from '@wordpress/keycodes';
 import { normalizeArrowKey } from '../keyboard';
 
 describe( 'normalizeArrowKey', () => {
-	it( 'should return the Arrow(Key) version for the presed key', () => {
-		const e = new window.KeyboardEvent( 'keydown', {
-			key: 'Right',
-			keyCode: RIGHT,
-		} );
+	it.each`
+		keyCode    | key               | normalized
+		${ RIGHT } | ${ 'Right' }      | ${ 'ArrowRight' }
+		${ UP }    | ${ 'Up' }         | ${ 'ArrowUp' }
+		${ DOWN }  | ${ 'Down' }       | ${ 'ArrowDown' }
+		${ LEFT }  | ${ 'Left' }       | ${ 'ArrowLeft' }
+		${ RIGHT } | ${ 'ArrowRight' } | ${ 'ArrowRight' }
+		${ UP }    | ${ 'ArrowUp' }    | ${ 'ArrowUp' }
+		${ DOWN }  | ${ 'ArrowDown' }  | ${ 'ArrowDown' }
+		${ LEFT }  | ${ 'ArrowLeft' }  | ${ 'ArrowLeft' }
+		${ SPACE } | ${ 'Space' }      | ${ 'Space' }
+	`(
+		'should return $normalized for $key with keycode $keyCode',
+		( { keyCode, key, normalized } ) => {
+			const e = new window.KeyboardEvent( 'keydown', {
+				key,
+				keyCode,
+			} );
 
-		expect( normalizeArrowKey( e ) ).toEqual( 'ArrowRight' );
-	} );
-
-	it( 'should return the non-normalized version if given a non arrow key event', () => {
-		const e = new window.KeyboardEvent( 'keydown', {
-			key: 'Space',
-			keyCode: SPACE,
-		} );
-
-		expect( normalizeArrowKey( e ) ).toEqual( 'Space' );
-	} );
+			expect( normalizeArrowKey( e ) ).toEqual( normalized );
+		}
+	);
 } );

--- a/packages/components/src/utils/test/keyboard.js
+++ b/packages/components/src/utils/test/keyboard.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { RIGHT, SPACE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { normalizeArrowKey } from '../keyboard';
+
+describe( 'normalizeArrowKey', () => {
+	it( 'should return the Arrow(Key) version for the presed key', () => {
+		const e = new window.KeyboardEvent( 'keydown', {
+			key: 'Right',
+			keyCode: RIGHT,
+		} );
+
+		expect( normalizeArrowKey( e ) ).toEqual( 'ArrowRight' );
+	} );
+
+	it( 'should return the non-normalized version if given a non arrow key event', () => {
+		const e = new window.KeyboardEvent( 'keydown', {
+			key: 'Space',
+			keyCode: SPACE,
+		} );
+
+		expect( normalizeArrowKey( e ) ).toEqual( 'Space' );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a new `normalizeArrowKey` utility required by TextInput

## How has this been tested?
Not sure how to test this effectively without testing the implementation details.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
