### PR TITLE
Duotone: Add a posterize option

### DIFF
--- a/packages/block-editor/src/components/duotone-control/duotone-picker-popover.js
+++ b/packages/block-editor/src/components/duotone-control/duotone-picker-popover.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Popover, MenuGroup, DuotonePicker } from '@wordpress/components';
+import {
+	Popover,
+	MenuGroup,
+	DuotonePicker,
+	ToggleControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function DuotonePickerPopover( {
@@ -12,6 +17,8 @@ function DuotonePickerPopover( {
 	colorPalette,
 	disableCustomColors,
 	disableCustomDuotone,
+	posterize,
+	onPosterizeToggle,
 } ) {
 	return (
 		<Popover
@@ -27,6 +34,11 @@ function DuotonePickerPopover( {
 					disableCustomDuotone={ disableCustomDuotone }
 					value={ value }
 					onChange={ onChange }
+				/>
+				<ToggleControl
+					checked={ posterize }
+					onChange={ onPosterizeToggle }
+					label={ __( 'Posterize' ) }
 				/>
 			</MenuGroup>
 		</Popover>

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -18,6 +18,8 @@ function DuotoneControl( {
 	disableCustomDuotone,
 	value,
 	onChange,
+	onPosterizeToggle,
+	posterize,
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -52,6 +54,8 @@ function DuotoneControl( {
 					colorPalette={ colorPalette }
 					disableCustomColors={ disableCustomColors }
 					disableCustomDuotone={ disableCustomDuotone }
+					onPosterizeToggle={ onPosterizeToggle }
+					posterize={ posterize }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -4,7 +4,8 @@
 		min-width: 214px;
 	}
 
-	.components-circular-option-picker {
+	.components-circular-option-picker,
+	.components-toggle-control {
 		padding: $grid-unit-15;
 	}
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -62,15 +62,17 @@ export function getValuesFromColors( colors = [] ) {
  * @param {string} props.selector Selector to apply the filter to.
  * @param {string} props.id       Unique id for this duotone filter.
  * @param {Values} props.values   R, G, and B values to filter with.
+ * @param {boolean} props.posterize Decides whether to use discrete values or table values for the filter.
  *
  * @return {WPElement} Duotone element.
  */
-function DuotoneFilter( { selector, id, values } ) {
+function DuotoneFilter( { selector, id, values, posterize } ) {
 	const stylesheet = `
 ${ selector } {
 	filter: url( #${ id } );
 }
 `;
+	const type = posterize ? 'discrete' : 'table';
 
 	return (
 		<>
@@ -104,15 +106,15 @@ ${ selector } {
 							colorInterpolationFilters="sRGB"
 						>
 							<feFuncR
-								type="table"
+								type={ type }
 								tableValues={ values.r.join( ' ' ) }
 							/>
 							<feFuncG
-								type="table"
+								type={ type }
 								tableValues={ values.g.join( ' ' ) }
 							/>
 							<feFuncB
-								type="table"
+								type={ type }
 								tableValues={ values.b.join( ' ' ) }
 							/>
 						</feComponentTransfer>
@@ -127,6 +129,7 @@ ${ selector } {
 function DuotonePanel( { attributes, setAttributes } ) {
 	const style = attributes?.style;
 	const duotone = style?.color?.duotone;
+	const posterize = style?.posterize;
 
 	const duotonePalette = useSetting( 'color.duotone' ) || EMPTY_ARRAY;
 	const colorPalette = useSetting( 'color.palette' ) || EMPTY_ARRAY;
@@ -154,6 +157,14 @@ function DuotonePanel( { attributes, setAttributes } ) {
 							...style?.color,
 							duotone: newDuotone,
 						},
+					};
+					setAttributes( { style: newStyle } );
+				} }
+				posterize={ posterize }
+				onPosterizeToggle={ ( newPosterize ) => {
+					const newStyle = {
+						...style,
+						posterize: newPosterize,
 					};
 					setAttributes( { style: newStyle } );
 				} }
@@ -227,6 +238,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 			'color.__experimentalDuotone'
 		);
 		const values = props?.attributes?.style?.color?.duotone;
+		const posterize = props?.attributes?.style?.posterize;
 
 		if ( ! duotoneSupport || ! values ) {
 			return <BlockListBlock { ...props } />;
@@ -252,6 +264,7 @@ const withDuotoneStyles = createHigherOrderComponent(
 							selector={ selectorsGroup }
 							id={ id }
 							values={ getValuesFromColors( values ) }
+							posterize={ posterize }
 						/>,
 						element
 					) }


### PR DESCRIPTION
## Description
Adds a posterize option to the duotone control. This can help create some interesting effects. 

## How has this been tested?
In empty theme

## Screenshots <!-- if applicable -->
Before:
<img width="889" alt="Screenshot 2021-07-24 at 20 21 26" src="https://user-images.githubusercontent.com/275961/126879218-669f95a8-3afb-4fa9-802e-7d18b0622e53.png">
After:
<img width="876" alt="Screenshot 2021-07-24 at 20 21 39" src="https://user-images.githubusercontent.com/275961/126879219-a280b0bf-7988-4956-8b8c-b567ca2e79e3.png">

Here's how it works with an image that has duotone enabled already:
Before:
<img width="864" alt="Screenshot 2021-07-24 at 20 22 01" src="https://user-images.githubusercontent.com/275961/126879229-6920585d-7a7c-4800-a05a-489d2ce73327.png">

After:
<img width="870" alt="Screenshot 2021-07-24 at 20 22 10" src="https://user-images.githubusercontent.com/275961/126879238-6d7c6bfd-4383-4246-bdc7-11c3f08d921a.png">

Sometimes it doesn't look so good :)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
