### PR TITLE
[docs] fix: `supports.color.gradients` is plural

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -226,7 +226,7 @@ This property adds UI controls which allow the user to apply a gradient backgrou
 ```js
 supports: {
     color: {
-        gradient: true,
+        gradients: true,
 
         // Default values must be disabled if you don't want to use them with gradient.
         background: false,


### PR DESCRIPTION
Small typo in the block supports documentation; `supports.color.gradient` should be `supports.color.gradients` as plural.