### PR TITLE
[RNMobile] Enable embed block

### DIFF
--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -28,12 +28,7 @@ import { View } from '@wordpress/primitives';
 
 const EmbedEdit = ( props ) => {
 	const {
-		attributes: {
-			providerNameSlug,
-			previewable,
-			responsive,
-			url: attributesUrl,
-		},
+		attributes: { providerNameSlug, responsive, url: attributesUrl },
 		attributes,
 		isSelected,
 		onReplace,
@@ -191,8 +186,6 @@ const EmbedEdit = ( props ) => {
 							insertBlocksAfter={ insertBlocksAfter }
 							isSelected={ isSelected }
 							label={ title }
-							preview={ preview }
-							previewable={ previewable }
 							url={ url }
 						/>
 					</View>

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TouchableWithoutFeedback, Image } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native';
 import { isEmpty } from 'lodash';
 
 /**
@@ -17,7 +17,6 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import EmbedNoPreview from './embed-no-preview';
-import styles from './styles.scss';
 
 const EmbedPreview = ( {
 	clientId,
@@ -27,8 +26,6 @@ const EmbedPreview = ( {
 	label,
 	onBlur,
 	onFocus,
-	preview,
-	previewable,
 } ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
 
@@ -56,13 +53,6 @@ const EmbedPreview = ( {
 		}
 	}
 
-	const cannotShowThumbnail =
-		! previewable ||
-		! preview ||
-		! preview.thumbnail_url?.length ||
-		! preview.height ||
-		! preview.width;
-
 	return (
 		<TouchableWithoutFeedback
 			accessible={ ! isSelected }
@@ -70,25 +60,12 @@ const EmbedPreview = ( {
 			disabled={ ! isSelected }
 		>
 			<View>
-				{ cannotShowThumbnail ? (
-					<EmbedNoPreview
-						label={ label }
-						icon={ icon }
-						isSelected={ isSelected }
-						onPress={ () => setIsCaptionSelected( false ) }
-					/>
-				) : (
-					<Image
-						style={ [
-							styles[ 'embed-preview__image' ],
-							{ aspectRatio: preview.width / preview.height },
-						] }
-						source={ {
-							uri: preview.thumbnail_url,
-						} }
-						resizeMode="cover"
-					/>
-				) }
+				<EmbedNoPreview
+					label={ label }
+					icon={ icon }
+					isSelected={ isSelected }
+					onPress={ () => setIsCaptionSelected( false ) }
+				/>
 				<BlockCaption
 					accessibilityLabelCreator={ accessibilityLabelCreator }
 					accessible

--- a/packages/block-library/src/embed/styles.native.scss
+++ b/packages/block-library/src/embed/styles.native.scss
@@ -79,10 +79,6 @@
 	background-color: $background-dark-secondary;
 }
 
-.embed-preview__image {
-	flex: 1 1 auto;
-}
-
 .embed-no-preview__container {
 	flex-direction: column;
 	align-items: center;

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -266,7 +266,7 @@ export const registerCoreBlocks = () => {
 		audio,
 		reusableBlock,
 		search,
-		devOnly( embed ),
+		embed,
 	].forEach( registerBlock );
 
 	registerBlockVariations( socialLink );


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3727

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Enable embed block and remove the thumbnail preview, for now, the embed preview will be disabled and it will only show the unavailable preview fallback.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Embed without thumbnail
1. Add an Embed block to a post
2. Set a valid embed URL without thumbnail (example.: https://twitter.com/wordpressdotcom/status/1388164029840044042)
3. Observe that the block's content displays a message that inline preview is coming soon and the text "PREVIEW POST"
4. Tap on the block to edit it
5. Observe that an info modal shows up explaining that previews are coming soon
6. Observe that tapping on the dismiss button closes the modal
7. Tap on the block again to open the previous modal
8. Tap on "Preview post"
9. Observe that the modal is closed and the preview modal is opened displaying the embed block

### Embed with thumbnail
1. Add an Embed block to a post
2. Set a valid embed URL with thumbnail (example: https://youtu.be/UOcroR50808)
3. Observe that the block's content displays a message that inline preview is coming soon and the text "PREVIEW POST"
4. Tap on the block to edit it
5. Observe that an info modal shows up explaining that previews are coming soon
6. Observe that tapping on the dismiss button closes the modal
7. Tap on the block again to open the previous modal
8. Tap on "Preview post"
9. Observe that the modal is closed and the preview modal is opened displaying the embed block

## Screenshots <!-- if applicable -->

**iOS:**

https://user-images.githubusercontent.com/14905380/125770413-51209f37-1ab0-439c-af91-b131bc6bc7f4.mp4

**Android:**

https://user-images.githubusercontent.com/14905380/125771616-e15d1719-a45a-49bc-a775-91bcc3db57f6.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
