### PR TITLE
[Block Library - Query Pagination Numbers]: Fix first page's link

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -45,6 +45,22 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 			'total'     => $total,
 			'prev_next' => false,
 		);
+		if ( 1 !== $page ) {
+			/**
+			 * `paginate_links` doesn't use the provided `format` when the page is `1`.
+			 * This is great for the main query as it removes the extra query params
+			 * making the URL shorter, but in the case of multiple custom queries is
+			 * problematic. It results in returning an empty link which ends up with
+			 * a link to the current page.
+			 *
+			 * A way to address this is to add a `fake` query arg with no value that
+			 * is the same for all custom queries. This way the link is not empty and
+			 * preserves all the other existent query args.
+			 *
+			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
+			 */
+			$paginate_args['add_args'] = array( 'cst' => '' );
+		}
 		// We still need to preserve `paged` query param if exists, as is used
 		// for Queries that inherit from global context.
 		$paged = empty( $_GET['paged'] ) ? null : (int) $_GET['paged'];

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -58,6 +58,12 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 			 * preserves all the other existent query args.
 			 *
 			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
+			 *
+			 * The proper fix of this should be in core. Track Ticket:
+			 * @see https://core.trac.wordpress.org/ticket/53868
+			 *
+			 * TODO: After two WP versions (starting from the WP version the core patch landed),
+			 * we should remove this and call `paginate_links` with the proper new arg.
 			 */
 			$paginate_args['add_args'] = array( 'cst' => '' );
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes: https://github.com/WordPress/gutenberg/issues/32792

`paginate_links` doesn't use the provided `format` when the page is `1`. This is great for the main query as it removes the extra query params making the URL shorter, but in the case of multiple custom queries is problematic. It results in returning an empty link which ends up with a link to the current page.

A way to address this is to add a `fake` query arg with no value that is the same for all custom queries. This way the link is not empty and preserves all the other existent query args.


Reference: https://developer.wordpress.org/reference/functions/paginate_links/
`$link = str_replace( '%_%', 1 == $n ? '' : $args['format'], $args['base'] );
                $link = str_replace( '%#%', $n, $link );`
<!-- Please describe what you have changed or added -->

## How has this been tested?
1. In page with many `Query Loop` blocks with `QueryPaginationNumbers` blocks check that by clicking another page number first, the pagination link for the first page (`1`), works as expected.
2. This can be tested with a single custom `Query` in a page as well, but it's better to have multiple `Query Loop` blocks which can be both `custom` and ones that `inherit the global query`.

## Notes
1. The issue can be replicated only when we have no other query args, because in that case the `link` is not empty - thus the `hacky` approach here to add an empty `query arg`.

I couldn't find any better alternative so a more elegant solution would be more than welcomed. We could also look at making some changes in core `paginate_links` but needs more exploration there. For example we could extend the `paginate_links` filter by passing the current `page number ($n)` and use this filter in the block??(🤔 ).


