### PR TITLE
Fix unwanted additional spaces added around pasted text on Windows 

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -18,7 +18,7 @@ import { isURL } from '@wordpress/url';
  * Internal dependencies
  */
 import { filePasteHandler } from './file-paste-handler';
-import { addActiveFormats, isShortcode, normalizeCopiedHtml } from './utils';
+import { addActiveFormats, isShortcode } from './utils';
 import { splitValue } from './split-value';
 
 export function usePasteHandler( props ) {
@@ -69,8 +69,8 @@ export function usePasteHandler( props ) {
 				}
 			}
 
-			// Remove OS-specific metadata appended within copied HTML text.
-			html = normalizeCopiedHtml( html );
+			// Remove Windows-specific metadata appended within copied HTML text.
+			html = removeWindowsFragments( html );
 
 			event.preventDefault();
 
@@ -224,4 +224,18 @@ export function usePasteHandler( props ) {
 			element.removeEventListener( 'paste', _onPaste );
 		};
 	}, [] );
+}
+
+/**
+ * Normalizes a given string of HTML to remove the Windows specific "Fragment" comments
+ * and any preceeding and trailing whitespace.
+ *
+ * @param {string} html the html to be normalized
+ * @return {string} the normalized html
+ */
+function removeWindowsFragments( html ) {
+	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
+	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
+
+	return html.replace( startReg, '' ).replace( endReg, '' );
 }

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -21,6 +21,13 @@ import { filePasteHandler } from './file-paste-handler';
 import { addActiveFormats, isShortcode } from './utils';
 import { splitValue } from './split-value';
 
+function normalizePastedHtml( html ) {
+	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
+	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
+
+	return html.replace( startReg, '' ).replace( endReg, '' );
+}
+
 export function usePasteHandler( props ) {
 	const propsRef = useRef( props );
 	propsRef.current = props;
@@ -68,6 +75,8 @@ export function usePasteHandler( props ) {
 					return;
 				}
 			}
+
+			html = normalizePastedHtml( html );
 
 			event.preventDefault();
 

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -234,8 +234,8 @@ export function usePasteHandler( props ) {
  * @return {string} the normalized html
  */
 function removeWindowsFragments( html ) {
-	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
-	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
+	const startReg = /.*<!--StartFragment-->/s;
+	const endReg = /<!--EndFragment-->.*/s;
 
 	return html.replace( startReg, '' ).replace( endReg, '' );
 }

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -18,15 +18,8 @@ import { isURL } from '@wordpress/url';
  * Internal dependencies
  */
 import { filePasteHandler } from './file-paste-handler';
-import { addActiveFormats, isShortcode } from './utils';
+import { addActiveFormats, isShortcode, normalizeCopiedHtml } from './utils';
 import { splitValue } from './split-value';
-
-function normalizePastedHtml( html ) {
-	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
-	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
-
-	return html.replace( startReg, '' ).replace( endReg, '' );
-}
 
 export function usePasteHandler( props ) {
 	const propsRef = useRef( props );
@@ -76,7 +69,8 @@ export function usePasteHandler( props ) {
 				}
 			}
 
-			html = normalizePastedHtml( html );
+			// Remove OS-specific metadata appended within copied HTML text.
+			html = normalizeCopiedHtml( html );
 
 			event.preventDefault();
 

--- a/packages/block-editor/src/components/rich-text/utils.js
+++ b/packages/block-editor/src/components/rich-text/utils.js
@@ -18,6 +18,20 @@ export function addActiveFormats( value, activeFormats ) {
 }
 
 /**
+ * Normalizes a given string of HTML to remove the Windows specific "Fragment" comments
+ * and any preceeding and trailing whitespace.
+ *
+ * @param {string} html the html to be normalized
+ * @return {string} the normalized html
+ */
+export function normalizeCopiedHtml( html ) {
+	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
+	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
+
+	return html.replace( startReg, '' ).replace( endReg, '' );
+}
+
+/**
  * Get the multiline tag based on the multiline prop.
  *
  * @param {?(string|boolean)} multiline The multiline prop.

--- a/packages/block-editor/src/components/rich-text/utils.js
+++ b/packages/block-editor/src/components/rich-text/utils.js
@@ -18,20 +18,6 @@ export function addActiveFormats( value, activeFormats ) {
 }
 
 /**
- * Normalizes a given string of HTML to remove the Windows specific "Fragment" comments
- * and any preceeding and trailing whitespace.
- *
- * @param {string} html the html to be normalized
- * @return {string} the normalized html
- */
-export function normalizeCopiedHtml( html ) {
-	const startReg = new RegExp( '.*<!--StartFragment-->', 's' );
-	const endReg = new RegExp( '<!--EndFragment-->.*', 's' );
-
-	return html.replace( startReg, '' ).replace( endReg, '' );
-}
-
-/**
  * Get the multiline tag based on the multiline prop.
  *
  * @param {?(string|boolean)} multiline The multiline prop.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

When pasting text internally within the editor on Windows additional spaces are added to either side of the pasted text.

* Copied text (i.e. what the user _intended_ to copy) `two`.
* Resulting text when pasted ` two `.

This appears to be due to [windows providing additional unwanted data when retrieving `text/html` from the clipboard event](https://discuss.prosemirror.net/t/space-added-on-paste/1274/7) data. The actual content copied is:

```
<html>
 <body>
   <!--StartFragment-->
   Copied text here
   <!--EndFragment-->
 </body>
</html>
```

When this passes through the editor's paste mechanics and the format API we end up with spaces around the text.

To fix this, this PR attempts to use regex to remove:

1. The two "Fragment" comments.
2. Whitespace either side of the comments.
It does not remove  whitespace inside the "Fragment" comments because the user may have intentionally copied some spaces which we would want to preserve.

Fixes https://github.com/WordPress/gutenberg/issues/33283

## How has this been tested?

* Use Windows 10 and latest MS Edge browser.
* Create a new Post.
* Write some text such as `Hello I am some text. Let's copy me`.
* Using your mouse highlight a word in that text being sure _not_ to copy any whitespace.
* Paste the copied text into the middle of another word.
* See that there are no spaces added either side of the text your pasted.
* Repeat but this time copy some text that does include some whitespace either side. We need to check that in this scenario the whitespace _is_ preserved.

Also test on Mac to ensure it doesn't regress this implementation.

## Screenshots <!-- if applicable -->

### Windows

#### Before

https://user-images.githubusercontent.com/444434/126521867-fdb613d2-6895-4490-bedd-7476fe09c83b.mov

#### After

https://user-images.githubusercontent.com/444434/126629281-2e5f0e68-7b59-4e95-b26e-a5f53ff0a632.mp4

### Mac OS

The below shows only the _after_ fix as the bug did not manifest itself on Mac even before this fix.

https://user-images.githubusercontent.com/444434/126629800-60050353-a75f-40e4-803a-57158cdacab6.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
