### PR TITLE
Fix the site editor breaking in firefox

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -87,6 +87,10 @@ export default function useMultiSelection() {
 	 * select the entire block contents.
 	 */
 	useEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+
 		const { ownerDocument } = ref.current;
 		const { defaultView } = ownerDocument;
 

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -6,7 +6,7 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -70,7 +70,6 @@ function selector( select ) {
 }
 
 export default function useMultiSelection() {
-	const ref = useRef();
 	const {
 		isMultiSelecting,
 		multiSelectedBlockClientIds,
@@ -86,74 +85,72 @@ export default function useMultiSelection() {
 	 * When the component updates, and there is multi selection, we need to
 	 * select the entire block contents.
 	 */
-	useEffect( () => {
-		if ( ! ref.current ) {
-			return;
-		}
+	return useRefEffect(
+		( node ) => {
+			const { ownerDocument } = node;
+			const { defaultView } = ownerDocument;
 
-		const { ownerDocument } = ref.current;
-		const { defaultView } = ownerDocument;
+			if ( ! hasMultiSelection || isMultiSelecting ) {
+				if ( ! selectedBlockClientId || isMultiSelecting ) {
+					return;
+				}
 
-		if ( ! hasMultiSelection || isMultiSelecting ) {
-			if ( ! selectedBlockClientId || isMultiSelecting ) {
+				const selection = defaultView.getSelection();
+
+				if ( selection.rangeCount && ! selection.isCollapsed ) {
+					const blockNode = selectedRef.current;
+					const {
+						startContainer,
+						endContainer,
+					} = selection.getRangeAt( 0 );
+
+					if (
+						!! blockNode &&
+						( ! blockNode.contains( startContainer ) ||
+							! blockNode.contains( endContainer ) )
+					) {
+						selection.removeAllRanges();
+					}
+				}
+
 				return;
 			}
 
-			const selection = defaultView.getSelection();
+			const { length } = multiSelectedBlockClientIds;
 
-			if ( selection.rangeCount && ! selection.isCollapsed ) {
-				const blockNode = selectedRef.current;
-				const { startContainer, endContainer } = selection.getRangeAt(
-					0
-				);
-
-				if (
-					!! blockNode &&
-					( ! blockNode.contains( startContainer ) ||
-						! blockNode.contains( endContainer ) )
-				) {
-					selection.removeAllRanges();
-				}
+			if ( length < 2 ) {
+				return;
 			}
 
-			return;
-		}
+			// For some browsers, like Safari, it is important that focus happens
+			// BEFORE selection.
+			node.focus();
 
-		const { length } = multiSelectedBlockClientIds;
+			const selection = defaultView.getSelection();
+			const range = ownerDocument.createRange();
 
-		if ( length < 2 ) {
-			return;
-		}
+			// These must be in the right DOM order.
+			// The most stable way to select the whole block contents is to start
+			// and end at the deepest points.
+			const startNode = getDeepestNode( startRef.current, 'start' );
+			const endNode = getDeepestNode( endRef.current, 'end' );
 
-		// For some browsers, like Safari, it is important that focus happens
-		// BEFORE selection.
-		ref.current.focus();
+			// While rich text will be disabled with a delay when there is a multi
+			// selection, we must do it immediately because it's not possible to set
+			// selection across editable hosts.
+			toggleRichText( node, false );
 
-		const selection = defaultView.getSelection();
-		const range = ownerDocument.createRange();
+			range.setStartBefore( startNode );
+			range.setEndAfter( endNode );
 
-		// These must be in the right DOM order.
-		// The most stable way to select the whole block contents is to start
-		// and end at the deepest points.
-		const startNode = getDeepestNode( startRef.current, 'start' );
-		const endNode = getDeepestNode( endRef.current, 'end' );
-
-		// While rich text will be disabled with a delay when there is a multi
-		// selection, we must do it immediately because it's not possible to set
-		// selection across editable hosts.
-		toggleRichText( ref.current, false );
-
-		range.setStartBefore( startNode );
-		range.setEndAfter( endNode );
-
-		selection.removeAllRanges();
-		selection.addRange( range );
-	}, [
-		hasMultiSelection,
-		isMultiSelecting,
-		multiSelectedBlockClientIds,
-		selectedBlockClientId,
-	] );
-
-	return ref;
+			selection.removeAllRanges();
+			selection.addRange( range );
+		},
+		[
+			hasMultiSelection,
+			isMultiSelecting,
+			multiSelectedBlockClientIds,
+			selectedBlockClientId,
+		]
+	);
 }


### PR DESCRIPTION
closes #33873 

I'm not entirely certain that this is a good solution but in Firefox the ref is null initially meaning that it's probably not being attached on mount.

Guarding against the ref solves the issue but doesn't explain why the ref is empty in the first place.

**Note:** It seems we don't have an error boundary in the site editor or if we do, it's not working well.

**Testing instructions**

 - Open the site editor in firefox
 - Make sure you don't get just a crash/