### PR TITLE
Add a new page/post button on publish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -92,6 +92,7 @@ class PostPublishPanelPostpublish extends Component {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+		const addNewPostLabel = get( postType, [ 'labels', 'add_new_item' ] );
 		const link =
 			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
 		const addLink = addQueryArgs( 'post-new.php', {
@@ -148,7 +149,7 @@ class PostPublishPanelPostpublish extends Component {
 							</Button>
 						) }
 						<Button variant="secondary" href={ addLink }>
-							{ __( 'Add Item' ) }
+							{ addNewPostLabel }
 						</Button>
 					</div>
 				</PanelBody>

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -107,7 +107,6 @@ class PostPublishPanelPostpublish extends Component {
 		const addLink = addQueryArgs( 'post-new.php', {
 			post_type: post.type,
 		} );
-		const dashboardLink = addQueryArgs( 'index.php', {} );
 
 		const postPublishNonLinkHeader = isScheduled ? (
 			<>
@@ -160,11 +159,6 @@ class PostPublishPanelPostpublish extends Component {
 						) }
 						<Button variant="secondary" href={ addLink }>
 							{ addNewPostLabel }
-						</Button>
-					</div>
-					<div className="post-publish-panel__dashboard-link">
-						<Button variant="link" href={ dashboardLink }>
-							{ __( 'Back to dashboard' ) }
 						</Button>
 					</div>
 				</PanelBody>

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -50,11 +50,6 @@ function CopyButton( { text, onCopy, children } ) {
 	);
 }
 
-function ConvertToSentenceCase( string ) {
-	const sentence = string.toLowerCase();
-	return sentence.charAt( 0 ).toUpperCase() + sentence.slice( 1 );
-}
-
 class PostPublishPanelPostpublish extends Component {
 	constructor() {
 		super( ...arguments );
@@ -96,12 +91,8 @@ class PostPublishPanelPostpublish extends Component {
 	render() {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
-		const viewPostLabel = ConvertToSentenceCase(
-			get( postType, [ 'labels', 'view_item' ] )
-		);
-		const addNewPostLabel = ConvertToSentenceCase(
-			get( postType, [ 'labels', 'add_new_item' ] )
-		);
+		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+		const addNewPostLabel = get( postType, [ 'labels', 'add_new_item' ] );
 		const link =
 			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
 		const addLink = addQueryArgs( 'post-new.php', {
@@ -142,7 +133,7 @@ class PostPublishPanelPostpublish extends Component {
 							onFocus={ this.onSelectInput }
 						/>
 
-						<div className="post-publish-panel__postpublish-post-address__button-wrap">
+						<div className="post-publish-panel__postpublish-post-address__copy-button-wrap">
 							<CopyButton text={ link } onCopy={ this.onCopy }>
 								{ this.state.showCopyConfirmation
 									? __( 'Copied!' )

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -144,11 +144,14 @@ class PostPublishPanelPostpublish extends Component {
 
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (
-							<Button variant="secondary" href={ link }>
+							<Button variant="primary" href={ link }>
 								{ viewPostLabel }
 							</Button>
 						) }
-						<Button variant="secondary" href={ addLink }>
+						<Button
+							variant={ isScheduled ? 'primary' : 'secondary' }
+							href={ addLink }
+						>
 							{ addNewPostLabel }
 						</Button>
 					</div>

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -10,7 +10,7 @@ import { PanelBody, Button, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { safeDecodeURIComponent } from '@wordpress/url';
+import { addQueryArgs, safeDecodeURIComponent } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -48,6 +48,11 @@ function CopyButton( { text, onCopy, children } ) {
 			{ children }
 		</Button>
 	);
+}
+
+function ConvertToSentenceCase( string ) {
+	const sentence = string.toLowerCase();
+	return sentence.charAt( 0 ).toUpperCase() + sentence.slice( 1 );
 }
 
 class PostPublishPanelPostpublish extends Component {
@@ -91,9 +96,18 @@ class PostPublishPanelPostpublish extends Component {
 	render() {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
-		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+		const viewPostLabel = ConvertToSentenceCase(
+			get( postType, [ 'labels', 'view_item' ] )
+		);
+		const addNewPostLabel = ConvertToSentenceCase(
+			get( postType, [ 'labels', 'add_new_item' ] )
+		);
 		const link =
 			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
+		const addLink = addQueryArgs( 'post-new.php', {
+			post_type: post.type,
+		} );
+		const dashboardLink = addQueryArgs( 'index.php', {} );
 
 		const postPublishNonLinkHeader = isScheduled ? (
 			<>
@@ -116,28 +130,42 @@ class PostPublishPanelPostpublish extends Component {
 					<p className="post-publish-panel__postpublish-subheader">
 						<strong>{ __( 'What’s next?' ) }</strong>
 					</p>
-					<TextControl
-						className="post-publish-panel__postpublish-post-address"
-						readOnly
-						label={ sprintf(
-							/* translators: %s: post type singular name */
-							__( '%s address' ),
-							postLabel
-						) }
-						value={ safeDecodeURIComponent( link ) }
-						onFocus={ this.onSelectInput }
-					/>
+					<div className="post-publish-panel__postpublish-post-address-container">
+						<TextControl
+							className="post-publish-panel__postpublish-post-address"
+							readOnly
+							label={ sprintf(
+								/* translators: %s: post type singular name */
+								__( '%s address' ),
+								postLabel
+							) }
+							value={ safeDecodeURIComponent( link ) }
+							onFocus={ this.onSelectInput }
+						/>
+
+						<div className="post-publish-panel__postpublish-post-address__button-wrap">
+							<CopyButton text={ link } onCopy={ this.onCopy }>
+								{ this.state.showCopyConfirmation
+									? __( 'Copied!' )
+									: __( 'Copy' ) }
+							</CopyButton>
+						</div>
+					</div>
+
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (
 							<Button variant="secondary" href={ link }>
 								{ viewPostLabel }
 							</Button>
 						) }
-						<CopyButton text={ link } onCopy={ this.onCopy }>
-							{ this.state.showCopyConfirmation
-								? __( 'Copied!' )
-								: __( 'Copy Link' ) }
-						</CopyButton>
+						<Button variant="secondary" href={ addLink }>
+							{ addNewPostLabel }
+						</Button>
+					</div>
+					<div className="post-publish-panel__dashboard-link">
+						<Button variant="link" href={ dashboardLink }>
+							{ __( 'Back to dashboard' ) }
+						</Button>
 					</div>
 				</PanelBody>
 				{ children }

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -92,7 +92,6 @@ class PostPublishPanelPostpublish extends Component {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
-		const addNewPostLabel = get( postType, [ 'labels', 'add_new_item' ] );
 		const link =
 			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
 		const addLink = addQueryArgs( 'post-new.php', {
@@ -149,7 +148,7 @@ class PostPublishPanelPostpublish extends Component {
 							</Button>
 						) }
 						<Button variant="secondary" href={ addLink }>
-							{ addNewPostLabel }
+							{ __( 'Add Item' ) }
 						</Button>
 					</div>
 				</PanelBody>

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -141,6 +141,7 @@
 		height: auto;
 		justify-content: center;
 		padding: 3px 10px 4px;
+		flex: 1;
 		line-height: 1.6;
 		text-align: center;
 		white-space: normal;
@@ -151,8 +152,18 @@
 	}
 }
 
-.post-publish-panel__postpublish-post-address {
+.post-publish-panel__postpublish-post-address-container {
+	display: flex;
+	align-items: flex-end;
 	margin-bottom: $grid-unit-20;
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.post-publish-panel__postpublish-post-address {
+		flex: 1;
+	}
 
 	input[readonly] {
 		padding: 10px;
@@ -161,6 +172,16 @@
 		text-overflow: ellipsis;
 	}
 }
+
+.post-publish-panel__postpublish-post-address__button-wrap {
+	flex-shrink: 0;
+	margin-left: 0 !important;
+
+	.components-button {
+		height: 38px;
+	}
+}
+
 
 .post-publish-panel__postpublish-header {
 	font-weight: 500;
@@ -172,4 +193,23 @@
 
 .post-publish-panel__tip {
 	color: $alert-yellow;
+}
+
+.post-publish-panel__dashboard-link {
+	margin-top: $grid-unit-15;
+	display: flex;
+	justify-content: center;
+
+	.components-button {
+		color: inherit;
+		text-decoration: none;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	.post-publish-panel__postpublish-post-address__button-wrap {
+		.components-button {
+			height: 40px;
+		}
+	}
 }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -195,17 +195,6 @@
 	color: $alert-yellow;
 }
 
-.post-publish-panel__dashboard-link {
-	margin-top: $grid-unit-15;
-	display: flex;
-	justify-content: center;
-
-	.components-button {
-		color: inherit;
-		text-decoration: none;
-	}
-}
-
 @media screen and (max-width: 782px) {
 	.post-publish-panel__postpublish-post-address__button-wrap {
 		.components-button {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -173,14 +173,15 @@
 	}
 }
 
-.post-publish-panel__postpublish-post-address__button-wrap {
+.post-publish-panel__postpublish-post-address__copy-button-wrap {
 	flex-shrink: 0;
-	margin-left: 8px;
+	margin-left: 8px; // margin left for copy button
+
+	// match copy button height to the address field height
 	.components-button {
 		height: 38px;
 	}
 }
-
 
 .post-publish-panel__postpublish-header {
 	font-weight: 500;
@@ -196,6 +197,7 @@
 
 @media screen and (max-width: 782px) {
 	.post-publish-panel__postpublish-post-address__button-wrap {
+		// match copy button height to the address field height in smaller screens
 		.components-button {
 			height: 40px;
 		}

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -175,8 +175,7 @@
 
 .post-publish-panel__postpublish-post-address__button-wrap {
 	flex-shrink: 0;
-	margin-left: 0 !important;
-
+	margin-left: 8px;
 	.components-button {
 		height: 38px;
 	}


### PR DESCRIPTION

Fixes https://github.com/WordPress/gutenberg/issues/32099

## Description
Adds a create "New Page/Post" button at the end of the publish check panel.

## How has this been tested?
1. Create a New Post
2. Publish the post
3. Check the post publish panel

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/69596988/124869867-76470900-dfdf-11eb-94ec-38f993e4d45c.mov



## Types of changes
New nonbreaking feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
