### PR TITLE
Editor: Set 'hide_empty' for the most used terms query

### DIFF
--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -20,6 +20,7 @@ const DEFAULT_QUERY = {
 	per_page: MAX_MOST_USED_TERMS,
 	orderby: 'count',
 	order: 'desc',
+	hide_empty: true,
 	_fields: 'id,name,count',
 };
 


### PR DESCRIPTION
## Description
The most used terms query shouldn't fetch terms not assigned to any post. A term with no post can't be the most used term.

## How has this been tested?

Tested on site where a few tags are assigned to posts.

1. Generate 15 new tags - `wp term generate post_tag --count=15`
2. Tags panel in the editor shouldn't display the "Most Used" section.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
