### PR TITLE
BoxControl: Prevent invalid style values

### DIFF
--- a/packages/components/src/box-control/axial-input-controls.js
+++ b/packages/components/src/box-control/axial-input-controls.js
@@ -13,6 +13,8 @@ export default function AxialInputControls( {
 	onHoverOn,
 	onHoverOff,
 	values,
+	selectedUnits,
+	setSelectedUnits,
 	sides,
 	...props
 } ) {
@@ -64,17 +66,36 @@ export default function AxialInputControls( {
 			return;
 		}
 		const nextValues = { ...values };
+		const isNumeric = ! isNaN( parseFloat( next ) );
+		const nextValue = isNumeric ? next : undefined;
 
 		if ( side === 'vertical' ) {
-			nextValues.top = next;
-			nextValues.bottom = next;
+			nextValues.top = nextValue;
+			nextValues.bottom = nextValue;
 		}
+
 		if ( side === 'horizontal' ) {
-			nextValues.left = next;
-			nextValues.right = next;
+			nextValues.left = nextValue;
+			nextValues.right = nextValue;
 		}
 
 		onChange( nextValues );
+	};
+
+	const createHandleOnUnitChange = ( side ) => ( next ) => {
+		const newUnits = { ...selectedUnits };
+
+		if ( side === 'vertical' ) {
+			newUnits.top = next;
+			newUnits.bottom = next;
+		}
+
+		if ( side === 'horizontal' ) {
+			newUnits.left = next;
+			newUnits.right = next;
+		}
+
+		setSelectedUnits( newUnits );
 	};
 
 	// Filter sides if custom configuration provided, maintaining default order.
@@ -98,8 +119,14 @@ export default function AxialInputControls( {
 					isFirst={ first === side }
 					isLast={ last === side }
 					isOnly={ only === side }
-					value={ 'vertical' === side ? values.top : values.left }
+					value={ side === 'vertical' ? values.top : values.left }
+					unit={
+						side === 'vertical'
+							? selectedUnits.top
+							: selectedUnits.left
+					}
 					onChange={ createHandleOnChange( side ) }
+					onUnitChange={ createHandleOnUnitChange( side ) }
 					onFocus={ createHandleOnFocus( side ) }
 					onHoverOn={ createHandleOnHoverOn( side ) }
 					onHoverOff={ createHandleOnHoverOff( side ) }

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -27,6 +27,7 @@ import {
 	Header,
 	HeaderControlWrapper,
 } from './styles/box-control-styles';
+import { parseUnit } from '../unit-control/utils';
 import {
 	DEFAULT_VALUES,
 	DEFAULT_VISUALIZER_VALUES,
@@ -74,6 +75,16 @@ export default function BoxControl( {
 		getInitialSide( isLinked, splitOnAxis )
 	);
 
+	// Tracking selected units via internal state allows filtering of CSS unit
+	// only values from being saved while maintaining preexisting unit selection
+	// behaviour. Filtering CSS only values prevents invalid style values.
+	const [ selectedUnits, setSelectedUnits ] = useState( {
+		top: parseUnit( valuesProp?.top )[ 1 ],
+		right: parseUnit( valuesProp?.right )[ 1 ],
+		bottom: parseUnit( valuesProp?.bottom )[ 1 ],
+		left: parseUnit( valuesProp?.left )[ 1 ],
+	} );
+
 	const id = useUniqueId( idProp );
 	const headingId = `${ id }-heading`;
 
@@ -103,6 +114,7 @@ export default function BoxControl( {
 	const handleOnReset = () => {
 		onChange( resetValues );
 		setValues( resetValues );
+		setSelectedUnits( resetValues );
 		setIsDirty( false );
 	};
 
@@ -114,6 +126,8 @@ export default function BoxControl( {
 		onHoverOff: handleOnHoverOff,
 		isLinked,
 		units,
+		selectedUnits,
+		setSelectedUnits,
 		sides,
 		values: inputValues,
 	};

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -7,10 +7,8 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import UnitControl from './unit-control';
-import { LABELS } from './utils';
+import { ALL_SIDES, LABELS } from './utils';
 import { LayoutContainer, Layout } from './styles/box-control-styles';
-
-const allSides = [ 'top', 'right', 'bottom', 'left' ];
 
 export default function BoxInputControls( {
 	onChange = noop,
@@ -18,6 +16,8 @@ export default function BoxInputControls( {
 	onHoverOn = noop,
 	onHoverOff = noop,
 	values,
+	selectedUnits,
+	setSelectedUnits,
 	sides,
 	...props
 } ) {
@@ -40,8 +40,10 @@ export default function BoxInputControls( {
 	const createHandleOnChange = ( side ) => ( next, { event } ) => {
 		const { altKey } = event;
 		const nextValues = { ...values };
+		const isNumeric = ! isNaN( parseFloat( next ) );
+		const nextValue = isNumeric ? next : undefined;
 
-		nextValues[ side ] = next;
+		nextValues[ side ] = nextValue;
 
 		/**
 		 * Supports changing pair sides. For example, holding the ALT key
@@ -50,16 +52,16 @@ export default function BoxInputControls( {
 		if ( altKey ) {
 			switch ( side ) {
 				case 'top':
-					nextValues.bottom = next;
+					nextValues.bottom = nextValue;
 					break;
 				case 'bottom':
-					nextValues.top = next;
+					nextValues.top = nextValue;
 					break;
 				case 'left':
-					nextValues.right = next;
+					nextValues.right = nextValue;
 					break;
 				case 'right':
-					nextValues.left = next;
+					nextValues.left = nextValue;
 					break;
 			}
 		}
@@ -67,10 +69,16 @@ export default function BoxInputControls( {
 		handleOnChange( nextValues );
 	};
 
+	const createHandleOnUnitChange = ( side ) => ( next ) => {
+		const newUnits = { ...selectedUnits };
+		newUnits[ side ] = next;
+		setSelectedUnits( newUnits );
+	};
+
 	// Filter sides if custom configuration provided, maintaining default order.
 	const filteredSides = sides?.length
-		? allSides.filter( ( side ) => sides.includes( side ) )
-		: allSides;
+		? ALL_SIDES.filter( ( side ) => sides.includes( side ) )
+		: ALL_SIDES;
 
 	const first = filteredSides[ 0 ];
 	const last = filteredSides[ filteredSides.length - 1 ];
@@ -90,7 +98,11 @@ export default function BoxInputControls( {
 						isLast={ last === side }
 						isOnly={ only === side }
 						value={ values[ side ] }
+						unit={
+							values[ side ] ? undefined : selectedUnits[ side ]
+						}
 						onChange={ createHandleOnChange( side ) }
+						onUnitChange={ createHandleOnUnitChange( side ) }
 						onFocus={ createHandleOnFocus( side ) }
 						onHoverOn={ createHandleOnHoverOn( side ) }
 						onHoverOff={ createHandleOnHoverOff( side ) }

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -188,6 +188,119 @@ describe( 'BoxControl', () => {
 				top: '100px',
 				right: undefined,
 				bottom: '100px',
+				left: undefined,
+			} );
+		} );
+	} );
+
+	describe( 'Unit selections', () => {
+		it( 'should update unlinked controls unit selection based on all input control', () => {
+			// Render control
+			render( <BoxControl /> );
+
+			// Make unit selection on all input control
+			const allUnitSelect = screen.getByLabelText( 'Select unit' );
+			allUnitSelect.focus();
+			fireEvent.change( allUnitSelect, { target: { value: 'em' } } );
+
+			// Unlink the controls
+			const unlink = screen.getByLabelText( /Unlink Sides/ );
+			fireEvent.click( unlink );
+
+			// Confirm that each individual control has the selected unit
+			const unlinkedSelects = screen.getAllByDisplayValue( 'em' );
+			expect( unlinkedSelects.length ).toEqual( 4 );
+		} );
+
+		it( 'should use individual side attribute unit when available', () => {
+			// Render control
+			const { rerender } = render( <BoxControl /> );
+
+			// Make unit selection on all input control
+			const allUnitSelect = screen.getByLabelText( 'Select unit' );
+			allUnitSelect.focus();
+			fireEvent.change( allUnitSelect, { target: { value: 'vw' } } );
+
+			// Unlink the controls
+			const unlink = screen.getByLabelText( /Unlink Sides/ );
+			fireEvent.click( unlink );
+
+			// Confirm that each individual control has the selected unit
+			const unlinkedSelects = screen.getAllByDisplayValue( 'vw' );
+			expect( unlinkedSelects.length ).toEqual( 4 );
+
+			// Rerender with individual side value & confirm unit is selected.
+			rerender( <BoxControl values={ { top: '2.5em' } } /> );
+
+			const topSelect = screen.getByDisplayValue( 'em' );
+			const otherSelects = screen.getAllByDisplayValue( 'vw' );
+
+			expect( topSelect ).toBeInTheDocument();
+			expect( otherSelects.length ).toEqual( 3 );
+		} );
+	} );
+
+	describe( 'onChange updates', () => {
+		it( 'should call onChange when values contain more than just CSS units', () => {
+			const setState = jest.fn();
+
+			render( <BoxControl onChange={ setState } /> );
+
+			const input = screen.getByLabelText( 'Box Control', {
+				selector: 'input',
+			} );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: '7.5rem' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( setState ).toHaveBeenCalledWith( {
+				top: '7.5rem',
+				right: '7.5rem',
+				bottom: '7.5rem',
+				left: '7.5rem',
+			} );
+		} );
+
+		it( 'should not pass invalid CSS unit only values to onChange', () => {
+			const setState = jest.fn();
+
+			render( <BoxControl onChange={ setState } /> );
+
+			const allUnitSelect = screen.getByLabelText( 'Select unit' );
+			allUnitSelect.focus();
+			fireEvent.change( allUnitSelect, { target: { value: 'rem' } } );
+
+			expect( setState ).toHaveBeenCalledWith( {
+				top: undefined,
+				right: undefined,
+				bottom: undefined,
+				left: undefined,
+			} );
+		} );
+
+		it( 'should clear side attribute when control is cleared', () => {
+			let state = {
+				top: '1em',
+				right: '1em',
+				bottom: '1em',
+				left: '1em',
+			};
+			const setState = jest.fn( ( newState ) => ( state = newState ) );
+
+			render( <BoxControl values={ state } onChange={ setState } /> );
+
+			const input = screen.getByLabelText( 'Box Control', {
+				selector: 'input',
+			} );
+			input.focus();
+			fireEvent.change( input, { target: { value: '' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( setState ).toHaveBeenCalledWith( {
+				top: undefined,
+				right: undefined,
+				bottom: undefined,
 				left: undefined,
 			} );
 		} );

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -278,31 +278,5 @@ describe( 'BoxControl', () => {
 				left: undefined,
 			} );
 		} );
-
-		it( 'should clear side attribute when control is cleared', () => {
-			let state = {
-				top: '1em',
-				right: '1em',
-				bottom: '1em',
-				left: '1em',
-			};
-			const setState = jest.fn( ( newState ) => ( state = newState ) );
-
-			render( <BoxControl values={ state } onChange={ setState } /> );
-
-			const input = screen.getByLabelText( 'Box Control', {
-				selector: 'input',
-			} );
-			input.focus();
-			fireEvent.change( input, { target: { value: '' } } );
-			fireEvent.keyDown( input, { keyCode: ENTER } );
-
-			expect( setState ).toHaveBeenCalledWith( {
-				top: undefined,
-				right: undefined,
-				bottom: undefined,
-				left: undefined,
-			} );
-		} );
 	} );
 } );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/33318

## Description

This PR fixes invalid values being saved via the `BoxControl` for block supports such as padding and margin.

#### Changes made in this PR include:

1. Change `BoxControl` to manage unit selections via internal state so they can be separated from the block attributes
2. Filtering values in `onChange` callback to not save invalid styles meant updating how mixed values etc were determined

#### Key aspects of this PR

- Simply filtering out CSS unit only values in the `onChange` handlers broke the existing method of determining mixed values in the box control. 
- Filtering of CSS unit only values meant the unlinked controls had no means of maintaining the user's unit selection unless the attribute for that field had been set
- Majority of the changes are around maintaining the existing behaviour while adding internal state to manage unit selections as a fallback if no attribute value is present.

#### Steps to replicate original issue
1. Add group block to a post, select it, then find the padding control in the sidebar
2. Change the unit on the box control without entering any value
3. Inspect the block or switch to the code editor view and see the CSS unit only values saved in the attributes and styles

## How has this been tested?
Via written tests and manual testing in block editor and [Gutenberg Storybook](http://localhost:50240/?path=/story/components-boxcontrol--default)

`npm run test-unit:watch packages/components/src/box-control/test/`

#### Test instructions

1. Checkout PR and run above tests
2. Add group block to a post, select it, then find the padding control in the sidebar
3. Change the unit on the box control without entering any value
4. Inspect the block or switch to the code editor view and confirm no invalid style values in attributes or inline styles
5. Unlink the BoxControl, adjust a value, save and confirm the block support styles still work

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![BoxControlBefore](https://user-images.githubusercontent.com/60436221/125736218-716d3e14-58bc-451d-8013-fa3ed35721d4.gif) | ![BoxControlAfter](https://user-images.githubusercontent.com/60436221/125881060-c5e5cc16-0f51-44d9-85f7-42658f9ac24f.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
