### PR TITLE
Add coverage folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build-style
 build-types
 node_modules
 gutenberg.zip
+coverage
 
 # Directories/files that may appear in your environment
 *.log


### PR DESCRIPTION
## Description
The  `coverage` folder is not included in the [`gutenberg` repository](https://github.com/WordPress/gutenberg) but this folder is generated every time I run the tests locally and is being tracked by git so you have to be careful not to add this folder in commits.

In this PR I added the `coverage` folder to `.gitignore` file so is not being tracked by git anymore

## How has this been tested?
By executing commands such as `npm run test-unit` and checking how the generated `coverage` folder is ignored by git when doing `git status`

## Types of changes
Minor Git control change. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
