### PR TITLE
Plugin: Fix `jsdoc/check-line-alignment` ESLint warnings

### DIFF
--- a/packages/block-editor/src/hooks/use-spacing-props.js
+++ b/packages/block-editor/src/hooks/use-spacing-props.js
@@ -11,7 +11,7 @@ import { getInlineStyles } from './style';
  * Provides the CSS class names and inline styles for a block's spacing support
  * attributes.
  *
- * @param  {Object} attributes Block attributes.
+ * @param {Object} attributes Block attributes.
  *
  * @return {Object} Spacing block support derived CSS classes & styles.
  */

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -144,7 +144,7 @@ function getSuggestionsQuery( type, kind ) {
  * 4: Theme colors
  * 5: Global styles
  *
- * @param {Object} context
+ * @param {Object}  context
  * @param {boolean} isSubMenu
  */
 function getColors( context, isSubMenu ) {

--- a/packages/components/src/flyout/flyout-content/component.js
+++ b/packages/components/src/flyout/flyout-content/component.js
@@ -8,7 +8,7 @@ import { contextConnect, useContextSystem } from '../../ui/context';
 /**
  *
  * @param {import('../../ui/context').PolymorphicComponentProps<import('../types').ContentProps, 'div', false>} props
- * @param {import('react').Ref<any>}                                                                     forwardedRef
+ * @param {import('react').Ref<any>}                                                                            forwardedRef
  */
 function FlyoutContent( props, forwardedRef ) {
 	const {

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -257,10 +257,10 @@ export function filterUnitsWithSettings( settings = [], units = [] ) {
  * TODO: ideally this hook shouldn't be needed
  * https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823
  *
- * @param {Object} args                                  An object containing units, settingPath & defaultUnits.
- * @param {Array<Object>|undefined} args.units           Collection of available units.
- * @param {Array<string>|undefined} args.availableUnits  The setting path. Defaults to 'spacing.units'.
- * @param {Object|undefined}        args.defaultValues   Collection of default values for defined units. Example: { px: '350', em: '15' }.
+ * @param {Object}                  args                An object containing units, settingPath & defaultUnits.
+ * @param {Array<Object>|undefined} args.units          Collection of available units.
+ * @param {Array<string>|undefined} args.availableUnits The setting path. Defaults to 'spacing.units'.
+ * @param {Object|undefined}        args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
  *
  * @return {Array|boolean} Filtered units based on settings.
  */

--- a/packages/dom/src/dom/is-entirely-selected.js
+++ b/packages/dom/src/dom/is-entirely-selected.js
@@ -65,9 +65,9 @@ export default function isEntirelySelected( element ) {
  * Check whether the contents of the element have been entirely selected.
  * Returns true if there is no possibility of selection.
  *
- * @param {HTMLElement|Node} query The element to check.
- * @param {HTMLElement} container The container that we suspect "query" may be a first or last child of.
- * @param {"firstChild"|"lastChild"} propName "firstChild" or "lastChild"
+ * @param {HTMLElement|Node}         query     The element to check.
+ * @param {HTMLElement}              container The container that we suspect "query" may be a first or last child of.
+ * @param {"firstChild"|"lastChild"} propName  "firstChild" or "lastChild"
  *
  * @return {boolean} True if query is a deep first/last child of container, false otherwise.
  */

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -164,7 +164,7 @@ export function subscribeReplaceBlock( callback ) {
  * Subscribe a listener for handling requests to open the editor help topics page.
  *
  * @param {Function} callback RN Callback function to display the editor
- * 							  help topics.
+ *                            help topics.
  */
 export function subscribeShowEditorHelp( callback ) {
 	return gutenbergBridgeEvents.addListener( 'showEditorHelp', callback );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

It's the result of running:

```bash
npm run lint-js -- --fix
```

It was applied to files that had reported violations for `jsdoc/check-line-alignment` rule.