### PR TITLE
Block Support: Add min-height block support

### DIFF
--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -26,7 +26,6 @@ function gutenberg_register_dimensions_support( $block_type ) {
 	}
 
 	$has_dimensions_support = gutenberg_block_has_support( $block_type, array( '__experimentalDimensions' ), false );
-	// Future block supports such as height & width will be added here.
 
 	if ( $has_dimensions_support ) {
 		$block_type->attributes['style'] = array(
@@ -44,14 +43,24 @@ function gutenberg_register_dimensions_support( $block_type ) {
  *
  * @return array Block dimensions CSS classes and inline styles.
  */
-function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
 	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
 		return array();
 	}
 
 	$styles = array();
 
-	// Height support to be added in near future.
+	// Height.
+	$has_height_support = gutenberg_block_has_support( $block_type, array( '__experimentalDimensions', 'height' ), false );
+
+	if ( $has_height_support ) {
+		$height_value = _wp_array_get( $block_attributes, array( 'style', 'dimensions', 'height' ), null );
+
+		if ( null !== $height_value ) {
+			$styles[] = sprintf( 'height: %s;', $height_value );
+		}
+	}
+
 	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
@@ -63,10 +72,11 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
  *
  * @param WP_Block_type $block_type Block type.
  *
- * @return boolean Whether to serialize spacing support styles & classes.
+ * @return boolean Whether to serialize dimensions support styles & classes.
  */
 function gutenberg_skip_dimensions_serialization( $block_type ) {
 	$dimensions_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions' ), false );
+
 	return is_array( $dimensions_support ) &&
 		array_key_exists( '__experimentalSkipSerialization', $dimensions_support ) &&
 		$dimensions_support['__experimentalSkipSerialization'];

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -43,7 +43,7 @@ function gutenberg_register_dimensions_support( $block_type ) {
  *
  * @return array Block dimensions CSS classes and inline styles.
  */
-function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
+function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
 		return array();
 	}

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -43,7 +43,7 @@ function gutenberg_register_dimensions_support( $block_type ) {
  *
  * @return array Block dimensions CSS classes and inline styles.
  */
-function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
 	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
 		return array();
 	}
@@ -61,7 +61,7 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 		}
 	}
 
-	// Minimum height support.
+	// Minimum height.
 	$has_min_height_support = gutenberg_block_has_support( $block_type, array( '__experimentalDimensions', 'minHeight' ), false );
 
 	if ( $has_min_height_support ) {

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -61,6 +61,17 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 		}
 	}
 
+	// Minimum height support.
+	$has_min_height_support = gutenberg_block_has_support( $block_type, array( '__experimentalDimensions', 'minHeight' ), false );
+
+	if ( $has_min_height_support ) {
+		$min_height_value = _wp_array_get( $block_attributes, array( 'style', 'dimensions', 'minHeight' ), null );
+
+		if ( null !== $min_height_value ) {
+			$styles[] = sprintf( 'min-height: %s;', $min_height_value );
+		}
+	}
+
 	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -60,6 +60,9 @@ class WP_Theme_JSON_Gutenberg {
 			'gradient'   => null,
 			'text'       => null,
 		),
+		'dimensions' => array(
+			'height' => null,
+		),
 		'spacing'    => array(
 			'margin'   => null,
 			'padding'  => null,
@@ -94,6 +97,9 @@ class WP_Theme_JSON_Gutenberg {
 			'palette'        => null,
 		),
 		'custom'     => null,
+		'dimensions' => array(
+			'customHeight' => null,
+		),
 		'layout'     => array(
 			'contentSize' => null,
 			'wideSize'    => null,
@@ -222,6 +228,7 @@ class WP_Theme_JSON_Gutenberg {
 		'font-size'                  => array( 'typography', 'fontSize' ),
 		'font-style'                 => array( 'typography', 'fontStyle' ),
 		'font-weight'                => array( 'typography', 'fontWeight' ),
+		'height'                     => array( 'dimensions', 'height' ),
 		'letter-spacing'             => array( 'typography', 'letterSpacing' ),
 		'line-height'                => array( 'typography', 'lineHeight' ),
 		'margin'                     => array( 'spacing', 'margin' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -61,7 +61,8 @@ class WP_Theme_JSON_Gutenberg {
 			'text'       => null,
 		),
 		'dimensions' => array(
-			'height' => null,
+			'height'    => null,
+			'minHeight' => null,
 		),
 		'spacing'    => array(
 			'margin'   => null,
@@ -98,7 +99,8 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'custom'     => null,
 		'dimensions' => array(
-			'height' => null,
+			'height'    => null,
+			'minHeight' => null,
 		),
 		'layout'     => array(
 			'contentSize' => null,
@@ -236,6 +238,7 @@ class WP_Theme_JSON_Gutenberg {
 		'margin-right'               => array( 'spacing', 'margin', 'right' ),
 		'margin-bottom'              => array( 'spacing', 'margin', 'bottom' ),
 		'margin-left'                => array( 'spacing', 'margin', 'left' ),
+		'min-height'                 => array( 'dimensions', 'minHeight' ),
 		'padding'                    => array( 'spacing', 'padding' ),
 		'padding-top'                => array( 'spacing', 'padding', 'top' ),
 		'padding-right'              => array( 'spacing', 'padding', 'right' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -98,7 +98,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'custom'     => null,
 		'dimensions' => array(
-			'customHeight' => null,
+			'height' => null,
 		),
 		'layout'     => array(
 			'contentSize' => null,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -210,6 +210,9 @@
 				}
 			]
 		},
+		"dimensions": {
+			"customHeight": false
+		},
 		"spacing": {
 			"customMargin": false,
 			"customPadding": false,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -211,7 +211,7 @@
 			]
 		},
 		"dimensions": {
-			"customHeight": false
+			"height": false
 		},
 		"spacing": {
 			"customMargin": false,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -211,7 +211,8 @@
 			]
 		},
 		"dimensions": {
-			"height": false
+			"height": false,
+			"minHeight": false
 		},
 		"spacing": {
 			"customMargin": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16487,9 +16487,9 @@
 			}
 		},
 		"@types/hammerjs": {
-			"version": "2.0.39",
-			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.39.tgz",
-			"integrity": "sha512-lYR2Y/tV2ujpk/WyUc7S0VLI0a9hrtVIN9EwnrNo5oSEJI2cK2/XrgwOQmXLL3eTulOESvh9qP6si9+DWM9cOA=="
+			"version": "2.0.40",
+			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
+			"integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA=="
 		},
 		"@types/hast": {
 			"version": "2.3.1",
@@ -18930,7 +18930,7 @@
 				"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
 				"node-fetch": "^2.6.0",
 				"react-native": "0.64.0",
-				"react-native-gesture-handler": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp",
+				"react-native-gesture-handler": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp-2",
 				"react-native-get-random-values": "git+https://github.com/wordpress-mobile/react-native-get-random-values.git#v1.4.0-wp",
 				"react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
 				"react-native-hsv-color-picker": "git+https://github.com/wordpress-mobile/react-native-hsv-color-picker.git#v1.0.1-wp",
@@ -30662,12 +30662,27 @@
 			}
 		},
 		"color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
 			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.4"
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
+			},
+			"dependencies": {
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				}
 			}
 		},
 		"color-convert": {
@@ -30684,9 +30699,9 @@
 			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
 		},
 		"color-string": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+			"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
 			"requires": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
@@ -32278,7 +32293,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
 			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-			"dev": true,
 			"requires": {
 				"mdn-data": "2.0.14",
 				"source-map": "^0.6.1"
@@ -32287,8 +32301,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -46283,8 +46296,7 @@
 		"mdn-data": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-			"dev": true
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
 		},
 		"mdurl": {
 			"version": "1.0.1",
@@ -47938,9 +47950,9 @@
 			"optional": true
 		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -53383,8 +53395,8 @@
 			}
 		},
 		"react-native-gesture-handler": {
-			"version": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#5282a8f3b5f4ef8439c9c60f90c99629658c4cc3",
-			"from": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp",
+			"version": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#0b284c3d26c2af4b99f9b631b9888df7e11502d0",
+			"from": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp-2",
 			"requires": {
 				"@egjs/hammerjs": "^2.0.17",
 				"fbjs": "^3.0.0",
@@ -53523,15 +53535,6 @@
 						"nth-check": "^1.0.2"
 					}
 				},
-				"css-tree": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-					"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-					"requires": {
-						"mdn-data": "2.0.14",
-						"source-map": "^0.6.1"
-					}
-				},
 				"css-what": {
 					"version": "3.4.2",
 					"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
@@ -53546,11 +53549,6 @@
 						"domelementtype": "1"
 					}
 				},
-				"mdn-data": {
-					"version": "2.0.14",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
-				},
 				"nth-check": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -53558,11 +53556,6 @@
 					"requires": {
 						"boolbase": "~1.0.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -21,6 +21,13 @@ import {
 	useIsHeightDisabled,
 } from './height';
 import {
+	MinHeightEdit,
+	hasMinHeightSupport,
+	hasMinHeightValue,
+	resetMinHeight,
+	useIsMinHeightDisabled,
+} from './min-height';
+import {
 	MarginEdit,
 	hasMarginSupport,
 	hasMarginValue,
@@ -51,6 +58,7 @@ export function DimensionsPanel( props ) {
 	const isPaddingDisabled = useIsPaddingDisabled( props );
 	const isMarginDisabled = useIsMarginDisabled( props );
 	const isHeightDisabled = useIsHeightDisabled( props );
+	const isMinHeightDisabled = useIsMinHeightDisabled( props );
 	const isDisabled = useIsDimensionsDisabled( props );
 	const isSupported = hasDimensionsSupport( props.name );
 
@@ -78,6 +86,7 @@ export function DimensionsPanel( props ) {
 				dimensions: {
 					...style?.dimensions,
 					height: undefined,
+					minHeight: undefined,
 				},
 				spacing: {
 					...style?.spacing,
@@ -104,6 +113,19 @@ export function DimensionsPanel( props ) {
 						isShownByDefault={ defaultDimensionsControls?.height }
 					>
 						<HeightEdit { ...props } />
+					</ToolsPanelItem>
+				) }
+				{ ! isMinHeightDisabled && (
+					<ToolsPanelItem
+						className="single-column"
+						hasValue={ () => hasMinHeightValue( props ) }
+						label={ __( 'Minimum height' ) }
+						onDeselect={ () => resetMinHeight( props ) }
+						isShownByDefault={
+							defaultDimensionsControls?.minHeight
+						}
+					>
+						<MinHeightEdit { ...props } />
 					</ToolsPanelItem>
 				) }
 				{ ! isPaddingDisabled && (
@@ -145,6 +167,7 @@ export function hasDimensionsSupport( blockName ) {
 
 	return (
 		hasHeightSupport( blockName ) ||
+		hasMinHeightSupport( blockName ) ||
 		hasPaddingSupport( blockName ) ||
 		hasMarginSupport( blockName )
 	);
@@ -158,10 +181,13 @@ export function hasDimensionsSupport( blockName ) {
  */
 const useIsDimensionsDisabled = ( props = {} ) => {
 	const heightDisabled = useIsHeightDisabled( props );
+	const minHeightDisabled = useIsMinHeightDisabled( props );
 	const paddingDisabled = useIsPaddingDisabled( props );
 	const marginDisabled = useIsMarginDisabled( props );
 
-	return heightDisabled && paddingDisabled && marginDisabled;
+	return (
+		heightDisabled && minHeightDisabled && paddingDisabled && marginDisabled
+	);
 };
 
 /**

--- a/packages/block-editor/src/hooks/height.js
+++ b/packages/block-editor/src/hooks/height.js
@@ -66,7 +66,7 @@ export function resetHeight( { attributes = {}, setAttributes } ) {
  * @return {boolean} Whether height control is disabled.
  */
 export function useIsHeightDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useSetting( 'dimensions.customHeight' );
+	const isDisabled = ! useSetting( 'dimensions.height' );
 	return ! hasHeightSupport( blockName ) || isDisabled;
 }
 

--- a/packages/block-editor/src/hooks/height.js
+++ b/packages/block-editor/src/hooks/height.js
@@ -1,0 +1,121 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import {
+	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '../components/use-setting';
+import { DIMENSIONS_SUPPORT_KEY } from './dimensions';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Determines if there is height support.
+ *
+ * @param {string|Object} blockType Block name or Block Type object.
+ * @return {boolean} Whether there is support.
+ */
+export function hasHeightSupport( blockType ) {
+	const support = getBlockSupport( blockType, DIMENSIONS_SUPPORT_KEY );
+	return !! ( true === support || support?.height );
+}
+
+/**
+ * Checks if there is a current value in the height block support attributes.
+ *
+ * @param {Object} props Block props.
+ * @return {boolean} Whether or not the block has a height value set.
+ */
+export function hasHeightValue( props ) {
+	return props.attributes.style?.dimensions?.height !== undefined;
+}
+
+/**
+ * Resets the height block support attributes. This can be used when
+ * disabling the height support controls for a block via a progressive
+ * discovery panel.
+ *
+ * @param {Object} props               Block props.
+ * @param {Object} props.attributes    Block's attributes.
+ * @param {Object} props.setAttributes Function to set block's attributes.
+ */
+export function resetHeight( { attributes = {}, setAttributes } ) {
+	const { style } = attributes;
+
+	setAttributes( {
+		style: cleanEmptyObject( {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				height: undefined,
+			},
+		} ),
+	} );
+}
+
+/**
+ * Custom hook that checks if height controls have been disabled.
+ *
+ * @param {string} name The name of the block.
+ * @return {boolean} Whether height control is disabled.
+ */
+export function useIsHeightDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useSetting( 'dimensions.customHeight' );
+	return ! hasHeightSupport( blockName ) || isDisabled;
+}
+
+/**
+ * Inspector control panel containing the height related configuration.
+ *
+ * @param {Object} props Block props.
+ * @return {WPElement} Edit component for height.
+ */
+export function HeightEdit( props ) {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'dimensions.units' ) || [
+			'%',
+			'px',
+			'em',
+			'rem',
+			'vh',
+			'vw',
+		],
+	} );
+
+	if ( useIsHeightDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( next ) => {
+		const newStyle = {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				height: next,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+	};
+
+	return (
+		<UnitControl
+			label={ __( 'Height' ) }
+			value={ style?.dimensions?.height }
+			units={ units }
+			onChange={ onChange }
+			min={ 0 }
+		/>
+	);
+}

--- a/packages/block-editor/src/hooks/min-height.js
+++ b/packages/block-editor/src/hooks/min-height.js
@@ -1,0 +1,122 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import {
+	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '../components/use-setting';
+import { DIMENSIONS_SUPPORT_KEY } from './dimensions';
+import { cleanEmptyObject } from './utils';
+
+/**
+ * Determines if there is min-height support.
+ *
+ * @param {string|Object} blockType Block name or Block Type object.
+ * @return {boolean} Whether there is support.
+ */
+export function hasMinHeightSupport( blockType ) {
+	const support = getBlockSupport( blockType, DIMENSIONS_SUPPORT_KEY );
+	return !! ( true === support || support?.minHeight );
+}
+
+/**
+ * Checks if there is a current value in the min-height block support attributes.
+ *
+ * @param {Object} props Block props.
+ * @return {boolean} Whether or not the block has a min-height value set.
+ */
+export function hasMinHeightValue( props ) {
+	return props.attributes.style?.dimensions?.minHeight !== undefined;
+}
+
+/**
+ * Resets the min-height block support attributes. This can be used when
+ * disabling the min-height support controls for a block via a progressive
+ * discovery panel.
+ *
+ * @param {Object} props               Block props.
+ * @param {Object} props.attributes    Block's attributes.
+ * @param {Object} props.setAttributes Function to set block's attributes.
+ */
+export function resetMinHeight( { attributes = {}, setAttributes } ) {
+	const { style } = attributes;
+
+	setAttributes( {
+		style: {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				minHeight: undefined,
+			},
+		},
+	} );
+}
+
+/**
+ * Custom hook that checks if min-height controls have been disabled.
+ *
+ * @param {Object} props Block props.
+ * @param {string} props.name The name of the block.
+ * @return {boolean} Whether min-height control is disabled.
+ */
+export function useIsMinHeightDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useSetting( 'dimensions.customMinHeight' );
+	return ! hasMinHeightSupport( blockName ) || isDisabled;
+}
+
+/**
+ * Inspector control panel containing the min-height related configuration.
+ *
+ * @param {Object} props Block props.
+ * @return {WPElement} Edit component for min-height.
+ */
+export function MinHeightEdit( props ) {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	const units = useCustomUnits( {
+		availableUnits: useSetting( 'dimensions.units' ) || [
+			'%',
+			'px',
+			'em',
+			'rem',
+			'vh',
+			'vw',
+		],
+	} );
+
+	if ( useIsMinHeightDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( next ) => {
+		const newStyle = {
+			...style,
+			dimensions: {
+				...style?.dimensions,
+				minHeight: next,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+	};
+
+	return (
+		<UnitControl
+			label={ __( 'Minimum height' ) }
+			value={ style?.dimensions?.minHeight }
+			units={ units }
+			onChange={ onChange }
+			min={ 0 }
+		/>
+	);
+}

--- a/packages/block-editor/src/hooks/min-height.js
+++ b/packages/block-editor/src/hooks/min-height.js
@@ -49,13 +49,13 @@ export function resetMinHeight( { attributes = {}, setAttributes } ) {
 	const { style } = attributes;
 
 	setAttributes( {
-		style: {
+		style: cleanEmptyObject( {
 			...style,
 			dimensions: {
 				...style?.dimensions,
 				minHeight: undefined,
 			},
-		},
+		} ),
 	} );
 }
 

--- a/packages/block-editor/src/hooks/min-height.js
+++ b/packages/block-editor/src/hooks/min-height.js
@@ -67,7 +67,7 @@ export function resetMinHeight( { attributes = {}, setAttributes } ) {
  * @return {boolean} Whether min-height control is disabled.
  */
 export function useIsMinHeightDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useSetting( 'dimensions.customMinHeight' );
+	const isDisabled = ! useSetting( 'dimensions.minHeight' );
 	return ! hasMinHeightSupport( blockName ) || isDisabled;
 }
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -37,13 +37,18 @@ import {
 	TYPOGRAPHY_SUPPORT_KEY,
 	TYPOGRAPHY_SUPPORT_KEYS,
 } from './typography';
-import { SPACING_SUPPORT_KEY, DimensionsPanel } from './dimensions';
+import {
+	DIMENSIONS_SUPPORT_KEY,
+	SPACING_SUPPORT_KEY,
+	DimensionsPanel,
+} from './dimensions';
 import useDisplayBlockControls from '../components/use-display-block-controls';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
 	BORDER_SUPPORT_KEY,
 	COLOR_SUPPORT_KEY,
+	DIMENSIONS_SUPPORT_KEY,
 	SPACING_SUPPORT_KEY,
 ];
 
@@ -152,8 +157,11 @@ const skipSerializationPaths = {
 	[ `${ TYPOGRAPHY_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		TYPOGRAPHY_SUPPORT_KEY,
 	],
+	[ `${ DIMENSIONS_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+		DIMENSIONS_SUPPORT_KEY,
+	],
 	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
-		'spacing',
+		SPACING_SUPPORT_KEY,
 	],
 };
 

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -23,6 +23,9 @@ describe( 'getInlineStyles', () => {
 					style: 'dotted',
 					color: '#21759b',
 				},
+				dimensions: {
+					height: '500px',
+				},
 				spacing: {
 					padding: { top: '10px' },
 					margin: { bottom: '15px' },
@@ -37,6 +40,7 @@ describe( 'getInlineStyles', () => {
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,
+			height: '500px',
 			marginBottom: '15px',
 			paddingTop: '10px',
 		} );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -25,6 +25,7 @@ describe( 'getInlineStyles', () => {
 				},
 				dimensions: {
 					height: '500px',
+					minHeight: '200px',
 				},
 				spacing: {
 					padding: { top: '10px' },
@@ -41,6 +42,7 @@ describe( 'getInlineStyles', () => {
 			lineHeight: 1.5,
 			fontSize: 10,
 			height: '500px',
+			minHeight: '200px',
 			marginBottom: '15px',
 			paddingTop: '10px',
 		} );

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -90,6 +90,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 			marginLeft: 'left',
 		},
 	},
+	minHeight: {
+		value: [ 'dimensions', 'minHeight' ],
+		support: [ '__experimentalDimensions', 'minHeight' ],
+	},
 	padding: {
 		value: [ 'spacing', 'padding' ],
 		support: [ 'spacing', 'padding' ],

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -72,6 +72,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'typography', 'fontWeight' ],
 		support: [ 'typography', '__experimentalFontWeight' ],
 	},
+	height: {
+		value: [ 'dimensions', 'height' ],
+		support: [ '__experimentalDimensions', 'height' ],
+	},
 	lineHeight: {
 		value: [ 'typography', 'lineHeight' ],
 		support: [ 'typography', 'lineHeight' ],

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -192,7 +192,13 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 
 	const pickStyleKeys = ( treeToPickFrom ) =>
 		pickBy( treeToPickFrom, ( value, key ) =>
-			[ 'border', 'color', 'spacing', 'typography' ].includes( key )
+			[
+				'border',
+				'color',
+				'dimensions',
+				'spacing',
+				'typography',
+			].includes( key )
 		);
 
 	// Top-level.

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -27,7 +27,7 @@ export function useHasDimensionsPanel( context ) {
 }
 
 function useHasHeight( { name, supports } ) {
-	const settings = useSetting( 'dimensions.customHeight', name );
+	const settings = useSetting( 'dimensions.height', name );
 
 	return settings && supports.includes( 'height' );
 }

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -7,6 +7,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
 
@@ -18,10 +19,17 @@ import { useSetting } from '../editor/utils';
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
 export function useHasDimensionsPanel( context ) {
+	const hasHeight = useHasHeight( context );
 	const hasPadding = useHasPadding( context );
 	const hasMargin = useHasMargin( context );
 
-	return hasPadding || hasMargin;
+	return hasHeight || hasPadding || hasMargin;
+}
+
+function useHasHeight( { name, supports } ) {
+	const settings = useSetting( 'dimensions.customHeight', name );
+
+	return settings && supports.includes( 'height' );
 }
 
 function useHasPadding( { name, supports } ) {
@@ -76,6 +84,7 @@ function splitStyleValue( value ) {
 
 export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	const { name } = context;
+	const showHeightControl = useHasHeight( context );
 	const showPaddingControl = useHasPadding( context );
 	const showMarginControl = useHasMargin( context );
 	const units = useCustomUnits( {
@@ -88,6 +97,13 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 		],
 	} );
 
+	// Height.
+	const heightValue = getStyle( name, 'height' );
+	const setHeightValue = ( next ) => setStyle( name, 'height', next );
+	const resetHeightValue = () => setHeightValue( undefined );
+	const hasHeightValue = () => !! heightValue;
+
+	// Padding.
 	const paddingValues = splitStyleValue( getStyle( name, 'padding' ) );
 	const paddingSides = useCustomSides( name, 'padding' );
 	const isAxialPadding =
@@ -102,6 +118,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	const hasPaddingValue = () =>
 		paddingValues && Object.keys( paddingValues ).length;
 
+	// Margin.
 	const marginValues = splitStyleValue( getStyle( name, 'margin' ) );
 	const marginSides = useCustomSides( name, 'margin' );
 	const isAxialMargin =
@@ -117,6 +134,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 		marginValues && Object.keys( marginValues ).length;
 
 	const resetAll = () => {
+		resetHeightValue();
 		resetPaddingValue();
 		resetMarginValue();
 	};
@@ -127,6 +145,23 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 			header={ __( 'Dimensions' ) }
 			resetAll={ resetAll }
 		>
+			{ showHeightControl && (
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ hasHeightValue }
+					label={ __( 'Height' ) }
+					onDeselect={ resetHeightValue }
+					isShownByDefault={ true }
+				>
+					<UnitControl
+						label={ __( 'Height' ) }
+						value={ heightValue }
+						onChange={ setHeightValue }
+						units={ units }
+						min={ 0 }
+					/>
+				</ToolsPanelItem>
+			) }
 			{ showPaddingControl && (
 				<ToolsPanelItem
 					hasValue={ hasPaddingValue }

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -20,16 +20,23 @@ const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
 export function useHasDimensionsPanel( context ) {
 	const hasHeight = useHasHeight( context );
+	const hasMinHeight = useHasMinHeight( context );
 	const hasPadding = useHasPadding( context );
 	const hasMargin = useHasMargin( context );
 
-	return hasHeight || hasPadding || hasMargin;
+	return hasHeight || hasMinHeight || hasPadding || hasMargin;
 }
 
 function useHasHeight( { name, supports } ) {
 	const settings = useSetting( 'dimensions.height', name );
 
 	return settings && supports.includes( 'height' );
+}
+
+function useHasMinHeight( { name, supports } ) {
+	const settings = useSetting( 'dimensions.customMinHeight', name );
+
+	return settings && supports.includes( 'minHeight' );
 }
 
 function useHasPadding( { name, supports } ) {
@@ -85,6 +92,7 @@ function splitStyleValue( value ) {
 export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	const { name } = context;
 	const showHeightControl = useHasHeight( context );
+	const showMinHeightControl = useHasMinHeight( context );
 	const showPaddingControl = useHasPadding( context );
 	const showMarginControl = useHasMargin( context );
 	const units = useCustomUnits( {
@@ -102,6 +110,12 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	const setHeightValue = ( next ) => setStyle( name, 'height', next );
 	const resetHeightValue = () => setHeightValue( undefined );
 	const hasHeightValue = () => !! heightValue;
+
+	// Min height.
+	const minHeightValue = getStyle( name, 'minHeight' );
+	const setMinHeightValue = ( next ) => setStyle( name, 'minHeight', next );
+	const resetMinHeightValue = () => setMinHeightValue( undefined );
+	const hasMinHeightValue = () => !! minHeightValue;
 
 	// Padding.
 	const paddingValues = splitStyleValue( getStyle( name, 'padding' ) );
@@ -135,6 +149,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 
 	const resetAll = () => {
 		resetHeightValue();
+		resetMinHeightValue();
 		resetPaddingValue();
 		resetMarginValue();
 	};
@@ -157,6 +172,23 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 						label={ __( 'Height' ) }
 						value={ heightValue }
 						onChange={ setHeightValue }
+						units={ units }
+						min={ 0 }
+					/>
+				</ToolsPanelItem>
+			) }
+			{ showMinHeightControl && (
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ hasMinHeightValue }
+					label={ __( 'Minimum height' ) }
+					onDeselect={ resetMinHeightValue }
+					isShownByDefault={ true }
+				>
+					<UnitControl
+						label={ __( 'Minimum height' ) }
+						value={ minHeightValue }
+						onChange={ setMinHeightValue }
 						units={ units }
 						min={ 0 }
 					/>

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -34,7 +34,7 @@ function useHasHeight( { name, supports } ) {
 }
 
 function useHasMinHeight( { name, supports } ) {
-	const settings = useSetting( 'dimensions.customMinHeight', name );
+	const settings = useSetting( 'dimensions.minHeight', name );
 
 	return settings && supports.includes( 'minHeight' );
 }

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -55,7 +55,7 @@
 		"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
 		"node-fetch": "^2.6.0",
 		"react-native": "0.64.0",
-		"react-native-gesture-handler": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp",
+		"react-native-gesture-handler": "git+https://github.com/wordpress-mobile/react-native-gesture-handler.git#1.10.1-wp-2",
 		"react-native-get-random-values": "git+https://github.com/wordpress-mobile/react-native-get-random-values.git#v1.4.0-wp",
 		"react-native-hr": "git+https://github.com/Riglerr/react-native-hr.git#2d01a5cf77212d100e8b99e0310cce5234f977b3",
 		"react-native-hsv-color-picker": "git+https://github.com/wordpress-mobile/react-native-hsv-color-picker#v1.0.1-wp",

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -289,17 +289,20 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'blocks'   => array(
 						'core/group'     => array(
-							'border'   => array(
+							'border'     => array(
 								'radius' => '10px',
 							),
-							'elements' => array(
+							'elements'   => array(
 								'link' => array(
 									'color' => array(
 										'text' => '#111',
 									),
 								),
 							),
-							'spacing'  => array(
+							'dimensions' => array(
+								'height' => '200px',
+							),
+							'spacing'    => array(
 								'padding' => '24px',
 							),
 						),
@@ -352,11 +355,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			'body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -300,7 +300,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 							'dimensions' => array(
-								'height' => '200px',
+								'height'    => '200px',
+								'minHeight' => '100px',
 							),
 							'spacing'    => array(
 								'padding' => '24px',
@@ -355,11 +356,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;min-height: 100px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet()
 		);
 		$this->assertEquals(
-			'body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
+			'body{color: var(--wp--preset--color--grey);}.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;height: 200px;min-height: 100px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}',
 			$theme_json->get_stylesheet( 'block_styles' )
 		);
 		$this->assertEquals(


### PR DESCRIPTION
Depends on [Block Support: Add height block support feature](https://github.com/WordPress/gutenberg/pull/32499), which, in turn, depends on 
[Dimensions Panel: Add new ToolsPanel component and update spacing supports](https://github.com/WordPress/gutenberg/pull/32392)


Related: [Block Support: Add width block support feature](https://github.com/WordPress/gutenberg/pull/32502)

## Description

Greetings!

This PR add minimum height block support, and builds on top of the great work in [Block Support: Add height block support](https://github.com/WordPress/gutenberg/pull/32499).

The motivation behind this addition, aside from opening up min-height to other blocks, is to achieve consolidation of the cover block controls. See: https://github.com/WordPress/gutenberg/issues/23770#issuecomment-895703471

## Screenshots

https://user-images.githubusercontent.com/6458278/128859652-803154a3-92ca-48e4-9d5d-2ebfad74e914.mp4

<img width="320" src="https://user-images.githubusercontent.com/6458278/128859353-31b5a752-b948-4fff-a36c-bba73982b894.gif" />

## Types of changes

New feature: addition to block supports.

## Testing

### Manual testing

In [group/block.json](https://github.com/WordPress/gutenberg/blob/74d6b30b10814f589e5c957ee12071a94610eabc/packages/block-library/src/group/block.json) add the following to the supports object:

```json
"__experimentalDimensions": {
    "minHeight": true
},
```


Then add the following to the settings object in `lib/experimental-default-theme.json` (or `lib/theme.json` once this is rebased on trunk)

```json
"dimensions": {
    "customHeight": false,
    "customMinHeight": true
},
```

Create a post and add a group block. Add some inner Blocks too if you like. A paragraph, an image. They're giving them away in that inserter!

Can you see the Dimensions control panel and the minimum height control? Great!

Adjust the minimum height of the group block. Save, then view the post. The frontend should reflect your changes in the editor.

Check global in the site editor. Under By Block Type, find the group block and play around with the min-height.

Also, fennel tea is great for digestion.

### Unit tests

Run from project root.

Theme.json tests

```shell
npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose --filter stylesheet /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php'
```

Style.js tests

```shell
npm run test-unit:watch packages/block-editor/src/hooks/test/style.js
```


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
