### PR TITLE
[RNMobile] Disables supportsLayout by default on mobile

### DIFF
--- a/packages/block-editor/src/store/defaults.native.js
+++ b/packages/block-editor/src/store/defaults.native.js
@@ -9,6 +9,7 @@ import {
 const SETTINGS_DEFAULTS = {
 	...SETTINGS,
 	alignWide: true,
+	supportsLayout: false,
 };
 
 export { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS };


### PR DESCRIPTION
## Description
This PR handles an incoming breakage after the merge of https://github.com/WordPress/gutenberg/pull/33359 making the `Wide width` and `Full width` alignment options unavailable. To achieve this the `supportsLayout` setting introduced in https://github.com/WordPress/gutenberg/pull/29335 is set by default to `false` on mobile. 

## How has this been tested?
1. Run the app using metro
2. Create a new Post/Page
3. Add an image block and choose an image
4. Tap on the alignment options at the bottom toolbar
5. **Verify** that the `Wide width` and `Full width` options are available

## Screenshots

|Before|After|
|---|---|
|![IMG_20BE77E7CBA5-1](https://user-images.githubusercontent.com/304044/128035883-b043290f-1bb4-4e28-8550-90d620333695.jpeg)|![IMG_675ABFF98181-1](https://user-images.githubusercontent.com/304044/128035895-d2706b23-f164-40f5-9b30-7006ae270917.jpeg)|

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
