### PR TITLE
Add: Site editor template mosaic view

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -225,6 +225,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template->title          = $template_file['slug'];
 	$template->status         = 'publish';
 	$template->has_theme_file = true;
+	$template->author         = null;
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];
@@ -272,6 +273,7 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->title          = $post->post_title;
 	$template->status         = $post->post_status;
 	$template->has_theme_file = $has_theme_file;
+	$template->author         = intval( $post->post_author );
 
 	if ( 'wp_template_part' === $post->post_type ) {
 		$type_terms = get_the_terms( $post, 'wp_template_part_area' );

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -408,6 +408,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
 			'has_theme_file' => $template->has_theme_file,
+			'author'         => $template->author,
 		);
 
 		if ( 'wp_template_part' === $template->type ) {
@@ -564,6 +565,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 				'has_theme_file' => array(
 					'description' => __( 'Theme file exists.', 'gutenberg' ),
 					'type'        => 'bool',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'author' => array(
+					'description' => __( 'Template author', 'gutenberg' ),
+					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -568,7 +568,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'author' => array(
+				'author'         => array(
 					'description' => __( 'Template author', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -87,4 +87,11 @@ class WP_Block_Template {
 	 * @var boolean
 	 */
 	public $has_theme_file;
+
+	/**
+	 * Template author.
+	 *
+	 * @var integer|null
+	 */
+	public $author;
 }

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -16,6 +16,7 @@ import BlockEditorProvider from '../provider';
 import LiveBlockPreview from './live';
 import AutoHeightBlockPreview from './auto';
 import { store as blockEditorStore } from '../../store';
+import { BlockContextProvider } from '../block-context';
 
 export function BlockPreview( {
 	blocks,
@@ -23,6 +24,7 @@ export function BlockPreview( {
 	viewportWidth = 1200,
 	__experimentalLive = false,
 	__experimentalOnClick,
+	context,
 } ) {
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -38,16 +40,18 @@ export function BlockPreview( {
 		return null;
 	}
 	return (
-		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
-			{ __experimentalLive ? (
-				<LiveBlockPreview onClick={ __experimentalOnClick } />
-			) : (
-				<AutoHeightBlockPreview
-					viewportWidth={ viewportWidth }
-					__experimentalPadding={ __experimentalPadding }
-				/>
-			) }
-		</BlockEditorProvider>
+		<BlockContextProvider value={ context }>
+			<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
+				{ __experimentalLive ? (
+					<LiveBlockPreview onClick={ __experimentalOnClick } />
+				) : (
+					<AutoHeightBlockPreview
+						viewportWidth={ viewportWidth }
+						__experimentalPadding={ __experimentalPadding }
+					/>
+				) }
+			</BlockEditorProvider>
+		</BlockContextProvider>
 	);
 }
 

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -16,7 +16,6 @@ import BlockEditorProvider from '../provider';
 import LiveBlockPreview from './live';
 import AutoHeightBlockPreview from './auto';
 import { store as blockEditorStore } from '../../store';
-import { BlockContextProvider } from '../block-context';
 
 export function BlockPreview( {
 	blocks,
@@ -24,7 +23,6 @@ export function BlockPreview( {
 	viewportWidth = 1200,
 	__experimentalLive = false,
 	__experimentalOnClick,
-	context,
 } ) {
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -40,18 +38,16 @@ export function BlockPreview( {
 		return null;
 	}
 	return (
-		<BlockContextProvider value={ context }>
-			<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
-				{ __experimentalLive ? (
-					<LiveBlockPreview onClick={ __experimentalOnClick } />
-				) : (
-					<AutoHeightBlockPreview
-						viewportWidth={ viewportWidth }
-						__experimentalPadding={ __experimentalPadding }
-					/>
-				) }
-			</BlockEditorProvider>
-		</BlockContextProvider>
+		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
+			{ __experimentalLive ? (
+				<LiveBlockPreview onClick={ __experimentalOnClick } />
+			) : (
+				<AutoHeightBlockPreview
+					viewportWidth={ viewportWidth }
+					__experimentalPadding={ __experimentalPadding }
+				/>
+			) }
+		</BlockEditorProvider>
 	);
 }
 

--- a/packages/edit-site/src/components/block-editor/block-editor-provider.js
+++ b/packages/edit-site/src/components/block-editor/block-editor-provider.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEntityBlockEditor } from '@wordpress/core-data';
+import { BlockEditorProvider } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function SiteEditorBlockEditorProvider( {
+	setIsInserterOpen,
+	children,
+} ) {
+	const { settings, templateType } = useSelect(
+		( select ) => {
+			const { getSettings, getEditedPostType } = select( editSiteStore );
+			return {
+				settings: getSettings( setIsInserterOpen ),
+				templateType: getEditedPostType(),
+			};
+		},
+		[ setIsInserterOpen ]
+	);
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		templateType
+	);
+	return (
+		<BlockEditorProvider
+			settings={ settings }
+			value={ blocks }
+			onInput={ onInput }
+			onChange={ onChange }
+			useSubRegistry={ false }
+		>
+			{ children }
+		</BlockEditorProvider>
+	);
+}

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -3,9 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
-import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
-	BlockEditorProvider,
 	__experimentalLinkControl,
 	BlockInspector,
 	BlockList,
@@ -35,26 +33,20 @@ const LAYOUT = {
 };
 
 export default function BlockEditor( { setIsInserterOpen } ) {
-	const { settings, templateType, page, deviceType } = useSelect(
+	const { styles, page, deviceType } = useSelect(
 		( select ) => {
 			const {
 				getSettings,
-				getEditedPostType,
 				getPage,
 				__experimentalGetPreviewDeviceType,
 			} = select( editSiteStore );
 			return {
-				settings: getSettings( setIsInserterOpen ),
-				templateType: getEditedPostType(),
+				styles: getSettings().styles,
 				page: getPage(),
 				deviceType: __experimentalGetPreviewDeviceType(),
 			};
 		},
 		[ setIsInserterOpen ]
-	);
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'postType',
-		templateType
 	);
 	const { setPage } = useDispatch( editSiteStore );
 	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
@@ -63,13 +55,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
 
 	return (
-		<BlockEditorProvider
-			settings={ settings }
-			value={ blocks }
-			onInput={ onInput }
-			onChange={ onChange }
-			useSubRegistry={ false }
-		>
+		<>
 			<TemplatePartConverter />
 			<__experimentalLinkControl.ViewerFill>
 				{ useCallback(
@@ -92,7 +78,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			>
 				<Iframe
 					style={ resizedCanvasStyles }
-					head={ <EditorStyles styles={ settings.styles } /> }
+					head={ <EditorStyles styles={ styles } /> }
 					ref={ ref }
 					contentRef={ mergedRefs }
 					name="editor-canvas"
@@ -108,6 +94,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					) }
 				</__unstableBlockSettingsMenuFirstItem>
 			</BlockTools>
-		</BlockEditorProvider>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -188,8 +188,6 @@ function Editor( { initialSettings, onError } ) {
 	return (
 		<>
 			<URLQueryController />
-			<FullscreenMode isActive />
-			<UnsavedChangesWarning />
 			<SlotFillProvider>
 				<EntityProvider kind="root" type="site">
 					<EntityProvider

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -10,11 +10,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
-import {
-	BlockContextProvider,
-	BlockBreadcrumb,
-	__unstableEditorStyles as EditorStyles,
-} from '@wordpress/block-editor';
+import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
 import {
 	FullscreenMode,
 	InterfaceSkeleton,
@@ -37,6 +33,7 @@ import { PluginArea } from '@wordpress/plugins';
 import Header from '../header';
 import { SidebarComplementaryAreaFills } from '../sidebar';
 import BlockEditor from '../block-editor';
+import SiteEditorBlockEditorProvider from '../block-editor/block-editor-provider';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import GlobalStylesProvider from './global-styles-provider';
 import NavigationSidebar from '../navigation-sidebar';
@@ -208,101 +205,99 @@ function Editor( { initialSettings, onError } ) {
 										settings.__experimentalGlobalStylesBaseStyles
 									}
 								>
-									{
-										// Template previews need the editor styles to be available.
-										<EditorStyles
-											styles={ settings.styles }
-										/>
-									}
-									<ErrorBoundary onError={ onError }>
-										<FullscreenMode isActive />
-										<UnsavedChangesWarning />
-										<KeyboardShortcuts.Register />
-										<SidebarComplementaryAreaFills />
-										<InterfaceSkeleton
-											labels={ interfaceLabels }
-											drawer={ <NavigationSidebar /> }
-											secondarySidebar={ secondarySidebar() }
-											sidebar={
-												sidebarIsOpened && (
-													<ComplementaryArea.Slot scope="core/edit-site" />
-												)
-											}
-											header={
-												<Header
-													openEntitiesSavedStates={
-														openEntitiesSavedStates
-													}
-												/>
-											}
-											notices={ <EditorSnackbars /> }
-											content={
-												<>
-													<EditorNotices />
-													{ editorMode === 'visual' &&
-														template && (
-															<BlockEditor
-																setIsInserterOpen={
-																	setIsInserterOpened
+									<SiteEditorBlockEditorProvider
+										setIsInserterOpen={
+											setIsInserterOpened
+										}
+									>
+										<ErrorBoundary onError={ onError }>
+											<FullscreenMode isActive />
+											<UnsavedChangesWarning />
+											<KeyboardShortcuts.Register />
+											<SidebarComplementaryAreaFills />
+											<InterfaceSkeleton
+												labels={ interfaceLabels }
+												drawer={ <NavigationSidebar /> }
+												secondarySidebar={ secondarySidebar() }
+												sidebar={
+													sidebarIsOpened && (
+														<ComplementaryArea.Slot scope="core/edit-site" />
+													)
+												}
+												header={
+													<Header
+														openEntitiesSavedStates={
+															openEntitiesSavedStates
+														}
+													/>
+												}
+												notices={ <EditorSnackbars /> }
+												content={
+													<>
+														<EditorNotices />
+														{ editorMode ===
+															'visual' &&
+															template && (
+																<BlockEditor />
+															) }
+														{ editorMode ===
+															'visual' &&
+															templateResolved &&
+															! template &&
+															settings?.siteUrl &&
+															entityId && (
+																<Notice
+																	status="warning"
+																	isDismissible={
+																		false
+																	}
+																>
+																	{ __(
+																		"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+																	) }
+																</Notice>
+															) }
+														{ editorMode ===
+															'mosaic' && (
+															<MosaicView />
+														) }
+														<KeyboardShortcuts />
+													</>
+												}
+												actions={
+													<>
+														{ isEntitiesSavedStatesOpen ? (
+															<EntitiesSavedStates
+																close={
+																	closeEntitiesSavedStates
 																}
 															/>
+														) : (
+															<div className="edit-site-editor__toggle-save-panel">
+																<Button
+																	variant="secondary"
+																	className="edit-site-editor__toggle-save-panel-button"
+																	onClick={
+																		openEntitiesSavedStates
+																	}
+																	aria-expanded={
+																		false
+																	}
+																>
+																	{ __(
+																		'Open save panel'
+																	) }
+																</Button>
+															</div>
 														) }
-													{ editorMode === 'visual' &&
-														templateResolved &&
-														! template &&
-														settings?.siteUrl &&
-														entityId && (
-															<Notice
-																status="warning"
-																isDismissible={
-																	false
-																}
-															>
-																{ __(
-																	"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-																) }
-															</Notice>
-														) }
-													{ editorMode ===
-														'mosaic' && (
-														<MosaicView />
-													) }
-													<KeyboardShortcuts />
-												</>
-											}
-											actions={
-												<>
-													{ isEntitiesSavedStatesOpen ? (
-														<EntitiesSavedStates
-															close={
-																closeEntitiesSavedStates
-															}
-														/>
-													) : (
-														<div className="edit-site-editor__toggle-save-panel">
-															<Button
-																variant="secondary"
-																className="edit-site-editor__toggle-save-panel-button"
-																onClick={
-																	openEntitiesSavedStates
-																}
-																aria-expanded={
-																	false
-																}
-															>
-																{ __(
-																	'Open save panel'
-																) }
-															</Button>
-														</div>
-													) }
-												</>
-											}
-											footer={ <BlockBreadcrumb /> }
-										/>
-										<Popover.Slot />
-										<PluginArea />
-									</ErrorBoundary>
+													</>
+												}
+												footer={ <BlockBreadcrumb /> }
+											/>
+											<Popover.Slot />
+											<PluginArea />
+										</ErrorBoundary>
+									</SiteEditorBlockEditorProvider>
 								</GlobalStylesProvider>
 							</BlockContextProvider>
 						</EntityProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -10,7 +10,11 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
-import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
+import {
+	BlockContextProvider,
+	BlockBreadcrumb,
+	__unstableEditorStyles as EditorStyles,
+} from '@wordpress/block-editor';
 import {
 	FullscreenMode,
 	InterfaceSkeleton,
@@ -39,6 +43,7 @@ import NavigationSidebar from '../navigation-sidebar';
 import URLQueryController from '../url-query-controller';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
+import ErrorBoundary from '../error-boundary';
 import { store as editSiteStore } from '../../store';
 import MosaicView from '../mosaic-view';
 
@@ -47,7 +52,7 @@ const interfaceLabels = {
 	drawer: __( 'Navigation Sidebar' ),
 };
 
-function Editor( { initialSettings } ) {
+function Editor( { initialSettings, onError } ) {
 	const {
 		isInserterOpen,
 		isListViewOpen,
@@ -205,90 +210,101 @@ function Editor( { initialSettings } ) {
 										settings.__experimentalGlobalStylesBaseStyles
 									}
 								>
-									<KeyboardShortcuts.Register />
-									<SidebarComplementaryAreaFills />
-									<InterfaceSkeleton
-										labels={ interfaceLabels }
-										drawer={ <NavigationSidebar /> }
-										secondarySidebar={ secondarySidebar() }
-										sidebar={
-											sidebarIsOpened && (
-												<ComplementaryArea.Slot scope="core/edit-site" />
-											)
-										}
-										header={
-											<Header
-												openEntitiesSavedStates={
-													openEntitiesSavedStates
-												}
-											/>
-										}
-										notices={ <EditorSnackbars /> }
-										content={
-											<>
-												<EditorNotices />
-												{ editorMode === 'visual' &&
-													template && (
-														<BlockEditor
-															setIsInserterOpen={
-																setIsInserterOpened
+									{
+										// Template previews need the editor styles to be available.
+										<EditorStyles
+											styles={ settings.styles }
+										/>
+									}
+									<ErrorBoundary onError={ onError }>
+										<FullscreenMode isActive />
+										<UnsavedChangesWarning />
+										<KeyboardShortcuts.Register />
+										<SidebarComplementaryAreaFills />
+										<InterfaceSkeleton
+											labels={ interfaceLabels }
+											drawer={ <NavigationSidebar /> }
+											secondarySidebar={ secondarySidebar() }
+											sidebar={
+												sidebarIsOpened && (
+													<ComplementaryArea.Slot scope="core/edit-site" />
+												)
+											}
+											header={
+												<Header
+													openEntitiesSavedStates={
+														openEntitiesSavedStates
+													}
+												/>
+											}
+											notices={ <EditorSnackbars /> }
+											content={
+												<>
+													<EditorNotices />
+													{ editorMode === 'visual' &&
+														template && (
+															<BlockEditor
+																setIsInserterOpen={
+																	setIsInserterOpened
+																}
+															/>
+														) }
+													{ editorMode === 'visual' &&
+														templateResolved &&
+														! template &&
+														settings?.siteUrl &&
+														entityId && (
+															<Notice
+																status="warning"
+																isDismissible={
+																	false
+																}
+															>
+																{ __(
+																	"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+																) }
+															</Notice>
+														) }
+													{ editorMode ===
+														'mosaic' && (
+														<MosaicView />
+													) }
+													<KeyboardShortcuts />
+												</>
+											}
+											actions={
+												<>
+													{ isEntitiesSavedStatesOpen ? (
+														<EntitiesSavedStates
+															close={
+																closeEntitiesSavedStates
 															}
 														/>
+													) : (
+														<div className="edit-site-editor__toggle-save-panel">
+															<Button
+																variant="secondary"
+																className="edit-site-editor__toggle-save-panel-button"
+																onClick={
+																	openEntitiesSavedStates
+																}
+																aria-expanded={
+																	false
+																}
+															>
+																{ __(
+																	'Open save panel'
+																) }
+															</Button>
+														</div>
 													) }
-												{ editorMode === 'visual' &&
-													templateResolved &&
-													! template &&
-													settings?.siteUrl &&
-													entityId && (
-														<Notice
-															status="warning"
-															isDismissible={
-																false
-															}
-														>
-															{ __(
-																"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-															) }
-														</Notice>
-													) }
-												{ editorMode === 'mosaic' && (
-													<MosaicView />
-												) }
-												<KeyboardShortcuts />
-											</>
-										}
-										actions={
-											<>
-												{ isEntitiesSavedStatesOpen ? (
-													<EntitiesSavedStates
-														close={
-															closeEntitiesSavedStates
-														}
-													/>
-												) : (
-													<div className="edit-site-editor__toggle-save-panel">
-														<Button
-															variant="secondary"
-															className="edit-site-editor__toggle-save-panel-button"
-															onClick={
-																openEntitiesSavedStates
-															}
-															aria-expanded={
-																false
-															}
-														>
-															{ __(
-																'Open save panel'
-															) }
-														</Button>
-													</div>
-												) }
-											</>
-										}
-										footer={ <BlockBreadcrumb /> }
-									/>
-									<Popover.Slot />
-									<PluginArea />
+												</>
+											}
+											footer={ <BlockBreadcrumb /> }
+										/>
+										<Popover.Slot />
+										<PluginArea />
+									</ErrorBoundary>
 								</GlobalStylesProvider>
 							</BlockContextProvider>
 						</EntityProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -39,15 +39,15 @@ import NavigationSidebar from '../navigation-sidebar';
 import URLQueryController from '../url-query-controller';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
-import ErrorBoundary from '../error-boundary';
 import { store as editSiteStore } from '../../store';
+import MosaicView from '../mosaic-view';
 
 const interfaceLabels = {
 	secondarySidebar: __( 'Block Library' ),
 	drawer: __( 'Navigation Sidebar' ),
 };
 
-function Editor( { initialSettings, onError } ) {
+function Editor( { initialSettings } ) {
 	const {
 		isInserterOpen,
 		isListViewOpen,
@@ -59,6 +59,7 @@ function Editor( { initialSettings, onError } ) {
 		template,
 		templateResolved,
 		isNavigationOpen,
+		editorMode,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -68,6 +69,7 @@ function Editor( { initialSettings, onError } ) {
 			getEditedPostId,
 			getPage,
 			isNavigationOpened,
+			getEditorMode,
 		} = select( editSiteStore );
 		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
 		const postType = getEditedPostType();
@@ -95,6 +97,7 @@ function Editor( { initialSettings, onError } ) {
 				: false,
 			entityId: postId,
 			isNavigationOpen: isNavigationOpened(),
+			editorMode: getEditorMode(),
 		};
 	}, [] );
 	const { updateEditorSettings } = useDispatch( editorStore );
@@ -180,6 +183,8 @@ function Editor( { initialSettings, onError } ) {
 	return (
 		<>
 			<URLQueryController />
+			<FullscreenMode isActive />
+			<UnsavedChangesWarning />
 			<SlotFillProvider>
 				<EntityProvider kind="root" type="site">
 					<EntityProvider
@@ -200,89 +205,90 @@ function Editor( { initialSettings, onError } ) {
 										settings.__experimentalGlobalStylesBaseStyles
 									}
 								>
-									<ErrorBoundary onError={ onError }>
-										<FullscreenMode isActive />
-										<UnsavedChangesWarning />
-										<KeyboardShortcuts.Register />
-										<SidebarComplementaryAreaFills />
-										<InterfaceSkeleton
-											labels={ interfaceLabels }
-											drawer={ <NavigationSidebar /> }
-											secondarySidebar={ secondarySidebar() }
-											sidebar={
-												sidebarIsOpened && (
-													<ComplementaryArea.Slot scope="core/edit-site" />
-												)
-											}
-											header={
-												<Header
-													openEntitiesSavedStates={
-														openEntitiesSavedStates
-													}
-												/>
-											}
-											notices={ <EditorSnackbars /> }
-											content={
-												<>
-													<EditorNotices />
-													{ template && (
+									<KeyboardShortcuts.Register />
+									<SidebarComplementaryAreaFills />
+									<InterfaceSkeleton
+										labels={ interfaceLabels }
+										drawer={ <NavigationSidebar /> }
+										secondarySidebar={ secondarySidebar() }
+										sidebar={
+											sidebarIsOpened && (
+												<ComplementaryArea.Slot scope="core/edit-site" />
+											)
+										}
+										header={
+											<Header
+												openEntitiesSavedStates={
+													openEntitiesSavedStates
+												}
+											/>
+										}
+										notices={ <EditorSnackbars /> }
+										content={
+											<>
+												<EditorNotices />
+												{ editorMode === 'visual' &&
+													template && (
 														<BlockEditor
 															setIsInserterOpen={
 																setIsInserterOpened
 															}
 														/>
 													) }
-													{ templateResolved &&
-														! template &&
-														settings?.siteUrl &&
-														entityId && (
-															<Notice
-																status="warning"
-																isDismissible={
-																	false
-																}
-															>
-																{ __(
-																	"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-																) }
-															</Notice>
-														) }
-													<KeyboardShortcuts />
-												</>
-											}
-											actions={
-												<>
-													{ isEntitiesSavedStatesOpen ? (
-														<EntitiesSavedStates
-															close={
-																closeEntitiesSavedStates
+												{ editorMode === 'visual' &&
+													templateResolved &&
+													! template &&
+													settings?.siteUrl &&
+													entityId && (
+														<Notice
+															status="warning"
+															isDismissible={
+																false
 															}
-														/>
-													) : (
-														<div className="edit-site-editor__toggle-save-panel">
-															<Button
-																variant="secondary"
-																className="edit-site-editor__toggle-save-panel-button"
-																onClick={
-																	openEntitiesSavedStates
-																}
-																aria-expanded={
-																	false
-																}
-															>
-																{ __(
-																	'Open save panel'
-																) }
-															</Button>
-														</div>
+														>
+															{ __(
+																"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+															) }
+														</Notice>
 													) }
-												</>
-											}
-											footer={ <BlockBreadcrumb /> }
-										/>
-										<Popover.Slot />
-										<PluginArea />
-									</ErrorBoundary>
+												{ editorMode === 'mosaic' && (
+													<MosaicView />
+												) }
+												<KeyboardShortcuts />
+											</>
+										}
+										actions={
+											<>
+												{ isEntitiesSavedStatesOpen ? (
+													<EntitiesSavedStates
+														close={
+															closeEntitiesSavedStates
+														}
+													/>
+												) : (
+													<div className="edit-site-editor__toggle-save-panel">
+														<Button
+															variant="secondary"
+															className="edit-site-editor__toggle-save-panel-button"
+															onClick={
+																openEntitiesSavedStates
+															}
+															aria-expanded={
+																false
+															}
+														>
+															{ __(
+																'Open save panel'
+															) }
+														</Button>
+													</div>
+												) }
+											</>
+										}
+										footer={ <BlockBreadcrumb /> }
+									/>
+									<Popover.Slot />
+									<PluginArea />
 								</GlobalStylesProvider>
 							</BlockContextProvider>
 						</EntityProvider>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -16,7 +16,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { _x, __, _n, sprintf } from '@wordpress/i18n';
-import { listView, plus } from '@wordpress/icons';
+import { listView, plus, closeSmall } from '@wordpress/icons';
 import { Button, Slot } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as editorStore } from '@wordpress/editor';
@@ -99,6 +99,7 @@ export default function Header( {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 		setIsInserterOpened,
 		setIsListViewOpened,
+		switchEditorMode,
 	} = useDispatch( editSiteStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -224,33 +225,41 @@ export default function Header( {
 					) }
 					{ editorMode === 'mosaic' &&
 						selectedTemplates.length === 0 && (
-							<Slot name="PinnedItems/core/edit-site">
-								{ ( fills ) => {
-									const globalStylesFill =
-										fills &&
-										fills.find &&
-										fills.find( ( element ) => {
-											if ( ! element ) {
-												return false;
-											}
-											const firstElement = first(
-												element
-											);
-											if ( ! firstElement ) {
-												return false;
-											}
-											return (
-												firstElement.props &&
-												firstElement.props
-													.identifier ===
-													'edit-site/global-styles'
-											);
-										} );
-									return globalStylesFill
-										? globalStylesFill
-										: null;
-								} }
-							</Slot>
+							<>
+								<Slot name="PinnedItems/core/edit-site">
+									{ ( fills ) => {
+										const globalStylesFill =
+											fills &&
+											fills.find &&
+											fills.find( ( element ) => {
+												if ( ! element ) {
+													return false;
+												}
+												const firstElement = first(
+													element
+												);
+												if ( ! firstElement ) {
+													return false;
+												}
+												return (
+													firstElement.props &&
+													firstElement.props
+														.identifier ===
+														'edit-site/global-styles'
+												);
+											} );
+										return globalStylesFill
+											? globalStylesFill
+											: null;
+									} }
+								</Slot>
+								<Button
+									icon={ closeSmall }
+									onClick={ () => {
+										switchEditorMode( 'visual' );
+									} }
+								/>
+							</>
 						) }
 					{ editorMode === 'mosaic' &&
 						selectedTemplates.length > 0 && (

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -37,7 +37,7 @@ $header-toolbar-min-width: 335px;
 	}
 	&.is-selecting-templates {
 		background-color: #1e1e1e;
-		color: $white
+		color: $white;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -35,6 +35,10 @@ $header-toolbar-min-width: 335px;
 	.edit-site-header_end {
 		justify-content: flex-end;
 	}
+	&.is-selecting-templates {
+		background-color: #1e1e1e;
+		color: $white
+	}
 }
 
 // Keeps the document title centered when the sidebar is open

--- a/packages/edit-site/src/components/mosaic-view/batch-delete-button.js
+++ b/packages/edit-site/src/components/mosaic-view/batch-delete-button.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { trash } from '@wordpress/icons';
+import { __, _n } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useSelect, useDispatch, select as storeSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function MosaicViewBatchDeleteButton() {
+	const { selectedTemplates } = useSelect( ( select ) => {
+		const { getSelectedTemplates } = select( editSiteStore );
+		return {
+			selectedTemplates: getSelectedTemplates(),
+		};
+	} );
+	const { revertTemplate, toggleSelectedTemplate } = useDispatch(
+		editSiteStore
+	);
+	const { deleteEntityRecord } = useDispatch( coreStore );
+	return (
+		<Button
+			onClick={ () => {
+				if (
+					// eslint-disable-next-line no-alert
+					window.confirm(
+						_n(
+							'Are you sure you want to delete or clear the customizations from the selected templates?',
+							'Are you sure you want to delete or clear the customizations from the selected template?',
+							selectedTemplates.length
+						)
+					)
+				) {
+					for ( const templateId of selectedTemplates ) {
+						const template = storeSelect(
+							coreStore
+						).getEntityRecord(
+							'postType',
+							'wp_template',
+							templateId
+						);
+						if ( template.has_theme_file ) {
+							revertTemplate( template );
+						} else {
+							deleteEntityRecord(
+								'postType',
+								'wp_template',
+								templateId
+							);
+						}
+						toggleSelectedTemplate( templateId );
+					}
+				}
+			} }
+			isDestructive
+			icon={ trash }
+			label={ __(
+				'Delete and remove customizations from selected templates'
+			) }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -1,37 +1,97 @@
 /**
  * WordPress dependencies
  */
- import { useSelect } from '@wordpress/data';
- import { store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+import {
+	CheckboxControl,
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+	__unstableCompositeItem as CompositeItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import TemplatePreview from './template-preview';
+import TemplateActions from './template-actions';
+import { store as editSiteStore } from '../../store';
+
+function TemplateContainer( { template, composite } ) {
+	const {
+		setTemplate,
+		setIsNavigationPanelOpened,
+		switchEditorMode,
+	} = useDispatch( editSiteStore );
+
+	const onActivateItem = () => {
+		setTemplate( template.id, template.slug );
+		setIsNavigationPanelOpened( false );
+		switchEditorMode( 'visual' );
+	};
+	const actionsPossible = ! template.has_theme_file || template.wp_id;
+	return (
+		<CompositeItem
+			{ ...composite }
+			as="div"
+			role="option"
+			className="edit-site-mosaic-view__mosaic-item"
+			tabIndex="0"
+			onKeyDown={ ( event ) => {
+				if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+					event.preventDefault();
+					onActivateItem();
+				}
+			} }
+		>
+			<TemplatePreview
+				className="edit-site-mosaic-view__template-preview"
+				templateId={ template.id }
+				onClick={ onActivateItem }
+			/>
+			<CheckboxControl
+				disabled={ ! actionsPossible }
+				label={ template.title.rendered }
+				help={ template.description }
+			/>
+			{ actionsPossible && (
+				<div>
+					<TemplateActions template={ template } />
+				</div>
+			) }
+		</CompositeItem>
+	);
+}
 
 export default function MosaicView() {
+	const composite = useCompositeState();
 	const { templates } = useSelect( ( select ) => {
-		const { getEntityRecords, getEditedEntityRecord } = select( coreStore );
+		const { getEntityRecords } = select( coreStore );
 		return {
 			templates: getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
-			} )
+			} ),
 		};
 	}, [] );
 	if ( ! templates ) {
 		return null;
 	}
 	return (
-		<div className="edit-site-mosaic-view">
-			{
-				templates.map( ( template ) => {
-					return (
-						<div className="edit-site-mosaic-view__mosaic-item">
-							<TemplatePreview key={ template.id } templateId={ template.id } />
-						</div>
-					);
-				} )
-			}
-		</div>
+		<Composite
+			{ ...composite }
+			className="edit-site-mosaic-view"
+			role="listbox"
+			aria-label={ __( 'Templates list' ) }
+		>
+			{ templates.map( ( template ) => (
+				<TemplateContainer
+					key={ template.id }
+					template={ template }
+					composite={ composite }
+				/>
+			) ) }
+		</Composite>
 	);
 }

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -19,19 +19,39 @@ import TemplatePreview from './template-preview';
 import TemplateActions from './template-actions';
 import { store as editSiteStore } from '../../store';
 
-function TemplateContainer( { template, composite } ) {
+function TemplateContainer( { templateId, composite } ) {
+	const { setTemplate, setIsNavigationPanelOpened } = useDispatch(
+		editSiteStore
+	);
 	const {
-		setTemplate,
-		setIsNavigationPanelOpened,
-		switchEditorMode,
-	} = useDispatch( editSiteStore );
-
+		hasThemeFile,
+		templateAuthor,
+		templateDescription,
+		templateSlug,
+		templateSource,
+		templateTitle,
+	} = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( coreStore );
+			const template = templateId
+				? getEditedEntityRecord( 'postType', 'wp_template', templateId )
+				: {};
+			console.log({ template });
+			return {
+				hasThemeFile: template.has_theme_file,
+				templateAuthor: template.author,
+				templateDescription: template.description,
+				templateSlug: template.slug,
+				templateSource: template.source,
+				templateTitle: template.title,
+			};
+		},
+		[ templateId ]
+	);
 	const onActivateItem = () => {
-		setTemplate( template.id, template.slug );
+		setTemplate( templateId, templateSlug );
 		setIsNavigationPanelOpened( false );
-		switchEditorMode( 'visual' );
 	};
-	const actionsPossible = ! template.has_theme_file || template.wp_id;
 	return (
 		<CompositeItem
 			{ ...composite }
@@ -48,17 +68,22 @@ function TemplateContainer( { template, composite } ) {
 		>
 			<TemplatePreview
 				className="edit-site-mosaic-view__template-preview"
-				templateId={ template.id }
+				templateId={ templateId }
 				onClick={ onActivateItem }
 			/>
 			<CheckboxControl
-				disabled={ ! actionsPossible }
-				label={ template.title.rendered }
-				help={ template.description }
+				disabled={ templateSource !== 'custom' }
+				label={ templateTitle }
+				help={ templateDescription }
 			/>
-			{ actionsPossible && (
+			{ templateSource === 'custom' && (
 				<div>
-					<TemplateActions template={ template } />
+					<TemplateActions
+						hasThemeFile={ hasThemeFile }
+						templateAuthor={ templateAuthor }
+						templateId={ templateId }
+						templateTitle={ templateTitle }
+					/>
 				</div>
 			) }
 		</CompositeItem>
@@ -88,7 +113,7 @@ export default function MosaicView() {
 			{ templates.map( ( template ) => (
 				<TemplateContainer
 					key={ template.id }
-					template={ template }
+					templateId={ template.id }
 					composite={ composite }
 				/>
 			) ) }

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -1,3 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+ import { useSelect } from '@wordpress/data';
+ import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import TemplatePreview from './template-preview';
+
 export default function MosaicView() {
-	return <div>ok</div>;
+	const { templates } = useSelect( ( select ) => {
+		const { getEntityRecords, getEditedEntityRecord } = select( coreStore );
+		return {
+			templates: getEntityRecords( 'postType', 'wp_template', {
+				per_page: -1,
+			} )
+		};
+	}, [] );
+	if ( ! templates ) {
+		return null;
+	}
+	return (
+		<div className="edit-site-mosaic-view">
+			{
+				templates.map( ( template ) => {
+					return (
+						<div className="edit-site-mosaic-view__mosaic-item">
+							<TemplatePreview key={ template.id } templateId={ template.id } />
+						</div>
+					);
+				} )
+			}
+		</div>
+	);
 }

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -1,0 +1,3 @@
+export default function MosaicView() {
+	return <div>ok</div>;
+}

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -20,9 +20,11 @@ import TemplateActions from './template-actions';
 import { store as editSiteStore } from '../../store';
 
 function TemplateContainer( { templateId, composite } ) {
-	const { setTemplate, setIsNavigationPanelOpened } = useDispatch(
-		editSiteStore
-	);
+	const {
+		setTemplate,
+		setIsNavigationPanelOpened,
+		toggleSelectedTemplate,
+	} = useDispatch( editSiteStore );
 	const {
 		hasThemeFile,
 		templateAuthor,
@@ -30,13 +32,14 @@ function TemplateContainer( { templateId, composite } ) {
 		templateSlug,
 		templateSource,
 		templateTitle,
+		isSelected,
 	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( coreStore );
+			const { isTemplateSelected } = select( editSiteStore );
 			const template = templateId
 				? getEditedEntityRecord( 'postType', 'wp_template', templateId )
 				: {};
-			console.log({ template });
 			return {
 				hasThemeFile: template.has_theme_file,
 				templateAuthor: template.author,
@@ -44,6 +47,7 @@ function TemplateContainer( { templateId, composite } ) {
 				templateSlug: template.slug,
 				templateSource: template.source,
 				templateTitle: template.title,
+				isSelected: isTemplateSelected( templateId ),
 			};
 		},
 		[ templateId ]
@@ -75,6 +79,8 @@ function TemplateContainer( { templateId, composite } ) {
 				disabled={ templateSource !== 'custom' }
 				label={ templateTitle }
 				help={ templateDescription }
+				checked={ isSelected }
+				onChange={ () => toggleSelectedTemplate( templateId ) }
 			/>
 			{ templateSource === 'custom' && (
 				<div>

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -9,6 +9,7 @@ import {
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
+	BaseControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -75,22 +76,34 @@ function TemplateContainer( { templateId, composite } ) {
 				templateId={ templateId }
 				onClick={ onActivateItem }
 			/>
-			<CheckboxControl
-				disabled={ templateSource !== 'custom' }
-				label={ templateTitle }
-				help={ templateDescription }
-				checked={ isSelected }
-				onChange={ () => toggleSelectedTemplate( templateId ) }
-			/>
 			{ templateSource === 'custom' && (
-				<div>
-					<TemplateActions
-						hasThemeFile={ hasThemeFile }
-						templateAuthor={ templateAuthor }
-						templateId={ templateId }
-						templateTitle={ templateTitle }
+				<>
+					<CheckboxControl
+						disabled={ templateSource !== 'custom' }
+						label={ templateTitle }
+						help={ templateDescription }
+						checked={ isSelected }
+						onChange={ () => toggleSelectedTemplate( templateId ) }
 					/>
-				</div>
+					<div>
+						<TemplateActions
+							hasThemeFile={ hasThemeFile }
+							templateAuthor={ templateAuthor }
+							templateId={ templateId }
+							templateTitle={ templateTitle }
+						/>
+					</div>
+				</>
+			) }
+			{ templateSource !== 'custom' && (
+				<BaseControl
+					help={ templateDescription }
+					className="edit-site-mosaic-view__template-actions-disabled"
+				>
+					<BaseControl.VisualLabel>
+						{ templateTitle }
+					</BaseControl.VisualLabel>
+				</BaseControl>
 			) }
 		</CompositeItem>
 	);

--- a/packages/edit-site/src/components/mosaic-view/index.js
+++ b/packages/edit-site/src/components/mosaic-view/index.js
@@ -9,7 +9,6 @@ import {
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
-	BaseControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -29,7 +28,6 @@ function TemplateContainer( { templateId, composite } ) {
 	const {
 		hasThemeFile,
 		templateAuthor,
-		templateDescription,
 		templateSlug,
 		templateSource,
 		templateTitle,
@@ -44,7 +42,6 @@ function TemplateContainer( { templateId, composite } ) {
 			return {
 				hasThemeFile: template.has_theme_file,
 				templateAuthor: template.author,
-				templateDescription: template.description,
 				templateSlug: template.slug,
 				templateSource: template.source,
 				templateTitle: template.title,
@@ -76,35 +73,20 @@ function TemplateContainer( { templateId, composite } ) {
 				templateId={ templateId }
 				onClick={ onActivateItem }
 			/>
-			{ templateSource === 'custom' && (
-				<>
-					<CheckboxControl
-						disabled={ templateSource !== 'custom' }
-						label={ templateTitle }
-						help={ templateDescription }
-						checked={ isSelected }
-						onChange={ () => toggleSelectedTemplate( templateId ) }
-					/>
-					<div>
-						<TemplateActions
-							hasThemeFile={ hasThemeFile }
-							templateAuthor={ templateAuthor }
-							templateId={ templateId }
-							templateTitle={ templateTitle }
-						/>
-					</div>
-				</>
-			) }
-			{ templateSource !== 'custom' && (
-				<BaseControl
-					help={ templateDescription }
-					className="edit-site-mosaic-view__template-actions-disabled"
-				>
-					<BaseControl.VisualLabel>
-						{ templateTitle }
-					</BaseControl.VisualLabel>
-				</BaseControl>
-			) }
+			<CheckboxControl
+				disabled={ templateSource !== 'custom' }
+				label={ templateTitle }
+				checked={ isSelected }
+				onChange={ () => toggleSelectedTemplate( templateId ) }
+			/>
+			<div>
+				<TemplateActions
+					hasThemeFile={ hasThemeFile }
+					templateAuthor={ templateAuthor }
+					templateId={ templateId }
+					templateTitle={ templateTitle }
+				/>
+			</div>
 		</CompositeItem>
 	);
 }

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -8,6 +8,10 @@
 }
 
 .edit-site-mosaic-view__mosaic-item {
+	border: $border-width solid $gray-400;
+	box-shadow: $shadow-popover;
+	border-radius: $radius-block-ui;
+	color: $gray-900;
 	height: 400px;
 	overflow: hidden;
 }

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -1,0 +1,13 @@
+.edit-site-mosaic-view {
+	display: grid;
+	align-items: center;
+	grid-template-columns: repeat(auto-fit, 400px);
+	grid-template-rows: repeat(auto-fit, 400px);
+	grid-gap: $grid-unit-60;
+
+}
+
+.edit-site-mosaic-view__mosaic-item {
+	height: 400px;
+	overflow: hidden;
+}

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -4,7 +4,8 @@
 	grid-template-columns: repeat(auto-fit, 400px);
 	grid-template-rows: repeat(auto-fit, 400px);
 	grid-gap: $grid-unit-40;
-	background-color: $white;
+	background-color: $gray-800;
+	color: $gray-200;
 	padding: $grid-unit-40;
 	justify-content: center;
 	min-height: 100%;
@@ -19,6 +20,7 @@
 	grid-gap: $grid-unit-20;
 	.components-base-control__help {
 		margin-left: $grid-unit-40;
+		color: $gray-600;
 	}
 	&:focus {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
@@ -28,16 +30,17 @@
 
 	&:hover {
 		border: $border-width solid var(--wp-admin-theme-color);
-		cursor: pointer;
 	}
 }
 
 .edit-site-mosaic-view__template-preview {
-	border: $border-width solid $gray-400;
 	border-radius: $radius-block-ui;
 	color: $gray-900;
 	grid-column: span 2;
 	overflow: hidden;
+	&:hover {
+		cursor: pointer;
+	}
 	.components-spinner {
 		position: relative;
 		top: calc(50% - #{ math.div($spinner-size, 2) });
@@ -62,4 +65,8 @@
 	.components-base-control__help {
 		margin-left: $grid-unit-10;
 	}
+}
+
+.edit-site-mosaic-view__template-actions .components-button {
+	color: $gray-200;
 }

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -7,6 +7,8 @@
 	background-color: $white;
 	padding: $grid-unit-40;
 	justify-content: center;
+	min-height: 100%;
+	overflow: auto;
 }
 
 .edit-site-mosaic-view__mosaic-item {

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -3,15 +3,36 @@
 	align-items: center;
 	grid-template-columns: repeat(auto-fit, 400px);
 	grid-template-rows: repeat(auto-fit, 400px);
-	grid-gap: $grid-unit-60;
-
+	grid-gap: $grid-unit-40;
+	background-color: $white;
+	padding: $grid-unit-40;
+	justify-content: center;
 }
 
 .edit-site-mosaic-view__mosaic-item {
+	height: 400px;
+	display: grid;
+	grid-template-columns: auto $button-size+$border-width-focus;
+	grid-template-rows: minmax(auto, calc(100% - 80px) ) minmax(auto, 80px);
+	grid-gap: $grid-unit-20;
+	.components-base-control__help {
+		margin-left: $grid-unit-40;
+	}
+	&:focus {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+}
+
+.edit-site-mosaic-view__template-preview {
 	border: $border-width solid $gray-400;
-	box-shadow: $shadow-popover;
 	border-radius: $radius-block-ui;
 	color: $gray-900;
-	height: 400px;
+	grid-column: span 2;
 	overflow: hidden;
+}
+
+.edit-site-mosaic-view__added-by-text {
+	margin-left: $grid-unit;
 }

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -25,6 +25,11 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
+
+	&:hover {
+		border: $border-width solid var(--wp-admin-theme-color);
+		cursor: pointer;
+	}
 }
 
 .edit-site-mosaic-view__template-preview {

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -15,7 +15,7 @@
 	height: 400px;
 	display: grid;
 	grid-template-columns: auto $button-size+$border-width-focus;
-	grid-template-rows: minmax(auto, calc(100% - 80px) ) minmax(auto, 80px);
+	grid-template-rows: minmax(auto, calc(100% - 80px)) minmax(auto, 80px);
 	grid-gap: $grid-unit-20;
 	.components-base-control__help {
 		margin-left: $grid-unit-40;
@@ -35,8 +35,8 @@
 	overflow: hidden;
 	.components-spinner {
 		position: relative;
-		top: calc( 50% - #{ math.div( $spinner-size, 2 ) } );
-		left: calc( 50% - #{ math.div( $spinner-size, 2 ) } );
+		top: calc(50% - #{ math.div($spinner-size, 2) });
+		left: calc(50% - #{ math.div($spinner-size, 2) });
 	}
 
 	.block-editor-block-preview__container {
@@ -50,4 +50,11 @@
 
 .edit-site-mosaic-view__added-by-text {
 	margin-left: $grid-unit;
+}
+
+.edit-site-mosaic-view__template-actions-disabled {
+	.components-base-control__label,
+	.components-base-control__help {
+		margin-left: $grid-unit-10;
+	}
 }

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -33,6 +33,19 @@
 	color: $gray-900;
 	grid-column: span 2;
 	overflow: hidden;
+	.components-spinner {
+		position: relative;
+		top: calc( 50% - #{ math.div( $spinner-size, 2 ) } );
+		left: calc( 50% - #{ math.div( $spinner-size, 2 ) } );
+	}
+
+	.block-editor-block-preview__container {
+		// We have a bug on packages/block-editor/src/components/block-preview/auto.js.
+		// Because of some reason contentHeight is always 0. Even thought the iframe used for the computation has an height.
+		// It seems like useResizeObserver is not rerunning on this case.
+		// This rule should be removed after the bug is addressed.
+		height: 100% !important;
+	}
 }
 
 .edit-site-mosaic-view__added-by-text {

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -8,6 +8,7 @@
 	justify-content: center;
 	min-height: 100%;
 	overflow: auto;
+	align-items: end;
 
 	@include break-small() {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -32,7 +33,7 @@
 .edit-site-mosaic-view__mosaic-item {
 	display: grid;
 	grid-template-columns: auto $button-size;
-	grid-template-rows: minmax(auto, calc(100% - 80px)) minmax(auto, 80px);
+	grid-template-rows: auto 96px;
 	grid-gap: $grid-unit-20;
 
 	.components-base-control__help {
@@ -42,21 +43,9 @@
 }
 
 .edit-site-mosaic-view__template-preview {
-	border-radius: $radius-block-ui;
 	color: $gray-900;
 	grid-column: span 2;
-	overflow: hidden;
-
-	&:focus {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-	}
-
-	&:hover {
-		cursor: pointer;
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-	}
+	display: flex;
 
 	.components-spinner {
 		position: relative;
@@ -65,13 +54,19 @@
 	}
 
 	.block-editor-block-preview__container {
-		// Todo: Make this the theme background color or similar
-		background: $gray-900;
-		// We have a bug on packages/block-editor/src/components/block-preview/auto.js.
-		// Because of some reason contentHeight is always 0. Even thought the iframe used for the computation has an height.
-		// It seems like useResizeObserver is not rerunning on this case.
-		// This rule should be removed after the bug is addressed.
-		height: 100% !important;
+		align-self: flex-end;
+		border-radius: $radius-block-ui;
+		cursor: pointer;
+
+		&:hover {
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+		}
 	}
 }
 
@@ -80,6 +75,8 @@
 }
 
 .edit-site-mosaic-view__template-actions-disabled {
+	grid-column: span 2;
+
 	.components-base-control__label,
 	.components-base-control__help {
 		margin-left: 0;

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -1,15 +1,34 @@
 .edit-site-mosaic-view {
 	display: grid;
 	align-items: center;
-	grid-template-columns: repeat(auto-fit, 400px);
+	grid-template-columns: repeat(1, minmax(0, 1fr));
 	grid-template-rows: repeat(auto-fit, 400px);
-	grid-gap: $grid-unit-40;
 	background-color: $gray-800;
 	color: $gray-200;
-	padding: $grid-unit-40;
+	grid-gap: $grid-unit-20;
+	padding: $grid-unit-20;
 	justify-content: center;
 	min-height: 100%;
 	overflow: auto;
+
+	@include break-small() {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	@include break-xlarge() {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-gap: $grid-unit-50;
+		padding: $grid-unit-50;
+	}
+
+	@include break-wide() {
+		grid-gap: $grid-unit-50 + $grid-unit-20;
+		padding: $grid-unit-50 * 2;
+	}
+
+	@include break-huge() {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
 }
 
 .edit-site-mosaic-view__mosaic-item {
@@ -18,10 +37,12 @@
 	grid-template-columns: auto $button-size+$border-width-focus;
 	grid-template-rows: minmax(auto, calc(100% - 80px)) minmax(auto, 80px);
 	grid-gap: $grid-unit-20;
+
 	.components-base-control__help {
 		margin-left: $grid-unit-40;
 		color: $gray-600;
 	}
+
 	&:focus {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
@@ -38,9 +59,11 @@
 	color: $gray-900;
 	grid-column: span 2;
 	overflow: hidden;
+
 	&:hover {
 		cursor: pointer;
 	}
+
 	.components-spinner {
 		position: relative;
 		top: calc(50% - #{ math.div($spinner-size, 2) });

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -1,8 +1,6 @@
 .edit-site-mosaic-view {
 	display: grid;
-	align-items: center;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
-	grid-template-rows: repeat(auto-fit, 400px);
 	background-color: $gray-800;
 	color: $gray-200;
 	grid-gap: $grid-unit-20;
@@ -32,25 +30,14 @@
 }
 
 .edit-site-mosaic-view__mosaic-item {
-	height: 400px;
 	display: grid;
-	grid-template-columns: auto $button-size+$border-width-focus;
+	grid-template-columns: auto $button-size;
 	grid-template-rows: minmax(auto, calc(100% - 80px)) minmax(auto, 80px);
 	grid-gap: $grid-unit-20;
 
 	.components-base-control__help {
 		margin-left: $grid-unit-40;
 		color: $gray-600;
-	}
-
-	&:focus {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-	}
-
-	&:hover {
-		border: $border-width solid var(--wp-admin-theme-color);
 	}
 }
 
@@ -60,8 +47,15 @@
 	grid-column: span 2;
 	overflow: hidden;
 
+	&:focus {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+
 	&:hover {
 		cursor: pointer;
+		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 
 	.components-spinner {
@@ -71,6 +65,8 @@
 	}
 
 	.block-editor-block-preview__container {
+		// Todo: Make this the theme background color or similar
+		background: $gray-900;
 		// We have a bug on packages/block-editor/src/components/block-preview/auto.js.
 		// Because of some reason contentHeight is always 0. Even thought the iframe used for the computation has an height.
 		// It seems like useResizeObserver is not rerunning on this case.
@@ -80,13 +76,13 @@
 }
 
 .edit-site-mosaic-view__added-by-text {
-	margin-left: $grid-unit;
+	margin-left: 0;
 }
 
 .edit-site-mosaic-view__template-actions-disabled {
 	.components-base-control__label,
 	.components-base-control__help {
-		margin-left: $grid-unit-10;
+		margin-left: 0;
 	}
 }
 

--- a/packages/edit-site/src/components/mosaic-view/style.scss
+++ b/packages/edit-site/src/components/mosaic-view/style.scss
@@ -33,7 +33,7 @@
 .edit-site-mosaic-view__mosaic-item {
 	display: grid;
 	grid-template-columns: auto $button-size;
-	grid-template-rows: auto 96px;
+	grid-template-rows: auto auto;
 	grid-gap: $grid-unit-20;
 
 	.components-base-control__help {
@@ -74,13 +74,8 @@
 	margin-left: 0;
 }
 
-.edit-site-mosaic-view__template-actions-disabled {
-	grid-column: span 2;
-
-	.components-base-control__label,
-	.components-base-control__help {
-		margin-left: 0;
-	}
+.edit-site .components-popover__content {
+	min-width: 240px;
 }
 
 .edit-site-mosaic-view__template-actions .components-button {

--- a/packages/edit-site/src/components/mosaic-view/template-actions.js
+++ b/packages/edit-site/src/components/mosaic-view/template-actions.js
@@ -40,7 +40,11 @@ export default function TemplateActions( {
 	);
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	return (
-		<DropdownMenu icon={ moreVertical } label={ __( 'Template actions' ) }>
+		<DropdownMenu
+			className="edit-site-mosaic-view__template-actions"
+			icon={ moreVertical }
+			label={ __( 'Template actions' ) }
+		>
 			{ ( { onClose } ) => (
 				<>
 					{ addedBy && (

--- a/packages/edit-site/src/components/mosaic-view/template-actions.js
+++ b/packages/edit-site/src/components/mosaic-view/template-actions.js
@@ -35,7 +35,9 @@ export default function TemplateActions( {
 		},
 		[ hasThemeFile, templateAuthor ]
 	);
-	const { revertTemplate } = useDispatch( editSiteStore );
+	const { revertTemplate, toggleSelectedTemplate } = useDispatch(
+		editSiteStore
+	);
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Template actions' ) }>
@@ -61,6 +63,7 @@ export default function TemplateActions( {
 											templateId
 										)
 									);
+									toggleSelectedTemplate( templateId );
 									onClose();
 								} }
 							>
@@ -87,6 +90,7 @@ export default function TemplateActions( {
 											'wp_template',
 											templateId
 										);
+										toggleSelectedTemplate( templateId );
 										onClose();
 									}
 								} }

--- a/packages/edit-site/src/components/mosaic-view/template-actions.js
+++ b/packages/edit-site/src/components/mosaic-view/template-actions.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+export default function TemplateActions( { template } ) {
+	const { has_theme_file: hasThemeFile, author } = template;
+	const addedBy = useSelect(
+		( select ) => {
+			if ( hasThemeFile ) {
+				const theme = select( coreStore ).getCurrentTheme()?.name
+					?.rendered;
+				return theme
+					? sprintf(
+							/* translators: %s: theme name. */
+							__( '%s theme' ),
+							theme
+					  )
+					: '';
+			}
+			return select( coreStore ).getUser( author )?.name;
+		},
+		[ hasThemeFile, author ]
+	);
+	return (
+		<DropdownMenu icon={ moreVertical } label={ __( 'Template actions' ) }>
+			{ ( { onClose } ) => (
+				<>
+					{ addedBy && (
+						<MenuGroup label={ __( 'Added by' ) }>
+							<p className="edit-site-mosaic-view__added-by-text">
+								{ addedBy }
+							</p>
+						</MenuGroup>
+					) }
+					<MenuGroup>
+						{ hasThemeFile ? (
+							<MenuItem>
+								{ __( 'Clear customizations' ) }
+							</MenuItem>
+						) : (
+							<MenuItem isDestructive>
+								{ __( 'Delete' ) }
+							</MenuItem>
+						) }
+					</MenuGroup>
+				</>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/packages/edit-site/src/components/mosaic-view/template-actions.js
+++ b/packages/edit-site/src/components/mosaic-view/template-actions.js
@@ -26,7 +26,7 @@ export default function TemplateActions( {
 				return theme
 					? sprintf(
 							/* translators: %s: theme name. */
-							__( '%s theme' ),
+							__( 'Theme: %s' ),
 							theme
 					  )
 					: '';
@@ -39,14 +39,32 @@ export default function TemplateActions( {
 		editSiteStore
 	);
 	const { deleteEntityRecord } = useDispatch( coreStore );
+	const { templateDescription, templateSource } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( coreStore );
+			const template = templateId
+				? getEditedEntityRecord( 'postType', 'wp_template', templateId )
+				: {};
+			return {
+				templateDescription: template.description,
+				templateSource: template.source,
+			};
+		},
+		[ templateId ]
+	);
 	return (
 		<DropdownMenu
 			className="edit-site-mosaic-view__template-actions"
 			icon={ moreVertical }
-			label={ __( 'Template actions' ) }
+			label={ __( 'Template info & actions' ) }
 		>
 			{ ( { onClose } ) => (
 				<>
+					{ templateDescription && (
+						<MenuGroup label={ __( 'Description' ) }>
+							{ templateDescription }
+						</MenuGroup>
+					) }
 					{ addedBy && (
 						<MenuGroup label={ __( 'Added by' ) }>
 							<p className="edit-site-mosaic-view__added-by-text">
@@ -54,55 +72,63 @@ export default function TemplateActions( {
 							</p>
 						</MenuGroup>
 					) }
-					<MenuGroup>
-						{ hasThemeFile ? (
-							<MenuItem
-								onClick={ () => {
-									revertTemplate(
-										storeSelect(
-											coreStore
-										).getEntityRecord(
-											'postType',
-											'wp_template',
-											templateId
-										)
-									);
-									toggleSelectedTemplate( templateId );
-									onClose();
-								} }
-							>
-								{ __( 'Clear customizations' ) }
-							</MenuItem>
-						) : (
-							<MenuItem
-								isDestructive
-								onClick={ () => {
-									if (
-										// eslint-disable-next-line no-alert
-										window.confirm(
-											sprintf(
-												/* translators: %s: template name */
-												__(
-													'Are you sure you want to delete the %s template? It may be in use by multiple pages and/or posts.'
-												),
-												templateTitle
+
+					{ templateSource === 'custom' && (
+						<MenuGroup>
+							{ hasThemeFile ? (
+								<MenuItem
+									info={ __(
+										'Restore template to theme default'
+									) }
+									onClick={ () => {
+										revertTemplate(
+											storeSelect(
+												coreStore
+											).getEntityRecord(
+												'postType',
+												'wp_template',
+												templateId
 											)
-										)
-									) {
-										deleteEntityRecord(
-											'postType',
-											'wp_template',
-											templateId
 										);
 										toggleSelectedTemplate( templateId );
 										onClose();
-									}
-								} }
-							>
-								{ __( 'Delete' ) }
-							</MenuItem>
-						) }
-					</MenuGroup>
+									} }
+								>
+									{ __( 'Clear customizations' ) }
+								</MenuItem>
+							) : (
+								<MenuItem
+									isDestructive
+									onClick={ () => {
+										if (
+											// eslint-disable-next-line no-alert
+											window.confirm(
+												sprintf(
+													/* translators: %s: template name */
+													__(
+														'Are you sure you want to delete the %s template? It may be in use by multiple pages and/or posts.'
+													),
+													templateTitle
+												)
+											)
+										) {
+											deleteEntityRecord(
+												'postType',
+												'wp_template',
+												templateId
+											);
+											toggleSelectedTemplate(
+												templateId
+											);
+											onClose();
+										}
+									} }
+								>
+									{ __( 'Delete' ) }
+								</MenuItem>
+							) }
+						</MenuGroup>
+					) }
 				</>
 			) }
 		</DropdownMenu>

--- a/packages/edit-site/src/components/mosaic-view/template-preview.js
+++ b/packages/edit-site/src/components/mosaic-view/template-preview.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { BlockPreview } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+
+export default function TemplatePreview( { templateId } ) {
+	console.error('TemplatePreview');
+	const { isResolved, template, postId, postType } = useSelect(
+		( select ) => {
+			const { getEntityRecord, hasFinishedResolution } = select(
+				coreStore
+			);
+			const { getCurrentPostId, getCurrentPostType } = select(
+				editorStore
+			);
+			const getEntityArgs = [ 'postType', 'wp_template', templateId ];
+			const entityRecord = templateId
+				? getEntityRecord( ...getEntityArgs )
+				: null;
+			const hasResolvedEntity = templateId
+				? hasFinishedResolution( 'getEntityRecord', getEntityArgs )
+				: false;
+
+			return {
+				template: entityRecord,
+				isResolved: hasResolvedEntity,
+				postId: getCurrentPostId(),
+				postType: getCurrentPostType(),
+			};
+		},
+		[ templateId ]
+	);
+
+	const blocks = useMemo( () => {
+		if ( ! template?.content?.raw ) {
+			return [];
+		}
+		return parse( template.content.raw );
+	}, [ template ] );
+	console.log({ blocks, template });
+	const defaultBlockContext = useMemo( () => {
+		return { postId, postType };
+	}, [ postId, postType ] );
+
+	return ! isResolved ? (
+		<Spinner />
+	) : (
+		<BlockPreview blocks={ blocks } context={ defaultBlockContext } />
+	);
+}

--- a/packages/edit-site/src/components/mosaic-view/template-preview.js
+++ b/packages/edit-site/src/components/mosaic-view/template-preview.js
@@ -48,13 +48,15 @@ export default function MosaicTemplatePreview( {
 	}, [ postId, postType ] );
 
 	return ! isResolved ? (
-		<Spinner className={ className } />
+		<div className={ className }>
+			<Spinner />
+		</div>
 	) : (
 		<TemplatePreview
-			onClick={ onClick }
 			className={ className }
+			onClick={ onClick }
 			rawContent={ templateContent }
-			context={ defaultBlockContext }
+			blockContext={ defaultBlockContext }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/mosaic-view/template-preview.js
+++ b/packages/edit-site/src/components/mosaic-view/template-preview.js
@@ -12,8 +12,12 @@ import { useMemo } from '@wordpress/element';
  */
 import TemplatePreview from '../navigation-sidebar/navigation-panel/template-preview';
 
-export default function MosaicTemplatePreview( { className, templateId, onClick } ) {
-	const { isResolved, template, postId, postType } = useSelect(
+export default function MosaicTemplatePreview( {
+	className,
+	templateId,
+	onClick,
+} ) {
+	const { isResolved, templateContent, postId, postType } = useSelect(
 		( select ) => {
 			const { getEntityRecord, hasFinishedResolution } = select(
 				coreStore
@@ -22,7 +26,7 @@ export default function MosaicTemplatePreview( { className, templateId, onClick 
 				editorStore
 			);
 			const getEntityArgs = [ 'postType', 'wp_template', templateId ];
-			const entityRecord = templateId
+			const template = templateId
 				? getEntityRecord( ...getEntityArgs )
 				: null;
 			const hasResolvedEntity = templateId
@@ -30,7 +34,7 @@ export default function MosaicTemplatePreview( { className, templateId, onClick 
 				: false;
 
 			return {
-				template: entityRecord,
+				templateContent: template?.content?.raw,
 				isResolved: hasResolvedEntity,
 				postId: getCurrentPostId(),
 				postType: getCurrentPostType(),
@@ -49,7 +53,7 @@ export default function MosaicTemplatePreview( { className, templateId, onClick 
 		<TemplatePreview
 			onClick={ onClick }
 			className={ className }
-			rawContent={ template?.content?.raw }
+			rawContent={ templateContent }
 			context={ defaultBlockContext }
 		/>
 	);

--- a/packages/edit-site/src/components/mosaic-view/template-preview.js
+++ b/packages/edit-site/src/components/mosaic-view/template-preview.js
@@ -12,7 +12,7 @@ import { useMemo } from '@wordpress/element';
  */
 import TemplatePreview from '../navigation-sidebar/navigation-panel/template-preview';
 
-export default function MosaicTemplatePreview( { templateId } ) {
+export default function MosaicTemplatePreview( { className, templateId, onClick } ) {
 	const { isResolved, template, postId, postType } = useSelect(
 		( select ) => {
 			const { getEntityRecord, hasFinishedResolution } = select(
@@ -44,9 +44,11 @@ export default function MosaicTemplatePreview( { templateId } ) {
 	}, [ postId, postType ] );
 
 	return ! isResolved ? (
-		<Spinner />
+		<Spinner className={ className } />
 	) : (
 		<TemplatePreview
+			onClick={ onClick }
+			className={ className }
 			rawContent={ template?.content?.raw }
 			context={ defaultBlockContext }
 		/>

--- a/packages/edit-site/src/components/mosaic-view/template-preview.js
+++ b/packages/edit-site/src/components/mosaic-view/template-preview.js
@@ -1,22 +1,18 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Spinner } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { BlockPreview } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
-import { parse } from '@wordpress/blocks';
 
-export default function TemplatePreview( { templateId } ) {
-	console.error('TemplatePreview');
+/**
+ * Internal dependencies
+ */
+import TemplatePreview from '../navigation-sidebar/navigation-panel/template-preview';
+
+export default function MosaicTemplatePreview( { templateId } ) {
 	const { isResolved, template, postId, postType } = useSelect(
 		( select ) => {
 			const { getEntityRecord, hasFinishedResolution } = select(
@@ -43,13 +39,6 @@ export default function TemplatePreview( { templateId } ) {
 		[ templateId ]
 	);
 
-	const blocks = useMemo( () => {
-		if ( ! template?.content?.raw ) {
-			return [];
-		}
-		return parse( template.content.raw );
-	}, [ template ] );
-	console.log({ blocks, template });
 	const defaultBlockContext = useMemo( () => {
 		return { postId, postType };
 	}, [ postId, postType ] );
@@ -57,6 +46,9 @@ export default function TemplatePreview( { templateId } ) {
 	return ! isResolved ? (
 		<Spinner />
 	) : (
-		<BlockPreview blocks={ blocks } context={ defaultBlockContext } />
+		<TemplatePreview
+			rawContent={ template?.content?.raw }
+			context={ defaultBlockContext }
+		/>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/content-navigation-item.js
@@ -76,6 +76,7 @@ export default function ContentNavigationItem( { item } ) {
 			{ isPreviewVisible && previewContent && (
 				<NavigationPanelPreviewFill>
 					<TemplatePreview
+						className="edit-site-navigation-panel__preview"
 						rawContent={ previewContent }
 						blockContext={ {
 							postType: item.type,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -11,7 +11,6 @@ import {
 	__experimentalNavigationBackButton as NavigationBackButton,
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
-	__experimentalNavigationGroup as NavigationGroup,
 } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -122,24 +122,26 @@ const NavigationPanel = ( { isOpen } ) => {
 						) }
 						<SiteMenu />
 					</Navigation>
-					<Navigation
-						className="edit-site-navigation-panel__all-templates"
-						activeItem={
-							editorMode === 'mosaic' ? 'all-templates' : ''
-						}
-					>
-						<NavigationMenu>
-							<NavigationItem
-								onClick={ () => {
-									if ( editorMode !== 'mosaic' ) {
-										switchEditorMode( 'mosaic' );
-									}
-								} }
-								item="all-templates"
-								title={ __( 'All templates' ) }
-							/>
-						</NavigationMenu>
-					</Navigation>
+					{ activeMenu.startsWith( 'templates' ) && (
+						<Navigation
+							className="edit-site-navigation-panel__all-templates"
+							activeItem={
+								editorMode === 'mosaic' ? 'all-templates' : ''
+							}
+						>
+							<NavigationMenu>
+								<NavigationItem
+									onClick={ () => {
+										if ( editorMode !== 'mosaic' ) {
+											switchEditorMode( 'mosaic' );
+										}
+									} }
+									item="all-templates"
+									title={ __( 'View all' ) }
+								/>
+							</NavigationMenu>
+						</Navigation>
+					) }
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -9,6 +9,9 @@ import classnames from 'classnames';
 import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationBackButton as NavigationBackButton,
+	__experimentalNavigationItem as NavigationItem,
+	__experimentalNavigationMenu as NavigationMenu,
+	Button,
 } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -56,6 +59,7 @@ const NavigationPanel = ( { isOpen } ) => {
 	const {
 		setNavigationPanelActiveMenu: setActive,
 		setIsNavigationPanelOpened,
+		switchEditorMode,
 	} = useDispatch( editSiteStore );
 
 	let activeItem;
@@ -116,6 +120,11 @@ const NavigationPanel = ( { isOpen } ) => {
 						) }
 						<SiteMenu />
 					</Navigation>
+					<div className="edit-site-navigation-panel__template-item edit-site-navigation-panel__all-templates">
+						<Button onClick={ () => switchEditorMode( 'mosaic' ) }>
+							{ __( 'All templates' ) }
+						</Button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalNavigationBackButton as NavigationBackButton,
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
-	Button,
+	__experimentalNavigationGroup as NavigationGroup,
 } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -35,12 +35,14 @@ const NavigationPanel = ( { isOpen } ) => {
 		editedPostType,
 		activeMenu,
 		siteTitle,
+		editorMode,
 	} = useSelect( ( select ) => {
 		const {
 			getEditedPostType,
 			getEditedPostId,
 			getNavigationPanelActiveMenu,
 			getPage,
+			getEditorMode,
 		} = select( editSiteStore );
 		const { getEntityRecord } = select( coreDataStore );
 
@@ -53,6 +55,7 @@ const NavigationPanel = ( { isOpen } ) => {
 			editedPostType: getEditedPostType(),
 			activeMenu: getNavigationPanelActiveMenu(),
 			siteTitle: siteData.name,
+			editorMode: getEditorMode(),
 		};
 	}, [] );
 
@@ -120,11 +123,24 @@ const NavigationPanel = ( { isOpen } ) => {
 						) }
 						<SiteMenu />
 					</Navigation>
-					<div className="edit-site-navigation-panel__template-item edit-site-navigation-panel__all-templates">
-						<Button onClick={ () => switchEditorMode( 'mosaic' ) }>
-							{ __( 'All templates' ) }
-						</Button>
-					</div>
+					<Navigation
+						className="edit-site-navigation-panel__all-templates"
+						activeItem={
+							editorMode === 'mosaic' ? 'all-templates' : ''
+						}
+					>
+						<NavigationMenu>
+							<NavigationItem
+								onClick={ () => {
+									if ( editorMode !== 'mosaic' ) {
+										switchEditorMode( 'mosaic' );
+									}
+								} }
+								item="all-templates"
+								title={ __( 'All templates' ) }
+							/>
+						</NavigationMenu>
+					</Navigation>
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -145,9 +145,6 @@ export default function TemplatesMenu() {
 				title={ __( 'Unused templates' ) }
 				templates={ templatesWithLocation }
 			/>
-			<NavigationItem className="edit-site-navigation-panel__template-item">
-				<Button onClick={ () => {} }>All templates1</Button>
-			</NavigationItem>
 		</NavigationMenu>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -9,6 +9,7 @@ import { map, find } from 'lodash';
 import {
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
+	Button,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -144,6 +145,9 @@ export default function TemplatesMenu() {
 				title={ __( 'Unused templates' ) }
 				templates={ templatesWithLocation }
 			/>
+			<NavigationItem className="edit-site-navigation-panel__template-item">
+				<Button onClick={ () => {} }>All templates1</Button>
+			</NavigationItem>
 		</NavigationMenu>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -9,7 +9,6 @@ import { map, find } from 'lodash';
 import {
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
-	Button,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -92,9 +92,7 @@
 
 .edit-site-navigation-panel__all-templates {
 	position: absolute;
-	bottom: $grid-unit-20;
-	left: $grid-unit-20;
-	color: $gray-600;
+	bottom: 0;
 }
 
 .edit-site-navigation-panel__template-item {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -90,6 +90,13 @@
 	}
 }
 
+.edit-site-navigation-panel__all-templates {
+	position: absolute;
+	bottom: $grid-unit-20;
+	left: $grid-unit-20;
+	color: $gray-600;
+}
+
 .edit-site-navigation-panel__template-item {
 	display: block;
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -18,7 +18,7 @@ import { NavigationPanelPreviewFill } from '../index';
 import { store as editSiteStore } from '../../../store';
 
 export default function TemplateNavigationItem( { item } ) {
-	const { title, description, editorMode } = useSelect( ( select ) => {
+	const { title, description } = useSelect( ( select ) => {
 		return {
 			...( 'wp_template' === item.type
 				? select( editorStore ).__experimentalGetTemplateInfo( item )
@@ -26,13 +26,11 @@ export default function TemplateNavigationItem( { item } ) {
 						title: item?.title?.rendered || item?.slug,
 						description: '',
 				  } ),
-			editorMode: select( editSiteStore ).getEditorMode(),
 		};
 	}, [] );
 	const {
 		setTemplate,
 		setTemplatePart,
-		switchEditorMode,
 		setIsNavigationPanelOpened,
 	} = useDispatch( editSiteStore );
 	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );
@@ -48,9 +46,6 @@ export default function TemplateNavigationItem( { item } ) {
 			setTemplatePart( item.id );
 		}
 		setIsNavigationPanelOpened( false );
-		if ( editorMode !== 'visual' ) {
-			switchEditorMode( 'visual' );
-		}
 	};
 
 	return (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -18,19 +18,21 @@ import { NavigationPanelPreviewFill } from '../index';
 import { store as editSiteStore } from '../../../store';
 
 export default function TemplateNavigationItem( { item } ) {
-	const { title, description } = useSelect(
-		( select ) =>
-			'wp_template' === item.type
+	const { title, description, editorMode } = useSelect( ( select ) => {
+		return {
+			...( 'wp_template' === item.type
 				? select( editorStore ).__experimentalGetTemplateInfo( item )
 				: {
 						title: item?.title?.rendered || item?.slug,
 						description: '',
-				  },
-		[]
-	);
+				  } ),
+			editorMode: select( editSiteStore ).getEditorMode(),
+		};
+	}, [] );
 	const {
 		setTemplate,
 		setTemplatePart,
+		switchEditorMode,
 		setIsNavigationPanelOpened,
 	} = useDispatch( editSiteStore );
 	const [ isPreviewVisible, setIsPreviewVisible ] = useState( false );
@@ -46,6 +48,9 @@ export default function TemplateNavigationItem( { item } ) {
 			setTemplatePart( item.id );
 		}
 		setIsNavigationPanelOpened( false );
+		if ( editorMode !== 'visual' ) {
+			switchEditorMode( 'visual' );
+		}
 	};
 
 	return (
@@ -75,7 +80,10 @@ export default function TemplateNavigationItem( { item } ) {
 
 			{ isPreviewVisible && (
 				<NavigationPanelPreviewFill>
-					<TemplatePreview rawContent={ item.content.raw } />
+					<TemplatePreview
+						className="edit-site-navigation-panel__preview"
+						rawContent={ item.content.raw }
+					/>
 				</NavigationPanelPreviewFill>
 			) }
 		</NavigationItem>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -6,10 +6,9 @@ import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 
 export default function TemplatePreview( {
-	...props,
 	rawContent,
 	blockContext,
-	onClick,
+	...props
 } ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
 		rawContent,
@@ -21,7 +20,7 @@ export default function TemplatePreview( {
 
 	if ( blockContext ) {
 		return (
-			<div {...props }>
+			<div { ...props }>
 				<BlockContextProvider value={ blockContext }>
 					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 				</BlockContextProvider>
@@ -30,7 +29,7 @@ export default function TemplatePreview( {
 	}
 
 	return (
-		<div {...props }>
+		<div { ...props }>
 			<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 		</div>
 	);

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -5,7 +5,11 @@ import { parse } from '@wordpress/blocks';
 import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 
-export default function TemplatePreview( { rawContent, blockContext } ) {
+export default function TemplatePreview( {
+	className,
+	rawContent,
+	blockContext,
+} ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
 		rawContent,
 	] );
@@ -16,7 +20,7 @@ export default function TemplatePreview( { rawContent, blockContext } ) {
 
 	if ( blockContext ) {
 		return (
-			<div className="edit-site-navigation-panel__preview">
+			<div className={ className }>
 				<BlockContextProvider value={ blockContext }>
 					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 				</BlockContextProvider>
@@ -25,7 +29,7 @@ export default function TemplatePreview( { rawContent, blockContext } ) {
 	}
 
 	return (
-		<div className="edit-site-navigation-panel__preview">
+		<div className={ className }>
 			<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 		</div>
 	);

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-preview.js
@@ -6,9 +6,10 @@ import { BlockPreview, BlockContextProvider } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 
 export default function TemplatePreview( {
-	className,
+	...props,
 	rawContent,
 	blockContext,
+	onClick,
 } ) {
 	const blocks = useMemo( () => ( rawContent ? parse( rawContent ) : [] ), [
 		rawContent,
@@ -20,7 +21,7 @@ export default function TemplatePreview( {
 
 	if ( blockContext ) {
 		return (
-			<div className={ className }>
+			<div {...props }>
 				<BlockContextProvider value={ blockContext }>
 					<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 				</BlockContextProvider>
@@ -29,7 +30,7 @@ export default function TemplatePreview( {
 	}
 
 	return (
-		<div className={ className }>
+		<div {...props }>
 			<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 		</div>
 	);

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -17,10 +17,14 @@ function NavigationToggle( { icon, isOpen } ) {
 		isRequestingSiteIcon,
 		navigationPanelMenu,
 		siteIconUrl,
+		hasSelectedTemplates,
+		editorMode,
 	} = useSelect( ( select ) => {
-		const { getCurrentTemplateNavigationPanelSubMenu } = select(
-			editSiteStore
-		);
+		const {
+			getCurrentTemplateNavigationPanelSubMenu,
+			getSelectedTemplates,
+			getEditorMode,
+		} = select( editSiteStore );
 		const { getEntityRecord, isResolving } = select( coreDataStore );
 		const siteData =
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
@@ -33,6 +37,8 @@ function NavigationToggle( { icon, isOpen } ) {
 			] ),
 			navigationPanelMenu: getCurrentTemplateNavigationPanelSubMenu(),
 			siteIconUrl: siteData.site_icon_url,
+			hasSelectedTemplates: getSelectedTemplates().length > 0,
+			editorMode: getEditorMode(),
 		};
 	}, [] );
 
@@ -40,6 +46,10 @@ function NavigationToggle( { icon, isOpen } ) {
 		openNavigationPanelToMenu,
 		setIsNavigationPanelOpened,
 	} = useDispatch( editSiteStore );
+
+	if ( editorMode === 'mosaic' && hasSelectedTemplates && ! isOpen ) {
+		return null;
+	}
 
 	const toggleNavigationPanel = () => {
 		if ( isOpen ) {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
@@ -34,6 +34,8 @@ describe( 'NavigationToggle', () => {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
 					isResolving: () => false,
+					getSelectedTemplates: () => [],
+					getEditorMode: () => 'visual',
 				} ) );
 			} );
 
@@ -53,6 +55,8 @@ describe( 'NavigationToggle', () => {
 						site_icon_url: '',
 					} ),
 					isResolving: () => false,
+					getSelectedTemplates: () => [],
+					getEditorMode: () => 'visual',
 				} ) );
 			} );
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -14,7 +14,6 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import isTemplateRevertable from '../../utils/is-template-revertable';
-import { MENU_TEMPLATES } from '../navigation-sidebar/navigation-panel/constants';
 import { store as editSiteStore } from '../../store';
 
 export default function TemplateDetails( { template, onClose } ) {
@@ -23,9 +22,7 @@ export default function TemplateDetails( { template, onClose } ) {
 			select( editorStore ).__experimentalGetTemplateInfo( template ),
 		[]
 	);
-	const { openNavigationPanelToMenu, revertTemplate } = useDispatch(
-		editSiteStore
-	);
+	const { revertTemplate, switchEditorMode } = useDispatch( editSiteStore );
 
 	if ( ! template ) {
 		return null;
@@ -33,7 +30,7 @@ export default function TemplateDetails( { template, onClose } ) {
 
 	const showTemplateInSidebar = () => {
 		onClose();
-		openNavigationPanelToMenu( MENU_TEMPLATES );
+		switchEditorMode( 'mosaic' );
 	};
 
 	const revert = () => {

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -462,3 +462,10 @@ export function* switchEditorMode( mode ) {
 		speak( messages[ mode ], 'assertive' );
 	}
 }
+
+export function toggleSelectedTemplate( templateId ) {
+	return {
+		type: 'TOGGLE_SELECTED_TEMPLATE',
+		templateId,
+	};
+}

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -8,6 +8,8 @@ import { addQueryArgs, getPathAndQueryString } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -439,5 +441,24 @@ export function* revertTemplate( template ) {
 			errorMessage,
 			{ type: 'snackbar' }
 		);
+	}
+}
+
+export function* switchEditorMode( mode ) {
+	yield {
+		type: 'SWITCH_MODE',
+		mode,
+	};
+
+	// Unselect blocks when we switch to a non visual mode.
+	if ( mode !== 'visual' ) {
+		yield controls.dispatch( blockEditorStore.name, 'clearSelectedBlock' );
+	}
+	const messages = {
+		visual: __( 'Visual editor selected' ),
+		mosaic: __( 'Mosaic view selected' ),
+	};
+	if ( messages[ mode ] ) {
+		speak( messages[ mode ], 'assertive' );
 	}
 }

--- a/packages/edit-site/src/store/defaults.js
+++ b/packages/edit-site/src/store/defaults.js
@@ -1,3 +1,4 @@
 export const PREFERENCES_DEFAULTS = {
 	features: {},
+	editorMode: 'visual',
 };

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -107,12 +107,6 @@ export function editedPost( state = {}, action ) {
 				type: 'wp_template_part',
 				id: action.templatePartId,
 			};
-		case 'SWITCH_MODE': {
-			if ( action.mode !== 'mosaic' ) {
-				return state;
-			}
-			return {};
-		}
 	}
 
 	return state;

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -33,6 +33,15 @@ export const preferences = combineReducers( {
 		if ( action.type === 'SWITCH_MODE' ) {
 			return action.mode;
 		}
+		if ( state === 'mosaic' ) {
+			if (
+				[ 'SET_TEMPLATE', 'SET_PAGE', 'SET_TEMPLATE_PART' ].includes(
+					action.type
+				)
+			) {
+				return 'visual';
+			}
+		}
 
 		return state;
 	},
@@ -98,6 +107,12 @@ export function editedPost( state = {}, action ) {
 				type: 'wp_template_part',
 				id: action.templatePartId,
 			};
+		case 'SWITCH_MODE': {
+			if ( action.mode !== 'mosaic' ) {
+				return state;
+			}
+			return {};
+		}
 	}
 
 	return state;
@@ -135,6 +150,16 @@ export function navigationPanel(
 	action
 ) {
 	switch ( action.type ) {
+		case 'SWITCH_MODE': {
+			if ( action.mode !== 'mosaic' ) {
+				return state;
+			}
+			return {
+				...state,
+				isOpen: false,
+				menu: MENU_ROOT,
+			};
+		}
 		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
 			return {
 				...state,

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -29,6 +29,13 @@ export const preferences = combineReducers( {
 				return state;
 		}
 	},
+	editorMode( state, action ) {
+		if ( action.type === 'SWITCH_MODE' ) {
+			return action.mode;
+		}
+
+		return state;
+	},
 } );
 
 /**

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -238,6 +238,18 @@ export function listViewPanel( state = false, action ) {
 	return state;
 }
 
+export function selectedTemplates( state = [], action ) {
+	if ( 'TOGGLE_SELECTED_TEMPLATE' === action.type ) {
+		if ( state.includes( action.templateId ) ) {
+			return state.filter(
+				( template ) => template !== action.templateId
+			);
+		}
+		return [ ...state, action.templateId ];
+	}
+	return state;
+}
+
 export default combineReducers( {
 	preferences,
 	deviceType,
@@ -247,4 +259,5 @@ export default combineReducers( {
 	navigationPanel,
 	blockInserterPanel,
 	listViewPanel,
+	selectedTemplates,
 } );

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -29,7 +29,7 @@ export const preferences = combineReducers( {
 				return state;
 		}
 	},
-	editorMode( state, action ) {
+	editorMode( state = PREFERENCES_DEFAULTS.editorMode, action ) {
 		if ( action.type === 'SWITCH_MODE' ) {
 			return action.mode;
 		}

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -267,3 +267,11 @@ export function isListViewOpened( state ) {
 export function getEditorMode( state ) {
 	return state.preferences.editorMode || 'visual';
 }
+
+export function getSelectedTemplates( state ) {
+	return state.selectedTemplates;
+}
+
+export function isTemplateSelected( state, templateId ) {
+	return state.selectedTemplates.includes( templateId );
+}

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -268,10 +268,25 @@ export function getEditorMode( state ) {
 	return state.preferences.editorMode || 'visual';
 }
 
+/**
+ * Returns the current selected templates.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} Array of selected template id's.
+ */
 export function getSelectedTemplates( state ) {
 	return state.selectedTemplates;
 }
 
+/**
+ * Returns if the template with id templateId is selected or not.
+ *
+ * @param {Object} state      Global application state.
+ * @param {string} templateId The id of the template.
+ *
+ * @return {boolean} True if the template is selected and false otherwise.
+ */
 export function isTemplateSelected( state, templateId ) {
 	return state.selectedTemplates.includes( templateId );
 }

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -256,3 +256,14 @@ export function __experimentalGetInsertionPoint( state ) {
 export function isListViewOpened( state ) {
 	return state.listViewPanel;
 }
+
+/**
+ * Returns the current editing mode.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Editing mode.
+ */
+export function getEditorMode( state ) {
+	return state.preferences.editorMode || 'visual';
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -13,6 +13,7 @@
 @import "./components/template-details/style.scss";
 @import "./components/template-part-converter/style.scss";
 @import "./components/secondary-sidebar/style.scss";
+@import "./components/mosaic-view/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color.
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations.

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -76,6 +76,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'type'           => 'wp_template',
 				'wp_id'          => null,
 				'has_theme_file' => true,
+				'author'         => null,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//index' )
 		);
@@ -101,6 +102,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'author'         => null,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -129,6 +131,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'type'           => 'wp_template',
 				'wp_id'          => null,
 				'has_theme_file' => true,
+				'author'         => null,
 			),
 			$data
 		);
@@ -155,6 +158,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'author'         => null,
 			),
 			$data
 		);
@@ -193,6 +197,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 					'raw' => 'Content',
 				),
 				'has_theme_file' => false,
+				'author'         => 2,
 			),
 			$data
 		);
@@ -231,6 +236,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				),
 				'area'           => 'header',
 				'has_theme_file' => false,
+				'author'         => 2,
 			),
 			$data
 		);


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/20477

This PR implements the site editor mosaic view.
It implements most of the functionality described in the mockups shared by @jameskoster and tries to follow the design proposal.

Functionality:
- View a grid of templates.
- Clear customization of a template and revert to the theme default.
- Delete a user template.
- Batch select multiple templates and delete/revert them all.

I did not add yet all the functionality in mockups because in this PR because it is already big. Missing functionality is the following:
- Add a new template.
- Search.
- Resize the size of the preview. 


This PR adds the following high-level changes:
- Implements an editor modes mechanism that is similar to edit post. The all templates view is just a mode. The code editor view will be another mode.
- Extends the template REST endpoint to include the template author so we can show this information in the UI.
- Implements a set of non-exposed UI components to accomplish the required UI.
- Implements a custom slot that filters the available actions to just show the global styles toggle (the only sidebar that is allowed on the mosaic view).





## How has this been tested?
Although the preview component itself is not working in the trunk and I'm debugging the issue/regression in parallel this PR itself could be reviewed, and I did the following tests :

- I verified I can open the mosaic view of templates by pressing the "All templates" button on the site editor menu.
- I verified a grid of templates appears (but the previews are empty because of an existing bug with the preview mechanism).
- I verified I could see the theme as the author of templates coming from the team and the user name of the author for user-created templates (by using the three dots menu).
- I verified I could delete user-created templates and revert back to theme templates with user changes (by using the three dots menu).
- I verified that for templates coming from the theme without any user customization the checkbox is not enabled and the three dots menu is not available because no action is possible on these templates.
- I verified I could select multiple templates using the checkbox and delete or revert them all.
