### PR TITLE
Button: update spacing support to use axial padding

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -585,4 +585,4 @@ supports: {
 }
 ```
 
-A spacing property may define an array of allowable sides that can be configured. When arbitrary sides are defined only UI controls for those sides are displayed. Axial sides are defined with the `vertical` and `horizontal` terms, and display a single UI control for each axial pair (for example, `vertical` controls both the top and bottom sides).
+A spacing property may define an array of allowable sides that can be configured. When arbitrary sides are defined only UI controls for those sides are displayed. Axial sides are defined with the `vertical` and `horizontal` terms, and display a single UI control for each axial pair (for example, `vertical` controls both the top and bottom sides). A spacing property may support arbitrary individual sides **or** axial sides, but not a mix of both.

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -585,4 +585,4 @@ supports: {
 }
 ```
 
-A spacing property may define an array of allowable sides that can be configured. When arbitrary sides are defined only UI controls for those sides are displayed.
+A spacing property may define an array of allowable sides that can be configured. When arbitrary sides are defined only UI controls for those sides are displayed. Axial sides are defined with the `vertical` and `horizontal` terms, and display a single UI control for each axial pair (for example, `vertical` controls both the top and bottom sides).

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -148,7 +148,7 @@ export function useCustomSides( blockName, feature ) {
 	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
 
 	// Skip when setting is boolean as theme isn't setting arbitrary sides.
-	if ( typeof support[ feature ] === 'boolean' ) {
+	if ( typeof support?.[ feature ] === 'boolean' ) {
 		return;
 	}
 
@@ -157,7 +157,7 @@ export function useCustomSides( blockName, feature ) {
 
 /**
  * Custom hook to determine whether the sides configured in the
- * block support are valid. A spacing property cannot declare
+ * block support are valid. A dimension property cannot declare
  * support for a mix of axial and individual sides.
  *
  * @param {string} blockName Block name.

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -30,6 +30,8 @@ import {
 import { cleanEmptyObject } from './utils';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
+export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
 /**
  * Inspector controls for dimensions support.
@@ -151,4 +153,32 @@ export function useCustomSides( blockName, feature ) {
 	}
 
 	return support[ feature ];
+}
+
+/**
+ * Custom hook to determine whether the sides configured in the
+ * block support are valid. A spacing property cannot declare
+ * support for a mix of axial and individual sides.
+ *
+ * @param {string} blockName Block name.
+ * @param {string} feature   The feature custom sides relate to e.g. padding or margins.
+ *
+ * @return {boolean} If the feature has a valid configuration of sides.
+ */
+export function useIsDimensionsSupportValid( blockName, feature ) {
+	const sides = useCustomSides( blockName, feature );
+
+	if (
+		sides &&
+		sides.some( ( side ) => ALL_SIDES.includes( side ) ) &&
+		sides.some( ( side ) => AXIAL_SIDES.includes( side ) )
+	) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`The ${ feature } support for the "${ blockName }" block can not be configured to support both axial and arbitrary sides.`
+		);
+		return false;
+	}
+
+	return true;
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -148,7 +148,7 @@ export function useCustomSides( blockName, feature ) {
 	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
 
 	// Skip when setting is boolean as theme isn't setting arbitrary sides.
-	if ( typeof support?.[ feature ] === 'boolean' ) {
+	if ( ! support || typeof support[ feature ] === 'boolean' ) {
 		return;
 	}
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -96,6 +96,9 @@ export function MarginEdit( props ) {
 		],
 	} );
 	const sides = useCustomSides( blockName, 'margin' );
+	const splitOnAxis =
+		sides &&
+		( sides.includes( 'horizontal' ) || sides.includes( 'vertical' ) );
 
 	if ( useIsMarginDisabled( props ) ) {
 		return null;
@@ -139,6 +142,7 @@ export function MarginEdit( props ) {
 					sides={ sides }
 					units={ units }
 					allowReset={ false }
+					splitOnAxis={ splitOnAxis }
 				/>
 			</>
 		),

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -13,7 +13,12 @@ import {
  * Internal dependencies
  */
 import useSetting from '../components/use-setting';
-import { SPACING_SUPPORT_KEY, useCustomSides } from './dimensions';
+import {
+	AXIAL_SIDES,
+	SPACING_SUPPORT_KEY,
+	useCustomSides,
+	useIsDimensionsSupportValid,
+} from './dimensions';
 import { cleanEmptyObject } from './utils';
 
 /**
@@ -69,7 +74,9 @@ export function resetMargin( { attributes = {}, setAttributes } ) {
  */
 export function useIsMarginDisabled( { name: blockName } = {} ) {
 	const isDisabled = ! useSetting( 'spacing.customMargin' );
-	return ! hasMarginSupport( blockName ) || isDisabled;
+	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'margin' );
+
+	return ! hasMarginSupport( blockName ) || isDisabled || isInvalid;
 }
 
 /**
@@ -97,8 +104,7 @@ export function MarginEdit( props ) {
 	} );
 	const sides = useCustomSides( blockName, 'margin' );
 	const splitOnAxis =
-		sides &&
-		( sides.includes( 'horizontal' ) || sides.includes( 'vertical' ) );
+		sides && sides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 
 	if ( useIsMarginDisabled( props ) ) {
 		return null;

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -96,6 +96,9 @@ export function PaddingEdit( props ) {
 		],
 	} );
 	const sides = useCustomSides( blockName, 'padding' );
+	const splitOnAxis =
+		sides &&
+		( sides.includes( 'horizontal' ) || sides.includes( 'vertical' ) );
 
 	if ( useIsPaddingDisabled( props ) ) {
 		return null;
@@ -139,6 +142,7 @@ export function PaddingEdit( props ) {
 					sides={ sides }
 					units={ units }
 					allowReset={ false }
+					splitOnAxis={ splitOnAxis }
 				/>
 			</>
 		),

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -13,7 +13,12 @@ import {
  * Internal dependencies
  */
 import useSetting from '../components/use-setting';
-import { SPACING_SUPPORT_KEY, useCustomSides } from './dimensions';
+import {
+	AXIAL_SIDES,
+	SPACING_SUPPORT_KEY,
+	useCustomSides,
+	useIsDimensionsSupportValid,
+} from './dimensions';
 import { cleanEmptyObject } from './utils';
 
 /**
@@ -69,7 +74,9 @@ export function resetPadding( { attributes = {}, setAttributes } ) {
  */
 export function useIsPaddingDisabled( { name: blockName } = {} ) {
 	const isDisabled = ! useSetting( 'spacing.customPadding' );
-	return ! hasPaddingSupport( blockName ) || isDisabled;
+	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'padding' );
+
+	return ! hasPaddingSupport( blockName ) || isDisabled || isInvalid;
 }
 
 /**
@@ -97,8 +104,7 @@ export function PaddingEdit( props ) {
 	} );
 	const sides = useCustomSides( blockName, 'padding' );
 	const splitOnAxis =
-		sides &&
-		( sides.includes( 'horizontal' ) || sides.includes( 'vertical' ) );
+		sides && sides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 
 	if ( useIsPaddingDisabled( props ) ) {
 		return null;

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -68,7 +68,10 @@
 		"reusable": false,
 		"spacing": {
 			"__experimentalSkipSerialization": true,
-			"padding": [ "horizontal", "vertical" ]
+			"padding": [ "horizontal", "vertical" ],
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
 		},
 		"__experimentalBorder": {
 			"radius": true,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -68,7 +68,7 @@
 		"reusable": false,
 		"spacing": {
 			"__experimentalSkipSerialization": true,
-			"padding": true
+			"padding": [ "horizontal", "vertical" ]
 		},
 		"__experimentalBorder": {
 			"radius": true,

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -15,6 +15,8 @@ import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block
  */
 import { useSetting } from '../editor/utils';
 
+const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
+
 export function useHasDimensionsPanel( context ) {
 	const hasPadding = useHasPadding( context );
 	const hasMargin = useHasMargin( context );
@@ -42,7 +44,17 @@ function filterValuesBySides( values, sides ) {
 
 	// Only include sides opted into within filtered values.
 	const filteredValues = {};
-	sides.forEach( ( side ) => ( filteredValues[ side ] = values[ side ] ) );
+	sides.forEach( ( side ) => {
+		if ( side === 'vertical' ) {
+			filteredValues.top = values.top;
+			filteredValues.bottom = values.bottom;
+		}
+		if ( side === 'horizontal' ) {
+			filteredValues.left = values.left;
+			filteredValues.right = values.right;
+		}
+		filteredValues[ side ] = values[ side ];
+	} );
 
 	return filteredValues;
 }
@@ -78,6 +90,9 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 
 	const paddingValues = splitStyleValue( getStyle( name, 'padding' ) );
 	const paddingSides = useCustomSides( name, 'padding' );
+	const isAxialPadding =
+		paddingSides &&
+		paddingSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 
 	const setPaddingValues = ( newPaddingValues ) => {
 		const padding = filterValuesBySides( newPaddingValues, paddingSides );
@@ -89,6 +104,9 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 
 	const marginValues = splitStyleValue( getStyle( name, 'margin' ) );
 	const marginSides = useCustomSides( name, 'margin' );
+	const isAxialMargin =
+		marginSides &&
+		marginSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 
 	const setMarginValues = ( newMarginValues ) => {
 		const margin = filterValuesBySides( newMarginValues, marginSides );
@@ -123,6 +141,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 						sides={ paddingSides }
 						units={ units }
 						allowReset={ false }
+						splitOnAxis={ isAxialPadding }
 					/>
 				</ToolsPanelItem>
 			) }
@@ -140,6 +159,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 						sides={ marginSides }
 						units={ units }
 						allowReset={ false }
+						splitOnAxis={ isAxialMargin }
 					/>
 				</ToolsPanelItem>
 			) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This is a follow up to #31774. This PR updates the spacing block supports to provide axial padding as an option. It also updates the Button block to use general and axial padding (as opposed to padding for each of the individual sides).

I added the padding support on Button recently in #31774, at which time it wasn't possible to enable axial selections via the block support. This PR is meant to be a relatively fast follow-up to address a suggestion to limit the controls to axial sides (anticipated to be the most common use case) until we see concrete requests for padding support on individual arbitrary sides (at which point we could easily go back).

In an example `block.json`:
```
supports: {
    spacing: {
        margin: [ 'top', 'bottom' ],
        padding: [ 'vertical' ]
    }
}
```
This block would support both margin and padding for the top and bottom sides. However the margin can be controlled for the top and bottom _individually_, while the padding UI will only display a 'vertical' control to update both sides at once.

**There are a couple of things I'd like to call out for feedback:**
1. I've chosen to disallow configuring the spacing supports for a mix of individual and axial sides -- eg no configuring padding for `vertical` and `left`. I think this would lead to confusion with naming, setting sensible defaults, etc. I disallow this by logging a warning when an invalid configuration is detected, and disabling the feature. I'm not aware of and couldn't find any other examples of block support configuration errors, so would love feedback here.

2. This PR makes use of the existing `splitOnAxis` feature of the `BoxControl` introduced in #32610. For the Button block, grouped 'horizontal' and 'vertical' controls will render when the controls are unlinked, as opposed to four individual controls. I want to call this out since the linking/unlinking for Button here is different compared to other blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Test Button Block**
1. Check out this PR. Create a new post and insert a Button block.
2. Open the Spacing controls in the Inspector Controls. The padding control should initially be linked (a single input controlling all sides). Test updating the padding for all sides.
3. Click the button to unlink the controls. There should only be two inputs displayed, for horizontal and vertical sides respectively. Test changing each separately.
4. Test that changes are persisted on the frontend.

**Test Block Supports**
_Test configuring the support for all sides by default_ 
Update `button/block.json` to enable padding for all sides by changing it to:
```
                "spacing": {
			"__experimentalSkipSerialization": true,
			"padding": true
		},
```
Test in the editor that all sides can be controlled individually when the controls are unlinked.

_Test configuring arbitrary individual sides still works_
Update `button/block.json` to enable padding for arbitrary sides:
```
    "padding": [ "top", "bottom", "left" ]
```
Test that only the supported sides are able to be controlled when the controls are unlinked.

_Test that invalid mixes of axial and individual sides are not allowed_
Update `button/block.json` to enable padding for an invalid mix of axial/individual sides:
```
    "padding": [ "vertical", "left" ]
```
Test that a warning is logged and the padding feature is disabled; UI should not display.

_Test margin support_
Add margin support to the button block and repeat all tests. You will need to make sure that your theme enables margin support for the button block in order to do this.
```
                "spacing": {
			"__experimentalSkipSerialization": true,
                       "padding": [ "horizontal", "vertical" ]
			"margin": [ "horizontal", "vertical" ]
		},
```


## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/63313398/128064123-5cf444c5-20de-45a9-8084-a6c826cbefeb.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
