### PR TITLE
Cover: add margin block support

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -230,6 +230,12 @@
 					"customRadius": true
 				}
 			},
+			"core/cover": {
+				"spacing": {
+					"customMargin": true,
+					"customPadding": true
+				}
+			},
 			"core/pullquote": {
 				"border": {
 					"customColor": true,

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -76,6 +76,7 @@
 		"html": false,
 		"spacing": {
 			"padding": true,
+			"margin": true,
 			"__experimentalDefaultControls": {
 				"padding": true
 			}

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -76,7 +76,7 @@
 		"html": false,
 		"spacing": {
 			"padding": true,
-			"margin": true,
+			"margin": [ "top", "bottom" ],
 			"__experimentalDefaultControls": {
 				"padding": true
 			}

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -24,7 +24,6 @@ import {
 	ToggleControl,
 	withNotices,
 	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalBoxControl as BoxControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -68,8 +68,6 @@ import {
 
 extend( [ namesPlugin ] );
 
-const { __Visualizer: BoxControlVisualizer } = BoxControl;
-
 function getInnerBlocksTemplate( attributes ) {
 	return [
 		[
@@ -322,7 +320,6 @@ function CoverEdit( {
 		isRepeated,
 		minHeight,
 		minHeightUnit,
-		style: styleAttribute,
 		url,
 		alt,
 		allowedBlocks,
@@ -698,10 +695,6 @@ function CoverEdit( {
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>
-				<BoxControlVisualizer
-					values={ styleAttribute?.spacing?.padding }
-					showValues={ styleAttribute?.visualizers?.padding }
-				/>
 				<ResizableCover
 					className="block-library-cover__resize-container"
 					onResizeStart={ () => {


### PR DESCRIPTION
❗ Hey! Since this change displays the [dimensions panel](https://github.com/WordPress/gutenberg/pull/32392), we should remove the duplicate dimensions panel first. That means adding min-height support. We are doing this in https://github.com/WordPress/gutenberg/pull/33970, on which this PR, therefore, is dependent.

## Description

This PR:

- activates margin block support for the cover block at the block level in `block.json` for web.
- activates margin block support in `theme.json` so that it's turned on in development by default.
- Turns on padding by default in the ToolsPanel. Margin is available but hidden until activated.
- removes `<BoxControlVisualizer />` for padding to avoid incongruity, that is, that it's on for padding and not for margin.

https://user-images.githubusercontent.com/6458278/128953852-354e2f70-6eb9-4d0d-a845-b6123ce15686.mp4

#### On the topic of BoxControlVisualizer

To add a  `<BoxControlVisualizer />` for margin we would have to introduce a wrapper around the entire block in `edit.js` for it to display. 

It appears the visualizer [has been removed in other blocks for this reason](https://github.com/WordPress/gutenberg/pull/30609#discussion_r649796274).

Here's what it looks like when we do add it:

https://user-images.githubusercontent.com/6458278/127960312-f88e63ac-f0f9-42de-8a00-2da7934452fe.mp4

## How has this been tested?

Manually, in Chrome, Safari, Firefox and Edge browsers.

In a new post, create a cover block. Check that the dimensions panel is there and margin controls are disabled by default.

Select margin under the ToolsPanel and adjust the value.

<img width="319" alt="Screen Shot 2021-08-11 at 11 01 52 am" src="https://user-images.githubusercontent.com/6458278/128953960-8c50eccd-b910-4232-b36f-b3d4856cdf10.png">

Check that your changes are reflected on the published post. 

Behold my ground-breaking results!

<img width="400" alt="Screen Shot 2021-08-11 at 11 03 36 am" src="https://user-images.githubusercontent.com/6458278/128954068-65fecd0c-2cb9-40f2-9eed-fc0246b9a5bf.png">

Rejoice!

## Types of changes

Switching on margin block support, which is available since #30608

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
