### PR TITLE
Post Content: Add some text to the Post Content block when used in a 404 context

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -17,6 +17,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	static $seen_ids = array();
 
 	if ( ! isset( $block->context['postId'] ) ) {
+		if ( is_404() ) {
+			return __( 'It looks like nothing was found at this location.' );
+		}
 		return '';
 	}
 
@@ -46,7 +49,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	unset( $seen_ids[ $post_id ] );
 
 	if ( empty( $content ) ) {
-		return '';
+		return 'hello';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -49,7 +49,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	unset( $seen_ids[ $post_id ] );
 
 	if ( empty( $content ) ) {
-		return 'hello';
+		return '';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Similarly to https://github.com/WordPress/gutenberg/pull/33515, we should output some default copy on the page when the post content block is used in a 404 context. This makes the creation of 404 templates much simpler as themes can simply use the same template as their index.

## How has this been tested?
- Add a post content block to a 404 template
- Confirm that you see the text "It looks like nothing was found at this location.".

Another benefit of this approach is that the default text can be translated. We might want to change the copy.

## Screenshots <!-- if applicable -->
<img width="394" alt="Screenshot 2021-07-20 at 14 40 05" src="https://user-images.githubusercontent.com/275961/126334112-26c32d7c-b866-4604-95ee-0e6fe605270d.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
