### PR TITLE
Allow custom fields to be hidden when enableCustomFields is null

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js
@@ -55,7 +55,8 @@ export default withSelect( ( select ) => {
 	return {
 		// This setting should not live in the block editor's store.
 		areCustomFieldsRegistered:
-			getEditorSettings().enableCustomFields !== undefined,
+			getEditorSettings().enableCustomFields !== undefined &&
+			getEditorSettings().enableCustomFields !== null,
 		metaBoxes: getAllMetaBoxes(),
 	};
 } )( MetaBoxesSection );


### PR DESCRIPTION
**Allow custom fields to be hidden when enableCustomFields is null**

## Scope of Problem

This is a coordination problem between WordPress and Gutenberg and requires changes on both sides. I have patches for both.

* trac.wordpress.org issue: https://core.trac.wordpress.org/ticket/53883
  * wordpress-develop pull request: https://github.com/WordPress/wordpress-develop/pull/1548
* Gutenberg issue: #33830

## Problem

When using a plugin to disable Custom Fields in the post editor, WordPress attempts to change `$editor_settings` to tell Gutenberg not to render the Custom Fields settings toggle in a preferences modal. However, Gutenberg is listening for a value that is impossible to send in PHP, and the settings toggle remains visible even when the feature itself is disabled.

This change tells Gutenberg to listen for an additional value to turn off the setting (`null`). It must be applied in conjunction with a WordPress change to send that value (Currently, it uses `unset()` to not send a value, which mean Gutenberg's state defaults apply).

## Alternative Approach

Here is a different approach for the same problem: #33931 This changes the default value to `undefined`, which allows WP.org's current `unset()` to work without any changes needed on that side.

* https://github.com/WordPress/gutenberg/pull/33931

## Steps to Reproduce

1. Have a WordPress.org installation.

2. Create `wp-content/plugins/disable-custom-fields.php`
```php
<?php
/**
 * Plugin Name: Disable Custom Fields
 * Plugin URI: http://www.mywebsite.com/disable-custom-fields
 * Description: Disable Custom Fields
 * Version: 1.0
 * Author: Your Name
 * Author URI: http://www.mywebsite.com
 */

add_action( 'add_meta_boxes', 'plugin_disable_custom_fields', 1 );

function plugin_disable_custom_fields() {
    remove_post_type_support( get_post_type(), 'custom-fields' );
}


add_action( 'do_meta_boxes', 'plugin_meta_boxes', 10, 2 );

function plugin_meta_boxes( $page, $context ) {
    remove_meta_box( 'postcustom', get_post_type(), 'normal' );
}
```

3. Visit /wp-admin and activate this plugin.
4. Visit post editor on WordPress.org site. With this plugin enabled, [this if condition will always trigger](https://github.com/WordPress/WordPress/blob/9a4280c75f7bf76062b61207e3ecdb3a0e0f298e/wp-admin/edit-form-blocks.php#L260), and [the `unset( $editor_settings['enableCustomFields'] );` always runs](https://github.com/WordPress/WordPress/blob/9a4280c75f7bf76062b61207e3ecdb3a0e0f298e/wp-admin/edit-form-blocks.php#L261).
5. Click the three dots menu in the top right
6. Click "preferences" at the bottom
![2021-08-05_10-07](https://user-images.githubusercontent.com/937354/128374126-c22ad772-d02f-4df4-9c4b-bb9be3748a71.png)
7. A modal appears. Click Panels on the left
8. Turn on "Custom Fields"
![2021-08-05_10-08](https://user-images.githubusercontent.com/937354/128374210-5d7311eb-6073-4ffa-8fd5-6754ac3c5aa3.png)
![2021-08-05_10-08_1](https://user-images.githubusercontent.com/937354/128374223-df55a53c-b4ae-4261-b664-b256ee202d28.png)
9. See message asking to enable and reload, click the button
10. Page reloads
11. Re-visit the custom fields setting, see that it is turned off. 

![2021-08-02_13-33_1](https://user-images.githubusercontent.com/937354/127907927-3beac46c-8127-4675-bd71-ece924a1bdbe.png)

Expected to see: The entire "Custom Settings" option does not appear, because `$editor_settings['enableCustomFields']` is unset [by this core code](https://github.com/WordPress/WordPress/blob/9a4280c75f7bf76062b61207e3ecdb3a0e0f298e/wp-admin/edit-form-blocks.php#L261).

Actually see: A toggle that does nothing after turning it on, because a plugin is disabling the option from working.

The "Custom Fields" settings is designed to be hidden by an editor setting set in WP.org core PHP code, however it cannot be hidden, due to these factors:
  * gutenberg JS strictly checks for an undefined value: [Code Link 1](https://github.com/WordPress/gutenberg/blob/333668e7149a1f3f2a39810372ecb11422fe4f7c/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js#L57-L58), [Code Link 2](https://github.com/WordPress/gutenberg/blob/333668e7149a1f3f2a39810372ecb11422fe4f7c/packages/edit-post/src/components/preferences-modal/meta-boxes-section.js#L31)
  * If PHP sends a null or false value, those don't match a === check against undefined
  * If PHP does not send a value, gutenberg's default settings apply a false to the value, which is also !== undefined. [Code Link 3.](https://github.com/WordPress/gutenberg/blob/333668e7149a1f3f2a39810372ecb11422fe4f7c/packages/editor/src/store/defaults.js#L30)

Therefore, to hide the "Custom Fields" setting, it wants an undefined to be sent in `getEditorSettings().enableCustomFields`, but it is impossible to send one.


## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
* Used a wordpress.org installation
* Added the simple plugin described in my steps above
* `cp wp-includes/js/dist/edit-post.js wp-includes/js/dist/edit-post.min.js`
* Edited `wp-includes/js/dist/edit-post.min.js`
* **Also applied changes to WP.org core code**. This is a coordination problem between WordPress and Gutenberg and requires changes on both sides to work.
  * Changes to `wp-admin/edit-form-blocks.php`.
    * See: https://github.com/WordPress/wordpress-develop/pull/1548
* Don't laugh, I don't usually work on Gutenberg and don't have a dev environment set up for it :smile:


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
* Bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
