### PR TITLE
Docs: Use block.json to add attributes in create block tutorial

### DIFF
--- a/docs/getting-started/tutorials/create-block/attributes.md
+++ b/docs/getting-started/tutorials/create-block/attributes.md
@@ -4,22 +4,18 @@ Attributes are the way a block stores data, they define how a block is parsed to
 
 For this block tutorial, we want to allow the user to type in a message that we will display stylized in the published post. So, we need to add a **message** attribute that will hold the user message. The following code defines a **message** attribute; the attribute type is a string; the source is the text from the selector which is a `div` tag.
 
-```js
-registerBlockType( 'create-block/gutenpride', {
-	apiVersion: 2,
-	attributes: {
-		message: {
-			type: 'string',
-			source: 'text',
-			selector: 'div',
-			default: '', // empty default
-		},
+```json
+"attributes": {
+	"message": {
+		"type": "string",
+		"source": "text",
+		"selector": "div",
+		"default": "",
 	},
-	// other settings, like the save and edit functions.
-} );
+},
 ```
 
-Add this to the `index.js` file within the `registerBlockType` function. The `attributes` are at the same level as the _edit_ and _save_ fields.
+Add this to the `block.json` file. The `attributes` are at the same level as the _name_ and _title_ fields.
 
 When the block loads it will look at the saved content for the block, look for the div tag, take the text portion, and store the content in an `attributes.message` variable.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Update create blocks tutorial to add attributes trough `block.json` instead of `registerBlockType`. This is the recommended way as described in the [block meteadata docs](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/)

> Starting in WordPress 5.8 release, we encourage using the block.json metadata file as the canonical way to register block types.
<!-- Please describe what you have changed or added -->

## How has this been tested?

## Screenshots <!-- if applicable -->

## Types of changes
Documentation 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
