### PR TITLE
[RNMobile] Fix/button radius update more units

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -243,7 +243,7 @@ class ButtonEdit extends Component {
 			...style,
 			border: {
 				...style?.border,
-				radius: newRadius,
+				radius: `${ newRadius }px`, // Store the value with the px value so that it works as expected.
 			},
 		};
 
@@ -368,6 +368,16 @@ class ButtonEdit extends Component {
 		}
 	}
 
+	getBorderRadiusValue( borderRadius, defaultBorderRadius ) {
+		// Return an integer value for the border Radius.
+		// Since that is what the we expect that value to be.
+		if ( Number.isInteger( parseInt( borderRadius ) ) ) {
+			return parseInt( borderRadius );
+		}
+
+		return defaultBorderRadius;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -395,10 +405,11 @@ class ButtonEdit extends Component {
 		}
 
 		const borderRadius = buttonStyle?.border?.radius;
+		const borderRadiusValue = this.getBorderRadiusValue(
+			borderRadius,
+			styles.defaultButton.borderRadius
+		);
 
-		const borderRadiusValue = Number.isInteger( borderRadius )
-			? borderRadius
-			: styles.defaultButton.borderRadius;
 		const outlineBorderRadius =
 			borderRadiusValue > 0
 				? borderRadiusValue + spacing + borderWidth

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -250,13 +250,7 @@ class ButtonEdit extends Component {
 		const { setAttributes, attributes } = this.props;
 		const { borderRadiusUnit } = this.state;
 		const { style } = attributes;
-		const newStyle = {
-			...style,
-			border: {
-				...style?.border,
-				radius: `${ newRadius }${ borderRadiusUnit }`, // Store the value with the unit value so that it works as expected.
-			},
-		};
+		const newStyle = this.getNewStyle( style, newRadius, borderRadiusUnit );
 
 		setAttributes( { style: newStyle } );
 	}
@@ -267,17 +261,19 @@ class ButtonEdit extends Component {
 		const borderRadius = this.getBorderRadiusValue(
 			attributes?.style?.border?.radius
 		);
+		const newStyle = this.getNewStyle( style, borderRadius, newRadiusUnit );
+		setAttributes( { style: newStyle } );
+		this.setState( { borderRadiusUnit: newRadiusUnit } );
+	}
 
-		const newStyle = {
+	getNewStyle( style, radius, radiusUnit ) {
+		return {
 			...style,
 			border: {
 				...style?.border,
-				radius: `${ borderRadius }${ newRadiusUnit }`, // Store the value with the unit value so that it works as expected.
+				radius: `${ radius }${ radiusUnit }`, // Store the value with the unit so that it works as expected.
 			},
 		};
-
-		setAttributes( { style: newStyle } );
-		this.setState( { borderRadiusUnit: newRadiusUnit } );
 	}
 
 	onShowLinkSettings() {

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -254,7 +254,7 @@ class ButtonEdit extends Component {
 			...style,
 			border: {
 				...style?.border,
-				radius: `${ newRadius }${ borderRadiusUnit }`, // Store the value with the px value so that it works as expected.
+				radius: `${ newRadius }${ borderRadiusUnit }`, // Store the value with the unit value so that it works as expected.
 			},
 		};
 
@@ -272,7 +272,7 @@ class ButtonEdit extends Component {
 			...style,
 			border: {
 				...style?.border,
-				radius: `${ borderRadius }${ newRadiusUnit }`, // Store the value with the px value so that it works as expected.
+				radius: `${ borderRadius }${ newRadiusUnit }`, // Store the value with the unit value so that it works as expected.
 			},
 		};
 

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -72,8 +72,8 @@ describe( 'when a button is shown', () => {
 		fireEvent( radiusSlider, 'valueChange', '25' );
 
 		const expectedHtml = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":25}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link" href="">Hello</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"25px"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:25px">Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -30,8 +30,8 @@ afterAll( () => {
 describe( 'when a button is shown', () => {
 	it( 'adjusts the border radius', async () => {
 		const initialHtml = `<!-- wp:buttons -->
-		<div class="wp-block-buttons"><!-- wp:button -->
-		<div class="wp-block-button"><a class="wp-block-button__link">Hello</a></div>
+		<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"5%"}}} -->
+		<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5%" >Hello</a></div>
 		<!-- /wp:button --></div>
 		<!-- /wp:buttons -->`;
 		const { getByA11yLabel, getByTestId } = await initializeEditor( {
@@ -72,8 +72,8 @@ describe( 'when a button is shown', () => {
 		fireEvent( radiusSlider, 'valueChange', '25' );
 
 		const expectedHtml = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"25px"}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:25px">Hello</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"25%"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:25%">Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -175,7 +175,6 @@ function ColumnEdit( {
 								onChange={ onChange }
 								onComplete={ onChangeWidth }
 								onUnitChange={ onChangeUnit }
-								decimalNum={ 1 }
 								value={
 									getWidths( columns )[ selectedColumnIndex ]
 								}

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -203,7 +203,6 @@ function ColumnsEditContainer( {
 							? 100
 							: undefined
 					}
-					decimalNum={ 1 }
 					value={ getWidths( innerWidths )[ index ] }
 					onChange={ ( nextWidth ) => {
 						onChange( nextWidth, valueUnit, column.clientId );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -187,6 +187,12 @@ describe( 'validation', () => {
 
 			expect( normalizedLength ).toBe( '50%' );
 		} );
+
+		it( 'adds leading zero to percentage', () => {
+			const normalizedLength = getNormalizedLength( '.5%' );
+
+			expect( normalizedLength ).toBe( '0.5%' );
+		} );
 	} );
 
 	describe( 'getNormalizedStyleValue()', () => {
@@ -206,6 +212,12 @@ describe( 'validation', () => {
 			);
 
 			expect( normalizedValue ).toBe( '44% 0 18em 0' );
+		} );
+
+		it( 'add leading zero to units that have it missing', () => {
+			const normalizedValue = getNormalizedStyleValue( '.23% .75em' );
+
+			expect( normalizedValue ).toBe( '0.23% 0.75em' );
 		} );
 
 		it( 'leaves zero values in calc() expressions alone', () => {

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -334,7 +334,15 @@ export function isEquivalentTextTokens(
  * @return {string} Normalized CSS length value.
  */
 export function getNormalizedLength( value ) {
-	return 0 === parseFloat( value ) ? '0' : value;
+	if ( 0 === parseFloat( value ) ) {
+		return '0';
+	}
+	// Normalize strings with floats to always include a leading zero.
+	if ( value.indexOf( '.' ) === 0 ) {
+		return '0' + value;
+	}
+
+	return value;
 }
 
 /**

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -54,6 +54,10 @@ export {
 	default as UnitControl,
 	useCustomUnits as __experimentalUseCustomUnits,
 } from './unit-control';
+export {
+	CSS_UNITS as CSS_UNITS,
+	filterUnitsWithSettings as filterUnitsWithSettings,
+} from './unit-control/utils';
 export { default as Disabled } from './disabled';
 
 // Higher-Order Components

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
@@ -240,7 +240,7 @@ class BottomSheetStepperCell extends Component {
 										label={ label }
 										onChange={ onChange }
 										defaultValue={ `${ inputValue }` }
-										value={ inputValue }
+										value={ value }
 										min={ min }
 										step={ 1 }
 										decimalNum={ decimalNum }

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
@@ -58,9 +58,8 @@ class BottomSheetStepperCell extends Component {
 	onIncrementValue() {
 		const { step, max, onChange, value, decimalNum } = this.props;
 		let newValue = toFixed( value + step, decimalNum );
-		newValue = parseInt( newValue ) === newValue 
-			? parseInt( newValue )
-			: newValue;
+		newValue =
+			parseInt( newValue ) === newValue ? parseInt( newValue ) : newValue;
 		if ( newValue <= max || max === undefined ) {
 			onChange( newValue );
 			this.setState( {
@@ -73,9 +72,8 @@ class BottomSheetStepperCell extends Component {
 	onDecrementValue() {
 		const { step, min, onChange, value, decimalNum } = this.props;
 		let newValue = toFixed( value - step, decimalNum );
-		newValue = parseInt( newValue ) === newValue 
-			? parseInt( newValue )
-			: newValue;
+		newValue =
+			parseInt( newValue ) === newValue ? parseInt( newValue ) : newValue;
 		if ( newValue >= min ) {
 			onChange( newValue );
 			this.setState( {

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/index.native.js
@@ -57,8 +57,10 @@ class BottomSheetStepperCell extends Component {
 
 	onIncrementValue() {
 		const { step, max, onChange, value, decimalNum } = this.props;
-		const newValue = toFixed( value + step, decimalNum );
-
+		let newValue = toFixed( value + step, decimalNum );
+		newValue = parseInt( newValue ) === newValue 
+			? parseInt( newValue )
+			: newValue;
 		if ( newValue <= max || max === undefined ) {
 			onChange( newValue );
 			this.setState( {
@@ -70,8 +72,10 @@ class BottomSheetStepperCell extends Component {
 
 	onDecrementValue() {
 		const { step, min, onChange, value, decimalNum } = this.props;
-		const newValue = toFixed( value - step, decimalNum );
-
+		let newValue = toFixed( value - step, decimalNum );
+		newValue = parseInt( newValue ) === newValue 
+			? parseInt( newValue )
+			: newValue;
 		if ( newValue >= min ) {
 			onChange( newValue );
 			this.setState( {

--- a/packages/components/src/mobile/utils/index.native.js
+++ b/packages/components/src/mobile/utils/index.native.js
@@ -5,5 +5,8 @@ export function removeNonDigit( text, decimalNum ) {
 }
 
 export function toFixed( num, decimalNum = 0 ) {
-	return Number.parseFloat( num ).toFixed( decimalNum );
+	const decimalOffset = decimalNum < 0 ? 0 : decimalNum;
+	return Number.parseFloat(
+		Number.parseFloat( num ).toFixed( decimalOffset )
+	);
 }

--- a/packages/components/src/mobile/utils/index.native.js
+++ b/packages/components/src/mobile/utils/index.native.js
@@ -5,6 +5,5 @@ export function removeNonDigit( text, decimalNum ) {
 }
 
 export function toFixed( num, decimalNum = 0 ) {
-	const fixed = Math.pow( 10, decimalNum < 0 ? 0 : decimalNum );
-	return Math.floor( num * fixed ) / fixed;
+	return Number.parseFloat( num ).toFixed( decimalNum );
 }

--- a/packages/components/src/mobile/utils/test/index.native.js
+++ b/packages/components/src/mobile/utils/test/index.native.js
@@ -50,7 +50,7 @@ describe( 'toFixed', () => {
 
 	it( 'function returns the number applying `decimalNum`', () => {
 		const result = toFixed( '123.4567', 2 );
-		expect( result ).toBe( 123.45 );
+		expect( result ).toBe( 123.46 );
 	} );
 
 	it( 'function returns the number applying `decimalNum` all point numbers', () => {

--- a/packages/components/src/mobile/utils/test/index.native.js
+++ b/packages/components/src/mobile/utils/test/index.native.js
@@ -53,6 +53,25 @@ describe( 'toFixed', () => {
 		expect( result ).toBe( 123.45 );
 	} );
 
+	it( 'function returns the number applying `decimalNum` all point numbers', () => {
+		const toCheck = [
+			1.01,
+			1.02,
+			1.03,
+			1.04,
+			1.05,
+			1.06,
+			1.07,
+			1.08,
+			1.09,
+			1.1,
+		];
+		toCheck.forEach( ( num ) => {
+			const result = toFixed( num, 2 );
+			expect( result ).toBe( num );
+		} );
+	} );
+
 	it( 'function returns number without decimals if `decimalNum` is negative', () => {
 		const result = toFixed( '12.34', -12 );
 		expect( result ).toBe( 12 );

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -105,8 +105,13 @@ function UnitControl( {
 	);
 
 	const getDecimal = ( step ) => {
+		// Return the decimal offset based on the step size.
+		// if step size is 0.1 we expect the offset to be 1.
+		// for example 12 + 0.1 we would expect the see 12.1 (not 12.10 or 12 );
+		// steps are defined in the CSS_UNITS and they vary from unit to unit.
 		const stepToString = step;
-		return step === 1 ? 0 : stepToString.toString().length - 2;
+		const splitStep = stepToString.toString().split( '.' );
+		return splitStep[ 1 ] ? splitStep[ 1 ].length : 0;
 	};
 
 	const renderUnitPicker = useCallback( () => {

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -38,7 +38,6 @@ function UnitControl( {
 	units = CSS_UNITS,
 	unit,
 	getStylesFromColorScheme,
-	decimalNum,
 	...props
 } ) {
 	const pickerRef = useRef();
@@ -105,6 +104,11 @@ function UnitControl( {
 		[ anchorNodeRef?.current ]
 	);
 
+	const getDecimal = ( step ) => {
+		const stepToString = step;
+		return step === 1 ? 0 : stepToString.toString().length - 2;
+	};
+
 	const renderUnitPicker = useCallback( () => {
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
@@ -121,7 +125,7 @@ function UnitControl( {
 				) : null }
 			</View>
 		);
-	}, [ pickerRef, units, onUnitChange, getAnchor ] );
+	}, [ pickerRef, units, onUnitChange, getAnchor, renderUnitButton ] );
 
 	let step = props.step;
 
@@ -147,7 +151,7 @@ function UnitControl( {
 					step={ step }
 					defaultValue={ initialControlValue }
 					shouldDisplayTextInput
-					decimalNum={ unit === 'px' ? 0 : decimalNum }
+					decimalNum={ getDecimal( step ) }
 					openUnitPicker={ onPickerPresent }
 					unitLabel={ parseA11yLabelForUnit( unit ) }
 					{ ...props }
@@ -165,7 +169,7 @@ function UnitControl( {
 					unit={ unit }
 					defaultValue={ initialControlValue }
 					separatorType={ separatorType }
-					decimalNum={ decimalNum }
+					decimalNum={ getDecimal( step ) }
 					openUnitPicker={ onPickerPresent }
 					unitLabel={ parseA11yLabelForUnit( unit ) }
 					{ ...props }

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -143,6 +143,8 @@ function UnitControl( {
 		step = activeUnit?.step ?? 1;
 	}
 
+	const decimalNum = getDecimal( step );
+
 	return (
 		<>
 			{ unit !== '%' ? (
@@ -156,7 +158,7 @@ function UnitControl( {
 					step={ step }
 					defaultValue={ initialControlValue }
 					shouldDisplayTextInput
-					decimalNum={ getDecimal( step ) }
+					decimalNum={ decimalNum }
 					openUnitPicker={ onPickerPresent }
 					unitLabel={ parseA11yLabelForUnit( unit ) }
 					{ ...props }
@@ -174,7 +176,7 @@ function UnitControl( {
 					unit={ unit }
 					defaultValue={ initialControlValue }
 					separatorType={ separatorType }
-					decimalNum={ getDecimal( step ) }
+					decimalNum={ decimalNum }
 					openUnitPicker={ onPickerPresent }
 					unitLabel={ parseA11yLabelForUnit( unit ) }
 					{ ...props }

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -129,4 +129,7 @@ module.exports = {
 	textInput: {
 		color: 'black',
 	},
+	buttonNoBg: {
+		color: 'orange',
+	}
 };

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -131,5 +131,5 @@ module.exports = {
 	},
 	buttonNoBg: {
 		color: 'orange',
-	}
+	},
 };


### PR DESCRIPTION
Gutenberg Mobile PR: wordpress-mobile/gutenberg-mobile#3723

## Description
This PR updates the Button Block component to support different kinds of button border-radius values that contain both values and units. 

It surpasses what https://github.com/WordPress/gutenberg/pull/33405 does by using the UnitControl component. 

## How has this been tested?
Create content with a different button radius. Such as:
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"10px"}}} -->
<div class="wp-block-button"><a class="wp-block-button__link" href="https://code.a8c.com/D64091" style="border-radius:10px" rel="">10px</a></div>
<!-- /wp:button -->

<!-- wp:button {"style":{"border":{"radius":"10em"}}} -->
<div class="wp-block-button"><a class="wp-block-button__link" href="https://code.a8c.com/D64091" style="border-radius:10em" rel="">10em</a></div>
<!-- /wp:button -->

<!-- wp:button {"style":{"border":{"radius":"10rem"}}} -->
<div class="wp-block-button"><a class="wp-block-button__link" href="https://code.a8c.com/D64091" style="border-radius:10rem" rel="">10 rem</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons -->
```

Not that the buttons radius settings looks and works as expected. 
Try updating the values. Do they update as you would expect? 
Are you able to use the - and + button? 
Are you able to use text input as you would expect?

## Screenshots <!-- if applicable -->

<img width="200" alt="Screen Shot 2021-07-14 at 1 01 37 PM" src="https://user-images.githubusercontent.com/115071/125685343-15600cca-ede0-4d75-a42d-7dd54866bdcb.png">
<img width="200" alt="Screen Shot 2021-07-14 at 1 01 30 PM" src="https://user-images.githubusercontent.com/115071/125685359-76d86166-53c3-49e4-9186-c201203c7646.png">


## Types of changes
Bug fix. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
