### PR TITLE
[Block Library - Heading]: Add heading levels as block variations

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -17,6 +17,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -59,4 +60,5 @@ export const settings = {
 	},
 	edit,
 	save,
+	variations,
 };

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -10,8 +10,11 @@ import HeadingLevelIcon from './heading-level-icon';
 
 const variations = [ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 	name: `heading-${ level }`,
-	/* translators: %d: heading level. */
-	title: sprintf( 'Heading %d', level ),
+	title: sprintf(
+		/* translators: %d: heading level. */
+		__( 'Heading %d' ),
+		level
+	),
 	icon: <HeadingLevelIcon level={ level } />,
 	attributes: { level },
 	scope: [ 'inserter' ],

--- a/packages/block-library/src/heading/variations.js
+++ b/packages/block-library/src/heading/variations.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import HeadingLevelIcon from './heading-level-icon';
+
+const variations = [ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
+	name: `heading-${ level }`,
+	/* translators: %d: heading level. */
+	title: sprintf( 'Heading %d', level ),
+	icon: <HeadingLevelIcon level={ level } />,
+	attributes: { level },
+	scope: [ 'inserter' ],
+} ) );
+
+export default variations;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/32472

This PR just tries out adding heading levels as block variations. This way when you type something like `/h4`, an available option will be shown with a heading with level 4. Noting that the way variations work now, these heading variations are also shown in the main inserter. This feels a bit bloated to me but would like some other thoughts. Regarding this an alternative would be to expand the API by adding a scope that separates main and slash inserters, but I don't think there are other use cases to justify that API change.

Also noting that there is a [similar transformation in place](https://github.com/WordPress/gutenberg/pull/26597) where you can type `/h3` and press `enter/return` with the only difference that there is no UI indication that this transformation will happen. You need to know about it 😄 
