### PR TITLE
Duotone: Avoid rendering duplicate stylesheet and SVG

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -354,11 +354,14 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	return $content . $duotone;
 }
 
-// Register the block support.
-WP_Block_Supports::get_instance()->register(
-	'duotone',
-	array(
-		'register_attribute' => 'gutenberg_register_duotone_support',
-	)
-);
-add_filter( 'render_block', 'gutenberg_render_duotone_support', 10, 2 );
+// This can be removed when plugin support requires WordPress 5.8.0+.
+if ( ! function_exists( 'wp_render_duotone_support' ) ) {
+	// Register the block support.
+	WP_Block_Supports::get_instance()->register(
+		'duotone',
+		array(
+			'register_attribute' => 'gutenberg_register_duotone_support',
+		)
+	);
+	add_filter( 'render_block', 'gutenberg_render_duotone_support', 10, 2 );
+}

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -354,14 +354,14 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	return $content . $duotone;
 }
 
-// This can be removed when plugin support requires WordPress 5.8.0+.
-if ( ! function_exists( 'wp_render_duotone_support' ) ) {
-	// Register the block support.
-	WP_Block_Supports::get_instance()->register(
-		'duotone',
-		array(
-			'register_attribute' => 'gutenberg_register_duotone_support',
-		)
-	);
-	add_filter( 'render_block', 'gutenberg_render_duotone_support', 10, 2 );
-}
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'duotone',
+	array(
+		'register_attribute' => 'gutenberg_register_duotone_support',
+	)
+);
+
+// Remove WordPress core filter to avoid rendering duplicate support elements.
+remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
+add_filter( 'render_block', 'gutenberg_render_duotone_support', 10, 2 );


### PR DESCRIPTION
## Description
Adds check to avoid rendering duplicate stylesheet and SVG elements when the plugin is used with WP 5.8.

## How has this been tested?
1. Create a post. 
2. Add an Image block.
3. Select the Duotone option.
4. Save the post.
5. On the front-end, WP shouldn't render duplicated stylesheet and SVG for Duotone.

## Screenshots <!-- if applicable -->
![CleanShot 2021-07-06 at 21 11 27](https://user-images.githubusercontent.com/240569/124641909-41806800-dea0-11eb-81da-2c5425c4b893.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
