### PR TITLE
Add flex layout support to the block editor

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -25,6 +25,48 @@ function gutenberg_register_layout_support( $block_type ) {
 	}
 }
 
+function gutenberg_get_layout_style( $selector, $layout ) {
+	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
+
+	$style = '';
+	if ( $layout_type === 'default' ) {
+		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
+		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
+
+		$all_max_width_value  = $content_size ? $content_size : $wide_size;
+		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
+
+		// Make sure there is a single CSS rule, and all tags are stripped for security.
+		// TODO: Use `safecss_filter_attr` instead - once https://core.trac.wordpress.org/ticket/46197 is patched.
+		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
+		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
+
+		$style = '';
+		if ( $content_size || $wide_size ) {
+			$style  = "$selector > * {";
+			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
+			$style .= 'margin-left: auto !important;';
+			$style .= 'margin-right: auto !important;';
+			$style .= '}';
+
+			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
+
+			$style .= "$selector .alignfull { max-width: none; }";
+		}
+
+		$style .= "$selector .alignleft { float: left; margin-right: 2em; }";
+		$style .= "$selector .alignright { float: right; margin-left: 2em; }";
+	} else if ( $layout_type === 'flex' ) {
+		$style  = "$selector {";
+		$style .= "display: flex;";
+		$style .= "column-gap: 0.5em;";
+		$style .= "align-items: center;";
+		$style .= '}';
+	}
+
+	return $style;
+}
+
 /**
  * Renders the layout config to the block wrapper.
  *
@@ -50,33 +92,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$id           = uniqid();
-	$content_size = isset( $used_layout['contentSize'] ) ? $used_layout['contentSize'] : null;
-	$wide_size    = isset( $used_layout['wideSize'] ) ? $used_layout['wideSize'] : null;
-
-	$all_max_width_value  = $content_size ? $content_size : $wide_size;
-	$wide_max_width_value = $wide_size ? $wide_size : $content_size;
-
-	// Make sure there is a single CSS rule, and all tags are stripped for security.
-	// TODO: Use `safecss_filter_attr` instead - once https://core.trac.wordpress.org/ticket/46197 is patched.
-	$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
-	$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
-
-	$style = '';
-	if ( $content_size || $wide_size ) {
-		$style  = ".wp-container-$id > * {";
-		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-		$style .= 'margin-left: auto !important;';
-		$style .= 'margin-right: auto !important;';
-		$style .= '}';
-
-		$style .= ".wp-container-$id > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-
-		$style .= ".wp-container-$id .alignfull { max-width: none; }";
-	}
-
-	$style .= ".wp-container-$id .alignleft { float: left; margin-right: 2em; }";
-	$style .= ".wp-container-$id .alignright { float: right; margin-left: 2em; }";
-
+	$style = gutenberg_get_layout_style(".wp-container-$id", $used_layout);
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
@@ -99,17 +115,17 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	return $content;
 }
 
-// This can be removed when plugin support requires WordPress 5.8.0+.
-if ( ! function_exists( 'wp_render_layout_support_flag' ) ) {
-	// Register the block support.
-	WP_Block_Supports::get_instance()->register(
-		'layout',
-		array(
-			'register_attribute' => 'gutenberg_register_layout_support',
-		)
-	);
-	add_filter( 'render_block', 'gutenberg_render_layout_support_flag', 10, 2 );
+// Register the block support. (overrides core one).
+WP_Block_Supports::get_instance()->register(
+	'layout',
+	array(
+		'register_attribute' => 'gutenberg_register_layout_support',
+	)
+);
+if ( function_exists( 'wp_render_layout_support_flag' ) ) {
+	remove_filter( 'render_block', 'wp_render_layout_support_flag' );
 }
+add_filter( 'render_block', 'gutenberg_render_layout_support_flag', 10, 2 );
 
 /**
  * For themes without theme.json file, make sure

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -25,11 +25,19 @@ function gutenberg_register_layout_support( $block_type ) {
 	}
 }
 
+/**
+ * Generates the CSS corresponding to the provided layout.
+ *
+ * @param string $selector CSS selector.
+ * @param array  $layout   Layout object.
+ *
+ * @return string CSS style.
+ */
 function gutenberg_get_layout_style( $selector, $layout ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
 	$style = '';
-	if ( $layout_type === 'default' ) {
+	if ( 'default' === $layout_type ) {
 		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
 		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
 
@@ -56,11 +64,11 @@ function gutenberg_get_layout_style( $selector, $layout ) {
 
 		$style .= "$selector .alignleft { float: left; margin-right: 2em; }";
 		$style .= "$selector .alignright { float: right; margin-left: 2em; }";
-	} else if ( $layout_type === 'flex' ) {
+	} elseif ( 'flex' === $layout_type ) {
 		$style  = "$selector {";
-		$style .= "display: flex;";
-		$style .= "column-gap: 0.5em;";
-		$style .= "align-items: center;";
+		$style .= 'display: flex;';
+		$style .= 'column-gap: 0.5em;';
+		$style .= 'align-items: center;';
 		$style .= '}';
 	}
 
@@ -91,8 +99,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$id           = uniqid();
-	$style = gutenberg_get_layout_style(".wp-container-$id", $used_layout);
+	$id    = uniqid();
+	$style = gutenberg_get_layout_style( ".wp-container-$id", $used_layout );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -26,7 +26,7 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 		[]
 	);
 	const layout = useLayout();
-	const layoutType = getLayoutType( layout?.type ?? 'default' );
+	const layoutType = getLayoutType( layout?.type );
 	const layoutAlignments = layoutType.getAlignments( layout );
 
 	if ( themeSupportsLayout ) {

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -8,22 +8,35 @@ import { useSelect } from '@wordpress/data';
  */
 import { useLayout } from '../block-list/layout';
 import { store as blockEditorStore } from '../../store';
+import { getLayoutType } from '../../layouts';
 
 const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
 export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
-	const { wideControlsEnabled = false } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const settings = getSettings();
-		return {
-			wideControlsEnabled: settings.alignWide,
-		};
-	}, [] );
+	const { wideControlsEnabled = false, themeSupportsLayout } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const settings = getSettings();
+			return {
+				wideControlsEnabled: settings.alignWide,
+				themeSupportsLayout: settings.supportsLayout,
+			};
+		},
+		[]
+	);
 	const layout = useLayout();
-	const supportsAlignments = layout.type === 'default';
+	const layoutType = getLayoutType( layout?.type ?? 'default' );
+	const layoutAlignments = layoutType.getAlignments( layout );
 
-	if ( ! supportsAlignments ) {
+	if ( themeSupportsLayout ) {
+		return layoutAlignments.filter( ( control ) =>
+			controls.includes( control )
+		);
+	}
+
+	// Starting here, it's the fallback for themes not supporting the layout config.
+	if ( layoutType.name !== 'default' ) {
 		return [];
 	}
 	const { alignments: availableAlignments = DEFAULT_CONTROLS } = layout;

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -25,8 +25,7 @@ export function useLayout() {
 }
 
 export function LayoutStyle( { layout = {}, ...props } ) {
-	const type = layout.type ?? 'default';
-	const layoutType = getLayoutType( type );
+	const layoutType = getLayoutType( layout.type );
 
 	if ( layoutType ) {
 		return <layoutType.save layout={ layout } { ...props } />;

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -3,25 +3,14 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { getLayoutType } from '../../layouts';
+
 export const defaultLayout = { type: 'default' };
 
 const Layout = createContext( defaultLayout );
-
-function appendSelectors( selectors, append ) {
-	// Ideally we shouldn't need the `.editor-styles-wrapper` increased specificity here
-	// The problem though is that we have a `.editor-styles-wrapper p { margin: reset; }` style
-	// it's used to reset the default margin added by wp-admin to paragraphs
-	// so we need this to be higher speficity otherwise, it won't be applied to paragraphs inside containers
-	// When the post editor is fully iframed, this extra classname could be removed.
-
-	return selectors
-		.split( ',' )
-		.map(
-			( subselector ) =>
-				`.editor-styles-wrapper ${ subselector } ${ append }`
-		)
-		.join( ',' );
-}
 
 /**
  * Allows to define the layout.
@@ -35,62 +24,12 @@ export function useLayout() {
 	return useContext( Layout );
 }
 
-function DefaultLayoutStyle( { selector, layout = {} } ) {
-	const { contentSize, wideSize } = layout;
-
-	let style =
-		!! contentSize || !! wideSize
-			? `
-				${ appendSelectors( selector, '> *' ) } {
-					max-width: ${ contentSize ?? wideSize };
-					margin-left: auto !important;
-					margin-right: auto !important;
-				}
-
-				${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
-					max-width: ${ wideSize ?? contentSize };
-				}
-
-				${ appendSelectors( selector, '> [data-align="full"]' ) } {
-					max-width: none;
-				}
-			`
-			: '';
-
-	style += `
-		${ appendSelectors( selector, '> [data-align="left"]' ) } {
-			float: left;
-			margin-right: 2em;
-		}
-
-		${ appendSelectors( selector, '> [data-align="right"]' ) } {
-			float: right;
-			margin-left: 2em;
-		}
-	`;
-
-	return <style>{ style }</style>;
-}
-
-function FlexLayoutStyle( { selector } ) {
-	return (
-		<style>{ `${ selector } {
-		display: flex;
-		column-gap: 0.5em;
-		align-items: center;
-	}` }</style>
-	);
-}
-
 export function LayoutStyle( { layout = {}, ...props } ) {
 	const type = layout.type ?? 'default';
+	const layoutType = getLayoutType( type );
 
-	if ( type === 'default' ) {
-		return <DefaultLayoutStyle layout={ layout } { ...props } />;
-	}
-
-	if ( type === 'flex' ) {
-		return <FlexLayoutStyle layout={ layout } { ...props } />;
+	if ( layoutType ) {
+		return <layoutType.save layout={ layout } { ...props } />;
 	}
 
 	return null;

--- a/packages/block-editor/src/components/block-list/layout.js
+++ b/packages/block-editor/src/components/block-list/layout.js
@@ -35,7 +35,7 @@ export function useLayout() {
 	return useContext( Layout );
 }
 
-export function LayoutStyle( { selector, layout = {} } ) {
+function DefaultLayoutStyle( { selector, layout = {} } ) {
 	const { contentSize, wideSize } = layout;
 
 	let style =
@@ -70,4 +70,28 @@ export function LayoutStyle( { selector, layout = {} } ) {
 	`;
 
 	return <style>{ style }</style>;
+}
+
+function FlexLayoutStyle( { selector } ) {
+	return (
+		<style>{ `${ selector } {
+		display: flex;
+		column-gap: 0.5em;
+		align-items: center;
+	}` }</style>
+	);
+}
+
+export function LayoutStyle( { layout = {}, ...props } ) {
+	const type = layout.type ?? 'default';
+
+	if ( type === 'default' ) {
+		return <DefaultLayoutStyle layout={ layout } { ...props } />;
+	}
+
+	if ( type === 'flex' ) {
+		return <FlexLayoutStyle layout={ layout } { ...props } />;
+	}
+
+	return null;
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -251,15 +251,6 @@
 	&[data-clear="true"] {
 		float: none;
 	}
-
-	// This essentially duplicates the mobile styles for the appender component.
-	// It would be nice to be able to use element queries in that component instead https://github.com/tomhodgins/element-queries-spec
-	.block-editor-block-list__layout {
-		.block-editor-default-block-appender .block-editor-inserter {
-			left: auto;
-			right: $grid-unit-10;
-		}
-	}
 }
 
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -37,7 +42,9 @@ export function DefaultBlockAppender( {
 	return (
 		<div
 			data-root-client-id={ rootClientId || '' }
-			className="block-editor-default-block-appender"
+			className={ classnames( 'block-editor-default-block-appender', {
+				'has-visible-prompt': showPrompt,
+			} ) }
 		>
 			<p
 				tabIndex="0"

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -38,8 +38,6 @@
 // Left side.
 .block-editor-block-list__empty-block-inserter,
 .block-editor-default-block-appender .block-editor-inserter {
-	right: $grid-unit-10; // Show to the right on mobile.
-
 	@include break-small {
 		display: flex;
 		height: 100%;
@@ -48,4 +46,9 @@
 	&:disabled {
 		display: none;
 	}
+}
+
+.block-editor-default-block-appender.has-visible-prompt .block-editor-inserter,
+.block-editor-block-list__empty-block-inserter {
+	right: 0;
 }

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-  className="block-editor-default-block-appender"
+  className="block-editor-default-block-appender has-visible-prompt"
   data-root-client-id=""
 >
   <p
@@ -38,7 +38,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-  className="block-editor-default-block-appender"
+  className="block-editor-default-block-appender has-visible-prompt"
   data-root-client-id=""
 >
   <p

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -55,7 +55,8 @@ function UncontrolledInnerBlocks( props ) {
 		allowedBlocks,
 		templateLock,
 		captureToolbars,
-		orientation
+		orientation,
+		__experimentalLayout
 	);
 
 	useInnerBlockTemplateSync(

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -79,7 +79,7 @@ export default function useNestedSettingsUpdate(
 		if ( orientation !== undefined ) {
 			newSettings.orientation = orientation;
 		} else {
-			const layoutType = getLayoutType( layout?.type || 'default' );
+			const layoutType = getLayoutType( layout?.type );
 			newSettings.orientation = layoutType.getOrientation( layout );
 		}
 

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -9,6 +9,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { getLayoutType } from '../../layouts';
 
 /**
  * This hook is a side effect which updates the block-editor store when changes
@@ -27,13 +28,15 @@ import { store as blockEditorStore } from '../../store';
  *                                   the child block.
  * @param {string}   orientation     The direction in which the block
  *                                   should face.
+ * @param {Object}   layout          The layout object for the block container.
  */
 export default function useNestedSettingsUpdate(
 	clientId,
 	allowedBlocks,
 	templateLock,
 	captureToolbars,
-	orientation
+	orientation,
+	layout
 ) {
 	const { updateBlockListSettings } = useDispatch( blockEditorStore );
 
@@ -71,8 +74,13 @@ export default function useNestedSettingsUpdate(
 			newSettings.__experimentalCaptureToolbars = captureToolbars;
 		}
 
+		// Orientation depends on layout,
+		// ideally the separate orientation prop should be deprecated.
 		if ( orientation !== undefined ) {
 			newSettings.orientation = orientation;
+		} else {
+			const layoutType = getLayoutType( layout?.type || 'default' );
+			newSettings.orientation = layoutType.getOrientation( layout );
 		}
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
@@ -87,5 +95,6 @@ export default function useNestedSettingsUpdate(
 		captureToolbars,
 		orientation,
 		updateBlockListSettings,
+		layout,
 	] );
 }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -16,11 +16,8 @@ import {
 	ButtonGroup,
 	ToggleControl,
 	PanelBody,
-	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 import { useContext, createPortal } from '@wordpress/element';
 
 /**
@@ -31,6 +28,7 @@ import { InspectorControls } from '../components';
 import useSetting from '../components/use-setting';
 import { LayoutStyle } from '../components/block-list/layout';
 import { Head } from '../components/block-list/head';
+import { getLayoutType, getLayoutTypes } from '../layouts';
 
 const layoutBlockSupportKey = '__experimentalLayout';
 
@@ -57,6 +55,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 
 	const allowLayoutSwitching = canBlockSwitchLayout( blockName );
 	const { inherit = false, type = 'default' } = layout;
+	const layoutType = getLayoutType( type );
 
 	const onChangeType = ( newType ) =>
 		setAttributes( { layout: { type: newType } } );
@@ -82,8 +81,9 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 						onChange={ onChangeType }
 					/>
 				) }
-				{ ! inherit && type === 'default' && (
-					<LayoutDefaultEdit
+
+				{ ! inherit && layoutType && (
+					<layoutType.edit
 						layout={ layout }
 						onChange={ onChangeLayout }
 					/>
@@ -93,18 +93,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	);
 }
 
-const availableTypes = [
-	{
-		name: 'default',
-		label: __( 'Default' ),
-	},
-	{ name: 'flex', label: __( 'Flex' ) },
-];
-
 function LayoutTypeSwitcher( { type, onChange } ) {
 	return (
 		<ButtonGroup>
-			{ availableTypes.map( ( { name, label } ) => {
+			{ getLayoutTypes().map( ( { name, label } ) => {
 				return (
 					<Button
 						key={ name }
@@ -116,84 +108,6 @@ function LayoutTypeSwitcher( { type, onChange } ) {
 				);
 			} ) }
 		</ButtonGroup>
-	);
-}
-
-function LayoutDefaultEdit( { layout, onChange } ) {
-	const { wideSize, contentSize } = layout;
-	const units = useCustomUnits( {
-		availableUnits: useSetting( 'spacing.units' ) || [
-			'%',
-			'px',
-			'em',
-			'rem',
-			'vw',
-		],
-	} );
-
-	return (
-		<>
-			<div className="block-editor-hooks__layout-controls">
-				<div className="block-editor-hooks__layout-controls-unit">
-					<UnitControl
-						label={ __( 'Content' ) }
-						labelPosition="top"
-						__unstableInputWidth="80px"
-						value={ contentSize || wideSize || '' }
-						onChange={ ( nextWidth ) => {
-							nextWidth =
-								0 > parseFloat( nextWidth ) ? '0' : nextWidth;
-							onChange( {
-								...layout,
-								contentSize: nextWidth,
-							} );
-						} }
-						units={ units }
-					/>
-					<Icon icon={ positionCenter } />
-				</div>
-				<div className="block-editor-hooks__layout-controls-unit">
-					<UnitControl
-						label={ __( 'Wide' ) }
-						labelPosition="top"
-						__unstableInputWidth="80px"
-						value={ wideSize || contentSize || '' }
-						onChange={ ( nextWidth ) => {
-							nextWidth =
-								0 > parseFloat( nextWidth ) ? '0' : nextWidth;
-							onChange( {
-								...layout,
-								wideSize: nextWidth,
-							} );
-						} }
-						units={ units }
-					/>
-					<Icon icon={ stretchWide } />
-				</div>
-			</div>
-			<div className="block-editor-hooks__layout-controls-reset">
-				<Button
-					variant="secondary"
-					isSmall
-					disabled={ ! contentSize && ! wideSize }
-					onClick={ () =>
-						onChange( {
-							contentSize: undefined,
-							wideSize: undefined,
-							inherit: false,
-						} )
-					}
-				>
-					{ __( 'Reset' ) }
-				</Button>
-			</div>
-
-			<p className="block-editor-hooks__layout-controls-helptext">
-				{ __(
-					'Customize the width for all elements that are assigned to the center or wide columns.'
-				) }
-			</p>
-		</>
 	);
 }
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -9,10 +9,11 @@ import { has } from 'lodash';
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
 	Button,
+	ButtonGroup,
 	ToggleControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
@@ -31,28 +32,37 @@ import useSetting from '../components/use-setting';
 import { LayoutStyle } from '../components/block-list/layout';
 import { Head } from '../components/block-list/head';
 
-function LayoutPanel( { setAttributes, attributes } ) {
+const layoutBlockSupportKey = '__experimentalLayout';
+
+const canBlockSwitchLayout = ( blockTypeOrName ) => {
+	const layoutBlockSupportConfig = getBlockSupport(
+		blockTypeOrName,
+		layoutBlockSupportKey
+	);
+
+	return layoutBlockSupportConfig?.allowSwitching;
+};
+
+function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const { layout = {} } = attributes;
-	const { wideSize, contentSize, inherit = false } = layout;
 	const defaultLayout = useSetting( 'layout' );
 	const themeSupportsLayout = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().supportsLayout;
 	}, [] );
 
-	const units = useCustomUnits( {
-		availableUnits: useSetting( 'spacing.units' ) || [
-			'%',
-			'px',
-			'em',
-			'rem',
-			'vw',
-		],
-	} );
-
 	if ( ! themeSupportsLayout ) {
 		return null;
 	}
+
+	const allowLayoutSwitching = canBlockSwitchLayout( blockName );
+	const { inherit = false, type = 'default' } = layout;
+
+	const onChangeType = ( newType ) =>
+		setAttributes( { layout: { type: newType } } );
+	const onChangeLayout = ( newLayout ) =>
+		setAttributes( { layout: newLayout } );
+
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Layout' ) }>
@@ -65,81 +75,125 @@ function LayoutPanel( { setAttributes, attributes } ) {
 						}
 					/>
 				) }
-				{ ! inherit && (
-					<>
-						<div className="block-editor-hooks__layout-controls">
-							<div className="block-editor-hooks__layout-controls-unit">
-								<UnitControl
-									label={ __( 'Content' ) }
-									labelPosition="top"
-									__unstableInputWidth="80px"
-									value={ contentSize || wideSize || '' }
-									onChange={ ( nextWidth ) => {
-										nextWidth =
-											0 > parseFloat( nextWidth )
-												? '0'
-												: nextWidth;
-										setAttributes( {
-											layout: {
-												...layout,
-												contentSize: nextWidth,
-											},
-										} );
-									} }
-									units={ units }
-								/>
-								<Icon icon={ positionCenter } />
-							</div>
-							<div className="block-editor-hooks__layout-controls-unit">
-								<UnitControl
-									label={ __( 'Wide' ) }
-									labelPosition="top"
-									__unstableInputWidth="80px"
-									value={ wideSize || contentSize || '' }
-									onChange={ ( nextWidth ) => {
-										nextWidth =
-											0 > parseFloat( nextWidth )
-												? '0'
-												: nextWidth;
-										setAttributes( {
-											layout: {
-												...layout,
-												wideSize: nextWidth,
-											},
-										} );
-									} }
-									units={ units }
-								/>
-								<Icon icon={ stretchWide } />
-							</div>
-						</div>
-						<div className="block-editor-hooks__layout-controls-reset">
-							<Button
-								variant="secondary"
-								isSmall
-								disabled={ ! contentSize && ! wideSize }
-								onClick={ () =>
-									setAttributes( {
-										layout: {
-											contentSize: undefined,
-											wideSize: undefined,
-											inherit: false,
-										},
-									} )
-								}
-							>
-								{ __( 'Reset' ) }
-							</Button>
-						</div>
-					</>
+
+				{ ! inherit && allowLayoutSwitching && (
+					<LayoutTypeSwitcher
+						type={ type }
+						onChange={ onChangeType }
+					/>
 				) }
-				<p className="block-editor-hooks__layout-controls-helptext">
-					{ __(
-						'Customize the width for all elements that are assigned to the center or wide columns.'
-					) }
-				</p>
+				{ ! inherit && type === 'default' && (
+					<LayoutDefaultEdit
+						layout={ layout }
+						onChange={ onChangeLayout }
+					/>
+				) }
 			</PanelBody>
 		</InspectorControls>
+	);
+}
+
+const availableTypes = [
+	{
+		name: 'default',
+		label: __( 'Default' ),
+	},
+	{ name: 'flex', label: __( 'Flex' ) },
+];
+
+function LayoutTypeSwitcher( { type, onChange } ) {
+	return (
+		<ButtonGroup>
+			{ availableTypes.map( ( { name, label } ) => {
+				return (
+					<Button
+						key={ name }
+						isPressed={ type === name }
+						onClick={ () => onChange( name ) }
+					>
+						{ label }
+					</Button>
+				);
+			} ) }
+		</ButtonGroup>
+	);
+}
+
+function LayoutDefaultEdit( { layout, onChange } ) {
+	const { wideSize, contentSize } = layout;
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'spacing.units' ) || [
+			'%',
+			'px',
+			'em',
+			'rem',
+			'vw',
+		],
+	} );
+
+	return (
+		<>
+			<div className="block-editor-hooks__layout-controls">
+				<div className="block-editor-hooks__layout-controls-unit">
+					<UnitControl
+						label={ __( 'Content' ) }
+						labelPosition="top"
+						__unstableInputWidth="80px"
+						value={ contentSize || wideSize || '' }
+						onChange={ ( nextWidth ) => {
+							nextWidth =
+								0 > parseFloat( nextWidth ) ? '0' : nextWidth;
+							onChange( {
+								...layout,
+								contentSize: nextWidth,
+							} );
+						} }
+						units={ units }
+					/>
+					<Icon icon={ positionCenter } />
+				</div>
+				<div className="block-editor-hooks__layout-controls-unit">
+					<UnitControl
+						label={ __( 'Wide' ) }
+						labelPosition="top"
+						__unstableInputWidth="80px"
+						value={ wideSize || contentSize || '' }
+						onChange={ ( nextWidth ) => {
+							nextWidth =
+								0 > parseFloat( nextWidth ) ? '0' : nextWidth;
+							onChange( {
+								...layout,
+								wideSize: nextWidth,
+							} );
+						} }
+						units={ units }
+					/>
+					<Icon icon={ stretchWide } />
+				</div>
+			</div>
+			<div className="block-editor-hooks__layout-controls-reset">
+				<Button
+					variant="secondary"
+					isSmall
+					disabled={ ! contentSize && ! wideSize }
+					onClick={ () =>
+						onChange( {
+							contentSize: undefined,
+							wideSize: undefined,
+							inherit: false,
+						} )
+					}
+				>
+					{ __( 'Reset' ) }
+				</Button>
+			</div>
+
+			<p className="block-editor-hooks__layout-controls-helptext">
+				{ __(
+					'Customize the width for all elements that are assigned to the center or wide columns.'
+				) }
+			</p>
+		</>
 	);
 }
 
@@ -154,7 +208,7 @@ export function addAttribute( settings ) {
 	if ( has( settings.attributes, [ 'layout', 'type' ] ) ) {
 		return settings;
 	}
-	if ( hasBlockSupport( settings, '__experimentalLayout' ) ) {
+	if ( hasBlockSupport( settings, layoutBlockSupportKey ) ) {
 		settings.attributes = {
 			...settings.attributes,
 			layout: {
@@ -178,7 +232,7 @@ export const withInspectorControls = createHigherOrderComponent(
 		const { name: blockName } = props;
 		const supportLayout = hasBlockSupport(
 			blockName,
-			'__experimentalLayout'
+			layoutBlockSupportKey
 		);
 
 		return [
@@ -199,7 +253,7 @@ export const withInspectorControls = createHigherOrderComponent(
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
-		const supportLayout = hasBlockSupport( name, '__experimentalLayout' );
+		const supportLayout = hasBlockSupport( name, layoutBlockSupportKey );
 		const id = useInstanceId( BlockListBlock );
 		const defaultLayout = useSetting( 'layout' ) || {};
 		if ( ! supportLayout ) {

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -213,7 +213,7 @@ describe( 'align', () => {
 			act( () => {
 				wrapper = renderer.create(
 					<BlockEditorProvider
-						settings={ { alignWide: true } }
+						settings={ { alignWide: true, supportsLayout: false } }
 						value={ [] }
 					>
 						<EnhancedComponent

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -26,4 +26,8 @@ export default {
         }` }</style>
 		);
 	},
+
+	getOrientation() {
+		return 'horizontal';
+	},
 };

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -30,4 +30,8 @@ export default {
 	getOrientation() {
 		return 'horizontal';
 	},
+
+	getAlignments() {
+		return [];
+	},
 };

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { appendSelectors } from './utils';
+
+export default {
+	name: 'flex',
+
+	label: __( 'Flex' ),
+
+	edit() {
+		return null;
+	},
+
+	save: function FlexLayoutStyle( { selector } ) {
+		return (
+			<style>{ `${ appendSelectors( selector ) } {
+            display: flex;
+            column-gap: 0.5em;
+            align-items: center;
+        }` }</style>
+		);
+	},
+};

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -138,4 +138,8 @@ export default {
 
 		return <style>{ style }</style>;
 	},
+
+	getOrientation() {
+		return 'vertical';
+	},
 };

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '../components/use-setting';
+import { appendSelectors } from './utils';
+
+export default {
+	name: 'default',
+
+	label: __( 'Flow' ),
+
+	edit: function LayoutDefaultEdit( { layout, onChange } ) {
+		const { wideSize, contentSize } = layout;
+		const units = useCustomUnits( {
+			availableUnits: useSetting( 'spacing.units' ) || [
+				'%',
+				'px',
+				'em',
+				'rem',
+				'vw',
+			],
+		} );
+
+		return (
+			<>
+				<div className="block-editor-hooks__layout-controls">
+					<div className="block-editor-hooks__layout-controls-unit">
+						<UnitControl
+							label={ __( 'Content' ) }
+							labelPosition="top"
+							__unstableInputWidth="80px"
+							value={ contentSize || wideSize || '' }
+							onChange={ ( nextWidth ) => {
+								nextWidth =
+									0 > parseFloat( nextWidth )
+										? '0'
+										: nextWidth;
+								onChange( {
+									...layout,
+									contentSize: nextWidth,
+								} );
+							} }
+							units={ units }
+						/>
+						<Icon icon={ positionCenter } />
+					</div>
+					<div className="block-editor-hooks__layout-controls-unit">
+						<UnitControl
+							label={ __( 'Wide' ) }
+							labelPosition="top"
+							__unstableInputWidth="80px"
+							value={ wideSize || contentSize || '' }
+							onChange={ ( nextWidth ) => {
+								nextWidth =
+									0 > parseFloat( nextWidth )
+										? '0'
+										: nextWidth;
+								onChange( {
+									...layout,
+									wideSize: nextWidth,
+								} );
+							} }
+							units={ units }
+						/>
+						<Icon icon={ stretchWide } />
+					</div>
+				</div>
+				<div className="block-editor-hooks__layout-controls-reset">
+					<Button
+						variant="secondary"
+						isSmall
+						disabled={ ! contentSize && ! wideSize }
+						onClick={ () =>
+							onChange( {
+								contentSize: undefined,
+								wideSize: undefined,
+								inherit: false,
+							} )
+						}
+					>
+						{ __( 'Reset' ) }
+					</Button>
+				</div>
+
+				<p className="block-editor-hooks__layout-controls-helptext">
+					{ __(
+						'Customize the width for all elements that are assigned to the center or wide columns.'
+					) }
+				</p>
+			</>
+		);
+	},
+
+	save: function DefaultLayoutStyle( { selector, layout = {} } ) {
+		const { contentSize, wideSize } = layout;
+
+		let style =
+			!! contentSize || !! wideSize
+				? `
+					${ appendSelectors( selector, '> *' ) } {
+						max-width: ${ contentSize ?? wideSize };
+						margin-left: auto !important;
+						margin-right: auto !important;
+					}
+	
+					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
+						max-width: ${ wideSize ?? contentSize };
+					}
+	
+					${ appendSelectors( selector, '> [data-align="full"]' ) } {
+						max-width: none;
+					}
+				`
+				: '';
+
+		style += `
+			${ appendSelectors( selector, '> [data-align="left"]' ) } {
+				float: left;
+				margin-right: 2em;
+			}
+	
+			${ appendSelectors( selector, '> [data-align="right"]' ) } {
+				float: right;
+				margin-left: 2em;
+			}
+		`;
+
+		return <style>{ style }</style>;
+	},
+};

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -142,4 +142,14 @@ export default {
 	getOrientation() {
 		return 'vertical';
 	},
+
+	getAlignments( layout ) {
+		if ( layout.alignments !== undefined ) {
+			return layout.alignments;
+		}
+
+		return layout.contentSize || layout.wideSize
+			? [ 'wide', 'full', 'left', 'center', 'right' ]
+			: [ 'left', 'center', 'right' ];
+	},
 };

--- a/packages/block-editor/src/layouts/index.js
+++ b/packages/block-editor/src/layouts/index.js
@@ -12,7 +12,7 @@ const layoutTypes = [ flow, flex ];
  * @param {string} name - The name of the layout type.
  * @return {Object} Layout type.
  */
-export function getLayoutType( name ) {
+export function getLayoutType( name = 'default' ) {
 	return layoutTypes.find( ( layoutType ) => layoutType.name === name );
 }
 

--- a/packages/block-editor/src/layouts/index.js
+++ b/packages/block-editor/src/layouts/index.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import flex from './flex';
+import flow from './flow';
+
+const layoutTypes = [ flow, flex ];
+
+/**
+ * Retrieves a layout type by name.
+ *
+ * @param {string} name - The name of the layout type.
+ * @return {Object} Layout type.
+ */
+export function getLayoutType( name ) {
+	return layoutTypes.find( ( layoutType ) => layoutType.name === name );
+}
+
+/**
+ * Retrieves the available layout types.
+ *
+ * @return {Array} Layout types.
+ */
+export function getLayoutTypes() {
+	return layoutTypes;
+}

--- a/packages/block-editor/src/layouts/utils.js
+++ b/packages/block-editor/src/layouts/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Utility to generate the proper CSS selector for layout styles.
+ *
+ * @param {string|string[]} selectors - CSS selectors
+ * @param {boolean}         append    - string to append.
+ *
+ * @return {string} - CSS selector.
+ */
+export function appendSelectors( selectors, append = '' ) {
+	// Ideally we shouldn't need the `.editor-styles-wrapper` increased specificity here
+	// The problem though is that we have a `.editor-styles-wrapper p { margin: reset; }` style
+	// it's used to reset the default margin added by wp-admin to paragraphs
+	// so we need this to be higher speficity otherwise, it won't be applied to paragraphs inside containers
+	// When the post editor is fully iframed, this extra classname could be removed.
+
+	return selectors
+		.split( ',' )
+		.map(
+			( subselector ) =>
+				`.editor-styles-wrapper ${ subselector } ${ append }`
+		)
+		.join( ',' );
+}

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -32,9 +32,7 @@
 			"style": true,
 			"width": true
 		},
-		"__experimentalLayout": {
-			"allowSwitching": true
-		}
+		"__experimentalLayout": true
 	},
 	"editorStyle": "wp-block-group-editor",
 	"style": "wp-block-group"

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -32,7 +32,9 @@
 			"style": true,
 			"width": true
 		},
-		"__experimentalLayout": true
+		"__experimentalLayout": {
+			"allowSwitching": true
+		}
 	},
 	"editorStyle": "wp-block-group-editor",
 	"style": "wp-block-group"

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -39,7 +39,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
-			__experimentalLayout: usedLayout,
+			__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 		}
 	);
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
@@ -29,21 +28,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const { tagName: TagName = 'div', templateLock, layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
-	const { contentSize, wideSize } = usedLayout;
-	const _layout = useMemo( () => {
-		if ( themeSupportsLayout ) {
-			const alignments =
-				contentSize || wideSize
-					? [ 'wide', 'full', 'left', 'center', 'right' ]
-					: [ 'left', 'center', 'right' ];
-			return {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments,
-			};
-		}
-		return undefined;
-	}, [ themeSupportsLayout, contentSize, wideSize ] );
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps(
@@ -55,7 +39,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
-			__experimentalLayout: _layout,
+			__experimentalLayout: usedLayout,
 		}
 	);
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useMemo, RawHTML } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import {
 	useBlockProps,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -46,21 +46,6 @@ function EditableContent( { layout, context = {} } ) {
 	}, [] );
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
-	const { contentSize, wideSize } = usedLayout;
-	const _layout = useMemo( () => {
-		if ( themeSupportsLayout ) {
-			const alignments =
-				contentSize || wideSize
-					? [ 'wide', 'full', 'left', 'center', 'right' ]
-					: [ 'left', 'center', 'right' ];
-			return {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments,
-			};
-		}
-		return undefined;
-	}, [ themeSupportsLayout, contentSize, wideSize ] );
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,
@@ -73,7 +58,7 @@ function EditableContent( { layout, context = {} } ) {
 			value: blocks,
 			onInput,
 			onChange,
-			__experimentalLayout: _layout,
+			__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 		}
 	);
 	return <div { ...props } />;

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
@@ -37,6 +42,12 @@ const deprecated = [
 		},
 		supports: {
 			html: false,
+		},
+		migrate( attributes ) {
+			return {
+				...omit( attributes, [ 'layout' ] ),
+				displayLayout: attributes.layout,
+			};
 		},
 		save() {
 			return <InnerBlocks.Content />;

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -4,7 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { cloneBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorAdvancedControls,
@@ -45,25 +45,10 @@ export function QueryContent( { attributes, setAttributes } ) {
 	}, [] );
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
-	const { contentSize, wideSize } = usedLayout;
 	const blockProps = useBlockProps();
-	const _layout = useMemo( () => {
-		if ( themeSupportsLayout ) {
-			const alignments =
-				contentSize || wideSize
-					? [ 'wide', 'full', 'left', 'center', 'right' ]
-					: [ 'left', 'center', 'right' ];
-			return {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments,
-			};
-		}
-		return undefined;
-	}, [ themeSupportsLayout, contentSize, wideSize ] );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
-		__experimentalLayout: _layout,
+		__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 	} );
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -10,7 +10,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 
 export default function TemplatePartInnerBlocks( {
 	postId: id,
@@ -26,21 +25,6 @@ export default function TemplatePartInnerBlocks( {
 	}, [] );
 	const defaultLayout = useSetting( 'layout' ) || {};
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
-	const { contentSize, wideSize } = usedLayout;
-	const _layout = useMemo( () => {
-		if ( themeSupportsLayout ) {
-			const alignments =
-				contentSize || wideSize
-					? [ 'wide', 'full', 'left', 'center', 'right' ]
-					: [ 'left', 'center', 'right' ];
-			return {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments,
-			};
-		}
-		return undefined;
-	}, [ themeSupportsLayout, contentSize, wideSize ] );
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
@@ -55,7 +39,7 @@ export default function TemplatePartInnerBlocks( {
 		renderAppender: hasInnerBlocks
 			? undefined
 			: InnerBlocks.ButtonBlockAppender,
-		__experimentalLayout: _layout,
+		__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 	} );
 
 	return (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -137,7 +137,6 @@ export default function VisualEditor( { styles } ) {
 	};
 	const resizedCanvasStyles = useResizeCanvas( deviceType, isTemplateMode );
 	const defaultLayout = useSetting( 'layout' );
-	const { contentSize, wideSize } = defaultLayout || {};
 	const previewMode = 'is-' + deviceType.toLowerCase() + '-preview';
 
 	let animatedStyles = isTemplateMode
@@ -178,18 +177,11 @@ export default function VisualEditor( { styles } ) {
 		}
 
 		if ( themeSupportsLayout ) {
-			const alignments =
-				contentSize || wideSize
-					? [ 'wide', 'full', 'left', 'center', 'right' ]
-					: [ 'left', 'center', 'right' ];
-			return {
-				type: 'default',
-				// Find a way to inject this in the support flag code (hooks).
-				alignments,
-			};
+			return defaultLayout;
 		}
+
 		return undefined;
-	}, [ isTemplateMode, themeSupportsLayout, contentSize, wideSize ] );
+	}, [ isTemplateMode, themeSupportsLayout ] );
 
 	return (
 		<div

--- a/test/integration/fixtures/blocks/core__query__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-1.json
@@ -19,7 +19,7 @@
 				"sticky": "",
 				"inherit": true
 			},
-			"layout": {
+			"displayLayout": {
 				"type": "list"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"list"}} -->
+<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"}} -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->


### PR DESCRIPTION
closes #24473 
Related #27324 

**Note** This is still in early stages and requires a lot of feedback and iterations.

In the previous WordPress release, we introduced the `layout` config and the `__experimentalLayout` prop for inner blocks. The initial reason for these was to make alignments and content widths more declarative for themes. While this was an ambitious goal on its own and a hard one to achieve for the default layout, the goal has always been to absorb and support more kinds of layouts in the editor than the regular vertical list of blocks: think about containers with grid or flex display, absolute positioning...

This PR introduces the first "non-default" layout, the **flex** layout. It's less ambitious than the **grid** layout but it will allow us to prove the multi-layout support. 

In terms of UI: (this deserves a lot of design work, this is very rough on purpose for now, just to get it working)

 - [x] This PR adds a layout type selector to the "group" block, meaning the group block can be now defined as having a **"flex layout"**
 - [x] When a container has a flex layout, children of that container should be rendered as flex children (horizontally by default)
 - Several things need to happen to the editor UI (not implemented entirely yet)
     - [x] By default, the movers and UI should adapt as if it was defined as "horizontal" orientation
     - [x] Alignment controls from inner blocks should disappear
  - The container should allow defining a few properties for this layout (not implemented yet)
      - [ ] The gap (column or row gap)
      - [ ] The orientation (by default vertical for flex containers)
      - [ ] Align items (by default items are centered)
      - [ ] Justify content (by default nothing)

In terms of DevX and APIs:

 - [x] This PRs adds a flag to the layout block support config to allow switching layout types for specific blocks, it's enabled for group blocks only right now. `__experimentalLayout: { allowSwitching: true }` 
 - [x] Extract all layout specific code (Edit component, generating styles, config) into layout type objects, adding a layout (like grid) would mean adding a new layout type object.

**Notes**

Right now, this layout is already used in several blocks in an adhoc way, the buttons, social icons and columns blocks are all blocks that should be using this layout instead of styling it in an adhoc way.

**Testing instructions**

 - Play a bit with the "layout" config for group blocks and share feedback. (the theme must have a theme.json file for the layout to be enabled)