### PR TITLE
Revert "Update getTermsInfo() to workaround parsing issue for translatable strings"

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -39,8 +39,9 @@ import { store as coreStore } from '@wordpress/core-data';
  * @param {WPTerm[]} terms The terms to extract of helper object.
  * @return {QueryTermsInfo} The object with the terms information.
  */
-export const getTermsInfo = ( terms ) => {
-	const mapping = terms?.reduce(
+export const getTermsInfo = ( terms ) => ( {
+	terms,
+	...terms?.reduce(
 		( accumulator, term ) => {
 			const { mapById, mapByName, names } = accumulator;
 			mapById[ term.id ] = term;
@@ -49,13 +50,8 @@ export const getTermsInfo = ( terms ) => {
 			return accumulator;
 		},
 		{ mapById: {}, mapByName: {}, names: [] }
-	);
-
-	return {
-		terms,
-		...mapping,
-	};
-};
+	),
+} );
 
 /**
  * Returns a helper object that contains:


### PR DESCRIPTION
Reverts WordPress/gutenberg#33341

The workaround is no longer required because https://github.com/mck89/peast/issues/38 has been fixed. The same fix is already implemented in a custom WP-CLI build used on w.org. The strings are now extracted: https://i18n.trac.wordpress.org/changeset/623359

This can also be pulled from https://github.com/WordPress/gutenberg/pull/33354 if it's not too late.