### PR TITLE
Enable the reusable blocks skipped test

### DIFF
--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -263,7 +263,7 @@ describe( 'Reusable blocks', () => {
 		expect( console ).toHaveErrored();
 	} );
 
-	it.skip( 'should be able to insert a reusable block twice', async () => {
+	it( 'should be able to insert a reusable block twice', async () => {
 		await createReusableBlock(
 			'Awesome Paragraph',
 			'Duplicated reusable block'
@@ -274,11 +274,16 @@ describe( 'Reusable blocks', () => {
 		await saveDraft();
 		await page.reload();
 
-		// Replace the content of the  first paragraph
-		const paragraphBlock = await page.waitForSelector(
+		// Wait for the paragraph to be loaded.
+		await page.waitForSelector(
 			'.block-editor-block-list__block[data-type="core/paragraph"]'
 		);
-		paragraphBlock.focus();
+		// The first click selects the reusable block wrapper.
+		// The second click selects the actual paragraph block.
+		await page.click( '.wp-block-block' );
+		await page.focus(
+			'.block-editor-block-list__block[data-type="core/paragraph"]'
+		);
 		await pressKeyWithModifier( 'primary', 'a' );
 		await page.keyboard.press( 'End' );
 		await page.keyboard.type( ' modified' );
@@ -289,13 +294,15 @@ describe( 'Reusable blocks', () => {
 
 		// Check that the content of the second reusable block has been updated.
 		const reusableBlocks = await page.$$( '.wp-block-block' );
-		reusableBlocks.forEach( async ( paragraph ) => {
-			const content = await paragraph.$eval(
-				'p',
-				( element ) => element.textContent
-			);
-			expect( content ).toEqual( 'Awesome Paragraph modified' );
-		} );
+		await Promise.all(
+			reusableBlocks.map( async ( paragraph ) => {
+				const content = await paragraph.$eval(
+					'p',
+					( element ) => element.textContent
+				);
+				expect( content ).toEqual( 'Awesome Paragraph modified' );
+			} )
+		);
 	} );
 
 	// Check for regressions of https://github.com/WordPress/gutenberg/issues/26421.


### PR DESCRIPTION
closes #33505 

I noticed that when the test failed, the whole page look "selected", so the "ctrl + a" was selecting the whole thing instead of just the focused paragraph block, it meant the paragraph block was not really focused.

I think it was due to the new "overlay" added to reusable blocks, this updates the test to focus the paragraph block properly.

**How did I ensure it's not flaky anymore**

Locally, I used to have the error once each 5/6 runs. After my changes, I've run the test 24 times without error.