### PR TITLE
Try to fix flaky customizer inspector test

### DIFF
--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -204,6 +204,15 @@ describe( 'Widgets Customizer', () => {
 
 		await expect( inspectorHeading ).not.toBeVisible();
 
+		// Wait for the transition to finish to prevent it from
+		// clicking on the wrong element.
+		// The transition takes 180ms, 200ms should be enough.
+		// This is a temporary solution, a more ideal alternative
+		// would be to disable the transition entirely.
+		// See https://github.com/WordPress/gutenberg/pull/33875#issuecomment-893122147
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitForTimeout( 200 );
+
 		await clickBlockToolbarButton( 'Options' );
 		showMoreSettingsButton = await find( {
 			role: 'menuitem',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Alternative to #33875, part of #33275.

During closing the inspector and going back to the editor, the transition is making the blocks positioning in an intermediate state. Since the toolbar is still opened, it could sometimes also be positioned in the wrong place according to intermediate state of the block.

This PR waits for the transition to finish (200ms). A better alternative could be:
1. Disable the transitions in tests (#32024)
2. Delay showing the block toolbar until the transition is finished

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Not yet found a reliable way to reproduce the issue, so maybe we just have to merge this and monitor it on trunk.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
