### PR TITLE
Fix: Block panel should be hidden taking into account gradient block support

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -12,12 +12,19 @@ import ContrastChecker from '../components/contrast-checker';
 import InspectorControls from '../components/inspector-controls';
 import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
 
+const EMPTY_OBJECT = {};
+const DISABLE_GRADIENT_SETTINGS = {
+	disableCustomGradients: true,
+	gradients: [],
+};
+
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
 export default function ColorPanel( {
 	settings,
+	hasGradient,
 	clientId,
 	enableContrastChecking = true,
 } ) {
@@ -58,6 +65,9 @@ export default function ColorPanel( {
 				title={ __( 'Color' ) }
 				initialOpen={ false }
 				settings={ settings }
+				{ ...( hasGradient
+					? EMPTY_OBJECT
+					: DISABLE_GRADIENT_SETTINGS ) }
 			>
 				{ enableContrastChecking && (
 					<ContrastChecker

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -319,6 +319,7 @@ export function ColorEdit( props ) {
 
 	return (
 		<ColorPanel
+			hasGradient={ hasGradient }
 			enableContrastChecking={
 				// Turn on contrast checker for web only since it's not supported on mobile yet.
 				Platform.OS === 'web' && ! gradient && ! style?.color?.gradient


### PR DESCRIPTION

We had a bug on the color supports hook: If a block did not support gradients and colors are disable it is not possible to do anything on the color panel and it should not render. But we did not checked for gradient support on the supports hook so unless both colors and gradients are explicitly disabled the panel would appear.

Fixes: https://github.com/WordPress/gutenberg/issues/33304

## How has this been tested?
I repeated the steps on https://github.com/WordPress/gutenberg/issues/33304 and verified the issue does not happen anymore.
