### PR TITLE
Embed block: Don't rely on a global `wp-embed-responsive` class

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -139,14 +139,13 @@ add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_ed
  * Adds admin classes necessary for the block-based widgets screen.
  *
  * - Adds `block-editor-page` editor body class to allow directly styling the admin pages that are based on the block editor.
- * - Shows responsive embeds correctly on the widgets screen by adding the `wp-embed-responsive` class.
  *
  * @param string $classes existing admin body classes.
  *
- * @return string admin body classes including the `block-editor-page` and `wp-embed-responsive` classes.
+ * @return string admin body classes including the `block-editor-page` class.
  */
 function gutenberg_widgets_editor_add_admin_body_classes( $classes ) {
-	return "$classes block-editor-page wp-embed-responsive";
+	return "$classes block-editor-page";
 }
 
 /**

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -154,11 +154,6 @@ function setBodyClassName( doc ) {
 	for ( const name of document.body.classList ) {
 		if ( name.startsWith( 'admin-color-' ) ) {
 			doc.body.classList.add( name );
-		} else if ( name === 'wp-embed-responsive' ) {
-			// Ideally ALL classes that are added through get_body_class should
-			// be added in the editor too, which we'll somehow have to get from
-			// the server in the future (which will run the PHP filters).
-			doc.body.classList.add( 'wp-embed-responsive' );
 		}
 	}
 }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -177,7 +177,7 @@ const EmbedEdit = ( props ) => {
 		}
 	}, [ preview, isEditingURL ] );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { className: 'wp-embed-responsive' } );
 
 	if ( fetching ) {
 		return (

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -177,6 +177,7 @@ const EmbedEdit = ( props ) => {
 		}
 	}, [ preview, isEditingURL ] );
 
+	// Shows responsive embeds correctly by adding the `wp-embed-responsive` class.
 	const blockProps = useBlockProps( { className: 'wp-embed-responsive' } );
 
 	if ( fetching ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Move the `wp-embed-responsive` class to embed block. This makes sure the embed block isn't dependent on a global classname. The current implementation requires the classname to be added on every screen the editor is used.

Related: https://github.com/WordPress/gutenberg/pull/32057#issuecomment-875498500

Fixes: https://core.trac.wordpress.org/ticket/53609

## How has this been tested?
Tested embeds in:
- Post editor
- Template editor
- Widget
- Customizer widgets

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
