### PR TITLE
Remove duplicate viewport and title element hooks

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -91,14 +91,6 @@ function gutenberg_override_query_template( $template, $type, array $templates )
 		}
 	}
 
-	// Add hooks for template canvas.
-	// Add viewport meta tag.
-	add_action( 'wp_head', 'gutenberg_viewport_meta_tag', 0 );
-
-	// Render title tag with content, regardless of whether theme has title-tag support.
-	remove_action( 'wp_head', '_wp_render_title_tag', 1 );    // Remove conditional title tag rendering...
-	add_action( 'wp_head', 'gutenberg_render_title_tag', 1 ); // ...and make it unconditional.
-
 	// This file will be included instead of the theme's template file.
 	return gutenberg_dir_path() . 'lib/template-canvas.php';
 }


### PR DESCRIPTION
## Description
The hooks to inject `gutenberg_viewport_meta_tag` and `gutenberg_render_title_tag` into `wp_head` were shipped as part of WordPress 5.8. Having them in the Gutenberg plugin and in WordPress core results in duplicate `<title>` and duplicate `<meta name="viewport"` tags in markup.

See https://github.com/WordPress/wordpress-develop/commit/ea49625d59f41e17312d4c08503cd2dd567f4bda

## How has this been tested?
1. View source on the front-end before the change.
2. View source on the front-end after the change.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- n/a I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- n/a My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- n/a I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- n/a I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
