### PR TITLE
Fix block appender position in classic themes

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -83,7 +83,10 @@ function BlockListAppender( {
 			//
 			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 			tabIndex={ -1 }
-			className={ classnames( 'block-list-appender', className ) }
+			className={ classnames(
+				'block-list-appender wp-block',
+				className
+			) }
 		>
 			{ appender }
 		</TagName>


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/33024/files#r659586330 the `wp-block` class has been removed from the block appender. I think this was an error, that class is used to define the max-width for blocks which the appender should adhere too, otherwise it will be position on the extreme left.

I'm not really sure why the class was removed there.

**Testing instructions**

 - Use a classic theme
 - Insert an image block
 - notice that the block appender after the image block is positioned properly.