### PR TITLE
Block editor: extract iframe component

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
-import { Iframe } from '@wordpress/components';
+import { __experimentalIframe as Iframe } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -196,13 +196,15 @@ function Styles() {
 
 		if ( TagName === 'style' ) {
 			return (
-				<TagName { ...{ id } } key={ id }>
+				<TagName { ...{ id } } key={ id } ref={ ref }>
 					{ textContent }
 				</TagName>
 			);
 		}
 
-		return <TagName { ...{ href, id, rel, media } } key={ id } />;
+		return (
+			<TagName { ...{ href, id, rel, media } } key={ id } ref={ ref } />
+		);
 	} );
 }
 

--- a/packages/components/src/iframe/index.js
+++ b/packages/components/src/iframe/index.js
@@ -9,6 +9,20 @@ import { useMergeRefs, useRefEffect } from '@wordpress/compose';
  */
 import StyleProvider from '../style-provider';
 
+/**
+ * Renders an iframe with the passed children inside it.
+ *
+ * @param {Object}          props            Component Props.
+ * @param {WPElement}       props.children   Children to render inside the
+ *                                           iframe body.
+ * @param {WPElement}       props.head       Head elements to render inside the
+ *                                           iframe head.
+ * @param {Object|Function} props.contentRef Ref to pass to the iframe body.
+ * @param {string}          props.title      Iframe title.
+ * @param {Object|Function} ref              Forwarded ref.
+ *
+ * @return {WPElement} The iframe component.
+ */
 function Iframe( { contentRef, children, head, title, ...props }, ref ) {
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const refEffect = useRefEffect( ( node ) => {

--- a/packages/components/src/iframe/index.js
+++ b/packages/components/src/iframe/index.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, createPortal, forwardRef } from '@wordpress/element';
+import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import StyleProvider from '../style-provider';
+
+function Iframe( { contentRef, children, head, title, ...props }, ref ) {
+	const [ iframeDocument, setIframeDocument ] = useState();
+	const refEffect = useRefEffect( ( node ) => {
+		function setDocumentIfReady() {
+			const { contentDocument } = node;
+			const { readyState, body } = contentDocument;
+
+			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
+				return false;
+			}
+
+			if ( typeof contentRef === 'function' ) {
+				contentRef( body );
+			} else if ( contentRef ) {
+				contentRef.current = body;
+			}
+
+			setIframeDocument( contentDocument );
+
+			return true;
+		}
+
+		if ( setDocumentIfReady() ) {
+			return;
+		}
+
+		// Document is not immediately loaded in Firefox.
+		node.addEventListener( 'load', () => {
+			setDocumentIfReady();
+		} );
+	}, [] );
+
+	head = (
+		<>
+			<style>{ 'body{margin:0}' }</style>
+			{ head }
+		</>
+	);
+
+	return (
+		<iframe
+			{ ...props }
+			ref={ useMergeRefs( [ ref, refEffect ] ) }
+			title={ title }
+		>
+			{ iframeDocument &&
+				createPortal(
+					<StyleProvider document={ iframeDocument }>
+						{ children }
+					</StyleProvider>,
+					iframeDocument.body
+				) }
+			{ iframeDocument && createPortal( head, iframeDocument.head ) }
+		</iframe>
+	);
+}
+
+export default forwardRef( Iframe );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -78,6 +78,7 @@ export { Heading as __experimentalHeading } from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export { default as IconButton } from './button/deprecated';
+export { default as Iframe } from './iframe';
 export { default as __experimentalInputControl } from './input-control';
 export { default as KeyboardShortcuts } from './keyboard-shortcuts';
 export { default as MenuGroup } from './menu-group';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -78,7 +78,7 @@ export { Heading as __experimentalHeading } from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export { default as IconButton } from './button/deprecated';
-export { default as Iframe } from './iframe';
+export { default as __experimentalIframe } from './iframe';
 export { default as __experimentalInputControl } from './input-control';
 export { default as KeyboardShortcuts } from './keyboard-shortcuts';
 export { default as MenuGroup } from './menu-group';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Extracts the iframe component that just manages rendering content in an iframe (block editor agnostic).
This will be useful when we want to iframe placeholder for example.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
