### PR TITLE
[RNmobile] Enable inserter block search

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -38,7 +38,7 @@ function InserterMenu( {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ showTabs, setShowTabs ] = useState( true );
 	// eslint-disable-next-line no-undef
-	const [ showSearchForm, setShowSearchForm ] = useState( __DEV__ );
+	const [ showSearchForm, setShowSearchForm ] = useState( true );
 	const [ tabIndex, setTabIndex ] = useState( 0 );
 
 	const {

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -45,7 +45,10 @@ import BottomSheetSubSheet from './sub-sheet';
 import NavigationHeader from './navigation-header';
 import { BottomSheetProvider } from './bottom-sheet-context';
 
-const DEFAULT_LAYOUT_ANIMATION = LayoutAnimation.Presets.easeInEaseOut;
+const DEFAULT_LAYOUT_ANIMATION_PROPERTIES = {
+	type: 'easeIn',
+	duration: 150,
+};
 
 class BottomSheet extends Component {
 	constructor() {
@@ -162,13 +165,28 @@ class BottomSheet extends Component {
 		}
 
 		const layoutAnimation = useLastLayoutAnimation
-			? this.lastLayoutAnimation || DEFAULT_LAYOUT_ANIMATION
-			: DEFAULT_LAYOUT_ANIMATION;
+			? this.lastLayoutAnimation || DEFAULT_LAYOUT_ANIMATION_PROPERTIES
+			: DEFAULT_LAYOUT_ANIMATION_PROPERTIES;
 
 		this.lastLayoutAnimationFinished = false;
-		LayoutAnimation.configureNext( layoutAnimation, () => {
-			this.lastLayoutAnimationFinished = true;
-		} );
+
+		LayoutAnimation.configureNext(
+			{
+				duration: layoutAnimation.duration,
+				update: layoutAnimation,
+				create: {
+					...layoutAnimation,
+					property: LayoutAnimation.Properties.opacity,
+				},
+				delete: {
+					...layoutAnimation,
+					property: LayoutAnimation.Properties.opacity,
+				},
+			},
+			() => {
+				this.lastLayoutAnimationFinished = true;
+			}
+		);
 		this.lastLayoutAnimation = layoutAnimation;
 	}
 

--- a/packages/components/src/search-control/platform-style.android.scss
+++ b/packages/components/src/search-control/platform-style.android.scss
@@ -1,7 +1,3 @@
-.search-control__container {
-	height: 40px;
-}
-
 .search-control__container--active {
 	border-bottom-color: $light-gray-500;
 	border-bottom-width: 1px;

--- a/packages/components/src/search-control/platform-style.android.scss
+++ b/packages/components/src/search-control/platform-style.android.scss
@@ -1,6 +1,7 @@
 .search-control__container--active {
 	border-bottom-color: $light-gray-500;
 	border-bottom-width: 1px;
+	margin-bottom: 0;
 	margin-left: 0;
 	margin-right: 0;
 	border-radius: 0;

--- a/packages/components/src/search-control/platform-style.ios.scss
+++ b/packages/components/src/search-control/platform-style.ios.scss
@@ -1,6 +1,3 @@
-.search-control__container {
-	height: 40px;
-}
 .search-control__container--active {
 	margin-right: 0;
 }

--- a/packages/components/src/search-control/style.native.scss
+++ b/packages/components/src/search-control/style.native.scss
@@ -1,8 +1,6 @@
 .search-control__container {
-	height: 46px;
+	height: 48px;
 	margin: 0 16px $grid-unit-10;
-	flex-direction: row;
-	justify-content: space-between;
 }
 
 .search-control__inner-container {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This enables the Inserter Block search feature on mobile Gutenberg.

Gutenberg Mobile companion PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/3735

## How has this been tested?
The feature has been tested in #33237

## Screenshots <!-- if applicable -->

## Types of changes
Replace `__DEV__` flag with `true` to enable the inserter search in production builds.
It also addresses some feedback from @iamthomasbishop (https://github.com/wordpress-mobile/WordPress-Android/pull/15044#issuecomment-883750475 ):
- Fix input text height
- Fix top padding when search is active on Android
- Adjust bottom sheet activation animation 
     -  @mchowning , @iamthomasbishop and I discussed the current bottom sheet animation issue (see https://github.com/WordPress/gutenberg/issues/31151) we decided on changing the animation by switching the type from the default `easeInEaseOut` to `easeIn` and lowering the duration from `300` to `150`. The idea is to reduce the attention that the existing animation draws while still preventing the visual glitch when the keyboard opens.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
