### PR TITLE
Fix Safari 13 metaboxes from overlapping the content.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -120,7 +120,8 @@ export default function VisualEditor( { styles } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
-		height: '100%',
+		// We intentionally omit a 100% height here. The container is a flex item, so the 100% height is granted by default.
+		// If a percentage height is present, older browsers such as Safari 13 apply that, but do so incorrectly as the inheritance is buggy.
 		width: '100%',
 		margin: 0,
 		display: 'flex',

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -22,15 +22,16 @@
 		}
 	}
 
-	flex: 1 1 auto;
+	// The following flex rule is important for the canvas layout, please be careful when refactoring,
+	// as older browser interpret flex height behavior differently. Be sure to test on Safari 13.
+	// The syntax is `flex: [flex-grow] [flex-shrink] [flex-basis];`
+	// We set the canvas to be allowed to grow (vertically), but not shrink.
+	flex: 1 0 auto;
 
-	// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
-	// But it works as expected without it.
-	// The flex-basis is needed for the other browsers to make sure the content area is full-height.
-	@supports (position: sticky) {
-		flex-basis: 100%;
-	}
-
+	// Since the parent container is also a flex container, a `flex-basis: 100%;` is not needed,
+	// as align-items: stretch is inherited by default.Additionally due to older browser's flex height
+	// interpretation, any percentage value is likely going to cause issues, such as metaboxes overlapping.
+	// See also https://www.w3.org/TR/CSS22/visudet.html#the-height-property.
 }
 
 // Ideally this wrapper div is not needed but if we want to match the positioning of blocks
@@ -69,4 +70,10 @@
 	height: 100%;
 	position: relative;
 	display: flex;
+
+	// This is necessary for older browsers due to their flex height interpretation.
+	// These browsers (including Safari 13) ignore the percentage value entirely.
+	// By setting flex-grow, the element stretches to fill the parent.
+	// See also https://www.w3.org/TR/CSS22/visudet.html#the-height-property
+	flex-grow: 1;
 }


### PR DESCRIPTION
## Description

Fixes #33668.

Flex is a delicate feature, especially when supporting a range of browsers. As it turns out, older versions of Safari have a pretty specific interpretation of how flex children should inherit the height of their parents. Which is to say, _they do if you don't provide a percentage height_. 

It gets a bit more gnarly than that, but [this SO comment](https://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent) elucidates a bit:

> Remove specified heights from flex items for this method to work. If a child has a height specified (e.g. height: 100%), then it will ignore the align-items: stretch coming from the parent. For the stretch default to work, the child's height must compute to auto.

I have developed this patch while using Browserstack to test Safari 13, because I'm no longer on MacOS Catalina. And as best I can tell the flex rules we have in place caused a sequence of events there:

- First it meant that the height of `.edit-post-visual-editor` was allowed to shrink, which happened when a metabox was present. This was fixed by disallowing shrinking (`flex: 1 0 auto;` instead of `flex: 1 1 auto;`) _and_ by removing `flex-basis: 100%;` (more on that in a second)
- When that was fixed, it became clear that the child element, `.edit-post-visual-editor__content-area` no longer expanded to fill the void. _Presumably_ because when `flex-basis: 100%;` was removed, inheritance there no longer worked. This was fixed by removing the explicit `height: 100%;` inline style applied to that element, _and_ by allowing it to grow (`flex-grow: 1;`). 

To summarize it to the best of my understanding: when we used percentages, the editing canvas didn't actually expand, causing the metaboxes to overlap it. By removing the percentages, I had to remove them from quite a few of the child items, and change those to rely in the intrinsic `align-items: stretch;` property they are given by `display: flex;` by default.

## How has this been tested?

In my testing, this threads the needle and accomplishes what it needs to in modern browsers, Chrome, Firefox, Edge and Safari 14. It also makes it all work with Safar 13. I have not tested older yet, but presume it works the same.

The behavior to test is:

- Test with and without the Custom Fields metabox present.
- Create a new post with no content, and you should not see the dark gray color behind the editing canvas peek through.
- Use the device preview dropdown and verify the sizes are correct. 
- Add a lot of content, and observe that the custom fields metabox keeps "riding below the content" as you press Enter. No overlap.

## Screenshots <!-- if applicable -->

The Safari 13 issue that ships in trunk (big GIF):

https://cldup.com/_zYngFvNTq.gif

Safari 13 after this PR is applied:

![saf 13 after](https://user-images.githubusercontent.com/1204802/127865217-0de80ec7-2906-4503-a4d8-6066bf7a6a75.gif)

Chrome after this PR applied (should be like before):

![chrome](https://user-images.githubusercontent.com/1204802/127865407-7ad3eaef-b067-44b8-895f-e5208342ea55.gif)

## Types of changes

Since this is a pretty sensitive part of the editor layout code, it's important to test this pretty broadly, notably with those of you with access to Safari 13. But it's still important to ensure identical behavior on modern browsers as well.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
