### PR TITLE
Template Part: Avoid button layout shift

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -49,6 +49,7 @@ export default function TemplatePartEdit( {
 		defaultWrapper,
 		area,
 		enableSelection,
+		hasResolvedReplacements,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -102,6 +103,10 @@ export default function TemplatePartEdit( {
 				defaultWrapper: defaultWrapperElement || 'div',
 				area: _area,
 				enableSelection: _enableSelection,
+				hasResolvedReplacements: hasFinishedResolution(
+					'getEntityRecords',
+					availableReplacementArgs
+				),
 			};
 		},
 		[ templatePartId, clientId ]
@@ -159,6 +164,7 @@ export default function TemplatePartEdit( {
 						clientId={ clientId }
 						setAttributes={ setAttributes }
 						enableSelection={ enableSelection }
+						hasResolvedReplacements={ hasResolvedReplacements }
 					/>
 				</TagName>
 			) }

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Placeholder, Dropdown, Button } from '@wordpress/components';
+import { Placeholder, Dropdown, Button, Spinner } from '@wordpress/components';
 import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -29,6 +29,7 @@ export default function TemplatePartPlaceholder( {
 	clientId,
 	setAttributes,
 	enableSelection,
+	hasResolvedReplacements,
 } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const [ step, setStep ] = useState( PLACEHOLDER_STEPS.initial );
@@ -102,44 +103,52 @@ export default function TemplatePartPlaceholder( {
 							  )
 					}
 				>
-					<Dropdown
-						contentClassName="wp-block-template-part__placeholder-preview-dropdown-content"
-						position="bottom right left"
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<>
-								{ enableSelection && (
-									<Button
-										variant="primary"
-										onClick={ onToggle }
-										aria-expanded={ isOpen }
-									>
-										{ __( 'Choose existing' ) }
-									</Button>
-								) }
-								<Button
-									variant={
-										enableSelection ? 'tertiary' : 'primary'
-									}
-									onClick={ () =>
-										setStep( PLACEHOLDER_STEPS.patterns )
-									}
-								>
-									{ sprintf(
-										// Translators: %s as template part area title ("Header", "Footer", etc.).
-										'New %s',
-										areaLabel.toLowerCase()
+					{ ! hasResolvedReplacements ? (
+						<Spinner />
+					) : (
+						<Dropdown
+							contentClassName="wp-block-template-part__placeholder-preview-dropdown-content"
+							position="bottom right left"
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<>
+									{ enableSelection && (
+										<Button
+											variant="primary"
+											onClick={ onToggle }
+											aria-expanded={ isOpen }
+										>
+											{ __( 'Choose existing' ) }
+										</Button>
 									) }
-								</Button>
-							</>
-						) }
-						renderContent={ ( { onClose } ) => (
-							<TemplatePartSelection
-								setAttributes={ setAttributes }
-								onClose={ onClose }
-								area={ area }
-							/>
-						) }
-					/>
+									<Button
+										variant={
+											enableSelection
+												? 'tertiary'
+												: 'primary'
+										}
+										onClick={ () =>
+											setStep(
+												PLACEHOLDER_STEPS.patterns
+											)
+										}
+									>
+										{ sprintf(
+											// Translators: %s as template part area title ("Header", "Footer", etc.).
+											'New %s',
+											areaLabel.toLowerCase()
+										) }
+									</Button>
+								</>
+							) }
+							renderContent={ ( { onClose } ) => (
+								<TemplatePartSelection
+									setAttributes={ setAttributes }
+									onClose={ onClose }
+									area={ area }
+								/>
+							) }
+						/>
+					) }
 				</Placeholder>
 			) }
 			{ step === PLACEHOLDER_STEPS.patterns && (


### PR DESCRIPTION
## Description
PR adds a simple loading state while template part replacements are loaded to avoid button layout shift. The layout shift was causing the "Multi-Entity Saving" e2e test to fail from time to time.

See #33169 for complete details.

## How has this been tested?
1. Enable TT1 Blocks theme.
2. Create page.
3. Throttle network to 3G via DevTools.
4. Add a Template Part block.
5. Spinned should be visible before displaying placeholder buttons.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/125302300-dec61b00-e33c-11eb-826d-6e05828f12c8.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
