### PR TITLE
E2E: Block Hierarchy Navigation wait for the column to be highlighted

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -118,11 +118,14 @@ describe( 'Navigating the block hierarchy', () => {
 		// Tweak the columns count by increasing it by one.
 		await page.keyboard.press( 'ArrowRight' );
 
-		// Navigate to the last column in the columns block.
+		// Navigate to the third column in the columns block.
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyTimes( 'Tab', 2 );
 		await pressKeyTimes( 'ArrowDown', 4 );
+		await page.waitForSelector(
+			'.is-highlighted[aria-label="Block: Column (3 of 3)"]'
+		);
 		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( '.is-selected[data-type="core/column"]' );
 


### PR DESCRIPTION
## Description
The "Block Hierarchy Navigation" e2e test [fails](https://github.com/WordPress/gutenberg/runs/3162134316) from time to time. Unfortunately, I'm unable to reproduce this locally.

Based on the screenshot from the artifacts, it looks like block selection happens before navigation reaches the third and last column block.

I'm adding an extra check to verify that the third block is highlighted before selecting it. This should also give keyboard navigation a little spare time to finish.

## How has this been tested?
Locally using the following command:

```
npm run test-e2e -- packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
```

## Screenshots <!-- if applicable -->
![should navigate block hierarchy using only the keyboard](https://user-images.githubusercontent.com/240569/127285118-90c8af20-a50e-4729-927c-6fa68dd7bfc2.jpg)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
