### PR TITLE
Template Mode: Remove 'per_page' argument from the template data selector

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -52,9 +52,7 @@ export function TemplatePanel() {
 			select( editorStore ).getEditorSettings().supportsTemplateMode &&
 			_isViewable;
 
-		const wpTemplates = getEntityRecords( 'postType', 'wp_template', {
-			per_page: -1,
-		} );
+		const wpTemplates = getEntityRecords( 'postType', 'wp_template' );
 
 		const newAvailableTemplates = fromPairs(
 			( wpTemplates || [] ).map( ( { slug, title } ) => [


### PR DESCRIPTION
## Description
Removes `per_page` query argument in TemplatesPanel component when fetching WP templates. This argument isn't supported by the `templates` endpoint nor by the `get_block_templates` function.

This also allows reusing data from the store between the `getEditedPostTemplate` and TemplatesPanel component and removes extra API requests.

## Screenshots
| Before  | After |
| ------------- | ------------- |
| ![template-mode-before](https://user-images.githubusercontent.com/240569/127444078-cca5f00b-106d-4ed0-bc62-bbf70ba17d53.png)  | ![template-mode-after](https://user-images.githubusercontent.com/240569/127444070-fdb82e5c-d3c2-45f8-b694-0325f3cb9fab.png)  |

## How has this been tested?
1. Enable TT1 Blocks theme
2. Create a new post.
3. The sidebar should render templates selection.

## Types of changes
Performance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
