### PR TITLE
components: Convert Select to TypeScript

### DIFF
--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -20,7 +20,7 @@ import {
  *                                                             That element should be passed as a child.
  * @property {import('react').ReactNode} help                  If this property is added, a help text will be
  *                                                             generated using help property as the content.
- * @property {import('react').ReactNode} label                 If this property is added, a label will be generated
+ * @property {import('react').ReactNode} [label]               If this property is added, a label will be generated
  *                                                             using label property as the content.
  * @property {boolean}                   [hideLabelFromVision] If true, the label will only be visible to screen readers.
  * @property {string}                    [className]           The class that will be added with "components-base-control" to the

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -21,6 +21,7 @@ import InputBase from '../input-control/input-base';
 import type { InputBaseProps, LabelPosition } from '../input-control/types';
 import { Select, DownArrowWrapper } from './styles/select-control-styles';
 import type { Size } from './types';
+import type { PolymorphicComponentProps } from '../ui/context';
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( SelectControl );
@@ -67,7 +68,7 @@ function SelectControl(
 		value: valueProp,
 		labelPosition = 'top',
 		...props
-	}: SelectControlProps,
+	}: PolymorphicComponentProps< SelectControlProps, 'select', false >,
 	ref: Ref< HTMLSelectElement >
 ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -114,15 +115,17 @@ function SelectControl(
 				label={ label }
 				size={ size }
 				suffix={
-					<DownArrowWrapper>
-						<Icon icon={ chevronDown } size={ 18 } />
-					</DownArrowWrapper>
+					props.suffix || (
+						<DownArrowWrapper>
+							<Icon icon={ chevronDown } size={ 18 } />
+						</DownArrowWrapper>
+					)
 				}
+				prefix={ props.prefix }
 				labelPosition={ labelPosition }
-				{ ...props }
 			>
 				<Select
-					{ ...omit( props, 'prefix' ) }
+					{ ...omit( props, 'prefix', 'suffix' ) }
 					aria-describedby={ helpId }
 					className="components-select-control__input"
 					disabled={ disabled }

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty, noop, omit } from 'lodash';
 import classNames from 'classnames';
+// eslint-disable-next-line no-restricted-imports
+import type { ChangeEvent, FocusEvent, Ref } from 'react';
 
 /**
  * WordPress dependencies
@@ -16,13 +18,36 @@ import { Icon, chevronDown } from '@wordpress/icons';
  */
 import BaseControl from '../base-control';
 import InputBase from '../input-control/input-base';
+import type { InputBaseProps, LabelPosition } from '../input-control/types';
 import { Select, DownArrowWrapper } from './styles/select-control-styles';
+import type { Size } from './types';
 
-function useUniqueId( idProp ) {
+function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( SelectControl );
 	const id = `inspector-select-control-${ instanceId }`;
 
 	return idProp || id;
+}
+
+export interface SelectControlProps extends Omit< InputBaseProps, 'children' > {
+	help?: string;
+	hideLabelFromVision?: boolean;
+	multiple?: boolean;
+	onBlur?: ( event: FocusEvent< HTMLSelectElement > ) => void;
+	onFocus?: ( event: FocusEvent< HTMLSelectElement > ) => void;
+	onChange?: (
+		value: string | string[],
+		extra?: { event?: ChangeEvent< HTMLSelectElement > }
+	) => void;
+	options?: {
+		label: string;
+		value: string;
+		id?: string;
+		disabled?: boolean;
+	}[];
+	size?: Size;
+	value?: string | string[];
+	labelPosition?: LabelPosition;
 }
 
 function SelectControl(
@@ -42,8 +67,8 @@ function SelectControl(
 		value: valueProp,
 		labelPosition = 'top',
 		...props
-	},
-	ref
+	}: SelectControlProps,
+	ref: Ref< HTMLSelectElement >
 ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const id = useUniqueId( idProp );
@@ -52,17 +77,17 @@ function SelectControl(
 	// Disable reason: A select with an onchange throws a warning
 	if ( isEmpty( options ) ) return null;
 
-	const handleOnBlur = ( event ) => {
+	const handleOnBlur = ( event: FocusEvent< HTMLSelectElement > ) => {
 		onBlur( event );
 		setIsFocused( false );
 	};
 
-	const handleOnFocus = ( event ) => {
+	const handleOnFocus = ( event: FocusEvent< HTMLSelectElement > ) => {
 		onFocus( event );
 		setIsFocused( true );
 	};
 
-	const handleOnChange = ( event ) => {
+	const handleOnChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
 		if ( multiple ) {
 			const selectedOptions = [ ...event.target.options ].filter(
 				( { selected } ) => selected
@@ -79,7 +104,7 @@ function SelectControl(
 
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (
-		<BaseControl help={ help }>
+		<BaseControl help={ help } id={ id }>
 			<InputBase
 				className={ classes }
 				disabled={ disabled }
@@ -97,7 +122,7 @@ function SelectControl(
 				{ ...props }
 			>
 				<Select
-					{ ...props }
+					{ ...omit( props, 'prefix' ) }
 					aria-describedby={ helpId }
 					className="components-select-control__input"
 					disabled={ disabled }
@@ -107,7 +132,7 @@ function SelectControl(
 					onChange={ handleOnChange }
 					onFocus={ handleOnFocus }
 					ref={ ref }
-					size={ size }
+					selectSize={ size }
 					value={ valueProp }
 				>
 					{ options.map( ( option, index ) => {

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -67,6 +67,8 @@ function SelectControl(
 		size = 'default',
 		value: valueProp,
 		labelPosition = 'top',
+		prefix,
+		suffix,
 		...props
 	}: PolymorphicComponentProps< SelectControlProps, 'select', false >,
 	ref: Ref< HTMLSelectElement >
@@ -115,17 +117,17 @@ function SelectControl(
 				label={ label }
 				size={ size }
 				suffix={
-					props.suffix || (
+					suffix || (
 						<DownArrowWrapper>
 							<Icon icon={ chevronDown } size={ 18 } />
 						</DownArrowWrapper>
 					)
 				}
-				prefix={ props.prefix }
+				prefix={ prefix }
 				labelPosition={ labelPosition }
 			>
 				<Select
-					{ ...omit( props, 'prefix', 'suffix' ) }
+					{ ...props }
 					aria-describedby={ helpId }
 					className="components-select-control__input"
 					disabled={ disabled }

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -8,8 +8,14 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { COLORS, rtl } from '../../utils';
+import type { Size } from '../types';
 
-const disabledStyles = ( { disabled } ) => {
+interface SelectProps {
+	disabled?: boolean;
+	selectSize?: Size;
+}
+
+const disabledStyles = ( { disabled }: SelectProps ) => {
 	if ( ! disabled ) return '';
 
 	return css( {
@@ -17,13 +23,13 @@ const disabledStyles = ( { disabled } ) => {
 	} );
 };
 
-const fontSizeStyles = ( { size } ) => {
+const fontSizeStyles = ( { selectSize }: SelectProps ) => {
 	const sizes = {
 		default: '13px',
 		small: '11px',
 	};
 
-	const fontSize = sizes[ size ];
+	const fontSize = sizes[ selectSize ];
 	const fontSizeMobile = '16px';
 
 	if ( ! fontSize ) return '';
@@ -37,7 +43,7 @@ const fontSizeStyles = ( { size } ) => {
 	`;
 };
 
-const sizeStyles = ( { size } ) => {
+const sizeStyles = ( { selectSize }: SelectProps ) => {
 	const sizes = {
 		default: {
 			height: 30,
@@ -51,7 +57,7 @@ const sizeStyles = ( { size } ) => {
 		},
 	};
 
-	const style = sizes[ size ] || sizes.default;
+	const style = sizes[ selectSize ] || sizes.default;
 
 	return css( style );
 };
@@ -59,7 +65,7 @@ const sizeStyles = ( { size } ) => {
 // TODO: Resolve need to use &&& to increase specificity
 // https://github.com/WordPress/gutenberg/issues/18483
 
-export const Select = styled.select`
+export const Select = styled.select< SelectProps >`
 	&&& {
 		appearance: none;
 		background: transparent;
@@ -75,7 +81,7 @@ export const Select = styled.select`
 		${ fontSizeStyles };
 		${ sizeStyles };
 
-		${ rtl( { paddingLeft: 8, paddingRight: 24 } )() }
+		${ rtl( { paddingLeft: 8, paddingRight: 24 } ) }
 	}
 `;
 
@@ -89,7 +95,7 @@ export const DownArrowWrapper = styled.div`
 	position: absolute;
 	top: 0;
 
-	${ rtl( { right: 0 } )() }
+	${ rtl( { right: 0 } ) }
 
 	svg {
 		display: block;

--- a/packages/components/src/select-control/types.ts
+++ b/packages/components/src/select-control/types.ts
@@ -1,0 +1,1 @@
+export type Size = 'default' | 'small';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Converts the SelectControl to TypeScript. Depends on the InputControl conversion.

I did this as part of https://github.com/WordPress/gutenberg/pull/33714 so just splitting it into a separate PR.

## How has this been tested?
Types should pass. There are no runtime changes 🙂 

## Types of changes
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [N/A] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
