### PR TITLE
[Mobile] - Color settings - Update label and show the selected color value

### DIFF
--- a/packages/components/src/mobile/color-settings/palette.screen.native.js
+++ b/packages/components/src/mobile/color-settings/palette.screen.native.js
@@ -56,6 +56,10 @@ const PaletteScreen = () => {
 		styles.clearButton,
 		styles.clearButtonDark
 	);
+	const selectedColorTextStyle = usePreferredColorSchemeStyle(
+		styles.colorText,
+		styles.colorTextDark
+	);
 
 	const isSolidSegment = currentSegment === segments[ 0 ];
 	const isCustomGadientShown = ! isSolidSegment && isGradientColor;
@@ -136,12 +140,22 @@ const PaletteScreen = () => {
 						/>
 					) }
 				</View>
-				<Text
-					style={ styles.selectColorText }
-					maxFontSizeMultiplier={ 2 }
-				>
-					{ __( 'Select a color' ) }
-				</Text>
+				{ currentValue ? (
+					<Text
+						style={ selectedColorTextStyle }
+						maxFontSizeMultiplier={ 2 }
+						selectable
+					>
+						{ currentValue.toUpperCase() }
+					</Text>
+				) : (
+					<Text
+						style={ styles.selectColorText }
+						maxFontSizeMultiplier={ 2 }
+					>
+						{ __( 'Select a color above' ) }
+					</Text>
+				) }
 				<View style={ styles.flex }>
 					{ currentValue && getClearButton() }
 				</View>

--- a/packages/components/src/mobile/color-settings/style.native.scss
+++ b/packages/components/src/mobile/color-settings/style.native.scss
@@ -29,6 +29,17 @@
 	line-height: 24px;
 }
 
+.colorText {
+	font-family: $default-monospace-font;
+	color: $light-primary;
+	font-size: 16px;
+	font-weight: 400;
+}
+
+.colorTextDark {
+	color: $dark-primary;
+}
+
 .flex {
 	flex: 1;
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3766

`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3817

## Description
This PR updates the label of the color settings palette from `Select a color` to `Select a color above`.

It also adds the functionality to display the color selected and the ability to copy it.

## How has this been tested?
- Open the app
- Use any block that allows color customization, like the `Paragraph` block.
- Open the settings of the block
- Select the Text Color setting
- **Expect** to see the updated label "Select a color above"
- Tap on any of the colors
- **Expect** to see the hex color where the label was

## Screenshots <!-- if applicable -->
iOS|Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/128859857-d1053331-c740-4722-9d22-9ed14b65aa84.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/128859787-70dc2218-c718-4530-b16d-824245491a0f.gif" width="200" /></kbd>

## Types of changes
New change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
