### PR TITLE
Template Part placeholder - Add title step to creation flow.

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -55,8 +55,10 @@ export default function TemplatePartPlaceholder( {
 	);
 
 	const onCreate = useCallback(
-		async ( startingBlocks = [] ) => {
-			const title = __( 'Untitled Template Part' );
+		async (
+			startingBlocks = [],
+			title = __( 'Untitled Template Part' )
+		) => {
 			// If we have `area` set from block attributes, means an exposed
 			// block variation was inserted. So add this prop to the template
 			// part entity on creation. Afterwards remove `area` value from

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -157,6 +157,7 @@ export default function TemplatePartPlaceholder( {
 				<PatternsSetup
 					area={ area }
 					areaLabel={ areaLabel }
+					areaIcon={ areaIcon }
 					onCreate={ onCreate }
 					clientId={ clientId }
 					resetPlaceholder={ () =>

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -156,6 +156,7 @@ export default function TemplatePartPlaceholder( {
 			{ step === PLACEHOLDER_STEPS.patterns && (
 				<PatternsSetup
 					area={ area }
+					areaLabel={ areaLabel }
 					onCreate={ onCreate }
 					clientId={ clientId }
 					resetPlaceholder={ () =>

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -158,6 +158,9 @@ export default function TemplatePartPlaceholder( {
 					area={ area }
 					onCreate={ onCreate }
 					clientId={ clientId }
+					resetPlaceholder={ () =>
+						setStep( PLACEHOLDER_STEPS.initial )
+					}
 				/>
 			) }
 		</>

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -3,7 +3,7 @@
  */
 import { __experimentalBlockPatternSetup as BlockPatternSetup } from '@wordpress/block-editor';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	TextControl,
 	Flex,
@@ -14,6 +14,7 @@ import {
 
 export default function PatternsSetup( {
 	area,
+	areaLabel,
 	clientId,
 	onCreate,
 	resetPlaceholder,
@@ -49,8 +50,11 @@ export default function PatternsSetup( {
 			/>
 			{ isTitleStep && (
 				<Modal
-					title={ __( 'Create a template part' ) }
-					closeLabel={ __( 'Close' ) }
+					title={ sprintf(
+						'Name and create your new %s',
+						areaLabel.toLowerCase()
+					) }
+					closeLabel={ __( 'Cancel' ) }
 					onRequestClose={ () => {
 						resetPlaceholder();
 					} }

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -34,6 +34,11 @@ export default function PatternsSetup( {
 		setIsTitleStep( true );
 	};
 
+	const submitForCreation = ( event ) => {
+		event.preventDefault();
+		onCreate( startingBlocks, title );
+	};
+
 	return (
 		<>
 			<BlockPatternSetup
@@ -55,32 +60,23 @@ export default function PatternsSetup( {
 						areaLabel.toLowerCase()
 					) }
 					closeLabel={ __( 'Cancel' ) }
-					onRequestClose={ () => {
-						resetPlaceholder();
-					} }
-					overlayClassName="wp-block-template-part__placeholder-title-form"
+					onRequestClose={ resetPlaceholder }
+					overlayClassName="wp-block-template-part__placeholder-create-new__title-form"
 				>
-					<form
-						onSubmit={ ( event ) => {
-							event.preventDefault();
-							onCreate( startingBlocks, title );
-						} }
-					>
+					<form onSubmit={ submitForCreation }>
 						<TextControl
 							label={ __( 'Name' ) }
 							value={ title }
 							onChange={ setTitle }
 						/>
 						<Flex
-							className="wp-block-template-part__placeholder-title-form-actions"
+							className="wp-block-template-part__placeholder-create-new__title-form-actions"
 							justify="flex-end"
 						>
 							<FlexItem>
 								<Button
 									variant="secondary"
-									onClick={ () => {
-										resetPlaceholder();
-									} }
+									onClick={ resetPlaceholder }
 								>
 									{ __( 'Cancel' ) }
 								</Button>

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -58,7 +58,7 @@ export default function PatternsSetup( {
 					onRequestClose={ () => {
 						resetPlaceholder();
 					} }
-					overlayClassName="edit-site-template-part-converter__modal"
+					overlayClassName="wp-block-template-part__placeholder-title-form"
 				>
 					<form
 						onSubmit={ ( event ) => {
@@ -72,7 +72,7 @@ export default function PatternsSetup( {
 							onChange={ setTitle }
 						/>
 						<Flex
-							className="edit-site-template-part-converter__convert-modal-actions"
+							className="wp-block-template-part__placeholder-title-form-actions"
 							justify="flex-end"
 						>
 							<FlexItem>

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -2,32 +2,102 @@
  * WordPress dependencies
  */
 import { __experimentalBlockPatternSetup as BlockPatternSetup } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	TextControl,
+	Flex,
+	FlexItem,
+	Button,
+	Modal,
+} from '@wordpress/components';
 
 export default function PatternsSetup( { area, clientId, onCreate } ) {
 	const blockNameWithArea = area
 		? `core/template-part/${ area }`
 		: 'core/template-part';
 
+	// Restructure onCreate to set the blocks on local state.
+	// Add modal to confirm title and trigger onCreate.
+	const [ title, setTitle ] = useState( __( 'Untitled Template Part' ) );
+	const [ startingBlocks, setStartingBlocks ] = useState( [] );
+	const [ isTitleStep, setIsTitleStep ] = useState( false );
+
+	const selectPattern = ( selectedPattern ) => {
+		setStartingBlocks( selectedPattern );
+		setIsTitleStep( true );
+	};
+
 	return (
-		<BlockPatternSetup
-			clientId={ clientId }
-			startBlankComponent={
-				<StartBlankComponent onCreate={ onCreate } />
-			}
-			onBlockPatternSelect={ onCreate }
-			filterPatternsFn={ ( pattern ) =>
-				pattern?.blockTypes?.some?.(
-					( blockType ) => blockType === blockNameWithArea
-				)
-			}
-		/>
+		<>
+			<BlockPatternSetup
+				clientId={ clientId }
+				startBlankComponent={
+					<StartBlankComponent setTitleStep={ setIsTitleStep } />
+				}
+				onBlockPatternSelect={ selectPattern }
+				filterPatternsFn={ ( pattern ) =>
+					pattern?.blockTypes?.some?.(
+						( blockType ) => blockType === blockNameWithArea
+					)
+				}
+			/>
+			{ isTitleStep && (
+				<Modal
+					title={ __( 'Create a template part' ) }
+					closeLabel={ __( 'Close' ) }
+					onRequestClose={ () => {
+						setIsTitleStep( false );
+						setTitle( __( 'Untitled Template Part' ) );
+					} }
+					overlayClassName="edit-site-template-part-converter__modal"
+				>
+					<form
+						onSubmit={ ( event ) => {
+							event.preventDefault();
+							onCreate( startingBlocks, title );
+							// setIsTitleStep( false );
+							// setTitle( __( 'Untitled Template Part' ) );
+						} }
+					>
+						<TextControl
+							label={ __( 'Name' ) }
+							value={ title }
+							onChange={ setTitle }
+						/>
+						<Flex
+							className="edit-site-template-part-converter__convert-modal-actions"
+							justify="flex-end"
+						>
+							<FlexItem>
+								<Button
+									variant="secondary"
+									onClick={ () => {
+										setIsTitleStep( false );
+										setTitle(
+											__( 'Untitled Template Part' )
+										);
+									} }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+							</FlexItem>
+							<FlexItem>
+								<Button variant="primary" type="submit">
+									{ __( 'Create' ) }
+								</Button>
+							</FlexItem>
+						</Flex>
+					</form>
+				</Modal>
+			) }
+		</>
 	);
 }
 
-function StartBlankComponent( { onCreate } ) {
+function StartBlankComponent( { setTitleStep } ) {
 	useEffect( () => {
-		onCreate();
+		setTitleStep( true );
 	}, [] );
 	return null;
 }

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -10,11 +10,13 @@ import {
 	FlexItem,
 	Button,
 	Modal,
+	Placeholder,
 } from '@wordpress/components';
 
 export default function PatternsSetup( {
 	area,
 	areaLabel,
+	areaIcon,
 	clientId,
 	onCreate,
 	resetPlaceholder,
@@ -44,7 +46,11 @@ export default function PatternsSetup( {
 			<BlockPatternSetup
 				clientId={ clientId }
 				startBlankComponent={
-					<StartBlankComponent setTitleStep={ setIsTitleStep } />
+					<StartBlankComponent
+						setTitleStep={ setIsTitleStep }
+						areaLabel={ areaLabel }
+						areaIcon={ areaIcon }
+					/>
 				}
 				onBlockPatternSelect={ selectPattern }
 				filterPatternsFn={ ( pattern ) =>
@@ -82,7 +88,12 @@ export default function PatternsSetup( {
 								</Button>
 							</FlexItem>
 							<FlexItem>
-								<Button variant="primary" type="submit">
+								<Button
+									variant="primary"
+									type="submit"
+									disabled={ ! title.length }
+									aria-disabled={ ! title.length }
+								>
 									{ __( 'Create' ) }
 								</Button>
 							</FlexItem>
@@ -94,9 +105,19 @@ export default function PatternsSetup( {
 	);
 }
 
-function StartBlankComponent( { setTitleStep } ) {
+function StartBlankComponent( { setTitleStep, areaLabel, areaIcon } ) {
 	useEffect( () => {
 		setTitleStep( true );
 	}, [] );
-	return null;
+	return (
+		<Placeholder
+			label={ areaLabel }
+			icon={ areaIcon }
+			instructions={ sprintf(
+				// Translators: %s as template part area title ("Header", "Footer", "Template Part", etc.).
+				'Creating your new %s...',
+				areaLabel.toLowerCase()
+			) }
+		/>
+	);
 }

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -12,7 +12,12 @@ import {
 	Modal,
 } from '@wordpress/components';
 
-export default function PatternsSetup( { area, clientId, onCreate } ) {
+export default function PatternsSetup( {
+	area,
+	clientId,
+	onCreate,
+	resetPlaceholder,
+} ) {
 	const blockNameWithArea = area
 		? `core/template-part/${ area }`
 		: 'core/template-part';
@@ -47,8 +52,7 @@ export default function PatternsSetup( { area, clientId, onCreate } ) {
 					title={ __( 'Create a template part' ) }
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ () => {
-						setIsTitleStep( false );
-						setTitle( __( 'Untitled Template Part' ) );
+						resetPlaceholder();
 					} }
 					overlayClassName="edit-site-template-part-converter__modal"
 				>
@@ -56,8 +60,6 @@ export default function PatternsSetup( { area, clientId, onCreate } ) {
 						onSubmit={ ( event ) => {
 							event.preventDefault();
 							onCreate( startingBlocks, title );
-							// setIsTitleStep( false );
-							// setTitle( __( 'Untitled Template Part' ) );
 						} }
 					>
 						<TextControl
@@ -73,10 +75,7 @@ export default function PatternsSetup( { area, clientId, onCreate } ) {
 								<Button
 									variant="secondary"
 									onClick={ () => {
-										setIsTitleStep( false );
-										setTitle(
-											__( 'Untitled Template Part' )
-										);
+										resetPlaceholder();
 									} }
 								>
 									{ __( 'Cancel' ) }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -78,8 +78,8 @@
 	}
 }
 
-.wp-block-template-part__placeholder-title-form {
-	.wp-block-template-part__placeholder-title-form-actions {
+.wp-block-template-part__placeholder-create-new__title-form {
+	.wp-block-template-part__placeholder-create-new__title-form-actions {
 		padding-top: $grid-unit-15;
 		// Unsure why these styles need to be added since we are using the Flex component with
 		// flex-end setting.

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -77,3 +77,17 @@
 		}
 	}
 }
+
+.wp-block-template-part__placeholder-title-form {
+	.wp-block-template-part__placeholder-title-form-actions {
+		padding-top: $grid-unit-15;
+		// Unsure why these styles need to be added since we are using the Flex component with
+		// flex-end setting.
+		display: flex;
+		justify-content: flex-end;
+
+		.components-flex-item {
+			margin-left: $grid-unit-15;
+		}
+	}
+}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -82,7 +82,8 @@
 	.wp-block-template-part__placeholder-create-new__title-form-actions {
 		padding-top: $grid-unit-15;
 		// Unsure why these styles need to be added since we are using the Flex component with
-		// flex-end setting.
+		// flex-end setting.  Created issue https://github.com/WordPress/gutenberg/issues/33735 to
+		// attempt document this issue.
 		display: flex;
 		justify-content: flex-end;
 

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -66,6 +66,8 @@ describe( 'Multi-entity save flow', () => {
 		const saveA11ySelector =
 			'.edit-post-layout__toggle-entities-saved-states-panel-button';
 		const publishPanelSelector = '.editor-post-publish-panel';
+		const confirmTitleButtonSelector =
+			'.wp-block-template-part__placeholder-create-new__title-form .components-button.is-primary';
 
 		// Reusable assertions inside Post editor.
 		const assertMultiSaveEnabled = async () => {
@@ -104,6 +106,11 @@ describe( 'Multi-entity save flow', () => {
 				createNewButtonSelector
 			);
 			await createNewButton.click();
+			const confirmTitleButton = await page.waitForSelector(
+				confirmTitleButtonSelector
+			);
+			await confirmTitleButton.click();
+
 			await page.waitForSelector( activatedTemplatePartSelector );
 			await page.click( '.block-editor-button-block-appender' );
 			await page.click( '.editor-block-list-item-paragraph' );

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -276,6 +276,8 @@ describe( 'Template Part', () => {
 			'//button[contains(text(), "New template part")]';
 		const chooseExistingButtonSelector =
 			'//button[contains(text(), "Choose existing")]';
+		const confirmTitleButtonSelector =
+			'.wp-block-template-part__placeholder-create-new__title-form .components-button.is-primary';
 
 		it( 'Should insert new template part on creation', async () => {
 			await createNewPost();
@@ -287,6 +289,10 @@ describe( 'Template Part', () => {
 				createNewButtonSelector
 			);
 			await createNewButton.click();
+			const confirmTitleButton = await page.waitForSelector(
+				confirmTitleButtonSelector
+			);
+			await confirmTitleButton.click();
 
 			const newTemplatePart = await page.waitForSelector(
 				activatedTemplatePartSelector


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Related to discussion on #29950 -  Adds a title step to the creation flow from the Template Part placeholder.  Here we prompt the user with a modal (similar to the "make template part" flow from the block settings ellipsis menu) to change the name of the title from "Untitled Template Part".  If the modal is cancelled, we revert to the placeholder and the template part is not created.

![Screen Shot 2021-07-26 at 2 47 41 PM](https://user-images.githubusercontent.com/28742426/127043576-2263a093-c1ab-44a8-859b-d299bd937820.png)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
With FSE enabled, test the following in both the Site and Post editor:
* Insert a template part block placeholder (Header, Footer, or Template Part).
* Select the "New %s" option.  
* A naming input should appear.
* Cancelling  (or clicking outside) the modal should revert the block back to the placeholder state.
* "Create" should create the new template part with the name that was given in the input field.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
