### PR TITLE
Try stickily positioned legacy widget wide popover

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -191,8 +191,8 @@ function setAttribute( element, name, value ) {
  *                           property.
  */
 function setStyle( element, property, value = '' ) {
-	if ( element.style[ property ] !== value ) {
-		element.style[ property ] = value;
+	if ( element.style.getPropertyValue( property ) !== value ) {
+		element.style.setProperty( property, value );
 	}
 }
 
@@ -257,6 +257,7 @@ const Popover = (
 		__unstableBoundaryParent,
 		__unstableForcePosition,
 		__unstableForceXAlignment,
+		__experimentalCustomProperties,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -358,8 +359,19 @@ const Popover = (
 				typeof popoverTop === 'number' &&
 				typeof popoverLeft === 'number'
 			) {
-				setStyle( containerRef.current, 'top', popoverTop + 'px' );
-				setStyle( containerRef.current, 'left', popoverLeft + 'px' );
+				let propY = 'top';
+				let propX = 'left';
+				if ( __experimentalCustomProperties ) {
+					propY = '--top';
+					propX = '--left';
+					setStyle(
+						containerRef.current,
+						'--contentHeight',
+						usedContentSize.height + 'px'
+					);
+				}
+				setStyle( containerRef.current, propY, popoverTop + 'px' );
+				setStyle( containerRef.current, propX, popoverLeft + 'px' );
 			}
 
 			setClass(
@@ -370,16 +382,20 @@ const Popover = (
 			setClass( containerRef.current, 'is-alternate', isAlternate );
 			setAttribute( containerRef.current, 'data-x-axis', xAxis );
 			setAttribute( containerRef.current, 'data-y-axis', yAxis );
-			setStyle(
-				contentRef.current,
-				'maxHeight',
-				typeof contentHeight === 'number' ? contentHeight + 'px' : ''
-			);
-			setStyle(
-				contentRef.current,
-				'maxWidth',
-				typeof contentWidth === 'number' ? contentWidth + 'px' : ''
-			);
+			if ( ! __experimentalCustomProperties ) {
+				setStyle(
+					contentRef.current,
+					'maxHeight',
+					typeof contentHeight === 'number'
+						? contentHeight + 'px'
+						: ''
+				);
+				setStyle(
+					contentRef.current,
+					'maxWidth',
+					typeof contentWidth === 'number' ? contentWidth + 'px' : ''
+				);
+			}
 
 			// Compute the animation position
 			const yAxisMapping = {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -256,7 +256,6 @@ const Popover = (
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 		__unstableForcePosition,
-		__unstableForceXAlignment,
 		__experimentalCustomProperties,
 		/* eslint-enable no-unused-vars */
 		...contentProps
@@ -351,8 +350,7 @@ const Popover = (
 				containerRef.current,
 				relativeOffsetTop,
 				boundaryElement,
-				__unstableForcePosition,
-				__unstableForceXAlignment
+				__unstableForcePosition
 			);
 
 			if (

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -21,7 +21,6 @@ const HEIGHT_OFFSET = 10; // used by the arrow and a bit of empty space
  * @param {string}  chosenYAxis           yAxis to be used.
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis
  *
  * @return {Object} Popover xAxis position and constraints.
  */
@@ -33,8 +32,7 @@ export function computePopoverXAxisPosition(
 	stickyBoundaryElement,
 	chosenYAxis,
 	boundaryElement,
-	forcePosition,
-	forceXAlignment
+	forcePosition
 ) {
 	const { width } = contentSize;
 
@@ -66,7 +64,7 @@ export function computePopoverXAxisPosition(
 
 	if ( corner === 'right' ) {
 		leftAlignmentX = anchorRect.right;
-	} else if ( chosenYAxis !== 'middle' && ! forceXAlignment ) {
+	} else if ( chosenYAxis !== 'middle' ) {
 		leftAlignmentX = anchorMidPoint;
 	}
 
@@ -74,7 +72,7 @@ export function computePopoverXAxisPosition(
 
 	if ( corner === 'left' ) {
 		rightAlignmentX = anchorRect.left;
-	} else if ( chosenYAxis !== 'middle' && ! forceXAlignment ) {
+	} else if ( chosenYAxis !== 'middle' ) {
 		rightAlignmentX = anchorMidPoint;
 	}
 
@@ -287,7 +285,6 @@ export function computePopoverYAxisPosition(
  *                                        relative positioned parent container.
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis
  *
  * @return {Object} Popover position and constraints.
  */
@@ -299,8 +296,7 @@ export function computePopoverPosition(
 	anchorRef,
 	relativeOffsetTop,
 	boundaryElement,
-	forcePosition,
-	forceXAlignment
+	forcePosition
 ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
@@ -322,8 +318,7 @@ export function computePopoverPosition(
 		stickyBoundaryElement,
 		yAxisPosition.yAxis,
 		boundaryElement,
-		forcePosition,
-		forceXAlignment
+		forcePosition
 	);
 
 	return {

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -102,14 +102,20 @@ export default function Form( {
 					</h3>
 				) }
 				<Popover
+					__experimentalCustomProperties
+					shouldAnchorIncludePadding
+					animate={ false }
+					hidden={ ! isVisible }
+					className="wp-block-legacy-widget__popover"
 					focusOnMount={ false }
 					position="middle right"
-					__unstableForceXAlignment
+					__unstableStickyBoundaryElement={
+						ref.current?.ownerDocument.body
+					}
 				>
 					<div
 						ref={ ref }
 						className="wp-block-legacy-widget__edit-form"
-						hidden={ ! isVisible }
 					></div>
 				</Popover>
 			</div>

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -159,6 +159,27 @@
 	min-width: 400px;
 }
 
+// Ensures the popover will be hidden when the attribute is applied.
+.wp-block-legacy-widget__popover[hidden] {
+	display: none;
+}
+
+.wp-block-legacy-widget__popover {
+	// The maximum height excludes 45px on top and bottom to match the height
+	// of the sidebar scrolling area.
+	--maxHeight: calc(100vh - 90px);
+	--usedHeight: min(var(--contentHeight), var(--maxHeight));
+	--remainingHeight: calc(100vh - var(--usedHeight));
+	--usedHalfHeight: calc(var(--usedHeight) / 2);
+	// Keeps the popover in the viewport even if its anchor has scrolled out of view
+	top: clamp(var(--usedHalfHeight), var(--top), calc(var(--usedHalfHeight) + var(--remainingHeight)));
+	left: calc(var(--left) + #{$grid-unit-40});
+}
+.wp-block-legacy-widget__popover .components-popover__content {
+	max-height: var(--maxHeight);
+}
+
+
 .wp-block-legacy-widget {
 	.components-base-control {
 		width: 100%;


### PR DESCRIPTION
Following up on #31736 and would close #32210 by obviating the need for it. 

The idea was to mostly reproduce how wide widgets display their forms in the Customizer without the block editor.

This supports it with some modification to the `Popover` component to apply its layout calculations by way of CSS custom properties. It's a fairly light change and the feature could have application in other popover use cases but, for now, I'd rather not change `Popover` and thus prefer #33236.

## How has this been tested?
Manually

## Screenshots

https://user-images.githubusercontent.com/9000376/124640046-b83a4880-de41-11eb-8b9f-d4bd632aadd3.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
