### PR TITLE
Fix positioning discrepancy with draggable chip.

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -188,7 +188,7 @@
 
 .block-editor-block-list__block-selection-button {
 	display: inline-flex;
-	padding: 0 ( $grid-unit-15 + $border-width );
+	padding: 0 $grid-unit-15;
 	z-index: z-index(".block-editor-block-list__block-selection-button");
 
 	// Dark block UI appearance.
@@ -212,6 +212,7 @@
 		padding: 0;
 		height: $grid-unit-30;
 		min-width: $grid-unit-30;
+		margin-left: -2px;
 
 		// Drag handle is smaller than the others.
 		svg {


### PR DESCRIPTION
## Description

The inverted block toolbar/drag handle in select mode is offset slightly compared to the block toolbar:

![currently](https://user-images.githubusercontent.com/1204802/128312691-5ba9219c-828d-407b-a09a-a0df7ca350b5.gif)

<img width="633" alt="Screenshot 2021-08-05 at 09 42 21" src="https://user-images.githubusercontent.com/1204802/128312698-29f9b0d6-cced-4cd0-a405-9df5eaf713c5.png">

This PR fixes that:

![after](https://user-images.githubusercontent.com/1204802/128312721-688ceff8-e734-4bda-932c-4caf5675c19f.gif)

Note that now that IE11 support is no longer necessary, there is a huge opportunity to refactor the block toolbar to leverage flex and remove all the gnarly margin rules on content inside, replace them entirely with `gap` and drastically simplifying things. But it's a larger undertaking, and this is a small fix in the mean time. 

## How has this been tested?

Insert a block, select it, then press Escape. Observe the block icon and drag handle ideally overlapping precisely in both states.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
