### PR TITLE
Remove event.stopPropagation for past WritingFlow/ObserveTyping compatibility

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -35,7 +35,6 @@ function BlockAlignmentMatrixControl( props ) {
 				const openOnArrowDown = ( event ) => {
 					if ( ! isOpen && event.keyCode === DOWN ) {
 						event.preventDefault();
-						event.stopPropagation();
 						onToggle();
 					}
 				};

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -176,7 +176,6 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 			const onToggleStub = jest.fn();
 			const mockKeyDown = {
 				preventDefault: () => {},
-				stopPropagation: () => {},
 				keyCode: DOWN,
 			};
 

--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -55,7 +55,6 @@ const renderToggleComponent = ( { TextColor, BackgroundColor } ) => ( {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
-			event.stopPropagation();
 			onToggle();
 		}
 	};

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -28,7 +28,6 @@ function DuotoneControl( {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
-			event.stopPropagation();
 			onToggle();
 		}
 	};

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -317,8 +317,7 @@ export function MediaPlaceholder( {
 					return (
 						<Button
 							variant="tertiary"
-							onClick={ ( event ) => {
-								event.stopPropagation();
+							onClick={ () => {
 								open();
 							} }
 						>

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -104,7 +104,6 @@ const MediaReplaceFlow = ( {
 	const openOnArrowDown = ( event ) => {
 		if ( event.keyCode === DOWN ) {
 			event.preventDefault();
-			event.stopPropagation();
 			event.target.click();
 		}
 	};

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -261,7 +261,6 @@ class URLInput extends Component {
 				// position.
 				case UP: {
 					if ( 0 !== event.target.selectionStart ) {
-						event.stopPropagation();
 						event.preventDefault();
 
 						// Set the input caret to position 0
@@ -275,7 +274,6 @@ class URLInput extends Component {
 					if (
 						this.props.value.length !== event.target.selectionStart
 					) {
-						event.stopPropagation();
 						event.preventDefault();
 
 						// Set the input caret to the last position
@@ -306,7 +304,6 @@ class URLInput extends Component {
 
 		switch ( event.keyCode ) {
 			case UP: {
-				event.stopPropagation();
 				event.preventDefault();
 				const previousIndex = ! selectedSuggestion
 					? suggestions.length - 1
@@ -317,7 +314,6 @@ class URLInput extends Component {
 				break;
 			}
 			case DOWN: {
-				event.stopPropagation();
 				event.preventDefault();
 				const nextIndex =
 					selectedSuggestion === null ||
@@ -339,7 +335,6 @@ class URLInput extends Component {
 			}
 			case ENTER: {
 				if ( this.state.selectedSuggestion !== null ) {
-					event.stopPropagation();
 					this.selectLink( suggestion );
 
 					if ( this.props.onSubmit ) {

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -72,7 +72,6 @@ class GalleryImage extends Component {
 			this.props.isSelected &&
 			[ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
 		) {
-			event.stopPropagation();
 			event.preventDefault();
 			this.props.onRemove();
 		}

--- a/packages/block-library/src/heading/heading-level-dropdown.js
+++ b/packages/block-library/src/heading/heading-level-dropdown.js
@@ -49,7 +49,6 @@ export default function HeadingLevelDropdown( { selectedLevel, onChange } ) {
 				const openOnArrowDown = ( event ) => {
 					if ( ! isOpen && event.keyCode === DOWN ) {
 						event.preventDefault();
-						event.stopPropagation();
 						onToggle();
 					}
 				};

--- a/packages/block-library/src/template-part/edit/selection/index.js
+++ b/packages/block-library/src/template-part/edit/selection/index.js
@@ -3,25 +3,12 @@
  */
 import { SearchControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
+
 /**
  * Internal dependencies
  */
 import TemplatePartPreviews from './template-part-previews';
 
-const preventArrowKeysPropagation = ( event ) => {
-	if (
-		[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].includes( event.keyCode )
-	) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
-const stopKeyPropagation = ( event ) => event.stopPropagation();
-
-// Disable reason (no-static-element-interactions): Navigational key-presses within
-// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 export default function TemplatePartSelection( {
 	setAttributes,
 	onClose,
@@ -30,10 +17,7 @@ export default function TemplatePartSelection( {
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	return (
-		<div
-			onKeyPress={ stopKeyPropagation }
-			onKeyDown={ preventArrowKeysPropagation }
-		>
+		<div>
 			<SearchControl
 				value={ filterValue }
 				onChange={ setFilterValue }
@@ -51,4 +35,3 @@ export default function TemplatePartSelection( {
 		</div>
 	);
 }
-/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -266,7 +266,6 @@ function useAutocomplete( {
 		// Any handled keycode should prevent original behavior. This relies on
 		// the early return in the default case.
 		event.preventDefault();
-		event.stopPropagation();
 	}
 
 	let textContent;

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -96,7 +96,6 @@ function DropdownMenu( {
 
 					if ( ! isOpen && event.keyCode === DOWN ) {
 						event.preventDefault();
-						event.stopPropagation();
 						onToggle();
 					}
 				};

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -89,7 +89,6 @@ function DropdownMenu( {
 				const openOnArrowDown = ( event ) => {
 					if ( ! isOpen && event.keyCode === DOWN ) {
 						event.preventDefault();
-						event.stopPropagation();
 						onToggle();
 					}
 				};

--- a/packages/components/src/dropdown-menu/test/index.js
+++ b/packages/components/src/dropdown-menu/test/index.js
@@ -73,7 +73,6 @@ describe( 'DropdownMenu', () => {
 			button.focus();
 			fireEvent.keyDown( button, {
 				keyCode: DOWN,
-				stopPropagation: () => {},
 				preventDefault: () => {},
 			} );
 			const menu = getNavigableMenu( dropdownMenuContainer );
@@ -95,7 +94,6 @@ describe( 'DropdownMenu', () => {
 			button.focus();
 			fireEvent.keyDown( button, {
 				keyCode: DOWN,
-				stopPropagation: () => {},
 				preventDefault: () => {},
 			} );
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -351,7 +351,6 @@ export class RichText extends Component {
 		// Add stubs for conformance in downstream autocompleters logic
 		this.customEditableOnKeyDown?.( {
 			preventDefault: () => undefined,
-			stopPropagation: () => undefined,
 			...event,
 		} );
 


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

These component used to be rendered inside the block's React tree, which meant WritingFlow and ObserveTyping would previously be triggered for these components. This is no longer needed because:

1. Most of these components are taken out of the block's React tree.
2. We now use DOM events for writing flow and typing observation.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
