### PR TITLE
Widget inserter: Clarify that the button toggles the inserter

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -74,7 +74,7 @@ describe( 'Widgets screen', () => {
 	async function getBlockInGlobalInserter( blockName ) {
 		const addBlockButton = await find( {
 			role: 'button',
-			name: 'Add block',
+			name: 'Toggle block inserter',
 			pressed: false,
 		} );
 		await addBlockButton.click();

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -97,7 +97,7 @@ function Header() {
 							/* translators: button label text should, if possible, be under 16
 					characters. */
 							label={ _x(
-								'Add block',
+								'Toggle block inserter',
 								'Generic label for block inserter button'
 							) }
 						/>

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -79,4 +79,15 @@
 	&::after {
 		content: none;
 	}
+
+	svg {
+		transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
+		@include reduce-motion("transition");
+	}
+
+	&.is-pressed {
+		svg {
+			transform: rotate(45deg);
+		}
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Follow-up on #29759
Add the same functionality to the inserter button on the widget screen and rename the label.

## How has this been tested?
Locally by toggling the inserter sidebar.

## Screenshots <!-- if applicable -->
![widget-inserter](https://user-images.githubusercontent.com/1415747/126214961-6a3c128f-0060-488c-ba2d-bbab82210df6.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
