### PR TITLE
Improve likelihood of getting rich link previews by modifying UA string for URL Details REST API endpoint

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -191,8 +191,18 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return string|WP_Error The HTTP response from the remote URL, or an error.
 	 */
 	private function get_remote_url( $url ) {
+
+		// Provide a modify UA string to workaround web properties which block WordPress "Pingbacks".
+		// Why? The UA string used for pingback requests contains `WordPress/` which is very similar
+		// to that used as the default UA string by the WP HTTP API. Therefore requests from this
+		// REST endpoint are being unintentionally blocked as they are misidentified as pingback requests.
+		// By slightly modifying the UA string, but still retaining the "WordPress" identification (via "WP")
+		// we are able to work around this issue.
+		$modified_user_agent = 'WP(' . get_bloginfo( 'version' ) . ') ' . get_bloginfo( 'url' ) . ': URL details request.';
+
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,
+			'user-agent'          => $modified_user_agent
 		);
 
 		/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -202,7 +202,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,
-			'user-agent'          => $modified_user_agent
+			'user-agent'          => $modified_user_agent,
 		);
 
 		/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -198,7 +198,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		// REST endpoint are being unintentionally blocked as they are misidentified as pingback requests.
 		// By slightly modifying the UA string, but still retaining the "WordPress" identification (via "WP")
 		// we are able to work around this issue.
-		$modified_user_agent = 'WP(' . get_bloginfo( 'version' ) . ') ' . get_bloginfo( 'url' ) . ': URL details request.';
+		// Example UA string: `WP-URLDetails/5.9-alpha-51389 (+http://localhost:8888)`.
+		$modified_user_agent = 'WP-URLDetails/' . get_bloginfo( 'version' ) . ' (+' . get_bloginfo( 'url' ) . ')';
 
 		$args = array(
 			'limit_response_size' => 150 * KB_IN_BYTES,

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -192,7 +192,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 */
 	private function get_remote_url( $url ) {
 
-		// Provide a modify UA string to workaround web properties which block WordPress "Pingbacks".
+		// Provide a modified UA string to workaround web properties which block WordPress "Pingbacks".
 		// Why? The UA string used for pingback requests contains `WordPress/` which is very similar
 		// to that used as the default UA string by the WP HTTP API. Therefore requests from this
 		// REST endpoint are being unintentionally blocked as they are misidentified as pingback requests.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

As described in https://github.com/WordPress/gutenberg/issues/33722#issuecomment-888341130 the UA string seems to be causing the `url-details` endpoint requests to be rejected by certain prominent web properties such as Google. This appears to be due to the default UA string used by the WP HTTP API being very similar to the UA string used by "Pingback" requests - many people block such requests.

If we change the UA string to something else the failing requests start to work. Therefore we need to use a different UA string from the default provided by the WP HTTP API.

The REST API Core team have advised that we should _not_ be seen to be spoofing the UA string. However, we can _modify_ it as long as it still has something to identify it as "WordPress".

Therefore this PR tweaks the UA string to:

* Use `WP` instead of `WordPress`.
* Includes the feature name in the UA string in order that properties can still easily identify it and block it if they wish to do so.

Closes https://github.com/WordPress/gutenberg/issues/33722

## How has this been tested?

### On trunk

1. New Post.
2. Open browser dev tools `Console`.
3. Type `copy(wpApiSettings.nonce)`.
4. Update the following URL replacing `YOUR_NONCE_HERE` with the value from the previous step.

```
http://localhost:8888/index.php?rest_route=%2F__experimental%2Furl-details&url=http%3A%2F%2Fwww.google.com&_locale=user&_wpnonce=YOUR_NONCE_HERE
```
5. Paste into your browser.
6. See the "404" response.
```
{
code: "no_response",
message: "URL not found. Response returned a non-200 status code for this URL.",
data: {
status: 404
}
}
```

### On this PR branch

1. Repeat the steps above. 
2. This time see the request suceed and rich results returned, eg:

```
{
title: "Google",
icon: "",
description: "",
image: "https://www.google.com/logos/doodles/2021/doodle-champion-island-games-july-29-6753651837109022-2xa.gif"
}
```

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
