### PR TITLE
Fix insertion point in Widgets editors

### DIFF
--- a/packages/customize-widgets/src/components/inserter/index.js
+++ b/packages/customize-widgets/src/components/inserter/index.js
@@ -5,12 +5,21 @@ import { __ } from '@wordpress/i18n';
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { store as customizeWidgetsStore } from '../../store';
 
 function Inserter( { setIsOpened } ) {
 	const inserterTitleId = useInstanceId(
 		Inserter,
 		'customize-widget-layout__inserter-panel-title'
+	);
+	const insertionPoint = useSelect( ( select ) =>
+		select( customizeWidgetsStore ).__experimentalGetInsertionPoint()
 	);
 
 	return (
@@ -34,6 +43,10 @@ function Inserter( { setIsOpened } ) {
 			</div>
 			<div className="customize-widgets-layout__inserter-panel-content">
 				<Library
+					rootClientId={ insertionPoint.rootClientId }
+					__experimentalInsertionIndex={
+						insertionPoint.insertionIndex
+					}
 					showInserterHelpPanel
 					onSelect={ () => setIsOpened( false ) }
 				/>

--- a/packages/customize-widgets/src/components/inserter/use-inserter.js
+++ b/packages/customize-widgets/src/components/inserter/use-inserter.js
@@ -1,16 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch, select as selectStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as customizeWidgetsStore } from '../../store';
 
 export default function useInserter( inserter ) {
-	const [ isInserterOpened, setIsInserterOpened ] = useState(
-		() => inserter.isOpen
+	const isInserterOpened = useSelect( ( select ) =>
+		select( customizeWidgetsStore ).isInserterOpened()
 	);
+	const { setIsInserterOpened } = useDispatch( customizeWidgetsStore );
 
 	useEffect( () => {
-		return inserter.subscribe( setIsInserterOpened );
-	}, [ inserter ] );
+		if ( isInserterOpened ) {
+			inserter.open();
+		} else {
+			inserter.close();
+		}
+	}, [ inserter, isInserterOpened ] );
 
 	return [
 		isInserterOpened,
@@ -18,16 +29,14 @@ export default function useInserter( inserter ) {
 			( updater ) => {
 				let isOpen = updater;
 				if ( typeof updater === 'function' ) {
-					isOpen = updater( inserter.isOpen );
+					isOpen = updater(
+						selectStore( customizeWidgetsStore ).isInserterOpened()
+					);
 				}
 
-				if ( isOpen ) {
-					inserter.open();
-				} else {
-					inserter.close();
-				}
+				setIsInserterOpened( isOpen );
 			},
-			[ inserter ]
+			[ setIsInserterOpened ]
 		),
 	];
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -88,6 +88,7 @@ export default function SidebarBlockEditor( {
 		blockEditorSettings,
 		isFixedToolbarActive,
 		keepCaretInsideBlock,
+		setIsInserterOpened,
 	] );
 
 	if ( isWelcomeGuideActive ) {

--- a/packages/customize-widgets/src/controls/inserter-outer-section.js
+++ b/packages/customize-widgets/src/controls/inserter-outer-section.js
@@ -75,12 +75,27 @@ export default function getInserterOuterSection() {
 			);
 
 			this.contentContainer.addClass( 'widgets-inserter' );
+
+			// Set a flag if the state is being changed from open() or close().
+			// Don't propagate the event if it's an internal action to prevent infinite loop.
+			this.isFromInternalAction = false;
+			this.expanded.bind( () => {
+				if ( ! this.isFromInternalAction ) {
+					// Propagate the event to React to sync the state.
+					dispatch( customizeWidgetsStore ).setIsInserterOpened(
+						this.expanded()
+					);
+				}
+				this.isFromInternalAction = false;
+			} );
 		}
 		open() {
 			if ( ! this.expanded() ) {
 				const contentContainer = this.contentContainer[ 0 ];
 				this.activeElementBeforeExpanded =
 					contentContainer.ownerDocument.activeElement;
+
+				this.isFromInternalAction = true;
 
 				this.expand( {
 					completeCallback() {
@@ -102,6 +117,8 @@ export default function getInserterOuterSection() {
 				const contentContainer = this.contentContainer[ 0 ];
 				const activeElement =
 					contentContainer.ownerDocument.activeElement;
+
+				this.isFromInternalAction = true;
 
 				this.collapse( {
 					completeCallback() {

--- a/packages/customize-widgets/src/controls/inserter-outer-section.js
+++ b/packages/customize-widgets/src/controls/inserter-outer-section.js
@@ -3,6 +3,12 @@
  */
 import { ESCAPE } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as customizeWidgetsStore } from '../store';
 
 export default function getInserterOuterSection() {
 	const {
@@ -52,14 +58,16 @@ export default function getInserterOuterSection() {
 				'keydown',
 				( event ) => {
 					if (
-						this.isOpen &&
+						this.expanded() &&
 						( event.keyCode === ESCAPE ||
 							event.code === 'Escape' ) &&
 						! event.defaultPrevented
 					) {
 						event.preventDefault();
 						event.stopPropagation();
-						this.close();
+						dispatch( customizeWidgetsStore ).setIsInserterOpened(
+							false
+						);
 					}
 				},
 				// Use capture mode to make this run before other event listeners.
@@ -68,15 +76,8 @@ export default function getInserterOuterSection() {
 
 			this.contentContainer.addClass( 'widgets-inserter' );
 		}
-		get isOpen() {
-			return this.expanded();
-		}
-		subscribe( handler ) {
-			this.expanded.bind( handler );
-			return () => this.expanded.unbind( handler );
-		}
 		open() {
-			if ( ! this.isOpen ) {
+			if ( ! this.expanded() ) {
 				const contentContainer = this.contentContainer[ 0 ];
 				this.activeElementBeforeExpanded =
 					contentContainer.ownerDocument.activeElement;
@@ -97,7 +98,7 @@ export default function getInserterOuterSection() {
 			}
 		}
 		close() {
-			if ( this.isOpen ) {
+			if ( this.expanded() ) {
 				const contentContainer = this.contentContainer[ 0 ];
 				const activeElement =
 					contentContainer.ownerDocument.activeElement;

--- a/packages/customize-widgets/src/controls/sidebar-control.js
+++ b/packages/customize-widgets/src/controls/sidebar-control.js
@@ -1,8 +1,14 @@
 /**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import SidebarAdapter from '../components/sidebar-block-editor/sidebar-adapter';
 import getInserterOuterSection from './inserter-outer-section';
+import { store as customizeWidgetsStore } from '../store';
 
 const getInserterId = ( controlId ) => `widgets-inserter-${ controlId }`;
 
@@ -45,7 +51,9 @@ export default function getSidebarControl() {
 			if ( ! args.unchanged ) {
 				// Close the inserter when the section collapses.
 				if ( ! expanded ) {
-					this.inserter.close();
+					dispatch( customizeWidgetsStore ).setIsInserterOpened(
+						false
+					);
 				}
 
 				this.subscribers.forEach( ( subscriber ) =>

--- a/packages/customize-widgets/src/store/actions.js
+++ b/packages/customize-widgets/src/store/actions.js
@@ -15,3 +15,22 @@ export function __unstableToggleFeature( feature ) {
 		feature,
 	};
 }
+
+/**
+ * Returns an action object used to open/close the inserter.
+ *
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
+ *
+ * @return {Object} Action object.
+ */
+export function setIsInserterOpened( value ) {
+	return {
+		type: 'SET_IS_INSERTER_OPENED',
+		value,
+	};
+}

--- a/packages/customize-widgets/src/store/reducer.js
+++ b/packages/customize-widgets/src/store/reducer.js
@@ -26,6 +26,20 @@ const createWithInitialState = ( initialState ) => ( reducer ) => {
 };
 
 /**
+ * Reducer tracking whether the inserter is open.
+ *
+ * @param {boolean|Object} state
+ * @param {Object}         action
+ */
+function blockInserterPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value;
+	}
+	return state;
+}
+
+/**
  * Reducer returning the user preferences.
  *
  * @param {Object} state  Current state.
@@ -50,5 +64,6 @@ export const preferences = flow( [
 } );
 
 export default combineReducers( {
+	blockInserterPanel,
 	preferences,
 } );

--- a/packages/customize-widgets/src/store/selectors.js
+++ b/packages/customize-widgets/src/store/selectors.js
@@ -18,3 +18,26 @@ import { get } from 'lodash';
 export function __unstableIsFeatureActive( state, feature ) {
 	return get( state.preferences.features, [ feature ], false );
 }
+
+/**
+ * Returns true if the inserter is opened.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the inserter is opened.
+ */
+export function isInserterOpened( state ) {
+	return !! state.blockInserterPanel;
+}
+
+/**
+ * Get the insertion point for the inserter.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The root client ID and index to insert at.
+ */
+export function __experimentalGetInsertionPoint( state ) {
+	const { rootClientId, insertionIndex } = state.blockInserterPanel;
+	return { rootClientId, insertionIndex };
+}

--- a/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
+++ b/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
@@ -8,6 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import { store as editWidgetsStore } from '../store';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 
 const useWidgetLibraryInsertionPoint = () => {
@@ -30,6 +31,16 @@ const useWidgetLibraryInsertionPoint = () => {
 				getBlockOrder,
 				getBlockIndex,
 			} = select( blockEditorStore );
+
+			const insertionPoint = select(
+				editWidgetsStore
+			).__experimentalGetInsertionPoint();
+
+			// "Browse all" in the quick inserter will set the rootClientId to the current block.
+			// Otherwise, it will just be undefined, and we'll have to handle it differently below.
+			if ( insertionPoint.rootClientId ) {
+				return insertionPoint;
+			}
 
 			const clientId = getBlockSelectionEnd() || firstRootId;
 			const rootClientId = getBlockRootClientId( clientId );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -223,6 +223,18 @@ export function isInserterOpened( state ) {
 }
 
 /**
+ * Get the insertion point for the inserter.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The root client ID and index to insert at.
+ */
+export function __experimentalGetInsertionPoint( state ) {
+	const { rootClientId, insertionIndex } = state.blockInserterPanel;
+	return { rootClientId, insertionIndex };
+}
+
+/**
  * Returns true if a block can be inserted into a widget area.
  *
  * @param {Array}  state     The open state of the widget areas.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix #33372.

Use `__experimentalGetInsertionPoint()` in both editors to get the insertion points and pass them to the inserter library.

I also refactored the inserter logic in the customizer a bit to better match the coding style in the widgets screen.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Widget screen:

1. Go to Appearance -> Widgets
2. Add a social icons block
3. Open the quick inserter in the social icons block
4. Click "Browse all" to open the global inserter
5. The inserter should only have the "Widgets" category

Widget customizer:

1. Go to Appearance -> Customize -> Widgets
2. Add a social icons block
3. Open the quick inserter in the social icons block
4. Click "Browse all" to open the global inserter
5. The inserter should only have the "Widgets" category

## Screenshots <!-- if applicable -->

Widgets screen:

https://user-images.githubusercontent.com/7753001/127765142-ae8b2cd3-30a8-4321-b2b2-4e8465acf8e7.mp4

Widgets customizer:

https://user-images.githubusercontent.com/7753001/127765145-bc49c4fc-be12-4d4c-ab9a-4306d7d78425.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
