### PR TITLE
Skip unstable e2e tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -82,7 +82,7 @@ describe( 'Multi-entity save flow', () => {
 			expect( multiSaveButton ).toBeNull();
 		};
 
-		it( 'Save flow should work as expected.', async () => {
+		it.skip( 'Save flow should work as expected.', async () => {
 			await createNewPost();
 			// Edit the page some.
 			await page.click( '.editor-post-title' );

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -150,7 +150,7 @@ describe( 'Widgets Customizer', () => {
 		);
 	} );
 
-	it( 'should open the inspector panel', async () => {
+	it.skip( 'should open the inspector panel', async () => {
 		const widgetsPanel = await find( {
 			role: 'heading',
 			name: /Widgets/,


### PR DESCRIPTION
Unfortunately, some e2e tests remain very unstable.

 - customizing-widgets: Originates in track (see https://core.trac.wordpress.org/ticket/53562#comment:9 )
 - multi-entity-saving: unknown but probably similar to #33020 

It's becoming very blocking for PRs and work on the repo. Please if you have some time, check some of the skipped e2e tests and try to enable them again.