### PR TITLE
Global Styles: Add slashes back to the Theme JSON

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -232,7 +232,7 @@ function gutenberg_experimental_global_styles_register_user_cpt() {
  * @return string Filtered post content with unsafe rules removed.
  */
 function gutenberg_global_styles_filter_post( $content ) {
-	$decoded_data        = json_decode( stripslashes( $content ), true );
+	$decoded_data        = json_decode( wp_unslash( $content ), true );
 	$json_decoding_error = json_last_error();
 	if (
 		JSON_ERROR_NONE === $json_decoding_error &&
@@ -245,7 +245,7 @@ function gutenberg_global_styles_filter_post( $content ) {
 		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data );
 
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
-		return wp_json_encode( addslashes( $data_to_encode ) );
+		return wp_slash( wp_json_encode( $data_to_encode ) );
 	}
 	return $content;
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -245,7 +245,7 @@ function gutenberg_global_styles_filter_post( $content ) {
 		$data_to_encode = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $decoded_data );
 
 		$data_to_encode['isGlobalStylesUserThemeJSON'] = true;
-		return wp_json_encode( $data_to_encode );
+		return wp_json_encode( addslashes( $data_to_encode ) );
 	}
 	return $content;
 }

--- a/phpunit/global-styles-test.php
+++ b/phpunit/global-styles-test.php
@@ -23,6 +23,6 @@ class WP_Global_Styles_Test extends WP_UnitTestCase {
 		}';
 
 		$filtered_user_theme_json = gutenberg_global_styles_filter_post( $user_theme_json );
-		$this->assertEqual( $user_theme_json, $filtered_user_theme_json );
+		$this->assertEquals( $user_theme_json, $filtered_user_theme_json );
 	}
 }

--- a/phpunit/global-styles-test.php
+++ b/phpunit/global-styles-test.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test the Global Styles lib
+ *
+ * @package Gutenberg
+ */
+
+class WP_Global_Styles_Test extends WP_UnitTestCase {
+	function test_gutenberg_global_styles_filter_post() {
+		$user_theme_json = '{
+			"isGlobalStylesUserThemeJSON": 1,
+			"version": 1,
+			"settings": {
+				"typography": {
+					"fontFamilies": {
+						"fontFamily": "\"DM Sans\", sans-serif",
+						"slug": "dm-sans",
+						"name": "DM Sans",
+					}
+				}
+			}
+		}';
+
+		$filtered_user_theme_json = gutenberg_global_styles_filter_post( $user_theme_json );
+		$this->assertEqual( $user_theme_json, $filtered_user_theme_json );
+	}
+}


### PR DESCRIPTION
## Description
On line 235 we remove slashes from theme.json using `stripslashes`, but then we don't readd them when we save the data. This adds a call to `addslashes` before we call `wp_json_encode`, so that the JSON remains valid.

## How has this been tested?
This is hard to test as this filter only gets applied when a user does not have the `unfiltered_html` capability, and when users don't have this they also don't have access to the Site Editor. 

However on WordPress.com all users do not have this capability, so you can test in that environment.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
