### PR TITLE
[Block Library - Query Loop]: Prevent block crashing when settting `0` items per page

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -61,11 +61,20 @@ export default function QueryToolbar( {
 										labelPosition="edge"
 										min={ 1 }
 										max={ 100 }
-										onChange={ ( value ) =>
-											setQuery( {
-												perPage: +value ?? -1,
-											} )
-										}
+										onChange={ ( value ) => {
+											/**
+											 * For now allow only a positive number and exclude `-1`
+											 * which will result in fetching all entities.
+											 */
+											const numValue = +value;
+											if (
+												numValue &&
+												numValue >= 1 &&
+												numValue <= 100
+											) {
+												setQuery( { perPage: +value } );
+											}
+										} }
 										step="1"
 										value={ query.perPage }
 										isDragEnabled={ false }

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -72,7 +72,9 @@ export default function QueryToolbar( {
 												numValue >= 1 &&
 												numValue <= 100
 											) {
-												setQuery( { perPage: +value } );
+												setQuery( {
+													perPage: numValue,
+												} );
 											}
 										} }
 										step="1"


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/33270


## Step-by-step reproduction instructions
1. Add a query loop block.
2. Using the block toolbar settings, set the items per page option under Display Settings to 0.
3. Verify that the block doesn't crash and if you focus out it will keep the previous inserted valid value
<!-- Please describe what you have changed or added -->

## Notes

1. In general this is relevant to `object` attributes and it's validation from GB.
2. `NumberControl` could be explored to augment the handling of values passed when `min,max` are provided.
3. Query Loop's initial set up of `perPage` should be handled differently per context ([issue](https://github.com/WordPress/gutenberg/issues/30369))
