### PR TITLE
Site Logo: Use getMedia shorthand

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -275,14 +275,12 @@ export default function LogoEdit( {
 		const _siteLogoId = _siteLogo || _readOnlyLogo;
 		const mediaItem =
 			_siteLogoId &&
-			select( coreStore ).getEntityRecord( 'root', 'media', _siteLogoId, {
+			select( coreStore ).getMedia( _siteLogoId, {
 				context: 'view',
 			} );
 		const _isRequestingMediaItem =
 			_siteLogoId &&
-			! select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
-				'root',
-				'media',
+			! select( coreStore ).hasFinishedResolution( 'getMedia', [
 				_siteLogoId,
 				{ context: 'view' },
 			] );


### PR DESCRIPTION
## Description
PR replaces `getEntityRecord` with `getMedia` shorthand for simplicity.

Similar PR: #33943.

## How has this been tested?
This is a non-breaking change. Tested that the "Site Logo" block works as expected.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
