### PR TITLE
Revert "Bootstrap wp-admin before rendering widgets – they may rely on wp-admin functions being loaded."

### DIFF
--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -421,9 +421,6 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Third-party widgets may rely on wp-admin functions. So let's load them before working with the widget object.
-		require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 		// Set the widget's number so that the id attributes in the HTML that we
 		// return are predictable.
 		if ( isset( $request['number'] ) && is_numeric( $request['number'] ) ) {

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -544,16 +544,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			rest_is_field_included( 'rendered', $fields ) &&
 			'wp_inactive_widgets' !== $sidebar_id
 		) {
-			// Some third-party widgets rely on wp-admin functions.
-			require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 			$prepared['rendered'] = trim( wp_render_widget( $widget_id, $sidebar_id ) );
 		}
 
 		if ( rest_is_field_included( 'rendered_form', $fields ) ) {
-			// Some third-party widgets rely on wp-admin functions.
-			require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 			$rendered_form = wp_render_widget_control( $widget_id );
 			if ( ! is_null( $rendered_form ) ) {
 				$prepared['rendered_form'] = trim( $rendered_form );


### PR DESCRIPTION
Reverts WordPress/gutenberg#33454

I have some concerns with this change, especially this late in the release cycle.

After a [lengthy discussion in Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1626368244228500), I'm going to revert this for the time being.