### PR TITLE
Editor: Extract snackbars into a separate component

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -226,6 +226,7 @@ function Layout( { styles } ) {
 						</>
 					)
 				}
+				notices={ <EditorSnackbars /> }
 				content={
 					<>
 						<EditorNotices />
@@ -258,20 +259,15 @@ function Layout( { styles } ) {
 					)
 				}
 				actions={
-					<>
-						<EditorSnackbars />
-						<ActionsPanel
-							closeEntitiesSavedStates={
-								closeEntitiesSavedStates
-							}
-							isEntitiesSavedStatesOpen={
-								entitiesSavedStatesCallback
-							}
-							setEntitiesSavedStatesCallback={
-								setEntitiesSavedStatesCallback
-							}
-						/>
-					</>
+					<ActionsPanel
+						closeEntitiesSavedStates={ closeEntitiesSavedStates }
+						isEntitiesSavedStatesOpen={
+							entitiesSavedStatesCallback
+						}
+						setEntitiesSavedStatesCallback={
+							setEntitiesSavedStatesCallback
+						}
+					/>
 				}
 				shortcuts={ {
 					previous: previousShortcut,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -247,31 +247,31 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
-					<>
-						<EditorSnackbars />
-						{ ! hasReducedUI &&
-							showBlockBreadcrumbs &&
-							! isMobileViewport &&
-							isRichEditingEnabled &&
-							mode === 'visual' && (
-								<div className="edit-post-layout__footer">
-									<BlockBreadcrumb
-										rootLabelText={ documentLabel }
-									/>
-								</div>
-							) }
-					</>
+					! hasReducedUI &&
+					showBlockBreadcrumbs &&
+					! isMobileViewport &&
+					isRichEditingEnabled &&
+					mode === 'visual' && (
+						<div className="edit-post-layout__footer">
+							<BlockBreadcrumb rootLabelText={ documentLabel } />
+						</div>
+					)
 				}
 				actions={
-					<ActionsPanel
-						closeEntitiesSavedStates={ closeEntitiesSavedStates }
-						isEntitiesSavedStatesOpen={
-							entitiesSavedStatesCallback
-						}
-						setEntitiesSavedStatesCallback={
-							setEntitiesSavedStatesCallback
-						}
-					/>
+					<>
+						<EditorSnackbars />
+						<ActionsPanel
+							closeEntitiesSavedStates={
+								closeEntitiesSavedStates
+							}
+							isEntitiesSavedStatesOpen={
+								entitiesSavedStatesCallback
+							}
+							setEntitiesSavedStatesCallback={
+								setEntitiesSavedStatesCallback
+							}
+						/>
+					</>
 				}
 				shortcuts={ {
 					previous: previousShortcut,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -12,6 +12,7 @@ import {
 	UnsavedChangesWarning,
 	EditorNotices,
 	EditorKeyboardShortcutsRegister,
+	EditorSnackbars,
 	store as editorStore,
 } from '@wordpress/editor';
 import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
@@ -246,15 +247,20 @@ function Layout( { styles } ) {
 					</>
 				}
 				footer={
-					! hasReducedUI &&
-					showBlockBreadcrumbs &&
-					! isMobileViewport &&
-					isRichEditingEnabled &&
-					mode === 'visual' && (
-						<div className="edit-post-layout__footer">
-							<BlockBreadcrumb rootLabelText={ documentLabel } />
-						</div>
-					)
+					<>
+						<EditorSnackbars />
+						{ ! hasReducedUI &&
+							showBlockBreadcrumbs &&
+							! isMobileViewport &&
+							isRichEditingEnabled &&
+							mode === 'visual' && (
+								<div className="edit-post-layout__footer">
+									<BlockBreadcrumb
+										rootLabelText={ documentLabel }
+									/>
+								</div>
+							) }
+					</>
 				}
 				actions={
 					<ActionsPanel

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -19,6 +19,7 @@ import {
 } from '@wordpress/interface';
 import {
 	EditorNotices,
+	EditorSnackbars,
 	EntitiesSavedStates,
 	UnsavedChangesWarning,
 	store as editorStore,
@@ -268,7 +269,12 @@ function Editor( { initialSettings } ) {
 												) }
 											</>
 										}
-										footer={ <BlockBreadcrumb /> }
+										footer={
+											<>
+												<EditorSnackbars />
+												<BlockBreadcrumb />
+											</>
+										}
 									/>
 									<Popover.Slot />
 									<PluginArea />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -243,6 +243,7 @@ function Editor( { initialSettings } ) {
 										}
 										actions={
 											<>
+												<EditorSnackbars />
 												{ isEntitiesSavedStatesOpen ? (
 													<EntitiesSavedStates
 														close={
@@ -269,12 +270,7 @@ function Editor( { initialSettings } ) {
 												) }
 											</>
 										}
-										footer={
-											<>
-												<EditorSnackbars />
-												<BlockBreadcrumb />
-											</>
-										}
+										footer={ <BlockBreadcrumb /> }
 									/>
 									<Popover.Slot />
 									<PluginArea />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -214,6 +214,7 @@ function Editor( { initialSettings } ) {
 												}
 											/>
 										}
+										notices={ <EditorSnackbars /> }
 										content={
 											<>
 												<EditorNotices />
@@ -243,7 +244,6 @@ function Editor( { initialSettings } ) {
 										}
 										actions={
 											<>
-												<EditorSnackbars />
 												{ isEntitiesSavedStatesOpen ? (
 													<EntitiesSavedStates
 														close={

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -6,7 +6,7 @@ import { filter } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { NoticeList, SnackbarList } from '@wordpress/components';
+import { NoticeList } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { store as noticesStore } from '@wordpress/notices';
@@ -25,9 +25,6 @@ export function EditorNotices( { notices, onRemove } ) {
 		isDismissible: false,
 		type: 'default',
 	} );
-	const snackbarNotices = filter( notices, {
-		type: 'snackbar',
-	} );
 
 	return (
 		<>
@@ -42,11 +39,6 @@ export function EditorNotices( { notices, onRemove } ) {
 			>
 				<TemplateValidationNotice />
 			</NoticeList>
-			<SnackbarList
-				notices={ snackbarNotices }
-				className="components-editor-notices__snackbar"
-				onRemove={ onRemove }
-			/>
 		</>
 	);
 }

--- a/packages/editor/src/components/editor-snackbars/index.js
+++ b/packages/editor/src/components/editor-snackbars/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { SnackbarList } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+export default function EditorSnackbars() {
+	const notices = useSelect(
+		( select ) => select( noticesStore ).getNotices(),
+		[]
+	);
+	const { removeNotice } = useDispatch( noticesStore );
+	const snackbarNotices = filter( notices, {
+		type: 'snackbar',
+	} );
+
+	return (
+		<SnackbarList
+			notices={ snackbarNotices }
+			className="components-editor-notices__snackbar"
+			onRemove={ removeNotice }
+		/>
+	);
+}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -11,6 +11,7 @@ export { default as EditorKeyboardShortcutsRegister } from './global-keyboard-sh
 export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
 export { default as EditorNotices } from './editor-notices';
+export { default as EditorSnackbars } from './editor-snackbars';
 export { default as EntitiesSavedStates } from './entities-saved-states';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as LocalAutosaveMonitor } from './local-autosave-monitor';

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -6,6 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+/**
+ * WordPress dependencies
+ */
 import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -31,6 +34,7 @@ function InterfaceSkeleton(
 		header,
 		sidebar,
 		secondarySidebar,
+		notices,
 		content,
 		drawer,
 		actions,
@@ -50,6 +54,8 @@ function InterfaceSkeleton(
 		drawer: __( 'Drawer' ),
 		/* translators: accessibility text for the top bar landmark region. */
 		header: __( 'Header' ),
+		/* translators: accessibility text for the notices landmark region. */
+		notices: __( 'Notices' ),
 		/* translators: accessibility text for the content landmark region. */
 		body: __( 'Content' ),
 		/* translators: accessibility text for the secondary sidebar landmark region. */
@@ -103,6 +109,16 @@ function InterfaceSkeleton(
 							tabIndex="-1"
 						>
 							{ secondarySidebar }
+						</div>
+					) }
+					{ !! notices && (
+						<div
+							className="interface-interface-skeleton__notices"
+							role="region"
+							aria-label={ mergedLabels.notices }
+							tabIndex="-1"
+						>
+							{ notices }
 						</div>
 					) }
 					<div

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -54,8 +54,6 @@ function InterfaceSkeleton(
 		drawer: __( 'Drawer' ),
 		/* translators: accessibility text for the top bar landmark region. */
 		header: __( 'Header' ),
-		/* translators: accessibility text for the notices landmark region. */
-		notices: __( 'Notices' ),
 		/* translators: accessibility text for the content landmark region. */
 		body: __( 'Content' ),
 		/* translators: accessibility text for the secondary sidebar landmark region. */
@@ -112,12 +110,7 @@ function InterfaceSkeleton(
 						</div>
 					) }
 					{ !! notices && (
-						<div
-							className="interface-interface-skeleton__notices"
-							role="region"
-							aria-label={ mergedLabels.notices }
-							tabIndex="-1"
-						>
+						<div className="interface-interface-skeleton__notices">
 							{ notices }
 						</div>
 					) }


### PR DESCRIPTION
## Description
Extracts snackbar notices list into a new component -  `EditorSnackbars,` which is rendered in the `InterfaceSkeleton` footer to avoid z-index context issues with Block Inserter.

Fixes #33114.

## How has this been tested?
1. Open Block Inserter.
2. Trigger snackbar notice.
3. The notice isn't hidden under the block inserter.

```js
wp.data.dispatch('core/notices').createSuccessNotice( 'Snackbar should be visible when block inserter is open', { type: 'snackbar' } );
```

## Screenshots <!-- if applicable -->

![CleanShot 2021-07-12 at 14 41 00](https://user-images.githubusercontent.com/240569/125275067-a06e3300-e31f-11eb-97a1-9865105ca161.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
