### PR TITLE
Add i18n filters to docs table of contents

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -570,6 +570,12 @@
 		"parent": "filters"
 	},
 	{
+		"title": "i18n Filters",
+		"slug": "i18n-filters",
+		"markdown_source": "../docs/reference-guides/filters/i18n-filters.md",
+		"parent": "filters"
+	},
+	{
 		"title": "Parser Filters",
 		"slug": "parser-filters",
 		"markdown_source": "../docs/reference-guides/filters/parser-filters.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -227,6 +227,7 @@
 				"docs/reference-guides/filters/README.md": [
 					{ "docs/reference-guides/filters/block-filters.md": [] },
 					{ "docs/reference-guides/filters/editor-filters.md": [] },
+					{ "docs/reference-guides/filters/i18n-filters.md": [] },
 					{ "docs/reference-guides/filters/parser-filters.md": [] },
 					{
 						"docs/reference-guides/filters/autocomplete-filters.md": []


### PR DESCRIPTION

## Description

It looks like the i18n filters doc got left out of toc.json at some
point. This PR adds it back so it shows up in the published docs.

Fixes #33550

## How has this been tested?

Only thing you can really do is confirm TOC link looks right.

You can't really test the publishing process, so merge and check 15-20 minutes after.


## Types of changes

Documentation
