### PR TITLE
Add search performance measure and make other measures more stable

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -29,29 +29,33 @@ const config = require( '../config' );
 /**
  * @typedef WPRawPerformanceResults
  *
- * @property {number[]} load          Load Time.
- * @property {number[]} type          Average type time.
- * @property {number[]} focus         Average block selection time.
- * @property {number[]} inserterOpen  Average time to open global inserter.
- * @property {number[]} inserterHover Average time to move mouse between two block item in the inserter.
+ * @property {number[]} load           Load Time.
+ * @property {number[]} type           Average type time.
+ * @property {number[]} focus          Average block selection time.
+ * @property {number[]} inserterOpen   Average time to open global inserter.
+ * @property {number[]} inserterSearch Average time to search the inserter.
+ * @property {number[]} inserterHover  Average time to move mouse between two block item in the inserter.
  */
 
 /**
  * @typedef WPPerformanceResults
  *
- * @property {number=} load             Load Time.
- * @property {number=} type             Average type time.
- * @property {number=} minType          Minium type time.
- * @property {number=} maxType          Maximum type time.
- * @property {number=} focus            Average block selection time.
- * @property {number=} minFocus         Min block selection time.
- * @property {number=} maxFocus         Max block selection time.
- * @property {number=} inserterOpen     Average time to open global inserter.
- * @property {number=} minInserterOpen  Min time to open global inserter.
- * @property {number=} maxInserterOpen  Max time to open global inserter.
- * @property {number=} inserterHover    Average time to move mouse between two block item in the inserter.
- * @property {number=} minInserterHover Min time to move mouse between two block item in the inserter.
- * @property {number=} maxInserterHover Max time to move mouse between two block item in the inserter.
+ * @property {number=} load              Load Time.
+ * @property {number=} type              Average type time.
+ * @property {number=} minType           Minium type time.
+ * @property {number=} maxType           Maximum type time.
+ * @property {number=} focus             Average block selection time.
+ * @property {number=} minFocus          Min block selection time.
+ * @property {number=} maxFocus          Max block selection time.
+ * @property {number=} inserterOpen      Average time to open global inserter.
+ * @property {number=} minInserterOpen   Min time to open global inserter.
+ * @property {number=} maxInserterOpen   Max time to open global inserter.
+ * @property {number=} inserterSearch    Average time to open global inserter.
+ * @property {number=} minInserterSearch Min time to open global inserter.
+ * @property {number=} maxInserterSearch Max time to open global inserter.
+ * @property {number=} inserterHover     Average time to move mouse between two block item in the inserter.
+ * @property {number=} minInserterHover  Min time to move mouse between two block item in the inserter.
+ * @property {number=} maxInserterHover  Max time to move mouse between two block item in the inserter.
  */
 
 /**
@@ -111,6 +115,9 @@ function curateResults( results ) {
 		inserterOpen: average( results.inserterOpen ),
 		minInserterOpen: Math.min( ...results.inserterOpen ),
 		maxInserterOpen: Math.max( ...results.inserterOpen ),
+		inserterSearch: average( results.inserterSearch ),
+		minInserterSearch: Math.min( ...results.inserterSearch ),
+		maxInserterSearch: Math.max( ...results.inserterSearch ),
 		inserterHover: average( results.inserterHover ),
 		minInserterHover: Math.min( ...results.inserterHover ),
 		maxInserterHover: Math.max( ...results.inserterHover ),
@@ -322,6 +329,15 @@ async function runPerformanceTests( branches, options ) {
 					),
 					maxInserterOpen: rawResults.map(
 						( r ) => r[ branch ].maxInserterOpen
+					),
+					inserterSearch: rawResults.map(
+						( r ) => r[ branch ].inserterSearch
+					),
+					minInserterSearch: rawResults.map(
+						( r ) => r[ branch ].minInserterSearch
+					),
+					maxInserterSearch: rawResults.map(
+						( r ) => r[ branch ].maxInserterSearch
 					),
 					inserterHover: rawResults.map(
 						( r ) => r[ branch ].inserterHover

--- a/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
+++ b/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
@@ -14,7 +14,7 @@ export async function getAllBlockInserterItemTitles() {
 	// Ideally, we shouldn't use a timeout and instead check the browser is idle for
 	// a specific duration, but didn't manage to find a simple way to do that.
 	// eslint-disable-next-line no-restricted-syntax
-	await page.waitFor( 500 );
+	await page.waitForTimeout( 500 );
 
 	const inserterItemTitles = await page.evaluate( () => {
 		return Array.from(

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -28,9 +28,14 @@ class PerformanceReporter {
 		}
 
 		const results = readFileSync( filepath, 'utf8' );
-		const { load, type, focus, inserterOpen, inserterHover } = JSON.parse(
-			results
-		);
+		const {
+			load,
+			type,
+			focus,
+			inserterOpen,
+			inserterHover,
+			inserterSearch,
+		} = JSON.parse( results );
 
 		if ( load && load.length ) {
 			// eslint-disable-next-line no-console
@@ -77,6 +82,21 @@ Slowest time to open global inserter: ${ success(
 			) }
 Fastest time to open global inserter: ${ success(
 				round( Math.min( ...inserterOpen ) ) + 'ms'
+			) }` );
+		}
+
+		if ( inserterSearch && inserterSearch.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Inserter Search Performance:' ) }
+Average time to type the inserter search input: ${ success(
+				round( average( inserterSearch ) ) + 'ms'
+			) }
+Slowest time to type the inserter search input: ${ success(
+				round( Math.max( ...inserterSearch ) ) + 'ms'
+			) }
+Fastest time to type the inserter search input: ${ success(
+				round( Math.min( ...inserterSearch ) ) + 'ms'
 			) }` );
 		}
 

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -3,6 +3,7 @@
  */
 import { basename, join } from 'path';
 import { writeFileSync } from 'fs';
+import { sum } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,12 +32,15 @@ jest.setTimeout( 1000000 );
 
 describe( 'Post Editor Performance', () => {
 	it( 'Loading, typing and selecting blocks', async () => {
+		const traceFile = __dirname + '/trace.json';
+		let traceResults;
 		const results = {
 			load: [],
 			type: [],
 			focus: [],
 			inserterOpen: [],
 			inserterHover: [],
+			inserterSearch: [],
 		};
 
 		const html = readFile(
@@ -60,9 +64,8 @@ describe( 'Post Editor Performance', () => {
 		}, html );
 		await saveDraft();
 
-		let i = 5;
-
 		// Measuring loading time
+		let i = 5;
 		while ( i-- ) {
 			const startTime = new Date();
 			await page.reload();
@@ -72,8 +75,6 @@ describe( 'Post Editor Performance', () => {
 
 		// Measure time to open inserter
 		await page.waitForSelector( '.edit-post-layout' );
-		const traceFile = __dirname + '/trace.json';
-		let traceResults;
 		for ( let j = 0; j < 10; j++ ) {
 			await page.tracing.start( {
 				path: traceFile,
@@ -82,7 +83,6 @@ describe( 'Post Editor Performance', () => {
 			} );
 			await openGlobalBlockInserter();
 			await page.tracing.stop();
-
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [ mouseClickEvents ] = getClickEventDurations( traceResults );
 			for ( let k = 0; k < mouseClickEvents.length; k++ ) {
@@ -90,6 +90,39 @@ describe( 'Post Editor Performance', () => {
 			}
 			await closeGlobalBlockInserter();
 		}
+
+		// Measure time to search the inserter and get results
+		await openGlobalBlockInserter();
+		for ( let j = 0; j < 10; j++ ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 500 );
+			await page.tracing.start( {
+				path: traceFile,
+				screenshots: false,
+				categories: [ 'devtools.timeline' ],
+			} );
+			await page.keyboard.type( 'p' );
+			await page.tracing.stop();
+			traceResults = JSON.parse( readFile( traceFile ) );
+			const [
+				keyDownEvents,
+				keyPressEvents,
+				keyUpEvents,
+			] = getTypingEventDurations( traceResults );
+			if (
+				keyDownEvents.length === keyPressEvents.length &&
+				keyPressEvents.length === keyUpEvents.length
+			) {
+				results.inserterSearch.push(
+					sum( keyDownEvents ) +
+						sum( keyPressEvents ) +
+						sum( keyUpEvents )
+				);
+			}
+			await page.keyboard.press( 'Backspace' );
+		}
+		await closeGlobalBlockInserter();
 
 		// Measure inserter hover performance
 		const paragraphBlockItem =
@@ -100,7 +133,10 @@ describe( 'Post Editor Performance', () => {
 		await page.waitForSelector( paragraphBlockItem );
 		await page.hover( paragraphBlockItem );
 		await page.hover( headingBlockItem );
-		for ( let j = 0; j < 20; j++ ) {
+		for ( let j = 0; j < 10; j++ ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 200 );
 			await page.tracing.start( {
 				path: traceFile,
 				screenshots: false,
@@ -124,16 +160,18 @@ describe( 'Post Editor Performance', () => {
 
 		// Measuring typing performance
 		await insertBlock( 'Paragraph' );
-		i = 200;
+		i = 20;
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
 		} );
 		while ( i-- ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 200 );
 			await page.keyboard.type( 'x' );
 		}
-
 		await page.tracing.stop();
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [
@@ -141,7 +179,6 @@ describe( 'Post Editor Performance', () => {
 			keyPressEvents,
 			keyUpEvents,
 		] = getTypingEventDurations( traceResults );
-
 		if (
 			keyDownEvents.length === keyPressEvents.length &&
 			keyPressEvents.length === keyUpEvents.length
@@ -163,31 +200,28 @@ describe( 'Post Editor Performance', () => {
 				.map( () => createBlock( 'core/paragraph' ) );
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
-
 		const paragraphs = await page.$$( '.wp-block' );
-
 		await page.tracing.start( {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
 		} );
 		for ( let j = 0; j < 10; j++ ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 200 );
 			await paragraphs[ j ].click();
 		}
-
 		await page.tracing.stop();
-
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [ focusEvents ] = getSelectionEventDurations( traceResults );
 		results.focus = focusEvents;
 
 		const resultsFilename = basename( __filename, '.js' ) + '.results.json';
-
 		writeFileSync(
 			join( __dirname, resultsFilename ),
 			JSON.stringify( results, null, 2 )
 		);
-
 		deleteFile( traceFile );
 
 		expect( true ).toBe( true );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -206,7 +206,8 @@ describe( 'Post Editor Performance', () => {
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
 		} );
-		for ( let j = 0; j < 10; j++ ) {
+		await paragraphs[ 0 ].click();
+		for ( let j = 1; j <= 10; j++ ) {
 			// Wait for the browser to be idle before starting the monitoring.
 			// eslint-disable-next-line no-restricted-syntax
 			await page.waitForTimeout( 200 );

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -44,6 +44,7 @@ describe( 'Site Editor Performance', () => {
 			focus: [],
 			inserterOpen: [],
 			inserterHover: [],
+			inserterSearch: [],
 		};
 
 		const html = readFile(


### PR DESCRIPTION
I noticed lags when searching the block inserter. I'd like to try some iterations to improve that (maybe using the same technique used for the regular inserter block list: lazy rendering).

Before jumping into the performance work, I'm adding a new performance measure here to track the time it takes for the browser to respond after an inserter search.

I'm also using this as an opportunity to make the other measures a bit more stable.