### PR TITLE
[RNMobile] Fix: Button button border-radius to be stored as a value + unit

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -243,7 +243,7 @@ class ButtonEdit extends Component {
 			...style,
 			border: {
 				...style?.border,
-				radius: newRadius,
+				radius: `${ newRadius }px`, // Store the value with the px value so that it works as expected.
 			},
 		};
 
@@ -368,6 +368,16 @@ class ButtonEdit extends Component {
 		}
 	}
 
+	getBorderRadiusValue( borderRadius, defaultBorderRadius ) {
+		// Return an integer value for the border Radius.
+		// Since that is what the we expect that value to be.
+		if ( Number.isInteger( parseInt( borderRadius ) ) ) {
+			return parseInt( borderRadius );
+		}
+
+		return defaultBorderRadius;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -395,10 +405,11 @@ class ButtonEdit extends Component {
 		}
 
 		const borderRadius = buttonStyle?.border?.radius;
+		const borderRadiusValue = this.getBorderRadiusValue(
+			borderRadius,
+			styles.defaultButton.borderRadius
+		);
 
-		const borderRadiusValue = Number.isInteger( borderRadius )
-			? borderRadius
-			: styles.defaultButton.borderRadius;
 		const outlineBorderRadius =
 			borderRadiusValue > 0
 				? borderRadiusValue + spacing + borderWidth

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -72,8 +72,8 @@ describe( 'when a button is shown', () => {
 		fireEvent( radiusSlider, 'valueChange', '25' );
 
 		const expectedHtml = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":25}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link" href="">Hello</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"25px"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:25px">Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );


### PR DESCRIPTION
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3723 

## Description
This PR adds the unit (px) value to the button radius attribute. 

In https://github.com/WordPress/gutenberg/pull/31483 the border radius allowed for other unit types. 
Which meant that the border radius once saved in the mobile Gutenberg editor didn't show up as expected. 

**Question**: This PR doesn't take into account the other possible units that we could add support for. (for example em, rem) Should we try to address that in this PR as well?

## How has this been tested?
1. Build this PR on an iOS simulator. 
2. Change the border-radius of a button block. (Found in the block settings bottom sheet)
3. Save the post or page. Notice that the value is saved as expected and it shows up on the front end as well.

## Screenshots <!-- if applicable -->
There are no visual changes.

## Types of changes
Fixes the changes that broke in mobile. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
