### PR TITLE
Fixes a typo in the docs for block supports

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -267,7 +267,7 @@ When the block declares support for `color.gradient`, the attributes definition 
           type: 'object',
           default: {
               color: {
-                  background: 'linear-gradient(135deg,rgb(170,187,204) 0%,rgb(17,34,51) 100%)',
+                  gradient: 'linear-gradient(135deg,rgb(170,187,204) 0%,rgb(17,34,51) 100%)',
               }
           }
       }


### PR DESCRIPTION
The example in the block support docs for gradients referred to `color.background` to set a default value, while it should have been `color.gradient`.