### PR TITLE
Close navigation sidebar when all posts clicked

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/content-posts.js
@@ -55,7 +55,9 @@ export default function ContentPostsMenu() {
 		[ searchQuery ]
 	);
 
-	const { setPage } = useDispatch( editSiteStore );
+	const { setPage, setIsNavigationPanelOpened } = useDispatch(
+		editSiteStore
+	);
 
 	const onActivateFrontItem = useCallback( () => {
 		setPage( {
@@ -65,7 +67,8 @@ export default function ContentPostsMenu() {
 				queryContext: { page: 1 },
 			},
 		} );
-	}, [ setPage ] );
+		setIsNavigationPanelOpened( false );
+	}, [ setPage, setIsNavigationPanelOpened ] );
 
 	const shouldShowLoadingForDebouncing = search && isDebouncing;
 	const showLoading = ! isResolved || shouldShowLoadingForDebouncing;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Close navigation sidebar when "Content -> Posts -> All Posts" selected

## How has this been tested?
* Make sure front page is set to blog posts
* Open site editor
* Open navigation sidebar
* Navigate to "Content -> Posts -> All Posts"
* Confirm sidebar is closed

## Screenshots <!-- if applicable -->
![2021-07-13 16 04 13](https://user-images.githubusercontent.com/5414230/125536176-81d28f44-7f48-4358-b096-7a23fa72ae5f.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
