### PR TITLE
Try: Rephrase the "Replace" word in the Media Replace flow

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -39,7 +39,6 @@ const MediaReplaceFlow = ( {
 	onSelect,
 	onSelectURL,
 	onFilesUpload = noop,
-	name = __( 'Replace' ),
 	createNotice,
 	removeNotice,
 } ) => {
@@ -112,6 +111,15 @@ const MediaReplaceFlow = ( {
 		isAlternate: true,
 	};
 
+	let name = __( 'Replace' );
+	if ( allowedTypes[ 0 ] === 'image' && allowedTypes.length === 1 ) {
+		name = __( 'Change image' );
+	} else if ( allowedTypes[ 0 ] === 'video' && allowedTypes.length === 1 ) {
+		name = __( 'Change video' );
+	} else if ( allowedTypes[ 0 ] === 'audio' && allowedTypes.length === 1 ) {
+		name = __( 'Change audio' );
+	}
+
 	return (
 		<Dropdown
 			popoverProps={ POPOVER_PROPS }
@@ -136,6 +144,7 @@ const MediaReplaceFlow = ( {
 							allowedTypes={ allowedTypes }
 							render={ ( { open } ) => (
 								<MenuItem icon={ mediaIcon } onClick={ open }>
+									{ allowedTypes }
 									{ __( 'Open Media Library' ) }
 								</MenuItem>
 							) }


### PR DESCRIPTION
## Description

For a longish time, we've used the word "Replace" in the Media Replace Flow component, to indicate that the media your block has can be _replaced_ with something else:

<img width="814" alt="Screenshot 2021-08-10 at 12 18 20" src="https://user-images.githubusercontent.com/1204802/128859377-b5e8c498-db01-49e0-be99-e155deedb87e.png">

The word is perfectly servicable and generic as it accommodates any type of media. But it's also not quite as clear as specific phrases, like "Change image", "Change video" or "Change audio". This PR attempts to ambiguate a little bit based on the allowed types, and if there's only one allowed type and it matches video audio or image, you get direct labels:

<img width="792" alt="Screenshot 2021-08-10 at 13 26 53" src="https://user-images.githubusercontent.com/1204802/128859445-bfececb5-e521-4a8b-8289-bb019bdd70c1.png">
<img width="750" alt="Screenshot 2021-08-10 at 13 27 03" src="https://user-images.githubusercontent.com/1204802/128859450-39458b15-cc2e-4e71-a5a4-47066faf3360.png">
<img width="786" alt="Screenshot 2021-08-10 at 13 27 13" src="https://user-images.githubusercontent.com/1204802/128859453-c97b4117-31b3-42e0-bbbf-d39c9307c95e.png">

Let me know your thoughts!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
