### PR TITLE
GitHub Issue Forms: Simplify the bug report form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -7,41 +7,10 @@ body:
           value: |
               Thanks for taking the time to fill out this bug report! If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress
 
-    - type: checkboxes
-      attributes:
-          label: Is there an existing issue for this?
-          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues.
-          options:
-              - label: I have searched the existing issues
-                required: true
-
-    - type: checkboxes
-      attributes:
-          label: Have you tried deactivating all plugins except Gutenberg?
-          description: Please make sure you have ruled out plugin conflicts before reporting.
-          options:
-              - label: I have tested with all plugins deactivated.
-                required: true
-
-    - type: checkboxes
-      attributes:
-          label: Have you tried replicating the bug using a default theme e.g. Twenty Twenty?
-          description: Please make sure you have confirmed it's not a theme specific problem.
-          options:
-              - label: I have tested with a default theme.
-                required: true
-
-    - type: textarea
-      attributes:
-          label: Description
-          description: Please write a brief description of the bug.
-      validations:
-          required: true
-
     - type: textarea
       attributes:
           label: Step-by-step reproduction instructions
-          description: Please list the steps needed to reproduce the bug.
+          description: Please write a brief description of the bug and the steps needed to reproduce it.
           placeholder: |
               1. Go to '...'
               2. Click on '...'
@@ -52,76 +21,43 @@ body:
 
     - type: textarea
       attributes:
-          label: Expected Behavior
-          description: Please describe what you expected to happen.
+          label: Expected vs Current Behavior
+          description: Please describe what you expected to happen and what you are actually experiencing.
       validations:
           required: true
 
     - type: textarea
       attributes:
-          label: Current Behavior
-          description: A concise description of what you're experiencing.
-      validations:
-          required: true
-
-    - type: textarea
-      attributes:
-          label: Screenshots or screen recording (optional)
+          label: Screenshots, screen recording, or code snippet (optional)
           description: |
               If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
               Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-      validations:
-          required: false
-
-    - type: textarea
-      attributes:
-          label: Code snippet (optional)
-          description: |
               If this bug is to related to a developer API, please share a code snippet that demonstrates the issue. For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
-              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue.
-      validations:
+              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
+          validations:
           required: false
 
     - type: textarea
       attributes:
-          label: WordPress Information
-          description: |
-              Please list what WordPress version you are using. You can find this information in Tools → Site Health → Info → WordPress
-      validations:
-          required: false
-
-    - type: textarea
-      attributes:
-          label: Gutenberg Information
+          label: Environment info
           description: |
               Please list what Gutenberg version you are using. If you aren't using Gutenberg, please note that it's not installed.
+          placeholder: |
+            - WordPress version, Gutenberg version.
+            - Browser(s) are you seeing the problem on.
+            - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.)
       validations:
           required: false
-
-    - type: dropdown
-      id: browsers
+          
+    - type: checkboxes
       attributes:
-          label: What browsers are you seeing the problem on?
-          multiple: true
+          label: Prechecks
+          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting it's neither related to another plugin nor theme specific.
           options:
-              - Firefox
-              - Chrome
-              - Safari
-              - Microsoft Edge
-              - Other
-
-    - type: textarea
-      attributes:
-          label: Device Information
-          description: |
-              Please list what device you are using e.g. "Desktop" or "iPhone 11".
-      validations:
-          required: false
-
-    - type: textarea
-      attributes:
-          label: Operating System Information
-          description: |
-              Please list what operating system you are using e.g. "Windows 10" or "iOS 14"
-      validations:
-          required: false
+              - label: I have searched the existing issues
+                required: true
+              - label: I have tested with all plugins deactivated except Gutenberg.
+                required: true
+              - label: I have tested with a default theme.
+                required: true
+ 

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -14,14 +14,17 @@ body:
               1. Go to '...'
               2. Click on '...'
               3. Scroll down to '...'
-              4. See error...
+              4. See error '...'
       validations:
           required: true
 
     - type: textarea
       attributes:
           label: Expected vs Current Behavior
-          description: Please describe what you expected to happen and what you are actually experiencing.
+          description: Please describe what you expect to happen and what is currently happening.
+          placeholder: |
+              - I expect '...' to happen
+              - However, '...' happens
       validations:
           required: true
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -6,10 +6,9 @@ body:
       attributes:
           value: |
               Thanks for taking the time to fill out this bug report! If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress
-
     - type: textarea
       attributes:
-          label: Step-by-step reproduction instructions
+          label: Description ands step-by-step reproduction instructions
           description: Please write a brief description of the bug and the steps needed to reproduce it.
           placeholder: |
               1. Go to '...'
@@ -28,13 +27,13 @@ body:
 
     - type: textarea
       attributes:
-          label: Screenshots, screen recording, or code snippet (optional)
+          label: Screenshots, screen recording, code snippet (optional)
           description: |
               If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
               Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
               If this bug is to related to a developer API, please share a code snippet that demonstrates the issue. For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
               Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
-          validations:
+      validations:
           required: false
 
     - type: textarea
@@ -52,12 +51,11 @@ body:
     - type: checkboxes
       attributes:
           label: Prechecks
-          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting it's neither related to another plugin nor theme specific.
+          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting the bug is neither related to another plugin nor theme specific.
           options:
-              - label: I have searched the existing issues
+              - label: I have searched the existing issues.
                 required: true
               - label: I have tested with all plugins deactivated except Gutenberg.
                 required: true
               - label: I have tested with a default theme.
                 required: true
- 

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -54,8 +54,5 @@ body:
           description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting the bug is neither related to another plugin nor theme specific.
           options:
               - label: I have searched the existing issues.
-                required: true
               - label: I have tested with all plugins deactivated except Gutenberg.
-                required: true
               - label: I have tested with a default theme.
-                required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -21,7 +21,7 @@ body:
 
     - type: textarea
       attributes:
-          label: Screenshots, screen recording, code snippet (optional)
+          label: Screenshots, screen recording, code snippet
           description: |
               If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
               Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
@@ -38,7 +38,7 @@ body:
           placeholder: |
             - WordPress version, Gutenberg version.
             - Browser(s) are you seeing the problem on.
-            - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.)
+            - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
       validations:
           required: false
           

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -8,23 +8,14 @@ body:
               Thanks for taking the time to fill out this bug report! If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress
     - type: textarea
       attributes:
-          label: Description ands step-by-step reproduction instructions
-          description: Please write a brief description of the bug and the steps needed to reproduce it.
+          label: Description and step-by-step reproduction instructions
+          description: Please write a brief description of the bug and the steps needed to reproduce it, including what you expect to happen and what is currently happening.
           placeholder: |
+              Feature '...' is not working properly because '...'. Steps to reproduce:
               1. Go to '...'
               2. Click on '...'
               3. Scroll down to '...'
-              4. See error '...'
-      validations:
-          required: true
-
-    - type: textarea
-      attributes:
-          label: Expected vs Current Behavior
-          description: Please describe what you expect to happen and what is currently happening.
-          placeholder: |
-              - I expect '...' to happen
-              - However, '...' happens
+              4. I expect '...' to happen, but '...' happens instead
       validations:
           required: true
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -8,14 +8,21 @@ body:
               Thanks for taking the time to fill out this bug report! If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress
     - type: textarea
       attributes:
-          label: Description and step-by-step reproduction instructions
-          description: Please write a brief description of the bug and the steps needed to reproduce it, including what you expect to happen and what is currently happening.
+          label: Description
+          description: Please write a brief description of the bug, including what you expect to happen and what is currently happening.
           placeholder: |
-              Feature '...' is not working properly because '...'. Steps to reproduce:
+              Feature '...' is not working properly. I expect '...' to happen, but '...' happens instead
+      validations:
+          required: true
+          
+    - type: textarea
+      attributes:
+          label: Step-by-step reproduction instructions
+          description: Please write the steps needed to reproduce the bug.
+          placeholder: |
               1. Go to '...'
               2. Click on '...'
               3. Scroll down to '...'
-              4. I expect '...' to happen, but '...' happens instead
       validations:
           required: true
 
@@ -36,7 +43,7 @@ body:
           description: |
               Please list what Gutenberg version you are using. If you aren't using Gutenberg, please note that it's not installed.
           placeholder: |
-            - WordPress version, Gutenberg version.
+            - WordPress version, Gutenberg version, and active Theme you are using.
             - Browser(s) are you seeing the problem on.
             - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
       validations:
@@ -45,8 +52,7 @@ body:
     - type: checkboxes
       attributes:
           label: Pre-checks
-          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting the bug is neither related to another plugin nor theme specific.
+          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure the bug is not related to another plugin.
           options:
               - label: I have searched the existing issues.
               - label: I have tested with all plugins deactivated except Gutenberg.
-              - label: I have tested with a default theme.

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -50,7 +50,7 @@ body:
           
     - type: checkboxes
       attributes:
-          label: Prechecks
+          label: Pre-checks
           description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure before reporting the bug is neither related to another plugin nor theme specific.
           options:
               - label: I have searched the existing issues.


### PR DESCRIPTION
## Description
Followup to #33713. The first iteration on using form templates directly translated the markdown template to a form template. However, markdown templates allow for users to easily delete parts of it and adjust it to the report, whereas with the form template the report needs to be adapted entirely to the form. This leads to:
- When reporting, a long form that can't be tweaked and creates friction.
- Once reported, long reports even when optional fields are left empty

## Proposed changes
- Grouped the pre-checks into a single group.
- Moved the pre-checks to the bottom. Although being on top might help some users that are not aware of those recommendations, in general, it should be ok having them at the bottom similar to how checkboxes to "Accept terms" are at the bottom of forms. The main benefit, though, is avoiding having these checkboxes at the start of the bug report once submitted, where the most relevant information should be.
- Grouped together description and steps to reproduce.
- Grouped together expected vs actual behavior.
- Grouped together screenshots and code snippets as extra resources.
- Grouped together all environment-related fields (WordPress and Gutenberg versions, browser, device, OS).

Update after review feedback:
- Grouped together description, steps to reproduce, expected vs actual behavior.
- Make checkboxes optional

Update 2021-08-12:
- Split description and reproduction steps. 
- Removed "default theme" checkbox and moved the theme information to the environment section.

You can try the proposed changes [in this fork](https://github.com/priethor/gutenberg/issues/new?assignees=&labels=&template=Bug_report.yml&title=%3Ctitle%3E).

## Screenshots <!-- if applicable -->
Current bug report result if fields are empty:

![image](https://user-images.githubusercontent.com/27339341/129007407-f6e46fc7-7194-4006-8560-d18b7a0480c8.png)

Proposed new form (updated with the last changes after review):

![image](https://user-images.githubusercontent.com/27339341/129183823-808e5a5a-e346-49a6-9f51-0add7b8d173a.png)





