### PR TITLE
Site Editor: Implement a settings object filter

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -101,7 +101,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		)
 	);
-	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = apply_filters( 'block_editor_settings_all', $settings );
 
 	gutenberg_initialize_editor(
 		'edit_site_editor',

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -89,22 +89,17 @@ function gutenberg_edit_site_init( $hook ) {
 	 */
 	$current_screen->is_block_editor( true );
 
-	$settings = array_merge(
-		gutenberg_get_default_block_editor_settings(),
-		array(
-			'siteUrl'                              => site_url(),
-			'postsPerPage'                         => get_option( 'posts_per_page' ),
-			'styles'                               => gutenberg_get_editor_styles(),
-			'defaultTemplateTypes'                 => gutenberg_get_indexed_default_template_types(),
-			'defaultTemplatePartAreas'             => gutenberg_get_allowed_template_part_areas(),
-			'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-			'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
-		)
+	$custom_settings     = array(
+		'siteUrl'                              => site_url(),
+		'postsPerPage'                         => get_option( 'posts_per_page' ),
+		'styles'                               => gutenberg_get_editor_styles(),
+		'defaultTemplateTypes'                 => gutenberg_get_indexed_default_template_types(),
+		'defaultTemplatePartAreas'             => gutenberg_get_allowed_template_part_areas(),
+		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
+		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	);
-
 	$site_editor_context = new WP_Block_Editor_Context();
-	/** This filter is documented in wp-includes/wp-block-editor.php */
-	$settings = apply_filters( 'block_editor_settings_all', $settings, $site_editor_context );
+	$settings            = gutenberg_get_block_editor_settings( $custom_settings, $site_editor_context );
 
 	gutenberg_initialize_editor(
 		'edit_site_editor',

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -101,7 +101,9 @@ function gutenberg_edit_site_init( $hook ) {
 			'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 		)
 	);
-	$settings = apply_filters( 'block_editor_settings_all', $settings );
+
+	$site_editor_context = new WP_Block_Editor_Context();
+	$settings = apply_filters( 'block_editor_settings_all', $settings, $site_editor_context );
 
 	gutenberg_initialize_editor(
 		'edit_site_editor',

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -103,6 +103,7 @@ function gutenberg_edit_site_init( $hook ) {
 	);
 
 	$site_editor_context = new WP_Block_Editor_Context();
+	/** This filter is documented in wp-includes/wp-block-editor.php */
 	$settings = apply_filters( 'block_editor_settings_all', $settings, $site_editor_context );
 
 	gutenberg_initialize_editor(


### PR DESCRIPTION
Potentially solves https://github.com/WordPress/gutenberg/issues/33736

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The **post editor** has the `block_editor_settings_all` and `block_editor_settings` filter that allows us to modify the `settings` object injected into the block editor. A similar filter, however, doesn't exist for the site editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**There should be no visible changes to the UI.**

1. Set up local Gutenberg dev environment
2. Activate a block based theme
3. Navigate to the site editor
4. Smoke test the site editor to ensure that updates still persist correctly, block insertion still functions as expected, etc.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
