### PR TITLE
Update conditions to hide duotone panel

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -169,6 +169,7 @@ The settings section has the following structure:
 	"settings": {
 		"color": {
 			"custom": true,
+			"customDuotone": true,
 			"customGradient": true,
 			"duotone": [],
 			"gradients": [],
@@ -220,6 +221,7 @@ The settings section has the following structure:
 		},
 		"color": {
 			"custom": true,
+			"customDuotone": true,
 			"customGradient": true,
 			"duotone": [],
 			"gradients": [],

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -85,6 +85,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'color'      => array(
 			'custom'         => null,
+			'customDuotone'  => null,
 			'customGradient' => null,
 			'duotone'        => null,
 			'gradients'      => null,

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -169,8 +169,9 @@
 				}
 			],
 			"custom": true,
-			"link": false,
-			"customGradient": true
+			"customDuotone": true,
+			"customGradient": true,
+			"link": false
 		},
 		"typography": {
 			"dropCap": true,

--- a/packages/block-editor/src/components/duotone-control/duotone-picker-popover.js
+++ b/packages/block-editor/src/components/duotone-control/duotone-picker-popover.js
@@ -11,6 +11,7 @@ function DuotonePickerPopover( {
 	duotonePalette,
 	colorPalette,
 	disableCustomColors,
+	disableCustomDuotone,
 } ) {
 	return (
 		<Popover
@@ -23,6 +24,7 @@ function DuotonePickerPopover( {
 					colorPalette={ colorPalette }
 					duotonePalette={ duotonePalette }
 					disableCustomColors={ disableCustomColors }
+					disableCustomDuotone={ disableCustomDuotone }
 					value={ value }
 					onChange={ onChange }
 				/>

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -15,6 +15,7 @@ function DuotoneControl( {
 	colorPalette,
 	duotonePalette,
 	disableCustomColors,
+	disableCustomDuotone,
 	value,
 	onChange,
 } ) {
@@ -51,6 +52,7 @@ function DuotoneControl( {
 					duotonePalette={ duotonePalette }
 					colorPalette={ colorPalette }
 					disableCustomColors={ disableCustomColors }
+					disableCustomDuotone={ disableCustomDuotone }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -20,10 +20,6 @@ function DuotoneControl( {
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	if ( ! duotonePalette ) {
-		return null;
-	}
-
 	const onToggle = () => {
 		setIsOpen( ( prev ) => ! prev );
 	};

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -120,13 +120,22 @@ ${ selector } {
 	);
 }
 
-function DuotonePanel( { attributes, setAttributes } ) {
+function DuotonePanel( { name, attributes, setAttributes } ) {
 	const style = attributes?.style;
 	const duotone = style?.color?.duotone;
 
 	const duotonePalette = useSetting( 'color.duotone' );
 	const colorPalette = useSetting( 'color.palette' );
 	const disableCustomColors = ! useSetting( 'color.custom' );
+
+	if (
+		! hasBlockSupport( name, 'color.__experimentalDuotone' ) ||
+		( duotonePalette?.length === 0 &&
+			colorPalette?.length === 0 &&
+			disableCustomColors )
+	) {
+		return null;
+	}
 
 	return (
 		<BlockControls group="block">
@@ -186,15 +195,10 @@ function addDuotoneAttributes( settings ) {
  */
 const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const hasDuotoneSupport = hasBlockSupport(
-			props.name,
-			'color.__experimentalDuotone'
-		);
-
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ hasDuotoneSupport && <DuotonePanel { ...props } /> }
+				<DuotonePanel { ...props } />
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -130,8 +130,8 @@ function DuotonePanel( { name, attributes, setAttributes } ) {
 
 	if (
 		! hasBlockSupport( name, 'color.__experimentalDuotone' ) ||
-		( duotonePalette?.length === 0 &&
-			colorPalette?.length === 0 &&
+		( ( ! duotonePalette || duotonePalette?.length === 0 ) &&
+			( ! colorPalette || colorPalette?.length === 0 ) &&
 			disableCustomColors )
 	) {
 		return null;

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -196,7 +196,7 @@ function addDuotoneAttributes( settings ) {
  */
 const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const hasDuotoneSupport = ! hasBlockSupport(
+		const hasDuotoneSupport = hasBlockSupport(
 			props.name,
 			'color.__experimentalDuotone'
 		);

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -21,6 +21,8 @@ import {
 	useSetting,
 } from '../components';
 
+const EMPTY_ARRAY = [];
+
 /**
  * Convert a list of colors to an object of R, G, and B values.
  *
@@ -124,14 +126,14 @@ function DuotonePanel( { name, attributes, setAttributes } ) {
 	const style = attributes?.style;
 	const duotone = style?.color?.duotone;
 
-	const duotonePalette = useSetting( 'color.duotone' );
-	const colorPalette = useSetting( 'color.palette' );
+	const duotonePalette = useSetting( 'color.duotone' ) || EMPTY_ARRAY;
+	const colorPalette = useSetting( 'color.palette' ) || EMPTY_ARRAY;
 	const disableCustomColors = ! useSetting( 'color.custom' );
 
 	if (
 		! hasBlockSupport( name, 'color.__experimentalDuotone' ) ||
-		( ( ! duotonePalette || duotonePalette?.length === 0 ) &&
-			( ! colorPalette || colorPalette?.length === 0 ) &&
+		( duotonePalette?.length === 0 &&
+			colorPalette?.length === 0 &&
 			disableCustomColors )
 	) {
 		return null;

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -122,7 +122,7 @@ ${ selector } {
 	);
 }
 
-function DuotonePanel( { name, attributes, setAttributes } ) {
+function DuotonePanel( { attributes, setAttributes } ) {
 	const style = attributes?.style;
 	const duotone = style?.color?.duotone;
 
@@ -133,10 +133,7 @@ function DuotonePanel( { name, attributes, setAttributes } ) {
 		! useSetting( 'color.customDuotone' ) ||
 		( colorPalette?.length === 0 && disableCustomColors );
 
-	if (
-		! hasBlockSupport( name, 'color.__experimentalDuotone' ) ||
-		( duotonePalette?.length === 0 && disableCustomDuotone )
-	) {
+	if ( duotonePalette?.length === 0 && disableCustomDuotone ) {
 		return null;
 	}
 
@@ -199,10 +196,15 @@ function addDuotoneAttributes( settings ) {
  */
 const withDuotoneControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		const hasDuotoneSupport = ! hasBlockSupport(
+			props.name,
+			'color.__experimentalDuotone'
+		);
+
 		return (
 			<>
 				<BlockEdit { ...props } />
-				<DuotonePanel { ...props } />
+				{ hasDuotoneSupport && <DuotonePanel { ...props } /> }
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -129,12 +129,13 @@ function DuotonePanel( { name, attributes, setAttributes } ) {
 	const duotonePalette = useSetting( 'color.duotone' ) || EMPTY_ARRAY;
 	const colorPalette = useSetting( 'color.palette' ) || EMPTY_ARRAY;
 	const disableCustomColors = ! useSetting( 'color.custom' );
+	const disableCustomDuotone =
+		! useSetting( 'color.customDuotone' ) ||
+		( colorPalette?.length === 0 && disableCustomColors );
 
 	if (
 		! hasBlockSupport( name, 'color.__experimentalDuotone' ) ||
-		( duotonePalette?.length === 0 &&
-			colorPalette?.length === 0 &&
-			disableCustomColors )
+		( duotonePalette?.length === 0 && disableCustomDuotone )
 	) {
 		return null;
 	}
@@ -144,6 +145,7 @@ function DuotonePanel( { name, attributes, setAttributes } ) {
 			<DuotoneControl
 				duotonePalette={ duotonePalette }
 				colorPalette={ colorPalette }
+				disableCustomDuotone={ disableCustomDuotone }
 				disableCustomColors={ disableCustomColors }
 				value={ duotone }
 				onChange={ ( newDuotone ) => {

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -29,43 +29,48 @@ function DuotonePicker( {
 		() => getDefaultColors( colorPalette ),
 		[ colorPalette ]
 	);
+
+	let duotonePresets = null;
+	if ( !! duotonePalette ) {
+		duotonePresets = duotonePalette.map( ( { colors, slug, name } ) => {
+			const style = {
+				background: getGradientFromCSSColors( colors, '135deg' ),
+				color: 'transparent',
+			};
+			const tooltipText =
+				name ??
+				sprintf(
+					// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
+					__( 'Duotone code: %s' ),
+					slug
+				);
+			const label = name
+				? sprintf(
+						// translators: %s: The name of the option e.g: "Dark grayscale".
+						__( 'Duotone: %s' ),
+						name
+				  )
+				: tooltipText;
+			const isSelected = isEqual( colors, value );
+
+			return (
+				<CircularOptionPicker.Option
+					key={ slug }
+					value={ colors }
+					isSelected={ isSelected }
+					aria-label={ label }
+					tooltipText={ tooltipText }
+					style={ style }
+					onClick={ () => {
+						onChange( isSelected ? undefined : colors );
+					} }
+				/>
+			);
+		} );
+	}
 	return (
 		<CircularOptionPicker
-			options={ duotonePalette.map( ( { colors, slug, name } ) => {
-				const style = {
-					background: getGradientFromCSSColors( colors, '135deg' ),
-					color: 'transparent',
-				};
-				const tooltipText =
-					name ??
-					sprintf(
-						// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
-						__( 'Duotone code: %s' ),
-						slug
-					);
-				const label = name
-					? sprintf(
-							// translators: %s: The name of the option e.g: "Dark grayscale".
-							__( 'Duotone: %s' ),
-							name
-					  )
-					: tooltipText;
-				const isSelected = isEqual( colors, value );
-
-				return (
-					<CircularOptionPicker.Option
-						key={ slug }
-						value={ colors }
-						isSelected={ isSelected }
-						aria-label={ label }
-						tooltipText={ tooltipText }
-						style={ style }
-						onClick={ () => {
-							onChange( isSelected ? undefined : colors );
-						} }
-					/>
-				);
-			} ) }
+			options={ duotonePresets }
 			actions={
 				<CircularOptionPicker.ButtonAction
 					onClick={ () => onChange( undefined ) }

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -77,25 +77,24 @@ function DuotonePicker( {
 			{ ! disableCustomColors && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
-			{ colorPalette && (
-				<ColorListPicker
-					labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
-					colors={ colorPalette }
-					value={ value }
-					disableCustomColors={ disableCustomColors }
-					onChange={ ( newColors ) => {
-						if ( ! newColors[ 0 ] ) {
-							newColors[ 0 ] = defaultDark;
-						}
-						if ( ! newColors[ 1 ] ) {
-							newColors[ 1 ] = defaultLight;
-						}
-						const newValue =
-							newColors.length >= 2 ? newColors : undefined;
-						onChange( newValue );
-					} }
-				/>
-			) }
+
+			<ColorListPicker
+				labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
+				colors={ colorPalette }
+				value={ value }
+				disableCustomColors={ disableCustomColors }
+				onChange={ ( newColors ) => {
+					if ( ! newColors[ 0 ] ) {
+						newColors[ 0 ] = defaultDark;
+					}
+					if ( ! newColors[ 1 ] ) {
+						newColors[ 1 ] = defaultLight;
+					}
+					const newValue =
+						newColors.length >= 2 ? newColors : undefined;
+					onChange( newValue );
+				} }
+			/>
 		</CircularOptionPicker>
 	);
 }

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -76,7 +76,7 @@ function DuotonePicker( {
 				</CircularOptionPicker.ButtonAction>
 			}
 		>
-			{ ! disableCustomColors && !disableCustomDuotone && (
+			{ ! disableCustomColors && ! disableCustomDuotone && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
 			{ ! disableCustomDuotone && (

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -77,7 +77,7 @@ function DuotonePicker( {
 			{ ! disableCustomColors && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
-			{ ( ! disableCustomColors || ( colorPalette?.length > 0 ) ) && (
+			{ ( ! disableCustomColors || colorPalette?.length > 0 ) && (
 				<ColorListPicker
 					labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
 					colors={ colorPalette }

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -76,7 +76,7 @@ function DuotonePicker( {
 				</CircularOptionPicker.ButtonAction>
 			}
 		>
-			{ ! disableCustomColors && (
+			{ ! disableCustomColors && !disableCustomDuotone && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
 			{ ! disableCustomDuotone && (

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -77,24 +77,25 @@ function DuotonePicker( {
 			{ ! disableCustomColors && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
-
-			<ColorListPicker
-				labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
-				colors={ colorPalette }
-				value={ value }
-				disableCustomColors={ disableCustomColors }
-				onChange={ ( newColors ) => {
-					if ( ! newColors[ 0 ] ) {
-						newColors[ 0 ] = defaultDark;
-					}
-					if ( ! newColors[ 1 ] ) {
-						newColors[ 1 ] = defaultLight;
-					}
-					const newValue =
-						newColors.length >= 2 ? newColors : undefined;
-					onChange( newValue );
-				} }
-			/>
+			{ ( ! disableCustomColors || ( colorPalette?.length > 0 ) ) && (
+				<ColorListPicker
+					labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
+					colors={ colorPalette }
+					value={ value }
+					disableCustomColors={ disableCustomColors }
+					onChange={ ( newColors ) => {
+						if ( ! newColors[ 0 ] ) {
+							newColors[ 0 ] = defaultDark;
+						}
+						if ( ! newColors[ 1 ] ) {
+							newColors[ 1 ] = defaultLight;
+						}
+						const newValue =
+							newColors.length >= 2 ? newColors : undefined;
+						onChange( newValue );
+					} }
+				/>
+			) }
 		</CircularOptionPicker>
 	);
 }

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -22,6 +22,7 @@ function DuotonePicker( {
 	colorPalette,
 	duotonePalette,
 	disableCustomColors,
+	disableCustomDuotone,
 	value,
 	onChange,
 } ) {
@@ -78,7 +79,7 @@ function DuotonePicker( {
 			{ ! disableCustomColors && (
 				<CustomDuotoneBar value={ value } onChange={ onChange } />
 			) }
-			{ ( ! disableCustomColors || colorPalette?.length > 0 ) && (
+			{ ! disableCustomDuotone && (
 				<ColorListPicker
 					labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
 					colors={ colorPalette }

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -30,47 +30,43 @@ function DuotonePicker( {
 		[ colorPalette ]
 	);
 
-	let duotonePresets = null;
-	if ( !! duotonePalette ) {
-		duotonePresets = duotonePalette.map( ( { colors, slug, name } ) => {
-			const style = {
-				background: getGradientFromCSSColors( colors, '135deg' ),
-				color: 'transparent',
-			};
-			const tooltipText =
-				name ??
-				sprintf(
-					// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
-					__( 'Duotone code: %s' ),
-					slug
-				);
-			const label = name
-				? sprintf(
-						// translators: %s: The name of the option e.g: "Dark grayscale".
-						__( 'Duotone: %s' ),
-						name
-				  )
-				: tooltipText;
-			const isSelected = isEqual( colors, value );
-
-			return (
-				<CircularOptionPicker.Option
-					key={ slug }
-					value={ colors }
-					isSelected={ isSelected }
-					aria-label={ label }
-					tooltipText={ tooltipText }
-					style={ style }
-					onClick={ () => {
-						onChange( isSelected ? undefined : colors );
-					} }
-				/>
-			);
-		} );
-	}
 	return (
 		<CircularOptionPicker
-			options={ duotonePresets }
+			options={ duotonePalette.map( ( { colors, slug, name } ) => {
+				const style = {
+					background: getGradientFromCSSColors( colors, '135deg' ),
+					color: 'transparent',
+				};
+				const tooltipText =
+					name ??
+					sprintf(
+						// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
+						__( 'Duotone code: %s' ),
+						slug
+					);
+				const label = name
+					? sprintf(
+							// translators: %s: The name of the option e.g: "Dark grayscale".
+							__( 'Duotone: %s' ),
+							name
+					  )
+					: tooltipText;
+				const isSelected = isEqual( colors, value );
+
+				return (
+					<CircularOptionPicker.Option
+						key={ slug }
+						value={ colors }
+						isSelected={ isSelected }
+						aria-label={ label }
+						tooltipText={ tooltipText }
+						style={ style }
+						onClick={ () => {
+							onChange( isSelected ? undefined : colors );
+						} }
+					/>
+				);
+			} ) }
 			actions={
 				<CircularOptionPicker.ButtonAction
 					onClick={ () => onChange( undefined ) }


### PR DESCRIPTION
Stems from this issue https://github.com/WordPress/gutenberg/pull/33280
Follows up https://github.com/WordPress/gutenberg/pull/32002 and https://github.com/WordPress/gutenberg/issues/31764

This updates the conditions to show/hide the duotone panel. See full panel enabled for reference:

![Captura de ecrã de 2021-07-08 17-03-19](https://user-images.githubusercontent.com/583546/124949441-dbb3ed80-e011-11eb-909e-3d4a8dee2f28.png)

- The duotone presets are hidden if `color.duotone` is empty or `null` (it no longer hides the whole duotone component if the `color.duotone` is null):

![Captura de ecrã de 2021-07-08 17-09-33](https://user-images.githubusercontent.com/583546/124946468-562f3e00-e00f-11eb-9bfd-09b69c209b6e.png)

- If `color.customDuotone` is false or ( `color.custom` is false and `color.palette` is empty) we have this:

![Captura de ecrã de 2021-07-08 21-33-44](https://user-images.githubusercontent.com/583546/124980374-9654e780-e034-11eb-8491-083702d914e2.png)

- If only `color.custom` is false we have this:

![Captura de ecrã de 2021-07-08 21-34-16](https://user-images.githubusercontent.com/583546/124980439-a967b780-e034-11eb-8ffd-a46de0f230b0.png)

- The shadows/highlight presets are hidden if `color.palette` is empty on null (the control is still visible if `color.custom` is not false):

![Captura de ecrã de 2021-07-08 17-02-59](https://user-images.githubusercontent.com/583546/124946070-ff296900-e00e-11eb-91b2-e3652de6a2f4.png)

- The duotone control is hidden if `color.duotone` is empty and `color.customDuotone` is false (and also if `color.palette` is empty and `color.custom` is false, independently from what the `color.customDuotone` value is):

![Captura de ecrã de 2021-07-08 17-01-11](https://user-images.githubusercontent.com/583546/124946614-752dd000-e00f-11eb-859a-ed6b8f77a804.png)
