### PR TITLE
[RNMobile] Fix BottomSheet.SubSheet/TextInput Conflict

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
@@ -6,21 +6,12 @@ import { SafeAreaView } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Children, useEffect } from '@wordpress/element';
+import { Children } from '@wordpress/element';
 import { createSlotFill, BottomSheetConsumer } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'BottomSheetSubSheet' );
 
-const BottomSheetSubSheet = ( {
-	children,
-	navigationButton,
-	showSheet,
-	isFullScreen,
-} ) => {
-	const BottomSheetScreen = ( { onMount } ) => {
-		useEffect( onMount, [] );
-		return children ?? null;
-	};
+const BottomSheetSubSheet = ( { children, navigationButton, showSheet } ) => {
 
 	return (
 		<>
@@ -28,13 +19,9 @@ const BottomSheetSubSheet = ( {
 				<Fill>
 					<SafeAreaView>
 						<BottomSheetConsumer>
-							{ ( { setIsFullScreen } ) => (
-								<BottomSheetScreen
-									onMount={ () =>
-										setIsFullScreen( isFullScreen )
-									}
-								/>
-							) }
+							{ () => {
+								return children;
+							} }
 						</BottomSheetConsumer>
 					</SafeAreaView>
 				</Fill>

--- a/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
@@ -6,12 +6,28 @@ import { SafeAreaView } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Children } from '@wordpress/element';
-import { createSlotFill, BottomSheetConsumer } from '@wordpress/components';
+import { Children, useEffect, useContext } from '@wordpress/element';
+import {
+	createSlotFill,
+	BottomSheetConsumer,
+	BottomSheetContext,
+} from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'BottomSheetSubSheet' );
 
-const BottomSheetSubSheet = ( { children, navigationButton, showSheet } ) => {
+const BottomSheetSubSheet = ( {
+	children,
+	navigationButton,
+	showSheet,
+	isFullScreen,
+} ) => {
+	const { setIsFullScreen } = useContext( BottomSheetContext );
+
+	useEffect( () => {
+		if ( showSheet ) {
+			setIsFullScreen( isFullScreen );
+		}
+	}, [ showSheet, isFullScreen ] );
 
 	return (
 		<>

--- a/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
@@ -29,11 +29,7 @@ const BottomSheetSubSheet = ( {
 		<>
 			{ showSheet && (
 				<Fill>
-					<SafeAreaView>
-						{ () => {
-							return children;
-						} }
-					</SafeAreaView>
+					<SafeAreaView>{ children }</SafeAreaView>
 				</Fill>
 			) }
 			{ Children.count( children ) > 0 && navigationButton }

--- a/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js
@@ -7,11 +7,7 @@ import { SafeAreaView } from 'react-native';
  * WordPress dependencies
  */
 import { Children, useEffect, useContext } from '@wordpress/element';
-import {
-	createSlotFill,
-	BottomSheetConsumer,
-	BottomSheetContext,
-} from '@wordpress/components';
+import { createSlotFill, BottomSheetContext } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'BottomSheetSubSheet' );
 
@@ -34,11 +30,9 @@ const BottomSheetSubSheet = ( {
 			{ showSheet && (
 				<Fill>
 					<SafeAreaView>
-						<BottomSheetConsumer>
-							{ () => {
-								return children;
-							} }
-						</BottomSheetConsumer>
+						{ () => {
+							return children;
+						} }
 					</SafeAreaView>
 				</Fill>
 			) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/33828

`gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/3784

## Description

As outlined in https://github.com/WordPress/gutenberg/issues/33828, the text editor for adding alt text to an image (accessed from the image block's settings) isn't currently working as expected. At the time of writing, the keyboard is immediately dismissed with each keystroke, making it extremely difficult, bordering on impossible, to add alt text to an image.

[BottomSheetTextControl](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/mobile/bottom-sheet-text-control) is the component behind the image block's alt text settings and is built on [the BottomSheet.SubSheet component](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js). There were changes to `BottomSheet.SubSheet` in https://github.com/WordPress/gutenberg/pull/33240/commits/d650b4f1df6e1699c7c45819a8afd4a2ec39a08e that led to a conflict with the `TextInput` component in `BottomSheetTextControl`, which brought this issue to the surface.

With this PR, I have refactored the changes in https://github.com/WordPress/gutenberg/pull/33240/commits/d650b4f1df6e1699c7c45819a8afd4a2ec39a08e in a way that enables the alt text entry to work as expected.  

## How has this been tested?

### Test Case 1: Alt Text Settings

<details>
<summary>The following steps outline an approach to test that the original bug is fixed with this PR.</summary>

1. Navigate to a new post then add an image block or tap on an existing one.
2. Access the image block's settings by tapping the cog/gear icon. 
3. Tap **Alt Text** and confirm that a new sub sheet opens with a text editor.
4. Enter a few lines into the text editor and confirm that it no longer closes with each keystroke.
</details>

### Test Case 2: Help Panel (Production Only)

<details>
<summary>As part of our testing, we should also verify that the new changes don't bring any unexpected side effects to other places where the component's used, such as the Help panel.</summary>

* Run the demo app.
* Open the menu on iOS by clicking the overflow menu icon in the ActionBar or by shaking the device on Android.
* Tap **Help**. The main help topics bottom sheet should be displayed.
* Tap one of the help topics and verify that the new sheet displays as expected.

</details>

### Test Case 3: Full Screen (Code Changes Required)

<details>
<summary>Lastly, we'll need to double-check that the "isFullScreen" parameter works as expected following the refactor. This will require code changes.</summary>

* Find a component in the app where [the BottomSheet.SubSheet component](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/mobile/bottom-sheet/sub-sheet/index.native.js) is being utilised, such as [the BottomSheetTextControl component](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/mobile/bottom-sheet-text-control/index.native.js).
* Add `isFullScreen={ true }` to the list of parameters being accepted by `BottomSheet.SubSheet`.
* Navigate to the area in the app where the edited component is being used and verify that it's rendered as a sheet that takes up the full screen.
</details>

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/2998162/128023488-cb4a35b3-34eb-4478-acf9-9e8835fc1ab3.mov

## Types of changes

Bug fix (non-breaking change which fixes an issue), with the following high-level rundown of the main code changes:

* The `setIsFullScreen( isFullScreen )` method was moved to [a standalone `useEffect` hook](https://github.com/WordPress/gutenberg/pull/33845/files#diff-d16d37d09ff59dce57c087e978ac5536503cb1642ec2b0ecdba9536f5c695b95R26), which fires only when [the values of either `showSheet` or `isFullScreen` change](https://github.com/WordPress/gutenberg/pull/33845/files#diff-d16d37d09ff59dce57c087e978ac5536503cb1642ec2b0ecdba9536f5c695b95R30).
* Moving the method to the standalone hook meant [the BottomSheetScreen component could be removed](https://github.com/WordPress/gutenberg/pull/33845/files#diff-d16d37d09ff59dce57c087e978ac5536503cb1642ec2b0ecdba9536f5c695b95L20). It appeared to be the addition of this component that was causing a conflict with the `TextInput` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
