### PR TITLE
Try: Show drag slot instead of hiding the item being dragged.

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -52,10 +52,6 @@
 	opacity: 0.05 !important;
 	border-radius: $radius-block-ui !important;
 
-	// We apply a max-height so that when dragging big selections, you don't have to drag by a tall slot.
-	max-height: 240px !important;
-	overflow: hidden !important;
-
 	// Disabling pointer events during the drag event is necessary,
 	// lest the block might affect your drag operation.
 	pointer-events: none !important;

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -45,8 +45,18 @@
 	}
 }
 
-// This hides the block being dragged.
-// The effect is that the block being dragged appears to be "lifted".
+// This creates a "slot" where the block you're dragging appeared.
+// We use !important as one of the rules are meant to be overriden.
 .is-dragging {
-	display: none !important;
+	background-color: currentColor !important;
+	opacity: 0.05 !important;
+	border-radius: $radius-block-ui !important;
+
+	// Disabling pointer events during the drag event is necessary,
+	// lest the block might affect your drag operation.
+	pointer-events: none !important;
+
+	&::after {
+		content: none !important;
+	}
 }

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -56,6 +56,11 @@
 	// lest the block might affect your drag operation.
 	pointer-events: none !important;
 
+	// Hide subsequent multiselected blocks, as they can become rather tall.
+	&.is-multi-selected + .is-multi-selected {
+		display: none !important;
+	}
+
 	// Hide the multi selection indicator when dragging.
 	&::selection {
 		background: transparent !important;

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -47,14 +47,23 @@
 
 // This creates a "slot" where the block you're dragging appeared.
 // We use !important as one of the rules are meant to be overriden.
-.is-dragging {
+.block-editor-block-list__layout .is-dragging {
 	background-color: currentColor !important;
 	opacity: 0.05 !important;
 	border-radius: $radius-block-ui !important;
 
+	// We apply a max-height so that when dragging big selections, you don't have to drag by a tall slot.
+	max-height: 240px !important;
+	overflow: hidden !important;
+
 	// Disabling pointer events during the drag event is necessary,
 	// lest the block might affect your drag operation.
 	pointer-events: none !important;
+
+	// Hide the multi selection indicator when dragging.
+	&::selection {
+		background: transparent !important;
+	}
 
 	&::after {
 		content: none !important;

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -56,11 +56,6 @@
 	// lest the block might affect your drag operation.
 	pointer-events: none !important;
 
-	// Hide subsequent multiselected blocks, as they can become rather tall.
-	&.is-multi-selected + .is-multi-selected {
-		display: none !important;
-	}
-
 	// Hide the multi selection indicator when dragging.
 	&::selection {
 		background: transparent !important;


### PR DESCRIPTION
## Description

This is only an experiment.

At the moment, when you drag and drop blocks, the block you're dragging is "lifted" off the page, removed from its original spot, until dropped in its new spot. Like so:

![before](https://user-images.githubusercontent.com/1204802/128689702-304cc8b3-f096-4303-a3be-ebdb82e01fa9.gif)

This PR experimentally changes the behavior to keep a slot where you drag from:

![after](https://user-images.githubusercontent.com/1204802/128689800-885f6056-e19b-41bf-ad56-1f12f67ea21f.gif)

This is an experiment based on feedback that the current behavior is a little imprecise and prone to error. From this experiment, I feel primarily two take-aways:

1. The auto-scrolling of the viewport that is meant to make dragging long distances easier, is way too easy to trigger, making drag operations meant to just happen inside the visible part of the viewport far more likely to be janky.
2. There's a big opportunity to refactor the drag and drop method entirely, perhaps leverage Framer Motion to handle the shortcomings of the current system.

In lieu of a bigger refactor, this could be an interim fix provided it's believed to be better. I don't necessarily think it is, but since it's easy to try, I thought it worth it.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
