### PR TITLE
Profiling: just a test to see how much time is spent rendering icons in the global inserter

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -16,7 +16,6 @@ import { ENTER } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import BlockIcon from '../block-icon';
 import { InserterListboxItem } from '../inserter-listbox';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
@@ -132,7 +131,6 @@ function InserterListItem( {
 							className="block-editor-block-types-list__item-icon"
 							style={ itemIconStyle }
 						>
-							<BlockIcon icon={ item.icon } showColors />
 						</span>
 						<span className="block-editor-block-types-list__item-title">
 							{ item.title }


### PR DESCRIPTION
Do not merge. Just a test commit to see how icons influence total inserter open time.


Not a huge difference, but ~20-40ms.
```
┌──────────────────┬──────────────────────────────────────────┬─────────────┐
│     (index)      │ 72c5e12bf6b126e84c61daf2679684bd1f053d23 │    trunk    │
├──────────────────┼──────────────────────────────────────────┼─────────────┤
│       load       │                '7105 ms'                 │ '7111.4 ms' │
│       type       │                '46.12 ms'                │ '46.74 ms'  │
│     minType      │                '37.89 ms'                │ '37.34 ms'  │
│     maxType      │                '82.58 ms'                │ '88.64 ms'  │
│      focus       │                '93.23 ms'                │ '106.78 ms' │
│     minFocus     │                '61.38 ms'                │ '69.44 ms'  │
│     maxFocus     │               '151.12 ms'                │ '348.66 ms' │
│   inserterOpen   │                '308.4 ms'                │ '327.65 ms' │
│ minInserterOpen  │               '237.66 ms'                │ '253.67 ms' │
│ maxInserterOpen  │               '708.44 ms'                │ '748.57 ms' │
│  inserterHover   │                '29.77 ms'                │ '31.69 ms'  │
│ minInserterHover │                '23.32 ms'                │ '22.54 ms'  │
│ maxInserterHover │                '47.26 ms'                │ '56.26 ms'  │
└──────────────────┴──────────────────────────────────────────┴─────────────┘
```