### PR TITLE
Improve the rendering/update performance of the image block

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -118,16 +118,11 @@ export default function Image( {
 			const {
 				getBlock: _getBlock,
 				getBlockRootClientId,
-				getBlockTransformItems,
 				getSettings,
+				canInsertBlockType,
 			} = select( blockEditorStore );
 
-			const block = _getBlock( clientId );
 			const rootClientId = getBlockRootClientId( clientId );
-			const transformations = getBlockTransformItems(
-				[ block ],
-				rootClientId
-			);
 			const settings = pick( getSettings(), [
 				'imageEditing',
 				'imageSizes',
@@ -135,16 +130,13 @@ export default function Image( {
 				'mediaUpload',
 			] );
 
-			const hasTransforms = !! transformations.length;
-
 			return {
 				...settings,
 				getBlock: _getBlock,
-				canInsertCover:
-					hasTransforms &&
-					!! transformations.find(
-						( { name } ) => name === 'core/cover'
-					),
+				canInsertCover: canInsertBlockType(
+					'core/cover',
+					rootClientId
+				),
 			};
 		},
 		[ clientId ]

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -87,6 +87,7 @@ export default function Image( {
 } ) {
 	const captionRef = useRef();
 	const prevUrl = usePrevious( url );
+	const { getBlock } = useSelect( blockEditorStore );
 	const { image, multiImageSelection } = useSelect(
 		( select ) => {
 			const { getMedia } = select( coreStore );
@@ -108,7 +109,6 @@ export default function Image( {
 	);
 	const {
 		canInsertCover,
-		getBlock,
 		imageEditing,
 		imageSizes,
 		maxWidth,
@@ -116,7 +116,6 @@ export default function Image( {
 	} = useSelect(
 		( select ) => {
 			const {
-				getBlock: _getBlock,
 				getBlockRootClientId,
 				getSettings,
 				canInsertBlockType,
@@ -132,7 +131,6 @@ export default function Image( {
 
 			return {
 				...settings,
-				getBlock: _getBlock,
 				canInsertCover: canInsertBlockType(
 					'core/cover',
 					rootClientId


### PR DESCRIPTION
While navigating the performance trace when typing the editor, I noticed some wasted milliseconds in the rendering of image blocks. This PR refactors the useSelect call of the image block a bit to improve the situation.

I'm not really certain whether the impact will be visible in any of our performance metrics, we'll see.