### PR TITLE
Generate sourcemap for production plugin builds

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -111,10 +111,10 @@ php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
 build_files=$(
-	ls build/*/*.{js,css,asset.php} \
+	ls build/*/*.{js,js.map,css,asset.php} \
 	build/block-library/blocks/*.php \
 	build/block-library/blocks/*/block.json \
-	build/block-library/blocks/*/*.{js,css,asset.php} \
+	build/block-library/blocks/*/*.{js,js.map,css,asset.php} \
 	build/edit-widgets/blocks/*/block.json \
 	build/widgets/blocks/*.php \
 	build/widgets/blocks/*/block.json \

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -26,7 +26,6 @@ const baseConfig = {
 		minimizer: [
 			new TerserPlugin( {
 				parallel: true,
-				sourceMap: true,
 				terserOptions: {
 					output: {
 						comments: /translators:/i,

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -14,7 +14,7 @@ const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-we
 
 const {
 	NODE_ENV: mode = 'development',
-	WP_DEVTOOL: devtool = mode === 'production' ? false : 'source-map',
+	WP_DEVTOOL: devtool = 'source-map',
 } = process.env;
 
 const baseConfig = {
@@ -26,6 +26,7 @@ const baseConfig = {
 		minimizer: [
 			new TerserPlugin( {
 				parallel: true,
+				sourceMap: true,
 				terserOptions: {
 					output: {
 						comments: /translators:/i,
@@ -44,7 +45,7 @@ const baseConfig = {
 	mode,
 	module: {
 		rules: compact( [
-			mode !== 'production' && {
+			{
 				test: /\.js$/,
 				use: require.resolve( 'source-map-loader' ),
 				enforce: 'pre',


### PR DESCRIPTION
## Description
We would like source maps in production builds, specifically after the plugin .zip is published. (Our primary goal is to upload source maps to assist with error reporting and debugging.)  I don't think there are any downsides beyond plugin size, since sourcemaps are only loaded when browser devtools are open. Since Gutenberg is OSS, the main argument against (that I could find) of hiding the source doesn't really apply either :)

Closes #15732

Related:
- #23960
- #29658 
- #31732
- #32621

## How has this been tested?

```
cd gutenberg
rm -rf build/
npm run build
find build/ -name "*.map"
# Verify there are map files for each bundle
```

- [ ] Verify sourcemaps are loaded when debugging in a production build
- [ ] Verify sourcemaps are included in the plugin .zip file
- [ ] Test if sourcemaps would now be included when publishing to npm

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
