### PR TITLE
Refactor of navigation block rendering using location attribute

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -199,7 +199,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$html .= '</span>';
 
-	if ( $block->context['showSubmenuIcon'] && $has_submenu ) {
+	if ( isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'] && $has_submenu ) {
 		// The submenu icon can be hidden by a CSS rule on the Navigation Block.
 		$html .= '<span class="wp-block-navigation-link__submenu-icon">' . block_core_navigation_link_render_submenu_icon() . '</span>';
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -93,11 +93,12 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  *
  * @param  string $location The location of the classic menu to display.
  * @param  object $attributes The block attributes.
- * @return string|false HTML markup of a generated Navigation Block or false if no location is specified.
+ * @return string HTML markup of a generated Navigation Block or empty string
+ *                if location is unspecified.
  */
 function gutenberg_render_menu_from_location( $location, $attributes ) {
 	if ( empty( $location ) ) {
-		return false;
+		return '';
 	}
 
 	return wp_nav_menu(
@@ -155,11 +156,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	if ( empty( $block->inner_blocks ) ) {
 		if ( array_key_exists( '__unstableLocation', $attributes ) ) {
-			$location                 = $attributes['__unstableLocation'];
-			$maybe_classic_navigation = gutenberg_render_menu_from_location( $location, $attributes );
-			if ( $maybe_classic_navigation ) {
-				return $maybe_classic_navigation;
-			}
+			$location = $attributes['__unstableLocation'];
+			return gutenberg_render_menu_from_location( $location, $attributes );
 		}
 
 		return '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -228,7 +228,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( empty( $inner_blocks ) && array_key_exists( '__unstableLocation', $attributes ) ) {
 		$menu_items = gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
-			return;
+			return '';
 		}
 
 		$menu_items_by_parent_id = gutenberg_sort_menu_items_by_parent_id( $menu_items );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -96,7 +96,7 @@ function gutenberg_get_menu_items_at_location( $location ) {
 		return;
 	}
 
-	// Build menu data. The following code is approximates the code in
+	// Build menu data. The following approximates the code in
 	// `wp_nav_menu()` and `gutenberg_output_block_nav_menu`.
 
 	// Find the location in the list of locations, returning early if the

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -85,6 +85,12 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 	return $font_sizes;
 }
 
+/**
+ * Returns the menu items for a WordPress menu location.
+ *
+ * @param string $location The menu location.
+ * @return array Menu items for the location.
+ */
 function gutenberg_get_menu_items_at_location( $location ) {
 	if ( empty( $location ) ) {
 		return;
@@ -113,6 +119,14 @@ function gutenberg_get_menu_items_at_location( $location ) {
 	return $menu_items;
 }
 
+/**
+ * Sorts a standard array of menu items into a nested structure keyed by the
+ * id of the parent menu.
+ *
+ * @param array $menu_items Menu items to sort.
+ * @return array An array keyed by the id of the parent menu where each element
+ *               is an array of menu items that belong to that parent.
+ */
 function gutenberg_sort_menu_items_by_parent_id( $menu_items ) {
 	$sorted_menu_items = array();
 	foreach ( (array) $menu_items as $menu_item ) {
@@ -128,6 +142,17 @@ function gutenberg_sort_menu_items_by_parent_id( $menu_items ) {
 	return $menu_items_by_parent_id;
 }
 
+/**
+ * Turns menu item data into a nested array of parsed blocks
+ *
+ * @param array $menu_items               An array of menu items that represent
+ *                                        an individual level of a menu.
+ * @param array $menu_items_by_parent_id  An array keyed by the id of the
+ *                                        parent menu where each element is an
+ *                                        array of menu items that belong to
+ *                                        that parent.
+ * @return array An array of parsed block data.
+ */
 function gutenberg_parse_blocks_from_menu_items( $menu_items, $menu_items_by_parent_id ) {
 	if ( empty( $menu_items ) ) {
 		return array();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -100,7 +100,8 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  */
 function gutenberg_navigation_convert_menu_items_to_blocks(
 	$menu_items,
-	&$menu_items_by_parent_id
+	&$menu_items_by_parent_id,
+	$navigation_block_attributes
 ) {
 	if ( empty( $menu_items ) ) {
 		return array();
@@ -121,10 +122,11 @@ function gutenberg_navigation_convert_menu_items_to_blocks(
 			isset( $menu_items_by_parent_id[ $menu_item->ID ] )
 					? $menu_items_by_parent_id[ $menu_item->ID ]
 					: array(),
-			$menu_items_by_parent_id
+			$menu_items_by_parent_id,
+			$navigation_block_attributes
 		);
 
-		$blocks[] = new WP_Block( $block, array() );
+		$blocks[] = new WP_Block( $block, $navigation_block_attributes );
 	}
 
 	return $blocks;
@@ -136,7 +138,7 @@ function gutenberg_navigation_convert_menu_items_to_blocks(
  * @param  string $location The location of the classic menu to display.
  * @return array  Inner blocks converted from the menu_items at the location.
  */
-function gutenberg_convert_menu_items_at_location_to_inner_blocks( $location ) {
+function gutenberg_convert_menu_items_at_location_to_inner_blocks( $location, $navigation_block_attributes ) {
 	if ( empty( $location ) ) {
 		return;
 	}
@@ -176,7 +178,8 @@ function gutenberg_convert_menu_items_at_location_to_inner_blocks( $location ) {
 		isset( $menu_items_by_parent_id[0] )
 		? $menu_items_by_parent_id[0]
 		: array(),
-		$menu_items_by_parent_id
+		$menu_items_by_parent_id,
+		$navigation_block_attributes
 	);
 }
 
@@ -225,7 +228,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	if ( empty( $inner_blocks ) && array_key_exists( '__unstableLocation', $attributes ) ) {
 		$inner_blocks = gutenberg_convert_menu_items_at_location_to_inner_blocks(
-			$attributes['__unstableLocation']
+			$attributes['__unstableLocation'],
+			$attributes
 		);
 	}
 


### PR DESCRIPTION
## Description
Alternative to #33224

The current way the navigation block renders content using its `__unstableLocation` attribute has some issues:
- It depends on the theme opting in to `block-nav-menus`. This is a theme option that controls the navigation screen. The block should ideally be portable and not have a dependency on how the experimental nav screen works. `__unstableLocation` should just work without some other configuration.
- It short circuits the navigation block's normal rendering by instead calling `wp_nav_menu`, which then eventually (because of the theme opt-in) calls back to `render_block( $navigation_block )`, meaning the same block rendering code is executed twice, and without some care infinite recursion can result (#33175)

This PR is a bit of a refactor of how it works. The navigation block is instead in charge of its own rendering. It pulls data from a specified menu location and parses the items into blocks, replacing the normal block's innerBlocks with the parsed menu items instead.

It's just a first iteration, but I think the good this is that this could lead to changing how the navigation screen works. That screen can now just render a navigation block with an `__unstableLocation` attribute when a theme has opted in, and instead have the block do all the work. I'll follow-up with a PR that does this.

## How has this been tested?
(I tested this using Twenty Twenty, which has a footer location and the specified colors)
1. Create a menu using the `appearance > menu` screen, set it to the footer location
2. Add a navigation block to a post by pasting the following snippet into the code editor:
```
<!-- wp:navigation {"orientation":"horizontal","textColor":"accent","backgroundColor":"subtle-background","__unstableLocation":"footer","style":{"typography":{"textTransform":"uppercase"}}} /-->
```
3. Save and view the post

Expected: The menu should render with the correct menu items and navigation block settings (color, typography etc) should work.

## Screenshots <!-- if applicable -->
<img width="624" alt="Screenshot 2021-07-07 at 3 41 52 pm" src="https://user-images.githubusercontent.com/677833/124719574-e1d69b00-df39-11eb-9c8a-8d5b5ab646d6.png">

## Types of changes
Refactor
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
