### PR TITLE
Block editor: iframe: load inline styles

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -239,12 +239,23 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 	head = (
 		<>
 			<style>{ 'body{margin:0}' }</style>
-			{ styles.map( ( { tagName, href, id, rel, media }, index ) => {
-				const TagName = tagName.toLowerCase();
-				return (
-					<TagName { ...{ href, id, rel, media } } key={ index } />
-				);
-			} ) }
+			{ styles.map(
+				( { tagName, href, id, rel, media, textContent } ) => {
+					const TagName = tagName.toLowerCase();
+
+					if ( TagName === 'style' ) {
+						return (
+							<TagName { ...{ id } } key={ id }>
+								{ textContent }
+							</TagName>
+						);
+					}
+
+					return (
+						<TagName { ...{ href, id, rel, media } } key={ id } />
+					);
+				}
+			) }
 			{ head }
 		</>
 	);

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -49,6 +49,12 @@ function styleSheetsCompat( doc ) {
 			return;
 		}
 
+		// Generally, ignore inline styles. We add inline styles belonging to a
+		// stylesheet later, which may or may not match the selectors.
+		if ( ownerNode.tagName !== 'LINK' ) {
+			return;
+		}
+
 		// Don't try to add the reset styles, which were removed as a dependency
 		// from `edit-blocks` for the iframe since we don't need to reset admin
 		// styles.
@@ -69,9 +75,17 @@ function styleSheetsCompat( doc ) {
 				`Stylesheet ${ ownerNode.id } was not properly added.
 For blocks, use the block API's style (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) or editorStyle (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style).
 For themes, use add_editor_style (https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#editor-styles).`,
-				ownerNode
+				ownerNode.outerHTML
 			);
 			doc.head.appendChild( ownerNode.cloneNode( true ) );
+
+			// Add inline styles belonging to the stylesheet.
+			const inlineCssId = ownerNode.id.replace( '-css', '-inline-css' );
+			const inlineCssElement = document.getElementById( inlineCssId );
+
+			if ( inlineCssElement ) {
+				doc.head.appendChild( inlineCssElement.cloneNode( true ) );
+			}
 		}
 	} );
 }

--- a/packages/e2e-tests/plugins/iframed-inline-styles.php
+++ b/packages/e2e-tests/plugins/iframed-inline-styles.php
@@ -33,7 +33,20 @@ add_action(
 			array(),
 			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-inline-styles/style.css' )
 		);
-		wp_add_inline_style( 'iframed-inline-styles-style', '.wp-block-test-iframed-inline-styles{padding: 20px}' );
+		wp_add_inline_style( 'iframed-inline-styles-style', '.wp-block-test-iframed-inline-styles{padding:20px}' );
 		register_block_type_from_metadata( __DIR__ . '/iframed-inline-styles' );
+	}
+);
+
+add_action(
+	'enqueue_block_editor_assets',
+	function() {
+		wp_enqueue_style(
+			'iframed-inline-styles-compat-style',
+			plugin_dir_url( __FILE__ ) . 'iframed-inline-styles/compat-style.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-inline-styles/compat-style.css' )
+		);
+		wp_add_inline_style( 'iframed-inline-styles-compat-style', '.wp-block-test-iframed-inline-styles{border-width:2px}' );
 	}
 );

--- a/packages/e2e-tests/plugins/iframed-inline-styles.php
+++ b/packages/e2e-tests/plugins/iframed-inline-styles.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed Inline Styles
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-inline-styles
+ */
+
+add_action(
+	'setup_theme',
+	function() {
+		add_theme_support( 'block-templates' );
+	}
+);
+
+add_action(
+	'init',
+	function() {
+		wp_register_script(
+			'iframed-inline-styles-editor-script',
+			plugin_dir_url( __FILE__ ) . 'iframed-inline-styles/editor.js',
+			array(
+				'wp-blocks',
+				'wp-block-editor',
+				'wp-element',
+			),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-inline-styles/editor.js' )
+		);
+		wp_register_style(
+			'iframed-inline-styles-style',
+			plugin_dir_url( __FILE__ ) . 'iframed-inline-styles/style.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-inline-styles/style.css' )
+		);
+		wp_add_inline_style( 'iframed-inline-styles-style', '.wp-block-test-iframed-inline-styles{padding: 20px}' );
+		register_block_type_from_metadata( __DIR__ . '/iframed-inline-styles' );
+	}
+);

--- a/packages/e2e-tests/plugins/iframed-inline-styles/block.json
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/block.json
@@ -1,0 +1,15 @@
+{
+	"apiVersion": 2,
+	"name": "test/iframed-inline-styles",
+	"title": "Iframed Inline Styles",
+	"category": "text",
+	"icon": "smiley",
+	"description": "",
+	"supports": {
+		"html": false
+	},
+	"textdomain": "iframed-inline-styles",
+	"editorScript": "iframed-inline-styles-editor-script",
+	"editorStyle": "file:./editor.css",
+	"style": "iframed-inline-styles-style"
+}

--- a/packages/e2e-tests/plugins/iframed-inline-styles/compat-style.css
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/compat-style.css
@@ -1,0 +1,4 @@
+/* Random rule with `wp-block` in the selector. */
+.wp-block-test-iframed-inline-styles {
+	display: block;
+}

--- a/packages/e2e-tests/plugins/iframed-inline-styles/editor.css
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/editor.css
@@ -1,0 +1,6 @@
+/**
+ * The following styles get applied inside the editor only.
+ */
+.wp-block-test-iframed-inline-styles {
+	border: 1px dotted #f00;
+}

--- a/packages/e2e-tests/plugins/iframed-inline-styles/editor.js
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/editor.js
@@ -1,0 +1,15 @@
+( ( { wp: { element, blocks, blockEditor } } ) => {
+	const { createElement: el } = element;
+	const { registerBlockType } = blocks;
+	const { useBlockProps } = blockEditor;
+
+	registerBlockType( 'test/iframed-inline-styles', {
+		apiVersion: 2,
+		edit: function Edit() {
+			return el( 'div', useBlockProps(), 'Edit' );
+		},
+		save: function Save() {
+			return el( 'div', useBlockProps.save(), 'Save' );
+		},
+	} );
+} )( window );

--- a/packages/e2e-tests/plugins/iframed-inline-styles/style.css
+++ b/packages/e2e-tests/plugins/iframed-inline-styles/style.css
@@ -1,0 +1,9 @@
+/**
+ * The following styles get applied both on the front of your site and in the
+ * editor.
+ */
+.wp-block-test-iframed-inline-styles {
+	background-color: #21759b;
+	color: #fff;
+	padding: 2px;
+}

--- a/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
+++ b/packages/e2e-tests/plugins/iframed-masonry-block/editor.js
@@ -28,7 +28,7 @@
 		el( 'div', { className: 'grid-item' } ),
 		el( 'div', { className: 'grid-item' } ),
 		el( 'div', { className: 'grid-item grid-item--height2' } ),
-	]
+	];
 
 	registerBlockType( 'test/iframed-masonry-block', {
 		apiVersion: 2,

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-inline-styles.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-inline-styles.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iframed inline styles should load inline styles in iframe 1`] = `
+"<!-- wp:test/iframed-inline-styles -->
+<div class=\\"wp-block-test-iframed-inline-styles\\">Save</div>
+<!-- /wp:test/iframed-inline-styles -->"
+`;

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-masonry-block.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/iframed-masonry-block.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`changing image size should load script and dependencies in iframe 1`] = `
+exports[`iframed masonry block should load script and dependencies in iframe 1`] = `
 "<!-- wp:test/iframed-masonry-block -->
 <div class=\\"wp-block-test-iframed-masonry-block\\"><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--width2 grid-item--height2\\"></div><div class=\\"grid-item grid-item--height3\\"></div><div class=\\"grid-item grid-item--height2\\"></div><div class=\\"grid-item grid-item--width3\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--height2\\"></div><div class=\\"grid-item grid-item--width2 grid-item--height3\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--height2\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--width2 grid-item--height2\\"></div><div class=\\"grid-item grid-item--width2\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--height2\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--height3\\"></div><div class=\\"grid-item grid-item--height2\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item\\"></div><div class=\\"grid-item grid-item--height2\\"></div></div>
 <!-- /wp:test/iframed-masonry-block -->"

--- a/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-inline-styles.test.js
@@ -12,35 +12,30 @@ import {
 	canvas,
 } from '@wordpress/e2e-test-utils';
 
-async function didMasonryLoadCorrectly( context ) {
+async function getPadding( context ) {
 	return await context.evaluate( () => {
 		const container = document.querySelector(
-			'.wp-block-test-iframed-masonry-block'
+			'.wp-block-test-iframed-inline-styles'
 		);
-		return (
-			// Expect Masonry to set a non-zero height.
-			parseInt( container.style.height, 10 ) > 0 &&
-			// Expect Masonry to absolute position items.
-			container.firstElementChild.style.position === 'absolute'
-		);
+		return window.getComputedStyle( container ).padding;
 	} );
 }
 
-describe( 'iframed masonry block', () => {
+describe( 'iframed inline styles', () => {
 	beforeEach( async () => {
-		await activatePlugin( 'gutenberg-test-iframed-masonry-block' );
+		await activatePlugin( 'gutenberg-test-iframed-inline-styles' );
 		await createNewPost( { postType: 'page' } );
 	} );
 
 	afterEach( async () => {
-		await deactivatePlugin( 'gutenberg-test-iframed-masonry-block' );
+		await deactivatePlugin( 'gutenberg-test-iframed-inline-styles' );
 	} );
 
-	it( 'should load script and dependencies in iframe', async () => {
-		await insertBlock( 'Iframed Masonry Block' );
+	it( 'should load inline styles in iframe', async () => {
+		await insertBlock( 'Iframed Inline Styles' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		expect( await didMasonryLoadCorrectly( page ) ).toBe( true );
+		expect( await getPadding( page ) ).toBe( '20px' );
 
 		await openDocumentSettingsSidebar();
 		await clickButton( 'Page' );
@@ -51,8 +46,10 @@ describe( 'iframed masonry block', () => {
 		await page.keyboard.type( 'Iframed Test' );
 		await clickButton( 'Create' );
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
-		await canvas().waitForSelector( '.grid-item[style]' );
+		await canvas().waitForSelector(
+			'.wp-block-test-iframed-inline-styles'
+		);
 
-		expect( await didMasonryLoadCorrectly( canvas() ) ).toBe( true );
+		expect( await getPadding( canvas() ) ).toBe( '20px' );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #33333.

* Currently we assume the HTML we're getting from the server is purely link tags, but it could include inline styles too, so this PR accounts for that.
* Also changes the compatibility layer so check if a stylesheet has inline styles that belong to it and then load them in the iframe too.
* Adds integration tests for the above.

|Before|After|
|-|-|
|<img width="447" alt="Screenshot 2021-07-15 at 16 17 19" src="https://user-images.githubusercontent.com/4710635/125794630-51419840-a718-43ea-8d8d-7f3d2b3af987.png">|<img width="547" alt="Screenshot 2021-07-15 at 16 20 02" src="https://user-images.githubusercontent.com/4710635/125794919-86ca4d67-1505-4e00-a5d0-1a168359c5a5.png">|


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
