### PR TITLE
Plugin: Remove deprecated APIs that are no longer supported in version 11.0

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The deprecated `registerBlockTypeFromMetadata` function was removed. Please use `registerBlockType` that covers the same functionality ([#32030](https://github.com/WordPress/gutenberg/pull/32030)).
+
 ## 9.1.0 (2021-05-20)
 
 ### New API

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -713,21 +713,6 @@ _Returns_
 
 -   `?WPBlock`: The block, if it has been successfully registered; otherwise `undefined`.
 
-<a name="registerBlockTypeFromMetadata" href="#registerBlockTypeFromMetadata">#</a> **registerBlockTypeFromMetadata**
-
-> **Deprecated** Use `registerBlockType` instead.
-
-Registers a new block provided from metadata stored in `block.json` file.
-
-_Parameters_
-
--   _metadata_ `Object`: Block metadata loaded from `block.json`.
--   _additionalSettings_ `Object`: Additional block settings.
-
-_Returns_
-
--   `?WPBlock`: The block, if it has been successfully registered; otherwise `undefined`.
-
 <a name="registerBlockVariation" href="#registerBlockVariation">#</a> **registerBlockVariation**
 
 Registers a new block variation for the given block type.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -108,7 +108,6 @@ export { getCategories, setCategories, updateCategory } from './categories';
 // children of another block.
 export {
 	registerBlockType,
-	registerBlockTypeFromMetadata,
 	registerBlockCollection,
 	unregisterBlockType,
 	setFreeformContentHandlerName,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -22,7 +22,6 @@ import {
 /**
  * WordPress dependencies
  */
-import deprecated from '@wordpress/deprecated';
 import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
@@ -422,27 +421,6 @@ function translateBlockSettingUsingI18nSchema(
 		}, {} );
 	}
 	return settingValue;
-}
-
-/**
- * Registers a new block provided from metadata stored in `block.json` file.
- *
- * @deprecated Use `registerBlockType` instead.
- *
- * @param {Object} metadata           Block metadata loaded from `block.json`.
- * @param {Object} additionalSettings Additional block settings.
- *
- * @return {?WPBlock} The block, if it has been successfully registered;
- *                    otherwise `undefined`.
- */
-export function registerBlockTypeFromMetadata( metadata, additionalSettings ) {
-	deprecated( 'wp.blocks.registerBlockTypeFromMetadata', {
-		since: '10.7',
-		plugin: 'Gutenberg',
-		alternative: 'wp.blocks.registerBlockType',
-		version: '11.0',
-	} );
-	return registerBlockType( metadata, additionalSettings );
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR removes the deprecated `registerBlockTypeFromMetadata` function from `@wordpress/blocks` that was scheduled for removal with Gutenberg 11.0.