### PR TITLE
Search Block: Removed components class from icon button and polished css

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -27,7 +27,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { search } from '@wordpress/icons';
+import { Icon, search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -211,7 +211,8 @@ export default function SearchEdit( {
 		const buttonClasses = classnames(
 			'wp-block-search__button',
 			colorProps.className,
-			isButtonPositionInside ? undefined : borderProps.className
+			isButtonPositionInside ? undefined : borderProps.className,
+			buttonUseIcon ? 'has-icon' : undefined
 		);
 		const buttonStyles = {
 			...colorProps.style,
@@ -223,11 +224,13 @@ export default function SearchEdit( {
 		return (
 			<>
 				{ buttonUseIcon && (
-					<Button
-						icon={ search }
+					<button
+						type="button"
 						className={ buttonClasses }
 						style={ buttonStyles }
-					/>
+					>
+						<Icon icon={ search } />
+					</button>
 				) }
 
 				{ ! buttonUseIcon && (

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -7,25 +7,11 @@
 }
 
 .wp-block-search {
-	.wp-block-search__input {
-		padding: $grid-unit-10;
-	}
-
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-		padding: $grid-unit-05;
-	}
-
 	.wp-block-search__button {
 		height: auto;
 		border-radius: initial;
-
-		// This needs high specificity because it otherwise inherits styles from `components-button`.
-		// stylelint-disable-line no-duplicate-selectors
-		&.wp-block-search__button.wp-block-search__button {
-			padding: 6px 10px;
-			display: flex;
-			align-items: center;
-		}
+		display: flex;
+		align-items: center;
 	}
 
 	&__components-button-group {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -34,7 +34,7 @@
 		padding: 8px;
 		flex-grow: 1;
 		min-width: 3em;
-		border: 1px solid $gray-600;
+		border: 1px solid #949494;
 	}
 
 	&.wp-block-search__button-only {
@@ -45,7 +45,7 @@
 
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		padding: 4px;
-		border: 1px solid $gray-600;
+		border: 1px solid #949494;
 
 		.wp-block-search__input {
 			border-radius: 0;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -31,7 +31,7 @@
 	}
 
 	.wp-block-search__input {
-		padding: $grid-unit-10;
+		padding: 8px;
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid $gray-600;
@@ -44,7 +44,7 @@
 	}
 
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-		padding: $grid-unit-05;
+		padding: 4px;
 		border: 1px solid $gray-600;
 
 		.wp-block-search__input {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -31,6 +31,7 @@
 	}
 
 	.wp-block-search__input {
+		padding: $grid-unit-10;
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid $gray-600;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
After #26446 was merged there was a level of specificity in the CSS created to bring inline the editor and frontend styles that is being caused by the components classes present on the icon button. This PR refactors the button to use the regular button tag instead and removes the extra specificity from the CSS. I also went ahead and refactored the styles that were no longer needed after this change and that were causing mismatches between the editor and the frontend. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested on Emptytheme using the following markup:

```
<!-- wp:search {"label":"Search","placeholder":"Placeholder text...","buttonText":"Search"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Placeholder text...","buttonText":"Search"} /-->

<!-- wp:separator {"className":"is-style-default"} -->
<hr class="wp-block-separator is-style-default"/>
<!-- /wp:separator -->

<!-- wp:search {"label":"Search","placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"button-inside"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"button-inside"} /-->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:search {"label":"Search","placeholder":"Placeholder text...","buttonText":"Search","buttonUseIcon":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Placeholder text...","buttonText":"Search","buttonUseIcon":true} /-->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:search {"label":"Search","placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:search {"label":"Search","placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"no-button"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Placeholder text...","buttonText":"Search","buttonPosition":"no-button"} /-->

```

## Screenshots <!-- if applicable -->

The differences in sizes between editor and frontend are caused by Emptytheme not defining font-family or font-size while the editor does (and tries to reset it with little success). I'd love to improve this so we can have the same on the frontend and the editor but I'm unsure as to what's the correct approach for this.

**Before:**

Frontent | Editor
--- | ---
<img width="935" alt="Screenshot 2021-08-09 at 20 36 26" src="https://user-images.githubusercontent.com/3593343/128756689-690f8c8f-dfca-4a77-b81c-611f11787cab.png"> | <img width="947" alt="Screenshot 2021-08-09 at 20 36 40" src="https://user-images.githubusercontent.com/3593343/128756686-2b3d6b65-2442-4ec2-90ad-ac5c443f9a37.png">


**After:**

Frontent | Editor
--- | ---
<img width="1020" alt="Screenshot 2021-08-09 at 20 28 02" src="https://user-images.githubusercontent.com/3593343/128756553-4c4771f8-9333-444b-8243-43df15ab17c6.png"> | <img width="926" alt="Screenshot 2021-08-09 at 20 27 59" src="https://user-images.githubusercontent.com/3593343/128756559-218a1bd8-5d92-4940-85e3-fd5e739cad5c.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
