### PR TITLE
Featured Image: Use getMedia shorthand

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -51,12 +51,7 @@ function PostFeaturedImageDisplay( {
 	const media = useSelect(
 		( select ) =>
 			featuredImage &&
-			select( coreStore ).getEntityRecord(
-				'root',
-				'media',
-				featuredImage,
-				{ context: 'view' }
-			),
+			select( coreStore ).getMedia( featuredImage, { context: 'view' } ),
 		[ featuredImage ]
 	);
 	const blockProps = useBlockProps( {

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -215,15 +215,13 @@ function PostFeaturedImage( {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getEntityRecord, getPostType } = select( coreStore );
+	const { getMedia, getPostType } = select( coreStore );
 	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
 		media: featuredImageId
-			? getEntityRecord( 'root', 'media', featuredImageId, {
-					context: 'view',
-			  } )
+			? getMedia( featuredImageId, { context: 'view' } )
 			: null,
 		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),


### PR DESCRIPTION
## Description
Since #33689, it's possible to pass query arguments to the code data shorthands. PR update code to use `getMedia` instead of `getEntityRecord` for simplicity, see - https://github.com/WordPress/gutenberg/pull/33567#discussion_r683975606

## How has this been tested?
1. Upload an image using an Administrator user account.
2. Switch to a user with an Author role.
3. Create a post.
4. Select the uploaded image using the "Post Featured Image" block or "Feature image" panel in the sidebar.
5. See that feature image is displayed.
6. DevTools has no 403 requests in the Networks panel.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
