### PR TITLE
[RNMobile] Embed block: Add undo/redo support

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -84,7 +84,10 @@ const EmbedEdit = ( props ) => {
 				return { fetching: false, cannotEmbed: false };
 			}
 
-			const embedPreview = getEmbedPreview( attributesUrl );
+			const embedPreview = Platform.select( {
+				web: getEmbedPreview( attributesUrl ),
+				native: attributesUrl,
+			} );
 			const previewIsFallback = isPreviewEmbedFallback( attributesUrl );
 
 			// The external oEmbed provider does not exist. We got no type info and no html.

--- a/packages/block-library/src/embed/embed-bottom-sheet.native.js
+++ b/packages/block-library/src/embed/embed-bottom-sheet.native.js
@@ -34,7 +34,7 @@ const EmbedBottomSheet = ( { value, isVisible, onClose, onSubmit } ) => {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const onDismiss = useCallback( () => {
-		if ( url !== '' && url !== value ) {
+		if ( url !== '' ) {
 			if ( isURL( url ) ) {
 				onSubmit( url );
 			} else {

--- a/packages/block-library/src/embed/embed-placeholder.native.js
+++ b/packages/block-library/src/embed/embed-placeholder.native.js
@@ -42,38 +42,33 @@ const EmbedPlaceholder = ( {
 		isSelected && wasBlockJustInserted && ! value
 	);
 
-	const emptyStateContainerStyle = usePreferredColorSchemeStyle(
-		styles.emptyStateContainer,
-		styles.emptyStateContainerDark
+	const containerStyle = usePreferredColorSchemeStyle(
+		styles.embed__container,
+		styles[ 'embed__container--dark' ]
 	);
-
-	const emptyStateTitleStyle = usePreferredColorSchemeStyle(
-		styles.emptyStateTitle,
-		styles.emptyStateTitleDark
+	const labelStyle = usePreferredColorSchemeStyle(
+		styles.embed__label,
+		styles[ 'embed__label--dark' ]
 	);
 
 	return (
 		<>
-			{ value ? (
-				<Text>{ value }</Text>
-			) : (
-				<TouchableWithoutFeedback
-					accessibilityRole={ 'button' }
-					accessibilityHint={ __( 'Double tap to add a link.' ) }
-					onPress={ ( event ) => {
-						onFocus( event );
-						setIsEmbedSheetVisible( true );
-					} }
-				>
-					<View style={ emptyStateContainerStyle }>
-						<View style={ styles.modalIcon }>{ icon }</View>
-						<Text style={ emptyStateTitleStyle }>{ label }</Text>
-						<Text style={ styles.emptyStateDescription }>
-							{ __( 'ADD LINK' ) }
-						</Text>
-					</View>
-				</TouchableWithoutFeedback>
-			) }
+			<TouchableWithoutFeedback
+				accessibilityRole={ 'button' }
+				accessibilityHint={ __( 'Double tap to add a link.' ) }
+				onPress={ ( event ) => {
+					onFocus( event );
+					setIsEmbedSheetVisible( true );
+				} }
+			>
+				<View style={ containerStyle }>
+					<View style={ styles.embed__icon }>{ icon }</View>
+					<Text style={ labelStyle }>{ label }</Text>
+					<Text style={ styles[ 'embed-empty__description' ] }>
+						{ __( 'ADD LINK' ) }
+					</Text>
+				</View>
+			</TouchableWithoutFeedback>
 			<EmbedBottomSheet
 				value={ value }
 				isVisible={ isEmbedSheetVisible }

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -27,6 +27,7 @@ const EmbedPreview = ( {
 	label,
 	onBlur,
 	onFocus,
+	preview,
 } ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
 	const containerStyle = usePreferredColorSchemeStyle(
@@ -77,10 +78,7 @@ const EmbedPreview = ( {
 				<View style={ containerStyle }>
 					<View style={ styles.embed__icon }>{ icon }</View>
 					<Text style={ labelStyle }>{ label }</Text>
-					<Text style={ stylePlaceholderText }>
-						Embed Preview will be directly above the Block Caption
-						component when it is implemented.
-					</Text>
+					<Text style={ stylePlaceholderText }>{ preview }</Text>
 				</View>
 				<BlockCaption
 					accessibilityLabelCreator={ accessibilityLabelCreator }

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -38,7 +38,7 @@ const EmbedPreview = ( {
 		styles.embed__label,
 		styles[ 'embed__label--dark' ]
 	);
-	const stylePlaceholderText = usePreferredColorSchemeStyle(
+	const placeholderTextStyle = usePreferredColorSchemeStyle(
 		styles[ 'embed-preview__placeholder-text' ],
 		styles[ 'embed-preview__placeholder-text--dark' ]
 	);
@@ -78,7 +78,7 @@ const EmbedPreview = ( {
 				<View style={ containerStyle }>
 					<View style={ styles.embed__icon }>{ icon }</View>
 					<Text style={ labelStyle }>{ label }</Text>
-					<Text style={ stylePlaceholderText }>{ preview }</Text>
+					<Text style={ placeholderTextStyle }>{ preview }</Text>
 				</View>
 				<BlockCaption
 					accessibilityLabelCreator={ accessibilityLabelCreator }

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -21,15 +21,21 @@ import styles from './styles.scss';
 
 const EmbedPreview = ( {
 	clientId,
+	icon,
 	insertBlocksAfter,
 	isSelected,
+	label,
 	onBlur,
 	onFocus,
 } ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
-	const stylePlaceholder = usePreferredColorSchemeStyle(
-		styles[ 'embed-preview__placeholder' ],
-		styles[ 'embed-preview__placeholder--dark' ]
+	const containerStyle = usePreferredColorSchemeStyle(
+		styles.embed__container,
+		styles[ 'embed__container--dark' ]
+	);
+	const labelStyle = usePreferredColorSchemeStyle(
+		styles.embed__label,
+		styles[ 'embed__label--dark' ]
 	);
 	const stylePlaceholderText = usePreferredColorSchemeStyle(
 		styles[ 'embed-preview__placeholder-text' ],
@@ -68,7 +74,9 @@ const EmbedPreview = ( {
 			disabled={ ! isSelected }
 		>
 			<View>
-				<View style={ stylePlaceholder }>
+				<View style={ containerStyle }>
+					<View style={ styles.embed__icon }>{ icon }</View>
+					<Text style={ labelStyle }>{ label }</Text>
 					<Text style={ stylePlaceholderText }>
 						Embed Preview will be directly above the Block Caption
 						component when it is implemented.

--- a/packages/block-library/src/embed/styles.native.scss
+++ b/packages/block-library/src/embed/styles.native.scss
@@ -1,6 +1,6 @@
-.emptyStateContainer {
+.embed__container {
 	flex: 1;
-	height: 142;
+	min-height: 142;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
@@ -15,31 +15,11 @@
 	border-bottom-right-radius: 4;
 }
 
-.emptyStateContainerDark {
+.embed__container--dark {
 	background-color: $background-dark-secondary;
 }
 
-.emptyStateTitle {
-	text-align: center;
-	margin-top: 4;
-	margin-bottom: 16;
-	font-size: 14;
-	color: #2e4453;
-}
-
-.emptyStateTitleDark {
-	color: $white;
-}
-
-.emptyStateDescription {
-	width: 100%;
-	text-align: center;
-	color: $blue-wordpress;
-	font-size: 14;
-	font-weight: 500;
-}
-
-.modalIcon {
+.embed__icon {
 	width: 24px;
 	height: 24px;
 	justify-content: center;
@@ -47,17 +27,24 @@
 	fill: $gray-dark;
 }
 
-.embed-preview__placeholder {
-	flex: 1;
-	padding-left: 12px;
-	padding-right: 12px;
-	padding-top: 40px;
-	padding-bottom: 40px;
-	background-color: $gray-lighten-30;
+.embed__label {
+	text-align: center;
+	margin-top: 4;
+	margin-bottom: 16;
+	font-size: 14;
+	color: #2e4453;
 }
 
-.embed-preview__placeholder--dark {
-	background-color: $gray-darken-30;
+.embed__label--dark {
+	color: $white;
+}
+
+.embed-empty__description {
+	width: 100%;
+	text-align: center;
+	color: $blue-wordpress;
+	font-size: 14;
+	font-weight: 500;
 }
 
 .embed-preview__placeholder-text {


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3700

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR addresses the undo/redo case of the embed block, for this purpose I modified the preview getter for the native version so now it uses the URL as the content to preview. It's just a temporary workaround to test the embed block functionality until we provide a fallback UI for the first version of this block.

Additionally, I made a small refactor on the native styles and adopt the BEM naming convention.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
## Undo and edit
1. Add an Embed block
2. Set a URL
3. Dismiss the bottom sheet either by tapping outside or tapping the Intro keyboard button
4. Tap on the undo button
5. Observe that the block is showing the empty state (shows `ADD LINK` message within the block)
6. Tap on the block
7. Observe that the previous URL is displayed in the Embed link text field
8. Set a new URL
9. Dismiss the bottom sheet either by tapping outside or tapping the Intro keyboard button
10. Observe that the preview displays the new URL

## Undo/redo
1. Add an Embed block
2. Set a URL
3. Tap on the undo button
4. Observe that the block is showing the empty state (shows `ADD LINK` message within the block)
5. Tap on the redo button
9. Observe that the preview displays the URL before executing the undo action

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/124593770-55f04080-de5f-11eb-81e8-ff370c773f80.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
