### PR TITLE
PWA manifest: icon: fix error when admin bar is gone

### DIFF
--- a/packages/admin-manifest/src/index.js
+++ b/packages/admin-manifest/src/index.js
@@ -88,6 +88,19 @@ function createIcon( { svgElement, size, color, backgroundColor, circle } ) {
 	} );
 }
 
+function getAdminBarColors() {
+	const adminBarDummy = document.createElement( 'div' );
+	adminBarDummy.id = 'wpadminbar';
+	document.body.appendChild( adminBarDummy );
+	const { color, backgroundColor } = window.getComputedStyle( adminBarDummy );
+	document.body.removeChild( adminBarDummy );
+	// Fall back to black and white if no admin/color stylesheet was loaded.
+	return {
+		color: color || 'white',
+		backgroundColor: backgroundColor || 'black',
+	};
+}
+
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.addEventListener( 'load', () => {
 	if ( ! ( 'serviceWorker' in window.navigator ) ) {
@@ -106,8 +119,7 @@ window.addEventListener( 'load', () => {
 		icons: [],
 	};
 
-	const adminBar = document.getElementById( 'wpadminbar' );
-	const { color, backgroundColor } = window.getComputedStyle( adminBar );
+	const { color, backgroundColor } = getAdminBarColors();
 	const svgElement = createSvgElement( logo );
 
 	Promise.all( [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #33591. Sometimes the admin bar is not available, so we can create a dummy admin bar just to get the main admin bar colors.

## How has this been tested?

Install the AMP plugin and use the onboarding wizard. There will be no admin bar. The web app should be installable and have the right background color.

## Screenshots <!-- if applicable -->

<img width="737" alt="Screenshot 2021-07-26 at 20 50 44" src="https://user-images.githubusercontent.com/4710635/127042734-e2e0de0a-66a8-4526-b27b-ce7dc5068a8e.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
