### PR TITLE
Interface: Update content z-index

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,7 +32,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
-	".interface-interface-skeleton__content": 20,
+	".interface-interface-skeleton__content": 91,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter


### PR DESCRIPTION
## Description
Fixes #33114.
Alternative to #33355.

The content z-index should be higher than a sidebar. It prevents Snackbar notices from appearing behind the block inserter.

I wasn't able to spot any regressions caused by changing the `.interface-interface-skeleton__content` z-index. It was initially introduced to prevent background bleed on Safari iOS on small viewports - #32631. I also noticed that without z-index Snackbars work as expected, so I think this is when the bug was introduced.

## How has this been tested?
1. Open Block Inserter.
2. Trigger snackbar notice.
3. The notice isn't hidden under the block inserter.

```js
wp.data.dispatch('core/notices').createSuccessNotice( 'Snackbar should be visible when block inserter is open', { type: 'snackbar' } );
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
