### PR TITLE
Fix justification for button block when selected

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -14,6 +14,10 @@
 		margin: $grid-unit-10 0;
 	}
 
+	// Add a uniform margin around the block.
+	// This can hopefully avoid havoc in flex containers.
+	margin: $grid-unit-10;
+
 	// Black square plus appender.
 	.block-list-appender__toggle {
 		padding: 0;

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -14,11 +14,6 @@
 		margin: $grid-unit-10 0;
 	}
 
-	// Add an explicit left margin of zero and auto right margin to work in horizontal
-	// flex containers. Without it, a "space-between"-like effect from two auto margins
-	// will cause the black plus to sit in the center of what space is left.
-	margin: 0 auto 0 0;
-
 	// Black square plus appender.
 	.block-list-appender__toggle {
 		padding: 0;


### PR DESCRIPTION

## Description

When selecting the button block and applying a justification, the justify doesn't apply until the box is unselected.

What is really happening is when the block is unselected the block appender is removed, and the rules for the block appender is forcing the button all the way to the left so when removed it allows the justification to apply and the block is then centered (or right).

Fixes #33487

## How has this been tested?

1. Confirm bug by adding buttons block and justify center or right, see bug #33487
2. Unselect the block to see justification applied
3. Apply PR fix
4. Repeat and notice justification applies immediately


![button-justify](https://user-images.githubusercontent.com/45363/127409926-b8794df5-faf1-4e01-ae14-e8772e3e3930.gif)


## Types of changes

This PR changes the block appender CSS rules that forced justified content all the way to the left. I did extra testing around but any additional checks are welcome to confirm no unintended consequences with the appender elsewhere.
