### PR TITLE
[Mobile] - Global styles - Add color to the block styles filter list

### DIFF
--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -7,6 +7,7 @@ export const BLOCK_STYLE_ATTRIBUTES = [
 	'textColor',
 	'backgroundColor',
 	'style',
+	'color',
 ];
 
 // Mapping style properties name to native


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3822

## Description
We [recently added](https://github.com/WordPress/gutenberg/pull/33782) some filtering to prevent passing block style attributes that mobile doesn't support yet, by doing this the `color` styles were being filtered out. This PR adds `color` to the style attributes we support.

## How has this been tested?
- Open the app
- Add a block that supports text color customization, like `Paragraph`
- Open the settings of the block
- Tap on `Text color`
- Go to the end of the list and select `CUSTOM`
- Change the color
- **Expect** to see the text color changing in the block

## Screenshots <!-- if applicable -->
Before|After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/128993918-3ce21e36-4f67-4abe-bd63-fc0760e7a84f.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/128993930-25e1e76e-1d21-4961-9011-4130f6db57ac.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
