### PR TITLE
FSE: Make nested layout containers expand the full width of their parent

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -63,7 +63,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$style = '';
 	if ( $content_size || $wide_size ) {
-		$style  = ".wp-container-$id > * {";
+		$style  = ".wp-container-$id > *:not([class*='wp-container-']) {";
 		$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 		$style .= 'margin-left: auto !important;';
 		$style .= 'margin-right: auto !important;';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When we have nested layout containers, the child container is being affected by the parent's max-width rules. This makes it mandatory for the child container to use align full for the grand children to be able to benefit from alignment rules

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Using emptytheme, I defined a layout on theme.json:

```
{
	"settings": {
		"layout": {
			"contentSize": "640px",
			"wideSize": "1100px"
		}
	}
}
```

I then created a template with the following markup (I just edited singular for this):

```
<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
<main class="wp-block-group post-content">
<!-- wp:post-content {"layout":{"inherit":true}} /-->
</main>
<!-- /wp:group -->
```

Without align full, the post-content block will never be able to have full or wide width children. With this PR, the align full rule is no longer needed



## Screenshots <!-- if applicable -->

Before this PR, with alignfull on the post-content block:

<img width="1619" alt="Screenshot 2021-07-16 at 12 56 42" src="https://user-images.githubusercontent.com/3593343/125940029-06850f90-2f07-4ebf-9e29-a9cf27ccc42d.png">

After this PR, without align full.
<img width="1624" alt="Screenshot 2021-07-16 at 12 57 01" src="https://user-images.githubusercontent.com/3593343/125940072-76316736-8e48-4669-b29b-fe3008ad1abc.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
