### PR TITLE
Refactor FlatTermSelector into a functional component

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -8,16 +8,13 @@ import { escape as escapeString, find, get, uniqBy } from 'lodash';
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import {
-	FormTokenField,
-	withFilters,
-	withSpokenMessages,
-} from '@wordpress/components';
+import { FormTokenField, withFilters } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { compose, useDebounce } from '@wordpress/compose';
+import { useDebounce } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -89,7 +86,7 @@ function findOrCreateTerm( termName, restBase ) {
 		.then( unescapeTerm );
 }
 
-function FlatTermSelector( { slug, speak } ) {
+function FlatTermSelector( { slug } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
@@ -288,7 +285,4 @@ function FlatTermSelector( { slug, speak } ) {
 	);
 }
 
-export default compose(
-	withSpokenMessages,
-	withFilters( 'editor.PostTaxonomyType' )
-)( FlatTermSelector );
+export default withFilters( 'editor.PostTaxonomyType' )( FlatTermSelector );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -56,12 +56,12 @@ const termNamesToIds = ( names, terms ) => {
 
 // Tries to create a term or fetch it if it already exists.
 function findOrCreateTerm( termName, restBase ) {
-	const escpapedTermName = escapeString( termName );
+	const escapedTermName = escapeString( termName );
 
 	return apiFetch( {
 		path: `/wp/v2/${ restBase }`,
 		method: 'POST',
-		data: { name: escpapedTermName },
+		data: { name: escapedTermName },
 	} )
 		.catch( ( error ) => {
 			const errorCode = error.code;
@@ -70,7 +70,7 @@ function findOrCreateTerm( termName, restBase ) {
 				const addRequest = apiFetch( {
 					path: addQueryArgs( `/wp/v2/${ restBase }`, {
 						...DEFAULT_QUERY,
-						search: escpapedTermName,
+						search: escapedTermName,
 					} ),
 				} ).then( unescapeTerms );
 

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -94,7 +94,6 @@ function FlatTermSelector( { slug } ) {
 		terms,
 		termIds,
 		taxonomy,
-		isLoading,
 		hasAssignAction,
 		hasCreateAction,
 	} = useSelect(
@@ -102,9 +101,8 @@ function FlatTermSelector( { slug } ) {
 			const { getCurrentPost, getEditedPostAttribute } = select(
 				editorStore
 			);
-			const { getEntityRecords, getTaxonomy, isResolving } = select(
-				coreStore
-			);
+			const { getEntityRecords, getTaxonomy } = select( coreStore );
+			const post = getCurrentPost();
 			const _taxonomy = getTaxonomy( slug );
 			const _termIds = _taxonomy
 				? getEditedPostAttribute( _taxonomy.rest_base )
@@ -119,7 +117,7 @@ function FlatTermSelector( { slug } ) {
 			return {
 				hasCreateAction: _taxonomy
 					? get(
-							getCurrentPost(),
+							post,
 							[
 								'_links',
 								'wp:action-create-' + _taxonomy.rest_base,
@@ -129,7 +127,7 @@ function FlatTermSelector( { slug } ) {
 					: false,
 				hasAssignAction: _taxonomy
 					? get(
-							getCurrentPost(),
+							post,
 							[
 								'_links',
 								'wp:action-assign-' + _taxonomy.rest_base,
@@ -142,11 +140,6 @@ function FlatTermSelector( { slug } ) {
 				terms: _termIds.length
 					? getEntityRecords( 'taxonomy', slug, query )
 					: EMPTY_ARRAY,
-				isLoading: isResolving( 'getEntityRecords', [
-					'taxonomy',
-					slug,
-					query,
-				] ),
 			};
 		},
 		[ slug ]
@@ -274,7 +267,6 @@ function FlatTermSelector( { slug } ) {
 				onChange={ onChange }
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
-				disabled={ isLoading }
 				label={ newTermLabel }
 				messages={ {
 					added: termAddedLabel,

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -90,7 +90,7 @@ function findOrCreateTerm( termName, restBase ) {
 
 function FlatTermSelector( { slug, speak } ) {
 	const [ search, setSearch ] = useState( '' );
-	const searchTerms = useDebounce( setSearch, 500 );
+	const debouncedSearch = useDebounce( setSearch, 500 );
 
 	const { terms, termIds, taxonomy, isLoading, hasAssignAction } = useSelect(
 		( select ) => {
@@ -172,7 +172,7 @@ function FlatTermSelector( { slug, speak } ) {
 
 	// The getEntityRecords returns null when items are unknown.
 	// This is the reason for the extra check and empty fallback array.
-	const selectedTerms =
+	const values =
 		terms?.map( ( term ) => unescapeString( term.name ) ) || EMPTY_ARRAY;
 	const suggestions =
 		searchResults?.map( ( term ) => unescapeString( term.name ) ) ||
@@ -261,10 +261,10 @@ function FlatTermSelector( { slug, speak } ) {
 	return (
 		<>
 			<FormTokenField
-				value={ selectedTerms }
-				suggestions={ suggestions || selectedTerms }
+				value={ values }
+				suggestions={ suggestions }
 				onChange={ onChange }
-				onInputChange={ searchTerms }
+				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				disabled={ isLoading }
 				label={ newTermLabel }

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -152,13 +152,12 @@ function FlatTermSelector( { slug, speak } ) {
 			const { getEntityRecords } = select( coreStore );
 
 			return {
-				searchResults:
-					search.length >= 3
-						? getEntityRecords( 'taxonomy', slug, {
-								...DEFAULT_QUERY,
-								search,
-						  } )
-						: EMPTY_ARRAY,
+				searchResults: !! search
+					? getEntityRecords( 'taxonomy', slug, {
+							...DEFAULT_QUERY,
+							search,
+					  } )
+					: EMPTY_ARRAY,
 			};
 		},
 		[ search ]

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -92,7 +92,14 @@ function FlatTermSelector( { slug, speak } ) {
 	const [ search, setSearch ] = useState( '' );
 	const debouncedSearch = useDebounce( setSearch, 500 );
 
-	const { terms, termIds, taxonomy, isLoading, hasAssignAction } = useSelect(
+	const {
+		terms,
+		termIds,
+		taxonomy,
+		isLoading,
+		hasAssignAction,
+		hasCreateAction,
+	} = useSelect(
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } = select(
 				editorStore
@@ -197,6 +204,10 @@ function FlatTermSelector( { slug, speak } ) {
 			);
 		}
 
+		if ( ! hasCreateAction ) {
+			return;
+		}
+
 		Promise.all(
 			newTermNames.map( ( termName ) =>
 				findOrCreateTerm( termName, taxonomy.rest_base )
@@ -215,7 +226,6 @@ function FlatTermSelector( { slug, speak } ) {
 		}
 
 		const newTermIds = [ ...termIds, newTerm.id ];
-
 		const termAddedMessage = sprintf(
 			/* translators: %s: term name. */
 			_x( '%s added', 'term' ),
@@ -227,7 +237,6 @@ function FlatTermSelector( { slug, speak } ) {
 		);
 
 		speak( termAddedMessage, 'assertive' );
-
 		onUpdateTerms( newTermIds );
 	}
 

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -27,6 +27,14 @@ import { unescapeString, unescapeTerm, unescapeTerms } from '../../utils/terms';
 import MostUsedTerms from './most-used-terms';
 
 /**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation.
+ *
+ * @type {Array<any>}
+ */
+const EMPTY_ARRAY = [];
+
+/**
  * Module constants
  */
 const MAX_TERMS_SUGGESTIONS = 20;
@@ -95,7 +103,7 @@ function FlatTermSelector( { slug, speak } ) {
 			const _taxonomy = getTaxonomy( slug );
 			const _termIds = _taxonomy
 				? getEditedPostAttribute( _taxonomy.rest_base )
-				: [];
+				: EMPTY_ARRAY;
 
 			const query = {
 				...DEFAULT_QUERY,
@@ -128,7 +136,7 @@ function FlatTermSelector( { slug, speak } ) {
 				termIds: _termIds,
 				terms: _termIds.length
 					? getEntityRecords( 'taxonomy', slug, query )
-					: [],
+					: EMPTY_ARRAY,
 				isLoading: isResolving( 'getEntityRecords', [
 					'taxonomy',
 					slug,
@@ -150,7 +158,7 @@ function FlatTermSelector( { slug, speak } ) {
 								...DEFAULT_QUERY,
 								search,
 						  } )
-						: [],
+						: EMPTY_ARRAY,
 			};
 		},
 		[ search ]
@@ -158,15 +166,15 @@ function FlatTermSelector( { slug, speak } ) {
 
 	const { editPost } = useDispatch( editorStore );
 
-	// @TODO useMemo, Luke.
-	const selectedTerms =
-		terms?.map( ( term ) => unescapeString( term.name ) ) || [];
-	const suggestions =
-		searchResults?.map( ( term ) => unescapeString( term.name ) ) || [];
-
 	if ( ! hasAssignAction ) {
 		return null;
 	}
+
+	// @TODO useMemo, Luke.
+	const selectedTerms = terms.map( ( term ) => unescapeString( term.name ) );
+	const suggestions = searchResults.map( ( term ) =>
+		unescapeString( term.name )
+	);
 
 	function onUpdateTerms( newTermIds ) {
 		editPost( { [ taxonomy.rest_base ]: newTermIds } );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -170,11 +170,13 @@ function FlatTermSelector( { slug, speak } ) {
 		return null;
 	}
 
-	// @TODO useMemo, Luke.
-	const selectedTerms = terms.map( ( term ) => unescapeString( term.name ) );
-	const suggestions = searchResults.map( ( term ) =>
-		unescapeString( term.name )
-	);
+	// The getEntityRecords returns null when items are unknown.
+	// This is the reason for the extra check and empty fallback array.
+	const selectedTerms =
+		terms?.map( ( term ) => unescapeString( term.name ) ) || EMPTY_ARRAY;
+	const suggestions =
+		searchResults?.map( ( term ) => unescapeString( term.name ) ) ||
+		EMPTY_ARRAY;
 
 	function onUpdateTerms( newTermIds ) {
 		editPost( { [ taxonomy.rest_base ]: newTermIds } );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -7,7 +7,7 @@ import { escape as escapeString, find, get, uniqBy } from 'lodash';
  * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { FormTokenField, withFilters } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -168,19 +168,21 @@ function FlatTermSelector( { slug } ) {
 		[ search ]
 	);
 
+	const values = useMemo( () => {
+		return ( terms ?? [] ).map( ( term ) => unescapeString( term.name ) );
+	}, [ terms ] );
+
+	const suggestions = useMemo( () => {
+		return ( searchResults ?? [] ).map( ( term ) =>
+			unescapeString( term.name )
+		);
+	}, [ searchResults ] );
+
 	const { editPost } = useDispatch( editorStore );
 
 	if ( ! hasAssignAction ) {
 		return null;
 	}
-
-	// The getEntityRecords returns null when items are unknown.
-	// This is the reason for the extra check and empty fallback array.
-	const values =
-		terms?.map( ( term ) => unescapeString( term.name ) ) || EMPTY_ARRAY;
-	const suggestions =
-		searchResults?.map( ( term ) => unescapeString( term.name ) ) ||
-		EMPTY_ARRAY;
 
 	function onUpdateTerms( newTermIds ) {
 		editPost( { [ taxonomy.rest_base ]: newTermIds } );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -117,7 +117,7 @@ function FlatTermSelector( { slug } ) {
 			const query = {
 				...DEFAULT_QUERY,
 				include: _termIds.join( ',' ),
-				per_page: _termIds.length,
+				per_page: -1,
 			};
 
 			return {

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -1,29 +1,21 @@
 /**
  * External dependencies
  */
-import {
-	debounce,
-	escape as escapeString,
-	find,
-	get,
-	invoke,
-	isEmpty,
-	uniqBy,
-} from 'lodash';
+import { escape as escapeString, find, get, uniqBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	FormTokenField,
 	withFilters,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { compose } from '@wordpress/compose';
+import { compose, useDebounce } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -56,170 +48,171 @@ const termNamesToIds = ( names, terms ) => {
 	);
 };
 
-class FlatTermSelector extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onChange = this.onChange.bind( this );
-		this.searchTerms = debounce( this.searchTerms.bind( this ), 500 );
-		this.findOrCreateTerm = this.findOrCreateTerm.bind( this );
-		this.appendTerm = this.appendTerm.bind( this );
-		this.state = {
-			loading: ! isEmpty( this.props.terms ),
-			availableTerms: [],
-			selectedTerms: [],
-		};
-	}
+// Tries to create a term or fetch it if it already exists.
+function findOrCreateTerm( termName, restBase ) {
+	const escpapedTermName = escapeString( termName );
 
-	componentDidMount() {
-		if ( ! isEmpty( this.props.terms ) ) {
-			this.initRequest = this.fetchTerms( {
-				include: this.props.terms.join( ',' ),
-				per_page: -1,
-			} );
-			this.initRequest.then(
-				() => {
-					this.setState( { loading: false } );
-				},
-				( xhr ) => {
-					if ( xhr.statusText === 'abort' ) {
-						return;
-					}
-					this.setState( {
-						loading: false,
-					} );
-				}
-			);
-		}
-	}
+	return apiFetch( {
+		path: `/wp/v2/${ restBase }`,
+		method: 'POST',
+		data: { name: escpapedTermName },
+	} )
+		.catch( ( error ) => {
+			const errorCode = error.code;
+			if ( errorCode === 'term_exists' ) {
+				// If the terms exist, fetch it instead of creating a new one.
+				const addRequest = apiFetch( {
+					path: addQueryArgs( `/wp/v2/${ restBase }`, {
+						...DEFAULT_QUERY,
+						search: escpapedTermName,
+					} ),
+				} ).then( unescapeTerms );
 
-	componentWillUnmount() {
-		invoke( this.initRequest, [ 'abort' ] );
-		invoke( this.searchRequest, [ 'abort' ] );
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.terms !== this.props.terms ) {
-			this.updateSelectedTerms( this.props.terms );
-		}
-	}
-
-	fetchTerms( params = {} ) {
-		const { taxonomy } = this.props;
-		const query = { ...DEFAULT_QUERY, ...params };
-		const request = apiFetch( {
-			path: addQueryArgs( `/wp/v2/${ taxonomy.rest_base }`, query ),
-		} );
-		request.then( unescapeTerms ).then( ( terms ) => {
-			this.setState( ( state ) => ( {
-				availableTerms: state.availableTerms.concat(
-					terms.filter(
-						( term ) =>
-							! find(
-								state.availableTerms,
-								( availableTerm ) =>
-									availableTerm.id === term.id
-							)
-					)
-				),
-			} ) );
-			this.updateSelectedTerms( this.props.terms );
-		} );
-
-		return request;
-	}
-
-	updateSelectedTerms( terms = [] ) {
-		const selectedTerms = terms.reduce( ( accumulator, termId ) => {
-			const termObject = find(
-				this.state.availableTerms,
-				( term ) => term.id === termId
-			);
-			if ( termObject ) {
-				accumulator.push( termObject.name );
+				return addRequest.then( ( searchResult ) => {
+					return find( searchResult, ( result ) =>
+						isSameTermName( result.name, termName )
+					);
+				} );
 			}
 
-			return accumulator;
-		}, [] );
-		this.setState( {
-			selectedTerms,
-		} );
-	}
-
-	findOrCreateTerm( termName ) {
-		const { taxonomy } = this.props;
-		const termNameEscaped = escapeString( termName );
-		// Tries to create a term or fetch it if it already exists.
-		return apiFetch( {
-			path: `/wp/v2/${ taxonomy.rest_base }`,
-			method: 'POST',
-			data: { name: termNameEscaped },
+			return Promise.reject( error );
 		} )
-			.catch( ( error ) => {
-				const errorCode = error.code;
-				if ( errorCode === 'term_exists' ) {
-					// If the terms exist, fetch it instead of creating a new one.
-					this.addRequest = apiFetch( {
-						path: addQueryArgs( `/wp/v2/${ taxonomy.rest_base }`, {
-							...DEFAULT_QUERY,
-							search: termNameEscaped,
-						} ),
-					} ).then( unescapeTerms );
-					return this.addRequest.then( ( searchResult ) => {
-						return find( searchResult, ( result ) =>
-							isSameTermName( result.name, termName )
-						);
-					} );
-				}
-				return Promise.reject( error );
-			} )
-			.then( unescapeTerm );
+		.then( unescapeTerm );
+}
+
+function FlatTermSelector( { slug, speak } ) {
+	const [ search, setSearch ] = useState( '' );
+	const searchTerms = useDebounce( setSearch, 500 );
+
+	const { hasAssignAction, termIds, taxonomy } = useSelect(
+		( select ) => {
+			const { getCurrentPost } = select( editorStore );
+			const { getTaxonomy } = select( coreStore );
+			const _taxonomy = getTaxonomy( slug );
+
+			return {
+				hasCreateAction: _taxonomy
+					? get(
+							getCurrentPost(),
+							[
+								'_links',
+								'wp:action-create-' + _taxonomy.rest_base,
+							],
+							false
+					  )
+					: false,
+				hasAssignAction: _taxonomy
+					? get(
+							getCurrentPost(),
+							[
+								'_links',
+								'wp:action-assign-' + _taxonomy.rest_base,
+							],
+							false
+					  )
+					: false,
+				termIds: _taxonomy
+					? select( editorStore ).getEditedPostAttribute(
+							_taxonomy.rest_base
+					  )
+					: [],
+				taxonomy: _taxonomy,
+			};
+		},
+		[ slug ]
+	);
+
+	const { terms, isLoading } = useSelect(
+		( select ) => {
+			const { getEntityRecords, isResolving } = select( coreStore );
+
+			const query = {
+				...DEFAULT_QUERY,
+				include: termIds.join( ',' ),
+				per_page: termIds.length || 1,
+			};
+
+			return {
+				terms: termIds.length
+					? getEntityRecords( 'taxonomy', slug, query )
+					: [],
+				isLoading: isResolving( 'getEntityRecords', [
+					'taxonomy',
+					taxonomy.slug,
+					query,
+				] ),
+			};
+		},
+		[ termIds ]
+	);
+
+	const { searchResults } = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+
+			return {
+				searchResults:
+					search.length >= 3
+						? getEntityRecords( 'taxonomy', slug, {
+								...DEFAULT_QUERY,
+								search,
+						  } )
+						: [],
+			};
+		},
+		[ search ]
+	);
+
+	const { editPost } = useDispatch( editorStore );
+
+	// @TODO useMemo, Luke.
+	const selectedTerms =
+		terms?.map( ( term ) => unescapeString( term.name ) ) || [];
+	const suggestions =
+		searchResults?.map( ( term ) => unescapeString( term.name ) ) || [];
+
+	if ( ! hasAssignAction ) {
+		return null;
 	}
 
-	onChange( termNames ) {
+	function onUpdateTerms( newTermIds ) {
+		editPost( { [ taxonomy.rest_base ]: newTermIds } );
+	}
+
+	function onChange( termNames ) {
+		const availableTerms = [ ...terms, ...searchResults ];
 		const uniqueTerms = uniqBy( termNames, ( term ) => term.toLowerCase() );
-		this.setState( { selectedTerms: uniqueTerms } );
 		const newTermNames = uniqueTerms.filter(
 			( termName ) =>
-				! find( this.state.availableTerms, ( term ) =>
+				! find( availableTerms, ( term ) =>
 					isSameTermName( term.name, termName )
 				)
 		);
 
 		if ( newTermNames.length === 0 ) {
-			return this.props.onUpdateTerms(
-				termNamesToIds( uniqueTerms, this.state.availableTerms ),
-				this.props.taxonomy.rest_base
+			return onUpdateTerms(
+				termNamesToIds( uniqueTerms, availableTerms )
 			);
 		}
-		Promise.all( newTermNames.map( this.findOrCreateTerm ) ).then(
-			( newTerms ) => {
-				const newAvailableTerms = this.state.availableTerms.concat(
-					newTerms
-				);
-				this.setState( { availableTerms: newAvailableTerms } );
-				return this.props.onUpdateTerms(
-					termNamesToIds( uniqueTerms, newAvailableTerms ),
-					this.props.taxonomy.rest_base
-				);
-			}
-		);
+
+		Promise.all(
+			newTermNames.map( ( termName ) =>
+				findOrCreateTerm( termName, taxonomy.rest_base )
+			)
+		).then( ( newTerms ) => {
+			const newAvailableTerms = availableTerms.concat( newTerms );
+			return onUpdateTerms(
+				termNamesToIds( uniqueTerms, newAvailableTerms )
+			);
+		} );
 	}
 
-	searchTerms( search = '' ) {
-		invoke( this.searchRequest, [ 'abort' ] );
-		if ( search.length >= 3 ) {
-			this.searchRequest = this.fetchTerms( { search } );
-		}
-	}
-
-	appendTerm( newTerm ) {
-		const { onUpdateTerms, taxonomy, terms = [], slug, speak } = this.props;
-
-		if ( terms.includes( newTerm.id ) ) {
+	function appendTerm( newTerm ) {
+		if ( termIds.includes( newTerm.id ) ) {
 			return;
 		}
 
-		const newTerms = [ ...terms, newTerm.id ];
+		const newTermIds = [ ...termIds, newTerm.id ];
 
 		const termAddedMessage = sprintf(
 			/* translators: %s: term name. */
@@ -233,108 +226,57 @@ class FlatTermSelector extends Component {
 
 		speak( termAddedMessage, 'assertive' );
 
-		this.setState( {
-			availableTerms: [ ...this.state.availableTerms, newTerm ],
-		} );
-
-		onUpdateTerms( newTerms, taxonomy.rest_base );
+		onUpdateTerms( newTermIds );
 	}
 
-	render() {
-		const { slug, taxonomy, hasAssignAction } = this.props;
+	const newTermLabel = get(
+		taxonomy,
+		[ 'labels', 'add_new_item' ],
+		slug === 'post_tag' ? __( 'Add new tag' ) : __( 'Add new Term' )
+	);
+	const singularName = get(
+		taxonomy,
+		[ 'labels', 'singular_name' ],
+		slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' )
+	);
+	const termAddedLabel = sprintf(
+		/* translators: %s: term name. */
+		_x( '%s added', 'term' ),
+		singularName
+	);
+	const termRemovedLabel = sprintf(
+		/* translators: %s: term name. */
+		_x( '%s removed', 'term' ),
+		singularName
+	);
+	const removeTermLabel = sprintf(
+		/* translators: %s: term name. */
+		_x( 'Remove %s', 'term' ),
+		singularName
+	);
 
-		if ( ! hasAssignAction ) {
-			return null;
-		}
-
-		const { loading, availableTerms, selectedTerms } = this.state;
-		const termNames = availableTerms.map( ( term ) => term.name );
-		const newTermLabel = get(
-			taxonomy,
-			[ 'labels', 'add_new_item' ],
-			slug === 'post_tag' ? __( 'Add new tag' ) : __( 'Add new Term' )
-		);
-		const singularName = get(
-			taxonomy,
-			[ 'labels', 'singular_name' ],
-			slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' )
-		);
-		const termAddedLabel = sprintf(
-			/* translators: %s: term name. */
-			_x( '%s added', 'term' ),
-			singularName
-		);
-		const termRemovedLabel = sprintf(
-			/* translators: %s: term name. */
-			_x( '%s removed', 'term' ),
-			singularName
-		);
-		const removeTermLabel = sprintf(
-			/* translators: %s: term name. */
-			_x( 'Remove %s', 'term' ),
-			singularName
-		);
-
-		return (
-			<>
-				<FormTokenField
-					value={ selectedTerms }
-					suggestions={ termNames }
-					onChange={ this.onChange }
-					onInputChange={ this.searchTerms }
-					maxSuggestions={ MAX_TERMS_SUGGESTIONS }
-					disabled={ loading }
-					label={ newTermLabel }
-					messages={ {
-						added: termAddedLabel,
-						removed: termRemovedLabel,
-						remove: removeTermLabel,
-					} }
-				/>
-				<MostUsedTerms
-					taxonomy={ taxonomy }
-					onSelect={ this.appendTerm }
-				/>
-			</>
-		);
-	}
+	return (
+		<>
+			<FormTokenField
+				value={ selectedTerms }
+				suggestions={ suggestions || selectedTerms }
+				onChange={ onChange }
+				onInputChange={ searchTerms }
+				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
+				disabled={ isLoading }
+				label={ newTermLabel }
+				messages={ {
+					added: termAddedLabel,
+					removed: termRemovedLabel,
+					remove: removeTermLabel,
+				} }
+			/>
+			<MostUsedTerms taxonomy={ taxonomy } onSelect={ appendTerm } />
+		</>
+	);
 }
 
 export default compose(
-	withSelect( ( select, { slug } ) => {
-		const { getCurrentPost } = select( editorStore );
-		const { getTaxonomy } = select( coreStore );
-		const taxonomy = getTaxonomy( slug );
-		return {
-			hasCreateAction: taxonomy
-				? get(
-						getCurrentPost(),
-						[ '_links', 'wp:action-create-' + taxonomy.rest_base ],
-						false
-				  )
-				: false,
-			hasAssignAction: taxonomy
-				? get(
-						getCurrentPost(),
-						[ '_links', 'wp:action-assign-' + taxonomy.rest_base ],
-						false
-				  )
-				: false,
-			terms: taxonomy
-				? select( editorStore ).getEditedPostAttribute(
-						taxonomy.rest_base
-				  )
-				: [],
-			taxonomy,
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		return {
-			onUpdateTerms( terms, restBase ) {
-				dispatch( editorStore ).editPost( { [ restBase ]: terms } );
-			},
-		};
-	} ),
 	withSpokenMessages,
 	withFilters( 'editor.PostTaxonomyType' )
 )( FlatTermSelector );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -42,7 +42,8 @@ const DEFAULT_QUERY = {
 	per_page: MAX_TERMS_SUGGESTIONS,
 	orderby: 'count',
 	order: 'desc',
-	_fields: 'id,name,count',
+	_fields: 'id,name',
+	context: 'view',
 };
 
 const isSameTermName = ( termA, termB ) =>


### PR DESCRIPTION
## Description
* Refactor FlatTermSelector to use data module instead of API calls.
* Changes from the class component into a functional component.

I tried refactoring the `findOrCreateTerm` function and use the `saveEntityRecord` action, but I cannot catch errors with action when the term already exits. I'm open to suggestions on this one 🙇 

Fixes #15147.

## How has this been tested?
Create a post and check the following:

- Test term suggestions
- Add terms to the post and make sure they are saved correctly.
- Opening and closing "Tags" panel shouldn't make extra requests for tags.
- Create a new term using a comma or enter key.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
