### PR TITLE
Performance: Set passive listener option for use popover scroll to avoid affecting scrolling performance

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-tools/use-popover-scroll.js
@@ -21,9 +21,12 @@ export function usePopoverScroll( scrollableRef ) {
 				const { deltaX, deltaY } = event;
 				scrollableRef.current.scrollBy( deltaX, deltaY );
 			}
-			node.addEventListener( 'wheel', onWheel );
+			// Tell the browser that we do not call event.preventDefault
+			// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners
+			const options = { passive: true };
+			node.addEventListener( 'wheel', onWheel, options );
 			return () => {
-				node.removeEventListener( 'wheel', onWheel );
+				node.removeEventListener( 'wheel', onWheel, options );
 			};
 		},
 		[ scrollableRef ]


### PR DESCRIPTION
Setting `{ passive: true }` lets a browser know that we don't intend to call `event.preventDefault` and avoids the need to block scrolling. Without it, scrolling performance may be affected see (https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md and https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners). As a plus, we can also get rid of this annoying warning in chrome :D 

<img width="1450" alt="Screen Shot 2021-07-15 at 11 50 11 AM" src="https://user-images.githubusercontent.com/1270189/125846578-8e5b779e-0574-48b0-88ab-ccf516f7c6dd.png">

### Two questions for folks:

#### Why do we need to add and remove this listener so often as we mouse over elements?
 
I notice that this the warning is showing up whenever I move my mouse in trunk.

#### Where is a good spot to put feature detection?

Unfortunately, the object option will be read as `false` on older browser. Mozilla recommends feature detection similar to the following. Is there a good package for this test, or do we already use something like https://modernizr.com/ ?

```js
let passiveSupported = false;

try {
  const options = {
    get passive() { // This function will be called when the browser
                    //   attempts to access the passive property.
      passiveSupported = true;
      return false;
    }
  };

  window.addEventListener("test", null, options);
  window.removeEventListener("test", null, options);
} catch(err) {
  passiveSupported = false;
}
```
