### PR TITLE
Readable JS assets Plugin: Fix webpack 5 support

### DIFF
--- a/packages/readable-js-assets-webpack-plugin/index.js
+++ b/packages/readable-js-assets-webpack-plugin/index.js
@@ -6,7 +6,9 @@ const path = require( 'path' );
 
 class AddReadableJsAssetsWebpackPlugin {
 	extractUnminifiedFiles( compilation ) {
-		const files = compilation.chunks.flatMap( ( chunk ) => chunk.files );
+		const files = [ ...compilation.chunks ].flatMap( ( chunk ) => [
+			...chunk.files,
+		] );
 		compilation.unminifiedAssets = files.map( ( file ) => {
 			const asset = compilation.assets[ file ];
 			const unminifiedFile = file.replace( /\.min\.js$/, '.js' );

--- a/packages/readable-js-assets-webpack-plugin/index.js
+++ b/packages/readable-js-assets-webpack-plugin/index.js
@@ -6,9 +6,9 @@ const path = require( 'path' );
 
 class AddReadableJsAssetsWebpackPlugin {
 	extractUnminifiedFiles( compilation ) {
-		const files = [ ...compilation.chunks ].flatMap( ( chunk ) => [
-			...chunk.files,
-		] );
+		const files = Array.from( compilation.chunks ).flatMap( ( chunk ) =>
+			Array.from( chunk.files )
+		);
 		compilation.unminifiedAssets = files.map( ( file ) => {
 			const asset = compilation.assets[ file ];
 			const unminifiedFile = file.replace( /\.min\.js$/, '.js' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In webpack v5 `Compilation.chunks` and `Chunk.files` changed from arrays to sets. See https://webpack.js.org/blog/2020-10-10-webpack-5-release/#arrays-to-sets

Support both v4 and v5 by making sure we work with arrays (converting the set to array for v5) when generating the files list.

## How has this been tested?
Tested the plugin both in webpack v4 and v5.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
