### PR TITLE
Build: Split config into two parts - blocks and packages

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -9,15 +9,7 @@ const fastGlob = require( 'fast-glob' );
 /**
  * Internal dependencies
  */
-const {
-	devtool,
-	mode,
-	moduleConfig,
-	optimization,
-	plugins,
-	stylesTransform,
-	watchOptions,
-} = require( './shared' );
+const { baseConfig, plugins, stylesTransform } = require( './shared' );
 
 /*
  * Matches a block's name in paths in the form
@@ -52,16 +44,14 @@ const createEntrypoints = () => {
 };
 
 module.exports = {
+	...baseConfig,
 	name: 'blocks',
-	optimization,
-	mode,
 	entry: createEntrypoints(),
 	output: {
 		devtoolNamespace: 'wp',
 		filename: './build/block-library/[name]/view.min.js',
 		path: join( __dirname, '..', '..' ),
 	},
-	module: moduleConfig,
 	plugins: [
 		...plugins,
 		new CopyWebpackPlugin( {
@@ -167,6 +157,4 @@ module.exports = {
 			),
 		} ),
 	].filter( Boolean ),
-	watchOptions,
-	devtool,
 };

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -1,0 +1,172 @@
+/**
+ * External dependencies
+ */
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const { escapeRegExp } = require( 'lodash' );
+const { join, sep } = require( 'path' );
+const fastGlob = require( 'fast-glob' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	devtool,
+	mode,
+	moduleConfig,
+	optimization,
+	plugins,
+	stylesTransform,
+	watchOptions,
+} = require( './shared' );
+
+/*
+ * Matches a block's name in paths in the form
+ * build-module/<blockName>/view.js
+ */
+const blockNameRegex = new RegExp( /(?<=build-module\/).*(?=(\/view))/g );
+
+const createEntrypoints = () => {
+	/*
+	 * Returns an array of paths to view.js files within the `@wordpress/block-library` package.
+	 * These paths can be matched by the regex `blockNameRegex` in order to extract
+	 * the block's name.
+	 *
+	 * Returns an empty array if no files were found.
+	 */
+	const blockViewScriptPaths = fastGlob.sync(
+		'./packages/block-library/build-module/**/view.js'
+	);
+
+	/*
+	 * Go through the paths found above, in order to define webpack entry points for
+	 * each block's view.js file.
+	 */
+	return blockViewScriptPaths.reduce( ( entries, scriptPath ) => {
+		const [ blockName ] = scriptPath.match( blockNameRegex );
+
+		return {
+			...entries,
+			[ 'blocks/' + blockName ]: scriptPath,
+		};
+	}, {} );
+};
+
+module.exports = {
+	name: 'blocks',
+	optimization,
+	mode,
+	entry: createEntrypoints(),
+	output: {
+		devtoolNamespace: 'wp',
+		filename: './build/block-library/[name]/view.min.js',
+		path: join( __dirname, '..', '..' ),
+	},
+	module: moduleConfig,
+	plugins: [
+		...plugins,
+		new CopyWebpackPlugin( {
+			patterns: [].concat(
+				[
+					'style',
+					'style-rtl',
+					'editor',
+					'editor-rtl',
+					'theme',
+					'theme-rtl',
+				].map( ( filename ) => ( {
+					from: `./packages/block-library/build-style/*/${ filename }.css`,
+					to( { absoluteFilename } ) {
+						const [ , dirname ] = absoluteFilename.match(
+							new RegExp(
+								`([\\w-]+)${ escapeRegExp(
+									sep
+								) }${ filename }\\.css$`
+							)
+						);
+
+						return join(
+							'build/block-library/blocks',
+							dirname,
+							filename + '.css'
+						);
+					},
+					transform: stylesTransform,
+				} ) ),
+				Object.entries( {
+					'./packages/block-library/src/':
+						'build/block-library/blocks/',
+					'./packages/edit-widgets/src/blocks/':
+						'build/edit-widgets/blocks/',
+					'./packages/widgets/src/blocks/': 'build/widgets/blocks/',
+				} ).flatMap( ( [ from, to ] ) => [
+					{
+						from: `${ from }/**/index.php`,
+						to( { absoluteFilename } ) {
+							const [ , dirname ] = absoluteFilename.match(
+								new RegExp(
+									`([\\w-]+)${ escapeRegExp(
+										sep
+									) }index\\.php$`
+								)
+							);
+
+							return join( to, `${ dirname }.php` );
+						},
+						transform: ( content ) => {
+							content = content.toString();
+
+							// Within content, search for any function definitions. For
+							// each, replace every other reference to it in the file.
+							return (
+								content
+									.match( /^function [^\(]+/gm )
+									.reduce( ( result, functionName ) => {
+										// Trim leading "function " prefix from match.
+										functionName = functionName.slice( 9 );
+
+										// Prepend the Gutenberg prefix, substituting any
+										// other core prefix (e.g. "wp_").
+										return result.replace(
+											new RegExp( functionName, 'g' ),
+											( match ) =>
+												'gutenberg_' +
+												match.replace( /^wp_/, '' )
+										);
+									}, content )
+									// The core blocks override procedure takes place in
+									// the init action default priority to ensure that core
+									// blocks would have been registered already. Since the
+									// blocks implementations occur at the default priority
+									// and due to WordPress hooks behavior not considering
+									// mutations to the same priority during another's
+									// callback, the Gutenberg build blocks are modified
+									// to occur at a later priority.
+									.replace(
+										/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
+										'$1, 20'
+									)
+							);
+						},
+						noErrorOnMissing: true,
+					},
+					{
+						from: `${ from }/*/block.json`,
+						to( { absoluteFilename } ) {
+							const [ , dirname ] = absoluteFilename.match(
+								new RegExp(
+									`([\\w-]+)${ escapeRegExp(
+										sep
+									) }block\\.json$`
+								)
+							);
+
+							return join( to, dirname, 'block.json' );
+						},
+					},
+				] )
+			),
+		} ),
+	].filter( Boolean ),
+	watchOptions,
+	devtool,
+};

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -1,22 +1,14 @@
 /**
  * External dependencies
  */
-const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
-const { DefinePlugin } = require( 'webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
-const TerserPlugin = require( 'terser-webpack-plugin' );
-const postcss = require( 'postcss' );
-const { escapeRegExp, compact } = require( 'lodash' );
-const { join, sep } = require( 'path' );
-const fastGlob = require( 'fast-glob' );
+const { join } = require( 'path' );
 
 /**
  * WordPress dependencies
  */
 const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
 const LibraryExportDefaultPlugin = require( '@wordpress/library-export-default-webpack-plugin' );
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
 const {
 	camelCaseDash,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/lib/util' );
@@ -25,11 +17,15 @@ const {
  * Internal dependencies
  */
 const { dependencies } = require( '../../package' );
-
 const {
-	NODE_ENV: mode = 'development',
-	WP_DEVTOOL: devtool = mode === 'production' ? false : 'source-map',
-} = process.env;
+	devtool,
+	mode,
+	moduleConfig,
+	optimization,
+	plugins,
+	stylesTransform,
+	watchOptions,
+} = require( './shared' );
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
@@ -43,149 +39,26 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
-const stylesTransform = ( content ) => {
-	if ( mode === 'production' ) {
-		return postcss( [
-			require( 'cssnano' )( {
-				preset: [
-					'default',
-					{
-						discardComments: {
-							removeAll: true,
-						},
-					},
-				],
-			} ),
-		] )
-			.process( content, {
-				from: 'src/app.css',
-				to: 'dest/app.css',
-			} )
-			.then( ( result ) => result.css );
-	}
-	return content;
-};
-
-/*
- * Matches a block's name in paths in the form
- * build-module/<blockName>/view.js
- */
-const blockNameRegex = new RegExp( /(?<=build-module\/).*(?=(\/view))/g );
-
-const createEntrypoints = () => {
-	/*
-	 * Returns an array of paths to view.js files within the `@wordpress/block-library` package.
-	 * These paths can be matched by the regex `blockNameRegex` in order to extract
-	 * the block's name.
-	 *
-	 * Returns an empty array if no files were found.
-	 */
-	const blockViewScriptPaths = fastGlob.sync(
-		'./packages/block-library/build-module/**/view.js'
-	);
-
-	/*
-	 * Go through the paths found above, in order to define webpack entry points for
-	 * each block's view.js file.
-	 */
-	const blockViewScriptEntries = blockViewScriptPaths.reduce(
-		( entries, scriptPath ) => {
-			const [ blockName ] = scriptPath.match( blockNameRegex );
-
-			return {
-				...entries,
-				[ 'blocks/' + blockName ]: scriptPath,
-			};
-		},
-		{}
-	);
-
-	const packageEntries = gutenbergPackages.reduce( ( memo, packageName ) => {
+module.exports = {
+	name: 'packages',
+	optimization,
+	mode,
+	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
 		return {
 			...memo,
 			[ packageName ]: `./packages/${ packageName }`,
 		};
-	}, {} );
-
-	return { ...packageEntries, ...blockViewScriptEntries };
-};
-
-module.exports = {
-	optimization: {
-		// Only concatenate modules in production, when not analyzing bundles.
-		concatenateModules:
-			mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
-		minimizer: [
-			new TerserPlugin( {
-				cache: true,
-				parallel: true,
-				sourceMap: mode !== 'production',
-				terserOptions: {
-					output: {
-						comments: /translators:/i,
-					},
-					compress: {
-						passes: 2,
-					},
-					mangle: {
-						reserved: [ '__', '_n', '_nx', '_x' ],
-					},
-				},
-				extractComments: false,
-			} ),
-		],
-	},
-	mode,
-	entry: createEntrypoints(),
+	}, {} ),
 	output: {
 		devtoolNamespace: 'wp',
-		filename: ( pathData ) => {
-			const { chunk } = pathData;
-			const { entryModule } = chunk;
-			const { rawRequest, rootModule } = entryModule;
-
-			// When processing ESM files, the requested path
-			// is defined in `entryModule.rootModule.rawRequest`, instead of
-			// being present in `entryModule.rawRequest`.
-			// In the context of frontend view files, they would be processed
-			// as ESM if they use `import` or `export` within it.
-			const request = rootModule?.rawRequest || rawRequest;
-
-			if ( request.includes( '/view.js' ) ) {
-				return `./build/block-library/[name]/view.min.js`;
-			}
-
-			return `./build/[name]/index.min.js`;
-		},
+		filename: './build/[name]/index.min.js',
 		path: join( __dirname, '..', '..' ),
 		library: [ 'wp', '[camelName]' ],
 		libraryTarget: 'window',
 	},
-	module: {
-		rules: compact( [
-			mode !== 'production' && {
-				test: /\.js$/,
-				use: require.resolve( 'source-map-loader' ),
-				enforce: 'pre',
-			},
-		] ),
-	},
+	module: moduleConfig,
 	plugins: [
-		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
-		// content as a convenient interactive zoomable treemap.
-		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
-		new DefinePlugin( {
-			// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
-			'process.env.GUTENBERG_PHASE': JSON.stringify(
-				parseInt(
-					process.env.npm_package_config_GUTENBERG_PHASE,
-					10
-				) || 1
-			),
-			'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
-				process.env.FORCE_REDUCED_MOTION
-			),
-		} ),
+		...plugins,
 		new CustomTemplatedPathPlugin( {
 			camelName( path, data ) {
 				return camelCaseDash( data.chunk.name );
@@ -202,120 +75,15 @@ module.exports = {
 			'warning',
 		] ),
 		new CopyWebpackPlugin( {
-			patterns: [].concat(
-				gutenbergPackages.map( ( packageName ) => ( {
-					from: `./packages/${ packageName }/build-style/*.css`,
-					to: `./build/${ packageName }/`,
-					flatten: true,
-					transform: stylesTransform,
-					noErrorOnMissing: true,
-				} ) ),
-				[
-					'style',
-					'style-rtl',
-					'editor',
-					'editor-rtl',
-					'theme',
-					'theme-rtl',
-				].map( ( filename ) => ( {
-					from: `./packages/block-library/build-style/*/${ filename }.css`,
-					to( { absoluteFilename } ) {
-						const [ , dirname ] = absoluteFilename.match(
-							new RegExp(
-								`([\\w-]+)${ escapeRegExp(
-									sep
-								) }${ filename }\\.css$`
-							)
-						);
-
-						return join(
-							'build/block-library/blocks',
-							dirname,
-							filename + '.css'
-						);
-					},
-					transform: stylesTransform,
-				} ) ),
-				Object.entries( {
-					'./packages/block-library/src/':
-						'build/block-library/blocks/',
-					'./packages/edit-widgets/src/blocks/':
-						'build/edit-widgets/blocks/',
-					'./packages/widgets/src/blocks/': 'build/widgets/blocks/',
-				} ).flatMap( ( [ from, to ] ) => [
-					{
-						from: `${ from }/**/index.php`,
-						to( { absoluteFilename } ) {
-							const [ , dirname ] = absoluteFilename.match(
-								new RegExp(
-									`([\\w-]+)${ escapeRegExp(
-										sep
-									) }index\\.php$`
-								)
-							);
-
-							return join( to, `${ dirname }.php` );
-						},
-						transform: ( content ) => {
-							content = content.toString();
-
-							// Within content, search for any function definitions. For
-							// each, replace every other reference to it in the file.
-							return (
-								content
-									.match( /^function [^\(]+/gm )
-									.reduce( ( result, functionName ) => {
-										// Trim leading "function " prefix from match.
-										functionName = functionName.slice( 9 );
-
-										// Prepend the Gutenberg prefix, substituting any
-										// other core prefix (e.g. "wp_").
-										return result.replace(
-											new RegExp( functionName, 'g' ),
-											( match ) =>
-												'gutenberg_' +
-												match.replace( /^wp_/, '' )
-										);
-									}, content )
-									// The core blocks override procedure takes place in
-									// the init action default priority to ensure that core
-									// blocks would have been registered already. Since the
-									// blocks implementations occur at the default priority
-									// and due to WordPress hooks behavior not considering
-									// mutations to the same priority during another's
-									// callback, the Gutenberg build blocks are modified
-									// to occur at a later priority.
-									.replace(
-										/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
-										'$1, 20'
-									)
-							);
-						},
-						noErrorOnMissing: true,
-					},
-					{
-						from: `${ from }/*/block.json`,
-						to( { absoluteFilename } ) {
-							const [ , dirname ] = absoluteFilename.match(
-								new RegExp(
-									`([\\w-]+)${ escapeRegExp(
-										sep
-									) }block\\.json$`
-								)
-							);
-
-							return join( to, dirname, 'block.json' );
-						},
-					},
-				] )
-			),
+			patterns: gutenbergPackages.map( ( packageName ) => ( {
+				from: `./packages/${ packageName }/build-style/*.css`,
+				to: `./build/${ packageName }/`,
+				flatten: true,
+				transform: stylesTransform,
+				noErrorOnMissing: true,
+			} ) ),
 		} ),
-		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-		mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 	].filter( Boolean ),
-	watchOptions: {
-		ignored: [ '**/node_modules', '**/packages/*/src' ],
-		aggregateTimeout: 500,
-	},
+	watchOptions,
 	devtool,
 };

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -17,15 +17,7 @@ const {
  * Internal dependencies
  */
 const { dependencies } = require( '../../package' );
-const {
-	devtool,
-	mode,
-	moduleConfig,
-	optimization,
-	plugins,
-	stylesTransform,
-	watchOptions,
-} = require( './shared' );
+const { baseConfig, plugins, stylesTransform } = require( './shared' );
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BUNDLED_PACKAGES = [ '@wordpress/icons', '@wordpress/interface' ];
@@ -40,9 +32,8 @@ const gutenbergPackages = Object.keys( dependencies )
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
 module.exports = {
+	...baseConfig,
 	name: 'packages',
-	optimization,
-	mode,
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
 		return {
 			...memo,
@@ -56,7 +47,6 @@ module.exports = {
 		library: [ 'wp', '[camelName]' ],
 		libraryTarget: 'window',
 	},
-	module: moduleConfig,
 	plugins: [
 		...plugins,
 		new CustomTemplatedPathPlugin( {
@@ -84,6 +74,4 @@ module.exports = {
 			} ) ),
 		} ),
 	].filter( Boolean ),
-	watchOptions,
-	devtool,
 };

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -18,6 +18,65 @@ const {
 	WP_DEVTOOL: devtool = mode === 'production' ? false : 'source-map',
 } = process.env;
 
+const baseConfig = {
+	optimization: {
+		// Only concatenate modules in production, when not analyzing bundles.
+		concatenateModules:
+			mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
+		minimizer: [
+			new TerserPlugin( {
+				cache: true,
+				parallel: true,
+				sourceMap: mode !== 'production',
+				terserOptions: {
+					output: {
+						comments: /translators:/i,
+					},
+					compress: {
+						passes: 2,
+					},
+					mangle: {
+						reserved: [ '__', '_n', '_nx', '_x' ],
+					},
+				},
+				extractComments: false,
+			} ),
+		],
+	},
+	mode,
+	module: {
+		rules: compact( [
+			mode !== 'production' && {
+				test: /\.js$/,
+				use: require.resolve( 'source-map-loader' ),
+				enforce: 'pre',
+			},
+		] ),
+	},
+	watchOptions: {
+		ignored: [ '**/node_modules', '**/packages/*/src' ],
+		aggregateTimeout: 500,
+	},
+	devtool,
+};
+
+const plugins = [
+	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+	// content as a convenient interactive zoomable treemap.
+	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
+	new DefinePlugin( {
+		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
+		'process.env.GUTENBERG_PHASE': JSON.stringify(
+			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
+		),
+		'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
+			process.env.FORCE_REDUCED_MOTION
+		),
+	} ),
+	new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
+];
+
 const stylesTransform = ( content ) => {
 	if ( mode === 'production' ) {
 		return postcss( [
@@ -41,69 +100,8 @@ const stylesTransform = ( content ) => {
 	return content;
 };
 
-const optimization = {
-	// Only concatenate modules in production, when not analyzing bundles.
-	concatenateModules:
-		mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
-	minimizer: [
-		new TerserPlugin( {
-			cache: true,
-			parallel: true,
-			sourceMap: mode !== 'production',
-			terserOptions: {
-				output: {
-					comments: /translators:/i,
-				},
-				compress: {
-					passes: 2,
-				},
-				mangle: {
-					reserved: [ '__', '_n', '_nx', '_x' ],
-				},
-			},
-			extractComments: false,
-		} ),
-	],
-};
-
-const moduleConfig = {
-	rules: compact( [
-		mode !== 'production' && {
-			test: /\.js$/,
-			use: require.resolve( 'source-map-loader' ),
-			enforce: 'pre',
-		},
-	] ),
-};
-
-const plugins = [
-	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
-	// content as a convenient interactive zoomable treemap.
-	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
-	new DefinePlugin( {
-		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
-		'process.env.GUTENBERG_PHASE': JSON.stringify(
-			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
-		),
-		'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
-			process.env.FORCE_REDUCED_MOTION
-		),
-	} ),
-	new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
-];
-
-const watchOptions = {
-	ignored: [ '**/node_modules', '**/packages/*/src' ],
-	aggregateTimeout: 500,
-};
-
 module.exports = {
-	devtool,
-	mode,
-	moduleConfig,
-	optimization,
+	baseConfig,
 	plugins,
 	stylesTransform,
-	watchOptions,
 };

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
+const { DefinePlugin } = require( 'webpack' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
+const { compact } = require( 'lodash' );
+const postcss = require( 'postcss' );
+
+/**
+ * WordPress dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
+
+const {
+	NODE_ENV: mode = 'development',
+	WP_DEVTOOL: devtool = mode === 'production' ? false : 'source-map',
+} = process.env;
+
+const stylesTransform = ( content ) => {
+	if ( mode === 'production' ) {
+		return postcss( [
+			require( 'cssnano' )( {
+				preset: [
+					'default',
+					{
+						discardComments: {
+							removeAll: true,
+						},
+					},
+				],
+			} ),
+		] )
+			.process( content, {
+				from: 'src/app.css',
+				to: 'dest/app.css',
+			} )
+			.then( ( result ) => result.css );
+	}
+	return content;
+};
+
+const optimization = {
+	// Only concatenate modules in production, when not analyzing bundles.
+	concatenateModules:
+		mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
+	minimizer: [
+		new TerserPlugin( {
+			cache: true,
+			parallel: true,
+			sourceMap: mode !== 'production',
+			terserOptions: {
+				output: {
+					comments: /translators:/i,
+				},
+				compress: {
+					passes: 2,
+				},
+				mangle: {
+					reserved: [ '__', '_n', '_nx', '_x' ],
+				},
+			},
+			extractComments: false,
+		} ),
+	],
+};
+
+const moduleConfig = {
+	rules: compact( [
+		mode !== 'production' && {
+			test: /\.js$/,
+			use: require.resolve( 'source-map-loader' ),
+			enforce: 'pre',
+		},
+	] ),
+};
+
+const plugins = [
+	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+	// content as a convenient interactive zoomable treemap.
+	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
+	new DefinePlugin( {
+		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
+		'process.env.GUTENBERG_PHASE': JSON.stringify(
+			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
+		),
+		'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
+			process.env.FORCE_REDUCED_MOTION
+		),
+	} ),
+	new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
+];
+
+const watchOptions = {
+	ignored: [ '**/node_modules', '**/packages/*/src' ],
+	aggregateTimeout: 500,
+};
+
+module.exports = {
+	devtool,
+	mode,
+	moduleConfig,
+	optimization,
+	plugins,
+	stylesTransform,
+	watchOptions,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+const blocksConfig = require( './tools/webpack/blocks' );
 const packagesConfig = require( './tools/webpack/packages' );
 
-module.exports = packagesConfig;
+module.exports = [ blocksConfig, packagesConfig ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Follow-up for https://github.com/WordPress/gutenberg/pull/33281.

This PR proposes to split webpack config into two subconfigs:

- packages
- blocks

It's similar to what's proposed in WordPress core in WordPress/wordpress-develop#1412. The main benefit is that we can have better control over the output generated for JavaScript files. In particular, for the block-related files, we shouldn't enforce `wp` global to be used. It also slightly decreases the size of files:

<img width="654" alt="Screen Shot 2021-07-08 at 16 32 14" src="https://user-images.githubusercontent.com/699132/124940300-27629900-e00a-11eb-9550-a2ca347c2f27.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run dev` and `npm run build` should work as before.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Refactoring

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
