### PR TITLE
Improve display of LinkURL menu and fix spacing.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -184,10 +184,11 @@ $preview-image-height: 140px;
 		position: relative;
 		top: 0.2em;
 		margin-right: $grid-unit-10;
+		max-height: 24px;
 		flex-shrink: 0;
 
 		img {
-			max-width: 32px;
+			width: 16px;
 		}
 	}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -184,13 +184,10 @@ $preview-image-height: 140px;
 		position: relative;
 		top: 0.2em;
 		margin-right: $grid-unit-10;
-		width: 18px; // half of 32px to improve perceived resolution.
-		height: 18px; // half of 32px to improve perceived resolution.
+		flex-shrink: 0;
 
-		svg,
 		img {
-			max-width: none;
-			width: 18px; // half of 32px to improve perceived resolution.
+			max-width: 24px;
 		}
 	}
 
@@ -385,7 +382,7 @@ $preview-image-height: 140px;
 	align-items: center;
 	border-top: $border-width solid $gray-300;
 	margin: 0;
-	padding: $grid-unit-20 $grid-unit-30;
+	padding: $grid-unit-20;
 }
 
 .block-editor-link-control__unlink {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -187,7 +187,7 @@ $preview-image-height: 140px;
 		flex-shrink: 0;
 
 		img {
-			max-width: 24px;
+			max-width: 32px;
 		}
 	}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -191,7 +191,7 @@ $preview-image-height: 140px;
 		justify-content: center;
 
 		img {
-			width: 16px;
+			width: 16px; // favicons often have a source of 32px
 		}
 	}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -186,6 +186,9 @@ $preview-image-height: 140px;
 		margin-right: $grid-unit-10;
 		max-height: 24px;
 		flex-shrink: 0;
+		width: 24px;
+		display: flex;
+		justify-content: center;
 
 		img {
 			width: 16px;


### PR DESCRIPTION
There were some spacing issues on the Link URL menu that would make the icon shrink:

<img width="651" alt="Screenshot 2021-07-23 at 16 01 02" src="https://user-images.githubusercontent.com/548849/126793962-81159625-3198-4215-be3c-26bca50e1ea7.png">

Which is corrected here. It also restores the true width of the icon (24px which was assumed to be 32 before?):

<img width="636" alt="Screenshot 2021-07-23 at 16 01 22" src="https://user-images.githubusercontent.com/548849/126794016-ef534c09-9de0-4b95-a471-863511f93559.png">

There's also some alignment issues that this corrects (note the bottom part with the toggle is now aligned):

<img width="614" alt="Screenshot 2021-07-23 at 16 05 10" src="https://user-images.githubusercontent.com/548849/126794119-0730cd6e-e1ae-4ac8-8580-9a7e048054fc.png">

cc @javierarce 

(The middle one still seems like it has spacing issues on the result list, but given it's there to accommodate the hover effect I think we can leave it be for now.)