### PR TITLE
Only show rich preview for image and description if data is available

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -94,34 +94,39 @@ export default function LinkPreview( {
 				( richData?.image || richData?.description ) ) ||
 				isFetching ) && (
 				<div className="block-editor-link-control__search-item-bottom">
-					<div
-						aria-hidden={ ! richData?.image }
-						className={ classnames(
-							'block-editor-link-control__search-item-image',
-							{
-								'is-placeholder': ! richData?.image,
-							}
-						) }
-					>
-						{ richData?.image && (
-							<img src={ richData?.image } alt="" />
-						) }
-					</div>
-					<div
-						aria-hidden={ ! richData?.description }
-						className={ classnames(
-							'block-editor-link-control__search-item-description',
-							{
-								'is-placeholder': ! richData?.description,
-							}
-						) }
-					>
-						{ richData?.description && (
-							<Text truncate numberOfLines="2">
-								{ richData.description }
-							</Text>
-						) }
-					</div>
+					{ ( richData?.image || isFetching ) && (
+						<div
+							aria-hidden={ ! richData?.image }
+							className={ classnames(
+								'block-editor-link-control__search-item-image',
+								{
+									'is-placeholder': ! richData?.image,
+								}
+							) }
+						>
+							{ richData?.image && (
+								<img src={ richData?.image } alt="" />
+							) }
+						</div>
+					) }
+
+					{ ( richData?.description || isFetching ) && (
+						<div
+							aria-hidden={ ! richData?.description }
+							className={ classnames(
+								'block-editor-link-control__search-item-description',
+								{
+									'is-placeholder': ! richData?.description,
+								}
+							) }
+						>
+							{ richData?.description && (
+								<Text truncate numberOfLines="2">
+									{ richData.description }
+								</Text>
+							) }
+						</div>
+					) }
 				</div>
 			) }
 		</div>

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -90,7 +90,9 @@ export default function LinkPreview( {
 				<ViewerSlot fillProps={ value } />
 			</div>
 
-			{ ( hasRichData || isFetching ) && (
+			{ ( ( hasRichData &&
+				( richData?.image || richData?.description ) ) ||
+				isFetching ) && (
 				<div className="block-editor-link-control__search-item-bottom">
 					<div
 						aria-hidden={ ! richData?.image }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -305,7 +305,6 @@ $preview-image-height: 140px;
 
 .block-editor-link-control__search-item-bottom {
 	transition: opacity 1.5s;
-	min-height: 100px;
 	width: 100%;
 }
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1998,7 +1998,7 @@ describe( 'Rich link previews', () => {
 	} );
 
 	it.each( [ 'image', 'description' ] )(
-		'should display a fallback placeholder when %s it is missing from the rich data',
+		'should not display the rich %s when it is missing from the data',
 		async ( dataItem ) => {
 			mockFetchRichUrlData.mockImplementation( () => {
 				const data = {
@@ -2035,10 +2035,10 @@ describe( 'Rich link previews', () => {
 			expect( isRichLinkPreview ).toBe( true );
 
 			const missingDataItem = linkPreview.querySelector(
-				`.block-editor-link-control__search-item-${ dataItem }.is-placeholder`
+				`.block-editor-link-control__search-item-${ dataItem }`
 			);
 
-			expect( missingDataItem ).toBeTruthy();
+			expect( missingDataItem ).toBeFalsy();
 		}
 	);
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1878,6 +1878,46 @@ describe( 'Rich link previews', () => {
 		expect( isRichLinkPreview ).toBe( true );
 	} );
 
+	it( 'should not display placeholders for the image and description if neither is available in the data', async () => {
+		mockFetchRichUrlData.mockImplementation( () =>
+			Promise.resolve( {
+				title: '',
+				icon: 'https://s.w.org/favicon.ico?2',
+				description: '',
+				image: '',
+			} )
+		);
+
+		act( () => {
+			render(
+				<LinkControl value={ selectedLink } hasRichPreviews />,
+				container
+			);
+		} );
+
+		// mockFetchRichUrlData resolves on next "tick" of event loop
+		await act( async () => {
+			await eventLoopTick();
+		} );
+
+		const linkPreview = container.querySelector(
+			"[aria-label='Currently selected']"
+		);
+
+		// Todo: refactor to use user-facing queries.
+		const hasRichImagePreview = linkPreview.querySelector(
+			'.block-editor-link-control__search-item-image'
+		);
+
+		// Todo: refactor to use user-facing queries.
+		const hasRichDescriptionPreview = linkPreview.querySelector(
+			'.block-editor-link-control__search-item-description'
+		);
+
+		expect( hasRichImagePreview ).toBeFalsy();
+		expect( hasRichDescriptionPreview ).toBeFalsy();
+	} );
+
 	it( 'should display a fallback when title is missing from rich data', async () => {
 		mockFetchRichUrlData.mockImplementation( () =>
 			Promise.resolve( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The Link UI's rich preview feature for remote URLs was showing placeholders for image and description even thought that data did not exist in the rich preview data.

This would allow you to arrive at states such as:

![image](https://user-images.githubusercontent.com/444434/126812983-e606765b-8166-4aa4-aebf-2bfe20a90129.png)

This PR corrects that by only showing the lower half of the rich preview if the necessary data is available. It will also only show the description or image if they are available.

@javierarce I think this was actually an intentional feature. I know that because we encoded the feature into the tests!

https://github.com/WordPress/gutenberg/blob/40a511ec0e89ae401d799c66625b6fe0db00aea5/packages/block-editor/src/components/link-control/test/index.js#L1960-L1961

Therefore I'm checking in with you to make sure you're aware that this change is being made. Essentially if the content doesn't exist then we won't see a placeholder.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Create a link to a page which doesn't return a description or an image but which does return a title or an icon. Good example is https://twitter.com/.
* Click on the link to show a link preview.
* See that the placeholders for image and description are not shown once the fetching has finished.
* Check another "normal" URL to make sure we haven't caused any regressions.

Note we have quite a bit of test coverage here so it should 🤞 🤞 🤞 🤞  be safe.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
