### PR TITLE
Allow themes to provide empty values for `color.duotone` and `spacing.units`

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1073,7 +1073,6 @@ class WP_Theme_JSON_Gutenberg {
 		// For leaf values that are arrays it will use the numeric indexes for replacement.
 		// In those cases, we want to replace the existing with the incoming value, if it exists.
 		$to_replace   = array();
-		$to_replace[] = array( 'layout', 'units' );
 		$to_replace[] = array( 'spacing', 'units' );
 		$to_replace[] = array( 'color', 'duotone' );
 		foreach ( self::VALID_ORIGINS as $origin ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1086,8 +1086,8 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $nodes as $metadata ) {
 			foreach ( $to_replace as $property_path ) {
 				$path = array_merge( $metadata['path'], $property_path );
-				$node = _wp_array_get( $incoming_data, $path, array() );
-				if ( ! empty( $node ) ) {
+				$node = _wp_array_get( $incoming_data, $path, null );
+				if ( isset( $node ) ) {
 					gutenberg_experimental_set( $this->theme_json, $path, $node );
 				}
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1073,6 +1073,7 @@ class WP_Theme_JSON_Gutenberg {
 		// For leaf values that are arrays it will use the numeric indexes for replacement.
 		// In those cases, we want to replace the existing with the incoming value, if it exists.
 		$to_replace   = array();
+		$to_replace[] = array( 'layout', 'units' );
 		$to_replace[] = array( 'spacing', 'units' );
 		$to_replace[] = array( 'color', 'duotone' );
 		foreach ( self::VALID_ORIGINS as $origin ) {

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -22,7 +22,7 @@ import useSetting from '../../components/use-setting';
  */
 export default function LetterSpacingControl( { value, onChange } ) {
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
 		defaultValues: { px: '2', em: '.2', rem: '.2' },
 	} );
 	return (

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -45,7 +45,7 @@ export const BorderWidthEdit = ( props ) => {
 	};
 
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [ 'px', 'em', 'rem' ],
+		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
 	} );
 
 	return (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -39,7 +39,7 @@ function LayoutPanel( { setAttributes, attributes } ) {
 	}, [] );
 
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [
+		availableUnits: useSetting( 'spacing.units' ) || [
 			'%',
 			'px',
 			'em',

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -34,7 +34,7 @@ function ColumnEdit( {
 	} );
 
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [
+		availableUnits: useSetting( 'spacing.units' ) || [
 			'%',
 			'px',
 			'em',

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -62,7 +62,7 @@ function ColumnEdit( {
 	const [ widthUnit, setWidthUnit ] = useState( valueUnit || '%' );
 
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [
+		availableUnits: useSetting( 'spacing.units' ) || [
 			'%',
 			'px',
 			'em',

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -107,7 +107,7 @@ function ColumnsEditContainer( {
 	const { width } = sizes || {};
 
 	const units = useCustomUnits( {
-		availableUnits: useSetting( 'layout.units' ) || [
+		availableUnits: useSetting( 'spacing.units' ) || [
 			'%',
 			'px',
 			'em',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -708,6 +708,94 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_merge_incoming_data_empty_presets() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'      => array(
+						'duotone'   => array(
+							array(
+								'slug'   => 'value',
+								'colors' => array( 'red', 'green' ),
+							),
+						),
+						'gradients' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
+						),
+						'palette'   => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+							),
+						),
+					),
+					'spacing'    => array(
+						'units' => array( 'px', 'em' ),
+					),
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug'  => 'size',
+								'value' => 'size',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$theme_json->merge(
+			new WP_Theme_JSON_Gutenberg(
+				array(
+					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'settings' => array(
+						'color'      => array(
+							'duotone'   => array(),
+							'gradients' => array(),
+							'palette'   => array(),
+						),
+						'spacing'    => array(
+							'units' => array(),
+						),
+						'typography' => array(
+							'fontSizes' => array(),
+						),
+					),
+				)
+			)
+		);
+
+		$actual   = $theme_json->get_raw_data();
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'      => array(
+					'duotone'   => array(),
+					'gradients' => array(
+						'theme' => array(),
+					),
+					'palette'   => array(
+						'theme' => array(),
+					),
+				),
+				'spacing'    => array(
+					'units' => array(),
+				),
+				'typography' => array(
+					'fontSizes' => array(
+						'theme' => array(),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	function test_remove_insecure_properties_removes_unsafe_styles() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -796,6 +796,115 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_merge_incoming_data_null_presets() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'      => array(
+						'duotone'   => array(
+							array(
+								'slug'   => 'value',
+								'colors' => array( 'red', 'green' ),
+							),
+						),
+						'gradients' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
+						),
+						'palette'   => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+							),
+						),
+					),
+					'spacing'    => array(
+						'units' => array( 'px', 'em' ),
+					),
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug'  => 'size',
+								'value' => 'size',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$theme_json->merge(
+			new WP_Theme_JSON_Gutenberg(
+				array(
+					'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'settings' => array(
+						'color'      => array(
+							'custom' => false,
+						),
+						'spacing'    => array(
+							'customMargin' => false,
+						),
+						'typography' => array(
+							'customLineHeight' => false,
+						),
+					),
+				)
+			)
+		);
+
+		$actual   = $theme_json->get_raw_data();
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'      => array(
+					'custom'    => false,
+					'duotone'   => array(
+						array(
+							'slug'   => 'value',
+							'colors' => array( 'red', 'green' ),
+						),
+					),
+					'gradients' => array(
+						'theme' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
+						),
+					),
+					'palette'   => array(
+						'theme' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+							),
+						),
+					),
+				),
+				'spacing'    => array(
+					'customMargin' => false,
+					'units'        => array( 'px', 'em' ),
+				),
+				'typography' => array(
+					'customLineHeight' => false,
+					'fontSizes'        => array(
+						'theme' => array(
+							array(
+								'slug'  => 'size',
+								'value' => 'size',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	function test_remove_insecure_properties_removes_unsafe_styles() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -733,6 +733,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'layout'     => array(
+						'units' => array( 'px', 'em' ),
+					),
 					'spacing'    => array(
 						'units' => array( 'px', 'em' ),
 					),
@@ -758,6 +761,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'gradients' => array(),
 							'palette'   => array(),
 						),
+						'layout'     => array(
+							'units' => array(),
+						),
 						'spacing'    => array(
 							'units' => array(),
 						),
@@ -781,6 +787,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'palette'   => array(
 						'theme' => array(),
 					),
+				),
+				'layout'     => array(
+					'units' => array(),
 				),
 				'spacing'    => array(
 					'units' => array(),
@@ -821,6 +830,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'layout'     => array(
+						'units' => array( 'px', 'em' ),
+					),
 					'spacing'    => array(
 						'units' => array( 'px', 'em' ),
 					),
@@ -843,6 +855,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'settings' => array(
 						'color'      => array(
 							'custom' => false,
+						),
+						'layout'     => array(
+							'contentSize' => '610px',
 						),
 						'spacing'    => array(
 							'customMargin' => false,
@@ -883,6 +898,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+				),
+				'layout'     => array(
+					'contentSize' => '610px',
+					'units'       => array( 'px', 'em' ),
 				),
 				'spacing'    => array(
 					'customMargin' => false,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -733,9 +733,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'layout'     => array(
-						'units' => array( 'px', 'em' ),
-					),
 					'spacing'    => array(
 						'units' => array( 'px', 'em' ),
 					),
@@ -761,9 +758,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'gradients' => array(),
 							'palette'   => array(),
 						),
-						'layout'     => array(
-							'units' => array(),
-						),
 						'spacing'    => array(
 							'units' => array(),
 						),
@@ -787,9 +781,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'palette'   => array(
 						'theme' => array(),
 					),
-				),
-				'layout'     => array(
-					'units' => array(),
 				),
 				'spacing'    => array(
 					'units' => array(),
@@ -830,9 +821,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'layout'     => array(
-						'units' => array( 'px', 'em' ),
-					),
 					'spacing'    => array(
 						'units' => array( 'px', 'em' ),
 					),
@@ -855,9 +843,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'settings' => array(
 						'color'      => array(
 							'custom' => false,
-						),
-						'layout'     => array(
-							'contentSize' => '610px',
 						),
 						'spacing'    => array(
 							'customMargin' => false,
@@ -898,10 +883,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-				),
-				'layout'     => array(
-					'contentSize' => '610px',
-					'units'       => array( 'px', 'em' ),
 				),
 				'spacing'    => array(
 					'customMargin' => false,


### PR DESCRIPTION
This fixes an issue with the `color.duotone` & `spacing.units` in which empty values didn't override previous origins, resulting in that a theme couldn't provide an empty set for this via its `theme.json`.

## How to test

Use the TT1-blocks theme.

### Test empty units work as expected

- Set to empty those presets in its `theme.json`:
```json
{
  "settings": {
    "color": {
      "duotone": []
    },
    "spacing": {
       "units": []
    }
  }
}
```

- Go to the editor and add an image. Select the duotone control. The expected result is that the duotone control doesn't show any color, but still shows the shadow and highlight options.

![Captura de ecrã de 2021-07-08 11-38-45](https://user-images.githubusercontent.com/583546/124900174-1ea99d00-dfe1-11eb-9373-284c568d7b59.png)

- Add a cover block, select it and go to its inspector. The cover height and the padding should only show `px` units.

### Test filtered units work as expected

- Set to empty those presets in its `theme.json`:
```json
{
  "settings": {
    "color": {
      "duotone": [
        {
          "name":  "Dark grayscale" ,
          "colors": [ "#000000", "#7f7f7f" ],
          "slug": "dark-grayscale"
          }
      ]
    },
    "spacing": {
       "units": [ "px", "em" ]
    }
  }
}
```

- Go to the editor and add an image. Select the duotone control. The expected result is that the duotone control only has the one we added.
- Add a cover block, select it and go to its inspector. The cover height and the padding should only show the two units added by the theme (`px`, `em`).

### Test no units work as expected

- Remove `color.duotone` and `spacing.units` from the `theme.json` of TT1-blocks. 
- Check that the controls show a list of duotone colors and units in the cases above.

---

I've also tested passing an empty array to the other presets and this is how it should work: colors and gradients should still work as before: hide the list of preset values, but users still can add custom values. Font sizes should still work as before: hide the control.
