### PR TITLE
UnitControl: Set correct unit when units has one option

### DIFF
--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -19,6 +19,8 @@ const getInput = () =>
 	document.body.querySelector( '.components-unit-control input' );
 const getSelect = () =>
 	document.body.querySelector( '.components-unit-control select' );
+const getUnitLabel = () =>
+	document.body.querySelector( '.components-unit-control__unit-label' );
 
 const fireKeyDown = ( data ) =>
 	fireEvent.keyDown( document.activeElement || document.body, data );
@@ -49,6 +51,16 @@ describe( 'UnitControl', () => {
 
 			expect( input ).toBeTruthy();
 			expect( select ).toBeFalsy();
+		} );
+
+		it( 'should render label if single units', () => {
+			render( <UnitControl units={ [ { value: '%', label: '%' } ] } /> );
+
+			const select = getSelect();
+			const label = getUnitLabel();
+
+			expect( select ).toBeFalsy();
+			expect( label ).toBeTruthy();
 		} );
 	} );
 
@@ -207,6 +219,26 @@ describe( 'UnitControl', () => {
 			fireEvent.change( select, { target: { value: 'pt' } } );
 
 			expect( state ).toBe( '50pt' );
+		} );
+
+		it( 'should set correct unit if single units', () => {
+			let state = '50%';
+			const setState = ( value ) => ( state = value );
+
+			render(
+				<UnitControl
+					value={ state }
+					unit="%"
+					units={ [ { value: '%', label: '%' } ] }
+					onChange={ setState }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: 62 } } );
+
+			expect( state ).toBe( '62%' );
 		} );
 	} );
 

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -31,7 +31,7 @@ export default function UnitSelectControl( {
 	value = 'px',
 	...props
 } ) {
-	if ( ! hasUnits( options ) ) {
+	if ( ! hasUnits( options ) || options.length === 1 ) {
 		return (
 			<UnitLabel
 				className="components-unit-control__unit-label"

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -163,7 +163,7 @@ export function getParsedValue( value, unit, units ) {
  * @return {boolean} Whether units are defined.
  */
 export function hasUnits( units ) {
-	return ! isEmpty( units ) && units.length > 1 && units !== false;
+	return ! isEmpty( units ) && units !== false;
 }
 
 /**


### PR DESCRIPTION
## Description
When only one option is passed to the `units` prop in `UnitControl` component the `onChange` always returns `px`.

Ex on pattern that will return `px`:
```js
const [ value, setValue ] = useState( '10%' );

<UnitControl
	value={ value }
	unit="%"
	units={ [ { value: '%', label: '%' } ] }
	onChange={ setValue }
/>
```

## How has this been tested?
Testet with both multiple and single option in `units` prop.

## Screenshots <!-- if applicable -->
### Before
![units](https://user-images.githubusercontent.com/1415747/126702723-626fce6c-054c-4e6a-9f6e-9f683410ec18.gif)

### After
![units-fixed](https://user-images.githubusercontent.com/1415747/126702770-d9114650-25d8-4871-9644-91f28f2faf6a.gif)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
