### PR TITLE
Escape key sanity (avoid event.stopPropagation)

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -166,8 +166,9 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		}
 		const startingBlockClientId = hasBlockMovingClientId();
 
-		if ( isEscape && startingBlockClientId ) {
+		if ( isEscape && startingBlockClientId && ! event.defaultPrevented ) {
 			setBlockMovingClientId( null );
+			event.preventDefault();
 		}
 		if ( ( isEnter || isSpace ) && startingBlockClientId ) {
 			const sourceRoot = getBlockRootClientId( startingBlockClientId );

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -18,7 +18,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { withDispatch, useSelect } from '@wordpress/data';
-import { DOWN, TAB, ESCAPE } from '@wordpress/keycodes';
+import { DOWN } from '@wordpress/keycodes';
 import { compose } from '@wordpress/compose';
 import { upload, media as mediaIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -164,23 +164,7 @@ const MediaReplaceFlow = ( {
 					</NavigableMenu>
 					{ onSelectURL && (
 						// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-						<form
-							className="block-editor-media-flow__url-input"
-							onKeyDown={ ( event ) => {
-								if (
-									! [ TAB, ESCAPE ].includes( event.keyCode )
-								) {
-									event.stopPropagation();
-								}
-							} }
-							onKeyPress={ ( event ) => {
-								if (
-									! [ TAB, ESCAPE ].includes( event.keyCode )
-								) {
-									event.stopPropagation();
-								}
-							} }
-						>
+						<form className="block-editor-media-flow__url-input">
 							<span className="block-editor-media-replace-flow__image-url-label">
 								{ __( 'Current media URL:' ) }
 							</span>

--- a/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
@@ -16,6 +16,10 @@ export function useUndoAutomaticChange() {
 		function onKeyDown( event ) {
 			const { keyCode } = event;
 
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
 			if (
 				keyCode !== DELETE &&
 				keyCode !== BACKSPACE &&

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -82,8 +82,11 @@ export default function useTabNav() {
 
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
 			if ( event.keyCode === ESCAPE && ! hasMultiSelection() ) {
-				event.stopPropagation();
 				event.preventDefault();
 				setNavigationMode( true );
 				return;

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -226,6 +226,9 @@ function useAutocomplete( {
 		if ( filteredOptions.length === 0 ) {
 			return;
 		}
+		if ( event.defaultPrevented ) {
+			return;
+		}
 		switch ( event.keyCode ) {
 			case UP:
 				setSelectedIndex(
@@ -244,6 +247,7 @@ function useAutocomplete( {
 			case ESCAPE:
 				setAutocompleter( null );
 				setAutocompleterUI( null );
+				event.preventDefault();
 				break;
 
 			case ENTER:

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -104,6 +104,10 @@ function ComboboxControl( {
 	const onKeyDown = ( event ) => {
 		let preventDefault = false;
 
+		if ( event.defaultPrevented ) {
+			return;
+		}
+
 		switch ( event.keyCode ) {
 			case ENTER:
 				if ( selectedSuggestion ) {
@@ -123,7 +127,6 @@ function ComboboxControl( {
 				setIsExpanded( false );
 				setSelectedSuggestion( null );
 				preventDefault = true;
-				event.stopPropagation();
 				break;
 			default:
 				break;

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -141,6 +141,10 @@ class FormTokenField extends Component {
 	onKeyDown( event ) {
 		let preventDefault = false;
 
+		if ( event.defaultPrevented ) {
+			return;
+		}
+
 		switch ( event.keyCode ) {
 			case BACKSPACE:
 				preventDefault = this.handleDeleteKey(
@@ -174,7 +178,6 @@ class FormTokenField extends Component {
 				break;
 			case ESCAPE:
 				preventDefault = this.handleEscapeKey( event );
-				event.stopPropagation();
 				break;
 			default:
 				break;

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -34,8 +34,12 @@ function ModalFrameContent( {
 	onRequestClose,
 } ) {
 	function handleEscapeKeyDown( event ) {
-		if ( shouldCloseOnEsc && event.keyCode === ESCAPE ) {
-			event.stopPropagation();
+		if (
+			shouldCloseOnEsc &&
+			event.keyCode === ESCAPE &&
+			! event.defaultPrevented
+		) {
+			event.preventDefault();
 			if ( onRequestClose ) {
 				onRequestClose( event );
 			}

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -67,8 +67,8 @@ function MenuTitleSearch( {
 	};
 
 	function onKeyDown( event ) {
-		if ( event.keyCode === ESCAPE ) {
-			event.stopPropagation();
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
 			onClose();
 		}
 	}

--- a/packages/compose/src/hooks/use-dialog/index.js
+++ b/packages/compose/src/hooks/use-dialog/index.js
@@ -61,8 +61,12 @@ function useDialog( options ) {
 			/** @type {KeyboardEvent} */ event
 		) => {
 			// Close on escape
-			if ( event.keyCode === ESCAPE && currentOptions.current?.onClose ) {
-				event.stopPropagation();
+			if (
+				event.keyCode === ESCAPE &&
+				! event.defaultPrevented &&
+				currentOptions.current?.onClose
+			) {
+				event.preventDefault();
 				currentOptions.current.onClose();
 			}
 		} );

--- a/packages/customize-widgets/src/controls/inserter-outer-section.js
+++ b/packages/customize-widgets/src/controls/inserter-outer-section.js
@@ -58,7 +58,7 @@ export default function getInserterOuterSection() {
 						! event.defaultPrevented
 					) {
 						event.preventDefault();
-
+						event.stopPropagation();
 						this.close();
 					}
 				},

--- a/packages/customize-widgets/src/controls/inserter-outer-section.js
+++ b/packages/customize-widgets/src/controls/inserter-outer-section.js
@@ -53,9 +53,11 @@ export default function getInserterOuterSection() {
 				( event ) => {
 					if (
 						this.isOpen &&
-						( event.keyCode === ESCAPE || event.code === 'Escape' )
+						( event.keyCode === ESCAPE ||
+							event.code === 'Escape' ) &&
+						! event.defaultPrevented
 					) {
-						event.stopPropagation();
+						event.preventDefault();
 
 						this.close();
 					}

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -34,8 +34,8 @@ export default function ListViewSidebar() {
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const focusReturnRef = useFocusReturn();
 	function closeOnEscape( event ) {
-		if ( event.keyCode === ESCAPE ) {
-			event.stopPropagation();
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
 			setIsListViewOpened( false );
 		}
 	}

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -77,8 +77,8 @@ const NavigationPanel = ( { isOpen } ) => {
 	}, [ activeMenu, isOpen ] );
 
 	const closeOnEscape = ( event ) => {
-		if ( event.keyCode === ESCAPE ) {
-			event.stopPropagation();
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
 			setIsNavigationPanelOpened( false );
 		}
 	};

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -34,8 +34,7 @@ export default function ListViewSidebar() {
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const focusReturnRef = useFocusReturn();
 	function closeOnEscape( event ) {
-		if ( event.keyCode === ESCAPE ) {
-			event.stopPropagation();
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			setIsListViewOpened( false );
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR removes `event.stopPropagation` calls in all components after the Escape key is handled. This method should be avoided as it completely stops event bubbling. Components should instead look if Escape has already been handled by checking `event.defaultPrevented`. Components should anyway call `event.preventDefault` after handling Escape to prevent default browser behaviour.

**Rule of thumb. Always prevent default behaviour when reacting to key events. `event.defaultPrevented` should generally be false. A component inside the current component could already be reacting to the same key event.**

Perhaps we could create an ESLint rule for this in the future.

Related: #19879, which mentions the following article: https://css-tricks.com/dangers-stopping-event-propagation/.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
