### PR TITLE
NumberControl: Allow empty values

### DIFF
--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -83,10 +83,11 @@ The position of the label (`top`, `side`, `bottom`, or `edge`).
 
 ### required
 
-If boolean false, allows an empty string as a valid value.
+If `true` enforces a valid number within the control's min/max range. If `false` allows an empty string as a valid value.
 
 -   Type: `Boolean`
 -   Required: No
+-   Default: `false`
 
 ### shiftStep
 

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -27,14 +27,6 @@ const Example = () => {
 
 ## Props
 
-### allowEmpty
-
-If true, allows an empty string as a valid value.
-
--   Type: `Boolean`
--   Required: No
--   Default: `false`
-
 ### dragDirection
 
 Determines the drag axis to increment/decrement the value.
@@ -87,6 +79,13 @@ If this property is added, a label will be generated using label property as the
 The position of the label (`top`, `side`, `bottom`, or `edge`).
 
 -   Type: `String`
+-   Required: No
+
+### required
+
+If boolean false, allows an empty string as a valid value.
+
+-   Type: `Boolean`
 -   Required: No
 
 ### shiftStep

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -27,6 +27,14 @@ const Example = () => {
 
 ## Props
 
+### allowEmpty
+
+If true, allows an empty string as a valid value.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`
+
 ### dragDirection
 
 Determines the drag axis to increment/decrement the value.

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -29,10 +29,10 @@ export function NumberControl(
 		hideHTMLArrows = false,
 		isDragEnabled = true,
 		isShiftStepEnabled = true,
-		allowEmpty = false,
 		label,
 		max = Infinity,
 		min = -Infinity,
+		required,
 		shiftStep = 10,
 		step = 1,
 		type: typeProp = 'number',
@@ -156,7 +156,7 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_ENTER ||
 			type === inputControlActionTypes.COMMIT
 		) {
-			const applyEmptyValue = allowEmpty && currentValue === '';
+			const applyEmptyValue = required === false && currentValue === '';
 
 			state.value = applyEmptyValue
 				? currentValue
@@ -179,6 +179,7 @@ export function NumberControl(
 			max={ max }
 			min={ min }
 			ref={ ref }
+			required={ required }
 			step={ jumpStep }
 			type={ typeProp }
 			value={ valueProp }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -29,6 +29,7 @@ export function NumberControl(
 		hideHTMLArrows = false,
 		isDragEnabled = true,
 		isShiftStepEnabled = true,
+		allowEmpty = false,
 		label,
 		max = Infinity,
 		min = -Infinity,
@@ -155,7 +156,11 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_ENTER ||
 			type === inputControlActionTypes.COMMIT
 		) {
-			state.value = roundClamp( currentValue, min, max, step );
+			const applyEmptyValue = allowEmpty && currentValue === '';
+
+			state.value = applyEmptyValue
+				? currentValue
+				: roundClamp( currentValue, min, max, step );
 		}
 
 		return state;

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -32,7 +32,7 @@ export function NumberControl(
 		label,
 		max = Infinity,
 		min = -Infinity,
-		required,
+		required = false,
 		shiftStep = 10,
 		step = 1,
 		type: typeProp = 'number',

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -30,7 +30,7 @@ function Example() {
 		min: number( 'min', 0 ),
 		max: number( 'max', 100 ),
 		placeholder: text( 'placeholder', 0 ),
-		required: boolean( 'required', true ),
+		required: boolean( 'required', false ),
 		shiftStep: number( 'shiftStep', 10 ),
 		step: number( 'step', 1 ),
 	};

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -30,6 +30,7 @@ function Example() {
 		min: number( 'min', 0 ),
 		max: number( 'max', 100 ),
 		placeholder: text( 'placeholder', 0 ),
+		required: boolean( 'required', true ),
 		shiftStep: number( 'shiftStep', 10 ),
 		step: number( 'step', 1 ),
 	};

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -82,8 +82,8 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '0' );
 		} );
 
-		it( 'should parse to number value on ENTER keypress', () => {
-			render( <NumberControl value={ 5 } /> );
+		it( 'should parse to number value on ENTER keypress when required', () => {
+			render( <NumberControl value={ 5 } required={ true } /> );
 
 			const input = getInput();
 			input.focus();
@@ -91,6 +91,17 @@ describe( 'NumberControl', () => {
 			fireKeyDown( { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '0' );
+		} );
+
+		it( 'should parse to empty string on ENTER keypress when not required', () => {
+			render( <NumberControl value={ 5 } required={ false } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '10 abc' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '' );
 		} );
 
 		it( 'should accept empty string on ENTER keypress for optional field', () => {
@@ -104,7 +115,7 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '' );
 		} );
 
-		it( 'should enforce numerical value for empty string when required is omitted', () => {
+		it( 'should not enforce numerical value for empty string when required is omitted', () => {
 			render( <NumberControl value={ 5 } /> );
 
 			const input = getInput();
@@ -112,7 +123,7 @@ describe( 'NumberControl', () => {
 			fireEvent.change( input, { target: { value: '' } } );
 			fireKeyDown( { keyCode: ENTER } );
 
-			expect( input.value ).toBe( '0' );
+			expect( input.value ).toBe( '' );
 		} );
 
 		it( 'should enforce numerical value for empty string when required', () => {

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -93,8 +93,8 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '0' );
 		} );
 
-		it( 'should accept empty string on ENTER keypress', () => {
-			render( <NumberControl value={ 5 } allowEmpty={ true } /> );
+		it( 'should accept empty string on ENTER keypress for optional field', () => {
+			render( <NumberControl value={ 5 } required={ false } /> );
 
 			const input = getInput();
 			input.focus();
@@ -102,6 +102,28 @@ describe( 'NumberControl', () => {
 			fireKeyDown( { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '' );
+		} );
+
+		it( 'should enforce numerical value for empty string when required is omitted', () => {
+			render( <NumberControl value={ 5 } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '0' );
+		} );
+
+		it( 'should enforce numerical value for empty string when required', () => {
+			render( <NumberControl value={ 5 } required={ true } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '0' );
 		} );
 	} );
 

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -92,6 +92,17 @@ describe( 'NumberControl', () => {
 
 			expect( input.value ).toBe( '0' );
 		} );
+
+		it( 'should accept empty string on ENTER keypress', () => {
+			render( <NumberControl value={ 5 } allowEmpty={ true } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: '' } } );
+			fireKeyDown( { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '' );
+		} );
 	} );
 
 	describe( 'Key UP interactions', () => {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/33319

## Description

This fixes an issue caused by the `NumberControl` effectively enforcing a numerical value only via its use of `roundClamp`.

An example use case where an empty value would be valid is with the `BoxControl` used for padding and margin block support styles. There is a need to be able to clear a field to an undefined value.

#### Proposed solution

To bring the `NumberControl` more in line with an HTML number input this PR utilises a `required` prop to determine if an empty value can be applied via its state reducer. HTML number inputs, when not required, deem an empty value as valid.

As the `NumberControl` is currently experimental, the new `required` prop will default to false. It is currently only used directly in a few places. It does form the basis for the `UnitControl` however from what I can see the existing uses of `UnitControl` are ok allowing the field to be cleared.

## How has this been tested?

`npm run test-unit:watch packages/components/src/number-control/test`

#### Test instructions

1. Checkout this PR and run above tests
2. Run `npm run storybook:dev`
3. Open up the local storybook page for the `NumberControl`, set a placeholder and toggle off `required`. Or, follow this [link](http://localhost:50240/?path=/story/components-numbercontrol--default&knob-disabled=&knob-hideLabelFromVision=&knob-isPressEnterToChange=&knob-isShiftStepEnabled=true&knob-label=Number&knob-min=0&knob-max=100&knob-placeholder=Empty&knob-required=&knob-shiftStep=10&knob-step=1).
4. Place your cursor in the `NumberControl`, using the keyboard delete the value, then press enter. The placeholder should remain after you click elsewhere.
5. Toggle the `required` knob back on and repeat step 4. The empty value will be replaced with `0`

## Screenshots <!-- if applicable -->

![NumberControl](https://user-images.githubusercontent.com/60436221/125886407-5604ee55-2f57-4cfd-bea0-d82b1c3c93b2.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
