### PR TITLE
Mobile - Global styles: Font sizes and line height data

### DIFF
--- a/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
@@ -22,20 +22,36 @@ export const GLOBAL_STYLES_PALETTE = [
 	},
 ];
 
-export const GLOBAL_STYLES_GRADIENTS = [
-	{
-		slug: 'purple-to-blue',
-		gradient:
-			'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
-		name: 'Purple to Blue',
-	},
-	{
-		slug: 'green-to-purple',
-		gradient:
-			'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
-		name: 'Green to Purple',
-	},
-];
+export const GLOBAL_STYLES_GRADIENTS = {
+	core: [
+		{
+			name: 'Vivid cyan blue to vivid purple',
+			gradient:
+				'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+			slug: 'vivid-cyan-blue-to-vivid-purple',
+		},
+		{
+			name: 'Light green cyan to vivid green cyan',
+			gradient:
+				'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
+			slug: 'light-green-cyan-to-vivid-green-cyan',
+		},
+	],
+	theme: [
+		{
+			slug: 'purple-to-blue',
+			gradient:
+				'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
+			name: 'Purple to Blue',
+		},
+		{
+			slug: 'green-to-purple',
+			gradient:
+				'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
+			name: 'Green to Purple',
+		},
+	],
+};
 
 export const DEFAULT_GLOBAL_STYLES = {
 	color: {
@@ -175,14 +191,12 @@ export const RAW_FEATURES = {
 			theme: [
 				{
 					slug: 'purple-to-blue',
-					gradient:
-						'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
+					gradient: 'linear-gradient(160deg, #D1D1E4, #D1DFE4)',
 					name: 'Purple to Blue',
 				},
 				{
 					slug: 'green-to-purple',
-					gradient:
-						'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
+					gradient: 'linear-gradient(160deg, #D1E4DD, #D1D1E4)',
 					name: 'Green to Purple',
 				},
 			],
@@ -243,9 +257,5 @@ export const MAPPED_VALUES = {
 	'font-size': {
 		values: RAW_FEATURES.typography.fontSizes.theme,
 		slug: 'size',
-	},
-
-	'line-height': {
-		values: RAW_FEATURES.custom[ 'line-height' ],
 	},
 };

--- a/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
@@ -1,0 +1,251 @@
+export const DEFAULT_COLORS = [
+	{ color: '#cd2653', name: 'Accent Color', slug: 'accent' },
+	{ color: '#000000', name: 'Primary', slug: 'primary' },
+	{ color: '#6d6d6d', name: 'Secondary', slug: 'secondary' },
+];
+
+export const GLOBAL_STYLES_PALETTE = [
+	{
+		slug: 'green',
+		color: '#D1E4DD',
+		name: 'Green',
+	},
+	{
+		slug: 'blue',
+		color: '#D1DFE4',
+		name: 'Blue',
+	},
+	{
+		slug: 'purple',
+		color: '#D1D1E4',
+		name: 'Purple',
+	},
+];
+
+export const GLOBAL_STYLES_GRADIENTS = [
+	{
+		slug: 'purple-to-blue',
+		gradient:
+			'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
+		name: 'Purple to Blue',
+	},
+	{
+		slug: 'green-to-purple',
+		gradient:
+			'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
+		name: 'Green to Purple',
+	},
+];
+
+export const DEFAULT_GLOBAL_STYLES = {
+	color: {
+		background: 'var(--wp--preset--color--green)',
+		text: 'var(--wp--preset--color--blue)',
+	},
+	typography: {
+		fontSize: 'var(--wp--preset--font-size--normal)',
+		lineHeight: 'var(--wp--custom--line-height--body)',
+	},
+	elements: {
+		link: {
+			color: {
+				text: 'var(--wp--preset--color--purple)',
+			},
+		},
+		h1: {
+			typography: {
+				fontSize: 'var(--wp--preset--font-size--gigantic)',
+				lineHeight: 'var(--wp--custom--line-height--page-title)',
+			},
+		},
+		h2: {
+			typography: {
+				fontSize: 'var(--wp--preset--font-size--extra-large)',
+				lineHeight: 'var(--wp--custom--line-height--heading)',
+			},
+		},
+	},
+	blocks: {
+		'core/button': {
+			color: {
+				background: 'var(--wp--preset--color--purple)',
+				text: 'var(--wp--preset--color--green)',
+			},
+			typography: {
+				fontSize: 'var(--wp--preset--font-size--normal)',
+			},
+		},
+	},
+};
+
+export const PARSED_GLOBAL_STYLES = {
+	color: {
+		background: '#D1E4DD',
+		text: '#D1DFE4',
+	},
+	typography: {
+		fontSize: '18px',
+		lineHeight: '1.7',
+	},
+	elements: {
+		link: {
+			color: {
+				text: '#D1D1E4',
+			},
+		},
+		h1: {
+			typography: {
+				fontSize: '144px',
+				lineHeight: '1.1',
+			},
+		},
+		h2: {
+			typography: {
+				fontSize: '40px',
+				lineHeight: '1.3',
+			},
+		},
+	},
+	blocks: {
+		'core/button': {
+			color: {
+				background: '#D1D1E4',
+				text: '#D1E4DD',
+			},
+			typography: {
+				fontSize: '18px',
+			},
+		},
+	},
+};
+
+export const RAW_FEATURES = {
+	color: {
+		palette: {
+			core: [
+				{
+					name: 'Black',
+					slug: 'black',
+					color: '#000000',
+				},
+				{
+					name: 'Cyan bluish gray',
+					slug: 'cyan-bluish-gray',
+					color: '#abb8c3',
+				},
+				{
+					name: 'White',
+					slug: 'white',
+					color: '#ffffff',
+				},
+			],
+			theme: [
+				{
+					slug: 'green',
+					color: '#D1E4DD',
+					name: 'Green',
+				},
+				{
+					slug: 'blue',
+					color: '#D1DFE4',
+					name: 'Blue',
+				},
+				{
+					slug: 'purple',
+					color: '#D1D1E4',
+					name: 'Purple',
+				},
+			],
+		},
+		gradients: {
+			core: [
+				{
+					name: 'Vivid cyan blue to vivid purple',
+					gradient:
+						'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+					slug: 'vivid-cyan-blue-to-vivid-purple',
+				},
+				{
+					name: 'Light green cyan to vivid green cyan',
+					gradient:
+						'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
+					slug: 'light-green-cyan-to-vivid-green-cyan',
+				},
+			],
+			theme: [
+				{
+					slug: 'purple-to-blue',
+					gradient:
+						'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
+					name: 'Purple to Blue',
+				},
+				{
+					slug: 'green-to-purple',
+					gradient:
+						'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
+					name: 'Green to Purple',
+				},
+			],
+		},
+	},
+	typography: {
+		fontSizes: {
+			core: [
+				{
+					name: 'Small',
+					slug: 'small',
+					size: '13px',
+				},
+				{
+					name: 'Normal',
+					slug: 'normal',
+					size: '16px',
+				},
+				{
+					name: 'Huge',
+					slug: 'huge',
+					size: '42px',
+				},
+			],
+			theme: [
+				{
+					name: 'Normal',
+					slug: 'normal',
+					size: '18px',
+				},
+				{
+					slug: 'extra-large',
+					size: '40px',
+					name: 'Extra large',
+				},
+				{
+					slug: 'gigantic',
+					size: '144px',
+					name: 'Gigantic',
+				},
+			],
+		},
+	},
+	custom: {
+		'line-height': {
+			body: 1.7,
+			heading: 1.3,
+			'page-title': 1.1,
+		},
+	},
+};
+
+export const MAPPED_VALUES = {
+	color: {
+		values: GLOBAL_STYLES_PALETTE,
+		slug: 'color',
+	},
+	'font-size': {
+		values: RAW_FEATURES.typography.fontSizes.theme,
+		slug: 'size',
+	},
+
+	'line-height': {
+		values: RAW_FEATURES.custom[ 'line-height' ],
+	},
+};

--- a/packages/components/src/mobile/global-styles-context/test/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/utils.native.js
@@ -4,13 +4,12 @@
 import {
 	getBlockPaddings,
 	getBlockColors,
-	parseVariables,
+	parseStylesVariables,
 	getGlobalStyles,
 } from '../utils';
 
 import {
 	DEFAULT_COLORS,
-	GLOBAL_STYLES_PALETTE,
 	GLOBAL_STYLES_GRADIENTS,
 	DEFAULT_GLOBAL_STYLES,
 	PARSED_GLOBAL_STYLES,
@@ -94,11 +93,16 @@ describe( 'getBlockColors', () => {
 	} );
 } );
 
-describe( 'parseVariables', () => {
-	it( 'returns the parsed colors values correctly', () => {
-		const blockColors = parseVariables(
-			JSON.stringify( DEFAULT_GLOBAL_STYLES ),
+describe( 'parseStylesVariables', () => {
+	it( 'returns the parsed preset values correctly', () => {
+		const customValues = parseStylesVariables(
+			JSON.stringify( RAW_FEATURES.custom ),
 			MAPPED_VALUES
+		);
+		const blockColors = parseStylesVariables(
+			JSON.stringify( DEFAULT_GLOBAL_STYLES ),
+			MAPPED_VALUES,
+			customValues
 		);
 		expect( blockColors ).toEqual(
 			expect.objectContaining( PARSED_GLOBAL_STYLES )
@@ -109,29 +113,24 @@ describe( 'parseVariables', () => {
 describe( 'getGlobalStyles', () => {
 	it( 'returns the global styles data correctly', () => {
 		const rawFeatures = JSON.stringify( RAW_FEATURES );
-		const globalStyles = getGlobalStyles(
-			JSON.stringify( DEFAULT_GLOBAL_STYLES ),
-			rawFeatures,
-			GLOBAL_STYLES_PALETTE,
-			GLOBAL_STYLES_GRADIENTS
-		);
-		const gradients = parseVariables(
+		const gradients = parseStylesVariables(
 			JSON.stringify( GLOBAL_STYLES_GRADIENTS ),
 			MAPPED_VALUES
 		);
-		const parsedExperimentalFeatures = parseVariables(
-			rawFeatures,
-			MAPPED_VALUES
+
+		const globalStyles = getGlobalStyles(
+			JSON.stringify( DEFAULT_GLOBAL_STYLES ),
+			rawFeatures
 		);
 
 		expect( globalStyles ).toEqual(
 			expect.objectContaining( {
-				colors: GLOBAL_STYLES_PALETTE,
+				colors: RAW_FEATURES.color,
 				gradients,
 				__experimentalFeatures: {
 					color: {
-						palette: parsedExperimentalFeatures?.color?.palette,
-						gradients: parsedExperimentalFeatures?.color?.gradients,
+						palette: RAW_FEATURES.color.palette,
+						gradients,
 					},
 					typography: {
 						fontSizes: RAW_FEATURES.typography.fontSizes,

--- a/packages/components/src/mobile/global-styles-context/test/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/utils.native.js
@@ -4,151 +4,19 @@
 import {
 	getBlockPaddings,
 	getBlockColors,
-	parseColorVariables,
+	parseVariables,
 	getGlobalStyles,
 } from '../utils';
 
-const DEFAULT_COLORS = [
-	{ color: '#cd2653', name: 'Accent Color', slug: 'accent' },
-	{ color: '#000000', name: 'Primary', slug: 'primary' },
-	{ color: '#6d6d6d', name: 'Secondary', slug: 'secondary' },
-];
-
-const GLOBAL_STYLES_PALETTE = [
-	{
-		slug: 'green',
-		color: '#D1E4DD',
-		name: 'Green',
-	},
-	{
-		slug: 'blue',
-		color: '#D1DFE4',
-		name: 'Blue',
-	},
-	{
-		slug: 'purple',
-		color: '#D1D1E4',
-		name: 'Purple',
-	},
-];
-
-const GLOBAL_STYLES_GRADIENTS = [
-	{
-		slug: 'purple-to-blue',
-		gradient:
-			'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
-		name: 'Purple to Blue',
-	},
-	{
-		slug: 'green-to-purple',
-		gradient:
-			'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
-		name: 'Green to Purple',
-	},
-];
-
-const DEFAULT_GLOBAL_STYLES = {
-	styles: {
-		color: {
-			background: 'var(--wp--preset--color--green)',
-			text: 'var(--wp--preset--color--blue)',
-		},
-		elements: {
-			link: {
-				color: {
-					text: 'var(--wp--preset--color--purple)',
-				},
-			},
-		},
-	},
-};
-
-const PARSED_GLOBAL_STYLES = {
-	styles: {
-		color: {
-			background: '#D1E4DD',
-			text: '#D1DFE4',
-		},
-		elements: {
-			link: {
-				color: {
-					text: '#D1D1E4',
-				},
-			},
-		},
-	},
-};
-
-const RAW_FEATURES = {
-	color: {
-		palette: {
-			core: [
-				{
-					name: 'Black',
-					slug: 'black',
-					color: '#000000',
-				},
-				{
-					name: 'Cyan bluish gray',
-					slug: 'cyan-bluish-gray',
-					color: '#abb8c3',
-				},
-				{
-					name: 'White',
-					slug: 'white',
-					color: '#ffffff',
-				},
-			],
-			theme: [
-				{
-					slug: 'green',
-					color: '#D1E4DD',
-					name: 'Green',
-				},
-				{
-					slug: 'blue',
-					color: '#D1DFE4',
-					name: 'Blue',
-				},
-				{
-					slug: 'purple',
-					color: '#D1D1E4',
-					name: 'Purple',
-				},
-			],
-		},
-		gradients: {
-			core: [
-				{
-					name: 'Vivid cyan blue to vivid purple',
-					gradient:
-						'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
-					slug: 'vivid-cyan-blue-to-vivid-purple',
-				},
-				{
-					name: 'Light green cyan to vivid green cyan',
-					gradient:
-						'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
-					slug: 'light-green-cyan-to-vivid-green-cyan',
-				},
-			],
-			theme: [
-				{
-					slug: 'purple-to-blue',
-					gradient:
-						'linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--blue))',
-					name: 'Purple to Blue',
-				},
-				{
-					slug: 'green-to-purple',
-					gradient:
-						'linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--purple))',
-					name: 'Green to Purple',
-				},
-			],
-		},
-	},
-};
+import {
+	DEFAULT_COLORS,
+	GLOBAL_STYLES_PALETTE,
+	GLOBAL_STYLES_GRADIENTS,
+	DEFAULT_GLOBAL_STYLES,
+	PARSED_GLOBAL_STYLES,
+	RAW_FEATURES,
+	MAPPED_VALUES,
+} from './fixtures/theme';
 
 describe( 'getBlockPaddings', () => {
 	const PADDING = 12;
@@ -226,11 +94,11 @@ describe( 'getBlockColors', () => {
 	} );
 } );
 
-describe( 'parseColorVariables', () => {
+describe( 'parseVariables', () => {
 	it( 'returns the parsed colors values correctly', () => {
-		const blockColors = parseColorVariables(
+		const blockColors = parseVariables(
 			JSON.stringify( DEFAULT_GLOBAL_STYLES ),
-			GLOBAL_STYLES_PALETTE
+			MAPPED_VALUES
 		);
 		expect( blockColors ).toEqual(
 			expect.objectContaining( PARSED_GLOBAL_STYLES )
@@ -247,13 +115,13 @@ describe( 'getGlobalStyles', () => {
 			GLOBAL_STYLES_PALETTE,
 			GLOBAL_STYLES_GRADIENTS
 		);
-		const gradients = parseColorVariables(
+		const gradients = parseVariables(
 			JSON.stringify( GLOBAL_STYLES_GRADIENTS ),
-			GLOBAL_STYLES_PALETTE
+			MAPPED_VALUES
 		);
-		const parsedExperimentalFeatures = parseColorVariables(
+		const parsedExperimentalFeatures = parseVariables(
 			rawFeatures,
-			GLOBAL_STYLES_PALETTE
+			MAPPED_VALUES
 		);
 
 		expect( globalStyles ).toEqual(
@@ -264,6 +132,12 @@ describe( 'getGlobalStyles', () => {
 					color: {
 						palette: parsedExperimentalFeatures?.color?.palette,
 						gradients: parsedExperimentalFeatures?.color?.gradients,
+					},
+					typography: {
+						fontSizes: RAW_FEATURES.typography.fontSizes,
+						custom: {
+							'line-height': RAW_FEATURES.custom[ 'line-height' ],
+						},
 					},
 				},
 				__experimentalGlobalStylesBaseStyles: PARSED_GLOBAL_STYLES,

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -155,18 +155,15 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 	return JSON.parse( stylesBase );
 }
 
-export function getMappedValues( features, colors ) {
+export function getMappedValues( features, palette ) {
 	const mappedValues = {
 		color: {
-			values: colors?.palette?.theme,
+			values: palette?.theme,
 			slug: 'color',
 		},
 		'font-size': {
 			values: features?.typography?.fontSizes?.theme,
 			slug: 'size',
-		},
-		'line-height': {
-			values: features?.custom?.[ 'line-height' ],
 		},
 	};
 	return mappedValues;
@@ -174,10 +171,13 @@ export function getMappedValues( features, colors ) {
 
 export function getGlobalStyles( rawStyles, rawFeatures ) {
 	const features = JSON.parse( rawFeatures );
-	const colors = features?.color;
-	const mappedValues = getMappedValues( features, colors );
+	const mappedValues = getMappedValues( features, features?.color?.palette );
+	const colors = parseStylesVariables(
+		JSON.stringify( features?.color ),
+		mappedValues
+	);
 	const gradients = parseStylesVariables(
-		JSON.stringify( colors?.gradients ),
+		JSON.stringify( features?.color?.gradients ),
 		mappedValues
 	);
 	const customValues = parseStylesVariables(

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -206,7 +206,7 @@ class NativeEditorProvider extends Component {
 	getThemeColors( { colors, gradients, rawStyles, rawFeatures } ) {
 		return {
 			...( rawStyles
-				? getGlobalStyles( rawStyles, rawFeatures, colors, gradients )
+				? getGlobalStyles( rawStyles, rawFeatures )
 				: {
 						colors: validateThemeColors( colors ),
 						gradients: validateThemeGradients( gradients ),

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -867,6 +867,7 @@ export class RichText extends Component {
 			parentBlockStyles,
 			accessibilityLabel,
 			disableEditingMenu = false,
+			baseGlobalStyles,
 		} = this.props;
 
 		const record = this.getRecord();
@@ -986,6 +987,7 @@ export class RichText extends Component {
 					placeholderTextColor={
 						style?.placeholderColor ||
 						this.props.placeholderTextColor ||
+						( baseGlobalStyles && baseGlobalStyles?.color?.text ) ||
 						defaultPlaceholderTextColor
 					}
 					deleteEnter={ this.props.deleteEnter }
@@ -1011,6 +1013,7 @@ export class RichText extends Component {
 					color={
 						( style && style.color ) ||
 						( parentBlockStyles && parentBlockStyles.color ) ||
+						( baseGlobalStyles && baseGlobalStyles?.color?.text ) ||
 						defaultColor
 					}
 					maxImagesWidth={ 200 }
@@ -1077,12 +1080,15 @@ export default compose( [
 			'attributes',
 			'childrenStyles',
 		] );
+		const baseGlobalStyles = getSettings()
+			?.__experimentalGlobalStylesBaseStyles;
 
 		return {
 			areMentionsSupported:
 				getSettings( 'capabilities' ).mentions === true,
 			areXPostsSupported: getSettings( 'capabilities' ).xposts === true,
 			...{ parentBlockStyles },
+			baseGlobalStyles,
 		};
 	} ),
 	withPreferredColorScheme,


### PR DESCRIPTION
## Description
This PR adds support to parse nested custom variables as well as passing font-size and line-height data to the mobile editor.

It also tweaks the rich text component to load the default text color of the theme.

## How has this been tested?
Since this new data is not being used yet, the only test needed is to double-check the current global styles colors implementation works correctly.

- Using a site that has a block-based theme activated and is running WordPress 5.8.
- Open the mobile editor with metro running with the WordPress app, make sure to have the feature flag of Global styles enabled.
- **Expect** to see the theme colors in the editor.

## Screenshots <!-- if applicable -->
<kbd><img src="https://user-images.githubusercontent.com/4885740/125979000-84cb2735-8139-46d2-85fa-6d98f83906c4.png" width=250 /></kbd>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
