### PR TITLE
Fix: Native UnitControl to handle single unit config

### DIFF
--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -74,7 +74,7 @@ function UnitControl( {
 			</View>
 		);
 
-		if ( hasUnits( units ) ) {
+		if ( hasUnits( units ) && units?.length > 1 ) {
 			return (
 				<TouchableWithoutFeedback
 					onPress={ onPickerPresent }
@@ -118,7 +118,7 @@ function UnitControl( {
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
 				{ renderUnitButton }
-				{ hasUnits( units ) ? (
+				{ hasUnits( units ) && units?.length > 1 ? (
 					<Picker
 						ref={ pickerRef }
 						options={ units }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/33634

## Description

The UnitControl util function `hasUnits` was changed in https://github.com/WordPress/gutenberg/pull/33634 to simply check that the passed units config wasn't empty or false. 

This changed its behaviour when the native UnitControl was relying on the previous behaviour where it checked there was more than 1 unit specified. The native UnitControl relied on this to avoid rendering a touchable button and picker when the user would have no alternative unit to select from.

This PR adds explicit checks for the length of units config into the native unit control.

## How has this been tested?
Manually.

1. Configure available units to only be a single unit e.g. `%`
2. Open up the native app
3. Insert a columns block, select an individual column and open its settings
4. Confirm that the unit control in the bottom sheet correctly displays the only available unit and there is no touchable button and picker for changing the unit.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![NativeUnitControlUnitsIssue](https://user-images.githubusercontent.com/60436221/126747402-8f3c8862-83a5-44f4-af39-3a8974e33955.gif) | ![NativeUnitControlUnitsIssueFixed](https://user-images.githubusercontent.com/60436221/126747414-c9a46663-79d2-4ccb-9d27-f2e4cdde91aa.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
