### PR TITLE
HierarchicalTermSelector: Use TextControl component

### DIFF
--- a/packages/e2e-tests/specs/editor/various/taxonomies.test.js
+++ b/packages/e2e-tests/specs/editor/various/taxonomies.test.js
@@ -87,7 +87,7 @@ describe( 'Taxonomies', () => {
 
 		// Type the category name in the field.
 		await page.type(
-			'.editor-post-taxonomies__hierarchical-terms-input[type=text]',
+			'.editor-post-taxonomies__hierarchical-terms-input input[type=text]',
 			'z rand category 1'
 		);
 

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -17,6 +17,7 @@ import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import {
 	CheckboxControl,
+	TextControl,
 	TreeSelect,
 	withSpokenMessages,
 	withFilters,
@@ -79,10 +80,8 @@ class HierarchicalTermSelector extends Component {
 		onUpdateTerms( newTerms, taxonomy.rest_base );
 	}
 
-	onChangeFormName( event ) {
-		const newValue =
-			event.target.value.trim() === '' ? '' : event.target.value;
-		this.setState( { formName: newValue } );
+	onChangeFormName( value ) {
+		this.setState( { formName: value } );
 	}
 
 	onChangeFormParent( newParent ) {
@@ -299,9 +298,9 @@ class HierarchicalTermSelector extends Component {
 		return termsTree;
 	}
 
-	setFilterValue( event ) {
+	setFilterValue( value ) {
 		const { availableTermsTree } = this.state;
-		const filterValue = event.target.value;
+		const filterValue = value;
 		const filteredTermsTree = availableTermsTree
 			.map( this.getFilterMatcher( filterValue ) )
 			.filter( ( term ) => term );
@@ -393,13 +392,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	render() {
-		const {
-			slug,
-			taxonomy,
-			instanceId,
-			hasCreateAction,
-			hasAssignAction,
-		} = this.props;
+		const { slug, taxonomy, hasCreateAction, hasAssignAction } = this.props;
 
 		if ( ! hasAssignAction ) {
 			return null;
@@ -442,8 +435,6 @@ class HierarchicalTermSelector extends Component {
 		);
 		const noParentOption = `— ${ parentSelectLabel } —`;
 		const newTermSubmitLabel = newTermButtonLabel;
-		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
-		const filterInputId = `editor-post-taxonomies__hierarchical-terms-filter-${ instanceId }`;
 		const filterLabel = get(
 			this.props.taxonomy,
 			[ 'labels', 'search_items' ],
@@ -458,18 +449,13 @@ class HierarchicalTermSelector extends Component {
 
 		return [
 			showFilter && (
-				<label key="filter-label" htmlFor={ filterInputId }>
-					{ filterLabel }
-				</label>
-			),
-			showFilter && (
-				<input
-					type="search"
-					id={ filterInputId }
+				<TextControl
+					key="term-filter-input"
+					className="editor-post-taxonomies__hierarchical-terms-filter"
+					label={ filterLabel }
 					value={ filterValue }
 					onChange={ this.setFilterValue }
-					className="editor-post-taxonomies__hierarchical-terms-filter"
-					key="term-filter-input"
+					required
 				/>
 			),
 			<div
@@ -496,16 +482,9 @@ class HierarchicalTermSelector extends Component {
 			),
 			showForm && (
 				<form onSubmit={ this.onAddTerm } key="hierarchical-terms-form">
-					<label
-						htmlFor={ inputId }
-						className="editor-post-taxonomies__hierarchical-terms-label"
-					>
-						{ newTermLabel }
-					</label>
-					<input
-						type="text"
-						id={ inputId }
+					<TextControl
 						className="editor-post-taxonomies__hierarchical-terms-input"
+						label={ newTermLabel }
 						value={ formName }
 						onChange={ this.onChangeFormName }
 						required

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -298,9 +298,8 @@ class HierarchicalTermSelector extends Component {
 		return termsTree;
 	}
 
-	setFilterValue( value ) {
+	setFilterValue( filterValue ) {
 		const { availableTermsTree } = this.state;
-		const filterValue = value;
 		const filteredTermsTree = availableTermsTree
 			.map( this.getFilterMatcher( filterValue ) )
 			.filter( ( term ) => term );

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -455,7 +455,6 @@ class HierarchicalTermSelector extends Component {
 					label={ filterLabel }
 					value={ filterValue }
 					onChange={ this.setFilterValue }
-					required
 				/>
 			),
 			<div

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -30,7 +30,6 @@
 
 .editor-post-taxonomies__hierarchical-terms-input {
 	margin-top: 8px;
-	width: 100%;
 }
 .editor-post-taxonomies__hierarchical-terms-filter {
 	margin-bottom: 8px;


### PR DESCRIPTION
## Description
`HierarchicalTermSelector` wasn't using the `TextControl` component for some of its inputs. As a result, the input fields design was slightly off from the rest of the screen. PR replaces input/labels elements with `TextControl` component.

Fixes #28577.

P.S. The `withInstanceId` HOC is no longer needed for the `HierarchicalTermSelector` component but left it here for backward compatibility.

## How has this been tested?
1. Create a post.
2. Open the "Categories" panel.
3. Click on the "Add New Category" button.
4. The "New Category Name" field should match other input fields by design.

## Screenshots <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-07-19 at 17 40 08](https://user-images.githubusercontent.com/240569/126169334-70c5b58f-c9c2-4970-b883-06bdfd6f48ed.png)  | ![CleanShot 2021-07-19 at 17 23 50](https://user-images.githubusercontent.com/240569/126169331-0f31cebe-25c7-4600-bde4-f84fdfa26111.png)  |

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
