### PR TITLE
URL Details: Avoid PHP notice when parsing protocol-relative icon URLs

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -269,7 +269,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		// If the icon is a data URL, return it.
 		$parsed_icon = parse_url( $icon );
-		if ( 'data' === $parsed_icon['scheme'] ) {
+		if ( isset( $parsed_icon['schema'] ) && 'data' === $parsed_icon['scheme'] ) {
 			return $icon;
 		}
 


### PR DESCRIPTION
## Description
Sites might use protocol-relative URLs for icons. When a similar URL is parsed with `parse_url`, it doesn't return schema and triggered PHP notice.

Example: https://3v4l.org/SFEiZ

## How has this been tested?
1. Create a post.
2. Add a paragraph with a link to `https://twitter.com/`
3. Display rich URL preview.
4. WP shouldn't log the `PHP Notice:  Undefined index: scheme` message.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
