### PR TITLE
Site Editor: Make NavigationToggle filterable

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button, Icon } from '@wordpress/components';
+import { Button, Icon, withFilters } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -12,7 +12,7 @@ import { store as coreDataStore } from '@wordpress/core-data';
  */
 import { store as editSiteStore } from '../../../store';
 
-function NavigationToggle( { icon, isOpen } ) {
+function NavigationToggle( { icon, isOpen, label, onClick } ) {
 	const {
 		isRequestingSiteIcon,
 		navigationPanelMenu,
@@ -73,8 +73,8 @@ function NavigationToggle( { icon, isOpen } ) {
 		>
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
-				label={ __( 'Toggle navigation' ) }
-				onClick={ toggleNavigationPanel }
+				label={ label || __( 'Toggle navigation' ) }
+				onClick={ onClick || toggleNavigationPanel }
 				showTooltip
 			>
 				{ buttonIcon }
@@ -83,4 +83,4 @@ function NavigationToggle( { icon, isOpen } ) {
 	);
 }
 
-export default NavigationToggle;
+export default withFilters( 'editSite.NavigationToggle' )( NavigationToggle );


### PR DESCRIPTION
## Description

Make the `NavigationToggle` component filterable, so that it's possible to override its props externally.

#### Note

Practically speaking, in order to allow third parties to override the toggle's `onClick`, this change will make them able to prevent opening the Navigation sidebar altogether.
I haven't spent too much time thinking of a catch-all solution, as it's reasonably easy to restore the sidebar opening functionality in a plugin by dispatching the relevant actions.

If anyone has a better solution, though, feel free to share it! 🙂 

## How has this been tested?

- Activate a block-based theme such as TT1 Blocks.
- Paste this code somewhere (for example in `packages/edit-site/src/plugins/index.js`:
```js
import { addFilter } from '@wordpress/hooks';
addFilter( 'editSite.NavigationToggle', 'test-plugin', ( NavigationToggle ) => {
	return () => (
		<NavigationToggle label="TEST" onClick={ () => console.log( 'TEST' ) } />
	);
} );
```
- Enter the Site Editor and open the browser console.
- Hover on the `NavigationToggle` component (the top-left WP or site icon).
- Make sure its label is "TEST" instead of "Toggle Navigation".
- Click on the `NavigationToggle`.
- Make sure the navigation sidebar doesn't open and a "TEST" shows up in the console.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
