### PR TITLE
[RNMobile] Fix crash caused by column block with padding having paragraph as a child

### DIFF
--- a/packages/components/src/mobile/global-styles-context/index.native.js
+++ b/packages/components/src/mobile/global-styles-context/index.native.js
@@ -36,10 +36,17 @@ export const getMergedGlobalStyles = (
 		blockAttributes,
 		BLOCK_STYLE_ATTRIBUTES
 	);
+	// This prevents certain wrapper styles from being applied to blocks that
+	// don't support them yet.
+	const wrapperPropsStyleFiltered = pick(
+		wrapperPropsStyle,
+		BLOCK_STYLE_ATTRIBUTES
+	);
+
 	const mergedStyle = {
 		...baseGlobalColors,
 		...globalStyle,
-		...wrapperPropsStyle,
+		...wrapperPropsStyleFiltered,
 	};
 	const blockColors = getBlockColors(
 		blockStyleAttributes,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/15016.

Column block has [a new feature](https://github.com/WordPress/gutenberg/pull/31778), where we can add paddings to a column block and it passes these to its child as `wrapperStyles`. These paddings can have units of `%` as well as `px`, `em`, etc. Since paragraph block on mobile doesn't yet support all of those units, the app crashes during layout. 


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

On web, using a self-hosted or atomic site with latest Gutenberg version.
1. Add a columns block
1. Select 100 to add a single column
1. Add a paragraph block inside this column and add some text
1. Select back the column
1. Add some padding from sidebar -> `Spacing` -> `Padding`
1. Save the post as draft and open from Mobile Gutenberg

<img width="276" alt="column-settings" src="https://user-images.githubusercontent.com/1845482/127677397-de6d9f79-5efa-499d-815d-57661f7a8071.png">

Alternatively you can use this HTML in the Gutenberg demo app by switching to HTML mode, pasting it and switching back to Visual mode to test:

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"5px","right":"5px","bottom":"5px","left":"5px"}}}} -->
<div class="wp-block-column" style="padding-top:5px;padding-right:5px;padding-bottom:5px;padding-left:5px"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

## Screenshots <!-- if applicable -->

Before | After
-- | -- 
<img width="300" src="https://user-images.githubusercontent.com/1845482/127371989-4e661df9-672f-4b8d-9640-cab8162d98e5.png">|<img width="300" src="https://user-images.githubusercontent.com/1845482/127678357-dd079032-73f8-4fa4-b1f1-24a86fe10947.png">





## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
