### PR TITLE
[Block Library - Post Excerpt]: Fix `excerpt_more` filter conflict and remove `wordCount` attribute

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -81,7 +81,7 @@ function register_gutenberg_patterns() {
 							<!-- wp:post-template -->
 							<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 							<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:post-title {"isLink":true} /-->
-							<!-- wp:post-excerpt {"wordCount":20} /-->
+							<!-- wp:post-excerpt /-->
 							<!-- wp:post-date /--></div>
 							<!-- /wp:group -->
 							<!-- /wp:post-template -->

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -9,10 +9,6 @@
 		"textAlign": {
 			"type": "string"
 		},
-		"wordCount": {
-			"type": "number",
-			"default": 55
-		},
 		"moreText": {
 			"type": "string"
 		},

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -54,7 +54,7 @@ export default function PostExcerptEditor( {
 			renderedExcerpt,
 			'text/html'
 		);
-		return document.body.innerText || '';
+		return document.body.textContent || document.body.innerText || '';
 	}, [ renderedExcerpt ] );
 	if ( ! postType || ! postId ) {
 		return (

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -16,12 +16,7 @@ import {
 	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	RangeControl,
-	ToggleControl,
-	Disabled,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -29,29 +24,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { useCanEditEntity } from '../utils/hooks';
 
-function usePostContentExcerpt( wordCount, postId, postType ) {
-	// Don't destrcuture items from content here, it can be undefined.
-	const [ , , content ] = useEntityProp(
-		'postType',
-		postType,
-		'content',
-		postId
-	);
-	const renderedPostContent = content?.rendered;
-	return useMemo( () => {
-		if ( ! renderedPostContent ) {
-			return '';
-		}
-		const excerptElement = document.createElement( 'div' );
-		excerptElement.innerHTML = renderedPostContent;
-		const excerpt =
-			excerptElement.textContent || excerptElement.innerText || '';
-		return excerpt.trim().split( ' ', wordCount ).join( ' ' );
-	}, [ renderedPostContent, wordCount ] );
-}
-
 export default function PostExcerptEditor( {
-	attributes: { textAlign, wordCount, moreText, showMoreOnNewLine },
+	attributes: { textAlign, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -64,17 +38,24 @@ export default function PostExcerptEditor( {
 		setExcerpt,
 		{ rendered: renderedExcerpt, protected: isProtected } = {},
 	] = useEntityProp( 'postType', postType, 'excerpt', postId );
-	const postContentExcerpt = usePostContentExcerpt(
-		wordCount,
-		postId,
-		postType
-	);
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
-
+	/**
+	 * When excerpt is editable, strip the html tags from
+	 * rendered excerpt. This will be used if the entity's
+	 * excerpt has been produced from the content.
+	 */
+	const strippedRenderedExcerpt = useMemo( () => {
+		if ( ! renderedExcerpt ) return '';
+		const document = new window.DOMParser().parseFromString(
+			renderedExcerpt,
+			'text/html'
+		);
+		return document.body.innerText || '';
+	}, [ renderedExcerpt ] );
 	if ( ! postType || ! postId ) {
 		return (
 			<div { ...blockProps }>
@@ -116,7 +97,7 @@ export default function PostExcerptEditor( {
 			aria-label={ __( 'Post excerpt text' ) }
 			value={
 				rawExcerpt ||
-				postContentExcerpt ||
+				strippedRenderedExcerpt ||
 				( isSelected ? '' : __( 'No post excerpt found' ) )
 			}
 			onChange={ setExcerpt }
@@ -141,17 +122,6 @@ export default function PostExcerptEditor( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Post Excerpt Settings' ) }>
-					{ ! rawExcerpt && (
-						<RangeControl
-							label={ __( 'Max words' ) }
-							value={ wordCount }
-							onChange={ ( newExcerptLength ) =>
-								setAttributes( { wordCount: newExcerptLength } )
-							}
-							min={ 10 }
-							max={ 100 }
-						/>
-					) }
 					<ToggleControl
 						label={ __( 'Show link on new line' ) }
 						checked={ showMoreOnNewLine }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -16,7 +16,12 @@ import {
 	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	RangeControl,
+	ToggleControl,
+	Disabled,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -69,33 +74,6 @@ export default function PostExcerptEditor( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
-	/**
-	 * Some themes might use `excerpt_more` filter to add links
-	 * to excerpts generated from content. Since we display the
-	 * renderedExcerpt from REST API links might be included.
-	 * Before the application of this filter all content has been
-	 * stripped of tags, so if we find any links there should come
-	 * from the filter.
-	 *
-	 * In order to avoid a possible `inception` effect
-	 * see: (https://github.com/WordPress/gutenberg/issues/33309)
-	 * we change the `href` attribute of links to a `pseudo link`.
-	 *
-	 */
-	const filteredRenderedExcerpt = useMemo( () => {
-		const document = new window.DOMParser().parseFromString(
-			renderedExcerpt,
-			'text/html'
-		);
-		const links = document.getElementsByTagName( 'a' );
-		if ( ! links?.length ) {
-			return renderedExcerpt;
-		}
-		for ( const link of links ) {
-			link.setAttribute( 'href', '#excerpt_more-pseudo-link' );
-		}
-		return document.body.innerHTML || '';
-	}, [ renderedExcerpt ] );
 
 	if ( ! postType || ! postId ) {
 		return (
@@ -144,15 +122,10 @@ export default function PostExcerptEditor( {
 			onChange={ setExcerpt }
 		/>
 	) : (
-		( filteredRenderedExcerpt && (
-			<RawHTML
-				key="html"
-				onClick={ ( event ) => {
-					event.preventDefault();
-				} }
-			>
-				{ filteredRenderedExcerpt }
-			</RawHTML>
+		( renderedExcerpt && (
+			<Disabled>
+				<RawHTML key="html">{ renderedExcerpt }</RawHTML>
+			</Disabled>
 		) ) ||
 		__( 'No post excerpt found' )
 	);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -32,15 +32,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 * result in showing only one `read more` link at a time.
 	 */
 	add_filter( 'excerpt_more', $filter_excerpt_more );
-
-	$filter_excerpt_length = function() use ( $attributes ) {
-		return isset( $attributes['wordCount'] ) ? $attributes['wordCount'] : 55;
-	};
-	add_filter( 'excerpt_length', $filter_excerpt_length );
-
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= 'has-text-align-' . $attributes['textAlign'];
+		$classes .= "has-text-align-{$attributes['textAlign']}";
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
@@ -50,10 +44,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	} else {
 		$content .= " $more_text</p>";
 	}
-
-	remove_filter( 'excerpt_length', $filter_excerpt_length );
 	remove_filter( 'excerpt_more', $filter_excerpt_more );
-
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
 }
 

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -38,8 +38,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
-	$content = '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
-	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
+	$content               = '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
+	$show_more_on_new_line = ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'];
+	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
 		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
 		$content .= " $more_text</p>";

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -20,8 +20,17 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . $attributes['moreText'] . '</a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
-		return empty( $more_text ) ? $more : ' [&hellip;]';
+		return empty( $more_text ) ? $more : '';
 	};
+	/**
+	 * Some themes might use `excerpt_more` filter to handle the
+	 * `more` link displayed after a trimmed excerpt. Since the
+	 * block has a `more text` attribute we have to check and
+	 * override if needed the return value from this filter.
+	 * So if the block's attribute is not empty override the
+	 * `excerpt_more` filter and return nothing. This will
+	 * result in showing only one `read more` link at a time.
+	 */
 	add_filter( 'excerpt_more', $filter_excerpt_more );
 
 	$filter_excerpt_length = function() use ( $attributes ) {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -18,15 +18,16 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$more_text = isset( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . $attributes['moreText'] . '</a>' : '';
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . $attributes['moreText'] . '</a>' : '';
+	$filter_excerpt_more = function( $more ) use ( $more_text ) {
+		return empty( $more_text ) ? $more : ' [&hellip;]';
+	};
+	add_filter( 'excerpt_more', $filter_excerpt_more );
 
 	$filter_excerpt_length = function() use ( $attributes ) {
 		return isset( $attributes['wordCount'] ) ? $attributes['wordCount'] : 55;
 	};
-	add_filter(
-		'excerpt_length',
-		$filter_excerpt_length
-	);
+	add_filter( 'excerpt_length', $filter_excerpt_length );
 
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
@@ -41,10 +42,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		$content .= " $more_text</p>";
 	}
 
-	remove_filter(
-		'excerpt_length',
-		$filter_excerpt_length
-	);
+	remove_filter( 'excerpt_length', $filter_excerpt_length );
+	remove_filter( 'excerpt_more', $filter_excerpt_more );
 
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
 }

--- a/packages/e2e-tests/fixtures/blocks/core__post-excerpt.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-excerpt.json
@@ -4,7 +4,6 @@
 		"name": "core/post-excerpt",
 		"isValid": true,
 		"attributes": {
-			"wordCount": 55,
 			"showMoreOnNewLine": true
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/33309
Fixes: https://github.com/WordPress/gutenberg/issues/32473
Fixes: https://github.com/WordPress/gutenberg/issues/33306

There are a couple of issues in `Post Excerpt` block that involve the `excerpt_length` and  [`excerpt_more` filter](https://developer.wordpress.org/reference/hooks/excerpt_more/). With `excerpt_more` filter someone (usually a theme) can filter the string in the “more” link displayed after a trimmed excerpt. Both filters are called if a post has no explicit excerpt set in [`wp_trim_excerpt` function](https://developer.wordpress.org/reference/functions/wp_trim_excerpt/).

## Problems
The problems are:
1. `Post Excerpt` block when is not editable, uses the `rendered excerpt` from REST API which makes it impossible to know what and if something has been added. This makes the `wordCount` in editor and the displayed excerpt in editor inconsistent.
2.  If the `Post Excerpt` is editable we create a preview excerpt from the `rendered content`, which isn't the same as the `rendered excerpt`. 
3. `word count` control is currently displayed only if the excerpt has been produced from content and its value is used properly in the front-end but is inconsistent in the editor because of the above problem depending on whether the block is editable or not.
4. We don't know what the filter returns in javascript. If it returns a link it can create `inception` problems which might cause the editor to crash (#33309).
 
## What I've done so far
1. In front-end if we have set a `moreText` in the block, show block's `moreText` and override theme's `excerpt_length` filter  to return nothing. If we have not set `moreText` apply the filters if provided (conflicting filter issue).
2. In the editor if the block is readonly which uses the `rendered excerpt`, I've wrapped it in a `Disabled` component in case `excerpt_more` filter is used and applies a link  (editor crash/inception issue).
3. Remove `wordCount` attribute altogether. This means that if a theme uses `excerpt_length` filter for posts with no excerpt, it will be used but you can't update it in javascript. This solves other inconsistencies described in above `Problems` section in `1 and 2`.



## Testing instructions
1. In order to reproduce the issues you have to enable a theme that has such a filter like `twenty twenty one`.
2. Please read the testing instructions from the issues: [editor crash/inception](https://github.com/WordPress/gutenberg/issues/33309), [conflict with `excerpt_more` filter](Conflict with excerpt_more filter).