### PR TITLE
Avoid double parsing the content when loading the editor

### DIFF
--- a/packages/e2e-tests/plugins/custom-post-types.php
+++ b/packages/e2e-tests/plugins/custom-post-types.php
@@ -39,7 +39,7 @@ function public_queryable_true_public_false_cpt() {
 			'show_in_rest'       => true,
 			'public'             => false,
 			'publicly_queryable' => true,
-			'supports'           => array( 'title', 'editor', 'revisions' ),
+			'supports'           => array( 'excerpt', 'title', 'editor', 'revisions' ),
 			'show_ui'            => true,
 			'show_in_menu'       => true,
 		)
@@ -59,7 +59,7 @@ function public_queryable_false_public_true_cpt() {
 			'show_in_rest'       => true,
 			'public'             => true,
 			'publicly_queryable' => false,
-			'supports'           => array( 'title', 'editor', 'revisions' ),
+			'supports'           => array( 'excerpt', 'title', 'editor', 'revisions' ),
 			'show_ui'            => true,
 			'show_in_menu'       => true,
 		)
@@ -79,7 +79,7 @@ function public_queryable_true_public_true_cpt() {
 			'show_in_rest'       => true,
 			'public'             => true,
 			'publicly_queryable' => true,
-			'supports'           => array( 'title', 'editor', 'revisions' ),
+			'supports'           => array( 'excerpt', 'title', 'editor', 'revisions' ),
 			'show_ui'            => true,
 			'show_in_menu'       => true,
 		)

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -400,7 +400,7 @@ describe( 'Post generator actions', () => {
 
 describe( 'Editor actions', () => {
 	describe( 'setupEditor()', () => {
-		it( 'should yield the setup editor actions but not reset blocks when the template is empty', () => {		
+		it( 'should yield the setup editor actions but not reset blocks when the template is empty', () => {
 			const post = { content: { raw: '' }, status: 'publish' };
 			const fulfillment = actions.setupEditor( post );
 			let { value } = fulfillment.next();

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -400,32 +400,17 @@ describe( 'Post generator actions', () => {
 
 describe( 'Editor actions', () => {
 	describe( 'setupEditor()', () => {
-		const post = { content: { raw: '' }, status: 'publish' };
-
-		let fulfillment;
-		const reset = ( edits, template ) =>
-			( fulfillment = actions.setupEditor( post, edits, template ) );
-		beforeAll( () => {
-			reset();
-		} );
-
-		it( 'should yield action object for resetPost', () => {
-			const { value } = fulfillment.next();
+		it( 'should yield the setup editor actions but not reset blocks when the template is empty', () => {		
+			const post = { content: { raw: '' }, status: 'publish' };
+			const fulfillment = actions.setupEditor( post );
+			let { value } = fulfillment.next();
 			expect( value ).toEqual( actions.resetPost( post ) );
-		} );
-		it( 'should yield the SETUP_EDITOR action', () => {
-			const { value } = fulfillment.next();
+			value = fulfillment.next().value;
 			expect( value ).toEqual( {
 				type: 'SETUP_EDITOR',
 				post: { content: { raw: '' }, status: 'publish' },
 			} );
-		} );
-		it( 'should yield action object for resetEditorBlocks', () => {
-			const { value } = fulfillment.next();
-			expect( Object.keys( value ) ).toEqual( [] );
-		} );
-		it( 'should yield action object for setupEditorState', () => {
-			const { value } = fulfillment.next();
+			value = fulfillment.next().value;
 			expect( value ).toEqual(
 				actions.setupEditorState( {
 					content: { raw: '' },


### PR DESCRIPTION
In the couple last WP releases, we introduced the EntityProvider and the `useEntityBlockEditor` React hook which allows us to retrieve the "blocks" of a given post entity. This hook also makes it easy to create block editors for widgets screens, reusable blocks, templates parts... 

The hook need to transform the "content" of the entity to "blocks" by parsing it on initial render if the blocks are not already parsed.

That said, historically in the post editor, parsing was done in the `setupEditor` action which is called in theory before that hook, the problem though is that the React effect is run before the `useSelect` call subscription triggers after `setupEditor` meaning the `blocks` will always be empty causing a double parsing.

The solution I came with is to avoid the parsing in `setupEditor` unless necessary. Ideally the `setupEditor` action shouldn't be needed at all and its logic moved to the components themselves. In other words, the "editor" should always be "setup"/"ready". This is something we've struggled with for a long time but I think we're making good progress towards that .

Right now, parsing is still done in `setupEditor` when a "template" is provided, that said, this is rare and especially for long posts (where the performance issues happen).

**Notes**

 - I had to change the order of some action calls in the `setupEditor` action. I don't think it's impactful but I know initialization is e2e tests heavily, so let's see the impact here.
 - This should result in a gain of half a second at least for long posts (like the one we test with)