### PR TITLE
Rnmobile/add/typography controls

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -53,6 +53,7 @@ $gray-text-min: darken($gray, 18%); //#537994
 $gray-lighten-10: lighten($gray, 10%); // #a8bece
 $gray-lighten-20: lighten($gray, 20%); // #c8d7e1
 $gray-lighten-30: lighten($gray, 30%); // #e9eff3
+$gray-darken-10: darken($gray, 10%);
 $gray-darken-20: darken($gray, 20%); // #4f748e
 $gray-darken-30: darken($gray, 30%); // #3d596d
 
@@ -102,6 +103,8 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
+$sub-heading: $gray-darken-10;
+$sub-heading-dark: $dark-tertiary;
 /**
  * Deprecated colors.
  * Please avoid using these.

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -103,8 +103,8 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$sub-heading: $gray-darken-10;
-$sub-heading-dark: $dark-tertiary;
+$sub-heading: $gray-text-min;
+$sub-heading-dark: $white;
 /**
  * Deprecated colors.
  * Please avoid using these.

--- a/packages/block-editor/src/components/font-sizes/index.native.js
+++ b/packages/block-editor/src/components/font-sizes/index.native.js
@@ -1,1 +1,7 @@
-export { getFontSize, getFontSizeClass } from './utils';
+export {
+	getFontSize,
+	getFontSizeClass,
+	getFontSizeObjectByValue,
+} from './utils';
+export { default as FontSizePicker } from './font-size-picker';
+export { default as withFontSizes } from './with-font-sizes';

--- a/packages/block-editor/src/components/line-height-control/index.native.js
+++ b/packages/block-editor/src/components/line-height-control/index.native.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { UnitControl } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import { BASE_DEFAULT_VALUE, STEP, isLineHeightDefined } from './utils';
+
+export default function LineHeightControl( { value: lineHeight, onChange } ) {
+	const isDefined = isLineHeightDefined( lineHeight );
+	const value = isDefined ? lineHeight : BASE_DEFAULT_VALUE;
+	return (
+		<UnitControl
+			label={ __( 'Line Height' ) }
+			min={ 0 }
+			max={ 5 }
+			step={ STEP }
+			value={ value }
+			onChange={ onChange }
+			units={ false }
+		/>
+	);
+}

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -6,7 +6,6 @@ import { hasBlockSupport } from '@wordpress/blocks';
  * External dependencies
  */
 import { PanelBody } from '@wordpress/components';
-import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -83,11 +82,8 @@ export function TypographyPanel( props ) {
 }
 
 const hasTypographySupport = ( blockName ) => {
-	return (
-		Platform.OS === 'web' &&
-		TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
-			hasBlockSupport( blockName, key )
-		)
+	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
+		hasBlockSupport( blockName, key )
 	);
 };
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -68,26 +68,26 @@ export function TypographyPanel( props ) {
 
 	if ( isDisabled || ! isSupported ) return null;
 
-	const isSupporteOnWeb = Platform.OS === 'web';
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Typography' ) }>
-				{ isSupporteOnWeb && <FontFamilyEdit { ...props } /> }
-				{ isSupporteOnWeb && <FontSizeEdit { ...props } /> }
-				{ isSupporteOnWeb && <FontAppearanceEdit { ...props } /> }
-				{ <LineHeightEdit { ...props } /> }
-				{ isSupporteOnWeb && (
-					<TextDecorationAndTransformEdit { ...props } />
-				) }
-				{ isSupporteOnWeb && <LetterSpacingEdit { ...props } /> }
+				<FontFamilyEdit { ...props } />
+				<FontSizeEdit { ...props } />
+				<FontAppearanceEdit { ...props } />
+				<LineHeightEdit { ...props } />
+				<TextDecorationAndTransformEdit { ...props } />
+				<LetterSpacingEdit { ...props } />
 			</PanelBody>
 		</InspectorControls>
 	);
 }
 
 const hasTypographySupport = ( blockName ) => {
-	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
-		hasBlockSupport( blockName, key )
+	return (
+		Platform.OS === 'web' &&
+		TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
+			hasBlockSupport( blockName, key )
+		)
 	);
 };
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -68,26 +68,26 @@ export function TypographyPanel( props ) {
 
 	if ( isDisabled || ! isSupported ) return null;
 
+	const isSupporteWeb = Platform.OS === 'web';
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Typography' ) }>
-				<FontFamilyEdit { ...props } />
-				<FontSizeEdit { ...props } />
-				<FontAppearanceEdit { ...props } />
-				<LineHeightEdit { ...props } />
-				<TextDecorationAndTransformEdit { ...props } />
-				<LetterSpacingEdit { ...props } />
+				{ isSupporteWeb && <FontFamilyEdit { ...props } /> }
+				{ isSupporteWeb && <FontSizeEdit { ...props } /> }
+				{ isSupporteWeb && <FontAppearanceEdit { ...props } /> }
+				{ <LineHeightEdit { ...props } /> }
+				{ isSupporteWeb && (
+					<TextDecorationAndTransformEdit { ...props } />
+				) }
+				{ isSupporteWeb && <LetterSpacingEdit { ...props } /> }
 			</PanelBody>
 		</InspectorControls>
 	);
 }
 
 const hasTypographySupport = ( blockName ) => {
-	return (
-		Platform.OS === 'web' &&
-		TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
-			hasBlockSupport( blockName, key )
-		)
+	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
+		hasBlockSupport( blockName, key )
 	);
 };
 

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -68,18 +68,18 @@ export function TypographyPanel( props ) {
 
 	if ( isDisabled || ! isSupported ) return null;
 
-	const isSupporteWeb = Platform.OS === 'web';
+	const isSupporteOnWeb = Platform.OS === 'web';
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Typography' ) }>
-				{ isSupporteWeb && <FontFamilyEdit { ...props } /> }
-				{ isSupporteWeb && <FontSizeEdit { ...props } /> }
-				{ isSupporteWeb && <FontAppearanceEdit { ...props } /> }
+				{ isSupporteOnWeb && <FontFamilyEdit { ...props } /> }
+				{ isSupporteOnWeb && <FontSizeEdit { ...props } /> }
+				{ isSupporteOnWeb && <FontAppearanceEdit { ...props } /> }
 				{ <LineHeightEdit { ...props } /> }
-				{ isSupporteWeb && (
+				{ isSupporteOnWeb && (
 					<TextDecorationAndTransformEdit { ...props } />
 				) }
-				{ isSupporteWeb && <LetterSpacingEdit { ...props } /> }
+				{ isSupporteOnWeb && <LetterSpacingEdit { ...props } /> }
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/typography.native.js
+++ b/packages/block-editor/src/hooks/typography.native.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { hasBlockSupport } from '@wordpress/blocks';
+/**
+ * External dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../components/inspector-controls';
+
+import {
+	LINE_HEIGHT_SUPPORT_KEY,
+	LineHeightEdit,
+	useIsLineHeightDisabled,
+} from './line-height';
+import {
+	FONT_SIZE_SUPPORT_KEY,
+	FontSizeEdit,
+	useIsFontSizeDisabled,
+} from './font-size';
+
+export const TYPOGRAPHY_SUPPORT_KEY = 'typography';
+export const TYPOGRAPHY_SUPPORT_KEYS = [
+	LINE_HEIGHT_SUPPORT_KEY,
+	FONT_SIZE_SUPPORT_KEY,
+];
+
+export function TypographyPanel( props ) {
+	const isDisabled = useIsTypographyDisabled( props );
+	const isSupported = hasTypographySupport( props.name );
+
+	if ( isDisabled || ! isSupported ) return null;
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Typography' ) }>
+				<FontSizeEdit { ...props } />
+				<LineHeightEdit { ...props } />
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
+const hasTypographySupport = ( blockName ) => {
+	return TYPOGRAPHY_SUPPORT_KEYS.some( ( key ) =>
+		hasBlockSupport( blockName, key )
+	);
+};
+
+function useIsTypographyDisabled( props = {} ) {
+	const configs = [
+		useIsFontSizeDisabled( props ),
+		useIsLineHeightDisabled( props ),
+	];
+
+	return configs.filter( Boolean ).length === configs.length;
+}

--- a/packages/block-editor/src/hooks/typography.native.js
+++ b/packages/block-editor/src/hooks/typography.native.js
@@ -34,7 +34,9 @@ export function TypographyPanel( props ) {
 	const isDisabled = useIsTypographyDisabled( props );
 	const isSupported = hasTypographySupport( props.name );
 
-	if ( isDisabled || ! isSupported ) return null;
+	// only enable TypographyPanel for development
+	// eslint-disable-next-line no-undef
+	if ( isDisabled || ! isSupported || ! __DEV__ ) return null;
 
 	return (
 		<InspectorControls>

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -126,7 +126,7 @@ function FontSizePicker( {
 								accessibilityLabel={
 									item.size === selectedValue
 										? sprintf(
-												// translators: %s: Select control option value e.g: "Auto, 25%".
+												// translators: %s: Select font size option value e.g: "Selected: Large".
 												__( 'Selected: %s' ),
 												item.name
 										  )

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import { Text, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { useNavigation } from '@react-navigation/native';
+import { useState } from '@wordpress/element';
+import { Icon, chevronRight, check } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { BottomSheet } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { default as UnitControl, useCustomUnits } from '../unit-control';
+import styles from './style.scss';
+
+function FontSizePicker( {
+	fontSizes = [],
+	disableCustomFontSizes = false,
+	onChange,
+	value: selectedValue,
+} ) {
+	const [ showSubSheet, setShowSubSheet ] = useState( false );
+	const navigation = useNavigation();
+
+	const onChangeValue = ( value ) => {
+		return () => {
+			goBack();
+			onChange( value );
+		};
+	};
+
+	const selectedOption = fontSizes.find(
+		( option ) => option.size === selectedValue
+	) ?? { label: 'Custom' };
+
+	const goBack = () => {
+		setShowSubSheet( false );
+		navigation.goBack();
+	};
+
+	const openSubSheet = () => {
+		navigation.navigate( BottomSheet.SubSheet.screenName );
+		setShowSubSheet( true );
+	};
+
+	const label = __( 'Font Size' );
+
+	const units = useCustomUnits( {
+		availableUnits: [ 'px', 'em', 'rem' ],
+	} );
+
+	return (
+		<BottomSheet.SubSheet
+			navigationButton={
+				<BottomSheet.Cell
+					label={ label }
+					separatorType="none"
+					value={ selectedValue ? selectedValue : 'Default' }
+					onPress={ openSubSheet }
+					accessibilityRole={ 'button' }
+					accessibilityLabel={ selectedOption.label }
+					accessibilityHint={ sprintf(
+						// translators: %s: Select control button label e.g. "Button width"
+						__( 'Navigates to select %s' ),
+						selectedOption.label
+					) }
+				>
+					<Icon icon={ chevronRight }></Icon>
+				</BottomSheet.Cell>
+			}
+			showSheet={ showSubSheet }
+		>
+			<>
+				<BottomSheet.NavigationHeader
+					screen={ label }
+					leftButtonOnPress={ goBack }
+				/>
+				<View style={ styles[ 'components-font-size-picker' ] }>
+					<BottomSheet.Cell
+						customActionButton
+						separatorType="none"
+						label={ __( 'Default' ) }
+						onPress={ onChangeValue( undefined ) }
+						leftAlign={ true }
+						key={ 'default' }
+						accessibilityRole={ 'button' }
+						accessibilityLabel={ __( 'Selected: Default' ) }
+						accessibilityHint={ __(
+							'Double tap to select default font size'
+						) }
+					>
+						<View>
+							{ selectedValue === undefined && (
+								<Icon icon={ check }></Icon>
+							) }
+						</View>
+					</BottomSheet.Cell>
+					{ fontSizes.map( ( item, index ) => (
+						<BottomSheet.Cell
+							customActionButton
+							separatorType="none"
+							label={
+								<>
+									{ item.name }{ ' ' }
+									<Text
+										style={
+											styles[
+												'components-font-size-picker__font-size'
+											]
+										}
+									>
+										{ item.size }
+									</Text>
+								</>
+							}
+							onPress={ onChangeValue( item.size ) }
+							leftAlign={ true }
+							key={ index }
+							accessibilityRole={ 'button' }
+							accessibilityLabel={
+								item.size === selectedValue
+									? sprintf(
+											// translators: %s: Select control option value e.g: "Auto, 25%".
+											__( 'Selected: %s' ),
+											item.name
+									  )
+									: item.name
+							}
+							accessibilityHint={ __(
+								'Double tap to select font size'
+							) }
+						>
+							<View>
+								{ item.size === selectedValue && (
+									<Icon icon={ check }></Icon>
+								) }
+							</View>
+						</BottomSheet.Cell>
+					) ) }
+					{ ! disableCustomFontSizes && (
+						<UnitControl
+							label={ __( 'Custom' ) }
+							min={ 0 }
+							max={ 200 }
+							step={ 1 }
+							value={ selectedValue }
+							onChange={ ( nextSize ) => {
+								if (
+									0 === parseFloat( nextSize ) ||
+									! nextSize
+								) {
+									onChange( undefined );
+								} else {
+									onChange( nextSize );
+								}
+							} }
+							units={ units }
+						/>
+					) }
+				</View>
+			</>
+		</BottomSheet.SubSheet>
+	);
+}
+
+export default FontSizePicker;

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -109,6 +109,7 @@ function FontSizePicker( {
 						</View>
 					</BottomSheet.Cell>
 					{ fontSizes.map( ( item, index ) => {
+						// Only display a choice that we can currenly select.
 						if ( ! parseFloat( item.size ) ) {
 							return null;
 						}

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -108,36 +108,41 @@ function FontSizePicker( {
 							) }
 						</View>
 					</BottomSheet.Cell>
-					{ fontSizes.map( ( item, index ) => (
-						<BottomSheet.Cell
-							customActionButton
-							separatorType="none"
-							label={ item.name }
-							subLabel={ item.size }
-							onPress={ onChangeValue( item.size ) }
-							leftAlign={ true }
-							key={ index }
-							accessibilityRole={ 'button' }
-							accessibilityLabel={
-								item.size === selectedValue
-									? sprintf(
-											// translators: %s: Select control option value e.g: "Auto, 25%".
-											__( 'Selected: %s' ),
-											item.name
-									  )
-									: item.name
-							}
-							accessibilityHint={ __(
-								'Double tap to select font size'
-							) }
-						>
-							<View>
-								{ item.size === selectedValue && (
-									<Icon icon={ check }></Icon>
+					{ fontSizes.map( ( item, index ) => {
+						if ( ! parseFloat( item.size ) ) {
+							return null;
+						}
+						return (
+							<BottomSheet.Cell
+								customActionButton
+								separatorType="none"
+								label={ item.name }
+								subLabel={ item.size }
+								onPress={ onChangeValue( item.size ) }
+								leftAlign={ true }
+								key={ index }
+								accessibilityRole={ 'button' }
+								accessibilityLabel={
+									item.size === selectedValue
+										? sprintf(
+												// translators: %s: Select control option value e.g: "Auto, 25%".
+												__( 'Selected: %s' ),
+												item.name
+										  )
+										: item.name
+								}
+								accessibilityHint={ __(
+									'Double tap to select font size'
 								) }
-							</View>
-						</BottomSheet.Cell>
-					) ) }
+							>
+								<View>
+									{ item.size === selectedValue && (
+										<Icon icon={ check }></Icon>
+									) }
+								</View>
+							</BottomSheet.Cell>
+						);
+					} ) }
 					{ ! disableCustomFontSizes && (
 						<UnitControl
 							label={ __( 'Custom' ) }

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -36,7 +36,7 @@ function FontSizePicker( {
 
 	const selectedOption = fontSizes.find(
 		( option ) => option.size === selectedValue
-	) ?? { label: 'Custom' };
+	) ?? { name: 'Custom' };
 
 	const goBack = () => {
 		setShowSubSheet( false );
@@ -47,7 +47,6 @@ function FontSizePicker( {
 		navigation.navigate( BottomSheet.SubSheet.screenName );
 		setShowSubSheet( true );
 	};
-
 	const label = __( 'Font Size' );
 
 	const units = useCustomUnits( {
@@ -60,14 +59,23 @@ function FontSizePicker( {
 				<BottomSheet.Cell
 					label={ label }
 					separatorType="none"
-					value={ selectedValue ? selectedValue : 'Default' }
+					value={
+						selectedValue
+							? sprintf(
+									// translators: %1$s: Select control font size e.g. 12px , %2$s: Select control font size name e.g. Small
+									__( '%1$s (%2$s)' ),
+									selectedValue,
+									selectedOption.name
+							  )
+							: __( 'Default' )
+					}
 					onPress={ openSubSheet }
 					accessibilityRole={ 'button' }
-					accessibilityLabel={ selectedOption.label }
+					accessibilityLabel={ selectedOption.name }
 					accessibilityHint={ sprintf(
-						// translators: %s: Select control button label e.g. "Button width"
+						// translators: %s: Select control button label e.g. Small
 						__( 'Navigates to select %s' ),
-						selectedOption.label
+						selectedOption.name
 					) }
 				>
 					<Icon icon={ chevronRight }></Icon>
@@ -104,20 +112,8 @@ function FontSizePicker( {
 						<BottomSheet.Cell
 							customActionButton
 							separatorType="none"
-							label={
-								<>
-									{ item.name }{ ' ' }
-									<Text
-										style={
-											styles[
-												'components-font-size-picker__font-size'
-											]
-										}
-									>
-										{ item.size }
-									</Text>
-								</>
-							}
+							label={ item.name }
+							subLabel={ item.size }
 							onPress={ onChangeValue( item.size ) }
 							leftAlign={ true }
 							key={ index }

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -62,10 +62,10 @@ function FontSizePicker( {
 					value={
 						selectedValue
 							? sprintf(
-									// translators: %1$s: Select control font size e.g. 12px , %2$s: Select control font size name e.g. Small
+									// translators: %1$s: Select control font size name e.g. Small, %2$s: Select control font size e.g. 12px
 									__( '%1$s (%2$s)' ),
-									selectedValue,
-									selectedOption.name
+									selectedOption.name,
+									selectedValue
 							  )
 							: __( 'Default' )
 					}

--- a/packages/components/src/font-size-picker/style.native.scss
+++ b/packages/components/src/font-size-picker/style.native.scss
@@ -1,0 +1,6 @@
+.components-font-size-picker {
+	padding: 0 $block-edge-to-content;
+}
+.components-font-size-picker__font-size {
+	font-size: 11px;
+}

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -15,7 +15,6 @@ export { default as Dashicon } from './dashicon';
 export { default as Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as FocalPointPicker } from './focal-point-picker';
-export { default as FontSizePicker } from './font-size-picker';
 export { default as Toolbar } from './toolbar';
 export { default as ToolbarButton } from './toolbar-button';
 export { default as __experimentalToolbarContext } from './toolbar-context';
@@ -31,6 +30,7 @@ export {
 	Fill,
 	Provider as SlotFillProvider,
 } from './slot-fill';
+export { default as FontSizePicker } from './font-size-picker'; // Intentionally called after slot-fill.
 export { default as __experimentalStyleProvider } from './style-provider';
 export { default as BaseControl } from './base-control';
 export { default as TextareaControl } from './textarea-control';

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -15,6 +15,7 @@ export { default as Dashicon } from './dashicon';
 export { default as Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as FocalPointPicker } from './focal-point-picker';
+export { default as FontSizePicker } from './font-size-picker';
 export { default as Toolbar } from './toolbar';
 export { default as ToolbarButton } from './toolbar-button';
 export { default as __experimentalToolbarContext } from './toolbar-context';

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -101,6 +101,7 @@ class BottomSheetCell extends Component {
 			onPress,
 			onLongPress,
 			label,
+			subLabel,
 			value,
 			valuePlaceholder = '',
 			icon,
@@ -146,6 +147,11 @@ class BottomSheetCell extends Component {
 			showValue || customActionButton || icon
 				? cellLabelStyle
 				: defaultMissingIconAndValue;
+
+		const defaultSubLabelStyleText = getStylesFromColorScheme(
+			styles.cellSubLabelText,
+			styles.cellSubLabelTextDark
+		);
 
 		const drawSeparator =
 			( separatorType && separatorType !== 'none' ) ||
@@ -366,7 +372,22 @@ class BottomSheetCell extends Component {
 									/>
 								</View>
 							) }
-							{ label && (
+							{ subLabel && label && (
+								<View>
+									<Text
+										style={ [
+											defaultLabelStyle,
+											labelStyle,
+										] }
+									>
+										{ label }
+									</Text>
+									<Text style={ defaultSubLabelStyleText }>
+										{ subLabel }
+									</Text>
+								</View>
+							) }
+							{ ! subLabel && label && (
 								<Text
 									style={ [ defaultLabelStyle, labelStyle ] }
 								>

--- a/packages/components/src/mobile/bottom-sheet/range-text-input.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-text-input.native.js
@@ -194,6 +194,7 @@ class RangeTextInput extends Component {
 			} ),
 			{
 				width: 50 * fontScale,
+				borderRightWidth: children ? 1 : 0,
 			},
 		];
 

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -298,9 +298,9 @@
 
 .cellSubLabelText {
 	font-size: 12px;
-	color: $gray-60;
+	color: $sub-heading;
 }
 
 .cellSubLabelTextDark {
-	color: $dark-secondary;
+	color: $sub-heading-dark;
 }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -295,3 +295,12 @@
 .cellHelpLabelIOS {
 	padding-bottom: $grid-unit-10;
 }
+
+.cellSubLabelText {
+	font-size: 12px;
+	color: $gray-60;
+}
+
+.cellSubLabelTextDark {
+	color: $dark-secondary;
+}

--- a/packages/components/src/mobile/global-styles-context/test/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/utils.native.js
@@ -134,9 +134,7 @@ describe( 'getGlobalStyles', () => {
 					},
 					typography: {
 						fontSizes: RAW_FEATURES.typography.fontSizes,
-						custom: {
-							'line-height': RAW_FEATURES.custom[ 'line-height' ],
-						},
+						customLineHeight: RAW_FEATURES.custom[ 'line-height' ],
 					},
 				},
 				__experimentalGlobalStylesBaseStyles: PARSED_GLOBAL_STYLES,

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -206,9 +206,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 			},
 			typography: {
 				fontSizes: features?.typography?.fontSizes,
-				custom: {
-					'line-height': features?.custom?.[ 'line-height' ],
-				},
+				customLineHeight: features?.custom?.[ 'line-height' ],
 			},
 		},
 		__experimentalGlobalStylesBaseStyles: globalStyles,

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -94,6 +94,7 @@ function UnitControl( {
 		accessibilityHint,
 		unitButtonTextStyle,
 		unit,
+		units,
 	] );
 
 	const getAnchor = useCallback(
@@ -115,19 +116,20 @@ function UnitControl( {
 	};
 
 	const renderUnitPicker = useCallback( () => {
+		if ( hasUnits( units ) ) {
+			return null;
+		}
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
 				{ renderUnitButton }
-				{ hasUnits( units ) && units?.length > 1 ? (
-					<Picker
-						ref={ pickerRef }
-						options={ units }
-						onChange={ onUnitChange }
-						hideCancelButton
-						leftAlign
-						getAnchor={ getAnchor }
-					/>
-				) : null }
+				<Picker
+					ref={ pickerRef }
+					options={ units }
+					onChange={ onUnitChange }
+					hideCancelButton
+					leftAlign
+					getAnchor={ getAnchor }
+				/>
 			</View>
 		);
 	}, [ pickerRef, units, onUnitChange, getAnchor, renderUnitButton ] );

--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -116,20 +116,22 @@ function UnitControl( {
 	};
 
 	const renderUnitPicker = useCallback( () => {
-		if ( hasUnits( units ) ) {
+		if ( units === false ) {
 			return null;
 		}
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
 				{ renderUnitButton }
-				<Picker
-					ref={ pickerRef }
-					options={ units }
-					onChange={ onUnitChange }
-					hideCancelButton
-					leftAlign
-					getAnchor={ getAnchor }
-				/>
+				{ hasUnits( units ) && units?.length > 1 ? (
+					<Picker
+						ref={ pickerRef }
+						options={ units }
+						onChange={ onUnitChange }
+						hideCancelButton
+						leftAlign
+						getAnchor={ getAnchor }
+					/>
+				) : null }
 			</View>
 		);
 	}, [ pickerRef, units, onUnitChange, getAnchor, renderUnitButton ] );


### PR DESCRIPTION
## Description
This Pr attempts to add the typographical controls needed to manipulate the font size and line height. 

## How has this been tested?
Prereqisits. 
1. WordPress 5.8. 
2. Gutenberg 11.1 
3. Theme that supports full site editing. (TT1 Blocks) for example.
4. Latest develop branch of iOS or Android. 

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/115071/126539233-bc06ff84-7f75-4fc8-8e5f-dd22595af0e1.mov


## Types of changes
New Feature for mobile app: Adds font size and line height controls blocks that have it.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
