### PR TITLE
Add group wrapper to the Standard alignment query block

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -20,17 +20,17 @@ function register_gutenberg_patterns() {
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-							<div class="wp-block-query">
-							<!-- wp:post-template -->
-							<!-- wp:post-title {"isLink":true} /-->
-							<!-- wp:post-featured-image  {"isLink":true,"align":"wide"} /-->
+							<div class="wp-block-query"><!-- wp:post-template -->
+							<!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
+							<div class="wp-block-group alignwide"><!-- wp:post-title {"isLink":true} /-->
+							<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 							<!-- wp:post-excerpt /-->
 							<!-- wp:separator -->
 							<hr class="wp-block-separator"/>
 							<!-- /wp:separator -->
-							<!-- wp:post-date /-->
-							<!-- /wp:post-template -->
-							</div>
+							<!-- wp:post-date /--></div>
+							<!-- /wp:group -->
+							<!-- /wp:post-template --></div>
 							<!-- /wp:query -->',
 		),
 		'query-medium-posts'                   => array(


### PR DESCRIPTION
The bundled "Standard" query block pattern is missing a wrapper container to inherit the default layout settings. As a result: 

- The text extends the full width of the page. 
- The featured image is set to be wide-aligned, but it appears full-width instead. 

This PR just adds a group block wrapper to ensure these are displaying as intended. 

Before|After
---|---
<img width="1157" alt="Screen Shot 2021-07-07 at 2 13 53 PM" src="https://user-images.githubusercontent.com/1202812/124809892-a5517200-df2e-11eb-99be-6cd83290ec07.png">|<img width="1157" alt="Screen Shot 2021-07-07 at 2 14 30 PM" src="https://user-images.githubusercontent.com/1202812/124809895-a5ea0880-df2e-11eb-9cda-8007adf7102d.png">
