### PR TITLE
ESLint Plugin: Include .jsx extenstion when linting import statements

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Include `.jsx` extension when linting import statements in case TypeScript not present ([#33746](https://github.com/WordPress/gutenberg/pull/33746)).
+
 ## 9.1.0 (2021-07-21)
 
 ### Enhancement

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -5,6 +5,9 @@ module.exports = {
 			jsx: true,
 		},
 	},
+	settings: {
+		'import/extensions': [ '.js', '.jsx' ],
+	},
 	plugins: [ '@wordpress', 'react', 'react-hooks' ],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': [

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -16,6 +16,13 @@ module.exports = {
 		document: true,
 		wp: 'readonly',
 	},
+	settings: {
+		'import/resolver': {
+			node: {
+				extensions: [ '.js', '.jsx' ],
+			},
+		},
+	},
 	rules: {
 		'import/no-extraneous-dependencies': [
 			'error',

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -16,13 +16,6 @@ module.exports = {
 		document: true,
 		wp: 'readonly',
 	},
-	settings: {
-		'import/resolver': {
-			node: {
-				extensions: [ '.js', '.jsx' ],
-			},
-		},
-	},
 	rules: {
 		'import/no-extraneous-dependencies': [
 			'error',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #32408.

Reported by @galloppinggryphon:

> When using `@wordpress/eslint-plugin`, ESLint is reporting the following error while trying to resolve `.jsx` files:
> 
> Unable to resolve path to module  './path/jsx-file-sans-extension'. eslint(import/no-unresolved)
> Adding the extension to the import statement makes the file resolve. All `.js` files resolve normally.

A similar setting is present when TypeScript is found in the project:

https://github.com/WordPress/gutenberg/blob/85cfab17de6a23a73a6163472d1c9d85581d86c2/packages/eslint-plugin/configs/recommended.js#L33-L36

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run lint-js` should work as before. 

It also needs to be tested in the 3rd party project that doesn't have TypeScript installed.