### PR TITLE
Gallery block: Add a filter to automatically convert transforms to and from 3rd party blocks

### DIFF
--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -83,7 +83,7 @@ addFilter(
 /**
  * Third party block plugins don't have an easy way to detect if the
  * innerBlocks version of the Gallery is running when they run a
- * 3rdPartyBlock -> GallaryBlock transform so this tranform filter
+ * GalleryBlock -> 3rdPartyBlock transform so this transform filter
  * will handle this. Once the innerBlocks version is the default
  * in a core release, this could be deprecated and removed after
  * plugin authors have been given time to update transforms.

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -59,8 +59,10 @@ function updateThirdPartyTransformToGallery( block ) {
 			( { url, id, alt } ) => {
 				return createBlock( 'core/image', {
 					url,
-					id,
+					id: parseInt( id, 10 ),
 					alt,
+					sizeSlug: block.attributes.sizeSlug,
+					linkDestination: block.attributes.linkDestination,
 				} );
 			}
 		);
@@ -107,7 +109,7 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 		const images = galleryBlock.innerBlocks.map(
 			( { attributes: { url, id, alt } } ) => ( {
 				url,
-				id,
+				id: parseInt( id, 10 ),
 				alt,
 			} )
 		);

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -55,12 +55,15 @@ function updateThirdPartyTransformToGallery( block ) {
 		block.name === 'core/gallery' &&
 		block.attributes?.images
 	) {
-		const innerBlocks = block.attributes.images.map( ( { url, id } ) => {
-			return createBlock( 'core/image', {
-				url,
-				id,
-			} );
-		} );
+		const innerBlocks = block.attributes.images.map(
+			( { url, id, alt } ) => {
+				return createBlock( 'core/image', {
+					url,
+					id,
+					alt,
+				} );
+			}
+		);
 
 		delete block.attributes.ids;
 		delete block.attributes.images;
@@ -102,9 +105,10 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 
 	if ( settings.__unstableGalleryWithImageBlocks && galleryBlock ) {
 		const images = galleryBlock.innerBlocks.map(
-			( { attributes: { url, id } } ) => ( {
+			( { attributes: { url, id, alt } } ) => ( {
 				url,
 				id,
+				alt,
 			} )
 		);
 		const ids = images.map( ( { id } ) => id );

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -46,7 +46,7 @@ const parseShortcodeIds = ( ids ) => {
  * @typedef  {Object} Block
  * @property {Attributes} attributes The attributes of the block.
  * @param    {Block}      block      The transformed block.
- * @return   {Block}     			 The transformed block.
+ * @return   {Block}                 The transformed block.
  */
 function updateThirdPartyTransformToGallery( block ) {
 	const settings = select( blockEditorStore ).getSettings();

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -96,6 +96,7 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 		( transformedBlock ) =>
 			transformedBlock.name === 'core/gallery' &&
 			transformedBlock.innerBlocks.length > 0 &&
+			! transformedBlock.attributes.images?.length > 0 &&
 			! toBlock.name.includes( 'core/' )
 	);
 
@@ -109,7 +110,6 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 		const ids = images.map( ( { id } ) => id );
 		galleryBlock.attributes.images = images;
 		galleryBlock.attributes.ids = ids;
-		galleryBlock.innerBlocks = [];
 	}
 
 	return toBlock;

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -91,8 +91,8 @@ addFilter(
  * @typedef  {Object} Attributes
  * @typedef  {Object} Block
  * @property {Attributes} attributes The attributes of the block.
- * @param    {Block}      toBlock    The block yo transform to.
- * @param    {Block[]}    fromBlocks The block yo transform to.
+ * @param    {Block}      toBlock    The block to transform to.
+ * @param    {Block[]}    fromBlocks The blocks to transform from.
  * @return   {Block}                 The transformed block.
  */
 function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -34,6 +34,20 @@ const parseShortcodeIds = ( ids ) => {
 	return ids.split( ',' ).map( ( id ) => parseInt( id, 10 ) );
 };
 
+/**
+ * Third party block plugins don't have an easy way to detect if the
+ * innerBlocks version of the Gallery is running when they run a
+ * 3rdPartyBlock -> GallaryBlock transform so this tranform filter
+ * will handle this. Once the innerBlocks version is the default
+ * in a core release, this could be deprecated and removed after
+ * plugin authors have been given time to update transforms.
+ *
+ * @typedef  {Object} Attributes
+ * @typedef  {Object} Block
+ * @property {Attributes} attributes The attributes of the block.
+ * @param    {Block}      block      The transformed block.
+ * @return   {string}     The internal widget id.
+ */
 function transformV1FormatFromThirdPartyBlocks( block ) {
 	const settings = select( blockEditorStore ).getSettings();
 	if (
@@ -41,10 +55,10 @@ function transformV1FormatFromThirdPartyBlocks( block ) {
 		block.name === 'core/gallery' &&
 		block.attributes?.images
 	) {
-		const innerBlocks = block.attributes.images.map( ( image ) => {
+		const innerBlocks = block.attributes.images.map( ( { url, id } ) => {
 			return createBlock( 'core/image', {
-				url: image.url,
-				id: image.id,
+				url,
+				id,
 			} );
 		} );
 
@@ -57,7 +71,7 @@ function transformV1FormatFromThirdPartyBlocks( block ) {
 }
 addFilter(
 	'blocks.switchToBlockType.transformedBlock',
-	'core.transformthirdpartygalleries',
+	'core/gallery/transform-third-party',
 	transformV1FormatFromThirdPartyBlocks
 );
 

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -53,13 +53,13 @@ function updateThirdPartyTransformToGallery( block ) {
 	if (
 		settings.__unstableGalleryWithImageBlocks &&
 		block.name === 'core/gallery' &&
-		block.attributes?.images
+		block.attributes?.images.length > 0
 	) {
 		const innerBlocks = block.attributes.images.map(
 			( { url, id, alt } ) => {
 				return createBlock( 'core/image', {
 					url,
-					id: parseInt( id, 10 ),
+					id: id ? parseInt( id, 10 ) : null,
 					alt,
 					sizeSlug: block.attributes.sizeSlug,
 					linkDestination: block.attributes.linkDestination,
@@ -109,7 +109,7 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 		const images = galleryBlock.innerBlocks.map(
 			( { attributes: { url, id, alt } } ) => ( {
 				url,
-				id: parseInt( id, 10 ),
+				id: id ? parseInt( id, 10 ) : null,
 				alt,
 			} )
 		);

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -96,7 +96,6 @@ addFilter(
  * @return   {Block}                 The transformed block.
  */
 function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
-	const settings = select( blockEditorStore ).getSettings();
 	const galleryBlock = fromBlocks.find(
 		( transformedBlock ) =>
 			transformedBlock.name === 'core/gallery' &&
@@ -105,7 +104,7 @@ function updateThirdPartyTransformFromGallery( toBlock, fromBlocks ) {
 			! toBlock.name.includes( 'core/' )
 	);
 
-	if ( settings.__unstableGalleryWithImageBlocks && galleryBlock ) {
+	if ( galleryBlock ) {
 		const images = galleryBlock.innerBlocks.map(
 			( { attributes: { url, id, alt } } ) => ( {
 				url,

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -37,7 +37,7 @@ const parseShortcodeIds = ( ids ) => {
 /**
  * Third party block plugins don't have an easy way to detect if the
  * innerBlocks version of the Gallery is running when they run a
- * 3rdPartyBlock -> GallaryBlock transform so this tranform filter
+ * 3rdPartyBlock -> GalleryBlock transform so this tranform filter
  * will handle this. Once the innerBlocks version is the default
  * in a core release, this could be deprecated and removed after
  * plugin authors have been given time to update transforms.


### PR DESCRIPTION
## Description
With the Gallery block refactor, any transforms coming from 3rd party blocks will fail if the gallery refactor is enabled. 

I think it would be good to initially provide an automated mapping for transformations rather than just expecting plugin developers to immediately update their `to->core/gallery` and `from->core/gallery`  transforms, particularly since I can't see any way for a 3rd party block to easily detect if they should be transforming to the new innerBlocks version of the block or not.

## To test

- Check out this PR and run in a local dev env with Jetpack and CoBlocks plugins also installed
- With gallery refactor experiment turned off add a Jetpack Tiled Gallery and Slideshow block, and some CoBlocks gallery blocks, and check that these transform correctly to the v1 core/gallery block, and from the Gallery block to the Jetpack blocks
- Enable the gallery refactor experiment and repeat the above, and check that they now convert to the v2 gallery format, and also from the v2 format

