### PR TITLE
Tools: Add depth to git fetch in npm publishing

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -65,6 +65,7 @@ async function runWordPressReleaseBranchSyncStep(
 				gitWorkingDirectoryPath,
 				wordpressReleaseBranch
 			);
+			await git.fetch( gitWorkingDirectoryPath, [ '--depth=100' ] );
 			log(
 				'>> The local release branch ' +
 					formats.success( wordpressReleaseBranch ) +

--- a/bin/plugin/lib/git.js
+++ b/bin/plugin/lib/git.js
@@ -27,6 +27,17 @@ async function clone( repositoryUrl ) {
 }
 
 /**
+ * Fetches changes from the repository.
+ *
+ * @param {string}          gitWorkingDirectoryPath Local repository path.
+ * @param {string[]|Object} options                 Git options to apply.
+ */
+async function fetch( gitWorkingDirectoryPath, options = [] ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.fetch( options );
+}
+
+/**
  * Commits changes to the repository.
  *
  * @param {string}   gitWorkingDirectoryPath Local repository path.
@@ -166,6 +177,7 @@ module.exports = {
 	checkoutRemoteBranch,
 	createLocalBranch,
 	createLocalTag,
+	fetch,
 	pushBranchToOrigin,
 	pushTagsToOrigin,
 	discardLocalChanges,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

All commands controlled through `./bin/plugin/cli.js` use a shallow clone of git repository:

https://github.com/WordPress/gutenberg/blob/4ee463bda4a7f8edf66da90144216ab1bc1312fd/bin/plugin/lib/git.js#L22-L25

In general, it's a good thing as it makes the download size necessary for commands to work much smaller. However, in the case of npm publishing, we need a bit of git history for the branch used in the release process so Lerna could do its stuff. This PR add a `get fetch --depth=100` call to npm publishing commands so Lerna could operate correctly. In practice, it allows us to publish only those packages that were modified. Without this change, it tried to publish all available packages in most of the cases.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I published a bugfix release with `./bin/plugin/cli.js npm-bugifx` and I can confirm that only two packages were published - as expected:

https://github.com/WordPress/gutenberg/commit/5bac0d709748534aecf080f2e9d456b091657d23