### PR TITLE
Site Editor: Remove styles reset as script dependency

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -759,8 +759,6 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	ob_start();
 
-	// We do not need reset styles for the iframed editor.
-	wp_styles()->done = array( 'wp-reset-editor-styles' );
 	wp_styles()->do_items( $style_handles );
 	wp_styles()->done = $done;
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -759,7 +759,8 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	ob_start();
 
-	wp_styles()->done = array();
+	// We do not need reset styles for the iframed editor.
+	wp_styles()->done = array( 'wp-reset-editor-styles' );
 	wp_styles()->do_items( $style_handles );
 	wp_styles()->done = $done;
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -759,6 +759,7 @@ function gutenberg_extend_block_editor_styles_html() {
 
 	ob_start();
 
+	wp_styles()->done = array();
 	wp_styles()->do_items( $style_handles );
 	wp_styles()->done = $done;
 

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -138,6 +138,8 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	// Remove wp-reset-editor-styles, as it's not needed in the iframed site editor.
+	// When the site editor is merged to Core, wp-edit-blocks can be updated to load
+	// without the styles reset for the site editor. Until then, we remove it manually.
 	if ( isset( $wp_styles->registered['wp-edit-blocks'] ) ) {
 		$wp_edit_blocks_dependencies                   = array_diff( $wp_styles->registered['wp-edit-blocks']->deps, array( 'wp-reset-editor-styles' ) );
 		$wp_styles->registered['wp-edit-blocks']->deps = $wp_edit_blocks_dependencies;

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -75,7 +75,7 @@ function gutenberg_get_editor_styles() {
  * @param string $hook Page.
  */
 function gutenberg_edit_site_init( $hook ) {
-	global $current_screen, $post, $editor_styles;
+	global $current_screen, $post, $editor_styles, $wp_styles;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
@@ -135,6 +135,12 @@ function gutenberg_edit_site_init( $hook ) {
 		( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )
 	) {
 		wp_enqueue_style( 'wp-block-library-theme' );
+	}
+
+	// Remove wp-reset-editor-styles, as it's not needed in the iframed site editor.
+	if ( isset( $wp_styles->registered['wp-edit-blocks'] ) ) {
+		$wp_edit_blocks_dependencies                   = array_diff( $wp_styles->registered['wp-edit-blocks']->deps, array( 'wp-reset-editor-styles' ) );
+		$wp_styles->registered['wp-edit-blocks']->deps = $wp_edit_blocks_dependencies;
 	}
 
 	/**

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -75,7 +75,7 @@ function gutenberg_get_editor_styles() {
  * @param string $hook Page.
  */
 function gutenberg_edit_site_init( $hook ) {
-	global $current_screen, $post, $editor_styles, $wp_styles;
+	global $current_screen, $post, $editor_styles;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
@@ -140,9 +140,9 @@ function gutenberg_edit_site_init( $hook ) {
 	// Remove wp-reset-editor-styles, as it's not needed in the iframed site editor.
 	// When the site editor is merged to Core, wp-edit-blocks can be updated to load
 	// without the styles reset for the site editor. Until then, we remove it manually.
-	if ( isset( $wp_styles->registered['wp-edit-blocks'] ) ) {
-		$wp_edit_blocks_dependencies                   = array_diff( $wp_styles->registered['wp-edit-blocks']->deps, array( 'wp-reset-editor-styles' ) );
-		$wp_styles->registered['wp-edit-blocks']->deps = $wp_edit_blocks_dependencies;
+	if ( isset( wp_styles()->registered['wp-edit-blocks'] ) ) {
+		$wp_edit_blocks_dependencies                    = array_diff( wp_styles()->registered['wp-edit-blocks']->deps, array( 'wp-reset-editor-styles' ) );
+		wp_styles()->registered['wp-edit-blocks']->deps = $wp_edit_blocks_dependencies;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Prevent loading the editor styles reset in the Site Editor.

Related to #33204. Removes the reset from `wp-edit-blocks` dependencies when the site editor loads, for better compatibility with asset concatenation plugins (for example, https://wordpress.org/plugins/page-optimize/).

Fixes a problem when some Global styles settings do not appear to work in the editor with such plugins because `wp-reset-editor-styles` is concatenated and and then loaded in the Site Editor iframe with along with all concatenated scripts.

## How has this been tested?

- With a block based theme activated, load the site editor
- Verify that `wp-reset-editor-styles` is not loaded, by searching the page markup for the stylesheet id (`wp-reset-editor-styles-css`) and/or checking to make sure the styles are not applied to `.editor-styles-wrapper` within the iframe
- Also load the post editor to make sure the styles reset continues to load there

## Screenshots <!-- if applicable -->

## Types of changes

Update to existing feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
