### PR TITLE
Documentation: Remove withState HOC references part 2

### DIFF
--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -8,18 +8,18 @@ Assuming you have a form component, you can disable all form inputs by wrapping 
 
 ```jsx
 import { Button, Disabled, TextControl } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyDisabled = withState( {
-	isDisabled: true,
-} )( ( { isDisabled, setState } ) => {
+const MyDisabled = () => {
+	const [ isDisabled, setIsDisabled ] = useState( true );
+
 	let input = <TextControl label="Input" onChange={ () => {} } />;
 	if ( isDisabled ) {
 		input = <Disabled>{ input }</Disabled>;
 	}
 
 	const toggleDisabled = () => {
-		setState( ( state ) => ( { isDisabled: ! state.isDisabled } ) );
+		setIsDisabled( ( state ) => ! state );
 	};
 
 	return (
@@ -30,7 +30,7 @@ const MyDisabled = withState( {
 			</Button>
 		</div>
 	);
-} );
+};
 ```
 
 A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Consumer`.

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -7,26 +7,25 @@ The component renders a user interface that allows the user to select predefined
 
 ```jsx
 import { FontSizePicker } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-...
-const MyFontSizePicker = withState( {
-	fontSize: 16,
-} )( ( { fontSize, setState } ) => {
-	const fontSizes = [
-		{
-			name: __( 'Small' ),
-			slug: 'small',
-			size: 12,
-		},
-		{
-			name: __( 'Big' ),
-			slug: 'big',
-			size: 26,
-		},
-	];
-	const fallbackFontSize = 16;
+const fontSizes = [
+	{
+		name: __( 'Small' ),
+		slug: 'small',
+		size: 12,
+	},
+	{
+		name: __( 'Big' ),
+		slug: 'big',
+		size: 26,
+	},
+];
+const fallbackFontSize = 16;
+
+const MyFontSizePicker = () => {
+	const [ fontSize, setFontSize ] = useState( 12 );
 
 	return (
 		<FontSizePicker
@@ -34,11 +33,11 @@ const MyFontSizePicker = withState( {
 			value={ fontSize }
 			fallbackFontSize={ fallbackFontSize }
 			onChange={ ( newFontSize ) => {
-				setState( { fontSize: newFontSize } );
+				setFontSize( newFontSize );
 			} }
 		/>
 	);
-} );
+};
 
 ...
 

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -55,18 +55,16 @@ When a user switches a toggle, its corresponding action takes effect immediately
 
 ```jsx
 import { FormToggle } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyFormToggle = withState( {
-	checked: true,
-} )( ( { checked, setState } ) => (
+const MyFormToggle = () => {
+	const [ isChecked, setChecked ] = useState( true );
+
 	<FormToggle
 		checked={ checked }
-		onChange={ () =>
-			setState( ( state ) => ( { checked: ! state.checked } ) )
-		}
+		onChange={ () => setChecked( ( state ) => ! state ) }
 	/>
-) );
+};
 ```
 
 ### Props

--- a/packages/components/src/form-token-field/README.md
+++ b/packages/components/src/form-token-field/README.md
@@ -64,23 +64,26 @@ The `value` property is handled in a manner similar to controlled form component
 
 ```jsx
 import { FormTokenField } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyFormTokenField = withState( {
-	tokens: [],
-	suggestions: [
-		'Africa',
-		'America',
-		'Antarctica',
-		'Asia',
-		'Europe',
-		'Oceania',
-	],
-} )( ( { tokens, suggestions, setState } ) => (
-	<FormTokenField
-		value={ tokens }
-		suggestions={ suggestions }
-		onChange={ ( tokens ) => setState( { tokens } ) }
-	/>
-) );
+const continents = [
+	'Africa',
+	'America',
+	'Antarctica',
+	'Asia',
+	'Europe',
+	'Oceania',
+];
+
+const MyFormTokenField = () => {
+	const [ selectedContinents, setSelectedContinents ] = useState( [] );
+
+	return(
+		<FormTokenField
+			value={ selectedContinents }
+			suggestions={ continents }
+			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
+		/>
+	);
+};
 ```

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -6,21 +6,21 @@ MenuItem is a component which renders a button intended to be used in combinatio
 
 ```jsx
 import { MenuItem } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyMenuItem = withState( {
-	isActive: true,
-} )( ( { isActive, setState } ) => (
-	<MenuItem
-		icon={ isActive ? 'yes' : 'no' }
-		isSelected={ isActive }
-		onClick={ () =>
-			setState( ( state ) => ( { isActive: ! state.isActive } ) )
-		}
-	>
-		Toggle
-	</MenuItem>
-) );
+const MyMenuItem = () => {
+	const [ isActive, setIsActive ] = useState( true );
+
+	return (
+		<MenuItem
+			icon={ isActive ? 'yes' : 'no' }
+			isSelected={ isActive }
+			onClick={ () => setIsActive( ( state ) => ! state ) }
+		>
+			Toggle
+		</MenuItem>
+	);
+};
 ```
 
 ## Props

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -8,21 +8,21 @@ Render a Popover within the parent to which it should anchor:
 
 ```jsx
 import { Button, Popover } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyPopover = withState( {
-	isVisible: false,
-} )( ( { isVisible, setState } ) => {
+const MyPopover = () => {
+	const [ isVisible, setIsVisible ] = useState( false );
 	const toggleVisible = () => {
-		setState( ( state ) => ( { isVisible: ! state.isVisible } ) );
+		setIsVisible( ( state ) => ! state );
 	};
+
 	return (
 		<Button variant="secondary" onClick={ toggleVisible }>
 			Toggle Popover!
 			{ isVisible && <Popover>Popover is toggled!</Popover> }
 		</Button>
 	);
-} );
+};
 ```
 
 If a Popover is returned by your component, it will be shown. To hide the popover, simply omit it from your component's render value.

--- a/packages/components/src/text-control/README.md
+++ b/packages/components/src/text-control/README.md
@@ -61,17 +61,19 @@ Render a user interface to input the name of an additional css class.
 
 ```js
 import { TextControl } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
-const MyTextControl = withState( {
-	className: '',
-} )( ( { className, setState } ) => (
-	<TextControl
-		label="Additional CSS Class"
-		value={ className }
-		onChange={ ( className ) => setState( { className } ) }
-	/>
-) );
+const MyTextControl = () => {
+	const [ className, setClassName ] = useState( '' );
+
+	return (
+		<TextControl
+			label="Additional CSS Class"
+			value={ className }
+			onChange={ ( value ) => setClassName( value ) }
+		/>
+	);
+};
 ```
 
 ### Props


### PR DESCRIPTION
## Description
The second part of #33173.

## Types of changes
Documentation update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
