### PR TITLE
Bootstrap wp-admin before rendering widgets – they may rely on wp-admin functions being loaded.

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -421,6 +421,9 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
+		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the preview.
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 		// Set the widget's number so that the id attributes in the HTML that we
 		// return are predictable.
 		if ( isset( $request['number'] ) && is_numeric( $request['number'] ) ) {
@@ -500,9 +503,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_widget_preview( $widget_object, $instance ) {
-		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the preview.
-		require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 		ob_start();
 		the_widget( get_class( $widget_object ), $instance );
 		return ob_get_clean();
@@ -517,9 +517,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_widget_form( $widget_object, $instance ) {
-		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the form.
-		require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 		ob_start();
 
 		/** This filter is documented in wp-includes/class-wp-widget.php */

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -421,7 +421,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the preview.
+		// Third-party widgets may rely on wp-admin functions. So let's load them before working with the widget object.
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
 
 		// Set the widget's number so that the id attributes in the HTML that we

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -500,6 +500,9 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_widget_preview( $widget_object, $instance ) {
+		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the preview.
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 		ob_start();
 		the_widget( get_class( $widget_object ), $instance );
 		return ob_get_clean();
@@ -514,6 +517,9 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_widget_form( $widget_object, $instance ) {
+		// Some third-party widgets rely on wp-admin functions so let's load them before rendering the form.
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 		ob_start();
 
 		/** This filter is documented in wp-includes/class-wp-widget.php */

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -544,10 +544,16 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			rest_is_field_included( 'rendered', $fields ) &&
 			'wp_inactive_widgets' !== $sidebar_id
 		) {
+			// Some third-party widgets rely on wp-admin functions
+			require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 			$prepared['rendered'] = trim( wp_render_widget( $widget_id, $sidebar_id ) );
 		}
 
 		if ( rest_is_field_included( 'rendered_form', $fields ) ) {
+			// Some third-party widgets rely on wp-admin functions
+			require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 			$rendered_form = wp_render_widget_control( $widget_id );
 			if ( ! is_null( $rendered_form ) ) {
 				$prepared['rendered_form'] = trim( $rendered_form );

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -544,14 +544,14 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			rest_is_field_included( 'rendered', $fields ) &&
 			'wp_inactive_widgets' !== $sidebar_id
 		) {
-			// Some third-party widgets rely on wp-admin functions
+			// Some third-party widgets rely on wp-admin functions.
 			require_once ABSPATH . 'wp-admin/includes/admin.php';
 
 			$prepared['rendered'] = trim( wp_render_widget( $widget_id, $sidebar_id ) );
 		}
 
 		if ( rest_is_field_included( 'rendered_form', $fields ) ) {
-			// Some third-party widgets rely on wp-admin functions
+			// Some third-party widgets rely on wp-admin functions.
 			require_once ABSPATH . 'wp-admin/includes/admin.php';
 
 			$rendered_form = wp_render_widget_control( $widget_id );


### PR DESCRIPTION
## Description
Improves the situation of https://github.com/WordPress/gutenberg/issues/33443

This PR ensures that wp-admin is bootstrapped before rendering any widgets. Some plugins, such as the [Compact Archives](https://wordpress.org/plugins/compact-archives/) plugin, assume that wp-admin functions are loaded and available because they were in the classic widgets editor.

This is a "quick" solution so that we may ship functional 5.8 RC4. A "proper" solution is still being discussed in https://github.com/WordPress/gutenberg/issues/33443.

## How has this been tested?
1. Install and activate Classic Widget plugin
1. Install and activate plugin using an admin function in its widget code (eg, [Compact Archives 4.0.0 (zip)](https://downloads.wordpress.org/plugin/compact-archives.4.0.0.zip))
1. Add the widget on the classic widget screen. Everything will work as expected 🌻
1. Deactivate the Classic Widget plugin
1. Add the widget on the new widget screen. Without this PR, an error alert will show in the browser and a fatal in the PHP logs. With this PR, there will be no error.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

