### PR TITLE
Fix move to widget area checkmark

### DIFF
--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 
-import {
-	BlockControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
@@ -32,23 +29,15 @@ const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 
 				const {
 					getWidgetAreas,
+					getParentWidgetAreaBlock,
 					canInsertBlockInWidgetArea: _canInsertBlockInWidgetArea,
 				} = select( editWidgetsStore );
-				const { getBlock, getBlockName, getBlockParents } = select(
-					blockEditorStore
-				);
 
-				// Find the widget area by searching through parent blocks.
-				const blockParents = getBlockParents( clientId );
-				const widgetAreaClientId = blockParents.find(
-					( parentClientId ) =>
-						getBlockName( parentClientId ) === 'core/widget-area'
-				);
-				const widgetAreaBlock = getBlock( widgetAreaClientId );
+				const widgetAreaBlock = getParentWidgetAreaBlock( clientId );
 
 				return {
 					widgetAreas: getWidgetAreas(),
-					currentWidgetAreaId: widgetAreaBlock.attributes.id,
+					currentWidgetAreaId: widgetAreaBlock?.attributes?.id,
 					canInsertBlockInWidgetArea: _canInsertBlockInWidgetArea(
 						blockName
 					),

--- a/packages/edit-widgets/src/filters/move-to-widget-area.js
+++ b/packages/edit-widgets/src/filters/move-to-widget-area.js
@@ -27,18 +27,16 @@ const withMoveToWidgetAreaToolbarItem = createHigherOrderComponent(
 					return {};
 				}
 
-				const {
-					getWidgetAreas,
-					getParentWidgetAreaBlock,
-					canInsertBlockInWidgetArea: _canInsertBlockInWidgetArea,
-				} = select( editWidgetsStore );
+				const selectors = select( editWidgetsStore );
 
-				const widgetAreaBlock = getParentWidgetAreaBlock( clientId );
+				const widgetAreaBlock = selectors.getParentWidgetAreaBlock(
+					clientId
+				);
 
 				return {
-					widgetAreas: getWidgetAreas(),
+					widgetAreas: selectors.getWidgetAreas(),
 					currentWidgetAreaId: widgetAreaBlock?.attributes?.id,
-					canInsertBlockInWidgetArea: _canInsertBlockInWidgetArea(
+					canInsertBlockInWidgetArea: selectors.canInsertBlockInWidgetArea(
 						blockName
 					),
 				};

--- a/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
@@ -8,6 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import { store as widgetsEditorStore } from '../store';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 
 /**
@@ -18,27 +19,24 @@ import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
  */
 const useLastSelectedWidgetArea = () =>
 	useSelect( ( select ) => {
-		const { getBlockSelectionEnd, getBlockParents, getBlockName } = select(
+		const { getBlockSelectionEnd, getBlockName } = select(
 			blockEditorStore
 		);
-		const blockSelectionEndClientId = getBlockSelectionEnd();
+		const selectionEndClientId = getBlockSelectionEnd();
 
 		// If the selected block is a widget area, return its clientId.
-		if (
-			getBlockName( blockSelectionEndClientId ) === 'core/widget-area'
-		) {
-			return blockSelectionEndClientId;
+		if ( getBlockName( selectionEndClientId ) === 'core/widget-area' ) {
+			return selectionEndClientId;
 		}
 
-		// Otherwise, find the clientId of the top-level widget area by looking
-		// through the selected block's parents.
-		const blockParents = getBlockParents( blockSelectionEndClientId );
-		const rootWidgetAreaClientId = blockParents.find(
-			( clientId ) => getBlockName( clientId ) === 'core/widget-area'
+		const { getParentWidgetAreaBlock } = select( widgetsEditorStore );
+		const widgetAreaBlock = getParentWidgetAreaBlock(
+			selectionEndClientId
 		);
+		const widgetAreaBlockClientId = widgetAreaBlock?.clientId;
 
-		if ( rootWidgetAreaClientId ) {
-			return rootWidgetAreaClientId;
+		if ( widgetAreaBlockClientId ) {
+			return widgetAreaBlockClientId;
 		}
 
 		// If no widget area has been selected, return the clientId of the first

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -80,6 +80,13 @@ export const getWidgetAreaForWidgetId = createRegistrySelector(
 	}
 );
 
+/**
+ * Given a child client id, returns the parent widget area block.
+ *
+ * @param {string} clientId The client id of a block in a widget area.
+ *
+ * @return {WPBlock} The widget area block.
+ */
 export const getParentWidgetAreaBlock = createRegistrySelector(
 	( select ) => ( state, clientId ) => {
 		const { getBlock, getBlockName, getBlockParents } = select(

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -80,6 +80,20 @@ export const getWidgetAreaForWidgetId = createRegistrySelector(
 	}
 );
 
+export const getParentWidgetAreaBlock = createRegistrySelector(
+	( select ) => ( state, clientId ) => {
+		const { getBlock, getBlockName, getBlockParents } = select(
+			blockEditorStore
+		);
+		const blockParents = getBlockParents( clientId );
+		const widgetAreaClientId = blockParents.find(
+			( parentClientId ) =>
+				getBlockName( parentClientId ) === 'core/widget-area'
+		);
+		return getBlock( widgetAreaClientId );
+	}
+);
+
 export const getEditedWidgetAreas = createRegistrySelector(
 	( select ) => ( state, ids ) => {
 		let widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();


### PR DESCRIPTION
## Description
I noticed that in `trunk`, some blocks don't have a checkmark in the Move To Widget Area dropdown to indicate which widget area they're currently in.

This seems to happen to nested blocks. The feature doesn't do a deep search to find the widget area for a block. But I think there's also an issue in that only root level blocks have widget ids, and the widgetId is used to find the widget area.

In this PR I've switched it over to use the client Id and the block editor store to find the widget area for a block. I've made this a selector since the `useLastSelectedWidgetArea` hook has exactly the same requirements, and it seems like a useful API to have.

## How has this been tested?
1. Open the standalone widget area
2. Add a group and an image block inside that group
3. Open the move to widget area dropdown for the image
4. The widget area should have a checkmark

## Screenshots <!-- if applicable -->
#### Before
<img width="217" alt="Screenshot 2021-07-06 at 11 51 52 am" src="https://user-images.githubusercontent.com/677833/124540299-b9737180-de51-11eb-801b-03434599b9a8.png">

#### After
<img width="219" alt="Screenshot 2021-07-06 at 12 00 32 pm" src="https://user-images.githubusercontent.com/677833/124540333-cdb76e80-de51-11eb-9bdf-b9104e496b35.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
