### PR TITLE
Scripts: Fix typo in format change message.

### DIFF
--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -26,7 +26,7 @@ const keypress = async () => {
 			'format-js'
 		) } script has been renamed to ${ chalk.green( 'format' ) }.\n` +
 		"If you're calling it from any of your own scripts, please update them accordingly.\n" +
-		'Press any key to continiue.';
+		'Press any key to continue.';
 
 	// eslint-disable-next-line no-console
 	console.log( message );


### PR DESCRIPTION
## Description
Fixes a small typo introduced in #30240.

`continiue` -> `continue`

## How has this been tested?
Ran locally.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Text update.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
