### PR TITLE
Handbook: Clarify the type of `apiVersion` in block metadata

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -79,6 +79,22 @@ register_block_type(
 
 This section describes all the properties that can be added to the `block.json` file to define the behavior and metadata of block types.
 
+### API Version
+
+-   Type: `number`
+-   Optional
+-   Localized: No
+-   Property: `apiVersion`
+-   Default: `1`
+
+```json
+{ "apiVersion": 2 }
+```
+
+The version of the Block API used by the block. The most recent version is `2` and it was introduced in WordPress 5.6.
+
+See the [the API versions documentation](/docs/reference-guides/block-api/block-api-versions.md) for more details.
+
 ### Name
 
 -   Type: `string`


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

It looks like there is some misunderstanding about what type `apiVersion` should have in the `block.json` file. It was raised by @richtabor on WordPress Slack https://wordpress.slack.com/archives/C02QB2JS7/p1625616501376100:

> Question. I’m checking a block ([Markdown Comment](https://richtabor.com/markdown-comments/)) with the Block Plugin Checker and I’m seeing this block.json file error. I’m using the same method  as indicated in core, as well as the recent [Block API Enhancements post](https://make.wordpress.org/core/2021/06/23/block-api-enhancements-in-wordpress-5-8/). Is this an invalid error, or am I missing something? Thanks!

![image](https://user-images.githubusercontent.com/699132/124724510-598dd100-df0c-11eb-8f66-fcf7942d8797.png)

This PR adds the missing section covering `apiVersion` in block metadata reference guide.

The changes in the Block Plugin Checker are discussed in https://meta.trac.wordpress.org/ticket/5303.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Documentation update.