### PR TITLE
Navigate regions: use React events for shortcuts (portal bubbles & contextual)

### DIFF
--- a/packages/e2e-tests/specs/editor/various/a11y.test.js
+++ b/packages/e2e-tests/specs/editor/various/a11y.test.js
@@ -15,7 +15,7 @@ describe( 'a11y', () => {
 	} );
 
 	it( 'tabs header bar', async () => {
-		await pressKeyWithModifier( 'ctrl', '~' );
+		await pressKeyWithModifier( 'ctrl', '`' );
 
 		await page.keyboard.press( 'Tab' );
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -112,12 +112,10 @@ function Layout( { styles } ) {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			previousShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutRawKeyCombinations(
-				'core/edit-post/previous-region'
-			),
+			).getAllShortcutKeyCombinations( 'core/edit-post/previous-region' ),
 			nextShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
+			).getAllShortcutKeyCombinations( 'core/edit-post/next-region' ),
 			showIconLabels: select( editPostStore ).isFeatureActive(
 				'showIconLabels'
 			),

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -65,14 +65,12 @@ function Interface( { blockEditorSettings } ) {
 			).__unstableIsFeatureActive( 'showBlockBreadcrumbs' ),
 			previousShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutRawKeyCombinations(
+			).getAllShortcutKeyCombinations(
 				'core/edit-widgets/previous-region'
 			),
 			nextShortcut: select(
 				keyboardShortcutsStore
-			).getAllShortcutRawKeyCombinations(
-				'core/edit-widgets/next-region'
-			),
+			).getAllShortcutKeyCombinations( 'core/edit-widgets/next-region' ),
 		} ),
 		[]
 	);

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useEffect, useRef } from '@wordpress/element';
+import { forwardRef, useEffect } from '@wordpress/element';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
@@ -44,8 +44,7 @@ function InterfaceSkeleton(
 	},
 	ref
 ) {
-	const fallbackRef = useRef();
-	const regionsClassName = useNavigateRegions( fallbackRef, shortcuts );
+	const navigateRegionsProps = useNavigateRegions( shortcuts );
 
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
 
@@ -70,11 +69,12 @@ function InterfaceSkeleton(
 
 	return (
 		<div
-			ref={ useMergeRefs( [ ref, fallbackRef ] ) }
+			{ ...navigateRegionsProps }
+			ref={ useMergeRefs( [ ref, navigateRegionsProps.ref ] ) }
 			className={ classnames(
 				className,
 				'interface-interface-skeleton',
-				regionsClassName,
+				navigateRegionsProps.className,
 				!! footer && 'has-footer'
 			) }
 		>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Similar to #32323.

Moves shortcut handlers from native events to React events for two reasons:

* Native events don't bubble through portals, which requires us to [hackily bubble events through the iframe](https://github.com/WordPress/gutenberg/commit/e54a9ec2f97e28db3293628e921e40e81cfe5f76#diff-ab17abd38e687edd56573694ae3017e105e96b319571c190e9d4705c1872bc9cR60-R104).
* The shortcuts should only work in the context of the block editor, rather than globally (on the `document`). This is important because you may have other things on the page beside the block editor, or multiple block editors. Shortcuts should only work if focus is within a certain context. Using React evens works nicely because they bubble both through the iframe and other portals such as the inspector.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
