### PR TITLE
Fix flaky widgets e2e tests by waiting for the snackbar correctly

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -51,16 +51,23 @@ describe( 'Widgets screen', () => {
 	beforeAll( async () => {
 		// TODO: Ideally we can bundle our test theme directly in the repo.
 		await activateTheme( 'twentytwenty' );
-		await deactivatePlugin(
-			'gutenberg-test-plugin-disables-the-css-animations'
-		);
+		// Reduced motion is needed to immediately show and dismiss the snackbars.
+		await page.emulateMediaFeatures( [
+			{
+				name: 'prefers-reduced-motion',
+				value: 'reduce',
+			},
+		] );
 		await deleteAllWidgets();
 	} );
 
 	afterAll( async () => {
-		await activatePlugin(
-			'gutenberg-test-plugin-disables-the-css-animations'
-		);
+		await page.emulateMediaFeatures( [
+			{
+				name: 'prefers-reduced-motion',
+				value: 'no-preference',
+			},
+		] );
 		await activateTheme( 'twentytwentyone' );
 	} );
 
@@ -888,14 +895,18 @@ async function saveWidgets() {
 	} );
 	await updateButton.click();
 
-	await findAll( {
+	// Expect the "Widgets saved." snackbar to appear.
+	const savedSnackbarQuery = {
+		role: 'button',
+		name: 'Dismiss this notice',
 		text: 'Widgets saved.',
-	} );
+	};
+	await expect( savedSnackbarQuery ).toBeFound();
 
-	// FIXME: The snackbar above is enough for the widget areas to get saved,
-	// but not enough for the widgets to get saved.
-	// eslint-disable-next-line no-restricted-syntax
-	await page.waitForTimeout( 500 );
+	// Close the snackbar.
+	const savedSnackbar = await find( savedSnackbarQuery );
+	await savedSnackbar.click();
+	await expect( savedSnackbarQuery ).not.toBeFound();
 }
 
 async function getSerializedWidgetAreas() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Related to #33275, but probably won't fix that entirely.

I think one reason behind the flaky e2e tests is that we are waiting for the wrong elements when the screen is being saved. We are waiting for elements with text of `Widgets saved.`, expecting it to be the snackbar element. But it turns out that there will always be a _a11y element_ that contains that text.

```html
<div id="a11y-speak-polite" class="a11y-speak-region" style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;" aria-live="polite" aria-relevant="additions text" aria-atomic="true">Widgets saved.&nbsp;</div>
```

Hence, the waiting resolves immediately, the widgets has not yet been saved. This is not always failing because we wait for another 500ms after saving, which is the root of the flakiness.

The solution is to correctly wait for the snackbar elements, and dismiss them once it's shown. We have to also enable **reduced motion** mode to disable the snackbar transition. (I think we should enable it for all of our e2e tests though, WDYT?)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
E2E tests should pass.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
