### PR TITLE
remove instagram reference from embed block's description

### DIFF
--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -3,7 +3,7 @@
 	"name": "core/embed",
 	"title": "Embed",
 	"category": "embed",
-	"description": "Add a block that displays content pulled from other sites, like Twitter, Instagram or YouTube.",
+	"description": "Add a block that displays content pulled from other sites, like Twitter or YouTube.",
 	"textdomain": "default",
 	"attributes": {
 		"url": {


### PR DESCRIPTION

## Description

Although relatively inconsequential, I removed the instagram reference from the embed block's description since instagram support has been removed as of https://github.com/WordPress/gutenberg/pull/24472 ([additional reference](https://developers.facebook.com/docs/instagram/oembed-legacy))

Before this PR, if you searched instagram in the block inserter, the embed block would appear in the results (because of the block description, leading you to believe that instagram embedding would be possible. 

## How has this been tested?
rebuilt gutenberg from source (`npm run build`) with my change; Instagram didn't appear in the inserter, worked as expected


## Screenshots <!-- if applicable -->

Before:
![image](https://user-images.githubusercontent.com/955351/125993308-54f36611-a688-411f-87da-a7df61cd7773.png)

After:

![image](https://user-images.githubusercontent.com/955351/125993379-91eabfd0-c06b-47b9-8545-244d18a89618.png)



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
