### PR TITLE
FocalPointPicker: Check if value is NaN

### DIFF
--- a/packages/components/src/focal-point-picker/controls.js
+++ b/packages/components/src/focal-point-picker/controls.js
@@ -30,11 +30,12 @@ export default function FocalPointPickerControls( {
 	const valueX = fractionToPercentage( percentages.x );
 	const valueY = fractionToPercentage( percentages.y );
 
-	const handleOnXChange = ( next ) => {
-		onChange( { ...percentages, x: parseInt( next ) / 100 } );
-	};
-	const handleOnYChange = ( next ) => {
-		onChange( { ...percentages, y: parseInt( next ) / 100 } );
+	const handleChange = ( value, axis ) => {
+		const num = parseInt( value, 10 );
+
+		if ( ! isNaN( num ) ) {
+			onChange( { ...percentages, [ axis ]: num / 100 } );
+		}
 	};
 
 	return (
@@ -42,13 +43,13 @@ export default function FocalPointPickerControls( {
 			<UnitControl
 				label={ __( 'Left' ) }
 				value={ valueX }
-				onChange={ handleOnXChange }
+				onChange={ ( next ) => handleChange( next, 'x' ) }
 				dragDirection="e"
 			/>
 			<UnitControl
 				label={ __( 'Top' ) }
 				value={ valueY }
-				onChange={ handleOnYChange }
+				onChange={ ( next ) => handleChange( next, 'y' ) }
 				dragDirection="s"
 			/>
 		</ControlWrapper>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Check if parsed value from `UnitControl` is `NaN` before setting axis values. This fixes a bug where the block crashes when deleting the value.

Fixes #33617
<!-- Please describe what you have changed or added -->

## How has this been tested?
Locally by following the steps in the issue.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
