### PR TITLE
Enable drag and drop in List View, fix performance issues

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -19,7 +19,6 @@ const BlockDraggable = ( {
 	cloneClassname,
 	onDragStart,
 	onDragEnd,
-	elementId,
 } ) => {
 	const { srcRootClientId, isDraggable, icon } = useSelect(
 		( select ) => {
@@ -75,7 +74,6 @@ const BlockDraggable = ( {
 	return (
 		<Draggable
 			cloneClassname={ cloneClassname }
-			elementId={ elementId }
 			__experimentalTransferDataType="wp-blocks"
 			transferData={ transferData }
 			onDragStart={ ( event ) => {

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -60,10 +60,7 @@ const ListViewBlockContents = forwardRef(
 		} );
 
 		return (
-			<BlockDraggable
-				clientIds={ [ block.clientId ] }
-				elementId={ `list-view-block-${ block.clientId }` }
-			>
+			<BlockDraggable clientIds={ [ block.clientId ] }>
 				{ ( { draggable, onDragStart, onDragEnd } ) =>
 					__experimentalFeatures ? (
 						<ListViewBlockSlot

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -32,18 +32,11 @@ const ListViewBlockContents = forwardRef(
 		},
 		ref
 	) => {
-		const {
-			__experimentalFeatures,
-			blockDropTarget,
-		} = useListViewContext();
+		const { __experimentalFeatures } = useListViewContext();
 
 		const { clientId } = block;
 
-		const {
-			rootClientId,
-			blockMovingClientId,
-			selectedBlockInBlockEditor,
-		} = useSelect(
+		const { blockMovingClientId, selectedBlockInBlockEditor } = useSelect(
 			( select ) => {
 				const {
 					getBlockRootClientId,
@@ -62,27 +55,8 @@ const ListViewBlockContents = forwardRef(
 		const isBlockMoveTarget =
 			blockMovingClientId && selectedBlockInBlockEditor === clientId;
 
-		const {
-			rootClientId: dropTargetRootClientId,
-			clientId: dropTargetClientId,
-			dropPosition,
-		} = blockDropTarget || {};
-
-		const isDroppingBefore =
-			dropTargetRootClientId === rootClientId &&
-			dropTargetClientId === clientId &&
-			dropPosition === 'top';
-		const isDroppingAfter =
-			dropTargetRootClientId === rootClientId &&
-			dropTargetClientId === clientId &&
-			dropPosition === 'bottom';
-		const isDroppingToInnerBlocks =
-			dropTargetRootClientId === clientId && dropPosition === 'inside';
-
 		const className = classnames( 'block-editor-list-view-block-contents', {
-			'is-dropping-before': isDroppingBefore || isBlockMoveTarget,
-			'is-dropping-after': isDroppingAfter,
-			'is-dropping-to-inner-blocks': isDroppingToInnerBlocks,
+			'is-dropping-before': isBlockMoveTarget,
 		} );
 
 		return (

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -34,7 +34,7 @@ const ListViewBlockContents = forwardRef(
 	) => {
 		const {
 			__experimentalFeatures,
-			blockDropTarget = {},
+			blockDropTarget,
 		} = useListViewContext();
 
 		const { clientId } = block;
@@ -66,7 +66,7 @@ const ListViewBlockContents = forwardRef(
 			rootClientId: dropTargetRootClientId,
 			clientId: dropTargetClientId,
 			dropPosition,
-		} = blockDropTarget;
+		} = blockDropTarget || {};
 
 		const isDroppingBefore =
 			dropTargetRootClientId === rootClientId &&
@@ -117,7 +117,7 @@ const ListViewBlockContents = forwardRef(
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }
 							level={ level }
-							draggable={ draggable && __experimentalFeatures }
+							draggable={ draggable }
 							onDragStart={ onDragStart }
 							onDragEnd={ onDragEnd }
 							{ ...props }

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { Popover } from '@wordpress/components';
+import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useListViewContext } from './context';
+
+export default function ListViewDropIndicator( { listViewRef } ) {
+	const { blockDropTarget } = useListViewContext();
+
+	const { clientId, dropPosition } = blockDropTarget || {};
+
+	const blockElement = useMemo( () => {
+		if ( ! clientId || ! listViewRef.current ) {
+			return;
+		}
+
+		return listViewRef.current.ownerDocument.getElementById(
+			`list-view-block-${ clientId }`
+		);
+	}, [ clientId ] );
+
+	const style = useMemo( () => {
+		if ( ! blockElement ) {
+			return {};
+		}
+
+		return {
+			width: blockElement.offsetWidth,
+		};
+	}, [ blockElement ] );
+
+	const getAnchorRect = useCallback( () => {
+		if ( ! blockElement ) {
+			return {};
+		}
+
+		const ownerDocument = blockElement.ownerDocument;
+		const rect = blockElement.getBoundingClientRect();
+
+		if ( dropPosition === 'top' ) {
+			return {
+				top: rect.top - 2,
+				bottom: rect.top,
+				left: rect.left,
+				right: rect.right,
+				width: rect.width,
+				height: rect.height,
+				ownerDocument,
+			};
+		}
+
+		if ( dropPosition === 'bottom' || dropPosition === 'inside' ) {
+			return {
+				top: rect.bottom,
+				bottom: rect.bottom + 2,
+				left: rect.left,
+				right: rect.right,
+				width: rect.width,
+				height: rect.height,
+				ownerDocument,
+			};
+		}
+
+		return {};
+	}, [ blockElement, dropPosition ] );
+
+	if ( ! clientId ) {
+		return null;
+	}
+
+	return (
+		<Popover
+			noArrow
+			animate={ false }
+			getAnchorRect={ getAnchorRect }
+			focusOnMount={ false }
+			// position="bottom middle"
+			className="block-editor-list-view-drop-indicator"
+		>
+			<div
+				style={ style }
+				className="block-editor-list-view-drop-indicator__line"
+			/>
+		</Popover>
+	);
+}

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -15,13 +15,11 @@ export default function ListViewDropIndicator( {
 			return [];
 		}
 
-		const ownerDocument = listViewRef.current.ownerDocument;
-
 		// The rootClientId will be defined whenever dropping into inner
 		// block lists, but is undefined when dropping at the root level.
 		const _rootBlockElement = rootClientId
-			? ownerDocument.getElementById(
-					`list-view-block-${ rootClientId }`
+			? listViewRef.current.querySelector(
+					`[data-block="${ rootClientId }"]`
 			  )
 			: undefined;
 
@@ -29,7 +27,9 @@ export default function ListViewDropIndicator( {
 		// usually be inserted adjacent to it. It will be undefined when
 		// dropping a block into an empty block list.
 		const _blockElement = clientId
-			? ownerDocument.getElementById( `list-view-block-${ clientId }` )
+			? listViewRef.current.querySelector(
+					`[data-block="${ clientId }"]`
+			  )
 			: undefined;
 
 		return [ _rootBlockElement, _blockElement ];

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -44,11 +44,11 @@ export default function ListViewDropIndicator( { listViewRef } ) {
 
 		if ( dropPosition === 'top' ) {
 			return {
-				top: rect.top - 2,
+				top: rect.top,
 				bottom: rect.top,
 				left: rect.left,
 				right: rect.right,
-				width: rect.width,
+				width: 0,
 				height: rect.height,
 				ownerDocument,
 			};
@@ -57,10 +57,10 @@ export default function ListViewDropIndicator( { listViewRef } ) {
 		if ( dropPosition === 'bottom' || dropPosition === 'inside' ) {
 			return {
 				top: rect.bottom,
-				bottom: rect.bottom + 2,
+				bottom: rect.bottom,
 				left: rect.left,
 				right: rect.right,
-				width: rect.width,
+				width: 0,
 				height: rect.height,
 				ownerDocument,
 			};
@@ -79,7 +79,6 @@ export default function ListViewDropIndicator( { listViewRef } ) {
 			animate={ false }
 			getAnchorRect={ getAnchorRect }
 			focusOnMount={ false }
-			// position="bottom middle"
 			className="block-editor-list-view-drop-indicator"
 		>
 			<div

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -70,16 +70,12 @@ export default function ListView( {
 	);
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
-	let { ref: treeGridRef, target: blockDropTarget } = useListViewDropZone();
+	const { ref: treeGridRef, target: blockDropTarget } = useListViewDropZone();
 
 	const isMounted = useRef( false );
 	useEffect( () => {
 		isMounted.current = true;
 	}, [] );
-
-	if ( ! __experimentalFeatures ) {
-		blockDropTarget = undefined;
-	}
 
 	const expand = ( clientId ) => {
 		if ( ! clientId ) {

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -104,7 +104,6 @@ export default function ListView( {
 		() => ( {
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
-			blockDropTarget,
 			isTreeGridMounted: isMounted.current,
 			expandedState,
 			expand,
@@ -113,7 +112,6 @@ export default function ListView( {
 		[
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
-			blockDropTarget,
 			isMounted.current,
 			expandedState,
 			expand,
@@ -123,7 +121,10 @@ export default function ListView( {
 
 	return (
 		<ListViewContext.Provider value={ contextValue }>
-			<ListViewDropIndicator listViewRef={ elementRef } />
+			<ListViewDropIndicator
+				listViewRef={ elementRef }
+				blockDropTarget={ blockDropTarget }
+			/>
 			<TreeGrid
 				className="block-editor-list-view-tree"
 				aria-label={ __( 'Block navigation structure' ) }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -120,7 +120,7 @@ export default function ListView( {
 	);
 
 	return (
-		<ListViewContext.Provider value={ contextValue }>
+		<>
 			<ListViewDropIndicator
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
@@ -132,13 +132,15 @@ export default function ListView( {
 				onCollapseRow={ collapseRow }
 				onExpandRow={ expandRow }
 			>
-				<ListViewBranch
-					blocks={ clientIdsTree }
-					selectBlock={ selectEditorBlock }
-					selectedBlockClientIds={ selectedClientIds }
-					{ ...props }
-				/>
+				<ListViewContext.Provider value={ contextValue }>
+					<ListViewBranch
+						blocks={ clientIdsTree }
+						selectBlock={ selectEditorBlock }
+						selectedBlockClientIds={ selectedClientIds }
+						{ ...props }
+					/>
+				</ListViewContext.Provider>
 			</TreeGrid>
-		</ListViewContext.Provider>
+		</>
 	);
 }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 
+import { useMergeRefs } from '@wordpress/compose';
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import {
@@ -18,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import ListViewBranch from './branch';
 import { ListViewContext } from './context';
+import ListViewDropIndicator from './drop-indicator';
 import useListViewClientIds from './use-list-view-client-ids';
 import useListViewDropZone from './use-list-view-drop-zone';
 import { store as blockEditorStore } from '../../store';
@@ -70,7 +72,9 @@ export default function ListView( {
 	);
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
-	const { ref: treeGridRef, target: blockDropTarget } = useListViewDropZone();
+	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone();
+	const elementRef = useRef();
+	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef ] );
 
 	const isMounted = useRef( false );
 	useEffect( () => {
@@ -118,21 +122,22 @@ export default function ListView( {
 	);
 
 	return (
-		<TreeGrid
-			className="block-editor-list-view-tree"
-			aria-label={ __( 'Block navigation structure' ) }
-			ref={ treeGridRef }
-			onCollapseRow={ collapseRow }
-			onExpandRow={ expandRow }
-		>
-			<ListViewContext.Provider value={ contextValue }>
+		<ListViewContext.Provider value={ contextValue }>
+			<ListViewDropIndicator listViewRef={ elementRef } />
+			<TreeGrid
+				className="block-editor-list-view-tree"
+				aria-label={ __( 'Block navigation structure' ) }
+				ref={ treeGridRef }
+				onCollapseRow={ collapseRow }
+				onExpandRow={ expandRow }
+			>
 				<ListViewBranch
 					blocks={ clientIdsTree }
 					selectBlock={ selectEditorBlock }
 					selectedBlockClientIds={ selectedClientIds }
 					{ ...props }
 				/>
-			</ListViewContext.Provider>
-		</TreeGrid>
+			</TreeGrid>
+		</ListViewContext.Provider>
 	);
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -18,11 +18,22 @@
 	&.is-selected .block-editor-list-view-block-contents {
 		background: var(--wp-admin-theme-color);
 		color: $white;
+
+		// Hide selection styles while a user is dragging blocks/files etc.
+		.is-dragging-components-draggable & {
+			background: none;
+			color: $gray-900;
+		}
 	}
 	&.is-selected .block-editor-list-view-block-contents:focus {
 		box-shadow:
 			inset 0 0 0 1px $white,
 			0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+		// Hide focus styles while a user is dragging blocks/files etc.
+		.is-dragging-components-draggable & {
+			box-shadow: none;
+		}
 	}
 
 	&.is-branch-selected.is-selected .block-editor-list-view-block-contents {
@@ -64,6 +75,11 @@
 		&:hover,
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+			// Hide hover styles while a user is dragging blocks/files etc.
+			.is-dragging-components-draggable & {
+				box-shadow: none;
+			}
 		}
 		&:focus {
 			z-index: 1;
@@ -302,6 +318,14 @@ $block-navigation-max-indent: 8;
 
 	.block-editor-list-view-drop-indicator__line {
 		background: var(--wp-admin-theme-color);
-		height: 2px;
+		height: $border-width;
 	}
 }
+
+// Reset some popover defaults for the drop indicator.
+.block-editor-list-view-drop-indicator:not([data-y-axis="middle"][data-x-axis="right"]) > .components-popover__content {
+	margin-left: 0;
+	border: none;
+	box-shadow: none;
+}
+

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -80,28 +80,6 @@
 			border-top: 4px solid var(--wp-admin-theme-color);
 		}
 
-		&.is-dropping-after::before {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
-			bottom: -2px;
-			right: 0;
-			left: 0;
-			border-bottom: 4px solid var(--wp-admin-theme-color);
-		}
-
-		&.is-dropping-to-inner-blocks::before {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
-			bottom: -2px;
-			right: 0;
-			left: $icon-size;
-			border-bottom: 4px solid var(--wp-admin-theme-color);
-		}
-
 		.components-modal__content & {
 			padding-left: 0;
 			padding-right: 0;
@@ -317,4 +295,13 @@ $block-navigation-max-indent: 8;
 	transform: rotate(0deg);
 	transition: transform 0.2s ease;
 	@include reduce-motion("transition");
+}
+
+.block-editor-list-view-drop-indicator {
+	pointer-events: none;
+
+	.block-editor-list-view-drop-indicator__line {
+		background: var(--wp-admin-theme-color);
+		height: 2px;
+	}
 }

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -210,7 +210,9 @@ export default function useListViewDropZone() {
 	const throttled = useThrottle(
 		useCallback( ( event, currentTarget ) => {
 			const position = { x: event.clientX, y: event.clientY };
-			const isBlockDrag = !! event.dataTransfer.getData( 'wp-blocks' );
+			const isBlockDrag = !! event.dataTransfer.types.includes(
+				'wp-blocks'
+			);
 
 			const draggedBlockClientIds = isBlockDrag
 				? getDraggedBlockClientIds()

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -207,49 +207,51 @@ export default function useListViewDropZone() {
 		target || {};
 
 	const onBlockDrop = useOnBlockDrop( targetRootClientId, targetBlockIndex );
+
+	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(
-		useCallback( ( event, currentTarget ) => {
-			const position = { x: event.clientX, y: event.clientY };
-			const isBlockDrag = !! event.dataTransfer.types.includes(
-				'wp-blocks'
-			);
+		useCallback(
+			( event, currentTarget ) => {
+				const position = { x: event.clientX, y: event.clientY };
+				const isBlockDrag = !! draggedBlockClientIds?.length;
 
-			const draggedBlockClientIds = isBlockDrag
-				? getDraggedBlockClientIds()
-				: undefined;
+				const blockElements = Array.from(
+					currentTarget.querySelectorAll( '[data-block]' )
+				);
 
-			const blockElements = Array.from(
-				currentTarget.querySelectorAll( '[data-block]' )
-			);
+				const blocksData = blockElements.map( ( blockElement ) => {
+					const clientId = blockElement.dataset.block;
+					const rootClientId = getBlockRootClientId( clientId );
 
-			const blocksData = blockElements.map( ( blockElement ) => {
-				const clientId = blockElement.dataset.block;
-				const rootClientId = getBlockRootClientId( clientId );
+					return {
+						clientId,
+						rootClientId,
+						blockIndex: getBlockIndex( clientId, rootClientId ),
+						element: blockElement,
+						isDraggedBlock: isBlockDrag
+							? draggedBlockClientIds.includes( clientId )
+							: false,
+						innerBlockCount: getBlockCount( clientId ),
+						canInsertDraggedBlocksAsSibling: isBlockDrag
+							? canInsertBlocks(
+									draggedBlockClientIds,
+									rootClientId
+							  )
+							: true,
+						canInsertDraggedBlocksAsChild: isBlockDrag
+							? canInsertBlocks( draggedBlockClientIds, clientId )
+							: true,
+					};
+				} );
 
-				return {
-					clientId,
-					rootClientId,
-					blockIndex: getBlockIndex( clientId, rootClientId ),
-					element: blockElement,
-					isDraggedBlock: isBlockDrag
-						? draggedBlockClientIds.includes( clientId )
-						: false,
-					innerBlockCount: getBlockCount( clientId ),
-					canInsertDraggedBlocksAsSibling: isBlockDrag
-						? canInsertBlocks( draggedBlockClientIds, rootClientId )
-						: true,
-					canInsertDraggedBlocksAsChild: isBlockDrag
-						? canInsertBlocks( draggedBlockClientIds, clientId )
-						: true,
-				};
-			} );
+				const newTarget = getListViewDropTarget( blocksData, position );
 
-			const newTarget = getListViewDropTarget( blocksData, position );
-
-			if ( newTarget ) {
-				setTarget( newTarget );
-			}
-		}, [] ),
+				if ( newTarget ) {
+					setTarget( newTarget );
+				}
+			},
+			[ draggedBlockClientIds ]
+		),
 		200
 	);
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -50,6 +50,26 @@ exports[`Navigating the block hierarchy should navigate using the block hierarch
 <!-- /wp:columns -->"
 `;
 
+exports[`Navigating the block hierarchy should navigate using the list view sidebar 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph -->
+<p>First column</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph -->
+<p>Third column</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
 exports[`Navigating the block hierarchy should select the wrapper div for a group 1`] = `
 "<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -30,26 +30,6 @@ exports[`Navigating the block hierarchy should navigate block hierarchy using on
 <!-- /wp:columns -->"
 `;
 
-exports[`Navigating the block hierarchy should navigate using the block hierarchy dropdown menu 1`] = `
-"<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
-<div class=\\"wp-block-column\\"><!-- wp:paragraph -->
-<p>First column</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class=\\"wp-block-column\\"></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class=\\"wp-block-column\\"><!-- wp:paragraph -->
-<p>Third column</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->"
-`;
-
 exports[`Navigating the block hierarchy should navigate using the list view sidebar 1`] = `
 "<!-- wp:columns -->
 <div class=\\"wp-block-columns\\"><!-- wp:column -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/list-view.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/list-view.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List view allows a user to drag a block to a new sibling position 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2></h2>
+<!-- /wp:heading -->
+
+<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -10,7 +10,7 @@ import {
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
-async function openBlockNavigator() {
+async function openListViewSidebar() {
 	await pressKeyWithModifier( 'access', 'o' );
 	await page.waitForSelector( '.block-editor-list-view-leaf.is-selected' );
 }
@@ -35,7 +35,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await createNewPost();
 	} );
 
-	it( 'should navigate using the block hierarchy dropdown menu', async () => {
+	it( 'should navigate using the list view sidebar', async () => {
 		await insertBlock( 'Columns' );
 		await page.click( '[aria-label="Two columns; equal split"]' );
 
@@ -105,7 +105,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks using the keyboard.
-		await openBlockNavigator();
+		await openListViewSidebar();
 		await pressKeyTimes( 'ArrowUp', 2 );
 		await page.keyboard.press( 'Enter' );
 
@@ -150,7 +150,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await insertBlock( 'Image' );
 
 		// Return to first block.
-		await openBlockNavigator();
+		await openListViewSidebar();
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Space' );
 

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -16,9 +16,7 @@ async function dragAndDrop( draggableElement, targetElement, offsetY ) {
 		y: targetClickablePoint.y + offsetY,
 	};
 
-	return await page.mouse.dragAndDrop( draggablePoint, targetPoint, {
-		delay: 1000,
-	} );
+	return await page.mouse.dragAndDrop( draggablePoint, targetPoint );
 }
 
 describe( 'List view', () => {

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	insertBlock,
+	getEditedPostContent,
+	pressKeyWithModifier,
+} from '@wordpress/e2e-test-utils';
+
+async function dragAndDrop( draggableElement, targetElement, offsetY ) {
+	const draggableRect = await draggableElement.boundingBox();
+	const dragPosition = {
+		x: draggableRect.x + draggableRect.width / 2,
+		y: draggableRect.y + draggableRect.height / 2,
+	};
+
+	const targetRect = await targetElement.boundingBox();
+	const targetPosition = {
+		x: targetRect.x + targetRect.width / 2,
+		y: offsetY + targetRect.y + targetRect.height / 2,
+	};
+
+	return await page.mouse.dragAndDrop( dragPosition, targetPosition, {
+		delay: 1000,
+	} );
+}
+
+describe( 'List view', () => {
+	beforeAll( async () => {
+		await page.setDragInterception( true );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await page.setDragInterception( false );
+	} );
+
+	it( 'allows a user to drag a block to a new sibling position', async () => {
+		// Insert some blocks of different types.
+		await insertBlock( 'Heading' );
+		await insertBlock( 'Image' );
+		await insertBlock( 'Paragraph' );
+
+		// Open list view.
+		await pressKeyWithModifier( 'access', 'o' );
+
+		const paragraphBlock = await page.waitForXPath(
+			'//button[contains(., "Paragraph")][@draggable="true"]'
+		);
+
+		// Drag above the heading block
+		const headingBlock = await page.waitForXPath(
+			'//button[contains(., "Heading")][@draggable="true"]'
+		);
+
+		await dragAndDrop( paragraphBlock, headingBlock, -5 );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -9,19 +9,14 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 async function dragAndDrop( draggableElement, targetElement, offsetY ) {
-	const draggableRect = await draggableElement.boundingBox();
-	const dragPosition = {
-		x: draggableRect.x + draggableRect.width / 2,
-		y: draggableRect.y + draggableRect.height / 2,
+	const draggablePoint = await draggableElement.clickablePoint();
+	const targetClickablePoint = await targetElement.clickablePoint();
+	const targetPoint = {
+		x: targetClickablePoint.x,
+		y: targetClickablePoint.y + offsetY,
 	};
 
-	const targetRect = await targetElement.boundingBox();
-	const targetPosition = {
-		x: targetRect.x + targetRect.width / 2,
-		y: offsetY + targetRect.y + targetRect.height / 2,
-	};
-
-	return await page.mouse.dragAndDrop( dragPosition, targetPosition, {
+	return await page.mouse.dragAndDrop( draggablePoint, targetPoint, {
 		delay: 1000,
 	} );
 }


### PR DESCRIPTION
## Description
Fixes #25067
Fixes #29727

Enables list view drag and drop and fixes the performance issues.

List view's drag and drop has been implemented for a while, but disabled due to some performance issues were solved. The main problem is that previously the drag and drop system in List View used borders on each individual block for displaying the drop indicator. This means that when dragging over a list of block, each individual block has to re-render.

This change makes the drop indicator a separate popover element, which mirrors how the InsertionPoint component in the normal block list works. Only this single component now has to re-render, which improves things significantly in my tests.

## How has this been tested?
Some things to try:
- Drag and drop blocks around reordering as siblings
- Drag blocks into groups/columns
- Test using a large number of blocks

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
