### PR TITLE
Remove extra dom element used for template part overlay

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/index.js
+++ b/packages/block-editor/src/components/block-content-overlay/index.js
@@ -87,13 +87,10 @@ export default function BlockContentOverlay( {
 			className={ classes }
 			onMouseEnter={ () => setIsHovered( true ) }
 			onMouseLeave={ () => setIsHovered( false ) }
+			onMouseUp={
+				isOverlayActive ? () => setIsOverlayActive( false ) : undefined
+			}
 		>
-			{ isOverlayActive && (
-				<div
-					className={ `${ baseClassName }__overlay` }
-					onMouseUp={ () => setIsOverlayActive( false ) }
-				/>
-			) }
 			{ wrapperProps?.children }
 		</TagName>
 	);

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -10,6 +10,7 @@
 		border: none;
 		border-radius: $radius-block-ui;
 		z-index: z-index(".block-editor-block-content-overlay__overlay");
+		pointer-events: none;
 	}
 
 	&:hover:not(.is-dragging-blocks).overlay-active::before,

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,5 +1,5 @@
 .block-editor-block-content-overlay {
-	&::before {
+	&.overlay-active::before {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -12,8 +12,8 @@
 		z-index: z-index(".block-editor-block-content-overlay__overlay");
 	}
 
-	&:hover:not(.is-dragging-blocks)::before,
-	&.parent-highlighted::before {
+	&:hover:not(.is-dragging-blocks).overlay-active::before,
+	&.parent-highlighted.overlay-active::before {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
@@ -24,7 +24,7 @@
 
 	&.is-dragging-blocks {
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-		&::before {
+		&.overlay-active::before {
 			pointer-events: none;
 		}
 	}

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -18,14 +18,11 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
-	&.overlay-active:not(.is-dragging-blocks)::before {
+	&.overlay-active * {
 		pointer-events: none;
 	}
 
 	&.is-dragging-blocks {
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-		&.overlay-active::before {
-			pointer-events: none;
-		}
 	}
 }

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,12 +1,6 @@
-// Specificity required to ensure overlay width is not restricted to that
-// of standard block content.  The overlay's width should be as wide as
-// its children require.
-.editor-styles-wrapper .wp-block .block-editor-block-content-overlay__overlay {
-	max-width: none;
-}
-
 .block-editor-block-content-overlay {
-	.block-editor-block-content-overlay__overlay {
+	&::before {
+		content: "";
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -18,23 +12,19 @@
 		z-index: z-index(".block-editor-block-content-overlay__overlay");
 	}
 
-	&:hover:not(.is-dragging-blocks),
-	&.parent-highlighted {
-		> .block-editor-block-content-overlay__overlay {
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-		}
+	&:hover:not(.is-dragging-blocks)::before,
+	&.parent-highlighted::before {
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
-	&.overlay-active:not(.is-dragging-blocks) {
-		*:not(.block-editor-block-content-overlay__overlay) {
-			pointer-events: none;
-		}
+	&.overlay-active:not(.is-dragging-blocks)::before {
+		pointer-events: none;
 	}
 
 	&.is-dragging-blocks {
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-		.block-editor-block-content-overlay__overlay {
+		&::before {
 			pointer-events: none;
 		}
 	}

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -18,7 +18,7 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
-	&.overlay-active * {
+	&.overlay-active:not(.is-dragging-blocks) * {
 		pointer-events: none;
 	}
 

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -107,6 +107,15 @@ export function useInBetweenInserter() {
 					}
 				}
 
+				// Don't show the insertion point if a parent block has an "overlay"
+				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
+				const parentOverlay = element.closest(
+					'.block-editor-block-content-overlay.overlay-active'
+				);
+				if ( parentOverlay && element !== parentOverlay ) {
+					return;
+				}
+
 				const clientId = element.id.slice( 'block-'.length );
 
 				if ( ! clientId ) {

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -109,10 +109,10 @@ export function useInBetweenInserter() {
 
 				// Don't show the insertion point if a parent block has an "overlay"
 				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
-				const parentOverlay = element.closest(
+				const parentOverlay = element.parentElement?.closest(
 					'.block-editor-block-content-overlay.overlay-active'
 				);
-				if ( parentOverlay && element !== parentOverlay ) {
+				if ( parentOverlay ) {
 					return;
 				}
 


### PR DESCRIPTION
Extra DOM elements in the canvas of the editor can have unexpected side effects and we tend to avoid them as much as possible. Recently we added an overlay div to have some kind of drill down behavior in template parts, it's causing some issues as you see here https://github.com/WordPress/gutenberg/pull/33812#issuecomment-896808646 

This PR tries to refactor it to avoid the extra element. I'm not very familiar with the expected behavior there so I might need some help getting everything right.

