### PR TITLE
Replace CRLF with LF when generating unminified assets

### DIFF
--- a/packages/readable-js-assets-webpack-plugin/index.js
+++ b/packages/readable-js-assets-webpack-plugin/index.js
@@ -17,7 +17,7 @@ class AddReadableJsAssetsWebpackPlugin {
 		for ( const [ file, source ] of compilation.unminifiedAssets ) {
 			await fs.promises.writeFile(
 				path.join( compilation.options.output.path, file ),
-				source
+				source.replace( /\r\n/g, '\n' )
 			);
 		}
 	}


### PR DESCRIPTION
## Description

Add a feature in `@wordpress/readable-js-assets-webpack-plugin` so it replaces CRLF with LF line endings when generating unminified assets.

## How has this been tested?
I run `npm run build` before and after this patch, and compared both outputs with `diff -qr build-base/ build-patch/`. Then I verified that the only differences are that CRLF characters are gone.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
