### PR TITLE
Add `PanelBody` for `InspectorControls`

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -20,7 +20,8 @@ var el = wp.element.createElement,
 	RadioControl = wp.components.RadioControl,
 	TextControl = wp.components.TextControl,
 	ToggleControl = wp.components.ToggleControl,
-	SelectControl = wp.components.SelectControl;
+	SelectControl = wp.components.SelectControl,
+	PanelBody = wp.components.PanelBody;
 
 registerBlockType( 'my-plugin/inspector-controls-example', {
 	apiVersion: 2,
@@ -96,58 +97,64 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 			el(
 				InspectorControls,
 				null,
-				el( CheckboxControl, {
-					heading: 'Checkbox Field',
-					label: 'Tick Me',
-					help: 'Additional help text',
-					checked: checkboxField,
-					onChange: onChangeCheckboxField,
-				} ),
-				el( RadioControl, {
-					label: 'Radio Field',
-					selected: radioField,
-					options: [
-						{
-							label: 'Yes',
-							value: 'yes',
-						},
-						{
-							label: 'No',
-							value: 'no',
-						},
-					],
-					onChange: onChangeRadioField,
-				} ),
-				el( TextControl, {
-					label: 'Text Field',
-					help: 'Additional help text',
-					value: textField,
-					onChange: onChangeTextField,
-				} ),
-				el( ToggleControl, {
-					label: 'Toggle Field',
-					checked: toggleField,
-					onChange: onChangeToggleField,
-				} ),
-				el( SelectControl, {
-					label: 'Select Field',
-					value: selectField,
-					options: [
-						{
-							value: 'a',
-							label: 'Option A',
-						},
-						{
-							value: 'b',
-							label: 'Option B',
-						},
-						{
-							value: 'c',
-							label: 'Option C',
-						},
-					],
-					onChange: onChangeSelectField,
-				} )
+				el(
+					PanelBody, 
+					{
+						title: 'Settings',
+					},
+					el( CheckboxControl, {
+						heading: 'Checkbox Field',
+						label: 'Tick Me',
+						help: 'Additional help text',
+						checked: checkboxField,
+						onChange: onChangeCheckboxField,
+					} ),
+					el( RadioControl, {
+						label: 'Radio Field',
+						selected: radioField,
+						options: [
+							{
+								label: 'Yes',
+								value: 'yes',
+							},
+							{
+								label: 'No',
+								value: 'no',
+							},
+						],
+						onChange: onChangeRadioField,
+					} ),
+					el( TextControl, {
+						label: 'Text Field',
+						help: 'Additional help text',
+						value: textField,
+						onChange: onChangeTextField,
+					} ),
+					el( ToggleControl, {
+						label: 'Toggle Field',
+						checked: toggleField,
+						onChange: onChangeToggleField,
+					} ),
+					el( SelectControl, {
+						label: 'Select Field',
+						value: selectField,
+						options: [
+							{
+								value: 'a',
+								label: 'Option A',
+							},
+							{
+								value: 'b',
+								label: 'Option B',
+							},
+							{
+								value: 'c',
+								label: 'Option C',
+							},
+						],
+						onChange: onChangeSelectField,
+					} )
+				)
 			),
 			el(
 				RichText,
@@ -202,6 +209,7 @@ import {
 	TextControl,
 	ToggleControl,
 	SelectControl,
+	PanelBody
 } from '@wordpress/components';
 import {
 	RichText,
@@ -281,47 +289,49 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 		return (
 			<>
 				<InspectorControls>
-					<CheckboxControl
-						heading="Checkbox Field"
-						label="Tick Me"
-						help="Additional help text"
-						checked={ checkboxField }
-						onChange={ onChangeCheckboxField }
-					/>
+					<PanelBody title={__('Settings')}>
+						<CheckboxControl
+							heading="Checkbox Field"
+							label="Tick Me"
+							help="Additional help text"
+							checked={ checkboxField }
+							onChange={ onChangeCheckboxField }
+						/>
 
-					<RadioControl
-						label="Radio Field"
-						selected={ radioField }
-						options={ [
-							{ label: 'Yes', value: 'yes' },
-							{ label: 'No', value: 'no' },
-						] }
-						onChange={ onChangeRadioField }
-					/>
+						<RadioControl
+							label="Radio Field"
+							selected={ radioField }
+							options={ [
+								{ label: 'Yes', value: 'yes' },
+								{ label: 'No', value: 'no' },
+							] }
+							onChange={ onChangeRadioField }
+						/>
 
-					<TextControl
-						label="Text Field"
-						help="Additional help text"
-						value={ textField }
-						onChange={ onChangeTextField }
-					/>
+						<TextControl
+							label="Text Field"
+							help="Additional help text"
+							value={ textField }
+							onChange={ onChangeTextField }
+						/>
 
-					<ToggleControl
-						label="Toggle Field"
-						checked={ toggleField }
-						onChange={ onChangeToggleField }
-					/>
+						<ToggleControl
+							label="Toggle Field"
+							checked={ toggleField }
+							onChange={ onChangeToggleField }
+						/>
 
-					<SelectControl
-						label="Select Control"
-						value={ selectField }
-						options={ [
-							{ value: 'a', label: 'Option A' },
-							{ value: 'b', label: 'Option B' },
-							{ value: 'c', label: 'Option C' },
-						] }
-						onChange={ onChangeSelectField }
-					/>
+						<SelectControl
+							label="Select Control"
+							value={ selectField }
+							options={ [
+								{ value: 'a', label: 'Option A' },
+								{ value: 'b', label: 'Option B' },
+								{ value: 'c', label: 'Option C' },
+							] }
+							onChange={ onChangeSelectField }
+						/>
+					</PanelBody>
 				</InspectorControls>
 
 				<RichText


### PR DESCRIPTION
Using  `PanelBody` in the `InspectorControls` and example helps to get the styles and according styles out of the box.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Updates on doc examples.

## How has this been tested?

This is a doc update.

## Screenshots <!-- if applicable -->

## Types of changes

Documentation update

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
