### PR TITLE
Improve function widgets test

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -452,20 +452,28 @@ describe( 'Widgets screen', () => {
 		it( 'Should add and save the marquee widget', async () => {
 			await addMarquee( 1 );
 
-			const [ marqueeInput ] = await page.$x(
-				'//input[@data-testid="marquee-greeting"]'
-			);
-			await marqueeInput.focus();
+			// Use find because the input might not be visible at first.
+			const marqueeInput = await find( {
+				selector: '[data-testid="marquee-greeting"]',
+			} );
+			// Clear the input.
+			await marqueeInput.evaluate( ( input ) => {
+				input.value = '';
+			} );
 			await marqueeInput.type( 'Howdy' );
 
 			// The first marquee is saved after clicking the form save button.
-			const [ marqueeSaveButton ] = await marqueeInput.$x(
-				'//input/ancestor::div[@data-block][contains(@class, "wp-block-legacy-widget")]//button[@type="submit"]'
+			const marqueeSaveButton = await marqueeInput.evaluateHandle(
+				( input ) =>
+					input
+						// Get the parent block element.
+						.closest( '[data-block]' )
+						// Get the save button.
+						.querySelector( 'button[type="submit"]' )
 			);
 			await marqueeSaveButton.click();
 
 			await saveWidgets();
-
 			let editedSerializedWidgetAreas = await getSerializedWidgetAreas();
 			await expect( editedSerializedWidgetAreas ).toMatchInlineSnapshot( `
 						Object {
@@ -489,11 +497,8 @@ describe( 'Widgets screen', () => {
 			);
 
 			expect( marqueeInputs ).toHaveLength( 2 );
-			await marqueeInputs[ 0 ].focus();
-			await marqueeInputs[ 0 ].type( 'first howdy' );
-
-			await marqueeInputs[ 1 ].focus();
-			await marqueeInputs[ 1 ].type( 'Second howdy' );
+			await marqueeInputs[ 0 ].type( 'first ' );
+			await marqueeInputs[ 1 ].type( 'Second ' );
 
 			// No marquee should be changed without clicking on their "save" button.
 			// The second marquee shouldn't be stored as a widget.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR doesn't have any effect on CI, but should help improving stability of the test locally.

The input in function widget will keep the last entered value after saved. We'll have to clear the input before sending typing command to ensure the we're at the right state.

I also removed some unnecessary `focus()` calls since that [`type()`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#elementhandletypetext-options) includes it by default. XPath selectors are also replaced with simpler CSS selectors.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

E2E tests should pass

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
