### PR TITLE
Update widget editor help links to point to the new support article

### DIFF
--- a/packages/customize-widgets/src/components/more-menu/index.js
+++ b/packages/customize-widgets/src/components/more-menu/index.js
@@ -87,7 +87,7 @@ export default function MoreMenu() {
 								role="menuitem"
 								icon={ external }
 								href={ __(
-									'https://wordpress.org/support/article/wordpress-editor/'
+									'https://wordpress.org/support/article/block-based-widgets-editor/'
 								) }
 								target="_blank"
 								rel="noopener noreferrer"

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -92,7 +92,7 @@ export default function MoreMenu() {
 								role="menuitem"
 								icon={ external }
 								href={ __(
-									'https://wordpress.org/support/article/wordpress-editor/'
+									'https://wordpress.org/support/article/block-based-widgets-editor/'
 								) }
 								target="_blank"
 								rel="noopener noreferrer"


### PR DESCRIPTION
## Description
Updates widget editor help links to point to the new support article

## How has this been tested?
#### Standalone screen
1. Go to Appearance > Widgets
2. Click on the editor more menu and select Help
3. The block-based widgets editor article should be shown

#### Customizer screen
1. Go to Appearance > Customize > Widgets > [ Select a widget area ]
2. Click on the editor more menu and select Help
3. The block-based widgets editor article should be shown

## Types of changes
Task