### PR TITLE
Featured Image: Allow authors to select images uploaded by other users

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -44,7 +44,13 @@ function PostFeaturedImageDisplay( {
 	);
 	const media = useSelect(
 		( select ) =>
-			featuredImage && select( coreStore ).getMedia( featuredImage ),
+			featuredImage &&
+			select( coreStore ).getEntityRecord(
+				'root',
+				'media',
+				featuredImage,
+				{ context: 'view' }
+			),
 		[ featuredImage ]
 	);
 	const blockProps = useBlockProps();

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -215,12 +215,16 @@ function PostFeaturedImage( {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getMedia, getPostType } = select( coreStore );
+	const { getEntityRecord, getPostType } = select( coreStore );
 	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
-		media: featuredImageId ? getMedia( featuredImageId ) : null,
+		media: featuredImageId
+			? getEntityRecord( 'root', 'media', featuredImageId, {
+					context: 'view',
+			  } )
+			: null,
 		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,


### PR DESCRIPTION
## Description
PR fixes the issue when users with the Author role couldn't select images uploaded by other users.

The media entity is only requested for display. Therefore, I think it makes sense to change the request `context` to the `view` argument.

Fixes #18510.

## How has this been tested?
1. Upload an image using an Administrator user account.
2. Switch to a user with an Author role.
3. Create a post.
4. Select the uploaded image using the "Post Featured Image" block or "Feature image" panel in the sidebar.
5. See that feature image is displayed.
6. DevTools has no 403 requests in the Networks panel.

## Types of changes
Bugfix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
