### PR TITLE
Specify what settings can be part of `settings.layout`

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -92,7 +92,10 @@ class WP_Theme_JSON_Gutenberg {
 			'palette'        => null,
 		),
 		'custom'     => null,
-		'layout'     => null,
+		'layout'     => array(
+			'contentSize' => null,
+			'wideSize'    => null,
+		),
 		'spacing'    => array(
 			'customMargin'  => null,
 			'customPadding' => null,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -16,6 +16,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'color'       => array(
 						'custom' => false,
 					),
+					'layout' => array(
+						'contentSize' => 'value',
+						'invalid/key' => 'value',
+					),
 					'invalid/key' => 'value',
 					'blocks'      => array(
 						'core/group' => array(
@@ -43,6 +47,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'color'  => array(
 				'custom' => false,
+			),
+			'layout' => array(
+				'contentSize' => 'value',
 			),
 			'blocks' => array(
 				'core/group' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -16,7 +16,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'color'       => array(
 						'custom' => false,
 					),
-					'layout' => array(
+					'layout'      => array(
 						'contentSize' => 'value',
 						'invalid/key' => 'value',
 					),


### PR DESCRIPTION
Stems from https://github.com/WordPress/gutenberg/pull/33280/ 

This PR makes it so that only the specific allowed settings can be part of `settings.layout`.

