### PR TITLE
Core Data: Pass query argument to data selector shortcuts

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -24,8 +24,8 @@ import { STORE_NAME } from './name';
 
 const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( state, key ) =>
-		selectors.getEntityRecord( state, kind, name, key );
+	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
+		selectors.getEntityRecord( state, kind, name, key, query );
 	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) =>
 		selectors.getEntityRecords( state, kind, name, ...args );
 	return result;
@@ -33,8 +33,8 @@ const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
 
 const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( key ) =>
-		resolvers.getEntityRecord( kind, name, key );
+	result[ getMethodName( kind, name ) ] = ( key, query ) =>
+		resolvers.getEntityRecord( kind, name, key, query );
 	const pluralMethodName = getMethodName( kind, name, 'get', true );
 	result[ pluralMethodName ] = ( ...args ) =>
 		resolvers.getEntityRecords( kind, name, ...args );


### PR DESCRIPTION
## Description
Allows passing query argument to singular data selector shortcuts like `getUser` and `getMedia`. The query argument can be used to set `context` for the selector.

Fixes #33566.

## How has this been tested?
1. Switch to a user with an Author role.
2. In the post editor, run the following snippet in the console.

```js
wp.data.select('core').getUser( userId, { context: 'view' } );
```

3. REST API request shouldn't fail with 403 error.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
