### PR TITLE
Fix codetabs syntax in theme.json docs

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -662,7 +662,7 @@ Each block declares which style properties it exposes via the [block supports me
 }
 ```
 
-{% end%}
+{% end %}
 
 ### Top-level styles
 


### PR DESCRIPTION
There's a typo in the codetabs syntax that causes the subsequent sections to be hidden: there's no "Top-level styles" section in the handbook and this is the styles section:

![Captura de ecrã de 2021-07-14 11-33-56](https://user-images.githubusercontent.com/583546/125599772-8732c8c3-c5de-4445-af86-ffd79bfd2a12.png)


