### PR TITLE
Remove a popover menu min-width.

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -29,10 +29,10 @@
 	}
 
 	.block-editor-link-control {
-		width: 200px; // hardcoded width avoids resizing of control when switching between preview/edit
+		width: 220px; // Hardcoded width avoids resizing of control when switching between preview/edit.
 
 		.block-editor-url-input {
-			padding: 0; // cancel unnecessary default 1px padding in this case
+			padding: 0; // Cancel unnecessary default 1px padding in this case.
 		}
 
 		.components-base-control .components-base-control__field {
@@ -41,6 +41,11 @@
 
 		.block-editor-link-control__search-item-title {
 			max-width: 180px;
+			white-space: nowrap;
+		}
+
+		.block-editor-link-control__search-item-info {
+			white-space: nowrap;
 		}
 
 		.block-editor-link-control__search-item.is-current {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -1,7 +1,3 @@
-.components-dropdown-menu__popover .components-popover__content {
-	min-width: 200px;
-}
-
 .components-dropdown-menu__menu {
 	width: 100%;
 	font-family: $default-font;

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -2,6 +2,12 @@
 	display: inline-block;
 }
 
-.components-dropdown__content .components-popover__content > div {
-	padding: $grid-unit-15;
+.components-dropdown__content {
+	.components-popover__content > div {
+		padding: $grid-unit-15;
+	}
+
+	[role="menuitem"] {
+		white-space: nowrap;
+	}
 }


### PR DESCRIPTION
## Description

This PR removes a min-width from the dropdown component. The min-width is meant to ensure that items inside don't collapse or become as small as possible by leveraging word wrapping, which is what happens if we only remove the min-width:

<img width="237" alt="Screenshot 2021-08-11 at 08 36 49" src="https://user-images.githubusercontent.com/1204802/128982588-507e8b64-91cf-4c08-904c-d688b9891c0a.png">

For that reason, I've also added a whitespace rule that ensures that menu items never wrap, as they arguably shouldn't ever do:

<img width="271" alt="Screenshot 2021-08-11 at 08 47 10" src="https://user-images.githubusercontent.com/1204802/128982632-7620c595-fed4-4c26-93f0-1eefd0eed010.png">

It would have been easy to add just the whitespace rule to the particular "open in new window" element. However in a desire to keep the behavior of the child item the responsibility of the parent, this PR puts the CSS directly in the dropdown component. 

<img width="271" alt="Screenshot 2021-08-11 at 08 47 10" src="https://user-images.githubusercontent.com/1204802/128982788-5288bace-39f2-4612-a6b4-ad601e2588d2.png">

What do you think?

The PR itself will also benefit #32926. 

## How has this been tested?

Please test every dropdown that opens a popover menu, and verify none of them look squished.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
