### PR TITLE
Polish the focus style for the segmented control.

### DIFF
--- a/packages/components/src/base-field/test/__snapshots__/index.js.snap
+++ b/packages/components/src/base-field/test/__snapshots__/index.js.snap
@@ -130,7 +130,7 @@ exports[`base field should render correctly 1`] = `
 .emotion-0:focus,
 .emotion-0[data-focused='true'] {
   border-color: var( --wp-admin-theme-color, #00669b);
-  box-shadow: 0 0 0,0.5px,var( --wp-admin-theme-color, #00669b);
+  box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b);
 }
 
 <div

--- a/packages/components/src/segmented-control/styles.ts
+++ b/packages/components/src/segmented-control/styles.ts
@@ -27,7 +27,7 @@ export const SegmentedControl = css`
 
 	&:focus-within {
 		border-color: ${ COLORS.ui.borderFocus };
-		box-shadow: ${ CONFIG.controlBoxShadowFocus };
+		box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b );
 		outline: none;
 		z-index: 1;
 	}

--- a/packages/components/src/segmented-control/styles.ts
+++ b/packages/components/src/segmented-control/styles.ts
@@ -27,7 +27,7 @@ export const SegmentedControl = css`
 
 	&:focus-within {
 		border-color: ${ COLORS.ui.borderFocus };
-		box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b );
+		box-shadow: ${ CONFIG.controlBoxShadowFocus };
 		outline: none;
 		z-index: 1;
 	}

--- a/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
@@ -30,7 +30,7 @@ exports[`SegmentedControl should render correctly 1`] = `
 
 .emotion-0:focus-within {
   border-color: var( --wp-admin-theme-color-darker-10, #007cba);
-  box-shadow: 0 0 0,0.5px,var( --wp-admin-theme-color, #00669b);
+  box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b);
   outline: none;
   z-index: 1;
 }

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -18,7 +18,7 @@ const CONTROL_PROPS = {
 	controlBorderColor: COLORS.gray[ 700 ],
 	controlBoxShadow: 'transparent',
 	controlBorderColorHover: COLORS.gray[ 700 ],
-	controlBoxShadowFocus: `0 0 0, 0.5px, ${ COLORS.admin.theme }`,
+	controlBoxShadowFocus: `0 0 0 0.5px ${ COLORS.admin.theme }`,
 	controlDestructiveBorderColor: COLORS.alert.red,
 	controlHeight: CONTROL_HEIGHT,
 	controlHeightXSmall: `calc( ${ CONTROL_HEIGHT } * 0.6 )`,


### PR DESCRIPTION
## Description

Followup to feedback in https://github.com/WordPress/gutenberg/pull/31937#issuecomment-880153741, this PR polishes the focus style for the new Segmented Control. Before:

![before](https://user-images.githubusercontent.com/1204802/128005511-81a68f09-ddf4-4870-b5ce-3889d915ca86.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/128005531-526c2de3-53fe-4c8c-966c-a85be69064c9.gif)

The focus style for buttons, unputs and selected blocks across the block editor is 1.5px blue focusring, which changes the shape from 1px inputs or controls, or sits outset of solid blue primary buttons.

In this case, the usage of focus-within feels correct, as when you tab to the segmented control, pressing tab again sets focus on the next control, not the next option inside; you have to use the arrow keys to change the property inside.

Note: This PR is a draft because it needs a bit more work. Specifically there appears to be a bug in how the `${ CONFIG.controlBoxShadowFocus };` variable is output. It generates the following incorrect box shadow, which then doesn't render at all:

```
box-shadow: 0 0 0,0.5px,var( --wp-admin-theme-color, #00669b);
```

The two commas are wrong. Here's how it should be:

```
box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b);
```

This PR simply outputs the corrected value directly, but ideally we find a way to output the variable correctly before we land this. If you know how to, please feel free to push directly to this branch.

## How has this been tested?

Insert a "Post Featured Image" block and focus the segmented control in the inspector.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
