### PR TITLE
Correct `function_exists()` check typo introduced in #33331.

### DIFF
--- a/lib/compat/wordpress-5.8/index.php
+++ b/lib/compat/wordpress-5.8/index.php
@@ -122,7 +122,7 @@ if ( ! function_exists( 'gutenberg_render_legacy_query_loop_block' ) ) {
 			sprintf( __( 'Block %1$s has been renamed to Post Template. %1$s will be supported until WordPress version 5.9.', 'gutenberg' ), $block->name ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
-		return render_block_core_post_template( $attributes, $content, $block );
+		return gutenberg_render_block_core_post_template( $attributes, $content, $block );
 	}
 }
 

--- a/lib/compat/wordpress-5.8/index.php
+++ b/lib/compat/wordpress-5.8/index.php
@@ -104,7 +104,7 @@ if ( ! function_exists( 'build_query_vars_from_query_block' ) ) {
 	}
 }
 
-if ( ! function_exists( 'gutenberg_register_legacy_query_loop_block' ) ) {
+if ( ! function_exists( 'gutenberg_render_legacy_query_loop_block' ) ) {
 	/**
 	 * Renders the legacy `core/query-loop` block on the server.
 	 * It triggers a developer warning and then calls the renamed


### PR DESCRIPTION
## Description
This corrects a `function_exists()` check introduced in #33331.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
