### PR TITLE
FontSizePicker: Use number values when the initial value is a number

### DIFF
--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -97,12 +97,9 @@ export default ( ...fontSizeNames ) => {
 						fontSizeAttributeName,
 						customFontSizeAttributeName
 					) {
-						return ( fontSizeUnit ) => {
-							const fontSizeValue = fontSizeUnit
-								? parseInt( fontSizeUnit, 10 )
-								: undefined;
+						return ( fontSizeValue ) => {
 							const fontSizeObject = find( this.props.fontSizes, {
-								size: fontSizeValue,
+								size: Number( fontSizeValue ),
 							} );
 							this.props.setAttributes( {
 								[ fontSizeAttributeName ]:

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -97,9 +97,12 @@ export default ( ...fontSizeNames ) => {
 						fontSizeAttributeName,
 						customFontSizeAttributeName
 					) {
-						return ( fontSizeValue ) => {
+						return ( fontSizeUnit ) => {
+							const fontSizeValue = fontSizeUnit
+								? parseInt( fontSizeUnit, 10 )
+								: undefined;
 							const fontSizeObject = find( this.props.fontSizes, {
-								size: Number( fontSizeValue ),
+								size: fontSizeValue,
 							} );
 							this.props.setAttributes( {
 								[ fontSizeAttributeName ]:

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -126,7 +126,11 @@ function FontSizePicker(
 							if ( 0 === parseFloat( nextSize ) || ! nextSize ) {
 								onChange( undefined );
 							} else {
-								onChange( nextSize );
+								onChange(
+									hasUnits
+										? nextSize
+										: parseInt( nextSize, 10 )
+								);
 							}
 						} }
 						units={ units }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -133,7 +133,7 @@ function FontSizePicker(
 								);
 							}
 						} }
-						units={ units }
+						units={ hasUnits ? units : false }
 					/>
 				) }
 				<Button

--- a/packages/components/src/font-size-picker/test/index.js
+++ b/packages/components/src/font-size-picker/test/index.js
@@ -8,6 +8,11 @@ import { render, fireEvent, screen } from '@testing-library/react';
  */
 import FontSizePicker from '../';
 
+const getUnitSelect = () =>
+	document.body.querySelector( '.components-unit-control select' );
+const getUnitLabel = () =>
+	document.body.querySelector( '.components-unit-control__unit-label' );
+
 describe( 'FontSizePicker', () => {
 	describe( 'onChange values', () => {
 		it( 'should not use units when the initial value is a number', () => {
@@ -20,6 +25,8 @@ describe( 'FontSizePicker', () => {
 				<FontSizePicker value={ fontSize } onChange={ setFontSize } />
 			);
 
+			const unitSelect = getUnitSelect();
+			const unitLabel = getUnitLabel();
 			const input = screen.getByLabelText( 'Custom', {
 				selector: 'input',
 			} );
@@ -27,6 +34,8 @@ describe( 'FontSizePicker', () => {
 			input.focus();
 			fireEvent.change( input, { target: { value: 16 } } );
 
+			expect( unitSelect ).toBeFalsy();
+			expect( unitLabel ).toBeTruthy();
 			expect( fontSize ).toBe( 16 );
 		} );
 
@@ -40,6 +49,8 @@ describe( 'FontSizePicker', () => {
 				<FontSizePicker value={ fontSize } onChange={ setFontSize } />
 			);
 
+			const unitSelect = getUnitSelect();
+			const unitLabel = getUnitLabel();
 			const input = screen.getByLabelText( 'Custom', {
 				selector: 'input',
 			} );
@@ -47,6 +58,8 @@ describe( 'FontSizePicker', () => {
 			input.focus();
 			fireEvent.change( input, { target: { value: 16 } } );
 
+			expect( unitSelect ).toBeTruthy();
+			expect( unitLabel ).toBeFalsy();
 			expect( fontSize ).toBe( '16px' );
 		} );
 
@@ -71,6 +84,8 @@ describe( 'FontSizePicker', () => {
 				/>
 			);
 
+			const unitSelect = getUnitSelect();
+			const unitLabel = getUnitLabel();
 			const input = screen.getByLabelText( 'Custom', {
 				selector: 'input',
 			} );
@@ -78,6 +93,8 @@ describe( 'FontSizePicker', () => {
 			input.focus();
 			fireEvent.change( input, { target: { value: 16 } } );
 
+			expect( unitSelect ).toBeFalsy();
+			expect( unitLabel ).toBeTruthy();
 			expect( fontSize ).toBe( 16 );
 		} );
 
@@ -102,6 +119,8 @@ describe( 'FontSizePicker', () => {
 				/>
 			);
 
+			const unitSelect = getUnitSelect();
+			const unitLabel = getUnitLabel();
 			const input = screen.getByLabelText( 'Custom', {
 				selector: 'input',
 			} );
@@ -109,6 +128,8 @@ describe( 'FontSizePicker', () => {
 			input.focus();
 			fireEvent.change( input, { target: { value: 16 } } );
 
+			expect( unitSelect ).toBeTruthy();
+			expect( unitLabel ).toBeFalsy();
 			expect( fontSize ).toBe( '16px' );
 		} );
 	} );

--- a/packages/components/src/font-size-picker/test/index.js
+++ b/packages/components/src/font-size-picker/test/index.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import FontSizePicker from '../';
+
+describe( 'FontSizePicker', () => {
+	describe( 'onChange values', () => {
+		it( 'should not use units when the initial value is a number', () => {
+			let fontSize = 12;
+			const setFontSize = jest.fn(
+				( nextSize ) => ( fontSize = nextSize )
+			);
+
+			render(
+				<FontSizePicker value={ fontSize } onChange={ setFontSize } />
+			);
+
+			const input = screen.getByLabelText( 'Custom', {
+				selector: 'input',
+			} );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: 16 } } );
+
+			expect( fontSize ).toBe( 16 );
+		} );
+
+		it( 'should use units when the initial value has a unit', () => {
+			let fontSize = '12px';
+			const setFontSize = jest.fn(
+				( nextSize ) => ( fontSize = nextSize )
+			);
+
+			render(
+				<FontSizePicker value={ fontSize } onChange={ setFontSize } />
+			);
+
+			const input = screen.getByLabelText( 'Custom', {
+				selector: 'input',
+			} );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: 16 } } );
+
+			expect( fontSize ).toBe( '16px' );
+		} );
+
+		it( 'should not use units when fontSizes size values are numbers', () => {
+			let fontSize;
+			const fontSizes = [
+				{
+					name: 'Small',
+					slug: 'small',
+					size: 12,
+				},
+			];
+			const setFontSize = jest.fn(
+				( nextSize ) => ( fontSize = nextSize )
+			);
+
+			render(
+				<FontSizePicker
+					fontSizes={ fontSizes }
+					value={ fontSize }
+					onChange={ setFontSize }
+				/>
+			);
+
+			const input = screen.getByLabelText( 'Custom', {
+				selector: 'input',
+			} );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: 16 } } );
+
+			expect( fontSize ).toBe( 16 );
+		} );
+
+		it( 'should use units when fontSizes size values have units', () => {
+			let fontSize;
+			const fontSizes = [
+				{
+					name: 'Small',
+					slug: 'small',
+					size: '12px',
+				},
+			];
+			const setFontSize = jest.fn(
+				( nextSize ) => ( fontSize = nextSize )
+			);
+
+			render(
+				<FontSizePicker
+					fontSizes={ fontSizes }
+					value={ fontSize }
+					onChange={ setFontSize }
+				/>
+			);
+
+			const input = screen.getByLabelText( 'Custom', {
+				selector: 'input',
+			} );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: 16 } } );
+
+			expect( fontSize ).toBe( '16px' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description
Updates `onChange` logic in FontSizePicker component. When the component detects that value or first object in `fonSizes` doesn't use units, it will pass the number value to the onChange callback.

Fixes #33651.
Fixes #33653.

## How has this been tested?
Tested with plugin provided in original issue report - https://github.com/NasKadir123/textBlock

## Types of changes
Bugfix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
