### PR TITLE
Remove padding from Home Link block

### DIFF
--- a/packages/block-library/src/home-link/style.scss
+++ b/packages/block-library/src/home-link/style.scss
@@ -4,7 +4,6 @@
 		// Inherit colors set by the block color definition.
 		color: inherit;
 		display: block;
-		padding: 0.5em 1em;
 	}
 
 	// Force links to inherit text decoration applied to navigation block.


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
No other link block in core includes padding, yet the Home Link block does. This forces theme developers to override this padding to ensure link consistency. Removing this default padding will improve implementation of the Navigation block. The current workaround it to use a Custom Link that manually directs to the site's homepage.

## How has this been tested?
Removing the offending CSS simply makes the Home Link block look like all other link blocks in the Navigation block.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
