### PR TITLE
Latest Comments in-editor preview of comment excerpts match front-end

### DIFF
--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -75,6 +75,10 @@ export default function LatestComments( { attributes, setAttributes } ) {
 				<ServerSideRender
 					block="core/latest-comments"
 					attributes={ attributes }
+					// The preview uses the site's locale to make it more true to how
+					// the block appears on the frontend. Setting the locale
+					// explicitly prevents any middleware from setting it to 'user'.
+					urlQueryArgs={ { _locale: 'site' } }
 				/>
 			</Disabled>
 		</div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When comment excerpts are included in the Latest Comments block, the truncation is done differently depending on the site's locale (see [`get_comment_excerpt()`](http://developer.wordpress.org/reference/functions/get_comment_excerpt/) and [`wp_trim_words()`](http://developer.wordpress.org/reference/functions/wp_trim_words/)). However when rendering the preview in the editor the preview is generated using the user's locale. These rules can result in a different preview on the front-end and the editor e.g. if the editing user's locale is `en` and the site's locale is `zh-tw`.

This fix ensures the in-editor preview of Latest Comments uses the site's locale, just as it would appear on the front-end. Specifying an empty `_locale` param bypasses the user-locale middleware which usually sets the param to `_locale=user`.

Another option would be to change the `/block-renderer` API so that it always renders block content using the site locale (and the `_locale` query param would continue to be in the user's locale for things like error messages). I wasn't sure if there'd be unexpected consequences to that (e.g. maybe there's some block renders content in the user locale on the front end?) so I went with this smaller change.

## How has this been tested?
Manually tested on WordPress instance where site and user language are set to different things.

When viewing a Latest Comments block in the editor, check the `/block-renderer` API call in the network inspector and verify that the request has a `_locale=site` parameter.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
This screenshot shows the bug before the patch is applied. The user's locale is `en` but the site's locale is `zh-tw`. The in-editor preview is truncating the comment to the first 20 words.
<img width="1680" alt="Screenshot 2021-08-09 at 5 26 46 PM" src="https://user-images.githubusercontent.com/1500769/128663570-9b690e53-97c6-45be-9ee8-403f8e2030df.png">

However on the front-end the comment is truncated to the first 20 characters (which is how truncation works in `zh-tw`).
<img width="1680" alt="Screenshot 2021-08-09 at 5 25 51 PM" src="https://user-images.githubusercontent.com/1500769/128663566-19028029-1aa7-4e77-a2bf-1a43cdb7ae3f.png">

This screenshot shows the editor after applying patch. Even though the editor controls is still in English, the block preview is now showing the excerpts the same way they'd appear on the front-end. You can also see the label and dates are in the same language they'd appear on the front-end.
<img width="1680" alt="Screenshot 2021-08-09 at 5 25 28 PM" src="https://user-images.githubusercontent.com/1500769/128663554-2ffbe2b3-ee1a-4713-9a98-ea42e4c58698.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
