### PR TITLE
[Mobile] Renames Gallery v2 Flag to __unstableGalleryWithImageBlocks

### DIFF
--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -86,11 +86,11 @@ class NativeEditorProvider extends Component {
 	}
 
 	componentDidMount() {
-		const { capabilities, updateSettings, galleryRefactor } = this.props;
+		const { capabilities, updateSettings, galleryWithImageBlocks } = this.props;
 
 		updateSettings( {
 			...capabilities,
-			...{ __experimentalGalleryRefactor: galleryRefactor },
+			...{ __unstableGalleryWithImageBlocks: galleryWithImageBlocks },
 			...this.getThemeColors( this.props ),
 		} );
 
@@ -142,8 +142,8 @@ class NativeEditorProvider extends Component {
 			( editorSettings ) => {
 				updateSettings( {
 					...{
-						__experimentalGalleryRefactor:
-							editorSettings.galleryRefactor,
+						__unstableGalleryWithImageBlocks:
+							editorSettings.galleryWithImageBlocks,
 					},
 					...this.getThemeColors( editorSettings ),
 				} );

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -86,7 +86,11 @@ class NativeEditorProvider extends Component {
 	}
 
 	componentDidMount() {
-		const { capabilities, updateSettings, galleryWithImageBlocks } = this.props;
+		const {
+			capabilities,
+			updateSettings,
+			galleryWithImageBlocks
+		} = this.props;
 
 		updateSettings( {
 			...capabilities,

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -89,7 +89,7 @@ class NativeEditorProvider extends Component {
 		const {
 			capabilities,
 			updateSettings,
-			galleryWithImageBlocks
+			galleryWithImageBlocks,
 		} = this.props;
 
 		updateSettings( {

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -193,7 +193,7 @@ public class Gutenberg: NSObject {
     private func properties(from editorSettings: GutenbergEditorSettings?) -> [String : Any] {
         var settingsUpdates = [String : Any]()
         settingsUpdates["isFSETheme"] = editorSettings?.isFSETheme ?? false
-        settingsUpdates["galleryRefactor"] = editorSettings?.galleryRefactor ?? false
+        settingsUpdates["galleryWithImageBlocks"] = editorSettings?.galleryWithImageBlocks ?? false
 
         if let rawStyles = editorSettings?.rawStyles {
             settingsUpdates["rawStyles"] = rawStyles

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -72,7 +72,7 @@ public extension GutenbergBridgeDataSource {
 
 public protocol GutenbergEditorSettings {
     var isFSETheme: Bool { get }
-    var galleryRefactor: Bool { get }
+    var galleryWithImageBlocks: Bool { get }
     var rawStyles: String? { get }
     var rawFeatures: String? { get }
     var colors: [[String: String]]? { get }

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -83,7 +83,7 @@ const setupInitHooks = () => {
 				gradients,
 				rawStyles,
 				rawFeatures,
-				galleryRefactor,
+				galleryWithImageBlocks,
 			} = props;
 
 			if ( initialData === undefined && __DEV__ ) {
@@ -111,7 +111,7 @@ const setupInitHooks = () => {
 				gradients,
 				rawStyles,
 				rawFeatures,
-				galleryRefactor,
+				galleryWithImageBlocks,
 			};
 		}
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

#### Depends on https://github.com/WordPress/gutenberg/pull/33314

## Description
Merges latest upstream [changes](https://github.com/WordPress/gutenberg/pull/31306) and [renames Gallery v2 Flag](https://github.com/WordPress/gutenberg/pull/33816/commits/5fbe583723d0ccdedc1b6839b1cc142ba5976435) from `__experimentalGalleryRefactor` to `__unstableGalleryWithImageBlocks`

## How has this been tested?
Check steps at https://github.com/WordPress/gutenberg/pull/33314

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
