### PR TITLE
Improve default selection in the Combobox Component

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -163,11 +163,9 @@ function ComboboxControl( {
 
 	// Update selections on filter change.
 	useEffect( () => {
-		const currentSelectionNotInSuggestions = matchingSuggestions.indexOf( selectedSugestion ) < 0;
-		if (
-			matchingSuggestions.length &&
-			currentSelectionNotInSuggestions
-		) {
+		const currentSelectionNotInSuggestions =
+			matchingSuggestions.indexOf( selectedSuggestion ) < 0;
+		if ( matchingSuggestions.length && currentSelectionNotInSuggestions ) {
 			// If the current selection isn't present in the list of suggestions, then automatically select the first item from the list of suggestion
 			setSelectedSuggestion( matchingSuggestions[ 0 ] );
 		}

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -161,12 +161,14 @@ function ComboboxControl( {
 		inputContainer.current.input.focus();
 	};
 
-	// Update selections on filter change.
+	// Update current selections when the filter input changes.
 	useEffect( () => {
-		const currentSelectionNotInSuggestions =
-			matchingSuggestions.indexOf( selectedSuggestion ) < 0;
-		if ( matchingSuggestions.length && currentSelectionNotInSuggestions ) {
-			// If the current selection isn't present in the list of suggestions, then automatically select the first item from the list of suggestion
+		const hasMatchingSuggestions = matchingSuggestions.length > 0;
+		const hasSelectedMatchingSuggestions =
+			matchingSuggestions.indexOf( selectedSuggestion ) > 0;
+
+		if ( hasMatchingSuggestions && ! hasSelectedMatchingSuggestions ) {
+			// If the current selection isn't present in the list of suggestions, then automatically select the first item from the list of suggestions.
 			setSelectedSuggestion( matchingSuggestions[ 0 ] );
 		}
 	}, [ matchingSuggestions, selectedSuggestion ] );

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -163,10 +163,12 @@ function ComboboxControl( {
 
 	// Update selections on filter change.
 	useEffect( () => {
+		const currentSelectionNotInSuggestions = matchingSuggestions.indexOf( selectedSugestion ) < 0;
 		if (
 			matchingSuggestions.length &&
-			matchingSuggestions.indexOf( selectedSuggestion ) < 0
+			currentSelectionNotInSuggestions
 		) {
+			// If the current selection isn't present in the list of suggestions, then automatically select the first item from the list of suggestion
 			setSelectedSuggestion( matchingSuggestions[ 0 ] );
 		}
 	}, [ matchingSuggestions, selectedSuggestion ] );

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -55,13 +55,15 @@ function ComboboxControl( {
 		selected: __( 'Item selected.' ),
 	},
 } ) {
+	const currentOption = options.find( ( option ) => option.value === value );
+	const currentLabel = currentOption?.label ?? '';
 	const instanceId = useInstanceId( ComboboxControl );
-	const [ selectedSuggestion, setSelectedSuggestion ] = useState( null );
+	const [ selectedSuggestion, setSelectedSuggestion ] = useState(
+		currentOption || null
+	);
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const inputContainer = useRef();
-	const currentOption = options.find( ( option ) => option.value === value );
-	const currentLabel = currentOption?.label ?? '';
 
 	const matchingSuggestions = useMemo( () => {
 		const startsWithMatch = [];

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -161,6 +161,16 @@ function ComboboxControl( {
 		inputContainer.current.input.focus();
 	};
 
+	// Update selections on filter change.
+	useEffect( () => {
+		if (
+			matchingSuggestions.length &&
+			matchingSuggestions.indexOf( selectedSuggestion ) < 0
+		) {
+			setSelectedSuggestion( matchingSuggestions[ 0 ] );
+		}
+	}, [ matchingSuggestions, selectedSuggestion ] );
+
 	// Announcements
 	useEffect( () => {
 		const hasMatchingSuggestions = matchingSuggestions.length > 0;


### PR DESCRIPTION
## Description

Filtering the results of the Combobox and pressing the enter key leads to an unexpected selection, ignoring your input. This can be reproduced easily in Storybook:

1. [Go to Storybook here](https://wordpress.github.io/gutenberg/?path=/story/components-comboboxcontrol--default)
2. Select Aland Islands in the combobox control.
3. Type "France". You'll see only one match show. Press the keyboard enter key only (do not arrow down to France).
4. Aland Islands is still selected. Any text you input is cleared.

My fix for this is to use a `useEffect` hook to update the current selection if the list of suggestions is filtered. If the current selection is no longer available, it's updated to the first match automatically. That means if you do hit enter,  you're going to select something more relevant to your input than the original selection.

Fixes #33920

## How has this been tested?

Tested with this patch on a checkout form using the same steps as above.

## Screenshots <!-- if applicable -->

This is after the fix. I enter the text and hit enter. My selection is preserved.

![2021-08-06 14 15 37](https://user-images.githubusercontent.com/90977/128515896-b915bb46-94a0-432a-8f33-09d3a2218342.gif)

## Types of changes

This is a bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->


