### PR TITLE
Revert the auto-enabling of the navigation mode when entering the canvas

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -103,7 +103,6 @@ export default function useTabNav() {
 			const direction = isShift ? 'findPrevious' : 'findNext';
 
 			if ( ! hasMultiSelection() && ! getSelectedBlockClientId() ) {
-				setNavigationMode( true );
 				return;
 			}
 


### PR DESCRIPTION
In #33446 this behavior was added and discussed here but according to the failing e2e test, it seems that this behavior doesn't exactly match the previous one https://github.com/WordPress/gutenberg/pull/33446/files#r670379713

