### PR TITLE
Site editor: Check template resolution

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -56,6 +56,7 @@ function Editor( { initialSettings } ) {
 		templateType,
 		page,
 		template,
+		templateResolved,
 		isNavigationOpen,
 	} = useSelect( ( select ) => {
 		const {
@@ -67,6 +68,7 @@ function Editor( { initialSettings } ) {
 			getPage,
 			isNavigationOpened,
 		} = select( editSiteStore );
+		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
 
@@ -81,12 +83,15 @@ function Editor( { initialSettings } ) {
 			templateType: postType,
 			page: getPage(),
 			template: postId
-				? select( coreStore ).getEntityRecord(
+				? getEntityRecord( 'postType', postType, postId )
+				: null,
+			templateResolved: postId
+				? hasFinishedResolution( 'getEntityRecord', [
 						'postType',
 						postType,
-						postId
-				  )
-				: null,
+						postId,
+				  ] )
+				: false,
 			entityId: postId,
 			isNavigationOpen: isNavigationOpened(),
 		};
@@ -225,7 +230,8 @@ function Editor( { initialSettings } ) {
 														}
 													/>
 												) }
-												{ ! template &&
+												{ templateResolved &&
+													! template &&
 													settings?.siteUrl &&
 													entityId && (
 														<Notice


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When reloading the page when viewing a template part in the site editor there is warning showing before the template has been fetched from the api. This notice shouldn't show before the request to fetch the template has 
been resolved. 

Steps to test:
1. Go to "Site Editor"
2. Navigate to `Theme > Template Parts > Headers > header`.
3. Reload the page and you see the notice before the temple is fetched.

## How has this been tested?
Locally with TT1 theme. See steps in description. Also tested that warning is still there when the template doesn't exists.

## Screenshots <!-- if applicable -->
### Before
https://user-images.githubusercontent.com/1415747/126067136-b6b7f25f-faeb-4a76-bdfc-ffd9d68fb86b.mov

### After
https://user-images.githubusercontent.com/1415747/126067522-30b11fd3-930e-4123-8504-d7ff4a8ae29c.mov

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
