### PR TITLE
Fix search block button position dropdown accessibility/UX issues.

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -16,8 +16,6 @@ import {
 } from '@wordpress/block-editor';
 import {
 	ToolbarDropdownMenu,
-	MenuGroup,
-	MenuItem,
 	ToolbarGroup,
 	Button,
 	ButtonGroup,
@@ -115,6 +113,42 @@ export default function SearchEdit( {
 		);
 	};
 
+	const buttonPositionControls = [
+		{
+			role: 'menuitemradio',
+			title: __( 'Button outside' ),
+			isActive: buttonPosition === 'button-outside',
+			icon: buttonOutside,
+			onClick: () => {
+				setAttributes( {
+					buttonPosition: 'button-outside',
+				} );
+			},
+		},
+		{
+			role: 'menuitemradio',
+			title: __( 'Button inside' ),
+			isActive: buttonPosition === 'button-inside',
+			icon: buttonInside,
+			onClick: () => {
+				setAttributes( {
+					buttonPosition: 'button-inside',
+				} );
+			},
+		},
+		{
+			role: 'menuitemradio',
+			title: __( 'No button' ),
+			isActive: buttonPosition === 'no-button',
+			icon: noButton,
+			onClick: () => {
+				setAttributes( {
+					buttonPosition: 'no-button',
+				} );
+			},
+		},
+	];
+
 	const getButtonPositionIcon = () => {
 		switch ( buttonPosition ) {
 			case 'button-inside':
@@ -204,46 +238,8 @@ export default function SearchEdit( {
 					<ToolbarDropdownMenu
 						icon={ getButtonPositionIcon() }
 						label={ __( 'Change button position' ) }
-					>
-						{ ( { onClose } ) => (
-							<MenuGroup className="wp-block-search__button-position-menu">
-								<MenuItem
-									icon={ noButton }
-									onClick={ () => {
-										setAttributes( {
-											buttonPosition: 'no-button',
-										} );
-										onClose();
-									} }
-								>
-									{ __( 'No Button' ) }
-								</MenuItem>
-								<MenuItem
-									icon={ buttonOutside }
-									onClick={ () => {
-										setAttributes( {
-											buttonPosition: 'button-outside',
-										} );
-										onClose();
-									} }
-								>
-									{ __( 'Button Outside' ) }
-								</MenuItem>
-								<MenuItem
-									icon={ buttonInside }
-									onClick={ () => {
-										setAttributes( {
-											buttonPosition: 'button-inside',
-										} );
-										onClose();
-									} }
-								>
-									{ __( 'Button Inside' ) }
-								</MenuItem>
-							</MenuGroup>
-						) }
-					</ToolbarDropdownMenu>
-
+						controls={ buttonPositionControls }
+					/>
 					{ 'no-button' !== buttonPosition && (
 						<ToolbarButton
 							title={ __( 'Use button with icon' ) }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -15,7 +15,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/block-editor';
 import {
-	DropdownMenu,
+	ToolbarDropdownMenu,
 	MenuGroup,
 	MenuItem,
 	ToolbarGroup,
@@ -201,7 +201,7 @@ export default function SearchEdit( {
 						} }
 						className={ showLabel ? 'is-pressed' : undefined }
 					/>
-					<DropdownMenu
+					<ToolbarDropdownMenu
 						icon={ getButtonPositionIcon() }
 						label={ __( 'Change button position' ) }
 					>
@@ -242,7 +242,7 @@ export default function SearchEdit( {
 								</MenuItem>
 							</MenuGroup>
 						) }
-					</DropdownMenu>
+					</ToolbarDropdownMenu>
 
 					{ 'no-button' !== buttonPosition && (
 						<ToolbarButton


### PR DESCRIPTION
## Description
Fixes #27330
Fixes https://github.com/WordPress/gutenberg/pull/33327#issuecomment-878709881

I discovered a few issues with the button position dropdown, which are fixed here:
- The `DropdownMenu` component was being used, but as this is in a toolbar it should be `ToolbarDropdownMenu`.
- The dropdown didn't visibly show the currently selected option.
- The dropdown items were missing the `menuitemradio` role.
- The dropdown items were missing the `aria-checked` attribute.
- The item text was capitalised incorrectly. Now switched to sentence cases.
- The items in the dropdown didn't seem to be in the right order. The default selected option was in the middle. It's now reordered so that the default is at the top.

This also makes the dropdown visually consistent with other similar interfaces like the alignment options, with the icon on the left.

## How has this been tested?
1. Add a search block
2. Change the button position - the feature should still work
3. Check the various items mentioned above are fixed.

## Screenshots <!-- if applicable -->
#### Before
<img width="211" alt="Screenshot 2021-07-13 at 10 32 19 am" src="https://user-images.githubusercontent.com/677833/125380964-afa7bc00-e3c5-11eb-87d0-abd6bd13aea3.png">

#### After
<img width="214" alt="Screenshot 2021-07-13 at 10 30 37 am" src="https://user-images.githubusercontent.com/677833/125380808-65263f80-e3c5-11eb-8a25-ad41aebdc491.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
