### PR TITLE
Use Tags instead of Keywords in Query Block filters

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -235,7 +235,7 @@ export default function QueryInspectorControls( {
 						}
 					/>
 					<TextControl
-						label={ __( 'Keyword' ) }
+						label={ __( 'Tags' ) }
 						value={ querySearch }
 						onChange={ setQuerySearch }
 					/>


### PR DESCRIPTION
Fixes #33966 
This PR replaces the "Keyword" label with "Tags".
Indeed, we're not speaking about "Keywords" but about "Tags", here :)
(also, it needs to be plural, not singular)