### PR TITLE
Template Part Block: Load content from the parent theme if there no template in a child theme

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -6,6 +6,30 @@
  */
 
 /**
+ * Gets the contents of a template file from the theme directory.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string The render or null.
+ */
+function get_block_template_part_from_theme( $attributes ) {
+	if ( 0 !== validate_file( $attributes['slug'] ) ) {
+		return null;
+	}
+
+	$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
+	if ( ! file_exists( $template_part_file_path ) ) {
+		$template_part_file_path = get_template_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
+	}
+
+	if ( file_exists( $template_part_file_path ) ) {
+		return _gutenberg_inject_theme_attribute_in_content( file_get_contents( $template_part_file_path ) );
+	}
+
+	return null;
+}
+
+/**
  * Renders the `core/template-part` block on the server.
  *
  * @param array $attributes The block attributes.
@@ -53,10 +77,7 @@ function render_block_core_template_part( $attributes ) {
 		} else {
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
-			$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
-			if ( 0 === validate_file( $attributes['slug'] ) && file_exists( $template_part_file_path ) ) {
-				$content = _gutenberg_inject_theme_attribute_in_content( file_get_contents( $template_part_file_path ) );
-			}
+			$content = get_block_template_part_from_theme( $attributes );
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
If a child theme wants to modify a template from a parent theme, it will then need to redefine the header and footer template parts. With this change the theme will fall back to the parent theme template unless the child theme defines it. With this change child themes will be able to be much simpler.

## How has this been tested?
With Skatepark: https://github.com/Automattic/themes/tree/7e8706ed7f703aacbbe00b9a1b182b2f2cede76e/skatepark

With this change, Skatepark won't need to redefine header and footer template parts, it will inherit the ones in Blockbase.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
