### PR TITLE
Block editor: iframe: incorporate writing flow

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -18,6 +18,7 @@ import { __experimentalStyleProvider as StyleProvider } from '@wordpress/compone
  * Internal dependencies
  */
 import { useBlockSelectionClearer } from '../block-selection-clearer';
+import { useWritingFlow } from '../writing-flow';
 
 const BODY_CLASS_NAME = 'editor-styles-wrapper';
 const BLOCK_PREFIX = 'wp-block';
@@ -191,6 +192,7 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 	const styles = useParsedAssets( window.__editorAssets.styles );
 	const scripts = useParsedAssets( window.__editorAssets.scripts );
 	const clearerRef = useBlockSelectionClearer();
+	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const setRef = useCallback( ( node ) => {
 		if ( ! node ) {
 			return;
@@ -216,6 +218,7 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 			setIframeDocument( contentDocument );
 			clearerRef( documentElement );
 			clearerRef( body );
+			writingFlowRef( body );
 
 			scripts
 				.reduce(
@@ -275,22 +278,26 @@ function Iframe( { contentRef, children, head, ...props }, ref ) {
 	);
 
 	return (
-		<iframe
-			{ ...props }
-			ref={ useMergeRefs( [ ref, setRef ] ) }
-			tabIndex="0"
-			title={ __( 'Editor canvas' ) }
-			name="editor-canvas"
-		>
-			{ iframeDocument &&
-				createPortal(
-					<StyleProvider document={ iframeDocument }>
-						{ children }
-					</StyleProvider>,
-					iframeDocument.body
-				) }
-			{ iframeDocument && createPortal( head, iframeDocument.head ) }
-		</iframe>
+		<>
+			{ before }
+			<iframe
+				{ ...props }
+				ref={ useMergeRefs( [ ref, setRef ] ) }
+				tabIndex="0"
+				title={ __( 'Editor canvas' ) }
+				name="editor-canvas"
+			>
+				{ iframeDocument &&
+					createPortal(
+						<StyleProvider document={ iframeDocument }>
+							{ children }
+						</StyleProvider>,
+						iframeDocument.body
+					) }
+				{ iframeDocument && createPortal( head, iframeDocument.head ) }
+			</iframe>
+			{ after }
+		</>
 	);
 }
 

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -68,5 +68,5 @@ export default function useSelectAll() {
 		return () => {
 			node.removeEventListener( 'keydown', onKeyDown );
 		};
-	} );
+	}, [] );
 }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -76,7 +76,7 @@ function MaybeIframe( {
 			contentRef={ contentRef }
 			style={ { width: '100%', height: '100%', display: 'block' } }
 		>
-			<WritingFlow>{ children }</WritingFlow>
+			{ children }
 		</Iframe>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -9,7 +9,6 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__experimentalLinkControl,
 	BlockInspector,
-	WritingFlow,
 	BlockList,
 	BlockTools,
 	__unstableBlockSettingsMenuFirstItem,
@@ -97,12 +96,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						ref={ ref }
 						contentRef={ mergedRefs }
 					>
-						<WritingFlow>
-							<BlockList
-								className="edit-site-block-editor__block-list"
-								__experimentalLayout={ LAYOUT }
-							/>
-						</WritingFlow>
+						<BlockList
+							className="edit-site-block-editor__block-list"
+							__experimentalLayout={ LAYOUT }
+						/>
 					</Iframe>
 				</BlockTools>
 				<__unstableBlockSettingsMenuFirstItem>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR restructures writing flow to a purely behavioural hook, which can be used in the iframe component to move the focus capture element out of the iframe (they are not content) and use the iframe body element as the writing flow container, so it removes yet another div wrapper. 

Note that for the non-iframed content, it is already the case that the focus capture elements are rendered outside the `.editor-styles-wrapper` element, and this element acts as the writing flow container.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Writing flow should work correctly in an iframed editor, which means you can arrow navigate between blocks and use tab to navigate in and out of the iframe.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
