### PR TITLE
Prevent focus trap in Legacy Widget block’s preview iframe

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -92,6 +92,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 					<iframe
 						ref={ ref }
 						className="wp-block-legacy-widget__edit-preview-iframe"
+						tabIndex="-1"
 						title={ __( 'Legacy Widget Preview' ) }
 						// TODO: This chokes when the query param is too big.
 						// Ideally, we'd render a <ServerSideRender>. Maybe by


### PR DESCRIPTION
Legacy widgets currently break upward traversing of the block list by keyboard. The preview iframe ends up trapping the focus. This PR fixes it by adding `tabIndex="-1"` on the iframe element.

## How has this been tested?
Using the arrow keys to traversing the block list in Customizer.

## Screenshots
### Before
getting stuck while attempting to move upward past the Meta Legacy Widget.

https://user-images.githubusercontent.com/9000376/126568705-d99101f6-3e53-482d-9263-e664b3906233.mp4

### After
keyboarding upward past the Meta Legacy Widget

https://user-images.githubusercontent.com/9000376/126568933-d43d7f6e-dc09-45fb-a69a-81e59f0d99cd.mp4


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
