### PR TITLE
Add documentation for mobile components directory

### DIFF
--- a/packages/components/src/mobile/README.md
+++ b/packages/components/src/mobile/README.md
@@ -1,0 +1,3 @@
+# Mobile Components
+
+This directory houses generic WordPress components to be used for creating common UI elements shared between screens and features of the WordPress native mobile apps. The components in this directory are generally mobile-specific, and not utilized for web interfaces.


### PR DESCRIPTION
## Description
Provides a high-level description of the intent of the `packages/components/src/mobile` directory, which houses mobile-specific components.

## How has this been tested?
Reviewed documentation file on GitHub.com.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
