### PR TITLE
Global Styles: Fix Global Styles transient key clash

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -26,7 +26,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 
 	if ( $can_use_cached ) {
 		// Check if we have the styles already cached.
-		$cached = get_transient( 'global_styles' );
+		$cached = get_transient( 'gutenberg_global_styles' );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -37,7 +37,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 	if ( $can_use_cached ) {
 		// Cache for a minute.
 		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-		set_transient( 'global_styles', $stylesheet, MINUTE_IN_SECONDS );
+		set_transient( 'gutenberg_global_styles', $stylesheet, MINUTE_IN_SECONDS );
 	}
 
 	return $stylesheet;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Now that we have a version of Global Styles in core, when you run the Gutenberg plugin activated, you're running a different version of Global Styles. However both versions currently use the same cache key. This means that once the core version of Global Styles has loaded and been cached, the Gutenberg version won't be generated since it will fall back to the same key.

This proposes that we introduce a new cache key for Global Styles in Gutenberg (`gutenberg_global_styles`) so that if you're running the Gutenberg plugin you will get the Gutenberg version of Global Styles.

Fixes https://github.com/WordPress/gutenberg/issues/33681

## How has this been tested?
Tested changing fonts in Blockbase.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
