### PR TITLE
Navigation component: Fix item handling onClick twice

### DIFF
--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -63,14 +63,15 @@ export default function NavigationItem( props ) {
 		onClick( event );
 	};
 	const icon = isRTL() ? chevronLeft : chevronRight;
-	const baseProps = isText
+	const baseProps = children ? props : { ...props, onClick: undefined };
+	const itemProps = isText
 		? restProps
 		: { as: Button, href, onClick: onItemClick, ...restProps };
 
 	return (
-		<NavigationItemBase { ...props } className={ classes }>
+		<NavigationItemBase { ...baseProps } className={ classes }>
 			{ children || (
-				<ItemUI { ...baseProps }>
+				<ItemUI { ...itemProps }>
 					<NavigationItemBaseContent
 						title={ title }
 						badge={ badge }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Both `NavigationItemBase` and `ItemUI` registered an `onClick` event listener. This PR tries to ensure that it is only registered once on the right component. (`ItemUI`)

When `children` is specified then we leave the choice of adding `onClick` to the `NavigationItemBase` to the consumer. In other case, we use the default `ItemUI` component which means we need to remove the `onClick` from the props passed to `NavigationItemBase` to avoid double event handling.

## How has this been tested?
1. Open Site Editor
2. Open Navigation sidebar
3. Navigate to Content -> Pages
4. Switch to a page
5. Make sure SET_PAGE action is only fired once (Redux DevTools, `core/edit-site` instance)

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
