### PR TITLE
Suggestion List: Check if a node exists to scroll into view

### DIFF
--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -21,7 +21,11 @@ class SuggestionsList extends Component {
 	componentDidUpdate() {
 		// only have to worry about scrolling selected suggestion into view
 		// when already expanded
-		if ( this.props.selectedIndex > -1 && this.props.scrollIntoView ) {
+		if (
+			this.props.selectedIndex > -1 &&
+			this.props.scrollIntoView &&
+			this.list.children[ this.props.selectedIndex ]
+		) {
 			this.scrollingIntoView = true;
 			scrollIntoView(
 				this.list.children[ this.props.selectedIndex ],


### PR DESCRIPTION
## Description
Missing node source will cause an error in the `scrollIntoView` function and crash the editor. PR adds a check before scrolling selected suggestions into the view.

Fixes #30932.

## How has this been tested?
1. Go to the post editor.
2. Start searching for a tag.
3. Press down on the keyboard to select the first tag suggestion.
4. Continue typing, but type any letter that's not next in the selected tag's name.
5. Editor shouldn't crash.

## Screenshots

https://user-images.githubusercontent.com/240569/125611226-c8102a17-9e2c-4b58-a962-cdeb8d1c0253.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
