### PR TITLE
Fix available alignments and layout for the post editor

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -181,7 +181,7 @@ export default function VisualEditor( { styles } ) {
 		}
 
 		return undefined;
-	}, [ isTemplateMode, themeSupportsLayout ] );
+	}, [ isTemplateMode, themeSupportsLayout, defaultLayout ] );
 
 	return (
 		<BlockTools


### PR DESCRIPTION
closes #33876
 
In #33359 there has been a small refactor in how the layout and alignments are computed in the post editor. Unfortunately a missed react hook dependency caused the used layout to be outdated. This should fix it.

**Testing instructions**

 - Use a theme with theme.json and layout defined like emptytheme or tt1-blocks
 - Make sure you can wide/full align blocks inserter in the top level in the post editor.