### PR TITLE
Core Data: Deprecate `getAuthors` in favor of `getUsers`

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -49,6 +49,8 @@ _Returns_
 
 ### getAuthors
 
+> **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
+
 Returns all available authors.
 
 _Parameters_

--- a/package-lock.json
+++ b/package-lock.json
@@ -14718,6 +14718,7 @@
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/data-controls": "file:packages/data-controls",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -19,9 +19,17 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 Below is an example of a component which simply renders a list of authors:
 
 ```jsx
-const { withSelect } = wp.data;
+const { useSelect } = wp.data;
 
-function MyAuthorsListBase( { authors } ) {
+function MyAuthorsListBase() {
+	const authors = useSelect( ( select ) => {
+		return select( 'core' ).getUsers( { who: 'authors' } );
+	}, [] );
+
+	if ( ! authors ) {
+		return null;
+	}
+
 	return (
 		<ul>
 			{ authors.map( ( author ) => (
@@ -30,10 +38,6 @@ function MyAuthorsListBase( { authors } ) {
 		</ul>
 	);
 }
-
-const MyAuthorsList = withSelect( ( select ) => ( {
-	authors: select( 'core' ).getAuthors(),
-} ) )( MyAuthorsListBase );
 ```
 
 ## Actions

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -290,6 +290,8 @@ _Returns_
 
 ### getAuthors
 
+> **Deprecated** since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
+
 Returns all available authors.
 
 _Parameters_

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/data": "file:../data",
 		"@wordpress/data-controls": "file:../data-controls",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -51,17 +51,6 @@ export function* getAuthors( query ) {
 }
 
 /**
- * Temporary approach to resolving editor access to author queries.
- *
- * @param {number} id The author id.
- */
-export function* __unstableGetAuthor( id ) {
-	const path = `/wp/v2/users?who=authors&include=${ id }`;
-	const users = yield apiFetch( { path } );
-	yield receiveUserQuery( 'author', users );
-}
-
-/**
  * Requests the current user from the REST API.
  */
 export function* getCurrentUser() {

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -57,8 +57,7 @@ export const isRequestingEmbedPreview = createRegistrySelector(
  */
 export function getAuthors( state, query ) {
 	deprecated( "select( 'core' ).getAuthors()", {
-		since: '11.3',
-		plugin: 'Gutenberg',
+		since: '5.9',
 		alternative: "select( 'core' ).getUsers({ who: 'authors' })",
 	} );
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -9,6 +9,7 @@ import { set, map, find, get, filter, compact } from 'lodash';
  */
 import { createRegistrySelector } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -47,12 +48,20 @@ export const isRequestingEmbedPreview = createRegistrySelector(
 /**
  * Returns all available authors.
  *
+ * @deprecated since 11.3. Callers should use `select( 'core' ).getUsers({ who: 'authors' })` instead.
+ *
  * @param {Object}           state Data state.
  * @param {Object|undefined} query Optional object of query parameters to
  *                                 include with request.
  * @return {Array} Authors list.
  */
 export function getAuthors( state, query ) {
+	deprecated( "select( 'core' ).getAuthors()", {
+		since: '11.3',
+		plugin: 'Gutenberg',
+		alternative: "select( 'core' ).getUsers({ who: 'authors' })",
+	} );
+
 	const path = addQueryArgs(
 		'/wp/v2/users/?who=authors&per_page=100',
 		query

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -70,18 +70,6 @@ export function getAuthors( state, query ) {
 }
 
 /**
- * Returns all available authors.
- *
- * @param {Object} state Data state.
- * @param {number} id    The author id.
- *
- * @return {Array} Authors list.
- */
-export function __unstableGetAuthor( state, id ) {
-	return get( state, [ 'users', 'byId', id ], null );
-}
-
-/**
  * Returns the current user.
  *
  * @param {Object} state Data state.


### PR DESCRIPTION
## Description
Deprecates `getAuthors` in favor of `getUsers` and removes `__unstableGetAuthor` selector.

## How has this been tested?
Running following code should display deprecation message in console:

```js
wp.data.select('core').getAuthors();
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-07-28 at 14 40 19](https://user-images.githubusercontent.com/240569/127309189-4b0bb6d5-d2cb-48ec-9699-1fc1b5e2a46b.png)

## Types of changes
Deprecation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
