### PR TITLE
Fix optional params in page list rendering

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -150,7 +150,7 @@ function block_core_page_list_render_nested_page_list( $nested_pages, $active_pa
 		}
 
 		// If this is the first level of submenus, include the overlay colors.
-		if ( 1 === $depth ) {
+		if ( 1 === $depth && isset( $colors['overlay_css_classes'], $colors['overlay_inline_styles'] ) ) {
 			$css_class .= ' ' . trim( implode( ' ', $colors['overlay_css_classes'] ) );
 			if ( '' !== $colors['overlay_inline_styles'] ) {
 				$style_attribute = sprintf( ' style="%s"', esc_attr( $colors['overlay_inline_styles'] ) );

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -135,7 +135,7 @@ function block_core_page_list_build_css_font_sizes( $context ) {
  *
  * @return string List markup.
  */
-function block_core_page_list_render_nested_page_list( $nested_pages, $active_page_ancestor_ids = array(), $colors, $depth = 0 ) {
+function block_core_page_list_render_nested_page_list( $nested_pages, $active_page_ancestor_ids = array(), $colors = array(), $depth = 0 ) {
 	if ( empty( $nested_pages ) ) {
 		return;
 	}


### PR DESCRIPTION
## Description
A forum post (https://wordpress.org/support/topic/bad-coding-practice-2/) pointed out that it's bad practice to have a required parameter after an optional parameter. One of the page list PHP functions used for rendering does that though.

I don't think the order of these params can be changed since there's a backwards compatibility contract on this public function. So this makes `$colors` also optional. Since it's now `$optional` some further checks for the existence of array keys was also needed to avoid future issues.

## Testing
For best results, you'll want to create some pages that have a 'parent' of another page.
1. Add a page list block to a navigation block.
2. Set some colors on the navigation block.
3. Preview the post, no errors should occur and the page list should be displaying colors correctly

## Types of changes
Code quality
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
