### PR TITLE
Update button block corner radius test to px

### DIFF
--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -75,8 +75,6 @@ describe( 'when a button is shown', () => {
 		);
 		fireEvent( incrementButton, 'onPressIn' );
 
-		await waitFor( () => getByA11yLabel( /Border Radius/ ) );
-
 		const expectedHtml = `<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"6px"}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:6px">Hello</a></div>

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -30,11 +30,11 @@ afterAll( () => {
 describe( 'when a button is shown', () => {
 	it( 'adjusts the border radius', async () => {
 		const initialHtml = `<!-- wp:buttons -->
-		<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"5%"}}} -->
-		<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5%" >Hello</a></div>
+		<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"5px"}}} -->
+		<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
 		<!-- /wp:button --></div>
 		<!-- /wp:buttons -->`;
-		const { getByA11yLabel, getByTestId } = await initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml,
 		} );
 
@@ -66,14 +66,20 @@ describe( 'when a button is shown', () => {
 		);
 		fireEvent.press( settingsButton );
 
-		const radiusSlider = await waitFor( () =>
-			getByTestId( 'Slider Border Radius' )
+		const radiusStepper = await waitFor( () =>
+			getByA11yLabel( /Border Radius/ )
 		);
-		fireEvent( radiusSlider, 'valueChange', '25' );
+
+		const incrementButton = await waitFor( () =>
+			within( radiusStepper ).getByTestId( 'Increment' )
+		);
+		fireEvent.press( incrementButton );
+
+		await waitFor( () => getByA11yLabel( /Border Radius/ ) );
 
 		const expectedHtml = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"25%"}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:25%">Hello</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"6px"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:6px">Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -73,7 +73,7 @@ describe( 'when a button is shown', () => {
 		const incrementButton = await waitFor( () =>
 			within( radiusStepper ).getByTestId( 'Increment' )
 		);
-		fireEvent.press( incrementButton );
+		fireEvent( incrementButton, 'onPressIn' );
 
 		await waitFor( () => getByA11yLabel( /Border Radius/ ) );
 

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.android.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.android.js
@@ -37,6 +37,7 @@ function Stepper( {
 	return (
 		<View style={ styles.container }>
 			<TouchableOpacity
+				testID={ 'Increment' }
 				disabled={ isMinValue }
 				onPressIn={ onPressInDecrement }
 				onPressOut={ onPressOut }

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.android.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.android.js
@@ -37,7 +37,6 @@ function Stepper( {
 	return (
 		<View style={ styles.container }>
 			<TouchableOpacity
-				testID={ 'Increment' }
 				disabled={ isMinValue }
 				onPressIn={ onPressInDecrement }
 				onPressOut={ onPressOut }
@@ -57,6 +56,7 @@ function Stepper( {
 			) }
 			{ children }
 			<TouchableOpacity
+				testID={ 'Increment' }
 				disabled={ isMaxValue }
 				onPressIn={ onPressInIncrement }
 				onPressOut={ onPressOut }

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.ios.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.ios.js
@@ -49,6 +49,7 @@ function Stepper( {
 				<Icon icon={ minus } size={ 24 } color={ buttonStyle.color } />
 			</TouchableOpacity>
 			<TouchableOpacity
+				testID={ 'Increment' }
 				disabled={ isMaxValue }
 				onPressIn={ onPressInIncrement }
 				onPressOut={ onPressOut }

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -126,6 +126,9 @@ module.exports = {
 	arrow: {
 		color: 'red',
 	},
+	button: {
+		color: 'red',
+	},
 	textInput: {
 		color: 'black',
 	},


### PR DESCRIPTION
## Description

The Button block "Border Radius" setting used to use a unit of `%` but now it defaults to `px` and can support other units (`em`, `rem`, and `%`). So it makes sense to update the test to use the default unit of `%`, which is likely the most common.

## How has this been tested?

```
npm run test-unit:native packages/block-library/src/buttons/test/edit.native.js
```

## Screenshots <!-- if applicable -->

Not applicable.

## Types of changes
- Modified test.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
