### PR TITLE
Switch to new puppeteer APIs for emulating conditions

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -190,11 +190,10 @@ async function simulateAdverseConditions() {
 	if ( OFFLINE ) {
 		await page.setOfflineMode( true );
 		await page.emulateNetworkConditions( {
-			// Download speed (bytes/s)
+			// Disable download/upload.
 			download: -1,
-			// Upload speed (bytes/s)
 			upload: -1,
-			// Latency (ms)
+			// Disable latency.
 			latency: 0,
 		} );
 	}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -189,13 +189,6 @@ async function simulateAdverseConditions() {
 
 	if ( OFFLINE ) {
 		await page.setOfflineMode( true );
-		await page.emulateNetworkConditions( {
-			// Disable download/upload.
-			download: -1,
-			upload: -1,
-			// Disable latency.
-			latency: 0,
-		} );
 	}
 
 	if ( SLOW_NETWORK ) {

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -187,18 +187,26 @@ async function simulateAdverseConditions() {
 		return;
 	}
 
-	const client = await page.target().createCDPSession();
+	if ( OFFLINE ) {
+		await page.setOfflineMode( true );
+		await page.emulateNetworkConditions( {
+			// Download speed (bytes/s)
+			download: -1,
+			// Upload speed (bytes/s)
+			upload: -1,
+			// Latency (ms)
+			latency: 0,
+		} );
+	}
 
-	if ( SLOW_NETWORK || OFFLINE ) {
+	if ( SLOW_NETWORK ) {
 		// See: https://chromedevtools.github.io/devtools-protocol/tot/Network#method-emulateNetworkConditions
 		// The values below simulate fast 3G conditions as per https://github.com/ChromeDevTools/devtools-frontend/blob/80c102878fd97a7a696572054007d40560dcdd21/front_end/sdk/NetworkManager.js#L252-L274
-		await client.send( 'Network.emulateNetworkConditions', {
-			// Network connectivity is absent
-			offline: Boolean( OFFLINE || false ),
+		await page.emulateNetworkConditions( {
 			// Download speed (bytes/s)
-			downloadThroughput: ( ( 1.6 * 1024 * 1024 ) / 8 ) * 0.9,
+			download: ( ( 1.6 * 1024 * 1024 ) / 8 ) * 0.9,
 			// Upload speed (bytes/s)
-			uploadThroughput: ( ( 750 * 1024 ) / 8 ) * 0.9,
+			upload: ( ( 750 * 1024 ) / 8 ) * 0.9,
 			// Latency (ms)
 			latency: 150 * 3.75,
 		} );
@@ -206,9 +214,7 @@ async function simulateAdverseConditions() {
 
 	if ( THROTTLE_CPU ) {
 		// See: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setCPUThrottlingRate
-		await client.send( 'Emulation.setCPUThrottlingRate', {
-			rate: Number( THROTTLE_CPU ),
-		} );
+		await page.emulateCPUThrottling( Number( THROTTLE_CPU ) );
 	}
 }
 


### PR DESCRIPTION
## Description
Some of the puppeteer functionality we use in tests has been replaced with friendlier APIs, that don't require calling `page.target().createCDPSession();`.

This PR updates them.

## How has this been tested?
1. Set one of the end to end tests to `it.only` to make only that test run
2. Run `OFFLINE=true npm run test-e2e:watch -- --puppeteer-interactive`
3. The test should fail, and you should be able to see that the test site has failed to load
4. Run `SLOW_NETWORK=true npm run test-e2e:watch -- --puppeteer-interactive`
5. When the browser opens, pages should load much more slowly
6. Run `THROTTLE_CPU=200 npm run test-e2e:watch -- --puppeteer-interactive`
7. When the browser opens, everything is very sluggish.

## Types of changes
Small refactor