### PR TITLE
Rich text: run input rules after composition end

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -60,7 +60,7 @@ export function useInputRules( props ) {
 		}
 
 		function onInput( event ) {
-			const { inputType } = event;
+			const { inputType, type } = event;
 			const {
 				value,
 				onChange,
@@ -69,7 +69,7 @@ export function useInputRules( props ) {
 			} = propsRef.current;
 
 			// Only run input rules when inserting text.
-			if ( inputType !== 'insertText' ) {
+			if ( inputType !== 'insertText' && type !== 'compositionend' ) {
 				return;
 			}
 
@@ -99,8 +99,10 @@ export function useInputRules( props ) {
 		}
 
 		element.addEventListener( 'input', onInput );
+		element.addEventListener( 'compositionend', onInput );
 		return () => {
 			element.removeEventListener( 'input', onInput );
+			element.removeEventListener( 'compositionend', onInput );
 		};
 	}, [] );
 }

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -110,6 +110,12 @@ exports[`RichText should return focus when pressing formatting button 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should run input rules after composition end 1`] = `
+"<!-- wp:paragraph -->
+<p><code>a</code></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should split rich text on paste 1`] = `
 "<!-- wp:paragraph -->
 <p>a</p>

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -454,6 +454,10 @@ describe( 'RichText', () => {
 
 	it( 'should run input rules after composition end', async () => {
 		await clickBlockAppender();
+		// Puppeteer doesn't support composition, so emulate it by inserting
+		// text in the DOM directly, setting selection in the right place, and
+		// firing `compositionend`.
+		// See https://github.com/puppeteer/puppeteer/issues/4981.
 		await page.evaluate( () => {
 			document.activeElement.textContent = '`a`';
 			const selection = window.getSelection();

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -451,4 +451,19 @@ describe( 'RichText', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		expect( await page.$( blockToolbarSelector ) ).toBe( null );
 	} );
+
+	it( 'should run input rules after composition end', async () => {
+		await clickBlockAppender();
+		await page.evaluate( () => {
+			document.activeElement.textContent = '`a`';
+			const selection = window.getSelection();
+			selection.selectAllChildren( document.activeElement );
+			selection.collapseToEnd();
+			document.activeElement.dispatchEvent(
+				new CompositionEvent( 'compositionend' )
+			);
+		} );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #33004.
Introduced by #31752 (thanks @mcsf).

Input rules used to run after `compositionend`, but that's no longer the case.

It's not possible to make an e2e test for this because Puppeteer doesn't have any APIs around it. I filed a request in the past: https://github.com/puppeteer/puppeteer/issues/4981.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Change to a keyboard with `` ` `` as a dead key and try to wrap text in it to wrap it in a code element.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
