### PR TITLE
Add: Sidebar/widget block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -47,6 +47,7 @@ function gutenberg_reregister_core_block_types() {
 				'verse',
 				'video',
 				'embed',
+				'sidebar-widget-area',
 			),
 			'block_names'   => array(
 				'archives.php'                  => 'core/archives',
@@ -95,6 +96,7 @@ function gutenberg_reregister_core_block_types() {
 				// 'table-of-contents.php'         => 'core/table-of-contents',
 				'template-part.php'             => 'core/template-part',
 				'term-description.php'          => 'core/term-description',
+				'sidebar-widget-area.php'         => 'core/sidebar-widget-area',
 			),
 		),
 		__DIR__ . '/../build/edit-widgets/blocks/'  => array(

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -60,6 +60,7 @@ import * as tagCloud from './tag-cloud';
 import * as classic from './freeform';
 import * as socialLinks from './social-links';
 import * as socialLink from './social-link';
+import * as sidebarWidgetArea from './sidebar-widget-area';
 
 // Full Site Editing Blocks
 import * as siteLogo from './site-logo';
@@ -186,6 +187,7 @@ export const __experimentalGetCoreBlocks = () => [
 	postTerms,
 
 	logInOut,
+	sidebarWidgetArea,
 ];
 
 /**

--- a/packages/block-library/src/sidebar-widget-area/block.json
+++ b/packages/block-library/src/sidebar-widget-area/block.json
@@ -1,0 +1,17 @@
+{
+	"apiVersion": 2,
+	"name": "core/sidebar-widget-area",
+	"title": "Widget Area",
+	"category": "design",
+	"description": "Displays a widget area.",
+	"supports": {
+		"html": false,
+		"inserter": false
+	},
+	"textdomain": "default",
+	"attributes": {
+		"id": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/sidebar-widget-area/edit.js
+++ b/packages/block-library/src/sidebar-widget-area/edit.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+
+const WidgetAreaEdit = ( { attributes } ) => {
+	return attributes.id;
+};
+
+export default WidgetAreaEdit;

--- a/packages/block-library/src/sidebar-widget-area/index.js
+++ b/packages/block-library/src/sidebar-widget-area/index.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import PatternEdit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit: PatternEdit,
+};

--- a/packages/block-library/src/sidebar-widget-area/index.php
+++ b/packages/block-library/src/sidebar-widget-area/index.php
@@ -1,0 +1,20 @@
+<?php
+
+function register_block_core_sidebar_widget_area() {
+	register_block_type_from_metadata(
+		__DIR__ . '/sidebar-widget-area',
+		array(
+			'render_callback' => 'render_block_sidebar_widget_area',
+		)
+	);
+}
+
+function render_block_sidebar_widget_area( $attributes ) {
+	ob_start();
+	dynamic_sidebar( $attributes['id'] );
+	$sidebar = ob_get_contents();
+	ob_end_clean();
+	return $sidebar;
+}
+
+add_action( 'init', 'register_block_core_sidebar_widget_area' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is an idea to work with this PR: https://href.li/?https://github.com/Automattic/themes/pull/4369

This is just a light wrapper around the WordPress function `dynamic_sidebar` so that we can display widget areas in block themes. I noticed that there's already similar code inside the `edit-widgets` package but I couldn't work out how to implement it.

This doesn't yet work in the editor - the purpose of the PR is really just to get feedback on the idea and see if there's a better way to achieve the same thing.

## How has this been tested?
- Add this to a post: `<!-- wp:sidebar-widget-area {"id":"sidebar-1"} /-->`
- Switch to a theme that supports sidebars (e.g. Seedlet)
- Add some content to the sidebar in the Widgets section
- Confirm that the content shows on the front end.

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
