### PR TITLE
Tools: Update CopyWebpackPlugin to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25468,38 +25468,49 @@
 			"dev": true
 		},
 		"cacache": {
-			"version": "12.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-			"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.2.0.tgz",
+			"integrity": "sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.5",
-				"chownr": "^1.1.1",
-				"figgy-pudding": "^3.5.1",
+				"@npmcli/move-file": "^1.0.1",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
 				"glob": "^7.1.4",
-				"graceful-fs": "^4.1.15",
-				"infer-owner": "^1.0.3",
-				"lru-cache": "^5.1.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^6.0.0",
+				"minipass": "^3.1.1",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.2",
+				"mkdirp": "^1.0.3",
+				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.3",
-				"ssri": "^6.0.1",
-				"unique-filename": "^1.1.1",
-				"y18n": "^4.0.0"
+				"rimraf": "^3.0.2",
+				"ssri": "^8.0.1",
+				"tar": "^6.0.2",
+				"unique-filename": "^1.1.1"
 			},
 			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
 				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
 				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -25510,40 +25521,67 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"graceful-fs": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-					"dev": true
-				},
 				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"yallist": "^3.0.2"
+						"yallist": "^4.0.0"
 					}
 				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+				"minipass": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 					"dev": true,
 					"requires": {
-						"glob": "^7.1.3"
+						"yallist": "^4.0.0"
 					}
 				},
-				"y18n": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-					"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"tar": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+					"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+					"dev": true,
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
 				},
 				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -27277,38 +27315,73 @@
 			}
 		},
 		"copy-webpack-plugin": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
-			"integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.0.tgz",
+			"integrity": "sha512-p4eIA0ZWk4UI+xewyxOBTDCSDfjK6nCkr3zhDenoi7SFd+NgDNH/D14IZeFaCEFcK/psNDcAUMOB+sAxZ3SsAA==",
 			"dev": true,
 			"requires": {
-				"cacache": "^12.0.3",
-				"find-cache-dir": "^2.1.0",
-				"glob-parent": "^3.1.0",
-				"globby": "^7.1.1",
-				"is-glob": "^4.0.1",
-				"loader-utils": "^1.2.3",
-				"minimatch": "^3.0.4",
+				"cacache": "^15.0.5",
+				"fast-glob": "^3.2.4",
+				"find-cache-dir": "^3.3.1",
+				"glob-parent": "^5.1.1",
+				"globby": "^11.0.1",
+				"loader-utils": "^2.0.0",
 				"normalize-path": "^3.0.0",
-				"p-limit": "^2.2.1",
-				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^4.0.0",
-				"webpack-log": "^2.0.0"
+				"p-limit": "^3.0.2",
+				"schema-utils": "^3.0.0",
+				"serialize-javascript": "^5.0.1",
+				"webpack-sources": "^1.4.3"
 			},
 			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"@types/json-schema": {
+					"version": "7.0.7",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+					"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
 				"big.js": {
 					"version": "5.2.2",
 					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 					"dev": true
 				},
-				"dir-glob": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-					"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 					"dev": true,
 					"requires": {
-						"path-type": "^3.0.0"
+						"fill-range": "^7.0.1"
 					}
 				},
 				"emojis-list": {
@@ -27317,18 +27390,55 @@
 					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 					"dev": true
 				},
-				"globby": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
+				},
+				"fast-glob": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+					"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
 					}
 				},
 				"is-glob": {
@@ -27340,24 +27450,46 @@
 						"is-extglob": "^2.1.1"
 					}
 				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "^1.2.5"
 					}
 				},
 				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
+						"json5": "^2.1.2"
+					}
+				},
+				"merge2": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.2.3"
 					}
 				},
 				"normalize-path": {
@@ -27367,25 +27499,64 @@
 					"dev": true
 				},
 				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"yocto-queue": "^0.1.0"
 					}
 				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
 					"dev": true
 				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+				"schema-utils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.0.tgz",
+					"integrity": "sha512-tTEaeYkyIhEZ9uWgAjDerWov3T9MgX8dhhy2r0IGeeX4W8ngtGl1++dUve/RUqzuaASSh7shwCDJjEzthxki8w==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.7",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				},
+				"serialize-javascript": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
 				}
 			}
 		},
@@ -32376,43 +32547,42 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^2.0.0",
-				"pkg-dir": "^3.0.0"
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
 			},
 			"dependencies": {
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 					"dev": true,
 					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
+						"semver": "^6.0.0"
 					}
 				},
 				"p-limit": {
@@ -32425,12 +32595,12 @@
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
 				},
 				"p-try": {
@@ -32439,25 +32609,25 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
 				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
 					"dev": true,
 					"requires": {
-						"find-up": "^3.0.0"
+						"find-up": "^4.0.0"
 					}
 				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -34624,9 +34794,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 			"dev": true
 		},
 		"ignore-emit-webpack-plugin": {
@@ -43655,36 +43825,6 @@
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
-			}
-		},
-		"mississippi": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-			"dev": true,
-			"requires": {
-				"concat-stream": "^1.5.0",
-				"duplexify": "^3.4.2",
-				"end-of-stream": "^1.1.0",
-				"flush-write-stream": "^1.0.0",
-				"from2": "^2.1.0",
-				"parallel-transform": "^1.1.0",
-				"pump": "^3.0.0",
-				"pumpify": "^1.3.3",
-				"stream-each": "^1.1.0",
-				"through2": "^2.0.0"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
 			}
 		},
 		"mixin-deep": {
@@ -53350,9 +53490,9 @@
 			"dev": true
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
 		"slice-ansi": {
@@ -53779,12 +53919,29 @@
 			}
 		},
 		"ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
 			"dev": true,
 			"requires": {
-				"figgy-pudding": "^3.5.1"
+				"minipass": "^3.1.1"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
 			}
 		},
 		"stable": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 		"chalk": "4.1.1",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",
-		"copy-webpack-plugin": "5.1.2",
+		"copy-webpack-plugin": "6.4.0",
 		"core-js-builder": "3.11.0",
 		"cross-env": "3.2.4",
 		"css-loader": "5.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const postcss = require( 'postcss' );
 const { escapeRegExp, compact } = require( 'lodash' );
-const { sep } = require( 'path' );
+const { join, sep } = require( 'path' );
 const fastGlob = require( 'fast-glob' );
 
 /**
@@ -205,122 +205,115 @@ module.exports = {
 			'shortcode',
 			'warning',
 		] ),
-		new CopyWebpackPlugin(
-			gutenbergPackages.map( ( packageName ) => ( {
-				from: `./packages/${ packageName }/build-style/*.css`,
-				to: `./build/${ packageName }/`,
-				flatten: true,
-				transform: stylesTransform,
-			} ) )
-		),
-		new CopyWebpackPlugin( [
-			{
-				from: './packages/block-library/build-style/*/style.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }style\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/style.css',
-				transform: stylesTransform,
-			},
-			{
-				from: './packages/block-library/build-style/*/style-rtl.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }style-rtl\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/style-rtl.css',
-				transform: stylesTransform,
-			},
-			{
-				from: './packages/block-library/build-style/*/editor.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }editor\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/editor.css',
-				transform: stylesTransform,
-			},
-			{
-				from: './packages/block-library/build-style/*/editor-rtl.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }editor-rtl\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/editor-rtl.css',
-				transform: stylesTransform,
-			},
-			{
-				from: './packages/block-library/build-style/*/theme.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }theme\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/theme.css',
-				transform: stylesTransform,
-			},
-			{
-				from: './packages/block-library/build-style/*/theme-rtl.css',
-				test: new RegExp(
-					`([\\w-]+)${ escapeRegExp( sep ) }theme-rtl\\.css$`
-				),
-				to: 'build/block-library/blocks/[1]/theme-rtl.css',
-				transform: stylesTransform,
-			},
-		] ),
-		new CopyWebpackPlugin(
-			Object.entries( {
-				'./packages/block-library/src/': 'build/block-library/blocks/',
-				'./packages/edit-widgets/src/blocks/':
-					'build/edit-widgets/blocks/',
-				'./packages/widgets/src/blocks/': 'build/widgets/blocks/',
-			} ).flatMap( ( [ from, to ] ) => [
-				{
-					from: `${ from }/**/index.php`,
-					test: new RegExp(
-						`([\\w-]+)${ escapeRegExp( sep ) }index\\.php$`
-					),
-					to: `${ to }/[1].php`,
-					transform: ( content ) => {
-						content = content.toString();
+		new CopyWebpackPlugin( {
+			patterns: [].concat(
+				gutenbergPackages.map( ( packageName ) => ( {
+					from: `./packages/${ packageName }/build-style/*.css`,
+					to: `./build/${ packageName }/`,
+					flatten: true,
+					transform: stylesTransform,
+					noErrorOnMissing: true,
+				} ) ),
+				[
+					'style',
+					'style-rtl',
+					'editor',
+					'editor-rtl',
+					'theme',
+					'theme-rtl',
+				].map( ( filename ) => ( {
+					from: `./packages/block-library/build-style/*/${ filename }.css`,
+					to( { absoluteFilename } ) {
+						const [ , dirname ] = absoluteFilename.match(
+							new RegExp(
+								`([\\w-]+)${ escapeRegExp(
+									sep
+								) }${ filename }\\.css$`
+							)
+						);
 
-						// Within content, search for any function definitions. For
-						// each, replace every other reference to it in the file.
-						return (
-							content
-								.match( /^function [^\(]+/gm )
-								.reduce( ( result, functionName ) => {
-									// Trim leading "function " prefix from match.
-									functionName = functionName.slice( 9 );
-
-									// Prepend the Gutenberg prefix, substituting any
-									// other core prefix (e.g. "wp_").
-									return result.replace(
-										new RegExp( functionName, 'g' ),
-										( match ) =>
-											'gutenberg_' +
-											match.replace( /^wp_/, '' )
-									);
-								}, content )
-								// The core blocks override procedure takes place in
-								// the init action default priority to ensure that core
-								// blocks would have been registered already. Since the
-								// blocks implementations occur at the default priority
-								// and due to WordPress hooks behavior not considering
-								// mutations to the same priority during another's
-								// callback, the Gutenberg build blocks are modified
-								// to occur at a later priority.
-								.replace(
-									/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
-									'$1, 20'
-								)
+						return join(
+							'build/block-library/blocks',
+							dirname,
+							filename + '.css'
 						);
 					},
-				},
-				{
-					from: `${ from }/*/block.json`,
-					test: new RegExp(
-						`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
-					),
-					to: `${ to }/[1]/block.json`,
-				},
-			] )
-		),
+					transform: stylesTransform,
+				} ) ),
+				Object.entries( {
+					'./packages/block-library/src/':
+						'build/block-library/blocks/',
+					'./packages/edit-widgets/src/blocks/':
+						'build/edit-widgets/blocks/',
+					'./packages/widgets/src/blocks/': 'build/widgets/blocks/',
+				} ).flatMap( ( [ from, to ] ) => [
+					{
+						from: `${ from }/**/index.php`,
+						to( { absoluteFilename } ) {
+							const [ , dirname ] = absoluteFilename.match(
+								new RegExp(
+									`([\\w-]+)${ escapeRegExp(
+										sep
+									) }index\\.php$`
+								)
+							);
+
+							return join( to, `${ dirname }.php` );
+						},
+						transform: ( content ) => {
+							content = content.toString();
+
+							// Within content, search for any function definitions. For
+							// each, replace every other reference to it in the file.
+							return (
+								content
+									.match( /^function [^\(]+/gm )
+									.reduce( ( result, functionName ) => {
+										// Trim leading "function " prefix from match.
+										functionName = functionName.slice( 9 );
+
+										// Prepend the Gutenberg prefix, substituting any
+										// other core prefix (e.g. "wp_").
+										return result.replace(
+											new RegExp( functionName, 'g' ),
+											( match ) =>
+												'gutenberg_' +
+												match.replace( /^wp_/, '' )
+										);
+									}, content )
+									// The core blocks override procedure takes place in
+									// the init action default priority to ensure that core
+									// blocks would have been registered already. Since the
+									// blocks implementations occur at the default priority
+									// and due to WordPress hooks behavior not considering
+									// mutations to the same priority during another's
+									// callback, the Gutenberg build blocks are modified
+									// to occur at a later priority.
+									.replace(
+										/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
+										'$1, 20'
+									)
+							);
+						},
+						noErrorOnMissing: true,
+					},
+					{
+						from: `${ from }/*/block.json`,
+						to( { absoluteFilename } ) {
+							const [ , dirname ] = absoluteFilename.match(
+								new RegExp(
+									`([\\w-]+)${ escapeRegExp(
+										sep
+									) }block\\.json$`
+								)
+							);
+
+							return join( to, dirname, 'block.json' );
+						},
+					},
+				] )
+			),
+		} ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 		mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 	].filter( Boolean ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Prerequisite to webpack 5 upgrade.

V6 is the last version that works with webpack 4 and it has several breaking changes as noted in:
https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run build`

`npm run dev`

Both commands work as before.

## Types of changes

Dependency upgrade.