### PR TITLE
Navigation Editor: Avoid React warning when creating a new menu

### DIFF
--- a/packages/edit-navigation/src/components/add-menu/index.js
+++ b/packages/edit-navigation/src/components/add-menu/index.js
@@ -3,6 +3,7 @@
  */
 import { some } from 'lodash';
 import classnames from 'classnames';
+
 /**
  * WordPress dependencies
  */
@@ -59,6 +60,9 @@ export default function AddMenu( {
 		setIsCreatingMenu( true );
 
 		const menu = await saveMenu( { name: menuName } );
+
+		setIsCreatingMenu( false );
+
 		if ( menu ) {
 			createInfoNotice( __( 'Menu created' ), {
 				type: 'snackbar',
@@ -68,8 +72,6 @@ export default function AddMenu( {
 				onCreate( menu.id );
 			}
 		}
-
-		setIsCreatingMenu( false );
 	};
 
 	return (


### PR DESCRIPTION
## Description
Currently, when creating a menu, there's React warning about state updates on unmounted components.

PR updates `createMenu` logic to set state right after the `saveMenu` action is dispatched. 

## How has this been tested?
1. Go to the experimental navigation screen.
2. Click on "Switch Menu" in the top right corner.
3. Choose the"Create a new menu" option.
4. After creating the menu, there shouldn't be an error in the browser console.

## Screenshots <!-- if applicable -->
![CleanShot 2021-08-03 at 15 17 52](https://user-images.githubusercontent.com/240569/128007292-91e71416-14e7-40e3-94c4-461ad411f0b2.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
