### PR TITLE
Fix font specificity.

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -5,16 +5,17 @@
  * of the editor by themes.
  */
 
+// The following styles revert to the browser defaults overriding the WPAdmin styles.
+// This is only needed while the block editor is not being loaded in an iframe.
+// The font-family is output as an inline style, so it needs higher specificity here.
+.editor-styles-wrapper {
+	font-family: serif; // unfortunately initial doesn't work for font-family.
+}
+
 // We use :where to keep specificity minimal.
 // https://css-tricks.com/almanac/selectors/w/where/
 html :where(.editor-styles-wrapper) {
 	padding: 8px;
-
-	/**
-	* The following styles revert to the browser defaults overriding the WPAdmin styles.
-	* This is only needed while the block editor is not being loaded in an iframe.
-	*/
-	font-family: serif; // unfortunately initial doesn't work for font-family.
 	font-size: initial;
 	line-height: initial;
 	color: initial;


### PR DESCRIPTION
## Description

This is a followup to #32659. 

As it turns out, we output the block editor UI font as an inline style, like so:

<img width="688" alt="Screenshot 2021-08-11 at 10 03 53" src="https://user-images.githubusercontent.com/1204802/128994989-4ba26c1b-0658-4859-a781-d70ec293a362.png">

That means the `:where` specificity for the font family was insufficient:

<img width="320" alt="Screenshot 2021-08-11 at 10 04 54" src="https://user-images.githubusercontent.com/1204802/128995025-ae258530-8083-41d1-b85c-a36ba5db3824.png">

_(don't mind the size and height, the screenshot is from a nav menu block where those are set elsewhere)_

The bug was visible in Empty Theme from https://github.com/WordPress/theme-experiments, where the theme doesn't load any styles, and should therefore show the default `serif` font. But it failed:

<img width="907" alt="Screenshot 2021-08-11 at 10 06 03" src="https://user-images.githubusercontent.com/1204802/128995137-2b2a5198-5b51-4413-9448-ca93a7a53ebf.png">

This PR simply restores the font-family rule to its [previous specificity](https://github.com/WordPress/gutenberg/blob/d449b7be08de44e80215e681ae50ce7b86428896/packages/block-library/src/reset.scss), fixing it:

<img width="927" alt="Screenshot 2021-08-11 at 10 17 36" src="https://user-images.githubusercontent.com/1204802/128995179-570d3fd1-a307-40e7-80bb-74c466b58c1c.png">

## How has this been tested?

Try using Empty Theme, and you should see a serif font. In all other themes you should see the fonts they set.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
