### PR TITLE
Force link text to wrap in the Link UI when encountering extra long link text

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -168,7 +168,12 @@ $preview-image-height: 140px;
 		align-items: flex-start;
 		margin-right: $grid-unit-10;
 		overflow: hidden;
-		white-space: nowrap;
+
+		// Force text to wrap to improve UX when encountering long lines
+		// of text, particular those with no spaces.
+		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
+		white-space: pre-wrap;
+		word-wrap: break-word;
 	}
 
 	&.is-preview .block-editor-link-control__search-item-header {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -124,7 +124,7 @@ $preview-image-height: 140px;
 .block-editor-link-control__search-item {
 	position: relative;
 	display: flex;
-	align-items: center;
+	align-items: flex-start; // when link text is very long it is important this indicator remains visible and thus should be aligned top.
 	font-size: $default-font-size;
 	cursor: pointer;
 	background: $white;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Currently in the Link UI, if the link text is particularly long then it is "clipped" and an ellipsis is shown. This is ok, but it does make the UI difficult to use if you are trying to [distinguish between similarly named posts](https://ibb.co/tczM3Y8).

Moreover, if you enter a link which has no spaces and is very long then you encounter the same problem.

This PR resolves this by allowing the UI to wrap the link text. This allow the user to see the full link text whilst avoid any unwanted horizontal overflow.

Closes https://github.com/WordPress/gutenberg/issues/33586


## How has this been tested?
1. Create a few posts with very long titles and publish them.
2. Create a new post and add some text content.
3. Create a link to one of your test posts (the ones with the long titles). 
4. See that the link UI wraps the long text both in edit and in preview mode.
5. Create a very long freeform link with no spaces at all.
6. Check that the link UI wraps the long text both in edit and in preview mode.

## Screenshots <!-- if applicable -->


<img width="880" alt="Screen Shot 2021-07-29 at 11 17 16" src="https://user-images.githubusercontent.com/444434/127484666-6d787d37-8ea8-43d0-a7cd-db6ae01306d8.png">
<img width="580" alt="Screen Shot 2021-07-29 at 11 17 03" src="https://user-images.githubusercontent.com/444434/127484669-21aed897-7026-4183-804d-51d5efa482b6.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
