### PR TITLE
Fix console errors when an Inner Block is deleted, and when using lightBlockWrapper

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -39,9 +39,14 @@ export function useBlockClassNames( clientId ) {
 				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
 				outlineMode,
 			} = getSettings();
+			const name = getBlockName( clientId );
+
+			if ( ! name ) {
+				return;
+			}
+
 			const isDragging = isBlockBeingDragged( clientId );
 			const isSelected = isBlockSelected( clientId );
-			const name = getBlockName( clientId );
 			const checkDeep = true;
 			// "ancestor" is the more appropriate label due to "deep" check
 			const isAncestorOfSelectedBlock = hasSelectedInnerBlock(


### PR DESCRIPTION
## Description
I am using some Inner Blocks that use apiVersion 2 and the light block wrapper. When one of these inner blocks are deleted, the console fills with errors:

![Screenshot 2021-07-20 at 15 32 36](https://user-images.githubusercontent.com/90977/126342476-23a1ff6c-dc0f-4b97-8425-84ec19bd7b1e.png)

This is because some API methods such as `getBlockName`, `getBlockType`, and `getBlockAttributes` return null or undefined once a block has been removed. My fix is to check that a value is returned first within the affected hooks. cc @nerrad 

Discovered in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4479

## Steps to Reproduce

Edit: I found a way to reproduce this with only Gutenberg blocks.

1. Add a columns block
2. Add an image block within a column. Assign an image.
3. Save the post.
4. Refresh the page.
5. Delete the image block by selecting it and hitting backspace or delete
6. See console

## How has this been tested?
Tested before and after patch and ensured the errors were not logged to the console and there was no regression in inner block functionality. Running locally using WP Local environment. The blocks affected by this bug are part of [woocommerce-gutenberg-products-block](https://github.com/woocommerce/woocommerce-gutenberg-products-block).

## Types of changes
Bug fix - Checking variables exist.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
