### PR TITLE
Image Block: Fix issue with canInsertCover not being set to false for empty arrays

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -135,11 +135,13 @@ export default function Image( {
 				'mediaUpload',
 			] );
 
+			const hasTransforms = !! transformations.length;
+
 			return {
 				...settings,
 				getBlock: _getBlock,
 				canInsertCover:
-					transformations?.length > 0 &&
+					hasTransforms &&
 					!! transformations.find(
 						( { name } ) => name === 'core/cover'
 					),

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -139,7 +139,7 @@ export default function Image( {
 				...settings,
 				getBlock: _getBlock,
 				canInsertCover:
-					transformations?.length &&
+					transformations?.length > 0 &&
 					!! transformations.find(
 						( { name } ) => name === 'core/cover'
 					),


### PR DESCRIPTION
## Description
The canInsertCover value in the Image block is being set to 0 instead of false when `transformations` is an empty array, which causes its subsequent use in the conditional display of the coverblock conversion toolbar item to output a 0, instead of moving in to the right most criteria

Fixes: #33862

## Testing

Check out PR in local dev env and add an Image block and make sure the convert to cover block option displays in toolbar still as expected
Check out this PR in conjunction with the Gallery refactor PR and enable the Gallery experiment
Add a gallery and make sure that the cover block option is not in the toolbar, and no 0 is displaying


## Screenshots 

Before:
<img width="698" alt="Screen Shot 2021-08-04 at 1 49 19 PM" src="https://user-images.githubusercontent.com/3629020/128109031-6770603c-fa32-48b1-bae0-0df060dd79fd.png">

After:
<img width="686" alt="Screen Shot 2021-08-04 at 1 48 38 PM" src="https://user-images.githubusercontent.com/3629020/128109044-353abe67-dcaf-4066-b065-ad1d0f534e82.png">
