### PR TITLE
Skip customizing widgets inspector e2e test

### DIFF
--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -146,7 +146,7 @@ describe( 'Widgets Customizer', () => {
 		} ).toBeFound( findOptions );
 	} );
 
-	it( 'should open the inspector panel', async () => {
+	it.skip( 'should open the inspector panel', async () => {
 		const widgetsPanel = await find( {
 			role: 'heading',
 			name: /Widgets/,


### PR DESCRIPTION
This one is probably one of the last flaky tests at the moment.

Here's some examples of failures https://github.com/WordPress/gutenberg/runs/3232443026

It seems the dropdown menu is not opening for some reason.