### PR TITLE
Block Editor: Warn only in `edit` implementation when using `useBlockProps`

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -64,7 +64,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const { clientId, className, wrapperProps = {}, isAligned } = useContext(
 		BlockListBlockContext
 	);
-	const blockEditContext = useBlockEditContext();
 	const {
 		index,
 		mode,
@@ -73,7 +72,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isPartOfSelection,
 		adjustScrolling,
 		enableAnimation,
-		hasBlockAPIVersionWarning,
+		lightBlockWrapper,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -95,9 +94,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			const blockName = getBlockName( clientId );
 			const rootClientId = getBlockRootClientId( clientId );
 			const blockType = getBlockType( blockName );
-			const lightBlockWrapper =
-				blockType.apiVersion > 1 ||
-				hasBlockSupport( blockType, 'lightBlockWrapper', false );
 
 			return {
 				index: getBlockIndex( clientId, rootClientId ),
@@ -110,9 +106,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				enableAnimation:
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
-				hasBlockAPIVersionWarning:
-					clientId === blockEditContext.clientId &&
-					! lightBlockWrapper,
+				lightBlockWrapper:
+					blockType.apiVersion > 1 ||
+					hasBlockSupport( blockType, 'lightBlockWrapper', false ),
 			};
 		},
 		[ clientId ]
@@ -141,7 +137,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		} ),
 	] );
 
-	if ( hasBlockAPIVersionWarning ) {
+	const blockEditContext = useBlockEditContext();
+	if ( ! lightBlockWrapper && clientId === blockEditContext.clientId ) {
 		warning(
 			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`
 		);

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -138,7 +138,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	] );
 
 	const blockEditContext = useBlockEditContext();
-	// Ensures it warns only inside the `edit` implemenation for the block.
+	// Ensures it warns only inside the `edit` implementation for the block.
 	if ( ! lightBlockWrapper && clientId === blockEditContext.clientId ) {
 		warning(
 			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -138,6 +138,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	] );
 
 	const blockEditContext = useBlockEditContext();
+	// Ensures it warns only inside the `edit` implemenation for the block.
 	if ( ! lightBlockWrapper && clientId === blockEditContext.clientId ) {
 		warning(
 			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	__unstableGetBlockProps as getBlockProps,
 	getBlockType,
+	hasBlockSupport,
 } from '@wordpress/blocks';
 import { useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -23,6 +24,7 @@ import useMovingAnimation from '../../use-moving-animation';
 import { BlockListBlockContext } from '../block';
 import { useFocusFirstElement } from './use-focus-first-element';
 import { useIsHovered } from './use-is-hovered';
+import { useBlockEditContext } from '../../block-edit/context';
 import { useBlockClassNames } from './use-block-class-names';
 import { useBlockDefaultClassName } from './use-block-default-class-name';
 import { useBlockCustomClassName } from './use-block-custom-class-name';
@@ -62,15 +64,16 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const { clientId, className, wrapperProps = {}, isAligned } = useContext(
 		BlockListBlockContext
 	);
+	const blockEditContext = useBlockEditContext();
 	const {
 		index,
 		mode,
 		name,
-		blockAPIVersion,
 		blockTitle,
 		isPartOfSelection,
 		adjustScrolling,
 		enableAnimation,
+		hasBlockAPIVersionWarning,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -92,11 +95,14 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			const blockName = getBlockName( clientId );
 			const rootClientId = getBlockRootClientId( clientId );
 			const blockType = getBlockType( blockName );
+			const lightBlockWrapper =
+				blockType.apiVersion > 1 ||
+				hasBlockSupport( blockType, 'lightBlockWrapper', false );
+
 			return {
 				index: getBlockIndex( clientId, rootClientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
-				blockAPIVersion: blockType.apiVersion,
 				blockTitle: blockType.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
@@ -104,6 +110,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				enableAnimation:
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
+				hasBlockAPIVersionWarning:
+					clientId === blockEditContext.clientId &&
+					! lightBlockWrapper,
 			};
 		},
 		[ clientId ]
@@ -132,7 +141,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		} ),
 	] );
 
-	if ( blockAPIVersion < 2 ) {
+	if ( hasBlockAPIVersionWarning ) {
 		warning(
 			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`
 		);

--- a/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
@@ -31,6 +31,7 @@
 	]
 
 	registerBlockType( 'test/iframed-masonry-block', {
+		apiVersion: 2,
 		edit: function Edit() {
 			const ref = useRefEffect( ( node ) => {
 				const { ownerDocument } = node;

--- a/packages/warning/src/index.js
+++ b/packages/warning/src/index.js
@@ -34,7 +34,7 @@ export default function warning( message ) {
 	}
 
 	// Skip if already logged.
-	if ( message in logged ) {
+	if ( logged.has( message ) ) {
 		return;
 	}
 
@@ -50,5 +50,5 @@ export default function warning( message ) {
 		// do nothing
 	}
 
-	logged[ message ] = true;
+	logged.add( message );
 }

--- a/packages/warning/src/test/index.js
+++ b/packages/warning/src/test/index.js
@@ -9,9 +9,7 @@ const initialNodeEnv = process.env.NODE_ENV;
 describe( 'warning', () => {
 	afterEach( () => {
 		process.env.NODE_ENV = initialNodeEnv;
-		for ( const key in logged ) {
-			delete logged[ key ];
-		}
+		logged.clear();
 	} );
 
 	it( 'logs to console.warn when NODE_ENV is not "production"', () => {

--- a/packages/warning/src/utils.js
+++ b/packages/warning/src/utils.js
@@ -2,6 +2,6 @@
  * Object map tracking messages which have been logged, for use in ensuring a
  * message is only logged once.
  *
- * @type {Record<string, true | undefined>}
+ * @type {Set<string>}
  */
-export const logged = Object.create( null );
+export const logged = new Set();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #33274.

As reported by @talldan and @kevin940726, the warning for using `useBlockProps` with `apiVersion` 1 triggers even when blocks don't use `useBlockProps` in the `edit` implementation. This is because the same hook is used by the block editor internally. This PR ensures that the warning is shown only when intended.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Go to the Widgets screen an insert the Legacy Widget block and confirm there are no warnings in the Browser Console.

To ensure that the warning still triggers as intended, updated one of the core blocks that use`useBlockProps` to have `apiVersion` set to 1 – for example the Heading block. Insert it into the post and you should see the warning:

<img width="1076" alt="Screen Shot 2021-07-13 at 09 34 52" src="https://user-images.githubusercontent.com/699132/125410846-9864d080-e3bd-11eb-8bd2-f6b15263c7f2.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
