### PR TITLE
Scripts: Add changlog entry for module update

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 -   Update `markdownlint` package to `0.23.1` ([#32633](https://github.com/WordPress/gutenberg/pull/32633)).
 -   Update `markdownlint-cli` package to `0.27.1` ([#32633](https://github.com/WordPress/gutenberg/pull/32633)).
+-   Update `eslint-plugin-markdown` package to `2.20.0` ([#33432](https://github.com/WordPress/gutenberg/pull/33432)).
 
 ## 16.1.0 (2021-05-20)
 


### PR DESCRIPTION

## Description

I forgot to update the CHANGELOG in #33432, this adds an entry for the
update of eslint-plugin-markdown module to 2.2.0

## How has this been tested?

- Documentation update

