### PR TITLE
Skip some widgets editing related tests

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -519,7 +519,7 @@ describe( 'Widgets screen', () => {
 		} );
 	} );
 
-	it( 'Should duplicate the widgets', async () => {
+	it.skip( 'Should duplicate the widgets', async () => {
 		let [ firstWidgetArea ] = await findAll( {
 			role: 'group',
 			name: 'Block: Widget Area',
@@ -743,7 +743,7 @@ describe( 'Widgets screen', () => {
 	` );
 	} );
 
-	it( 'allows widgets to be moved between widget areas using the dropdown in the block toolbar', async () => {
+	it.skip( 'allows widgets to be moved between widget areas using the dropdown in the block toolbar', async () => {
 		const widgetAreas = await findAll( {
 			role: 'group',
 			name: 'Block: Widget Area',


### PR DESCRIPTION
Here are some examples of failures for these tests:

 - https://github.com/WordPress/gutenberg/runs/3102235350
 - https://github.com/WordPress/gutenberg/runs/3104176531

I think they have been flaky for some time now and might be related to #33275