### PR TITLE
Bail out if get_current_screen() returns null.

### DIFF
--- a/lib/widgets-customize.php
+++ b/lib/widgets-customize.php
@@ -156,15 +156,20 @@ function gutenberg_customize_widgets_init() {
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_customize_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if (
-		gutenberg_use_widgets_block_editor() &&
-		is_callable( 'get_current_screen' ) &&
-		'customize' === get_current_screen()->base
-	) {
-		return true;
+	if ( ! gutenberg_use_widgets_block_editor() ) {
+		return $is_block_editor_screen;
 	}
 
-	return $is_block_editor_screen;
+	if ( ! is_callable( 'get_current_screen' ) ) {
+		return $is_block_editor_screen;
+	}
+
+	$current_screen = get_current_screen();
+	if ( is_null( $current_screen ) ) {
+		return $is_block_editor_screen;
+	}
+
+	return 'customize' === $current_screen->base ? true : $is_block_editor_screen;
 }
 
 // Test for wp_use_widgets_block_editor(), as the existence of this in core


### PR DESCRIPTION
## Description
In function `gutenberg_widgets_customize_load_block_editor_scripts_and_styles()` on < WordPress 5.8-RC2, a PHP notice is thrown _when_ `get_current_screen()` returns `null`. 

```
PHP Warning:  Attempt to read property "base" on null in /.../wp-content/plugins/gutenberg/lib/widgets-customize.php on line 162
```

This happens because the instance is used to get the `base` property as part of the conditional check.

This PR breaks up the conditional checks into guard clauses and then checks if the value returned from `get_current_screen(0` is `null`. If yes, it bails out. If no, then the `base` property is checked.

## How has this been tested?

Local machine => Notice in debug log before fix. No notice after fix.

Environment:
- OS: macOS Big Sur
- WP: 5.7.2
- Browser: Chrome and Firefox

Note: The PHP notice does not happen with WordPress 5.8-RC2.

## Screenshots 

<img width="857" alt="Screenshot 2021-07-07 at 13 17 15" src="https://user-images.githubusercontent.com/7284611/124764557-b2ed0480-defa-11eb-8b3b-13e30af79626.png">


## Types of changes
- Breaks up the conditionals and converts each into a guard clause
- Checks for `null` and bails out if returned

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
