### PR TITLE
Block editor: prevent inline-block editable element from capturing focus from clearer element

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -40,7 +40,11 @@ export function useBlockSelectionClearer() {
 					return;
 				}
 
+				const { ownerDocument } = node;
+				const { defaultView } = ownerDocument;
+
 				clearSelectedBlock();
+				defaultView.getSelection().removeAllRanges();
 			}
 
 			node.addEventListener( 'mousedown', onMouseDown );

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -25,12 +25,18 @@ export function useBlockSelectionClearer() {
 	return useRefEffect(
 		( node ) => {
 			function onMouseDown( event ) {
-				if ( ! hasSelectedBlock() && ! hasMultiSelection() ) {
+				// Only handle clicks on the element, not the children.
+				if ( event.target !== node ) {
 					return;
 				}
 
-				// Only handle clicks on the element, not the children.
-				if ( event.target !== node ) {
+				// Prevent default browser behaviour:
+				// Some browsers redirect focus to the horizontally closest
+				// inline-block element.
+				// See https://stackoverflow.com/questions/34354085/clicking-outside-a-contenteditable-div-stills-give-focus-to-it
+				event.preventDefault();
+
+				if ( ! hasSelectedBlock() && ! hasMultiSelection() ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -35,6 +35,7 @@ export function useBlockSelectionClearer() {
 				// inline-block element.
 				// See https://stackoverflow.com/questions/34354085/clicking-outside-a-contenteditable-div-stills-give-focus-to-it
 				event.preventDefault();
+				node.closest( '[tabindex]' ).focus();
 
 				if ( ! hasSelectedBlock() && ! hasMultiSelection() ) {
 					return;

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,20 +21,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import { usePopoverScroll } from './use-popover-scroll';
 
-/**
- * Renders block tools (the block toolbar, select/navigation mode toolbar, the
- * insertion point and a slot for the inline rich text toolbar). Must be wrapped
- * around the block content and editor styles wrapper or iframe.
- *
- * @param {Object} $0                      Props.
- * @param {Object} $0.children             The block content and style container.
- * @param {Object} $0.__unstableContentRef Ref holding the content scroll container.
- */
-export default function BlockTools( {
-	children,
-	__unstableContentRef,
-	...props
-} ) {
+function BlockTools( { children, __unstableContentRef, ...props }, ref ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const hasFixedToolbar = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().hasFixedToolbar,
@@ -114,7 +102,7 @@ export default function BlockTools( {
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div { ...props } onKeyDown={ onKeyDown }>
+		<div { ...props } onKeyDown={ onKeyDown } ref={ ref }>
 			<InsertionPoint __unstableContentRef={ __unstableContentRef }>
 				{ ( hasFixedToolbar || ! isLargeViewport ) && (
 					<BlockContextualToolbar isFixed />
@@ -134,3 +122,14 @@ export default function BlockTools( {
 		</div>
 	);
 }
+
+/**
+ * Renders block tools (the block toolbar, select/navigation mode toolbar, the
+ * insertion point and a slot for the inline rich text toolbar). Must be wrapped
+ * around the block content and editor styles wrapper or iframe.
+ *
+ * @param {Object} $0                      Props.
+ * @param {Object} $0.children             The block content and style container.
+ * @param {Object} $0.__unstableContentRef Ref holding the content scroll container.
+ */
+export default forwardRef( BlockTools );

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -160,19 +160,15 @@ export default function Layout( { blockEditorSettings } ) {
 											/>
 										) }
 									{ isBlockEditorReady && (
-										<div
+										<BlockTools
 											className="edit-navigation-layout__content-area"
 											ref={ contentAreaRef }
 										>
-											<BlockTools>
-												<Editor
-													isPending={
-														! hasLoadedMenus
-													}
-													blocks={ blocks }
-												/>
-											</BlockTools>
-										</div>
+											<Editor
+												isPending={ ! hasLoadedMenus }
+												blocks={ blocks }
+											/>
+										</BlockTools>
 									) }
 								</>
 							}


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #33692.

See https://stackoverflow.com/questions/34354085/clicking-outside-a-contenteditable-div-stills-give-focus-to-it for some more information.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Place focus in a button block. Clear selection. Now click next to the button block. The button block should not receive focus.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
