### PR TITLE
Prevent color panel from showing as empty

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -217,9 +217,11 @@ function immutableSet( object, path, value ) {
  */
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
-	const isLinkColorEnabled = useSetting( 'color.link' );
-	const colors = useSetting( 'color.palette' ) || EMPTY_ARRAY;
+	const solids = useSetting( 'color.palette' ) || EMPTY_ARRAY;
 	const gradients = useSetting( 'color.gradients' ) || EMPTY_ARRAY;
+	const areCustomSolidsEnabled = useSetting( 'color.custom' );
+	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
+	const isLinkEnabled = useSetting( 'color.link' );
 
 	// Shouldn't be needed but right now the ColorGradientsPanel
 	// can trigger both onChangeColor and onChangeBackground
@@ -234,19 +236,39 @@ export function ColorEdit( props ) {
 		return null;
 	}
 
-	const hasBackground = hasBackgroundColorSupport( blockName );
-	const hasGradient = hasGradientSupport( blockName );
+	const hasLinkColor =
+		hasLinkColorSupport( blockName ) &&
+		isLinkEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasTextColor =
+		hasTextColorSupport( blockName ) &&
+		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasBackgroundColor =
+		hasBackgroundColorSupport( blockName ) &&
+		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasGradientColor =
+		hasGradientSupport( blockName ) &&
+		( gradients.length > 0 || areCustomGradientsEnabled );
+
+	if (
+		! hasLinkColor &&
+		! hasTextColor &&
+		! hasBackgroundColor &&
+		! hasGradientColor
+	) {
+		return null;
+	}
 
 	const { style, textColor, backgroundColor, gradient } = attributes;
 	let gradientValue;
-	if ( hasGradient && gradient ) {
+	if ( hasGradientColor && gradient ) {
 		gradientValue = getGradientValueBySlug( gradients, gradient );
-	} else if ( hasGradient ) {
+	} else if ( hasGradientColor ) {
 		gradientValue = style?.color?.gradient;
 	}
 
 	const onChangeColor = ( name ) => ( value ) => {
-		const colorObject = getColorObjectByColorValue( colors, value );
+		const colorObject = getColorObjectByColorValue( solids, value );
 		const attributeName = name + 'Color';
 		const newStyle = {
 			...localAttributes.current.style,
@@ -305,7 +327,7 @@ export function ColorEdit( props ) {
 	};
 
 	const onChangeLinkColor = ( value ) => {
-		const colorObject = getColorObjectByColorValue( colors, value );
+		const colorObject = getColorObjectByColorValue( solids, value );
 		const newLinkColorValue = colorObject?.slug
 			? `var:preset|color|${ colorObject.slug }`
 			: value;
@@ -325,45 +347,45 @@ export function ColorEdit( props ) {
 			}
 			clientId={ props.clientId }
 			settings={ [
-				...( hasTextColorSupport( blockName )
+				...( hasTextColor
 					? [
 							{
 								label: __( 'Text color' ),
 								onColorChange: onChangeColor( 'text' ),
 								colorValue: getColorObjectByAttributeValues(
-									colors,
+									solids,
 									textColor,
 									style?.color?.text
 								).color,
 							},
 					  ]
 					: [] ),
-				...( hasBackground || hasGradient
+				...( hasBackgroundColor || hasGradientColor
 					? [
 							{
 								label: __( 'Background color' ),
-								onColorChange: hasBackground
+								onColorChange: hasBackgroundColor
 									? onChangeColor( 'background' )
 									: undefined,
 								colorValue: getColorObjectByAttributeValues(
-									colors,
+									solids,
 									backgroundColor,
 									style?.color?.background
 								).color,
 								gradientValue,
-								onGradientChange: hasGradient
+								onGradientChange: hasGradientColor
 									? onChangeGradient
 									: undefined,
 							},
 					  ]
 					: [] ),
-				...( isLinkColorEnabled && hasLinkColorSupport( blockName )
+				...( hasLinkColor
 					? [
 							{
 								label: __( 'Link Color' ),
 								onColorChange: onChangeLinkColor,
 								colorValue: getLinkColorFromAttributeValue(
-									colors,
+									solids,
 									style?.elements?.link?.color?.text
 								),
 								clearable: !! style?.elements?.link?.color


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33304
Alternative to https://github.com/WordPress/gutenberg/pull/33311

The color panel visibility logic is not accounting for the colors the block actually supports, resulting in cases in which it's empty. 

![Captura de ecrã de 2021-07-08 19-49-04](https://user-images.githubusercontent.com/583546/124968160-94cff300-e025-11eb-896e-d55131db5f6a.png)

## How to test

### Block doesn't support gradients and they are the only enabled

Described at https://github.com/WordPress/gutenberg/issues/33304

- Add a paragraph block (it supports text, background and link but not gradients). Alternatively, add this to the `block.json` of any block:

```json
    "supports": {
        "color": {
          "text": true,
          "background": true,
          "gradients": false,
          "link": true
        },
    }
```

- Add this to the `theme.json` of a theme (e.g.: empty theme):

```json
{
  "version": 1,
  "settings": {
    "color": {
      "custom": false,
      "palette": [],
      "link": false
    }
  }	
}
```

The expected result is that the panel is hidden. In `trunk` is shown as empty.

Note: with `"link": true` the panel should also be hidden, as the link depends on solid colors being available, and they aren't with the piece of code above.

### Block only supports link and gradients but they are disabled

Described at https://github.com/WordPress/gutenberg/pull/33311#issuecomment-877030586 

Add this to the `block.json` of any block (e.g.: paragraph):

```json
    "supports": {
        "color": {
          "text": false,
          "background": false,
          "gradients": true,
          "link": true
        },
    }
```

Add this to the `theme.json` of a theme (e.g.: empty theme):

```json
{
  "version": 1,
  "settings": {
    "color": {
	  "customGradients": false,
	  "gradients": [],
	  "link": false
    }
  }	
}
```

The expected result is that the panel is hidden. In `trunk` is shown as empty.

### Other situations

Play a bit with the block.json and theme.json settings and verify that it works as expected: all colors can be via `theme.json`, only some of them enabled, etc.
