### PR TITLE
Automation: Track Gutenberg performance metrics over time.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,7 +5,7 @@ on:
     release:
         types: [published]
     push:
-        branches: [trunk, add/log-perf]
+        branches: [trunk]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -4,6 +4,8 @@ on:
     pull_request:
     release:
         types: [published]
+    push:
+        branches: [trunk]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -49,3 +51,22 @@ jobs:
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
                   ./bin/plugin/cli.js perf --ci "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --wp-version "$WP_MAJOR"
+
+            - name: Compare performance with base branch
+              if: github.event_name == 'push'
+              run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA wp/5.8 --tests-branch $GITHUB_SHA
+
+            - uses: actions/github-script@0.3.0
+              if: github.event_name == 'push'
+              id: commit-timestamp
+              with:
+                  github-token: ${{secrets.GITHUB_TOKEN}}
+                  script: |
+                      const commit_details = await github.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
+                      return commit_details.data.author.date
+
+            - name: Publish performance results
+              if: github.event_name == 'push'
+              env:
+                  COMMITTED_AT: ${{ steps.commit-timestamp.outputs.result }}
+              run: ./bin/log-perormance-results.js trunk $GITHUB_SHA wp/5.8 $COMMITTED_AT

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,7 +5,7 @@ on:
     release:
         types: [published]
     push:
-        branches: [trunk]
+        branches: [trunk,add/log-perf]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,7 +5,7 @@ on:
     release:
         types: [published]
     push:
-        branches: [trunk,add/log-perf]
+        branches: [trunk, add/log-perf]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -63,7 +63,7 @@ jobs:
                   github-token: ${{secrets.GITHUB_TOKEN}}
                   script: |
                       const commit_details = await github.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
-                      return commit_details.data.author.date
+                      return parseInt((new Date( commit_details.data.author.date ).getTime() / 1000).toFixed(0))
 
             - name: Publish performance results
               if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build-types
 node_modules
 gutenberg.zip
 coverage
+*-performance-results.json
 
 # Directories/files that may appear in your environment
 *.log

--- a/bin/log-perormance-results.js
+++ b/bin/log-perormance-results.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const https = require( 'https' );
+const [ branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
+
+const performanceResults = JSON.parse(
+	fs.readFileSync(
+		path.join( __dirname, '../post-editor-performance-results.json' ),
+		'utf8'
+	)
+);
+
+const data = new TextEncoder().encode(
+	JSON.stringify( {
+		branch,
+		hash,
+		baseHash,
+		timestamp: parseInt( timestamp, 10 ),
+		metrics: performanceResults[ hash ],
+		baseMetrics: performanceResults[ baseHash ],
+	} )
+);
+
+const options = {
+	hostname: 'codehealth-riad.vercel.app',
+	port: 443,
+	path: '/api/log',
+	method: 'POST',
+	headers: {
+		'Content-Type': 'application/json',
+		'Content-Length': data.length,
+	},
+};
+
+const req = https.request( options, ( res ) => {
+	console.log( `statusCode: ${ res.statusCode }` );
+
+	res.on( 'data', ( d ) => {
+		process.stdout.write( d );
+	} );
+} );
+
+req.on( 'error', ( error ) => {
+	console.error( error );
+} );
+
+req.write( data );
+req.end();


### PR DESCRIPTION
I've built an experimental performance metric tracking service here https://codehealth-riad.vercel.app
This PRs adds the logging call to Gutenberg to start measuring trunk commits performance.
For now, it's not that useful until we gather more metrics.

 - The UI of the tool is also not great at the moment
 - The API is also unprotected 

But it's a start, we can improve these over time.