### PR TITLE
[Mobile] - Global styles: Check for undefined values and merge user colors

### DIFF
--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -124,6 +124,10 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 	let stylesBase = styles;
 	const variables = [ 'preset', 'custom' ];
 
+	if ( ! stylesBase ) {
+		return styles;
+	}
+
 	variables.forEach( ( variable ) => {
 		// Examples
 		// var(--wp--preset--color--gray)
@@ -156,9 +160,10 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 }
 
 export function getMappedValues( features, palette ) {
+	const colors = { ...palette?.theme, ...palette?.user };
 	const mappedValues = {
 		color: {
-			values: palette?.theme,
+			values: colors,
 			slug: 'color',
 		},
 		'font-size': {
@@ -170,7 +175,7 @@ export function getMappedValues( features, palette ) {
 }
 
 export function getGlobalStyles( rawStyles, rawFeatures ) {
-	const features = JSON.parse( rawFeatures );
+	const features = rawFeatures ? JSON.parse( rawFeatures ) : {};
 	const mappedValues = getMappedValues( features, features?.color?.palette );
 	const colors = parseStylesVariables(
 		JSON.stringify( features?.color ),

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -186,7 +186,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 		mappedValues
 	);
 	const customValues = parseStylesVariables(
-		JSON.stringify( features.custom ),
+		JSON.stringify( features?.custom ),
 		mappedValues
 	);
 	const globalStyles = parseStylesVariables(

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -207,7 +207,7 @@ class NativeEditorProvider extends Component {
 
 	getThemeColors( { colors, gradients, rawStyles, rawFeatures } ) {
 		return {
-			...( rawStyles
+			...( rawStyles && rawFeatures
 				? getGlobalStyles( rawStyles, rawFeatures )
 				: {
 						colors: validateThemeColors( colors ),


### PR DESCRIPTION
## Description
While testing the mobile editor an issue was found when one of the Global styles values was undefined, causing it to crash. This PR checks those values before parsing the variables.

## How has this been tested?

### Test case 1 

With a simple site

- Open the WordPress iOS app with metro running
- Open and close the editor a couple of times
- **Expect** the editor to work correctly without crashing

### Test case 2

With a self-hosted site with WordPress 5.8 and Gutenberg 11.1 and a theme.json theme activated

- Open the WordPress iOS app with metro running
- Open the editor
- **Expect** to see the theme colors (background, text)

## Screenshots <!-- if applicable -->

Test case 1|Test case 2
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/127139157-54e02f96-efb4-4975-9c19-076bdad9ccff.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/127139171-9daf9b21-3595-4fc0-a421-320157cffd7b.png" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
