### PR TITLE
Example for rest_endpoints filter in PHP

### DIFF
--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -57,6 +57,24 @@ The HTTP request method to use, either 'GET' or 'POST'. It's 'GET' by default. T
 -   Type: `String`
 -   Required: No
 
+#### Example:
+```php
+function add_rest_method( $endpoints ) {
+    if ( is_wp_version_compatible( '5.5' ) ) {
+        return $endpoints;
+    }
+
+    foreach ( $endpoints as $route => $handler ) {
+        if ( isset( $endpoints[ $route ][0] ) ) {
+            $endpoints[ $route ][0]['methods'] = [ WP_REST_Server::READABLE, WP_REST_Server::CREATABLE ];
+        }
+    }
+
+    return $endpoints;
+}
+add_filter( 'rest_endpoints', 'add_rest_method');
+```
+
 ### urlQueryArgs
 
 Query arguments to apply to the request URL.


### PR DESCRIPTION
`httpMethod` is added recently. It can be set to `POST`, which allows bigger attributes object.
However, before WP 5.5 it does not work and gives 404 error. it will be solved with filtered `rest_endpoints` and here is that example.
Thanks to @kienstra, who pointed me out [here](https://github.com/studiopress/genesis-custom-blocks/blob/3670937b8d0a7326c7a4e28413c09e48bae457e4/php/Blocks/Loader.php#L613).