### PR TITLE
Image block: fix replace link control styling

### DIFF
--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -1,4 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 // Used as a unique identifier for the "Create" option within search results.
 // Used to help distinguish the "Create" suggestion within the search results in
 // order to handle it as a unique case.
 export const CREATE_TYPE = '__CREATE__';
+
+export const DEFAULT_LINK_SETTINGS = [
+	{
+		id: 'opensInNewTab',
+		title: __( 'Open in new tab' ),
+	},
+];

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -21,6 +21,7 @@ import LinkControlSearchInput from './search-input';
 import LinkPreview from './link-preview';
 import useCreatePage from './use-create-page';
 import { ViewerFill } from './viewer-slot';
+import { DEFAULT_LINK_SETTINGS } from './constants';
 
 /**
  * Default properties associated with a link control value.
@@ -104,7 +105,7 @@ import { ViewerFill } from './viewer-slot';
 function LinkControl( {
 	searchInputPlaceholder,
 	value,
-	settings,
+	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,
 	onRemove,
 	noDirectEntry = false,
@@ -193,7 +194,7 @@ function LinkControl( {
 	const shownUnlinkControl =
 		onRemove && value && ! isEditingLink && ! isCreatingPage;
 
-	const showSettingsDrawer = settings?.length;
+	const showSettingsDrawer = !! settings?.length;
 
 	return (
 		<div
@@ -266,26 +267,25 @@ function LinkControl( {
 				/>
 			) }
 
-			{ showSettingsDrawer ||
-				( shownUnlinkControl && (
-					<div className="block-editor-link-control__tools">
-						<LinkControlSettingsDrawer
-							value={ value }
-							settings={ settings }
-							onChange={ onChange }
-						/>
-						{ shownUnlinkControl && (
-							<Button
-								className="block-editor-link-control__unlink"
-								isDestructive
-								variant="link"
-								onClick={ onRemove }
-							>
-								{ __( 'Unlink' ) }
-							</Button>
-						) }
-					</div>
-				) ) }
+			{ ( showSettingsDrawer || shownUnlinkControl ) && (
+				<div className="block-editor-link-control__tools">
+					<LinkControlSettingsDrawer
+						value={ value }
+						settings={ settings }
+						onChange={ onChange }
+					/>
+					{ shownUnlinkControl && (
+						<Button
+							className="block-editor-link-control__unlink"
+							isDestructive
+							variant="link"
+							onClick={ onRemove }
+						>
+							{ __( 'Unlink' ) }
+						</Button>
+					) }
+				</div>
+			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -190,6 +190,11 @@ function LinkControl( {
 		stopEditing();
 	};
 
+	const shownUnlinkControl =
+		onRemove && value && ! isEditingLink && ! isCreatingPage;
+
+	const showSettingsDrawer = settings?.length;
+
 	return (
 		<div
 			tabIndex={ -1 }
@@ -261,23 +266,26 @@ function LinkControl( {
 				/>
 			) }
 
-			<div className="block-editor-link-control__tools">
-				<LinkControlSettingsDrawer
-					value={ value }
-					settings={ settings }
-					onChange={ onChange }
-				/>
-				{ onRemove && value && ! isEditingLink && ! isCreatingPage && (
-					<Button
-						className="block-editor-link-control__unlink"
-						isDestructive
-						variant="link"
-						onClick={ onRemove }
-					>
-						{ __( 'Unlink' ) }
-					</Button>
-				) }
-			</div>
+			{ showSettingsDrawer ||
+				( shownUnlinkControl && (
+					<div className="block-editor-link-control__tools">
+						<LinkControlSettingsDrawer
+							value={ value }
+							settings={ settings }
+							onChange={ onChange }
+						/>
+						{ shownUnlinkControl && (
+							<Button
+								className="block-editor-link-control__unlink"
+								isDestructive
+								variant="link"
+								onClick={ onRemove }
+							>
+								{ __( 'Unlink' ) }
+							</Button>
+						) }
+					</div>
+				) ) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -9,18 +9,7 @@ import { noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, VisuallyHidden } from '@wordpress/components';
 
-const defaultSettings = [
-	{
-		id: 'opensInNewTab',
-		title: __( 'Open in new tab' ),
-	},
-];
-
-const LinkControlSettingsDrawer = ( {
-	value,
-	onChange = noop,
-	settings = defaultSettings,
-} ) => {
+const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	if ( ! settings || ! settings.length ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -27,7 +27,6 @@
 	}
 
 	.block-editor-link-control {
-		margin-top: -16px;
 		width: auto;
 
 		.components-base-control .components-base-control__field {
@@ -36,7 +35,6 @@
 
 		.block-editor-link-control__search-item-title {
 			max-width: 180px;
-			margin-top: $grid-unit-20;
 		}
 
 		.block-editor-link-control__search-item.is-current {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -23,7 +23,9 @@
 	padding: $grid-unit-15 $grid-unit-30 0;
 
 	.block-editor-media-replace-flow__image-url-label {
+		display: block;
 		top: $grid-unit-20;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.block-editor-link-control {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -29,7 +29,11 @@
 	}
 
 	.block-editor-link-control {
-		width: auto;
+		width: 200px; // hardcoded width avoids resizing of control when switching between preview/edit
+
+		.block-editor-url-input {
+			padding: 0; // cancel unnecessary default 1px padding in this case
+		}
 
 		.components-base-control .components-base-control__field {
 			margin-bottom: 0;
@@ -45,11 +49,12 @@
 		}
 
 		.block-editor-link-control__search-input.block-editor-link-control__search-input input[type="text"] {
-			margin: 16px 0 0 0;
+			margin: 0;
 			width: 100%;
 		}
 
 		.block-editor-link-control__search-actions {
+			top: 0; // cancel default top positioning
 			right: 4px;
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The DOM and styling updates to `<LinkControl>` necessitated by the introduction of the the rich link previews feature caused the Image block `Replace` flow dropdown to suffer a visual layout regression.

![123964709-c82ad600-d9c4-11eb-87f0-9378698b1c3f](https://user-images.githubusercontent.com/444434/125062061-e91ab780-e0a5-11eb-86a0-eee8704ff4d4.png)

This PR resolves this by aligning everything nicely again. See screenshots below.

Fixes https://github.com/WordPress/gutenberg/issues/33096

## How has this been tested?

* Add an Image block.
* Upload an Image and set it.
* Click `Replace` on the Image block.
* See the link UI without any obvious visual layout glitches.

## Screenshots <!-- if applicable -->

| Before | After |
| ------ | ------ | 
| ![123964709-c82ad600-d9c4-11eb-87f0-9378698b1c3f](https://user-images.githubusercontent.com/444434/125062061-e91ab780-e0a5-11eb-86a0-eee8704ff4d4.png) | <img width="445" alt="Screenshot 2021-07-09 at 11 08 49" src="https://user-images.githubusercontent.com/444434/125062217-0f405780-e0a6-11eb-87f0-e62a669da914.png"> |

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
