### PR TITLE
Global Styles: Avoid rendering duplicate elements stylesheet

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -63,5 +63,6 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 
 }
 
-
+// Remove WordPress core filter to avoid rendering duplicate elements stylesheet.
+remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_elements_support', 10, 2 );


### PR DESCRIPTION
## Description
Removes WP Core filter for "elements support" to avoid rendering duplicate stylesheet.

Fixes #33669.

Similar PRs - #33005 and #33233.

## How has this been tested?
1. Add the Paragraph block.
2. Select text and add a link.
3. Set link color for the paragraph.
4. Save post.
5. On the front-end, WP shouldn't render duplicated stylesheet for link color.

## Screenshots <!-- if applicable -->
![CleanShot 2021-07-26 at 10 58 36](https://user-images.githubusercontent.com/240569/126946197-0c76e6d3-6d7a-4aaa-bb0d-2c2608fc790c.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
