### PR TITLE
Editor: Safer isPreviewingPost check

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -890,7 +890,7 @@ export function isPreviewingPost( state ) {
 	if ( ! isSavingPost( state ) ) {
 		return false;
 	}
-	return !! state.saving.options.isPreview;
+	return !! get( state.saving, [ 'options', 'isPreview' ] );
 }
 
 /**


### PR DESCRIPTION
## Description
The `options` property might not always be defined for the `saving` state and, in some cases, might result in an error.

PR updates selector to use lodash `get` to safely check `options.isPreview` reference. It also matches the signature in the `isAutosavingPost` selector.

Fixes #29711.

## How has this been tested?
1. Comment out `isSavingPost` condition from the `isPreviewingPost()` selector.
2. Run the following code in the browser console:

```js
wp.data.select( 'core/editor' ).isPreviewingPost();
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
