### PR TITLE
Site Editor: Add a slot to replace the navigation sidebar content

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -6,65 +6,32 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalNavigation as Navigation,
-	__experimentalNavigationBackButton as NavigationBackButton,
-} from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import SiteMenu from './menus';
-import MainDashboardButton from '../../main-dashboard-button';
+import NavigationMenu from './navigation-menu';
 import { store as editSiteStore } from '../../../store';
-import { MENU_ROOT } from './constants';
 
 const NavigationPanel = ( { isOpen } ) => {
-	const {
-		page: { context: { postType, postId } = {} } = {},
-		editedPostId,
-		editedPostType,
-		activeMenu,
-		siteTitle,
-	} = useSelect( ( select ) => {
-		const {
-			getEditedPostType,
-			getEditedPostId,
-			getNavigationPanelActiveMenu,
-			getPage,
-		} = select( editSiteStore );
+	const { activeMenu, siteTitle } = useSelect( ( select ) => {
+		const { getNavigationPanelActiveMenu } = select( editSiteStore );
 		const { getEntityRecord } = select( coreDataStore );
 
 		const siteData =
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 		return {
-			page: getPage(),
-			editedPostId: getEditedPostId(),
-			editedPostType: getEditedPostType(),
 			activeMenu: getNavigationPanelActiveMenu(),
 			siteTitle: siteData.name,
 		};
 	}, [] );
 
-	const {
-		setNavigationPanelActiveMenu: setActive,
-		setIsNavigationPanelOpened,
-	} = useDispatch( editSiteStore );
-
-	let activeItem;
-	if ( activeMenu !== MENU_ROOT ) {
-		if ( activeMenu.startsWith( 'content' ) ) {
-			activeItem = `${ postType }-${ postId }`;
-		} else {
-			activeItem = `${ editedPostType }-${ editedPostId }`;
-		}
-	}
+	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
 
 	// Ensures focus is moved to the panel area when it is activated
 	// from a separate component (such as document actions in the header).
@@ -99,22 +66,7 @@ const NavigationPanel = ( { isOpen } ) => {
 					</div>
 				</div>
 				<div className="edit-site-navigation-panel__scroll-container">
-					<Navigation
-						activeItem={ activeItem }
-						activeMenu={ activeMenu }
-						onActivateMenu={ setActive }
-					>
-						{ activeMenu === MENU_ROOT && (
-							<MainDashboardButton.Slot>
-								<NavigationBackButton
-									backButtonLabel={ __( 'Dashboard' ) }
-									className="edit-site-navigation-panel__back-to-dashboard"
-									href="index.php"
-								/>
-							</MainDashboardButton.Slot>
-						) }
-						<SiteMenu />
-					</Navigation>
+					<NavigationMenu />
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -14,6 +14,7 @@ import { ESCAPE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
+import Navigation from './navigation';
 import NavigationMenu from './navigation-menu';
 import { store as editSiteStore } from '../../../store';
 
@@ -66,7 +67,9 @@ const NavigationPanel = ( { isOpen } ) => {
 					</div>
 				</div>
 				<div className="edit-site-navigation-panel__scroll-container">
-					<NavigationMenu />
+					<Navigation.Slot>
+						<NavigationMenu />
+					</Navigation.Slot>
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-menu.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation-menu.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalNavigation as Navigation,
+	__experimentalNavigationBackButton as NavigationBackButton,
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SiteMenu from './menus';
+import MainDashboardButton from '../../main-dashboard-button';
+import { store as editSiteStore } from '../../../store';
+import { MENU_ROOT } from './constants';
+
+export default function NavigationMenu() {
+	const {
+		activeMenu,
+		editedPostId,
+		editedPostType,
+		page: { context: { postType, postId } = {} } = {},
+	} = useSelect( ( select ) => {
+		const {
+			getEditedPostId,
+			getEditedPostType,
+			getNavigationPanelActiveMenu,
+			getPage,
+		} = select( editSiteStore );
+
+		return {
+			activeMenu: getNavigationPanelActiveMenu(),
+			editedPostId: getEditedPostId(),
+			editedPostType: getEditedPostType(),
+			page: getPage(),
+		};
+	}, [] );
+
+	const { setNavigationPanelActiveMenu } = useDispatch( editSiteStore );
+
+	let activeItem;
+	if ( activeMenu !== MENU_ROOT ) {
+		if ( activeMenu.startsWith( 'content' ) ) {
+			activeItem = `${ postType }-${ postId }`;
+		} else {
+			activeItem = `${ editedPostType }-${ editedPostId }`;
+		}
+	}
+
+	return (
+		<Navigation
+			activeItem={ activeItem }
+			activeMenu={ activeMenu }
+			onActivateMenu={ setNavigationPanelActiveMenu }
+		>
+			{ activeMenu === MENU_ROOT && (
+				<MainDashboardButton.Slot>
+					<NavigationBackButton
+						backButtonLabel={ __( 'Dashboard' ) }
+						className="edit-site-navigation-panel__back-to-dashboard"
+						href="index.php"
+					/>
+				</MainDashboardButton.Slot>
+			) }
+			<SiteMenu />
+		</Navigation>
+	);
+}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/navigation.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalUseSlot as useSlot,
+	createSlotFill,
+} from '@wordpress/components';
+
+const slotName = '__experimentalEditSiteNavigation';
+
+const { Fill, Slot: NavigationSlot } = createSlotFill( slotName );
+
+const Navigation = Fill;
+
+const Slot = ( { children } ) => {
+	const slot = useSlot( slotName );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
+	if ( ! hasFills ) {
+		return children;
+	}
+
+	return <NavigationSlot bubblesVirtually />;
+};
+
+Navigation.Slot = Slot;
+
+export default Navigation;

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -41,4 +41,5 @@ export function initialize( id, settings ) {
 }
 
 export { default as __experimentalMainDashboardButton } from './components/main-dashboard-button';
+export { default as __experimentalNavigation } from './components/navigation-sidebar/navigation-panel/navigation';
 export { default as __experimentalNavigationToggle } from './components/navigation-sidebar/navigation-toggle';


### PR DESCRIPTION
## Description

WIP

## How has this been tested?

- Activate a block-based theme such as TT1 Blocks.
- Open the Site Editor, and click on the WP/site icon in the top left.
- Check that the navigation sidebar works normally.
- Add this snippet of code to `packages/edit-site/src/plugins/index.js` to test the slot functionality.
```js
registerPlugin( 'edit-site-nav-test', {
	render: () => (
		<Navigation>
			<p>TEST</p>
		</Navigation>
	),
} );
```
- Reload the Site Editor and open the navigation sidebar again.
- Make sure its content has been replaced with "TEST! (See comparison screenshots to have a better idea of the expected changes.)

| Default navigation | Replaced with the test code |
| - | - |
| <img width="297" alt="Screenshot 2021-07-08 at 16 44 31" src="https://user-images.githubusercontent.com/2070010/124952006-c936b580-e00b-11eb-96be-5ec509dbf8f3.png"> | <img width="298" alt="Screenshot 2021-07-08 at 16 44 04" src="https://user-images.githubusercontent.com/2070010/124952020-cc31a600-e00b-11eb-94f1-61547deb824d.png"> |

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
