### PR TITLE
Add spaces in add_theme_support docs code

### DIFF
--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -21,23 +21,23 @@ To opt-in for one of these features, call `add_theme_support` in the `functions.
 function mytheme_setup_theme_supported_features() {
 	add_theme_support( 'editor-color-palette', array(
 		array(
-			'name' => esc_attr__( 'strong magenta', 'themeLangDomain' ),
-			'slug' => 'strong-magenta',
+			'name'  => esc_attr__( 'strong magenta', 'themeLangDomain' ),
+			'slug'  => 'strong-magenta',
 			'color' => '#a156b4',
 		),
 		array(
-			'name' => esc_attr__( 'light grayish magenta', 'themeLangDomain' ),
-			'slug' => 'light-grayish-magenta',
+			'name'  => esc_attr__( 'light grayish magenta', 'themeLangDomain' ),
+			'slug'  => 'light-grayish-magenta',
 			'color' => '#d0a5db',
 		),
 		array(
-			'name' => esc_attr__( 'very light gray', 'themeLangDomain' ),
-			'slug' => 'very-light-gray',
+			'name'  => esc_attr__( 'very light gray', 'themeLangDomain' ),
+			'slug'  => 'very-light-gray',
 			'color' => '#eee',
 		),
 		array(
-			'name' => esc_attr__( 'very dark gray', 'themeLangDomain' ),
-			'slug' => 'very-dark-gray',
+			'name'  => esc_attr__( 'very dark gray', 'themeLangDomain' ),
+			'slug'  => 'very-dark-gray',
 			'color' => '#444',
 		),
 	) );
@@ -105,23 +105,23 @@ Different blocks have the possibility of customizing colors. The block editor pr
 ```php
 add_theme_support( 'editor-color-palette', array(
 	array(
-		'name' => esc_attr__( 'strong magenta', 'themeLangDomain' ),
-		'slug' => 'strong-magenta',
+		'name'  => esc_attr__( 'strong magenta', 'themeLangDomain' ),
+		'slug'  => 'strong-magenta',
 		'color' => '#a156b4',
 	),
 	array(
-		'name' => esc_attr__( 'light grayish magenta', 'themeLangDomain' ),
-		'slug' => 'light-grayish-magenta',
+		'name'  => esc_attr__( 'light grayish magenta', 'themeLangDomain' ),
+		'slug'  => 'light-grayish-magenta',
 		'color' => '#d0a5db',
 	),
 	array(
-		'name' => esc_attr__( 'very light gray', 'themeLangDomain' ),
-		'slug' => 'very-light-gray',
+		'name'  => esc_attr__( 'very light gray', 'themeLangDomain' ),
+		'slug'  => 'very-light-gray',
 		'color' => '#eee',
 	),
 	array(
-		'name' => esc_attr__( 'very dark gray', 'themeLangDomain' ),
-		'slug' => 'very-dark-gray',
+		'name'  => esc_attr__( 'very dark gray', 'themeLangDomain' ),
+		'slug'  => 'very-dark-gray',
 		'color' => '#444',
 	),
 ) );
@@ -388,7 +388,7 @@ add_theme_support( 'responsive-embeds' );
 Some blocks can have padding controls. This is off by default, and requires the theme to opt in by declaring support:
 
 ```php
-add_theme_support('custom-spacing');
+add_theme_support( 'custom-spacing' );
 ```
 
 ## Link color control
@@ -406,7 +406,7 @@ Link support has been made stable as part of WordPress 5.8. It's `false` by defa
 }
 ```
 
-> Alternatively, with the Gutenberg plugin active, the old legacy support `add_theme_support('experimental-link-color')` would also work. This fallback would be removed when the Gutenberg plugin requires WordPress 5.8 as the minimum version.
+> Alternatively, with the Gutenberg plugin active, the old legacy support `add_theme_support( 'experimental-link-color' )` would also work. This fallback would be removed when the Gutenberg plugin requires WordPress 5.8 as the minimum version.
 
 When the user sets the link color of a block, a new style will be added in the form of:
 


### PR DESCRIPTION
## Description
Added missing space in theme support docs

## Types of changes
<!-- What types of changes does your code introduce?  -->
Updated the documentation

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
