### PR TITLE
Add documentation to disable remote calls for block patterns

### DIFF
--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -134,3 +134,15 @@ The Block Directory enables installing new block plugins from [WordPress.org.](h
 
 remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 ```
+
+### Block Patterns
+
+#### `should_load_remote_block_patterns`
+
+Default `true`. The filter is checked when registering remote block patterns, set to false to disable.
+
+For example, to disable use:
+
+```
+add_filter( 'should_load_remote_block_patterns', '__return_false' );
+```


### PR DESCRIPTION

## Description

Adds a new section to the editor filters documentation
for the filter `should_load_remote_block_patterns`

Fixes #32591


## How has this been tested?

Confirm documentation works as expected.

1. Add filter to a plugin or theme
2. Confirm remote block patterns are not loaded


## Types of changes

Documentation

