### PR TITLE
Enable ability to remove a link from the Nav Link block in the Nav Block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -419,6 +419,23 @@ export default function NavigationLinkEdit( {
 		selection.addRange( range );
 	}
 
+	/**
+	 * Removes the current link if set.
+	 */
+	function removeLink() {
+		// Reset all attributes that comprise the link.
+		setAttributes( {
+			url: '',
+			label: '',
+			id: '',
+			kind: '',
+			type: '',
+		} );
+
+		// Close the link editing UI.
+		setIsLinkOpen( false );
+	}
+
 	let userCanCreate = false;
 	if ( ! type || type === 'page' ) {
 		userCanCreate = userCanCreatePages;
@@ -690,6 +707,7 @@ export default function NavigationLinkEdit( {
 										attributes
 									)
 								}
+								onRemove={ removeLink }
 							/>
 						</Popover>
 					) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/issues/18866 we see that it is impossible to remove a link from the Nav Link block once it's been added. That's not good.

[I've already added a `Unlink` feature to the link UI in the format library](https://github.com/WordPress/gutenberg/pull/32541) for rich text and I've been meaning to port it over to the Nav Block link implementation.

This PR enables the ability to unset links on the Nav Link block using the `Unlink` button in the link UI.

**Note**: we are intentionally not mirroring this unlink behaviour in the block toolbar for [the reasons outlined in this comment](https://github.com/WordPress/gutenberg/pull/33777#issuecomment-889829952).

## How has this been tested?

* Create a new Post.
* Add Nav Block.
* Add a custom link to anything you want.
* Click on link.
* See `Unlink` button in popover.
* Click button.
* Remove is removed and the UI of the `Nav Link` block should be reset to default state.
* Check you can click and re-add the link as required.
* Check you can do the same in the Nav Editor screen.

## Screenshots <!-- if applicable -->


#### Post Editor
https://user-images.githubusercontent.com/444434/127629489-927586d7-6bb8-49eb-85a9-b09e3de7263e.mp4


#### Nav Editor
https://user-images.githubusercontent.com/444434/127629484-e5837372-a98c-40a8-8678-7afd8d48b98f.mp4




## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
