### PR TITLE
Site editor: fix for how CSS Custom Properties are generated

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -253,10 +253,11 @@ export const getNodesWithSettings = ( tree, blockSelectors ) => {
 
 	// Top-level.
 	const presets = pickPresets( tree.settings );
-	if ( ! isEmpty( presets ) ) {
+	const custom = tree.settings?.custom;
+	if ( ! isEmpty( presets ) || !! custom ) {
 		nodes.push( {
 			presets,
-			custom: tree.settings?.custom,
+			custom,
 			selector: ROOT_BLOCK_SELECTOR,
 		} );
 	}
@@ -264,10 +265,11 @@ export const getNodesWithSettings = ( tree, blockSelectors ) => {
 	// Blocks.
 	forEach( tree.settings?.blocks, ( node, blockName ) => {
 		const blockPresets = pickPresets( node );
-		if ( ! isEmpty( blockPresets ) ) {
+		const blockCustom = node.custom;
+		if ( ! isEmpty( blockPresets ) || !! blockCustom ) {
 			nodes.push( {
 				presets: blockPresets,
-				custom: node.custom,
+				custom: blockCustom,
 				selector: blockSelectors[ blockName ].selector,
 			} );
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33300