### PR TITLE
[Block Editor]: Conditionally show `Styles` if block is in Placeholder state

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -845,6 +845,21 @@ _Returns_
 
 -   `boolean`: Whether the block is currently highlighted.
 
+### isBlockInPlaceholderState
+
+Checks if a given block is in Placeholder state. This is
+useful for showing/hiding controls and other things,
+depending on this state.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _clientId_ `string`: The block to check.
+
+_Returns_
+
+-   `boolean`: True if the block is in Placeholder state.
+
 ### isBlockInsertionPointVisible
 
 Returns true if we should show the block insertion point.
@@ -1391,6 +1406,15 @@ _Parameters_
 
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
+
+### setIsInPlaceholderState
+
+Returns an action object that sets whether the block is in Placeholder state.
+
+_Parameters_
+
+-   _clientId_ `string`: The block's clientId.
+-   _isInPlaceholderState_ `boolean`: True if the block is in Placeholder state.
 
 ### setNavigationMode
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -38,11 +38,13 @@ const BlockInspector = ( {
 		selectedBlockName,
 		selectedBlockClientId,
 		blockType,
+		isInPlaceholderState,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
 			getSelectedBlockCount,
 			getBlockName,
+			isBlockInPlaceholderState,
 		} = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 
@@ -60,6 +62,9 @@ const BlockInspector = ( {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
+			isInPlaceholderState: isBlockInPlaceholderState(
+				_selectedBlockClientId
+			),
 		};
 	}, [] );
 
@@ -99,6 +104,7 @@ const BlockInspector = ( {
 			blockName={ blockType.name }
 			hasBlockStyles={ hasBlockStyles }
 			bubblesVirtually={ bubblesVirtually }
+			isInPlaceholderState={ isInPlaceholderState }
 		/>
 	);
 };
@@ -107,6 +113,7 @@ const BlockInspectorSingleBlock = ( {
 	clientId,
 	blockName,
 	hasBlockStyles,
+	isInPlaceholderState,
 	bubblesVirtually,
 } ) => {
 	const blockInformation = useBlockDisplayInformation( clientId );
@@ -114,7 +121,7 @@ const BlockInspectorSingleBlock = ( {
 		<div className="block-editor-block-inspector">
 			<BlockCard { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
-			{ hasBlockStyles && (
+			{ hasBlockStyles && ! isInPlaceholderState && (
 				<div>
 					<PanelBody title={ __( 'Styles' ) }>
 						<BlockStyles clientId={ clientId } />

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -42,21 +42,26 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 		icon,
 		blockTitle,
 		patterns,
+		isInPlaceholderState,
 	} = useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
 				getBlockTransformItems,
 				__experimentalGetPatternTransformItems,
+				isBlockInPlaceholderState,
 			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType } = select( blocksStore );
 			const rootClientId = getBlockRootClientId(
 				castArray( clientIds )[ 0 ]
 			);
-			const [ { name: firstBlockName } ] = blocks;
+			const [
+				{ name: firstBlockName, clientId: firstBlockClientId },
+			] = blocks;
 			const _isSingleBlockSelected = blocks.length === 1;
 			const styles =
 				_isSingleBlockSelected && getBlockStyles( firstBlockName );
+			const _hasBlockStyles = !! styles?.length;
 			let _icon;
 			if ( _isSingleBlockSelected ) {
 				_icon = blockInformation?.icon; // Take into account active block variations.
@@ -69,18 +74,22 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					? getBlockType( firstBlockName )?.icon
 					: stack;
 			}
+
 			return {
 				possibleBlockTransformations: getBlockTransformItems(
 					blocks,
 					rootClientId
 				),
-				hasBlockStyles: !! styles?.length,
+				hasBlockStyles: _hasBlockStyles,
 				icon: _icon,
 				blockTitle: getBlockType( firstBlockName ).title,
 				patterns: __experimentalGetPatternTransformItems(
 					blocks,
 					rootClientId
 				),
+				isInPlaceholderState:
+					_hasBlockStyles &&
+					isBlockInPlaceholderState( firstBlockClientId ),
 			};
 		},
 		[ clientIds, blocks, blockInformation?.icon ]
@@ -195,12 +204,13 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 											} }
 										/>
 									) }
-									{ hasBlockStyles && (
-										<BlockStylesMenu
-											hoveredBlock={ blocks[ 0 ] }
-											onSwitch={ onClose }
-										/>
-									) }
+									{ hasBlockStyles &&
+										! isInPlaceholderState && (
+											<BlockStylesMenu
+												hoveredBlock={ blocks[ 0 ] }
+												onSwitch={ onClose }
+											/>
+										) }
 								</div>
 							)
 						}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1404,3 +1404,17 @@ export function setHasControlledInnerBlocks(
 		clientId,
 	};
 }
+
+/**
+ * Returns an action object that sets whether the block is in Placeholder state.
+ *
+ * @param {string}  clientId             The block's clientId.
+ * @param {boolean} isInPlaceholderState True if the block is in Placeholder state.
+ */
+export function setIsInPlaceholderState( clientId, isInPlaceholderState ) {
+	return {
+		type: 'SET_IS_IN_PLACEHOLDER_STATE',
+		isInPlaceholderState,
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1105,6 +1105,15 @@ export const blocks = flow(
 		}
 		return state;
 	},
+	inPlaceholderState( state = {}, { type, clientId, isInPlaceholderState } ) {
+		if ( type === 'SET_IS_IN_PLACEHOLDER_STATE' ) {
+			return {
+				...state,
+				[ clientId ]: isInPlaceholderState,
+			};
+		}
+		return state;
+	},
 } );
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2242,3 +2242,17 @@ export function wasBlockJustInserted( state, clientId, source ) {
 		lastBlockInserted.source === source
 	);
 }
+
+/**
+ * Checks if a given block is in Placeholder state. This is
+ * useful for showing/hiding controls and other things,
+ * depending on this state.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The block to check.
+ *
+ * @return {boolean} True if the block is in Placeholder state.
+ */
+export function isBlockInPlaceholderState( state, clientId ) {
+	return !! state.blocks.inPlaceholderState[ clientId ];
+}

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -294,6 +294,7 @@ describe( 'state', () => {
 						[ newChildBlockId ]: {},
 					},
 					controlledInnerBlocks: {},
+					inPlaceholderState: {},
 				} );
 				expect( state.cache.chicken ).not.toBe(
 					existingState.cache.chicken
@@ -376,6 +377,7 @@ describe( 'state', () => {
 						[ newChildBlockId ]: {},
 					},
 					controlledInnerBlocks: {},
+					inPlaceholderState: {},
 				} );
 				expect( state.cache.chicken ).not.toBe(
 					existingState.cache.chicken
@@ -517,6 +519,7 @@ describe( 'state', () => {
 						[ newChildBlockId2 ]: {},
 						[ newChildBlockId3 ]: {},
 					},
+					inPlaceholderState: {},
 					controlledInnerBlocks: {},
 				} );
 			} );
@@ -608,6 +611,7 @@ describe( 'state', () => {
 						chicken: {},
 						[ newChildBlockId ]: {},
 					},
+					inPlaceholderState: {},
 					controlledInnerBlocks: {},
 				} );
 
@@ -629,6 +633,7 @@ describe( 'state', () => {
 				isPersistentChange: true,
 				isIgnoredChange: false,
 				cache: {},
+				inPlaceholderState: {},
 				controlledInnerBlocks: {},
 			} );
 		} );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -53,6 +53,7 @@ const {
 	isDraggingBlocks,
 	getDraggedBlockClientIds,
 	isBlockBeingDragged,
+	isBlockInPlaceholderState,
 	isAncestorBeingDragged,
 	isCaretWithinFormattedText,
 	getBlockInsertionPoint,
@@ -3682,6 +3683,29 @@ describe( 'selectors', () => {
 			expect(
 				wasBlockJustInserted( state, clientId, expectedSource )
 			).toBe( false );
+		} );
+	} );
+	describe( 'isBlockInPlaceholderState', () => {
+		it( 'when clientId is not in state', () => {
+			const state = {
+				blocks: { inPlaceholderState: { clientId1: true } },
+			};
+			expect( isBlockInPlaceholderState( state, 'clientId2' ) ).toBe(
+				false
+			);
+		} );
+		it( 'when clientId state is set', () => {
+			const state = {
+				blocks: {
+					inPlaceholderState: { clientId1: false, clientId2: true },
+				},
+			};
+			expect( isBlockInPlaceholderState( state, 'clientId1' ) ).toBe(
+				false
+			);
+			expect( isBlockInPlaceholderState( state, 'clientId2' ) ).toBe(
+				true
+			);
 		} );
 	} );
 } );

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -14,7 +14,7 @@ import {
 	RangeControl,
 	ToggleControl,
 } from '@wordpress/components';
-
+import { useEffect } from '@wordpress/element';
 import {
 	InspectorControls,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -273,6 +273,10 @@ const ColumnsEdit = ( props ) => {
 			select( blockEditorStore ).getBlocks( clientId ).length > 0,
 		[ clientId ]
 	);
+	const { setIsInPlaceholderState } = useDispatch( blockEditorStore );
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, ! hasInnerBlocks );
+	}, [ hasInnerBlocks ] );
 	const Component = hasInnerBlocks
 		? ColumnsEditContainerWrapper
 		: Placeholder;

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -45,7 +45,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { withDispatch, useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { cover as icon } from '@wordpress/icons';
 import { isBlobURL } from '@wordpress/blob';
 
@@ -307,7 +307,6 @@ function CoverEdit( {
 	overlayColor,
 	setAttributes,
 	setOverlayColor,
-	toggleSelection,
 } ) {
 	const {
 		contentPosition,
@@ -323,6 +322,9 @@ function CoverEdit( {
 		url,
 		alt,
 	} = attributes;
+	const { setIsInPlaceholderState, toggleSelection } = useDispatch(
+		blockEditorStore
+	);
 	const {
 		gradientClass,
 		gradientValue,
@@ -595,7 +597,11 @@ function CoverEdit( {
 		}
 	);
 
-	if ( ! hasInnerBlocks && ! hasBackground ) {
+	const inPlaceholderState = ! hasInnerBlocks && ! hasBackground;
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, inPlaceholderState );
+	}, [ inPlaceholderState ] );
+	if ( inPlaceholderState ) {
 		return (
 			<>
 				{ controls }
@@ -714,13 +720,6 @@ function CoverEdit( {
 }
 
 export default compose( [
-	withDispatch( ( dispatch ) => {
-		const { toggleSelection } = dispatch( blockEditorStore );
-
-		return {
-			toggleSelection,
-		};
-	} ),
 	withColors( { overlayColor: 'background-color' } ),
 	withNotices,
 	withInstanceId,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -89,9 +89,10 @@ function GalleryEdit( props ) {
 	} = attributes;
 	const [ selectedImage, setSelectedImage ] = useState();
 	const [ attachmentCaptions, setAttachmentCaptions ] = useState();
-	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
-		blockEditorStore
-	);
+	const {
+		__unstableMarkNextChangeAsNotPersistent,
+		setIsInPlaceholderState,
+	} = useDispatch( blockEditorStore );
 
 	const {
 		imageSizes,
@@ -408,6 +409,10 @@ function GalleryEdit( props ) {
 	);
 
 	const blockProps = useBlockProps();
+
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, ! hasImages );
+	}, [ hasImages ] );
 
 	if ( ! hasImages ) {
 		return <View { ...blockProps }>{ mediaPlaceholder }</View>;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -9,7 +9,7 @@ import { get, has, omit, pick } from 'lodash';
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { withNotices } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockAlignmentControl,
 	BlockControls,
@@ -284,6 +284,11 @@ export function ImageEdit( {
 			revokeBlobURL( temporaryURL );
 		};
 	}, [ temporaryURL ] );
+
+	const { setIsInPlaceholderState } = useDispatch( blockEditorStore );
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, ! url );
+	}, [ url ] );
 
 	const isExternal = isExternalImage( id, url );
 	const src = isExternal ? url : undefined;

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -109,7 +109,9 @@ function Navigation( {
 		false
 	);
 
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, setIsInPlaceholderState } = useDispatch(
+		blockEditorStore
+	);
 
 	const navRef = useRef();
 
@@ -196,7 +198,9 @@ function Navigation( {
 			);
 		}
 	} );
-
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, isPlaceholderShown );
+	}, [ isPlaceholderShown ] );
 	if ( isPlaceholderShown ) {
 		return (
 			<div { ...blockProps }>

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -159,6 +159,10 @@ const QueryEdit = ( props ) => {
 			!! select( blockEditorStore ).getBlocks( clientId ).length,
 		[ clientId ]
 	);
+	const { setIsInPlaceholderState } = useDispatch( blockEditorStore );
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, ! hasInnerBlocks );
+	}, [ hasInnerBlocks ] );
 	const Component = hasInnerBlocks ? QueryContent : QueryPatternSetup;
 	return <Component { ...props } />;
 };

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -5,6 +5,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	Button,
@@ -16,7 +17,8 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 import { grid, list, edit, rss } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -24,7 +26,7 @@ import ServerSideRender from '@wordpress/server-side-render';
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 10;
 
-export default function RSSEdit( { attributes, setAttributes } ) {
+export default function RSSEdit( { attributes, setAttributes, clientId } ) {
 	const [ isEditing, setIsEditing ] = useState( ! attributes.feedURL );
 
 	const {
@@ -56,6 +58,10 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 	const blockProps = useBlockProps();
 
+	const { setIsInPlaceholderState } = useDispatch( blockEditorStore );
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, isEditing );
+	}, [ isEditing ] );
 	if ( isEditing ) {
 		return (
 			<div { ...blockProps }>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -16,6 +16,7 @@ import {
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalUseBorderProps as useBorderProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -40,6 +41,7 @@ import {
 	table,
 } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -95,6 +97,7 @@ function TableEdit( {
 	setAttributes,
 	insertBlocksAfter,
 	isSelected,
+	clientId,
 } ) {
 	const { hasFixedLayout, caption, head, foot } = attributes;
 	const [ initialRowCount, setInitialRowCount ] = useState( 2 );
@@ -423,6 +426,10 @@ function TableEdit( {
 	) );
 
 	const isEmpty = ! sections.length;
+	const { setIsInPlaceholderState } = useDispatch( blockEditorStore );
+	useEffect( () => {
+		setIsInPlaceholderState( clientId, isEmpty );
+	}, [ isEmpty ] );
 
 	return (
 		<figure { ...useBlockProps() }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Partially addresses: https://github.com/WordPress/gutenberg/issues/23122 
Related: https://github.com/WordPress/gutenberg/pull/33466

There is the need to show/hide some controls or other things like `Styles` based on whether the block is in `Placeholder` state or not. For example when we have an `Image` block with no image set, there is no need to show the `Styles` tab or the `Styles` in `BlockSwitcher`.

This PR adds to the `block-editor` store an `inPlaceholderState` which tracks which blocks are in such state. This value can be consumed to conditionally show/hide things. In order to be a complete solution for `block.supports` it will need one more property to the state per `support`.

For start I've implemented this for `Image` block and will wait for feedback for the approach. If there is a consensus, I'll follow up on this by writing tests and add it to more blocks that can utilize this like Cover block(issue: https://github.com/WordPress/gutenberg/issues/23198)


## Testing instructions
1. Insert an `Image` block and observe that if you have not set an image, the `Styles` are not shown.
2. Set an image and observe that `Styles` are shown.
<!-- Please describe what you have changed or added -->


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
