### PR TITLE
[RNMobile] Use random `postId` in integration tests

### DIFF
--- a/test/native/helpers.js
+++ b/test/native/helpers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { act, render, fireEvent } from '@testing-library/react-native';
+import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies
@@ -35,7 +36,12 @@ provideToNativeHtml.mockImplementation( ( html ) => {
 
 export async function initializeEditor( props ) {
 	const renderResult = render(
-		<Editor postId={ 0 } postType="post" initialTitle="test" { ...props } />
+		<Editor
+			postId={ `post-id-${ uuid() }` }
+			postType="post"
+			initialTitle="test"
+			{ ...props }
+		/>
 	);
 	const { getByTestId } = renderResult;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

We were using the same `postId` value when initializing the editor in the integration tests, due to incoming changes related to the logic of loading the editor (https://github.com/WordPress/gutenberg/pull/33727), now we need to assure that each test uses a unique `postId` value.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Verify that all the tests pass by running the command `npm run native test` or by the CI check.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
