### PR TITLE
Fix gutenberg_resolve_template() return documentation

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -110,10 +110,7 @@ function gutenberg_override_query_template( $template, $type, array $templates )
  *
  * @param string   $template_type      The current template type.
  * @param string[] $template_hierarchy (optional) The current template hierarchy, ordered by priority.
- * @return null|array {
- *  @type WP_Post|null template_post A template post object, or null if none could be found.
- *  @type int[] A list of template parts IDs for the template.
- * }
+ * @return null|WP_Block_Template A block template if found. Null if not.
  */
 function gutenberg_resolve_template( $template_type, $template_hierarchy ) {
 	if ( ! $template_type ) {


### PR DESCRIPTION
`gutenberg_resolve_template()` now returns a `WP_Block_Template` instance rather than an array of data.