### PR TITLE
E2E: Navigation wait for links before counting them

### DIFF
--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -343,14 +343,15 @@ describe( 'Navigation', () => {
 
 			await selectDropDownOption( 'Test Menu 2' );
 
-			await page.waitForSelector(
-				'.interface-interface-skeleton__content .wp-block-navigation__container'
-			);
-
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
+			const navLinkSelector =
+				'[aria-label="Editor content"][role="region"] div[aria-label="Block: Custom Link"]';
+
+			await page.waitForSelector( navLinkSelector );
+
 			const navBlockItemsLength = await page.$$eval(
-				'.interface-interface-skeleton__content .wp-block-navigation__container [data-type="core/navigation-link"]',
+				navLinkSelector,
 				( els ) => els.length
 			);
 
@@ -374,7 +375,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the "Editor content" as otherwise it picks up on
 			// Block Style live previews.
 			const navBlockItemsLength = await page.$$eval(
-				'.interface-interface-skeleton__content .wp-block-navigation__container [data-type="core/navigation-link"]',
+				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Link"]',
 				( els ) => els.length
 			);
 

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -343,7 +343,9 @@ describe( 'Navigation', () => {
 
 			await selectDropDownOption( 'Test Menu 2' );
 
-			await page.waitForSelector( '.wp-block-navigation__container' );
+			await page.waitForSelector(
+				'.interface-interface-skeleton__content .wp-block-navigation__container'
+			);
 
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -348,7 +348,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Editor content"][role="region"] div[aria-label="Block: Custom Link"]',
+				'.interface-interface-skeleton__content .wp-block-navigation__container [data-type="core/navigation-link"]',
 				( els ) => els.length
 			);
 
@@ -372,7 +372,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the "Editor content" as otherwise it picks up on
 			// Block Style live previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Link"]',
+				'.interface-interface-skeleton__content .wp-block-navigation__container [data-type="core/navigation-link"]',
 				( els ) => els.length
 			);
 


### PR DESCRIPTION
The Navigation Block Test [sometimes fails](https://github.com/WordPress/gutenberg/runs/3162163042). I'm unable to reproduce the issue locally, but from the failure artifact it looks like this is inserting the menu correctly which means it's either a timing or selector issue.

~~I've tried modifying the selectors in this PR to avoid aria labels (which can depend on i18n locale and copy changes) and also changed a wait selector to target a navigation block inside of editor content. Not sure if this fixes the overall flakiness, but the CI runs were green.~~

I tried @talldan's suggestion to wait for the navigation links before counting them. Looks ✅ in CI so far, but not sure  that this is the cause of flakiness. We can maybe give this a try and see if failures still appear in other runs.

| Failure Screenshot | Where to find the failure artifact |
|-----|-----|
| <img src="https://user-images.githubusercontent.com/1270189/127045650-d0bfb3dd-3a16-4d92-8e2b-990cfdb8ee23.jpg"> | <img width="929" alt="Screen Shot 2021-07-26 at 12 13 54 PM" src="https://user-images.githubusercontent.com/1270189/127045525-05ff1312-c365-4582-b1ca-8b9b3ab0bccf.png"> |





