### PR TITLE
WIP: [Block Library - Social Icons]: Make the block use the new `flex` layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -65,10 +65,13 @@ function gutenberg_get_layout_style( $selector, $layout ) {
 		$style .= "$selector .alignleft { float: left; margin-right: 2em; }";
 		$style .= "$selector .alignright { float: right; margin-left: 2em; }";
 	} elseif ( 'flex' === $layout_type ) {
+		$justify_content = isset( $layout['justifyContent'] ) ? $layout['justifyContent'] : 'flex-start';
+
 		$style  = "$selector {";
 		$style .= 'display: flex;';
+		$style .= 'flex-direction: row;';
 		$style .= 'column-gap: 0.5em;';
-		$style .= 'align-items: center;';
+		$style .= "justify-content: $justify_content;";
 		$style .= '}';
 	}
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -33,23 +33,6 @@ import { getLayoutType, getLayoutTypes } from '../layouts';
 
 const layoutBlockSupportKey = '__experimentalLayout';
 
-const getLayoutBlockSettings = ( blockTypeOrName ) => {
-	const layoutBlockSupportConfig = getBlockSupport(
-		blockTypeOrName,
-		layoutBlockSupportKey
-	);
-
-	const {
-		allowSwitching: canBlockSwitchLayout,
-		default: defaultBlockLayout,
-	} = layoutBlockSupportConfig || {}; // TODO: check if this is needed based on the value return by `getBlockSupport`.
-
-	return {
-		canBlockSwitchLayout,
-		defaultBlockLayout,
-	};
-};
-
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const { layout } = attributes;
 	// TODO: check if a theme should provide default values per `layoutType`.
@@ -66,23 +49,24 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		return null;
 	}
 
-	const { allowLayoutSwitching, defaultBlockLayout } = getLayoutBlockSettings(
-		blockName
-	);
+	const {
+		allowSwitching: canBlockSwitchLayout,
+		default: defaultBlockLayout,
+	} = getBlockSupport( blockName, layoutBlockSupportKey ) || {};
 
 	const usedLayout = layout ? layout : defaultBlockLayout || {};
 	const { inherit = false, type = 'default' } = usedLayout;
 	const layoutType = getLayoutType( type );
 
 	const onChangeType = ( newType ) =>
-		setAttributes( { layout: { type: newType } } );
+		setAttributes( { layout: { type: newType } } ); // TODO needs checking with block defaults.
 	const onChangeLayout = ( newLayout ) =>
 		setAttributes( { layout: newLayout } );
 
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Layout' ) }>
-				{ layoutType.canInherit && !! defaultThemeLayout && (
+				{ inherit && !! defaultThemeLayout && (
 					<ToggleControl
 						label={ __( 'Inherit default layout' ) }
 						checked={ !! inherit }
@@ -91,7 +75,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 						}
 					/>
 				) }
-				{ ! inherit && allowLayoutSwitching && (
+				{ ! inherit && canBlockSwitchLayout && (
 					<LayoutTypeSwitcher
 						type={ type }
 						onChange={ onChangeType }

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -7,22 +7,44 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { appendSelectors } from './utils';
+import { JustifyContentControl } from '../components/justify-content-control';
+
+const HORIZONTAL_JUSTIFY_CONTROLS = {
+	left: 'flex-start',
+	center: 'center',
+	right: 'flex-end',
+	'space-between': 'space-between',
+};
 
 export default {
 	name: 'flex',
 
 	label: __( 'Flex' ),
 
-	edit() {
-		return null;
+	edit: function LayoutFlexEdit( { layout = {}, onChange } ) {
+		const { justifyContent = 'flex-start' } = layout;
+		return (
+			<JustifyContentControl
+				allowedControls={ Object.keys( HORIZONTAL_JUSTIFY_CONTROLS ) }
+				value={ justifyContent }
+				onChange={ ( value ) => {
+					onChange( {
+						...layout,
+						justifyContent: HORIZONTAL_JUSTIFY_CONTROLS[ value ],
+					} );
+				} }
+			/>
+		);
 	},
 
-	save: function FlexLayoutStyle( { selector } ) {
+	save: function FlexLayoutStyle( { selector, layout = {} } ) {
+		const { justifyContent = 'flex-start' } = layout;
 		return (
 			<style>{ `${ appendSelectors( selector ) } {
             display: flex;
             column-gap: 0.5em;
-            align-items: center;
+			flex-direction: row;
+            justify-content: ${ justifyContent };
         }` }</style>
 		);
 	},
@@ -34,4 +56,5 @@ export default {
 	getAlignments() {
 		return [];
 	},
+	canInherit: false,
 };

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -56,5 +56,4 @@ export default {
 	getAlignments() {
 		return [];
 	},
-	canInherit: false,
 };

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -113,11 +113,9 @@ export default {
 						margin-left: auto !important;
 						margin-right: auto !important;
 					}
-	
 					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
 						max-width: ${ wideSize ?? contentSize };
 					}
-	
 					${ appendSelectors( selector, '> [data-align="full"]' ) } {
 						max-width: none;
 					}
@@ -129,7 +127,6 @@ export default {
 				float: left;
 				margin-right: 2em;
 			}
-	
 			${ appendSelectors( selector, '> [data-align="right"]' ) } {
 				float: right;
 				margin-left: 2em;
@@ -152,4 +149,5 @@ export default {
 			? [ 'wide', 'full', 'left', 'center', 'right' ]
 			: [ 'left', 'center', 'right' ];
 	},
+	canInherit: true,
 };

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -149,5 +149,4 @@ export default {
 			? [ 'wide', 'full', 'left', 'center', 'right' ]
 			: [ 'left', 'center', 'right' ];
 	},
-	canInherit: true,
 };

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -43,6 +43,7 @@
 		"anchor": true,
 		"__experimentalLayout": {
 			"allowSwitching": false,
+			"inherit": false,
 			"default": {
 				"type": "flex",
 				"justifyContent": "flex-start",

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -40,7 +40,15 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
-		"anchor": true
+		"anchor": true,
+		"__experimentalLayout": {
+			"allowSwitching": false,
+			"default": {
+				"type": "flex",
+				"justifyContent": "flex-start",
+				"column-gap": "normal"
+			}
+		}
 	},
 	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -10,18 +10,12 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( props ) {
 	const {
-		attributes: {
-			iconBackgroundColorValue,
-			iconColorValue,
-			itemsJustification,
-			size,
-		},
+		attributes: { iconBackgroundColorValue, iconColorValue, size },
 	} = props;
 
 	const className = classNames( size, {
 		'has-icon-color': iconColorValue,
 		'has-icon-background-color': iconBackgroundColorValue,
-		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
 	} );
 
 	return (

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,6 +1,6 @@
 .wp-block-social-links {
-	display: flex;
-	flex-wrap: wrap;
+	// display: flex;
+	// flex-wrap: wrap;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,6 +1,4 @@
 .wp-block-social-links {
-	// display: flex;
-	// flex-wrap: wrap;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Related to: https://github.com/WordPress/gutenberg/pull/33359

This PR is in very early stage, super rough 😄  and tries to explore the new `flex layout` to be used by `Social Icons` block. These explorations will result in discussions about finding the best approach to utilize `layout` to existent blocks like `Buttons` etc..

I'll update the PR's description with my observations and questions. For now I've some comments in the code, for early reviewers.

## Notes
1. I've found a bug in `Social Icons` block and I'll create a separate issue for it, regarding `itemsJustification` attribute which was introduced in https://github.com/WordPress/gutenberg/pull/28980 and wasn't declared in block.json. 
<!-- Please describe what you have changed or added -->
2. I observed that also on `trunk` if you select the block, the alignment is different than the one applied at the end (it uses `flex-start`.


## Early testing instructions
1. Insert `Social Icons` block and in Inspector controls play with the justify content control which has icons for now 😆 
