### PR TITLE
Gallery block refactor: remove the imageCount attribute 

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -92,10 +92,6 @@
 		"allowResize": {
 			"type": "boolean",
 			"default": false
-		},
-		"imageCount": {
-			"type": "number",
-			"default": 0
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/gallery/edit-wrapper.js
+++ b/packages/block-library/src/gallery/edit-wrapper.js
@@ -16,7 +16,14 @@ import EditWithoutInnerBlocks from './v1/edit';
  * use of hooks lint errors if adding this logic to the top of the edit component.
  */
 export default function GalleryEditWrapper( props ) {
-	const { attributes } = props;
+	const { attributes, clientId } = props;
+
+	const innerBlockImages = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).getBlock( clientId )?.innerBlocks;
+		},
+		[ clientId ]
+	);
 
 	const __unstableGalleryWithImageBlocks = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
@@ -26,7 +33,7 @@ export default function GalleryEditWrapper( props ) {
 	// This logic is used to infer version information from content with higher
 	// precedence than the flag. New galleries (and existing empty galleries) will
 	// honor the flag.
-	const hasNewVersionContent = !! attributes?.imageCount;
+	const hasNewVersionContent = !! innerBlockImages.length;
 	const hasOldVersionContent =
 		0 < attributes?.ids?.length || 0 < attributes?.images?.length;
 	if (

--- a/packages/block-library/src/gallery/edit-wrapper.js
+++ b/packages/block-library/src/gallery/edit-wrapper.js
@@ -33,7 +33,7 @@ export default function GalleryEditWrapper( props ) {
 	// This logic is used to infer version information from content with higher
 	// precedence than the flag. New galleries (and existing empty galleries) will
 	// honor the flag.
-	const hasNewVersionContent = !! innerBlockImages.length;
+	const hasNewVersionContent = !! innerBlockImages?.length;
 	const hasOldVersionContent =
 		0 < attributes?.ids?.length || 0 < attributes?.images?.length;
 	if (

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -86,8 +86,7 @@ function GalleryEdit( props ) {
 	} = props;
 
 	const {
-		imageCount,
-		columns = defaultColumnsNumber( imageCount ),
+		columns,
 		imageCrop,
 		linkTarget,
 		linkTo,
@@ -155,17 +154,6 @@ function GalleryEdit( props ) {
 		setAttributes( { shortCodeTransforms: undefined } );
 	}, [ shortCodeTransforms, shortCodeImages ] );
 
-	useEffect( () => {
-		if ( ! images ) {
-			setAttributes( { imageCount: undefined } );
-			return;
-		}
-
-		if ( images.length !== imageCount ) {
-			setAttributes( { imageCount: images.length } );
-		}
-	}, [ images ] );
-
 	const imageSizeOptions = useImageSizes(
 		imageData,
 		isSelected,
@@ -181,8 +169,8 @@ function GalleryEdit( props ) {
 	 * it already existed in the gallery. If the image is in fact new, we need
 	 * to apply the gallery's current settings to the image.
 	 *
-	 * @param  {Object} existingBlock Existing Image block that still exists after gallery update.
-	 * @param  {Object} image         Media object for the actual image.
+	 * @param {Object} existingBlock Existing Image block that still exists after gallery update.
+	 * @param {Object} image         Media object for the actual image.
 	 * @return {Object}               Attributes to set on the new image block.
 	 */
 	function buildImageAttributes( existingBlock, image ) {
@@ -462,7 +450,11 @@ function GalleryEdit( props ) {
 					{ images.length > 1 && (
 						<RangeControl
 							label={ __( 'Columns' ) }
-							value={ columns }
+							value={
+								columns
+									? columns
+									: defaultColumnsNumber( images.length )
+							}
 							onChange={ setColumnsNumber }
 							min={ 1 }
 							max={ Math.min( MAX_COLUMNS, images.length ) }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -32,7 +32,7 @@ export const Gallery = ( props ) => {
 		blockProps,
 	} = props;
 
-	const { align, columns = 'default', caption, imageCrop } = attributes;
+	const { align, columns, caption, imageCrop } = attributes;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
@@ -73,7 +73,8 @@ export const Gallery = ( props ) => {
 				'blocks-gallery-grid',
 				{
 					[ `align${ align }` ]: align,
-					[ `columns-${ columns }` ]: columns,
+					[ `columns-${ columns }` ]: columns !== undefined,
+					[ `columns-default` ]: columns === undefined,
 					'is-cropped': imageCrop,
 				}
 			) }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -20,11 +20,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { defaultColumnsNumber } from './shared';
-
 const allowedBlocks = [ 'core/image' ];
 
 export const Gallery = ( props ) => {
@@ -37,13 +32,7 @@ export const Gallery = ( props ) => {
 		blockProps,
 	} = props;
 
-	const {
-		imageCount,
-		align,
-		columns = defaultColumnsNumber( imageCount ),
-		caption,
-		imageCrop,
-	} = attributes;
+	const { align, columns = 'default', caption, imageCrop } = attributes;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -21,7 +21,6 @@ export const settings = {
 	example: {
 		attributes: {
 			columns: 2,
-			imageCount: 2,
 		},
 		innerBlocks: [
 			{

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
@@ -13,11 +18,13 @@ export default function saveWithInnerBlocks( { attributes } ) {
 		return saveWithoutInnerBlocks( { attributes } );
 	}
 
-	const { caption, columns = 'default', imageCrop } = attributes;
+	const { caption, columns, imageCrop } = attributes;
 
-	const className = `blocks-gallery-grid has-nested-images columns-${ columns } ${
-		imageCrop ? 'is-cropped' : ''
-	}`;
+	const className = classnames( 'blocks-gallery-grid', 'has-nested-images', {
+		[ `columns-${ columns }` ]: columns !== undefined,
+		[ `columns-default` ]: columns === undefined,
+		'is-cropped': imageCrop,
+	} );
 
 	return (
 		<figure { ...useBlockProps.save( { className } ) }>

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -6,7 +6,6 @@ import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { defaultColumnsNumber } from './shared';
 import saveWithoutInnerBlocks from './v1/save';
 
 export default function saveWithInnerBlocks( { attributes } ) {
@@ -14,12 +13,7 @@ export default function saveWithInnerBlocks( { attributes } ) {
 		return saveWithoutInnerBlocks( { attributes } );
 	}
 
-	const {
-		imageCount,
-		caption,
-		columns = defaultColumnsNumber( imageCount ),
-		imageCrop,
-	} = attributes;
+	const { caption, columns = 'default', imageCrop } = attributes;
 
 	const className = `blocks-gallery-grid has-nested-images columns-${ columns } ${
 		imageCrop ? 'is-cropped' : ''

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -166,11 +166,29 @@
 				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
 			}
 		}
-
 		// Unset the right margin on every rightmost gallery item to ensure center balance.
 		@for $column-count from 1 through 8 {
 			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type(#{ $column-count }n) {
 				margin-right: 0;
+			}
+		}
+		// If number of columns not explicitly set default to 3 columns if 3 or more images.
+		&.columns-default {
+			figure.wp-block-image:not(#individual-image) {
+				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				width: calc(33.33% - calc(var(--gallery-block--gutter-size, 16px) * calc(2) / 3))
+			}
+			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
+				margin-right: 0;
+			}
+			// If only 2 child images use 2 columns.
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
+				width: calc(50% - (var(--gallery-block--gutter-size, 16px) / 2));
+			}
+			// For a single image set to 100%.
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {
+				width: 100%;
 			}
 		}
 	}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -158,7 +158,7 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
 				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(#{100% / $i} - calc(var(--gallery-block--gutter-size, #{$grid-unit-20}) * calc(#{$i - 1}) / #{$i}));
+				width: calc(#{100% / $i} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{$i - 1} / #{$i}));
 			}
 
 			// Prevent collapsing margin while sibling is being dragged.
@@ -176,7 +176,7 @@
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
 				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(33.33% - calc(var(--gallery-block--gutter-size, 16px) * 2 / 3))
+				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * 2 / 3));
 			}
 			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
 				margin-right: 0;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -176,7 +176,7 @@
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
 				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(33.33% - calc(var(--gallery-block--gutter-size, 16px) * calc(2) / 3))
+				width: calc(33.33% - calc(var(--gallery-block--gutter-size, 16px) * 2 / 3))
 			}
 			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
 				margin-right: 0;

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -61,7 +61,6 @@ const transforms = {
 					return createBlock(
 						'core/gallery',
 						{
-							imageCount: innerBlocks.length,
 							align,
 							sizeSlug,
 						},


### PR DESCRIPTION
## Description
Based on feedback from [main PR](https://github.com/WordPress/gutenberg/pull/25940), this PR removes the imageCount attribute and instead sets columns in CSS if no column attribute is set.

## Testing

- Check out PR to local dev env and enable the experimental gallery flag
- Add galleries with 1, 2, 3 and 3+ images and make sure that the max columns is 3 in editor and front end
- Manually set the number of columns with a variety of image counts and make sure they display as expected
- Disable the experiment and make sure the added galleries display as expected
- Add some galleries in old format and make sure columns options work as expected