### PR TITLE
Block Editor: Absorb parent block toolbar controls

### DIFF
--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -15,8 +15,7 @@ import {
 /**
  * Internal dependencies
  */
-import useDisplayBlockControls from '../use-display-block-controls';
-import groups from './groups';
+import useBlockControlsFill from './hook';
 
 export default function BlockControlsFill( {
 	group = 'default',
@@ -24,10 +23,10 @@ export default function BlockControlsFill( {
 	children,
 	__experimentalExposeToChildren = false,
 } ) {
-	if ( ! useDisplayBlockControls( { __experimentalExposeToChildren } ) ) {
+	const Fill = useBlockControlsFill( group, __experimentalExposeToChildren );
+	if ( ! Fill ) {
 		return null;
 	}
-	const Fill = groups[ group ].Fill;
 
 	return (
 		<StyleProvider document={ document }>

--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -22,8 +22,9 @@ export default function BlockControlsFill( {
 	group = 'default',
 	controls,
 	children,
+	__experimentalExposeToChildren = false,
 } ) {
-	if ( ! useDisplayBlockControls() ) {
+	if ( ! useDisplayBlockControls( { __experimentalExposeToChildren } ) ) {
 		return null;
 	}
 	const Fill = groups[ group ].Fill;

--- a/packages/block-editor/src/components/block-controls/groups.js
+++ b/packages/block-editor/src/components/block-controls/groups.js
@@ -7,12 +7,14 @@ const BlockControlsDefault = createSlotFill( 'BlockControls' );
 const BlockControlsBlock = createSlotFill( 'BlockControlsBlock' );
 const BlockControlsInline = createSlotFill( 'BlockFormatControls' );
 const BlockControlsOther = createSlotFill( 'BlockControlsOther' );
+const BlockControlsParent = createSlotFill( 'BlockControlsParent' );
 
 const groups = {
 	default: BlockControlsDefault,
 	block: BlockControlsBlock,
 	inline: BlockControlsInline,
 	other: BlockControlsOther,
+	parent: BlockControlsParent,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -16,9 +17,18 @@ export default function useBlockControlsFill( group, exposeToChildren ) {
 	const { clientId } = useBlockEditContext();
 	const isParentDisplayed = useSelect(
 		( select ) => {
+			const { getBlockName, hasSelectedInnerBlock } = select(
+				blockEditorStore
+			);
+			const { hasBlockSupport } = select( blocksStore );
 			return (
 				exposeToChildren &&
-				select( blockEditorStore ).hasSelectedInnerBlock( clientId )
+				hasBlockSupport(
+					getBlockName( clientId ),
+					'__experimentalCaptureToolbars',
+					false
+				) &&
+				hasSelectedInnerBlock( clientId )
 			);
 		},
 		[ exposeToChildren, clientId ]

--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -25,7 +25,7 @@ export default function useBlockControlsFill( group, exposeToChildren ) {
 				exposeToChildren &&
 				hasBlockSupport(
 					getBlockName( clientId ),
-					'__experimentalCaptureToolbars',
+					'__experimentalExposeControlsToChildren',
 					false
 				) &&
 				hasSelectedInnerBlock( clientId )

--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import groups from './groups';
+import { store as blockEditorStore } from '../../store';
+import { useBlockEditContext } from '../block-edit/context';
+import useDisplayBlockControls from '../use-display-block-controls';
+
+export default function useBlockControlsFill( group, exposeToChildren ) {
+	const isDisplayed = useDisplayBlockControls();
+	const { clientId } = useBlockEditContext();
+	const isParentDisplayed = useSelect(
+		( select ) => {
+			return (
+				exposeToChildren &&
+				select( blockEditorStore ).hasSelectedInnerBlock( clientId )
+			);
+		},
+		[ exposeToChildren, clientId ]
+	);
+
+	if ( isDisplayed ) {
+		return groups[ group ]?.Fill;
+	}
+	if ( isParentDisplayed ) {
+		return groups.parent.Fill;
+	}
+	return null;
+}

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -108,7 +108,15 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	return (
 		<div className={ classes }>
 			{ ! isMultiToolbar && ! displayHeaderToolbar && (
-				<BlockParentSelector clientIds={ blockClientIds } />
+				<>
+					<BlockParentSelector clientIds={ blockClientIds } />
+					{ shouldShowVisualToolbar && (
+						<BlockControls.Slot
+							group="parent"
+							className="block-editor-block-toolbar__slot"
+						/>
+					) }
+				</>
 			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -108,15 +108,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	return (
 		<div className={ classes }>
 			{ ! isMultiToolbar && ! displayHeaderToolbar && (
-				<>
-					<BlockParentSelector clientIds={ blockClientIds } />
-					{ shouldShowVisualToolbar && (
-						<BlockControls.Slot
-							group="parent"
-							className="block-editor-block-toolbar__slot"
-						/>
-					) }
-				</>
+				<BlockParentSelector clientIds={ blockClientIds } />
 			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
@@ -131,6 +123,10 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			</div>
 			{ shouldShowVisualToolbar && (
 				<>
+					<BlockControls.Slot
+						group="parent"
+						className="block-editor-block-toolbar__slot"
+					/>
 					<BlockControls.Slot
 						group="block"
 						className="block-editor-block-toolbar__slot"

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -144,7 +144,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 	const { __experimentalCaptureToolbars, hasOverlay } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return;
+				return {};
 			}
 
 			const {
@@ -160,7 +160,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 					blocksStore
 				).hasBlockSupport(
 					blockName,
-					'__experimentalCaptureToolbars',
+					'__experimentalExposeControlsToChildren',
 					false
 				),
 				hasOverlay:

--- a/packages/block-editor/src/components/use-display-block-controls/index.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.js
@@ -9,11 +9,9 @@ import { useSelect } from '@wordpress/data';
 import { useBlockEditContext } from '../block-edit/context';
 import { store as blockEditorStore } from '../../store';
 
-export default function useDisplayBlockControls( {
-	__experimentalExposeToChildren = false,
-} = {} ) {
+export default function useDisplayBlockControls() {
 	const { isSelected, clientId, name } = useBlockEditContext();
-	const isActive = useSelect(
+	return useSelect(
 		( select ) => {
 			if ( isSelected ) {
 				return true;
@@ -23,7 +21,6 @@ export default function useDisplayBlockControls( {
 				getBlockName,
 				isFirstMultiSelectedBlock,
 				getMultiSelectedBlockClientIds,
-				hasSelectedInnerBlock,
 			} = select( blockEditorStore );
 
 			if ( isFirstMultiSelectedBlock( clientId ) ) {
@@ -31,14 +28,9 @@ export default function useDisplayBlockControls( {
 					( id ) => getBlockName( id ) === name
 				);
 			}
-			if ( __experimentalExposeToChildren ) {
-				return hasSelectedInnerBlock( clientId );
-			}
 
 			return false;
 		},
 		[ clientId, isSelected, name ]
 	);
-
-	return isActive;
 }

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -140,18 +140,20 @@ export const withToolbarControls = createHigherOrderComponent(
 			props.setAttributes( { align: nextAlign } );
 		};
 
-		return [
-			validAlignments.length > 0 && props.isSelected && (
-				<BlockControls key="align-controls" group="block">
-					<BlockAlignmentControl
-						value={ props.attributes.align }
-						onChange={ updateAlignment }
-						controls={ validAlignments }
-					/>
-				</BlockControls>
-			),
-			<BlockEdit key="edit" { ...props } />,
-		];
+		return (
+			<>
+				{ validAlignments.length > 0 && (
+					<BlockControls group="block" __experimentalExposeToChildren>
+						<BlockAlignmentControl
+							value={ props.attributes.align }
+							onChange={ updateAlignment }
+							controls={ validAlignments }
+						/>
+					</BlockControls>
+				) }
+				<BlockEdit { ...props } />
+			</>
+		);
 	},
 	'withToolbarControls'
 );

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -140,7 +140,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 	}
 
 	return (
-		<BlockControls group="block">
+		<BlockControls group="block" __experimentalExposeToChildren>
 			<DuotoneControl
 				duotonePalette={ duotonePalette }
 				colorPalette={ colorPalette }

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -18,7 +18,7 @@
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],
-		"__experimentalCaptureToolbars": true
+		"__experimentalExposeControlsToChildren": true
 	},
 	"editorStyle": "wp-block-buttons-editor",
 	"style": "wp-block-buttons"

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -17,7 +17,8 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"__experimentalCaptureToolbars": true
 	},
 	"editorStyle": "wp-block-buttons-editor",
 	"style": "wp-block-buttons"

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -59,7 +59,6 @@ function ButtonsEdit( {
 			],
 		],
 		orientation,
-		__experimentalCaptureToolbars: true,
 		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,
 	} );

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -59,6 +59,7 @@ function ButtonsEdit( {
 			],
 		],
 		orientation,
+		__experimentalCaptureToolbars: true,
 		__experimentalLayout: LAYOUT,
 		templateInsertUpdatesSelection: true,
 	} );
@@ -70,7 +71,7 @@ function ButtonsEdit( {
 
 	return (
 		<>
-			<BlockControls group="block">
+			<BlockControls group="block" __experimentalExposeToChildren>
 				<JustifyContentControl
 					allowedControls={ justifyControls }
 					value={ contentJustification }

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -40,7 +40,8 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
-		"anchor": true
+		"anchor": true,
+		"__experimentalCaptureToolbars": true
 	},
 	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -41,7 +41,7 @@
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"anchor": true,
-		"__experimentalCaptureToolbars": true
+		"__experimentalExposeControlsToChildren": true
 	},
 	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -100,7 +100,6 @@ export function SocialLinksEdit( props ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
-		__experimentalCaptureToolbars: true,
 		placeholder: isSelected ? SelectedSocialPlaceholder : SocialPlaceholder,
 		templateLock: false,
 		__experimentalAppenderTagName: 'li',

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -100,6 +100,7 @@ export function SocialLinksEdit( props ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
+		__experimentalCaptureToolbars: true,
 		placeholder: isSelected ? SelectedSocialPlaceholder : SocialPlaceholder,
 		templateLock: false,
 		__experimentalAppenderTagName: 'li',
@@ -111,7 +112,7 @@ export function SocialLinksEdit( props ) {
 
 	return (
 		<Fragment>
-			<BlockControls group="block">
+			<BlockControls group="block" __experimentalExposeToChildren>
 				<JustifyContentControl
 					allowedControls={ [
 						'left',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Exploration for #26313.

> One apparent difficulty that has risen with more and more blocks leveraging child blocks for controls (Buttons, Social Icons, Navigation, etc) is a general lack of intuitiveness when it comes to modifying attributes of the parent. Example: changing the alignment of Buttons when editing a single Button; changing the color of Navigation (a parent block attribute) when editing a single Navigation Item.
> To address this, I'd like to explore ideas around when and how the toolbar and sidebar controls of a parent block could be exposed on their children. There are many challenges around clarity to overcome. This should not be a default true property, since groupings like Group, Columns, Cover, etc, should not present this behaviour.

This PR explores changes for the Buttons and Social Icons blocks. The very first iteration tries passing an experimental flag `__experimentalExposeToChildren` in `BlockControl` usage in the edit implementation of the parent block. It takes advantage of the SlotFill behavior and conditionally renders the control in the child block when it's selected.

The behavior is limited to the child block at the moment, but we could also cover ancestors if we would like to go one step further. The challenge is how to handle blocks that can be nested in themselves, but I think it's doable if we feel more adventurous. The current approach is enough for the Buttons and Social Icons blocks that have a very simple parent-child relation.

Please note that I also used `__experimentalCaptureToolbars` flag for the inner block containers so the toolbar is always present in the same place like in the Navigation block.

It should be possible to use the same technique for Inspector Controls.

### Before

<img width="776" alt="Screen Shot 2021-08-12 at 18 16 52" src="https://user-images.githubusercontent.com/699132/129231756-9cd3beaf-7d5f-4fca-8b1a-55df8cb18ca8.png">

### After

<img width="732" alt="Screen Shot 2021-08-12 at 18 18 02" src="https://user-images.githubusercontent.com/699132/129231877-5671bfbb-dcd2-40c8-8337-0f723c312238.png">


## How has this been tested?
See the screencast:

https://user-images.githubusercontent.com/699132/128717588-269b0833-3b31-4bcd-925f-783b8b41c67f.mov

I used multiple blocks of the same type to ensure that the control isn't present multiple times in the child block. I was able to ensure that the control updates only the parent block.

## Knows Issues

Everything works perfectly fine for the Buttons block.

There is something strange happening with the Social Icons block that needs further investigation but it seems to be present in the `trunk` as well.

I still need to figure out how to handle controls that get injected through block `supports` like `align`.

## Open Questions

Where should be parent controls located? It's the same group as in the parent in the prototype. Should we create a special group? Where should it be placed?

<img width="453" alt="Screen Shot 2021-08-09 at 16 08 39" src="https://user-images.githubusercontent.com/699132/128719996-f7e71d26-35e4-4e75-9ba5-6465329f10dc.png">

In the Buttons block, you can see controls from the parent (items justification) mixed with those from the child (link). If we would move parent controls to their own group we would make it more clear what we edit. We could even move this group next to the `Select Buttons` (Select parent) button to make it even more glued together.

## Types of changes
New feature (non-breaking change which adds functionality).
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
