### PR TITLE
Build Workflow: Revert version bump if build job fails

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -238,6 +238,7 @@ jobs:
                   github.event.inputs.version == 'stable' ||
                   contains( steps.get_version.outputs.old_version, 'rc' )
               run: |
+                  git pull
                   git revert --no-edit ${{ needs.bump-version.outputs.release_branch_commit }}
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
 

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -239,7 +239,7 @@ jobs:
                   git revert --no-edit ${{ needs.bump-version.outputs.release_branch_commit }}
                   git push --set-upstream origin "${{ needs.bump-version.outputs.release_branch }}"
 
-            - name: Delete release branch
+            - name: Delete release branch if it was only just created for the RC
               if: |
                   github.event.inputs.version == 'rc' &&
                   ! contains( needs.bump-version.outputs.old_version, 'rc' )

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -237,17 +237,17 @@ jobs:
             - name: Revert version bump commit on release branch
               if: |
                   github.event.inputs.version == 'stable' ||
-                  contains( steps.get_version.outputs.old_version, 'rc' )
+                  contains( needs.bump-version.outputs.old_version, 'rc' )
               run: |
                   git revert --no-edit ${{ needs.bump-version.outputs.release_branch_commit }}
-                  git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
+                  git push --set-upstream origin "${{ needs.bump-version.outputs.release_branch }}"
 
             - name: Delete release branch
               if: |
                   github.event.inputs.version == 'rc' &&
-                  ! contains( steps.get_version.outputs.old_version, 'rc' )
+                  ! contains( needs.bump-version.outputs.old_version, 'rc' )
               run: |
-                  git push origin :"${{ steps.get_version.outputs.release_branch }}"
+                  git push origin :"${{ needs.bump-version.outputs.release_branch }}"
 
             - name: Revert version bump on trunk
               if: ${{ needs.bump-version.outputs.trunk_commit }}

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -169,6 +169,9 @@ jobs:
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
+            - name: Fail
+              run: exit 1
+
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -64,6 +64,8 @@ jobs:
             old_version: ${{ steps.get_version.outputs.old_version }}
             new_version: ${{ steps.get_version.outputs.new_version }}
             release_branch: ${{ steps.get_version.outputs.release_branch }}
+            release_branch_commit: ${{ steps.commit_version_bump_to_release_branch.outputs.version_bump_commit }}
+            trunk_commit: ${{ steps.commit_version_bump_to_trunk.outputs.version_bump_commit }}
 
         steps:
             - name: Checkout code
@@ -125,16 +127,19 @@ jobs:
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" readme.txt
 
             - name: Commit the version bump to the release branch
+              id: commit_version_bump_to_release_branch
               run: |
                   git add gutenberg.php package.json package-lock.json readme.txt
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
+                  echo "::set-output name=version_bump_commit::$(git rev-parse --verify --short HEAD)"
 
             - name: Fetch trunk
               if: ${{ github.ref != 'refs/heads/trunk' }}
               run: git fetch --depth=1 origin trunk
 
             - name: Cherry-pick the version bump commit to trunk
+              id: commit_version_bump_to_trunk
               run: |
                   git checkout trunk
                   git pull
@@ -142,6 +147,7 @@ jobs:
                   if [[ ${{ steps.get_version.outputs.old_version }} == "$TRUNK_VERSION" ]]; then
                     git cherry-pick "${{ steps.get_version.outputs.release_branch }}"
                     git push
+                    echo "::set-output name=version_bump_commit::$(git rev-parse --verify --short HEAD)"
                   fi
 
     build:
@@ -154,6 +160,8 @@ jobs:
               github.event_name == 'workflow_dispatch' ||
               github.repository == 'WordPress/gutenberg'
             )
+        outputs:
+            job_status: ${{ job.status }}
 
         steps:
             - name: Checkout code
@@ -200,6 +208,50 @@ jobs:
               with:
                   name: release-notes
                   path: ./release-notes.txt
+
+    revert-version-bump:
+        name: Revert version bump if build failed
+        needs: [bump-version, build]
+        runs-on: ubuntu-latest
+        if: |
+            always() &&
+            ( needs.build.outputs.job_status == 'failure' ) &&
+            needs.bump-version.outputs.release_branch_commit
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  ref: ${{ needs.bump-version.outputs.release_branch }}
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Configure git user name and email
+              run: |
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Revert version bump commit on release branch
+              if: |
+                  github.event.inputs.version == 'stable' ||
+                  contains( steps.get_version.outputs.old_version, 'rc' )
+              run: |
+                  git revert --no-edit ${{ needs.bump-version.outputs.release_branch_commit }}
+                  git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
+
+            - name: Delete release branch
+              if: |
+                  github.event.inputs.version == 'rc' &&
+                  ! contains( steps.get_version.outputs.old_version, 'rc' )
+              run: |
+                  git push origin :"${{ steps.get_version.outputs.release_branch }}"
+
+            - name: Revert version bump on trunk
+              if: ${{ needs.bump-version.outputs.trunk_commit }}
+              run: |
+                  git fetch --depth=1 origin trunk
+                  git checkout trunk
+                  git revert --no-edit ${{ needs.bump-version.outputs.trunk_commit }}
+                  git push --set-upstream origin trunk
 
     create-release:
         name: Create Release Draft and Attach Asset

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -225,6 +225,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
+                  fetch-depth: 2
                   ref: ${{ needs.bump-version.outputs.release_branch }}
                   token: ${{ secrets.GUTENBERG_TOKEN }}
 
@@ -238,7 +239,6 @@ jobs:
                   github.event.inputs.version == 'stable' ||
                   contains( steps.get_version.outputs.old_version, 'rc' )
               run: |
-                  git pull
                   git revert --no-edit ${{ needs.bump-version.outputs.release_branch_commit }}
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
 

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -252,7 +252,7 @@ jobs:
             - name: Revert version bump on trunk
               if: ${{ needs.bump-version.outputs.trunk_commit }}
               run: |
-                  git fetch --depth=1 origin trunk
+                  git fetch --depth=2 origin trunk
                   git checkout trunk
                   git revert --no-edit ${{ needs.bump-version.outputs.trunk_commit }}
                   git push --set-upstream origin trunk

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -169,9 +169,6 @@ jobs:
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
-            - name: Fail
-              run: exit 1
-
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:


### PR DESCRIPTION
## Description

In our plugin build workflow, which, when manually triggered, also contains a version bump step, and a step to create a release draft with the plugin build attached as an asset, the build step sometimes fails (e.g. because of npm flakiness) ([see e.g.](https://github.com/WordPress/gutenberg/runs/2951792952?check_suite_focus=true)).

It's natural for people to try and re-trigger the step. However, this is also bound to fail, since at that point, the release branch has already been created, and the plugin version has already been bumped ([see e.g.](https://github.com/WordPress/gutenberg/runs/2952331107?check_suite_focus=true)).

To prevent this, we can add another job to the workflow that upon build failure, reverts the version bump commit, and, if necessary, also deletes the release branch.

See this thread for more background, and potential alternative approaches: https://github.com/WordPress/gutenberg/pull/33105/files#r664591278

## How has this been tested?

You'd basically need to fork the repo, force-push this branch to the fork's `trunk`, and add a commit that makes the build job reliably fail. Something like

```
git push ockham update/build-workflow-revert-version-bump-if-build-fails:trunk -f
```

and 

```diff
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -169,6 +169,9 @@ jobs:
               with:
                   ref: ${{ needs.bump-version.outputs.release_branch || github.ref }}
 
+            - name: Fail
+              run: exit 1
+
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
```

For your convenience, I've done that on my fork 😬 

Here's a test run for a `stable` release:  https://github.com/ockham/gutenberg/actions/runs/1015794749.
The `release/11.0` branch contains both the version bump commit (`11.0.1`), and the revert: https://github.com/ockham/gutenberg/commits/release/11.0
(Same for `trunk`: https://github.com/ockham/gutenberg/commits/trunk -- the commits are below the ones for the RC test.) 

Here's a test run for an `rc` release: https://github.com/ockham/gutenberg/actions/runs/1015804736
The `release/11.1` branch was deleted after the build step failed; the version bump commit and revert for `11.1.0-rc.1` are however present on `trunk`: https://github.com/ockham/gutenberg/commits/trunk