### PR TITLE
Closing the block inserter decrements block type impressions

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -164,27 +164,30 @@ export class Inserter extends Component {
 	onToggle( isOpen ) {
 		const { blockTypeImpressions, onToggle, updateSettings } = this.props;
 
-		const impressionsRemain = Object.values( blockTypeImpressions ).some(
-			( count ) => count > 0
-		);
-		if ( ! isOpen && impressionsRemain ) {
-			const decrementedImpressions = Object.entries(
+		if ( ! isOpen ) {
+			const impressionsRemain = Object.values(
 				blockTypeImpressions
-			).reduce(
-				( acc, [ blockName, count ] ) => ( {
-					...acc,
-					[ blockName ]: Math.max( count - 1, 0 ),
-				} ),
-				{}
-			);
+			).some( ( count ) => count > 0 );
 
-			// Persist block type impression to JavaScript store
-			updateSettings( {
-				impressions: decrementedImpressions,
-			} );
+			if ( impressionsRemain ) {
+				const decrementedImpressions = Object.entries(
+					blockTypeImpressions
+				).reduce(
+					( acc, [ blockName, count ] ) => ( {
+						...acc,
+						[ blockName ]: Math.max( count - 1, 0 ),
+					} ),
+					{}
+				);
 
-			// Persist block type impression count to native app store
-			setBlockTypeImpressions( decrementedImpressions );
+				// Persist block type impression to JavaScript store
+				updateSettings( {
+					impressions: decrementedImpressions,
+				} );
+
+				// Persist block type impression count to native app store
+				setBlockTypeImpressions( decrementedImpressions );
+			}
 		}
 
 		// Surface toggle callback to parent component

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -10,7 +10,7 @@ import { delay } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Dropdown, ToolbarButton, Picker } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import {
@@ -20,6 +20,7 @@ import {
 	insertAfter,
 	insertBefore,
 } from '@wordpress/icons';
+import { setBlockTypeImpressions } from '@wordpress/react-native-bridge';
 
 /**
  * Internal dependencies
@@ -161,7 +162,30 @@ export class Inserter extends Component {
 	}
 
 	onToggle( isOpen ) {
-		const { onToggle } = this.props;
+		const { blockTypeImpressions, onToggle, updateSettings } = this.props;
+
+		const impressionsRemain = Object.values( blockTypeImpressions ).some(
+			( count ) => count > 0
+		);
+		if ( ! isOpen && impressionsRemain ) {
+			const decrementedImpressions = Object.entries(
+				blockTypeImpressions
+			).reduce(
+				( acc, [ blockName, count ] ) => ( {
+					...acc,
+					[ blockName ]: Math.max( count - 1, 0 ),
+				} ),
+				{}
+			);
+
+			// Persist block type impression to JavaScript store
+			updateSettings( {
+				impressions: decrementedImpressions,
+			} );
+
+			// Persist block type impression count to native app store
+			setBlockTypeImpressions( decrementedImpressions );
+		}
 
 		// Surface toggle callback to parent component
 		if ( onToggle ) {
@@ -308,6 +332,10 @@ export class Inserter extends Component {
 }
 
 export default compose( [
+	withDispatch( ( dispatch ) => {
+		const { updateSettings } = dispatch( blockEditorStore );
+		return { updateSettings };
+	} ),
 	withSelect( ( select, { clientId, isAppender, rootClientId } ) => {
 		const {
 			getBlockRootClientId,
@@ -378,6 +406,7 @@ export default compose( [
 		const insertionIndexEnd = endOfRootIndex;
 
 		return {
+			blockTypeImpressions: getBlockEditorSettings().impressions,
 			displayEditorOnboardingTooltip:
 				getBlockEditorSettings().editorOnboarding &&
 				getBlockEditorSettings().firstGutenbergEditorSession,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -288,7 +288,7 @@ export const registerCoreBlocks = () => {
  * @constant {{ string, number }}
  */
 export const NEW_BLOCK_TYPES = {
-	[ embed.name ]: 10,
-	[ search.name ]: 10,
-	[ audio.name ]: 10,
+	[ embed.name ]: 40,
+	[ search.name ]: 40,
+	[ audio.name ]: 40,
 };

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -288,7 +288,7 @@ export const registerCoreBlocks = () => {
  * @constant {{ string, number }}
  */
 export const NEW_BLOCK_TYPES = {
-	[ embed.name ]: 3,
-	[ search.name ]: 3,
-	[ audio.name ]: 3,
+	[ embed.name ]: 10,
+	[ search.name ]: 10,
+	[ audio.name ]: 10,
 };

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -40,7 +40,9 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 		addEventListener: jest.fn(),
 		mediaUploadSync: jest.fn(),
 		removeEventListener: jest.fn(),
-		requestBlockTypeImpressions: jest.fn( () => {} ),
+		requestBlockTypeImpressions: jest.fn( ( callback ) => {
+			callback( {} );
+		} ),
 		requestFocalPointPickerTooltipShown: jest.fn( () => true ),
 		setBlockTypeImpressions: jest.fn(),
 		subscribeParentToggleHTMLMode: jest.fn(),


### PR DESCRIPTION
* **Gutenberg:** Self
* **Gutenberg Mobile:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3802

## Description
Fixes #33907. Closing the block inserter will decrement the block type impression counts. This results in blocks that are marked as "new" to slowly lose the designation as a user utilizes the block inserter over time. 

## How has this been tested?
1. Clone this branch. 
2. Apply the below diff. 
	<details><summary>Patch Enabling New Badge</summary>

	```diff
	diff --git a/packages/block-editor/src/components/inserter/hooks/use-block-type-impressions.native.js b/packages/block-editor/src/components/inserter/hooks/use-block-type-impressions.native.js
	index 2fcd6dc1c9..7bd08a2594 100644
	--- a/packages/block-editor/src/components/inserter/hooks/use-block-type-impressions.native.js
	+++ b/packages/block-editor/src/components/inserter/hooks/use-block-type-impressions.native.js
	@@ -19,7 +19,7 @@ function useBlockTypeImpressions( blockTypes ) {
	
				return {
					blockTypeImpressions: impressions,
	-				enableEditorOnboarding: editorOnboarding,
	+				enableEditorOnboarding: true,
				};
			},
			[]
	```

	</details>
3. Start the server and build the Demo app to an emulator/device. 
4. Open the block inserter, note the new "sparkles" badge on the Search, Embed, and Audio block buttons. 
5. Insert one of the aforementioned blocks. 
6. Open the block inserter, note the new "sparkles" badge should only be present on two of the aforementioned blocks _not_ inserted. 
7. Close the block inserter. 
8. Repeat steps 6-7 9 more times. 
9. ℹ️ **Expected:** the new "sparkles" badge is _no longer present_ on any block buttons. 

## Screenshots <!-- if applicable -->
<img width="285" alt="new-block-sparkles-badge" src="https://user-images.githubusercontent.com/438664/128391944-51323d2e-bf29-46b3-9c92-8fbb338079d8.png">

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
