### PR TITLE
Block Editor: Warn when `useBlockProps` hook used with a wrong Block API version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14506,6 +14506,7 @@
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/token-list": "file:packages/token-list",
 				"@wordpress/url": "file:packages/url",
+				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
 				"css-mediaquery": "^0.1.2",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -55,6 +55,7 @@
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/token-list": "file:../token-list",
 		"@wordpress/url": "file:../url",
+		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
 		"css-mediaquery": "^0.1.2",

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/blocks';
 import { useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -65,6 +66,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		index,
 		mode,
 		name,
+		blockAPIVersion,
 		blockTitle,
 		isPartOfSelection,
 		adjustScrolling,
@@ -89,11 +91,13 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				isAncestorMultiSelected( clientId );
 			const blockName = getBlockName( clientId );
 			const rootClientId = getBlockRootClientId( clientId );
+			const blockType = getBlockType( blockName );
 			return {
 				index: getBlockIndex( clientId, rootClientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
-				blockTitle: getBlockType( blockName ).title,
+				blockAPIVersion: blockType.apiVersion,
+				blockTitle: blockType.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
 					isSelected || isFirstMultiSelectedBlock( clientId ),
@@ -127,6 +131,12 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			triggerAnimationOnChange: index,
 		} ),
 	] );
+
+	if ( blockAPIVersion < 2 ) {
+		warning(
+			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`
+		);
+	}
 
 	return {
 		...wrapperProps,

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/heading",
 	"title": "Heading",
 	"category": "text",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 1,
 	"name": "core/heading",
 	"title": "Heading",
 	"category": "text",

--- a/packages/warning/CHANGELOG.md
+++ b/packages/warning/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Ensure that the warning for a given message is logged only once.
+
 ## 2.1.0 (2021-05-20)
 
 ## 2.0.0 (2021-05-14)

--- a/packages/warning/src/index.js
+++ b/packages/warning/src/index.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { logged } from './utils';
+
 function isDev() {
 	return (
 		typeof process !== 'undefined' &&
@@ -28,6 +33,11 @@ export default function warning( message ) {
 		return;
 	}
 
+	// Skip if already logged.
+	if ( message in logged ) {
+		return;
+	}
+
 	// eslint-disable-next-line no-console
 	console.warn( message );
 
@@ -39,4 +49,6 @@ export default function warning( message ) {
 	} catch ( x ) {
 		// do nothing
 	}
+
+	logged[ message ] = true;
 }

--- a/packages/warning/src/test/index.js
+++ b/packages/warning/src/test/index.js
@@ -2,12 +2,16 @@
  * Internal dependencies
  */
 import warning from '..';
+import { logged } from '../utils';
 
 const initialNodeEnv = process.env.NODE_ENV;
 
 describe( 'warning', () => {
 	afterEach( () => {
 		process.env.NODE_ENV = initialNodeEnv;
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
 	} );
 
 	it( 'logs to console.warn when NODE_ENV is not "production"', () => {
@@ -20,5 +24,14 @@ describe( 'warning', () => {
 		process.env.NODE_ENV = 'production';
 		warning( 'warning' );
 		expect( console ).not.toHaveWarned();
+	} );
+
+	it( 'should show a message once', () => {
+		warning( 'warning' );
+		warning( 'warning' );
+
+		expect( console ).toHaveWarned();
+		// eslint-disable-next-line no-console
+		expect( console.warn ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/warning/src/utils.js
+++ b/packages/warning/src/utils.js
@@ -1,0 +1,7 @@
+/**
+ * Object map tracking messages which have been logged, for use in ensuring a
+ * message is only logged once.
+ *
+ * @type {Record<string, true | undefined>}
+ */
+export const logged = Object.create( null );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

API version mismatch when using `useBlockProps` seems to be the most common issue reported recently. This PR proposes that we detect when someone is using `useBlockProps` with `apiVersion` set to `1` for a block type that is using also `useBlockProps`. The warning is going to be printed only in the development mode.

### `@wordpress/warning` changes

This PR also ensures that a given unique message is reported only once when calling `warning` method from `@wordpress/warning`. It mirrors the implementation used with `deprecated` from `@wordpress/deprecated`. The rationale is to avoid seeing a flood of the same messages reported on the Browser Console. It was very annoying for the `useBlockProps` hook that would print the warning for every block and on every re-render.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create a new post and insert the Heading block that has the `apiVersion` downgraded to `1` to throw the warning. Observe the warning on the Browser Console.

## Screenshots <!-- if applicable -->

<img width="1067" alt="Screen Shot 2021-07-08 at 08 09 40" src="https://user-images.githubusercontent.com/699132/124871137-f9f2fc80-dfc3-11eb-85ba-9112ec1d9662.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
