### PR TITLE
eslint-plugin: Disable the eqeqeq rule for null

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -8,7 +8,6 @@ import {
 	isArray,
 	isEmpty,
 	isFunction,
-	isNil,
 	isObject,
 	isPlainObject,
 	isString,
@@ -186,7 +185,7 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 			continue;
 		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
-			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
+			pickBy( definitions[ blockName ], ( value ) => value != null ),
 			( value, key ) => camelCase( key )
 		);
 	}

--- a/packages/components/src/elevation/hook.js
+++ b/packages/components/src/elevation/hook.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { css } from '@emotion/react';
-import { isNil } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -49,13 +48,13 @@ export function useElevation( props ) {
 
 	const classes = useMemo( () => {
 		/** @type {number | undefined} */
-		let hoverValue = ! isNil( hover ) ? hover : value * 2;
+		let hoverValue = hover != null ? hover : value * 2;
 		/** @type {number | undefined} */
-		let activeValue = ! isNil( active ) ? active : value / 2;
+		let activeValue = active != null ? active : value / 2;
 
 		if ( ! isInteractive ) {
-			hoverValue = ! isNil( hover ) ? hover : undefined;
-			activeValue = ! isNil( active ) ? active : undefined;
+			hoverValue = hover != null ? hover : undefined;
+			activeValue = active != null ? active : undefined;
 		}
 
 		const transition = `box-shadow ${ CONFIG.transitionDuration } ${ CONFIG.transitionTimingFunction }`;
@@ -76,7 +75,7 @@ export function useElevation( props ) {
 			reduceMotion( 'transition' )
 		);
 
-		if ( ! isNil( hoverValue ) ) {
+		if ( hoverValue != null ) {
 			sx.hover = css`
 				*:hover > & {
 					box-shadow: ${ getBoxShadow( hoverValue ) };
@@ -84,7 +83,7 @@ export function useElevation( props ) {
 			`;
 		}
 
-		if ( ! isNil( activeValue ) ) {
+		if ( activeValue != null ) {
 			sx.active = css`
 				*:active > & {
 					box-shadow: ${ getBoxShadow( activeValue ) };
@@ -92,7 +91,7 @@ export function useElevation( props ) {
 			`;
 		}
 
-		if ( ! isNil( focus ) ) {
+		if ( focus != null ) {
 			sx.focus = css`
 				*:focus > & {
 					box-shadow: ${ getBoxShadow( focus ) };

--- a/packages/components/src/h-stack/utils.js
+++ b/packages/components/src/h-stack/utils.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { isNil } from 'lodash';
-
 /** @type {import('./types').Alignments} */
 const ALIGNMENTS = {
 	bottom: { align: 'flex-end', justify: 'center' },
@@ -41,7 +36,7 @@ const V_ALIGNMENTS = {
  */
 /* eslint-enable jsdoc/valid-types */
 export function getAlignmentProps( alignment, direction = 'row' ) {
-	if ( isNil( alignment ) ) {
+	if ( alignment == null ) {
 		return {};
 	}
 	const isVertical = direction === 'column';

--- a/packages/components/src/truncate/utils.js
+++ b/packages/components/src/truncate/utils.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { isNil } from 'lodash';
-
 export const TRUNCATE_ELLIPSIS = '…';
 export const TRUNCATE_TYPE = {
 	auto: 'auto',
@@ -38,7 +33,7 @@ export function truncateMiddle( word, headLength, tailLength, ellipsis ) {
 	// eslint-disable-next-line no-bitwise
 	const backLength = ~~tailLength;
 	/* istanbul ignore next */
-	const truncateStr = ! isNil( ellipsis ) ? ellipsis : TRUNCATE_ELLIPSIS;
+	const truncateStr = ellipsis != null ? ellipsis : TRUNCATE_ELLIPSIS;
 
 	if (
 		( frontLength === 0 && backLength === 0 ) ||

--- a/packages/components/src/utils/hooks/use-cx.ts
+++ b/packages/components/src/utils/hooks/use-cx.ts
@@ -20,7 +20,6 @@ const EmotionCacheContext: Context< EmotionCache > = CacheProvider._context;
 const useEmotionCacheContext = () => useContext( EmotionCacheContext );
 
 const isSerializedStyles = ( o: any ): o is SerializedStyles =>
-	// eslint-disable-next-line eqeqeq
 	o != null &&
 	[ 'name', 'styles' ].every( ( p ) => typeof o[ p ] !== 'undefined' );
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   Adds JSDoc alignment check ([#25300](https://github.com/WordPress/gutenberg/pull/25300)).
+-	Ignore the `eqeqeq` rule for comparing against null ([#33598](https://github.com/WordPress/gutenberg/pull/33598))
 
 ## 9.0.1 (2021-03-19)
 

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -16,7 +16,7 @@ module.exports = {
 		curly: [ 'error', 'all' ],
 		'dot-notation': 'error',
 		'eol-last': 'error',
-		eqeqeq: 'error',
+		eqeqeq: [ 'error', 'always', { null: 'ignore' } ],
 		'func-call-spacing': 'error',
 		indent: [ 'error', 'tab', { SwitchCase: 1 } ],
 		'key-spacing': 'error',

--- a/packages/eslint-plugin/configs/jshint.js
+++ b/packages/eslint-plugin/configs/jshint.js
@@ -1,7 +1,7 @@
 module.exports = {
 	rules: {
 		curly: 'error',
-		eqeqeq: 'error',
+		eqeqeq: [ 'error', 'always', { null: 'ignore' } ],
 		'no-caller': 'error',
 		'no-cond-assign': [ 'error', 'except-parens' ],
 		'no-eq-null': 'error',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Disables the `eqeqeq` rule for `null` so that you can do `obj != null` to consolidate checks against `undefined` and `null`. This would allow us to stop using the `isNil` function from `lodash` and instead rely on existing language semantics for the same check.

Also removes the usages of the `isNil` function.

Thanks to @diegohaz for pointing out this option exists in ESLint.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Removed an instance of disabling this rule and eslint does not complain about using `!=` or `==` for `null`. Also removed all instances of `isNil` and relaced it with `!= null` or `== null` depending on the context and eslint doesn't complain.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
