### PR TITLE
Fix Metro local static image paths

### DIFF
--- a/packages/react-native-editor/metro.config.js
+++ b/packages/react-native-editor/metro.config.js
@@ -2,6 +2,13 @@
  * External dependencies
  */
 const path = require( 'path' );
+const fs = require( 'fs' );
+
+const PACKAGES_DIR = path.resolve( __dirname, '..' );
+const packageNames = fs.readdirSync( PACKAGES_DIR ).filter( ( file ) => {
+	const stats = fs.statSync( path.join( PACKAGES_DIR, file ) );
+	return stats.isDirectory();
+} );
 
 module.exports = {
 	watchFolders: [ path.resolve( __dirname, '../..' ) ],
@@ -17,5 +24,27 @@ module.exports = {
 				inlineRequires: false,
 			},
 		} ),
+	},
+	server: {
+		enhanceMiddleware: ( middleware ) => ( req, res, next ) => {
+			/**
+			 * Loading local static assets from a different package within a monorepo
+			 * appears broken in Metro for Android. The below fixes paths to packages
+			 * within this project to include the necessary `/assets/..` that Metro's
+			 * server expects to traverse to the correct directory.
+			 *
+			 * - https://git.io/JBV4e
+			 * - https://git.io/JBFon
+			 */
+			const firstUrlSegment = req.url.split( '/' )[ 1 ];
+			if ( packageNames.includes( firstUrlSegment ) ) {
+				req.url = req.url.replace(
+					`/${ firstUrlSegment }`,
+					`/assets/../${ firstUrlSegment }`
+				);
+			}
+
+			return middleware( req, res, next );
+		},
 	},
 };

--- a/patches/react-native+0.64.0.patch
+++ b/patches/react-native+0.64.0.patch
@@ -23,27 +23,3 @@ index 52cbda4..3e3b71e 100644
    hidesWhenStopped: true,
    size: 'small',
  };
-diff --git a/node_modules/react-native/Libraries/Image/AssetSourceResolver.js b/node_modules/react-native/Libraries/Image/AssetSourceResolver.js
-index 5ebd97a..3f511b9 100644
---- a/node_modules/react-native/Libraries/Image/AssetSourceResolver.js
-+++ b/node_modules/react-native/Libraries/Image/AssetSourceResolver.js
-@@ -92,9 +92,18 @@ class AssetSourceResolver {
-    */
-   assetServerURL(): ResolvedAssetSource {
-     invariant(!!this.serverUrl, 'need server to load from');
-+		/**
-+		 * The monorepo configuration we have set up is suffering from local static
-+		 * images not displaying. It would appear the server URL is incorrect. This
-+		 * is not a proper fix, but a stopgap.
-+		 * - https://git.io/JBV4e
-+		 * - https://git.io/JBV4k
-+		 */
-+		const brokenMonorepoAsset = /(^assets\/\.\.\/)(?!\.\.\/|node_modules)(.*)/g;
-     return this.fromSource(
-       this.serverUrl +
--        getScaledAssetPath(this.asset) +
-+        getScaledAssetPath(this.asset)
-+					.replace(brokenMonorepoAsset, '$1packages/$2') +
-         '?platform=' +
-         Platform.OS +
-         '&hash=' +


### PR DESCRIPTION
## Description
Relates to #33790. Loading local static assets from a different package within a monorepo appears broken in Metro for Android. This issue only occurs when running the Demo application from the `gutenberg` repository. It does not occur within the `gutenberg-mobile` repository. 

The below fixes paths to packages within this project to include the necessary `/assets/..` that Metro's server expects to traverse to the correct directory. This PR includes an alternative approach that leverages Metro middleware configuration, rather than patching third-party code. 

- https://git.io/JBV4e
- https://git.io/JBFon

## How has this been tested?
1. `npm run native start:reset`
2. `npm run native android` 
3. Shake the device to access the developer menu. 
4. Tap Help. 
5. Tap one of the help sections. 
6. Verify the images display as expected. 

## Screenshots 
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
