### PR TITLE
Try custom dialog for wide legacy widgets

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -256,7 +256,6 @@ const Popover = (
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 		__unstableForcePosition,
-		__unstableForceXAlignment,
 		/* eslint-enable no-unused-vars */
 		...contentProps
 	},
@@ -350,8 +349,7 @@ const Popover = (
 				containerRef.current,
 				relativeOffsetTop,
 				boundaryElement,
-				__unstableForcePosition,
-				__unstableForceXAlignment
+				__unstableForcePosition
 			);
 
 			if (

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -21,7 +21,6 @@ const HEIGHT_OFFSET = 10; // used by the arrow and a bit of empty space
  * @param {string}  chosenYAxis           yAxis to be used.
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis
  *
  * @return {Object} Popover xAxis position and constraints.
  */
@@ -33,8 +32,7 @@ export function computePopoverXAxisPosition(
 	stickyBoundaryElement,
 	chosenYAxis,
 	boundaryElement,
-	forcePosition,
-	forceXAlignment
+	forcePosition
 ) {
 	const { width } = contentSize;
 
@@ -66,7 +64,7 @@ export function computePopoverXAxisPosition(
 
 	if ( corner === 'right' ) {
 		leftAlignmentX = anchorRect.right;
-	} else if ( chosenYAxis !== 'middle' && ! forceXAlignment ) {
+	} else if ( chosenYAxis !== 'middle' ) {
 		leftAlignmentX = anchorMidPoint;
 	}
 
@@ -74,7 +72,7 @@ export function computePopoverXAxisPosition(
 
 	if ( corner === 'left' ) {
 		rightAlignmentX = anchorRect.left;
-	} else if ( chosenYAxis !== 'middle' && ! forceXAlignment ) {
+	} else if ( chosenYAxis !== 'middle' ) {
 		rightAlignmentX = anchorMidPoint;
 	}
 
@@ -287,7 +285,6 @@ export function computePopoverYAxisPosition(
  *                                        relative positioned parent container.
  * @param {Element} boundaryElement       Boundary element.
  * @param {boolean} forcePosition         Don't adjust position based on anchor.
- * @param {boolean} forceXAlignment       Don't adjust alignment based on YAxis
  *
  * @return {Object} Popover position and constraints.
  */
@@ -299,8 +296,7 @@ export function computePopoverPosition(
 	anchorRef,
 	relativeOffsetTop,
 	boundaryElement,
-	forcePosition,
-	forceXAlignment
+	forcePosition
 ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
@@ -322,8 +318,7 @@ export function computePopoverPosition(
 		stickyBoundaryElement,
 		yAxisPosition.yAxis,
 		boundaryElement,
-		forcePosition,
-		forceXAlignment
+		forcePosition
 	);
 
 	return {

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -9,8 +9,10 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __, sprintf } from '@wordpress/i18n';
-import { Popover } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import {
+	useViewportMatch,
+	__experimentalUseDialog as useDialog,
+} from '@wordpress/compose';
 /**
  * Internal dependencies
  */
@@ -89,29 +91,31 @@ export default function Form( {
 		isMediumLargeViewport,
 	] );
 
+	const [ dialogRef, dialogProps ] = useDialog( {
+		focusOnMount: false,
+	} );
+
 	if ( isWide && isMediumLargeViewport ) {
 		return (
-			<div
-				className={ classnames( {
-					'wp-block-legacy-widget__container': isVisible,
-				} ) }
-			>
+			<div className="wp-block-legacy-widget__container">
 				{ isVisible && (
 					<h3 className="wp-block-legacy-widget__edit-form-title">
 						{ title }
 					</h3>
 				) }
-				<Popover
-					focusOnMount={ false }
-					position="middle right"
-					__unstableForceXAlignment
+				<div
+					className={ classnames(
+						'wp-block-legacy-widget__edit-form',
+						'is-wide',
+						{
+							'is-visible': isVisible,
+						}
+					) }
+					ref={ dialogRef }
+					{ ...dialogProps }
 				>
-					<div
-						ref={ ref }
-						className="wp-block-legacy-widget__edit-form"
-						hidden={ ! isVisible }
-					></div>
-				</Popover>
+					<div ref={ ref } hidden={ ! isVisible }></div>
+				</div>
 			</div>
 		);
 	}

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -19,7 +19,7 @@ import { closeSmall } from '@wordpress/icons';
  * Internal dependencies
  */
 import Control from './control';
-import { useBudgeYAxisBy } from './utils';
+import { useBudgeTopBy } from './utils';
 
 export default function Form( {
 	title,
@@ -131,7 +131,7 @@ function WideFormDialog( { isVisible, children } ) {
 	const {
 		ref: budgeRef,
 		resizeObserver,
-	} = useBudgeYAxisBy( containerRef.current, { isEnabled: isVisible } );
+	} = useBudgeTopBy( containerRef.current, { isEnabled: isVisible } );
 	return (
 		<div
 			ref={ containerRef }

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -19,7 +19,7 @@ import { closeSmall } from '@wordpress/icons';
  * Internal dependencies
  */
 import Control from './control';
-import { useBudgeTopBy } from './utils';
+import { useAlignTopWithinViewport } from './utils';
 
 export default function Form( {
 	title,
@@ -109,7 +109,7 @@ export default function Form( {
 
 	if ( isWide ) {
 		return (
-			<WideFormDialog isVisible={ isVisible }>
+			<WideFormDialog isVisible={ isVisible } onClose={ onClose }>
 				{ formCore }
 			</WideFormDialog>
 		);
@@ -125,16 +125,19 @@ export default function Form( {
 	);
 }
 
-function WideFormDialog( { isVisible, children } ) {
-	const containerRef = useRef();
-	const [ dialogRef, dialogProps ] = useDialog( { focusOnMount: false } );
+function WideFormDialog( { isVisible, onClose, children } ) {
+	const ref = useRef();
+	const [ dialogRef, dialogProps ] = useDialog( {
+		focusOnMount: false,
+		onClose,
+	} );
 	const {
-		ref: budgeRef,
+		ref: alignTopRef,
 		resizeObserver,
-	} = useBudgeTopBy( containerRef.current, { isEnabled: isVisible } );
+	} = useAlignTopWithinViewport( ref.current, { isEnabled: isVisible } );
 	return (
 		<div
-			ref={ containerRef }
+			ref={ ref }
 			className={ classnames( 'wp-block-legacy-widget__container', {
 				'is-visible': isVisible,
 			} ) }
@@ -142,7 +145,7 @@ function WideFormDialog( { isVisible, children } ) {
 			<Fill name="Popover">
 				<div
 					className="wp-block-legacy-widget__edit-form is-wide"
-					ref={ useMergeRefs( [ dialogRef, budgeRef ] ) }
+					ref={ useMergeRefs( [ dialogRef, alignTopRef ] ) }
 					{ ...dialogProps }
 					hidden={ ! isVisible }
 				>

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -8,13 +8,10 @@ import classnames from 'classnames';
 import { useRef, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __, sprintf  } from '@wordpress/i18n';
-import { Fill } from '@wordpress/components';
-import {
-	useRefEffect,
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Fill } from '@wordpress/components';
+import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
+import { closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -32,8 +29,6 @@ export default function Form( {
 	onClose,
 } ) {
 	const ref = useRef();
-
-	const isMediumLargeViewport = useViewportMatch( 'small' );
 
 	// We only want to remount the control when the instance changes
 	// *externally*. For example, if the user performs an undo. To do this, we
@@ -85,51 +80,39 @@ export default function Form( {
 
 			control.destroy();
 		};
-	}, [
-		id,
-		idBase,
-		instance,
-		onChangeInstance,
-		onChangeHasPreview,
-		isMediumLargeViewport,
-		isWide,
-	] );
+	}, [ id, idBase, instance, onChangeInstance, onChangeHasPreview, isWide ] );
 
-	// Moves the form in and out of the dialog on mount and unmount.
-	const dialogContentRef = useRefEffect( ( node ) => {
-		if ( node ) {
-			node.appendChild( ref.current.firstElementChild );
-			return () => {
-				ref.current.appendChild( node.firstElementChild );
-			};
-		}
-	}, [] );
+	const [ dialogRef, dialogProps ] = useDialog( { focusOnMount: false } );
 
-	const [ dialogRef, dialogProps ] = useDialog( { onClose } );
-
-	if ( isWide && isMediumLargeViewport ) {
+	if ( isWide ) {
 		return (
 			<div
 				className={ classnames( 'wp-block-legacy-widget__container', {
 					'is-visible': isVisible,
 				} ) }
 			>
-				{ isVisible && (
-					<h3 className="wp-block-legacy-widget__edit-form-title">
-						{ title }
-					</h3>
-				) }
-				<div ref={ ref } hidden></div>
 				<Fill name="Popover">
-					{ isVisible && (
+					<div
+						className="wp-block-legacy-widget__edit-form is-wide"
+						ref={ dialogRef }
+						{ ...dialogProps }
+						hidden={ ! isVisible }
+					>
+						<header className="wp-block-legacy-widget__edit-form-header">
+							<h3 className="wp-block-legacy-widget__edit-form-title">
+								{ title }
+							</h3>
+							<Button
+								icon={ closeSmall }
+								label={ __( 'Close dialog' ) }
+								onClick={ onClose }
+							/>
+						</header>
 						<div
-							className="wp-block-legacy-widget__edit-form is-wide"
-							ref={ dialogRef }
-							{ ...dialogProps }
-						>
-							<div ref={ dialogContentRef }></div>
-						</div>
-					) }
+							className="wp-block-legacy-widget__edit-form-body"
+							ref={ ref }
+						/>
+					</div>
 				</Fill>
 			</div>
 		);

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -16,7 +16,7 @@ import {
 import { Spinner, Placeholder } from '@wordpress/components';
 import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -93,6 +93,7 @@ function NotEmpty( {
 	isWide = false,
 } ) {
 	const [ hasPreview, setHasPreview ] = useState( null );
+	const [ mode, setMode ] = useState( 'preview' );
 
 	const { widgetType, hasResolvedWidgetType, isNavigationMode } = useSelect(
 		( select ) => {
@@ -112,6 +113,10 @@ function NotEmpty( {
 		setAttributes( { instance: nextInstance } );
 	}, [] );
 
+	useEffect( () => {
+		setMode( isNavigationMode || ! isSelected ? 'preview' : 'edit' );
+	}, [ isNavigationMode, isSelected ] );
+
 	if ( ! widgetType && hasResolvedWidgetType ) {
 		return (
 			<Placeholder
@@ -130,9 +135,6 @@ function NotEmpty( {
 			</Placeholder>
 		);
 	}
-
-	const mode =
-		idBase && ( isNavigationMode || ! isSelected ) ? 'preview' : 'edit';
 
 	return (
 		<>
@@ -161,6 +163,7 @@ function NotEmpty( {
 				isWide={ isWide }
 				onChangeInstance={ setInstance }
 				onChangeHasPreview={ setHasPreview }
+				onClose={ () => setMode( 'preview' ) }
 			/>
 
 			{ idBase && (
@@ -178,7 +181,10 @@ function NotEmpty( {
 						/>
 					) }
 					{ hasPreview === false && mode === 'preview' && (
-						<NoPreview name={ widgetType.name } />
+						<NoPreview
+							name={ widgetType.name }
+							onClick={ () => setMode( 'edit' ) }
+						/>
 					) }
 				</>
 			) }

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -40,30 +40,22 @@ export default function Edit( props ) {
 		ref.current.focus();
 	}, [ setIsEditing ] );
 
-	props = { ...props, isEditing, stopEditing };
-
-	// isWide is applicable only at breakpoints greater than small
+	// wide display of widgets applies only at breakpoints greater than small
 	const canWideFit = useViewportMatch( 'small' );
-	props.isWide &&= canWideFit;
+	const isWide = props.isWide && canWideFit;
 
 	const ref = useRef();
 
-	useEffect( () => {
-		if ( props.isSelected ) {
-			setIsEditing( true );
-		} else {
-			setIsEditing( false );
-		}
-	}, [ props.isSelected ] );
+	useEffect( () => setIsEditing( props.isSelected ), [ props.isSelected ] );
 
 	const blockProps = useBlockProps( {
 		ref,
 		className: classnames( {
-			'is-wide-widget': props.isWide,
+			'is-wide-widget': isWide,
 		} ),
 	} );
 
-	if ( props.isWide ) {
+	if ( isWide ) {
 		blockProps.onClick = ( { currentTarget, target } ) => {
 			if ( currentTarget.contains( target ) ) {
 				setIsEditing( true );
@@ -76,7 +68,7 @@ export default function Edit( props ) {
 			{ ! id && ! idBase ? (
 				<Empty { ...props } />
 			) : (
-				<NotEmpty { ...props } />
+				<NotEmpty { ...{ ...props, isWide, isEditing, stopEditing } } />
 			) }
 		</div>
 	);

--- a/packages/widgets/src/blocks/legacy-widget/edit/utils.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/utils.js
@@ -1,0 +1,146 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useRef,
+	useEffect,
+	useLayoutEffect,
+	useState,
+} from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
+
+function getScrollContext( node ) {
+	let at = node.parentNode;
+	while ( at && at.clientHeight === at.scrollHeight ) {
+		at = at.parentNode;
+	}
+	return at;
+}
+
+/**
+ * Positions an element by the vertical edges of an objective element if it can
+ * fit or otherwise as close as possible within the bounds of the objective’s
+ * scrolling context.
+ *
+ * @param {Element} objective    Element to take position from.
+ * @param {Object}  $1           Options.
+ * @param {boolean} $1.isEnabled Whether to apply the hook or not.
+ *
+ * @return {Object} A ref and resize observer element.
+ */
+export function useBudgeYAxisBy( objective, { isEnabled } ) {
+	const subjectRef = useRef();
+	const objectiveRef = useRef();
+	const scrollContextRef = useRef();
+	const [ scrollBounds = {}, setScrollBounds ] = useState();
+	const boundsUpdaterRef = useRef();
+
+	const hasSubject = !! subjectRef.current;
+	const hasObjective = !! objective;
+	const objectiveHasChanged = objectiveRef.current !== objective;
+
+	let scrollContextHasChanged;
+	if ( objectiveHasChanged ) {
+		objectiveRef.current = objective;
+		const scrollContext = hasObjective
+			? getScrollContext( objective )
+			: null;
+		scrollContextHasChanged = scrollContextRef.current !== scrollContext;
+		scrollContextRef.current = scrollContext;
+	}
+	const hasScrollContext = !! scrollContextRef.current;
+
+	// Defines the bounds updating function a single time
+	if ( ! boundsUpdaterRef.current ) {
+		boundsUpdaterRef.current = () => {
+			const rect = scrollContextRef.current.getBoundingClientRect();
+			subjectRef.current.style.maxHeight = rect.height + 'px';
+			setScrollBounds( rect );
+		};
+	}
+
+	// Handles window resizes to update scroll bounds
+	useEffect( () => {
+		if ( ! hasSubject || ! hasObjective || ! isEnabled ) {
+			return;
+		}
+		const { defaultView } = objective.ownerDocument;
+		const updateBounds = boundsUpdaterRef.current;
+		defaultView.addEventListener( 'resize', updateBounds );
+		return () => defaultView.removeEventListener( 'resize', updateBounds );
+	}, [ hasObjective, hasSubject, isEnabled ] );
+
+	// Handles mutations on the scrolling element to update scroll bounds
+	useLayoutEffect( () => {
+		if ( ! hasScrollContext || ! isEnabled ) {
+			return;
+		}
+		boundsUpdaterRef.current();
+		const { MutationObserver } = objective.ownerDocument.defaultView;
+		const observer = new MutationObserver( boundsUpdaterRef.current );
+		observer.observe( scrollContextRef.current, { attributes: true } );
+		return () => observer.disconnect();
+	}, [ scrollContextHasChanged, isEnabled ] );
+
+	const [ resizeObserver, contentSize ] = useResizeObserver();
+
+	// Handles scrolling, if needed, to update subject position
+	useLayoutEffect( () => {
+		if (
+			! isEnabled ||
+			! hasSubject ||
+			! hasObjective ||
+			! hasScrollContext
+		) {
+			return;
+		}
+		// The subject fills the bounds so scroll handling is not needed.
+		// Positions subject at the top of bounds and returns.
+		if ( contentSize.height >= scrollBounds.height ) {
+			subjectRef.current.style.top = scrollBounds.top + 'px';
+			return;
+		}
+		const layout = () => {
+			const objectiveRect = objectiveRef.current.getBoundingClientRect();
+			let { top } = objectiveRect;
+			const height = contentSize.height;
+			const bottom = top + height;
+			const { bottom: boundsBottom, top: boundsTop } = scrollBounds;
+			if ( top < boundsTop || bottom > boundsBottom ) {
+				const fromTop = Math.abs( boundsTop - top );
+				const fromBottom = Math.abs( boundsBottom - bottom );
+				top = fromTop < fromBottom ? boundsTop : boundsBottom - height;
+			}
+			subjectRef.current.style.top = top + 'px';
+		};
+		layout();
+		const scrollNode = scrollContextRef.current;
+		const options = { passive: true };
+		scrollNode.addEventListener( 'scroll', layout, options );
+		return () => {
+			scrollNode.removeEventListener( 'scroll', layout, options );
+		};
+	}, [
+		hasSubject,
+		hasScrollContext,
+		objectiveHasChanged,
+		contentSize.height,
+		scrollBounds.height,
+		scrollBounds.top,
+		scrollBounds.bottom,
+		isEnabled,
+	] );
+
+	// Cleans up subject styles when not enabled
+	useLayoutEffect( () => {
+		if ( isEnabled && !! subjectRef.current ) {
+			const subject = subjectRef.current;
+			return () => {
+				subject.style.top = '';
+				subject.style.maxHeight = '';
+			};
+		}
+	}, [ isEnabled ] );
+
+	return { ref: subjectRef, resizeObserver };
+}

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -7,6 +7,21 @@
 	border: 1px solid $gray-900;
 	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
+	&.is-wide {
+		overflow: auto;
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		left: 299px;
+		border-radius: 0;
+		border: 1px solid #dcdcde;
+		display: none;
+
+		&.is-visible {
+			display: block;
+		}
+	}
+
 	.wp-block-legacy-widget__edit-form-title {
 		color: $black;
 		font-family: $default-font;

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -16,7 +16,7 @@ $wide-header-height: 46px;
 	&.is-wide {
 		flex-direction: column;
 		position: fixed;
-		top: max(#{$wide-header-height}, var(--budge-top, 0));
+		top: max(#{$wide-header-height}, var(--align-top, 0));
 		left: 299px;
 		min-width: 300px;
 		width: calc(100vw - 299px);

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -12,30 +12,37 @@ $wide-header-height: 46px;
 	background: $white;
 	border-radius: $radius-block-ui;
 	border: 1px solid $gray-900;
-	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
 	&.is-wide {
 		flex-direction: column;
 		position: fixed;
-		top: 0;
+		top: max(#{$wide-header-height}, var(--budge-top, 0));
 		left: 299px;
 		min-width: 300px;
 		width: calc(100vw - 299px);
 		max-width: 660px;
-		max-height: 100%;
+		max-height: calc(100% - #{$wide-header-height});
 		padding: 0;
+		background: none;
 		border-radius: 0;
-		border: 1px solid #dcdcde;
+		border: none;
 
-		// Include the top and bottom border in the resizeObserver’s height.
-		> iframe {
-			margin: -1px 0;
-			height: calc(100% + 2px) !important;
+		@media (min-width: 641px) {
+			// The customizer sidebar has a footer and the bottom of the form
+			// is offset from it.
+			padding-bottom: $wide-header-height;
+			// Allows pointer interaction to pass through.
+			pointer-events: none;
+
+			// Restores pointer interaction for the content.
+			.wp-block-legacy-widget__edit-form-header,
+			.wp-block-legacy-widget__edit-form-body {
+				pointer-events: auto;
+			}
 		}
 
 		.wp-block-legacy-widget__edit-form-header {
 			position: absolute;
-			top: 0;
 			left: 0;
 			width: 100%;
 			z-index: 1;
@@ -45,15 +52,25 @@ $wide-header-height: 46px;
 			background: #f0f0f1;
 			height: $wide-header-height;
 			padding: 0 5px 0 21px;
-			border-bottom: 1px solid #dcdcde;
+			margin: 0;
+			border: 1px solid #dcdcde;
 		}
 
 		.wp-block-legacy-widget__edit-form-body {
 			overflow: auto;
-			height: 100%;
-			// Add the header height to the top and subtract the border width from horizontal sides.
-			padding: ($wide-header-height + $grid-unit-15) ($grid-unit-15 - 1px) $grid-unit-15;
+			margin-top: $wide-header-height;
+			border: 1px solid #dcdcde;
+			border-top-width: 0;
+			background: #fff;
 		}
+	}
+
+	.wp-block-legacy-widget__edit-form-header {
+		margin: 0 0 $grid-unit-15 0;
+		padding: $grid-unit-20 21px 0;
+	}
+	.wp-block-legacy-widget__edit-form-body {
+		padding: 0 $grid-unit-15 $grid-unit-05;
 	}
 
 	.wp-block-legacy-widget__edit-form-title {
@@ -61,6 +78,7 @@ $wide-header-height: 46px;
 		font-family: $default-font;
 		font-size: 14px;
 		font-weight: 600;
+		margin: 0;
 	}
 
 	.widget-inside.widget-inside {
@@ -119,6 +137,10 @@ $wide-header-height: 46px;
 		select {
 			padding-left: $grid-unit-05;
 		}
+	}
+
+	.widget {
+		margin-bottom: 0;
 	}
 
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -1,26 +1,37 @@
 $wide-header-height: 46px;
 
-.wp-block-legacy-widget__edit-form {
-	&:not([hidden]) {
-		display: flow-root;
+.wp-block-legacy-widget__edit-form:not([hidden]) {
+	display: flow-root;
+
+	&.is-wide {
+		display: flex;
 	}
+}
+
+.wp-block-legacy-widget__edit-form {
 	background: $white;
 	border-radius: $radius-block-ui;
 	border: 1px solid $gray-900;
 	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
 	&.is-wide {
+		flex-direction: column;
 		position: fixed;
 		top: 0;
-		bottom: 0;
 		left: 299px;
-		min-width: 400px;
+		min-width: 300px;
 		width: calc(100vw - 299px);
 		max-width: 660px;
-		padding: $wide-header-height 0 0 0;
+		max-height: 100%;
+		padding: 0;
 		border-radius: 0;
 		border: 1px solid #dcdcde;
-		border-width: 0 1px;
+
+		// Include the top and bottom border in the resizeObserver’s height.
+		> iframe {
+			margin: -1px 0;
+			height: calc(100% + 2px) !important;
+		}
 
 		.wp-block-legacy-widget__edit-form-header {
 			position: absolute;
@@ -40,7 +51,8 @@ $wide-header-height: 46px;
 		.wp-block-legacy-widget__edit-form-body {
 			overflow: auto;
 			height: 100%;
-			padding: $grid-unit-15 - 1px; //Subtract the border width.
+			// Add the header height to the top and subtract the border width from horizontal sides.
+			padding: ($wide-header-height + $grid-unit-15) ($grid-unit-15 - 1px) $grid-unit-15;
 		}
 	}
 

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -1,3 +1,12 @@
+// When wide widget is selected and not in navigation mode (.is-visible) its
+// form opens in a popover but its container should still have a bit of height.
+.is-selected {
+	.is-visible.wp-block-legacy-widget__container {
+		padding: $grid-unit-10 $grid-unit-15;
+		min-height: 50px;
+	}
+}
+
 .wp-block-legacy-widget__edit-form {
 	&:not([hidden]) {
 		display: flow-root;
@@ -15,11 +24,7 @@
 		left: 299px;
 		border-radius: 0;
 		border: 1px solid #dcdcde;
-		display: none;
-
-		&.is-visible {
-			display: block;
-		}
+		min-width: 400px;
 	}
 
 	.wp-block-legacy-widget__edit-form-title {
@@ -159,19 +164,6 @@
 .interface-complementary-area .wp-block-legacy-widget-inspector-card__name {
 	margin: 0 0 5px;
 	font-weight: 500;
-}
-
-// When wide widget is selected it opens in a popover but its container should still have a bit of height.
-.is-selected {
-	.wp-block-legacy-widget__container {
-		padding: $grid-unit-10 $grid-unit-15;
-		min-height: 50px;
-	}
-}
-
-// Wide widgets opening in popovers in the Customizer should have a min-width
-.components-popover__content .wp-block-legacy-widget__edit-form {
-	min-width: 400px;
 }
 
 .wp-block-legacy-widget {

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -1,11 +1,4 @@
-// When wide widget is selected and not in navigation mode (.is-visible) its
-// form opens in a popover but its container should still have a bit of height.
-.is-selected {
-	.is-visible.wp-block-legacy-widget__container {
-		padding: $grid-unit-10 $grid-unit-15;
-		min-height: 50px;
-	}
-}
+$wide-header-height: 46px;
 
 .wp-block-legacy-widget__edit-form {
 	&:not([hidden]) {
@@ -17,14 +10,38 @@
 	padding: $grid-unit-15 - 1px; //Subtract the border width.
 
 	&.is-wide {
-		overflow: auto;
 		position: fixed;
 		top: 0;
 		bottom: 0;
 		left: 299px;
+		min-width: 400px;
+		width: calc(100vw - 299px);
+		max-width: 660px;
+		padding: $wide-header-height 0 0 0;
 		border-radius: 0;
 		border: 1px solid #dcdcde;
-		min-width: 400px;
+		border-width: 0 1px;
+
+		.wp-block-legacy-widget__edit-form-header {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			z-index: 1;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			background: #f0f0f1;
+			height: $wide-header-height;
+			padding: 0 5px 0 21px;
+			border-bottom: 1px solid #dcdcde;
+		}
+
+		.wp-block-legacy-widget__edit-form-body {
+			overflow: auto;
+			height: 100%;
+			padding: $grid-unit-15 - 1px; //Subtract the border width.
+		}
 	}
 
 	.wp-block-legacy-widget__edit-form-title {
@@ -32,7 +49,6 @@
 		font-family: $default-font;
 		font-size: 14px;
 		font-weight: 600;
-		margin: 0 0 $grid-unit-15 0;
 	}
 
 	.widget-inside.widget-inside {


### PR DESCRIPTION
Exploratory alternative to #33230, following up on #31736 and would close #32210 by obviating the need for it.

This is here for demonstration and if some of the changes here are desired would likely be better to break them off as their own PRs. The high-level changes with some reasoning:
- Replaces the use of `Popover` to display wide widgets with a dialog (with `useDialog` and a custom hook for positioning). Nice in that it requires no modifications to the `Popover` component.
- Displays previews for wide widgets while being edited. Why not? It reduces content shifts in the sidebar due to changing from preview to title display.
- Adds a header bar to the wide widget dialog. Goes well with the above change. Also, overflow in the sidebar seems much more likely with the block editor so this helps identify the dialog even if its widget is scrolled out of view.

## How has this been tested?
Manually

## Screenshots 

https://user-images.githubusercontent.com/9000376/124642483-bf168a80-de44-11eb-9a9d-2c89e773ec0a.mp4

## Types of changes
Enhancements

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
