### PR TITLE
Change default value of enableCustomFields to undefined

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -243,14 +243,12 @@ export default function PreferencesModal() {
 								/>
 							</PageAttributesCheck>
 						</Section>
-						<Section
+						<MetaBoxesSection
 							title={ __( 'Additional' ) }
 							description={ __(
 								'Add extra areas to the editor.'
 							) }
-						>
-							<MetaBoxesSection />
-						</Section>
+						/>
 					</>
 				),
 			},

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -179,12 +179,10 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             />
           </PageAttributesCheck>
         </Section>
-        <Section
+        <WithSelect(MetaBoxesSection)
           description="Add extra areas to the editor."
           title="Additional"
-        >
-          <WithSelect(MetaBoxesSection) />
-        </Section>
+        />
       </NavigationItem>
     </NavigationMenu>
   </Navigation>

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -27,6 +27,6 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	richEditingEnabled: true,
 	codeEditingEnabled: true,
-	enableCustomFields: false,
+	enableCustomFields: undefined,
 	supportsLayout: true,
 };

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -14,7 +14,11 @@ export const PREFERENCES_DEFAULTS = {
  *  allowedBlockTypes  boolean|Array Allowed block types
  *  richEditingEnabled boolean       Whether rich editing is enabled or not
  *  codeEditingEnabled boolean       Whether code editing is enabled or not
- *  enableCustomFields boolean       Whether the WordPress custom fields are enabled or not
+ *  enableCustomFields boolean       Whether the WordPress custom fields are enabled or not.
+ *                                     true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
+ *                                     false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
+ *                                     undefined = the current environment does not support Custom Fields,
+ *                                                 and the user doesn't see the option toggle.
  *  autosaveInterval   number        Autosave Interval
  *  availableTemplates array?        The available post templates
  *  disablePostFormats boolean       Whether or not the post formats are disabled

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -18,7 +18,8 @@ export const PREFERENCES_DEFAULTS = {
  *                                     true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
  *                                     false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
  *                                     undefined = the current environment does not support Custom Fields,
- *                                                 and the user doesn't see the option toggle.
+ *                                                 so the option toggle in Preferences -> Panels to
+ *                                                 enable the Custom Fields panel is not displayed.
  *  autosaveInterval   number        Autosave Interval
  *  availableTemplates array?        The available post templates
  *  disablePostFormats boolean       Whether or not the post formats are disabled


### PR DESCRIPTION
## Problem

When using a plugin to disable Custom Fields in the post editor, WordPress attempts to change `$editor_settings` to tell Gutenberg not to render the Custom Fields settings toggle in a preferences modal. However, Gutenberg is listening for a value that is impossible to send in PHP, and the settings toggle remains visible even when the feature itself is disabled.

This change makes it so when PHP uses `unset()` to not send a value, then `undefined` is the value, allowing the field to be hidden.

## Steps to reproduce and more context

Please see https://github.com/WordPress/gutenberg/pull/33912. This is tackling the same problem but in a different way.