### PR TITLE
Experiment: Measure performance impact of loading blocks and patterns 

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -270,7 +270,7 @@ async function runPerformanceTests( branches, options ) {
 	// 4- Running the tests.
 	log( '\n>> Running the tests' );
 
-	const testSuites = [ 'post-editor', 'site-editor' ];
+	const testSuites = [ 'post-editor' ];
 
 	/** @type {Record<string,Record<string, WPPerformanceResults>>} */
 	const results = {};

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -244,7 +244,7 @@ add_action(
 			return;
 		}
 		remove_core_patterns();
-		register_gutenberg_patterns();
+		// register_gutenberg_patterns();
 	}
 );
 
@@ -257,7 +257,7 @@ add_action(
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
 		if ( $current_screen->is_block_editor || $is_site_editor ) {
-			load_remote_patterns();
+			// load_remote_patterns();
 		}
 	}
 );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -133,8 +133,20 @@ function gutenberg_reregister_core_block_types() {
 				$registry->unregister( $metadata['name'] );
 			}
 
-			gutenberg_register_core_block_assets( $folder_name );
-			register_block_type_from_metadata( $block_json_file );
+			if ( in_array( $metadata['name'], array(
+				'core/paragraph',
+				'core/image',
+				'core/heading',
+				'core/gallery',
+				'core/list',
+				'core/quote',
+				'core/group',
+				'core/freeform',
+				'core/missing',
+			) ) ) {
+				gutenberg_register_core_block_assets( $folder_name );
+				register_block_type_from_metadata( $block_json_file );
+			}
 		}
 
 		foreach ( $block_names as $file => $sub_block_names ) {
@@ -147,10 +159,10 @@ function gutenberg_reregister_core_block_types() {
 				if ( $registry->is_registered( $block_name ) ) {
 					$registry->unregister( $block_name );
 				}
-				gutenberg_register_core_block_assets( $block_name );
+				// gutenberg_register_core_block_assets( $block_name );
 			}
 
-			require_once $blocks_dir . $file;
+			// require_once $blocks_dir . $file;
 		}
 	}
 }

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -17,79 +17,10 @@ import * as image from './image';
 import * as heading from './heading';
 import * as quote from './quote';
 import * as gallery from './gallery';
-import * as archives from './archives';
-import * as audio from './audio';
-import * as buttons from './buttons';
-import * as button from './button';
-import * as calendar from './calendar';
-import * as categories from './categories';
-import * as code from './code';
-import * as columns from './columns';
-import * as column from './column';
-import * as cover from './cover';
-import * as embed from './embed';
-import * as file from './file';
-import * as html from './html';
-import * as mediaText from './media-text';
-import * as navigation from './navigation';
-import * as navigationLink from './navigation-link';
-import * as homeLink from './home-link';
-import * as latestComments from './latest-comments';
-import * as latestPosts from './latest-posts';
-import * as logInOut from './loginout';
 import * as list from './list';
 import * as missing from './missing';
-import * as more from './more';
-import * as nextpage from './nextpage';
-import * as pageList from './page-list';
-import * as preformatted from './preformatted';
-import * as pullquote from './pullquote';
-import * as reusableBlock from './block';
-import * as rss from './rss';
-import * as search from './search';
 import * as group from './group';
-import * as separator from './separator';
-import * as shortcode from './shortcode';
-import * as spacer from './spacer';
-import * as table from './table';
-// import * as tableOfContents from './table-of-contents';
-import * as textColumns from './text-columns';
-import * as verse from './verse';
-import * as video from './video';
-import * as tagCloud from './tag-cloud';
 import * as classic from './freeform';
-import * as socialLinks from './social-links';
-import * as socialLink from './social-link';
-
-// Full Site Editing Blocks
-import * as siteLogo from './site-logo';
-import * as siteTagline from './site-tagline';
-import * as siteTitle from './site-title';
-import * as templatePart from './template-part';
-import * as query from './query';
-import * as postTemplate from './post-template';
-import * as queryTitle from './query-title';
-import * as queryPagination from './query-pagination';
-import * as queryPaginationNext from './query-pagination-next';
-import * as queryPaginationNumbers from './query-pagination-numbers';
-import * as queryPaginationPrevious from './query-pagination-previous';
-import * as postNavigationLink from './post-navigation-link';
-import * as postTitle from './post-title';
-import * as postContent from './post-content';
-import * as postAuthor from './post-author';
-import * as postComment from './post-comment';
-import * as postCommentAuthor from './post-comment-author';
-import * as postCommentContent from './post-comment-content';
-import * as postCommentDate from './post-comment-date';
-import * as postComments from './post-comments';
-import * as postCommentsCount from './post-comments-count';
-import * as postCommentsForm from './post-comments-form';
-import * as postCommentsLink from './post-comments-link';
-import * as postDate from './post-date';
-import * as postExcerpt from './post-excerpt';
-import * as postFeaturedImage from './post-featured-image';
-import * as postTerms from './post-terms';
-import * as termDescription from './term-description';
 
 /**
  * Function to register an individual block.
@@ -126,66 +57,9 @@ export const __experimentalGetCoreBlocks = () => [
 	quote,
 
 	// Register all remaining core blocks.
-	shortcode,
-	archives,
-	audio,
-	button,
-	buttons,
-	calendar,
-	categories,
-	code,
-	columns,
-	column,
-	cover,
-	embed,
-	file,
 	group,
 	window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context
-	html,
-	mediaText,
-	latestComments,
-	latestPosts,
 	missing,
-	more,
-	nextpage,
-	pageList,
-	preformatted,
-	pullquote,
-	rss,
-	search,
-	separator,
-	reusableBlock,
-	socialLinks,
-	socialLink,
-	spacer,
-	table,
-	// tableOfContents,
-	tagCloud,
-	textColumns,
-	verse,
-	video,
-
-	// Theme blocks
-	siteLogo,
-	siteTagline,
-	siteTitle,
-
-	query,
-	postTemplate,
-	queryTitle,
-	queryPagination,
-	queryPaginationNext,
-	queryPaginationNumbers,
-	queryPaginationPrevious,
-
-	postTitle,
-	postContent,
-	postDate,
-	postExcerpt,
-	postFeaturedImage,
-	postTerms,
-
-	logInOut,
 ];
 
 /**
@@ -215,40 +89,5 @@ export const registerCoreBlocks = (
 
 /**
  * Function to register experimental core blocks depending on editor settings.
- *
- * @param {boolean} enableFSEBlocks Whether to enable the full site editing blocks.
- * @example
- * ```js
- * import { __experimentalRegisterExperimentalCoreBlocks } from '@wordpress/block-library';
- *
- * __experimentalRegisterExperimentalCoreBlocks( settings );
- * ```
  */
-export const __experimentalRegisterExperimentalCoreBlocks =
-	process.env.GUTENBERG_PHASE === 2
-		? ( { enableFSEBlocks } = {} ) => {
-				[
-					navigation,
-					navigationLink,
-					homeLink,
-
-					// Register Full Site Editing Blocks.
-					...( enableFSEBlocks
-						? [
-								templatePart,
-								postAuthor,
-								postComment,
-								postCommentAuthor,
-								postCommentContent,
-								postCommentDate,
-								postComments,
-								postCommentsCount,
-								postCommentsForm,
-								postCommentsLink,
-								postNavigationLink,
-								termDescription,
-						  ]
-						: [] ),
-				].forEach( registerBlock );
-		  }
-		: undefined;
+export const __experimentalRegisterExperimentalCoreBlocks = () => {};

--- a/packages/e2e-tests/assets/small-post.html
+++ b/packages/e2e-tests/assets/small-post.html
@@ -1,0 +1,11 @@
+<!-- wp:heading {"level":1} -->
+<h1>At iam decimum annum in spelunca iacet.</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="http://example.com/" target="_blank" rel="noreferrer noopener">Sit enim idem caecus, debilis.</a> Potius inflammat, ut coercendi magis quam dedocendi esse videantur. Quis non odit sordidos, vanos, leves, futtiles? Age sane, inquam. Duo Reges: constructio interrete. Nam ante Aristippus, et ille melius. Sed quamvis comis in amicis tuendis fuerit, tamen, si haec vera sunt-nihil enim affirmo-, non satis acutus fuit. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>At habetur! Et ego id scilicet nesciebam! Sed ut sit, etiamne post mortem coletur?</li><li>Totum genus hoc Zeno et qui ab eo sunt aut non potuerunt aut noluerunt, certe reliquerunt.</li><li>At quicum ioca seria, ut dicitur, quicum arcana, quicum occulta omnia?</li></ul>
+<!-- /wp:list -->

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -40,7 +40,7 @@ describe( 'Post Editor Performance', () => {
 		};
 
 		const html = readFile(
-			join( __dirname, '../../assets/large-post.html' )
+			join( __dirname, '../../assets/small-post.html' )
 		);
 
 		await createNewPost();

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -24,7 +24,7 @@ import { readFile, deleteFile, getTypingEventDurations } from './utils';
 
 jest.setTimeout( 1000000 );
 
-describe( 'Site Editor Performance', () => {
+describe.skip( 'Site Editor Performance', () => {
 	beforeAll( async () => {
 		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Opened to measure the impact of loading core blocks and block patterns on the block editor's performance.

I want to check the performance metrics when:
- core block patterns are removed
- non-essential core blocks are removed