### PR TITLE
Lazy render the inserter search results

### DIFF
--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -26,6 +26,15 @@ import useBlockTypesState from './hooks/use-block-types-state';
 import { searchBlockItems, searchItems } from './search-items';
 import InserterListbox from '../inserter-listbox';
 
+const INITIAL_INSERTER_RESULTS = 9;
+/**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation and rerendering the component.
+ *
+ * @type {Array}
+ */
+const EMPTY_ARRAY = [];
+
 function InserterSearchResults( {
 	filterValue,
 	onSelect,
@@ -101,7 +110,14 @@ function InserterSearchResults( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	const currentShownPatterns = useAsyncList( filteredBlockPatterns );
+	const currentShownBlockTypes = useAsyncList( filteredBlockTypes, {
+		step: INITIAL_INSERTER_RESULTS,
+	} );
+	const currentShownPatterns = useAsyncList(
+		currentShownBlockTypes.length === filteredBlockTypes.length
+			? filteredBlockPatterns
+			: EMPTY_ARRAY
+	);
 
 	const hasItems =
 		! isEmpty( filteredBlockTypes ) || ! isEmpty( filteredBlockPatterns );
@@ -117,7 +133,7 @@ function InserterSearchResults( {
 					}
 				>
 					<BlockTypesList
-						items={ filteredBlockTypes }
+						items={ currentShownBlockTypes }
 						onSelect={ onSelectBlockType }
 						onHover={ onHover }
 						label={ __( 'Blocks' ) }

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -128,6 +128,7 @@ This behavior is useful if we want to render a list of items asynchronously for 
 _Parameters_
 
 -   _list_ `T[]`: Source array.
+-   _config_ `AsyncListConfig`: Configuration object.
 
 _Returns_
 

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -39,7 +39,10 @@ function getFirstItemsPresentInState< T >( list: T[], state: T[] ): T[] {
  *
  * @return Async array.
  */
-function useAsyncList< T >( list: T[], config: AsyncListConfig ): T[] {
+function useAsyncList< T >(
+	list: T[],
+	config: AsyncListConfig = { step: 1 }
+): T[] {
 	const { step = 1 } = config;
 	const [ current, setCurrent ] = useState( [] as T[] );
 

--- a/packages/compose/src/hooks/use-async-list/index.ts
+++ b/packages/compose/src/hooks/use-async-list/index.ts
@@ -4,6 +4,10 @@
 import { useEffect, useState } from '@wordpress/element';
 import { createQueue } from '@wordpress/priority-queue';
 
+type AsyncListConfig = {
+	step: number;
+};
+
 /**
  * Returns the first items from list that are present on state.
  *
@@ -30,26 +34,39 @@ function getFirstItemsPresentInState< T >( list: T[], state: T[] ): T[] {
  * React hook returns an array which items get asynchronously appended from a source array.
  * This behavior is useful if we want to render a list of items asynchronously for performance reasons.
  *
- * @param  list Source array.
+ * @param  list   Source array.
+ * @param  config Configuration object.
+ *
  * @return Async array.
  */
-function useAsyncList< T >( list: T[] ): T[] {
+function useAsyncList< T >( list: T[], config: AsyncListConfig ): T[] {
+	const { step = 1 } = config;
 	const [ current, setCurrent ] = useState( [] as T[] );
 
 	useEffect( () => {
 		// On reset, we keep the first items that were previously rendered.
-		const firstItems = getFirstItemsPresentInState( list, current );
+		let firstItems = getFirstItemsPresentInState( list, current );
+		if ( firstItems.length < step ) {
+			firstItems = firstItems.concat(
+				list.slice( firstItems.length, step )
+			);
+		}
 		setCurrent( firstItems );
+		let nextIndex = firstItems.length;
 
 		const asyncQueue = createQueue();
-		const append = ( index: number ) => () => {
-			if ( list.length <= index ) {
+		const append = () => {
+			if ( list.length <= nextIndex ) {
 				return;
 			}
-			setCurrent( ( state ) => [ ...state, list[ index ] ] );
-			asyncQueue.add( {}, append( index + 1 ) );
+			setCurrent( ( state ) => [
+				...state,
+				...list.slice( nextIndex, nextIndex + step ),
+			] );
+			nextIndex += step;
+			asyncQueue.add( {}, append );
 		};
-		asyncQueue.add( {}, append( firstItems.length ) );
+		asyncQueue.add( {}, append );
 
 		return () => asyncQueue.reset();
 	}, [ list ] );


### PR DESCRIPTION
This PR tries to improve the feeling of responsiveness in the inserter when searching block types and patterns. It does this by lazy-rendering the search results. It adds a `step` config into the `useAsyncList` hook to render the block types 9 by 9.