### PR TITLE
Components: fix incorrect style of Guide component on mobile devices

### DIFF
--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -93,11 +93,14 @@
 	max-height: 575px;
 
 	@media (max-width: $break-small) {
+		position: absolute;
 		bottom: 5%;
 		left: $grid-unit-20;
 		right: $grid-unit-20;
 		top: 5%;
 		margin: 0 auto;
+		min-width: 280px;
+		max-width: calc(100vw - #{$grid-unit-20} * 2);
 	}
 }
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -62,11 +62,6 @@
 		padding: 0 $grid-unit-40;
 		position: relative;
 		width: 100%;
-
-		@media (max-width: $break-small) {
-			position: absolute;
-			bottom: 0;
-		}
 	}
 
 	&__page-control {
@@ -92,15 +87,15 @@
 	height: 80vh;
 	max-height: 575px;
 
-	@media (max-width: $break-small) {
-		position: absolute;
-		bottom: 5%;
-		left: $grid-unit-20;
-		right: $grid-unit-20;
-		top: 5%;
-		margin: 0 auto;
+	@media ( max-width: $break-small ) {
+		margin: auto;
 		min-width: 280px;
 		max-width: calc(100vw - #{$grid-unit-20} * 2);
+
+		// This can be avoided if we add styles to let the image resize or don't change the min-width
+		&.components-modal__content {
+			overflow-x: hidden;
+		}
 	}
 }
 

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -89,13 +89,7 @@
 
 	@media ( max-width: $break-small ) {
 		margin: auto;
-		min-width: 280px;
 		max-width: calc(100vw - #{$grid-unit-20} * 2);
-
-		// This can be avoided if we add styles to let the image resize or don't change the min-width
-		&.components-modal__content {
-			overflow-x: hidden;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The Guide UI is broken on mobile devices, so update the styles to fix the problem

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Start storybook
2. Select Guide > default
3. Change the size of the preview to **Small mobile (P)**

## Screenshots <!-- if applicable -->

### Before
<img width="300px" src="https://user-images.githubusercontent.com/13596067/127316273-eacdc3c9-0607-4078-8342-95ace210ffac.png" />

### After
<img width="300px" src="https://user-images.githubusercontent.com/13596067/127316299-4d0cd6d2-1e52-4eaa-a262-3469d2eac675.png" />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
