### PR TITLE
Tune appender margin.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -16,7 +16,7 @@
 
 	// Add a uniform margin around the block.
 	// This can hopefully avoid havoc in flex containers.
-	margin: $grid-unit-10;
+	margin: 0 $grid-unit-10;
 
 	// Black square plus appender.
 	.block-list-appender__toggle {

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -14,9 +14,8 @@
 		margin: $grid-unit-10 0;
 	}
 
-	// Add a uniform margin around the block.
-	// This can hopefully avoid havoc in flex containers.
-	margin: 0 $grid-unit-10;
+	// Zero out the margin that's inherited from common.scss.
+	margin-bottom: revert;
 
 	// Black square plus appender.
 	.block-list-appender__toggle {


### PR DESCRIPTION
## Description

Followup to #33739. There was a teeeeensy side effect of the uniform 8px margin around the appender. Specifically that it in some cases made the height of blocks larger. See here how the navigation block grows 4px taller on select:

![before](https://user-images.githubusercontent.com/1204802/128143618-5cfb57b0-070f-4e2e-8224-c1ebab0faa64.gif)

That's because the 24px image plus 2x8px margins comes to 40px, but in this theme the menu is 36px tall by default.

This PR mitigates that by removing the top/bottom margin:

![after](https://user-images.githubusercontent.com/1204802/128143703-b6a5d8bf-0020-4529-a0e5-32f96a9d5502.gif)

I say _mitigates_ because if the menu is <24px tall the appender would still make it bigger. That's a separate and bigger issue to solve (see conversation in #31886). But it still seems like a good, small improvement. The appender is still vertically centered due to the flex rules.

## How has this been tested?

Insert social links, buttons, navigation blocks, and verify the appender on select still looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
