### PR TITLE
Global Styles: Display font families from theme, core, and user in font family picker

### DIFF
--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -51,6 +51,19 @@ function useHasLetterSpacingControl( { supports, name } ) {
 	);
 }
 
+function mergeWithoutDuplicateFontFamilies( firstList, secondList ) {
+	const fontFamilies = [ ...firstList, ...secondList ];
+	const mergedFonts = fontFamilies.reduce( ( mergedList, font ) => {
+		if ( ! mergedList[ font.slug ] ) {
+			mergedList[ font.slug ] = font;
+		}
+
+		return mergedList;
+	}, {} );
+
+	return Object.values( mergedFonts );
+}
+
 export default function TypographyPanel( {
 	context: { supports, name },
 	getStyle,
@@ -61,7 +74,18 @@ export default function TypographyPanel( {
 		'typography.customFontSize',
 		name
 	);
-	const fontFamilies = useSetting( 'typography.fontFamilies', name );
+	const coreFontFamilies = useSetting( 'typography.fontFamilies.core', name );
+	const userFontFamilies = useSetting( 'typography.fontFamilies.user', name );
+	const themeFontFamilies = useSetting(
+		'typography.fontFamilies.theme',
+		name
+	);
+	const fontFamilies = mergeWithoutDuplicateFontFamilies(
+		themeFontFamilies,
+		userFontFamilies,
+		coreFontFamilies
+	);
+
 	const hasFontStyles =
 		useSetting( 'typography.customFontStyle', name ) &&
 		supports.includes( 'fontStyle' );

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -51,17 +51,20 @@ function useHasLetterSpacingControl( { supports, name } ) {
 	);
 }
 
-function mergeWithoutDuplicateFontFamilies( firstList, secondList ) {
-	const fontFamilies = [ ...firstList, ...secondList ];
-	const mergedFonts = fontFamilies.reduce( ( mergedList, font ) => {
-		if ( ! mergedList[ font.slug ] ) {
-			mergedList[ font.slug ] = font;
+function mergeWithoutDuplicateFontFamilies( ...fontLists ) {
+	const allFonts = fontLists.reduce( ( mergedList, fontList ) => {
+		return fontList ? mergedList.concat( ...fontList ) : mergedList;
+	}, [] );
+
+	const uniqueFonts = allFonts.reduce( ( uniqueList, font ) => {
+		if ( ! uniqueList[ font.slug ] ) {
+			uniqueList[ font.slug ] = font;
 		}
 
-		return mergedList;
+		return uniqueList;
 	}, {} );
 
-	return Object.values( mergedFonts );
+	return Object.values( uniqueFonts );
 }
 
 export default function TypographyPanel( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
I'm attempting to extend global styles by adding more font family options to the global styles font family picker, and am running into issues with how global styles "merges" data from different origins.

The current behavior displays `user` font families _or_ `theme` font families _or_ `core` font families in the picker. If font families from multiple origins exist, the priority is `user > theme > core`, and again, only one set of font families is made available.

https://github.com/WordPress/gutenberg/blob/27942d70e1cfaba14bc4c8d28933ff3047d56ef0/packages/edit-site/src/components/editor/utils.js#L108-L110

This makes extending fonts tricky, because we have to determine which origins are present and to merge values into the correct origin, otherwise they're not displayed. Semantically, we also have an odd situation where we're having to extend font options by adding to the `theme` origin settings to have them appear in the picker, even though the new fonts are _not_ theme related.

I was curious what we think about merging font families from _all_ origins, which is what I've done in this PR.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
