### PR TITLE
components: Use updated range styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Listen to `resize` events correctly in `useBreakpointIndex`. This hook is used in `useResponsiveValue` and consequently in the `Flex` and `Grid` components  ([#33902](https://github.com/WordPress/gutenberg/pull/33902))
 
+### Breaking Change
+
+-	Updated the visual styles of the RangeControl component ([#33824](https://github.com/WordPress/gutenberg/pull/33824))
+
 ## 15.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -55,7 +55,7 @@ function RangeControl(
 		onFocus = noop,
 		onMouseMove = noop,
 		onMouseLeave = noop,
-		railColor,
+		railColor = 'var( --wp-admin-theme-color )',
 		resetFallbackValue,
 		renderTooltipContent = ( v ) => v,
 		showTooltip: showTooltipProp,

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -249,10 +249,11 @@ function RangeControl(
 						style={ { width: fillValueOffset } }
 						trackColor={ trackColor }
 					/>
-					<ThumbWrapper style={ offsetStyle }>
+					<ThumbWrapper style={ offsetStyle } disabled={ disabled }>
 						<Thumb
 							aria-hidden={ true }
 							isFocused={ isThumbFocused }
+							disabled={ disabled }
 						/>
 					</ThumbWrapper>
 					{ enableTooltip && (

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -101,6 +101,7 @@ function RangeControl(
 	const calculatedFillValue = ( ( value - min ) / ( max - min ) ) * 100;
 	const fillValue = isValueReset ? 50 : calculatedFillValue;
 	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
+	const tooltipOffset = `calc( ${ fillValueOffset } - 4px )`;
 
 	const classes = classnames( 'components-range-control', className );
 
@@ -189,6 +190,9 @@ function RangeControl(
 	const offsetStyle = {
 		[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
 	};
+	const tooltipOffsetStyle = {
+		[ isRTL() ? 'right' : 'left' ]: tooltipOffset,
+	};
 
 	return (
 		<BaseControl
@@ -257,7 +261,7 @@ function RangeControl(
 							inputRef={ inputRef }
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
-							style={ offsetStyle }
+							style={ tooltipOffsetStyle }
 							value={ value }
 						/>
 					) }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -101,7 +101,6 @@ function RangeControl(
 	const calculatedFillValue = ( ( value - min ) / ( max - min ) ) * 100;
 	const fillValue = isValueReset ? 50 : calculatedFillValue;
 	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
-	const tooltipOffset = `calc( ${ fillValueOffset } - 4px )`;
 
 	const classes = classnames( 'components-range-control', className );
 
@@ -190,9 +189,6 @@ function RangeControl(
 	const offsetStyle = {
 		[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
 	};
-	const tooltipOffsetStyle = {
-		[ isRTL() ? 'right' : 'left' ]: tooltipOffset,
-	};
 
 	return (
 		<BaseControl
@@ -262,7 +258,7 @@ function RangeControl(
 							inputRef={ inputRef }
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
-							style={ tooltipOffsetStyle }
+							style={ offsetStyle }
 							value={ value }
 						/>
 					) }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -55,7 +55,7 @@ function RangeControl(
 		onFocus = noop,
 		onMouseMove = noop,
 		onMouseLeave = noop,
-		railColor = 'var( --wp-admin-theme-color )',
+		railColor,
 		resetFallbackValue,
 		renderTooltipContent = ( v ) => v,
 		showTooltip: showTooltipProp,

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -163,6 +163,15 @@ export const MarkLabel = styled.span`
 	${ markLabelFill };
 `;
 
+const thumbColor = ( { disabled } ) =>
+	disabled
+		? css`
+				background-color: ${ COLORS.lightGray[ 800 ] };
+		  `
+		: css`
+				background-color: var( --wp-admin-theme-color );
+		  `;
+
 export const ThumbWrapper = styled.span`
 	align-items: center;
 	box-sizing: border-box;
@@ -176,9 +185,9 @@ export const ThumbWrapper = styled.span`
 	top: 0;
 	user-select: none;
 	width: ${ thumbSize }px;
-	background-color: var( --wp-admin-theme-color );
 	border-radius: 50%;
 
+	${ thumbColor };
 	${ rtl( { marginLeft: -10 } ) };
 `;
 
@@ -202,7 +211,6 @@ const thumbFocus = ( { isFocused } ) => {
 
 export const Thumb = styled.span`
 	align-items: center;
-	background-color: var( --wp-admin-theme-color );
 	border-radius: 50%;
 	box-sizing: border-box;
 	height: 100%;
@@ -211,6 +219,7 @@ export const Thumb = styled.span`
 	user-select: none;
 	width: 100%;
 
+	${ thumbColor };
 	${ thumbFocus };
 `;
 

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -44,8 +44,6 @@ export const Wrapper = styled.div`
 	${ wrapperColor };
 	${ rangeHeight };
 	${ wrapperMargin };
-
-	${ rtl( { marginLeft: 10 } ) }
 `;
 
 export const BeforeIconWrapper = styled.span`
@@ -83,7 +81,7 @@ export const Rail = styled.span`
 	position: absolute;
 	margin-top: 14px;
 	top: 0;
-	border-radius: 3px;
+	border-radius: 9999px;
 
 	${ railBackgroundColor };
 `;
@@ -102,7 +100,7 @@ const trackBackgroundColor = ( { disabled, trackColor } ) => {
 
 export const Track = styled.span`
 	background-color: currentColor;
-	border-radius: 3px;
+	border-radius: 9999px;
 	box-sizing: border-box;
 	height: 3px;
 	pointer-events: none;

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -12,7 +12,7 @@ import { COLORS, reduceMotion, rtl } from '../../utils';
 import { space } from '../../ui/utils/space';
 
 const rangeHeight = () => css( { height: 30, minHeight: 30 } );
-const thumbSize = 20;
+const thumbSize = 12;
 
 export const Root = styled.div`
 	-webkit-tap-highlight-color: transparent;
@@ -37,7 +37,7 @@ export const Wrapper = styled.div`
 	color: ${ COLORS.blue.medium.focus };
 	display: block;
 	flex: 1;
-	padding-top: 15px;
+	padding-top: 18px;
 	position: relative;
 	width: 100%;
 
@@ -83,6 +83,7 @@ export const Rail = styled.span`
 	position: absolute;
 	margin-top: 14px;
 	top: 0;
+	border-radius: 3px;
 
 	${ railBackgroundColor };
 `;
@@ -101,7 +102,7 @@ const trackBackgroundColor = ( { disabled, trackColor } ) => {
 
 export const Track = styled.span`
 	background-color: currentColor;
-	border-radius: 1px;
+	border-radius: 3px;
 	box-sizing: border-box;
 	height: 3px;
 	pointer-events: none;
@@ -170,35 +171,32 @@ export const ThumbWrapper = styled.span`
 	display: flex;
 	height: ${ thumbSize }px;
 	justify-content: center;
-	margin-top: 5px;
+	margin-top: 9px;
 	outline: 0;
 	pointer-events: none;
 	position: absolute;
 	top: 0;
 	user-select: none;
 	width: ${ thumbSize }px;
+	background-color: var( --wp-admin-theme-color );
+	border-radius: 50%;
 
-	${ rtl( { marginLeft: -10 } ) }
+	${ rtl( { marginLeft: -10 } ) };
 `;
 
 const thumbFocus = ( { isFocused } ) => {
-	return css( {
-		borderColor: isFocused ? COLORS.ui.borderFocus : COLORS.darkGray[ 200 ],
-		boxShadow: isFocused
-			? `
-				0 0 0 1px ${ COLORS.ui.borderFocus }
-			`
-			: `
-				0 0 0 rgba(0, 0, 0, 0)
-			`,
-	} );
+	return isFocused
+		? css`
+				outline: solid 1px var( --wp-admin-theme-color );
+				outline-offset: 2px;
+		  `
+		: '';
 };
 
 export const Thumb = styled.span`
 	align-items: center;
-	background-color: white;
+	background-color: var( --wp-admin-theme-color );
 	border-radius: 50%;
-	border: 1px solid ${ COLORS.darkGray[ 200 ] };
 	box-sizing: border-box;
 	height: 100%;
 	outline: 0;

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -187,8 +187,17 @@ export const ThumbWrapper = styled.span`
 const thumbFocus = ( { isFocused } ) => {
 	return isFocused
 		? css`
-				outline: solid 1px var( --wp-admin-theme-color );
-				outline-offset: 2px;
+				&::before {
+					content: ' ';
+					position: absolute;
+					background-color: transparent;
+					box-shadow: 0 0 0 1.5px var( --wp-admin-theme-color );
+					border-radius: 50%;
+					height: ${ thumbSize + 4 }px;
+					width: ${ thumbSize + 4 }px;
+					top: -2px;
+					left: -2px;
+				}
 		  `
 		: '';
 };

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -186,6 +186,7 @@ export const ThumbWrapper = styled.span`
 	user-select: none;
 	width: ${ thumbSize }px;
 	border-radius: 50%;
+	transform: translateX( 4.5px );
 
 	${ thumbColor };
 	${ rtl( { marginLeft: -10 } ) };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Use the updated range styles from the Global Styles figma: https://www.figma.com/file/oEkcAyhIvPFMVEAO8EImvA/Global-Styles

## How has this been tested?
Run storybook and check out the range control page: `iframe.html?id=components-rangecontrol--default`

## Screenshots <!-- if applicable -->

### Unfocused

<img width="1072" alt="Captura de Tela 2021-08-02 às 10 30 28" src="https://user-images.githubusercontent.com/24264157/127901085-e8b175a9-9171-4a5e-8f90-a93207f61a85.png">

### Focused

<img width="1072" alt="Captura de Tela 2021-08-02 às 10 30 30" src="https://user-images.githubusercontent.com/24264157/127901095-12dab52c-650f-45ec-9f93-653a04326bc6.png">


## Types of changes
Style changes (new feature???)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
