### PR TITLE
Fix screenshots not being captured when snapshots failed

### DIFF
--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Bail out tests if a prior snapshot failed. Fixed a bug which failing snapshots won't trigger screenshots [#33448](https://github.com/WordPress/gutenberg/pull/33448).
+
 ## 2.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot';
 
 /**
  * WordPress dependencies
@@ -209,6 +210,22 @@ async function simulateAdverseConditions() {
 		await page.emulateCPUThrottling( Number( THROTTLE_CPU ) );
 	}
 }
+
+// Override snapshot matchers to throw errors as soon as possible,
+// See https://jestjs.io/docs/expect#bail-out
+// This is to fix a bug in Jest that snapshot failures won't trigger `test_fn_failure` events.
+expect.extend( {
+	toMatchInlineSnapshot( ...args ) {
+		this.dontThrow = () => {};
+
+		return toMatchInlineSnapshot.call( this, ...args );
+	},
+	toMatchSnapshot( ...args ) {
+		this.dontThrow = () => {};
+
+		return toMatchSnapshot.call( this, ...args );
+	},
+} );
 
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -36,6 +36,7 @@
 	},
 	"peerDependencies": {
 		"jest": ">=26",
+		"jest-snapshot": ">=26",
 		"puppeteer": ">=1.19.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Jest will default to try to match every snapshot even if one of them failed. This makes sense in unit tests, but not in e2e tests. We want to bail out/fail fast when a snapshot failed, so that we can capture the page's screenshot at that time as soon as possible.

This PR changes that behavior by overriding both snapshot matchers (`toMatchSnapshot` and `toMatchInlineSnapshot`) in e2e tests to throw errors when they failed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Change something in existing snapshot tests to let them fail
2. Run tests
3. It should capture the screenshots at that time in `artifacts` folder.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
