### PR TITLE
Prevent entering invalid values in the Query Loop block config

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -61,11 +61,18 @@ export default function QueryToolbar( {
 										labelPosition="edge"
 										min={ 1 }
 										max={ 100 }
-										onChange={ ( value ) =>
+										onChange={ ( value ) => {
+											if (
+												isNaN( value ) ||
+												value < 1 ||
+												value > 100
+											) {
+												return;
+											}
 											setQuery( {
-												perPage: +value ?? -1,
-											} )
-										}
+												perPage: value,
+											} );
+										} }
 										step="1"
 										value={ query.perPage }
 										isDragEnabled={ false }
@@ -78,9 +85,16 @@ export default function QueryToolbar( {
 										labelPosition="edge"
 										min={ 0 }
 										max={ 100 }
-										onChange={ ( value ) =>
-											setQuery( { offset: +value } )
-										}
+										onChange={ ( value ) => {
+											if (
+												isNaN( value ) ||
+												value < 0 ||
+												value > 100
+											) {
+												return;
+											}
+											setQuery( { offset: value } );
+										} }
 										step="1"
 										value={ query.offset }
 										isDragEnabled={ false }
@@ -98,9 +112,12 @@ export default function QueryToolbar( {
 										label={ __( 'Max page to show' ) }
 										labelPosition="edge"
 										min={ 0 }
-										onChange={ ( value ) =>
-											setQuery( { pages: +value } )
-										}
+										onChange={ ( value ) => {
+											if ( isNaN( value ) || value < 0 ) {
+												return;
+											}
+											setQuery( { pages: value } );
+										} }
 										step="1"
 										value={ query.pages }
 										isDragEnabled={ false }


### PR DESCRIPTION
closes #33270 

Right now, you can enter `0` in the Query Loop per page config which will result in an infinite loop breaking the block.
This PR fixes that by adding some validation to the Query Loop Config inputs.

This more a stop gap fix for 5.8. I think a better solution would be to do that validation automatically in the `NumberControl` component. I tried this quickly but felt a bit impactful for 5.8 given how complex that component looks (not sure if that complexity is needed tbh) so I think I'd rather leave this for our components devs if you all have time, what do you think @ciampo @sarayourfriend. 

**Testing instructions**

 - Insert a query loop block
 - pick a variation
 - click the "Display settings" button in the toolbar and change the settings and try putting 0 I n the "items per page".
 - No error is displayed and the value reverts when you focus out of the input.