### PR TITLE
`useBreakpointIndex`: attach `resize` event listener to `window` instead of `document`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Listen to `resize` events correctly in `useBreakpointIndex`. This hook is used in `useResponsiveValue` and consequently in the `Flex` and `Grid` components  ([#33902](https://github.com/WordPress/gutenberg/pull/33902))
+
 ## 15.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/components/src/ui/utils/use-responsive-value.ts
+++ b/packages/components/src/ui/utils/use-responsive-value.ts
@@ -40,14 +40,14 @@ export const useBreakpointIndex = (
 
 		onResize();
 
-		if ( typeof document !== 'undefined' ) {
+		if ( typeof window !== 'undefined' ) {
 			// Disable reason: We don't really care about what document we listen to, we just want to know that we're resizing.
 			/* eslint-disable @wordpress/no-global-event-listener */
-			document.addEventListener( 'resize', onResize );
+			window.addEventListener( 'resize', onResize );
 		}
 		return () => {
-			if ( typeof document !== 'undefined' ) {
-				document.removeEventListener( 'resize', onResize );
+			if ( typeof window !== 'undefined' ) {
+				window.removeEventListener( 'resize', onResize );
 				/* eslint-enable @wordpress/no-global-event-listener */
 			}
 		};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fix a bug in the `useBreakpointIndex` component utility hook, where the `resize` event listener was previously attached to the `document` object.

This was resulting in the event listener function never being called, since [the `resize` event only gets fired on the `window` object](https://developer.mozilla.org/en-US/docs/Web/API/Window/resize_event).

The fix is quite simple — change `document` to `window`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

One way to test this is to check the `Flex` component's Storybook example:

- in [production](https://wordpress.github.io/gutenberg/?path=/story/g2-components-experimental-flex--default), notice how resizing the window doesn't cause the second row of items to switch from `row` to `column` (and viceversa)
- When running Storybook on this PR branch, notice how the behaviour just described above is fixed

## Screenshots <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/1083581/128360451-048af45b-6728-4298-8fac-19990f0f9ebd.mp4

**After**

https://user-images.githubusercontent.com/1083581/128360624-3dd7263e-ee91-44b3-83fe-c6cee342f61d.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
