### PR TITLE
Performance: only trigger dropzone handling when a user intends to drop an item

### DIFF
--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -67,6 +67,12 @@ export default function useDropZone( {
 			}
 
 			let isDragging = false;
+			/** @type {number} */
+			let lastDragX = 0;
+			/** @type {number} */
+			let lastDragY = 0;
+			/** @type { number } */
+			let lastTimestamp = Date.now(); // Note that FF will reduce precision to 100ms when privacy.resistFingerprinting is enabled
 
 			const { ownerDocument } = element;
 
@@ -100,6 +106,9 @@ export default function useDropZone( {
 				}
 
 				isDragging = true;
+				lastTimestamp = Date.now();
+				lastDragX = event.clientX;
+				lastDragY = event.clientY;
 
 				ownerDocument.removeEventListener(
 					'dragenter',
@@ -138,27 +147,11 @@ export default function useDropZone( {
 				}
 			}
 
-			/** @type {number | undefined} */
-			let lastDragX;
-			/** @type {number | undefined} */
-			let lastDragY;
-			/** @type { number | undefined } */
-			let lastTime; // Note that FF will reduce precision to 100ms when privacy.resistFingerprinting is enabled
 			function onDragOver( /** @type {DragEvent} */ event ) {
 				// Only call onDragOver for the innermost hovered drop zones.
 				if ( ! event.defaultPrevented && onDragOverRef.current ) {
 					const time = Date.now();
-					if (
-						lastTime === undefined ||
-						lastDragX === undefined ||
-						lastDragY === undefined
-					) {
-						//first frame
-						lastTime = time;
-						lastDragX = event.clientX;
-						lastDragY = event.clientY;
-					}
-					if ( time - lastTime > 33 ) {
+					if ( time - lastTimestamp > 33 ) {
 						const distance =
 							Math.abs( event.clientY - lastDragY ) +
 							Math.abs( event.clientX - lastDragX );
@@ -167,7 +160,7 @@ export default function useDropZone( {
 						}
 						lastDragX = event.clientX;
 						lastDragY = event.clientY;
-						lastTime = time;
+						lastTimestamp = time;
 					}
 				}
 				// Prevent the browser default while also signalling to parent

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -138,12 +138,30 @@ export default function useDropZone( {
 				}
 			}
 
+			/** @type {number | undefined} */
+			let lastDragX;
+			/** @type {number | undefined} */
+			let lastDragY;
+			/** @type { number } */
+			let lastTime = Date.now(); // Note that FF will reduce precision to 100ms when privacy.resistFingerprinting is enabled
 			function onDragOver( /** @type {DragEvent} */ event ) {
 				// Only call onDragOver for the innermost hovered drop zones.
 				if ( ! event.defaultPrevented && onDragOverRef.current ) {
-					onDragOverRef.current( event );
+					const x = lastDragX ?? event.clientX;
+					const y = lastDragY ?? event.clientY;
+					const time = Date.now();
+					if ( time - lastTime > 100 ) {
+						const distance =
+							Math.abs( event.clientY - y ) +
+							Math.abs( event.clientX - x );
+						if ( distance < 50 ) {
+							onDragOverRef.current( event );
+						}
+						lastDragX = event.clientX;
+						lastDragY = event.clientY;
+						lastTime = time;
+					}
 				}
-
 				// Prevent the browser default while also signalling to parent
 				// drop zones that `onDragOver` is already handled.
 				event.preventDefault();

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -155,7 +155,7 @@ export default function useDropZone( {
 					dragTimingRef.current
 				) {
 					const time = Date.now();
-					if ( time - dragTimingRef.current.timestamp > 33 ) {
+					if ( time - dragTimingRef.current.timestamp > 16 ) {
 						const distance =
 							Math.abs(
 								event.clientY - dragTimingRef.current.dragY

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -142,19 +142,27 @@ export default function useDropZone( {
 			let lastDragX;
 			/** @type {number | undefined} */
 			let lastDragY;
-			/** @type { number } */
-			let lastTime = Date.now(); // Note that FF will reduce precision to 100ms when privacy.resistFingerprinting is enabled
+			/** @type { number | undefined } */
+			let lastTime; // Note that FF will reduce precision to 100ms when privacy.resistFingerprinting is enabled
 			function onDragOver( /** @type {DragEvent} */ event ) {
 				// Only call onDragOver for the innermost hovered drop zones.
 				if ( ! event.defaultPrevented && onDragOverRef.current ) {
-					const x = lastDragX ?? event.clientX;
-					const y = lastDragY ?? event.clientY;
 					const time = Date.now();
-					if ( time - lastTime > 100 ) {
+					if (
+						lastTime === undefined ||
+						lastDragX === undefined ||
+						lastDragY === undefined
+					) {
+						//first frame
+						lastTime = time;
+						lastDragX = event.clientX;
+						lastDragY = event.clientY;
+					}
+					if ( time - lastTime > 33 ) {
 						const distance =
-							Math.abs( event.clientY - y ) +
-							Math.abs( event.clientX - x );
-						if ( distance < 50 ) {
+							Math.abs( event.clientY - lastDragY ) +
+							Math.abs( event.clientX - lastDragX );
+						if ( distance < 10 ) {
 							onDragOverRef.current( event );
 						}
 						lastDragX = event.clientX;

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -16,7 +16,9 @@ async function dragAndDrop( draggableElement, targetElement, offsetY ) {
 		y: targetClickablePoint.y + offsetY,
 	};
 
-	return await page.mouse.dragAndDrop( draggablePoint, targetPoint );
+	return await page.mouse.dragAndDrop( draggablePoint, targetPoint, {
+		delay: 100,
+	} );
 }
 
 describe( 'List view', () => {


### PR DESCRIPTION
### Background 

Our drop zone handlers are also causing major performance issues when dragging quickly. We have dragging listeners on every component that is a drop zone. These events are currently not throttled and when dragging quickly we can queue up quite a number of events to resolve. We will also trigger a number of unneeded animations. This slows things down quite a bit.

In this PR we try and infer what the user intends to do. Are they trying to move the item quickly, someplace else or are they ready to drop an item into a drop zone? If they're not ready to drop, we can skip work.

I profiled using the Armando theme, and the "alternating rows with images and headings" pattern.

| before | after |
|-----|-----|
| <img width="1422" alt="before" src="https://user-images.githubusercontent.com/1270189/126818329-7a32d9bc-0794-40db-a5a0-1857268c22f1.png"> | <img width="1263" alt="after-16" src="https://user-images.githubusercontent.com/1270189/127193155-e22090dd-603b-45ba-8bf0-ce91f5bc106c.png"> |

Here are some videos of the type of actions I was performing while profiling. Note that screenrecording + profiling also impacts performance, so I took separate profiling screencaps above.

#### Profiling In Trunk 

https://user-images.githubusercontent.com/1270189/126814474-11aeca2e-bbe0-407a-a075-353506b0a74f.mp4

#### Branch 

https://user-images.githubusercontent.com/1270189/127194167-b6eae4f8-3858-46db-b084-e9e7223f4e9b.mp4

### Testing Instructions

- No regressions in dropzone
- Verify that the drop indicators feel responsive enough. (We can still tune this further if we're sampling not often enough.)

#### Follow Up

To improve drag performance further I think there's two areas of interest I've spotted:
- Incremental follow up of exploring if dragleave events can be throttled further.
- Invert control, and explore a global drag handler instead of many child listeners trying to cancel each other's events. Much larger refactor, but I'd typically pick this setup for a complex editor/app.




