### PR TITLE
FormTokenField: Avoid error when maxLength value is hit

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -7,6 +7,7 @@ import {
 	clone,
 	uniq,
 	map,
+	noop,
 	difference,
 	each,
 	identity,
@@ -599,6 +600,7 @@ class FormTokenField extends Component {
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this.onBlur,
+			onChange: noop,
 			isExpanded: this.state.isExpanded,
 			selectedSuggestionIndex: this.state.selectedSuggestionIndex,
 		};

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -7,7 +7,6 @@ import {
 	clone,
 	uniq,
 	map,
-	noop,
 	difference,
 	each,
 	identity,
@@ -600,7 +599,6 @@ class FormTokenField extends Component {
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this.onBlur,
-			onChange: noop,
 			isExpanded: this.state.isExpanded,
 			selectedSuggestionIndex: this.state.selectedSuggestionIndex,
 		};

--- a/packages/components/src/form-token-field/token-input.js
+++ b/packages/components/src/form-token-field/token-input.js
@@ -40,6 +40,7 @@ class TokenInput extends Component {
 			instanceId,
 			selectedSuggestionIndex,
 			className,
+			onChange,
 			...props
 		} = this.props;
 		const size = value ? value.length + 1 : 0;
@@ -51,7 +52,7 @@ class TokenInput extends Component {
 				type="text"
 				{ ...props }
 				value={ value || '' }
-				onChange={ this.onChange }
+				onChange={ onChange ? this.onChange : undefined }
 				size={ size }
 				className={ classnames(
 					className,


### PR DESCRIPTION
## Description
Sets no-operation function as a `onChange` default for the `TokenInput` component.

CodeSandbox showcasing the issue - https://codesandbox.io/s/formtokenfield-dv9nb

Fixes #18463.

## How has this been tested?
Temporarily added `maxLength` to the `FlatTermSelector` component for testings, but probably there's a better way to do it.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
