### PR TITLE
Do not execute `rtl` function in `styled` components

### DIFF
--- a/packages/components/src/box-control/styles/box-control-styles.js
+++ b/packages/components/src/box-control/styles/box-control-styles.js
@@ -46,10 +46,10 @@ export const Layout = styled( Flex )`
 
 const unitControlBorderRadiusStyles = ( { isFirst, isLast, isOnly } ) => {
 	if ( isFirst ) {
-		return rtl( { borderTopRightRadius: 0, borderBottomRightRadius: 0 } )();
+		return rtl( { borderTopRightRadius: 0, borderBottomRightRadius: 0 } );
 	}
 	if ( isLast ) {
-		return rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )();
+		return rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } );
 	}
 	if ( isOnly ) {
 		return css( { borderRadius: 2 } );
@@ -63,7 +63,7 @@ const unitControlBorderRadiusStyles = ( { isFirst, isLast, isOnly } ) => {
 const unitControlMarginStyles = ( { isFirst, isOnly } ) => {
 	const marginLeft = isFirst || isOnly ? 0 : -1;
 
-	return rtl( { marginLeft } )();
+	return rtl( { marginLeft } );
 };
 
 export const UnitControl = styled( BaseUnitControl )`

--- a/packages/components/src/select-control/styles/select-control-styles.js
+++ b/packages/components/src/select-control/styles/select-control-styles.js
@@ -75,7 +75,7 @@ export const Select = styled.select`
 		${ fontSizeStyles };
 		${ sizeStyles };
 
-		${ rtl( { paddingLeft: 8, paddingRight: 24 } )() }
+		${ rtl( { paddingLeft: 8, paddingRight: 24 } ) }
 	}
 `;
 
@@ -89,7 +89,7 @@ export const DownArrowWrapper = styled.div`
 	position: absolute;
 	top: 0;
 
-	${ rtl( { right: 0 } )() }
+	${ rtl( { right: 0 } ) }
 
 	svg {
 		display: block;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The function returned by `rtl()` doesn't need to be invoked inline in `styled` component. This allows Emotion to interpolate that function when props change, thus allowing RTL styles to be more reactive.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Check that the `SelectControl` component behaves correctly in Storybook

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
