### PR TITLE
Fix: Site editor template previews

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -10,7 +10,11 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
-import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
+import {
+	BlockContextProvider,
+	BlockBreadcrumb,
+	__unstableEditorStyles as EditorStyles,
+} from '@wordpress/block-editor';
 import {
 	FullscreenMode,
 	InterfaceSkeleton,
@@ -201,6 +205,12 @@ function Editor( { initialSettings } ) {
 										settings.__experimentalGlobalStylesBaseStyles
 									}
 								>
+									{
+										// Template previews need the editor styles to be available.
+										<EditorStyles
+											styles={ settings.styles }
+										/>
+									}
 									<KeyboardShortcuts.Register />
 									<SidebarComplementaryAreaFills />
 									<InterfaceSkeleton

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -88,6 +88,14 @@
 	@include break-medium {
 		display: block;
 	}
+	.block-editor-block-preview__container {
+		// We have a bug on packages/block-editor/src/components/block-preview/auto.js.
+		// Because of some reason contentHeight is always 0. Even thought the iframe used for the computation has an height.
+		// It seems like useResizeObserver is not rerunning on this case.
+		// This rule should be removed after the bug is addressed.
+		height: 100% !important;
+		min-height: 200px;
+	}
 }
 
 .edit-site-navigation-panel__template-item {


### PR DESCRIPTION
Template previews are currently broken because of two reasons the height is 0 so they are not visible and the editor styles are not reflected (so they don't reflect the true look of a template).

This PR fixes the editor styles issue and proposes a temporary solution for the height issue.

We have a bug on packages/block-editor/src/components/block-preview/auto.js. Because of some reason contentHeight is always 0. Even though the iframe used for the computation has a height. It seems like useResizeObserver is not returning the height in this case. cc: @youknowriad as someone that worked on packages/block-editor/src/components/block-preview/auto.js in case you are able to help find the root cause of the issue.

## How has this been tested?
I went to site editor opened the templates menu navigated with the mouse over the items and verified the template previews appeared.
