### PR TITLE
Add information about selected element types for Group Block

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -10,7 +10,7 @@ import {
 	useSetting,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
@@ -48,23 +48,27 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	return (
 		<>
 			<InspectorControls __experimentalGroup="advanced">
-				<SelectControl
-					label={ __( 'HTML element' ) }
-					options={ [
-						{ label: __( 'Default (<div>)' ), value: 'div' },
-						{ label: '<header>', value: 'header' },
-						{ label: '<main>', value: 'main' },
-						{ label: '<section>', value: 'section' },
-						{ label: '<article>', value: 'article' },
-						{ label: '<aside>', value: 'aside' },
-						{ label: '<footer>', value: 'footer' },
-					] }
-					value={ TagName }
-					onChange={ ( value ) =>
-						setAttributes( { tagName: value } )
-					}
-				/>
+				<div className="block-library-group-block-html-element-control">
+					<SelectControl
+						label={ __( 'HTML element' ) }
+						options={ [
+							{ label: __( 'Default (<div>)' ), value: 'div' },
+							{ label: '<header>', value: 'header' },
+							{ label: '<main>', value: 'main' },
+							{ label: '<section>', value: 'section' },
+							{ label: '<article>', value: 'article' },
+							{ label: '<aside>', value: 'aside' },
+							{ label: '<footer>', value: 'footer' },
+						] }
+						value={ TagName }
+						onChange={ ( value ) =>
+							setAttributes( { tagName: value } )
+						}
+					/>
+					<HTMLElementCheckerMessage element={ TagName } />
+				</div>
 			</InspectorControls>
+
 			{ layoutSupportEnabled && <TagName { ...innerBlocksProps } /> }
 			{ /* Ideally this is not needed but it's there for backward compatibility reason
 				to keep this div for themes that might rely on its presence */ }
@@ -74,6 +78,43 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 				</TagName>
 			) }
 		</>
+	);
+}
+
+function HTMLElementCheckerMessage( { element } ) {
+	const messages = {
+		header: __(
+			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+		),
+		main: __(
+			'The <main> element should be used for the primary content of your document only. '
+		),
+		section: __(
+			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+		),
+		article: __(
+			'The <article> element should represent a self contained, syndicatable portion of the document.'
+		),
+		aside: __(
+			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+		),
+		footer: __(
+			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+		),
+	};
+
+	const msg = messages[ element ];
+
+	if ( ! msg ) {
+		return null;
+	}
+
+	return (
+		<div className="block-library-group-block-html-element-control__notice">
+			<Notice status="warning" isDismissible={ false }>
+				{ msg }
+			</Notice>
+		</div>
 	);
 }
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -13,36 +13,26 @@ import {
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function getHTMLElementMessage( element ) {
-	const messages = {
-		header: __(
-			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
-		),
-		main: __(
-			'The <main> element should be used for the primary content of your document only. '
-		),
-		section: __(
-			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
-		),
-		article: __(
-			'The <article> element should represent a self contained, syndicatable portion of the document.'
-		),
-		aside: __(
-			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
-		),
-		footer: __(
-			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
-		),
-	};
-
-	const msg = messages[ element ];
-
-	if ( ! msg ) {
-		return '';
-	}
-
-	return msg;
-}
+const htmlElementMessages = {
+	header: __(
+		'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+	),
+	main: __(
+		'The <main> element should be used for the primary content of your document only. '
+	),
+	section: __(
+		"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+	),
+	article: __(
+		'The <article> element should represent a self contained, syndicatable portion of the document.'
+	),
+	aside: __(
+		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+	),
+	footer: __(
+		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+	),
+};
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
@@ -79,25 +69,23 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	return (
 		<>
 			<InspectorControls __experimentalGroup="advanced">
-				<div className="block-library-group-block-html-element-control">
-					<SelectControl
-						label={ __( 'HTML element' ) }
-						options={ [
-							{ label: __( 'Default (<div>)' ), value: 'div' },
-							{ label: '<header>', value: 'header' },
-							{ label: '<main>', value: 'main' },
-							{ label: '<section>', value: 'section' },
-							{ label: '<article>', value: 'article' },
-							{ label: '<aside>', value: 'aside' },
-							{ label: '<footer>', value: 'footer' },
-						] }
-						value={ TagName }
-						onChange={ ( value ) =>
-							setAttributes( { tagName: value } )
-						}
-						help={ getHTMLElementMessage( TagName ) }
-					/>
-				</div>
+				<SelectControl
+					label={ __( 'HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<div>)' ), value: 'div' },
+						{ label: '<header>', value: 'header' },
+						{ label: '<main>', value: 'main' },
+						{ label: '<section>', value: 'section' },
+						{ label: '<article>', value: 'article' },
+						{ label: '<aside>', value: 'aside' },
+						{ label: '<footer>', value: 'footer' },
+					] }
+					value={ TagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+					help={ htmlElementMessages[ TagName ] }
+				/>
 			</InspectorControls>
 
 			{ layoutSupportEnabled && <TagName { ...innerBlocksProps } /> }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -87,7 +87,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 					help={ htmlElementMessages[ TagName ] }
 				/>
 			</InspectorControls>
-
 			{ layoutSupportEnabled && <TagName { ...innerBlocksProps } /> }
 			{ /* Ideally this is not needed but it's there for backward compatibility reason
 				to keep this div for themes that might rely on its presence */ }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -10,8 +10,39 @@ import {
 	useSetting,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { SelectControl, Notice } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+function getHTMLElementMessage( element ) {
+	const messages = {
+		header: __(
+			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+		),
+		main: __(
+			'The <main> element should be used for the primary content of your document only. '
+		),
+		section: __(
+			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+		),
+		article: __(
+			'The <article> element should represent a self contained, syndicatable portion of the document.'
+		),
+		aside: __(
+			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+		),
+		footer: __(
+			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+		),
+	};
+
+	const msg = messages[ element ];
+
+	if ( ! msg ) {
+		return '';
+	}
+
+	return msg;
+}
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
@@ -64,8 +95,8 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 						onChange={ ( value ) =>
 							setAttributes( { tagName: value } )
 						}
+						help={ getHTMLElementMessage( TagName ) }
 					/>
-					<HTMLElementCheckerMessage element={ TagName } />
 				</div>
 			</InspectorControls>
 
@@ -78,43 +109,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 				</TagName>
 			) }
 		</>
-	);
-}
-
-function HTMLElementCheckerMessage( { element } ) {
-	const messages = {
-		header: __(
-			'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
-		),
-		main: __(
-			'The <main> element should be used for the primary content of your document only. '
-		),
-		section: __(
-			"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
-		),
-		article: __(
-			'The <article> element should represent a self contained, syndicatable portion of the document.'
-		),
-		aside: __(
-			"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
-		),
-		footer: __(
-			'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
-		),
-	};
-
-	const msg = messages[ element ];
-
-	if ( ! msg ) {
-		return null;
-	}
-
-	return (
-		<div className="block-library-group-block-html-element-control__notice">
-			<Notice status="warning" isDismissible={ false }>
-				{ msg }
-			</Notice>
-		</div>
 	);
 }
 

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -22,3 +22,16 @@
 		margin-bottom: $block-padding + $grid-unit-05;
 	}
 }
+
+
+.block-library-group-block-html-element-control {
+	margin-bottom: $grid-unit-20;
+
+	.components-base-control {
+		margin-bottom: $grid-unit-10;
+	}
+
+	.components-notice {
+		margin: 0;
+	}
+}

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -22,16 +22,3 @@
 		margin-bottom: $block-padding + $grid-unit-05;
 	}
 }
-
-
-.block-library-group-block-html-element-control {
-	margin-bottom: $grid-unit-20;
-
-	.components-base-control {
-		margin-bottom: $grid-unit-10;
-	}
-
-	.components-notice {
-		margin: 0;
-	}
-}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The group block allows you to select an HTML element to be used as it's TagName. However, there is no inline guidance for the purpose of these elements which could lead to the introduce of a11y issues.

This PR takes a first step of adding a notice which explains a little about the selected element. 

Currently the info was gleaned from MDN docs, but I'm open to suggestions and improvements.

In future we could look to scan the document and provide more contextual advice (eg: "We've noticed you already have a `<main>` element in your page" etc.) but for now let's keep things simple.

Closes https://github.com/WordPress/gutenberg/issues/31502

## How has this been tested?

1. Add Group Block
2. Toggle block sidebar.
3. Toggle "Advanced" section.
4. Select an alternative HTML element from the dropdown.
5. See a different message displayed for each with the exception of the `<div>` default.
6. Check messages for suitability and spelling/grammar.


## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/132721579-deef40f6-0c9c-428f-8198-2e1e128d0719.mov




## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
