### PR TITLE
components: Add deprecated props adapter for ColorPicker

### DIFF
--- a/packages/components/src/ui/color-picker/component.tsx
+++ b/packages/components/src/ui/color-picker/component.tsx
@@ -32,7 +32,7 @@ import { useControlledValue } from '../../utils/hooks';
 
 import type { ColorType } from './types';
 
-interface ColorPickerProps {
+export interface ColorPickerProps {
 	enableAlpha?: boolean;
 	color?: ColorFormats.HSL | ColorFormats.HSLA;
 	onChange?: ( color: ColorFormats.HSL | ColorFormats.HSLA ) => void;
@@ -62,6 +62,7 @@ const ColorPicker = (
 		onChange,
 		defaultValue,
 		copyFormat,
+		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
 	const [ color, setColor ] = useControlledValue( {
@@ -88,7 +89,7 @@ const ColorPicker = (
 	);
 
 	return (
-		<ColorfulWrapper ref={ forwardedRef }>
+		<ColorfulWrapper ref={ forwardedRef } { ...divProps }>
 			<Picker
 				onChange={ handleChange }
 				color={ safeColor }

--- a/packages/components/src/ui/color-picker/index.ts
+++ b/packages/components/src/ui/color-picker/index.ts
@@ -1,1 +1,1 @@
-export { default as ColorPicker } from './component';
+export { LegacyAdapter as ColorPicker } from './legacy-adapter';

--- a/packages/components/src/ui/color-picker/legacy-adapter.tsx
+++ b/packages/components/src/ui/color-picker/legacy-adapter.tsx
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import ColorPicker from './component';
+import { useDeprecatedProps } from './use-deprecated-props';
+
+type LegacyAdapterProps = Parameters< typeof useDeprecatedProps >[ 0 ];
+
+export const LegacyAdapter = ( props: LegacyAdapterProps ) => {
+	return <ColorPicker { ...useDeprecatedProps( props ) } />;
+};

--- a/packages/components/src/ui/color-picker/stories/index.js
+++ b/packages/components/src/ui/color-picker/stories/index.js
@@ -64,6 +64,7 @@ const LegacyExample = () => {
 	const legacyProps = {
 		color: legacyColor,
 		onChangeComplete: setLegacyColor,
+		disableAlpha: boolean( 'disableAlpha', true ),
 	};
 
 	return (

--- a/packages/components/src/ui/color-picker/stories/index.js
+++ b/packages/components/src/ui/color-picker/stories/index.js
@@ -13,7 +13,6 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { ColorPicker } from '..';
-import { LegacyAdapter } from '../legacy-adapter';
 import { Flex } from '../../../flex';
 import { Spacer } from '../../../spacer';
 import { space } from '../../utils/space';
@@ -69,7 +68,7 @@ const LegacyExample = () => {
 
 	return (
 		<Flex align="flex-start" justify="flex-start">
-			<LegacyAdapter { ...legacyProps } />
+			<ColorPicker { ...legacyProps } />
 			<pre style={ { width: '20em' } }>
 				{ JSON.stringify( legacyColor, undefined, 4 ) }
 			</pre>

--- a/packages/components/src/ui/color-picker/stories/index.js
+++ b/packages/components/src/ui/color-picker/stories/index.js
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { ColorPicker } from '..';
+import { LegacyAdapter } from '../legacy-adapter';
 import { Flex } from '../../../flex';
 import { Spacer } from '../../../spacer';
 import { space } from '../../utils/space';
@@ -57,3 +58,22 @@ const Example = () => {
 export const _default = () => {
 	return <Example />;
 };
+
+const LegacyExample = () => {
+	const [ legacyColor, setLegacyColor ] = useState( '#fff' );
+	const legacyProps = {
+		color: legacyColor,
+		onChangeComplete: setLegacyColor,
+	};
+
+	return (
+		<Flex align="flex-start" justify="flex-start">
+			<LegacyAdapter { ...legacyProps } />
+			<pre style={ { width: '20em' } }>
+				{ JSON.stringify( legacyColor, undefined, 4 ) }
+			</pre>
+		</Flex>
+	);
+};
+
+export const legacy = () => <LegacyExample />;

--- a/packages/components/src/ui/color-picker/test/index.js
+++ b/packages/components/src/ui/color-picker/test/index.js
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPicker } from '..';
+
+/**
+ * Ordinarily we'd try to select the compnoent by role but the silder role appears
+ * on several elements and we'd end up encoding assumptions about order when
+ * trying to select the appropriate element. We might as well just use the classname
+ * on the container which will be more durable if, for example, the order changes.
+ *
+ * @param {HTMLElement} container
+ * @return {HTMLElement} The saturation element
+ */
+function getSaturation( container ) {
+	return container.querySelector(
+		'.react-colorful__saturation .react-colorful__interactive'
+	);
+}
+
+// Fix to pass `pageX` and `pageY`
+// See https://github.com/testing-library/react-testing-library/issues/268
+class FakeMouseEvent extends window.MouseEvent {
+	constructor( type, values = {} ) {
+		super( type, { buttons: 1, bubbles: true, ...values } );
+
+		Object.assign( this, {
+			pageX: values.pageX || 0,
+			pageY: values.pageY || 0,
+		} );
+	}
+}
+
+function moveReactColorfulSlider( sliderElement, from, to ) {
+	fireEvent( sliderElement, new FakeMouseEvent( 'mousedown', from ) );
+	fireEvent( sliderElement, new FakeMouseEvent( 'mousemove', to ) );
+}
+
+const sleep = ( ms ) => {
+	const promise = new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+	jest.advanceTimersByTime( ms + 1 );
+	return promise;
+};
+
+const hslMatcher = expect.objectContaining( {
+	h: expect.any( Number ),
+	s: expect.any( Number ),
+	l: expect.any( Number ),
+} );
+
+const hslaMatcher = expect.objectContaining( {
+	h: expect.any( Number ),
+	s: expect.any( Number ),
+	l: expect.any( Number ),
+	a: expect.any( Number ),
+} );
+
+const legacyColorMatcher = {
+	color: expect.anything(),
+	hex: expect.any( String ),
+	hsl: hslaMatcher,
+	hsv: expect.objectContaining( {
+		h: expect.any( Number ),
+		s: expect.any( Number ),
+		v: expect.any( Number ),
+		a: expect.any( Number ),
+	} ),
+	rgb: expect.objectContaining( {
+		r: expect.any( Number ),
+		g: expect.any( Number ),
+		b: expect.any( Number ),
+		a: expect.any( Number ),
+	} ),
+	oldHue: expect.any( Number ),
+	source: 'hex',
+};
+
+describe( 'ColorPicker', () => {
+	describe( 'legacy props', () => {
+		it( 'should fire onChangeComplete with the legacy color format', async () => {
+			const onChangeComplete = jest.fn();
+			const color = '#fff';
+
+			const { container } = render(
+				<ColorPicker
+					onChangeComplete={ onChangeComplete }
+					color={ color }
+				/>
+			);
+
+			const saturation = getSaturation( container );
+			moveReactColorfulSlider(
+				saturation,
+				{ pageX: 0, pageY: 0 },
+				{ pageX: 10, pageY: 10 }
+			);
+
+			// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+			await sleep( 1 );
+
+			expect( onChangeComplete ).toHaveBeenCalledWith(
+				legacyColorMatcher
+			);
+		} );
+	} );
+
+	it( 'should fire onChange with the HSLA value', async () => {
+		const onChange = jest.fn();
+		const color = {
+			h: 125,
+			s: 0.2,
+			l: 0.5,
+			a: 0.5,
+		};
+
+		const { container } = render(
+			<ColorPicker onChange={ onChange } color={ color } enableAlpha />
+		);
+
+		const saturation = getSaturation( container );
+		moveReactColorfulSlider(
+			saturation,
+			{ pageX: 0, pageY: 0 },
+			{ pageX: 10, pageY: 10 }
+		);
+
+		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+		await sleep( 1 );
+
+		expect( onChange ).toHaveBeenCalledWith( hslaMatcher );
+	} );
+
+	it( 'should fire onChange with the HSL value', async () => {
+		const onChange = jest.fn();
+		const color = {
+			h: 125,
+			s: 0.2,
+			l: 0.5,
+			// add alpha to prove it's ignored
+			a: 0.5,
+		};
+
+		const { container } = render(
+			<ColorPicker
+				onChange={ onChange }
+				color={ color }
+				enableAlpha={ false }
+			/>
+		);
+
+		const saturation = getSaturation( container );
+		moveReactColorfulSlider(
+			saturation,
+			{ pageX: 0, pageY: 0 },
+			{ pageX: 10, pageY: 10 }
+		);
+
+		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+		await sleep( 1 );
+
+		expect( onChange ).toHaveBeenCalledWith( hslMatcher );
+	} );
+} );

--- a/packages/components/src/ui/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/ui/color-picker/use-deprecated-props.ts
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import colorize, { ColorFormats } from 'tinycolor2';
+// eslint-disable-next-line no-restricted-imports
+import type { ComponentProps } from 'react';
+import memoize from 'memize';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type ColorPicker from './component';
+
+type ColorPickerProps = ComponentProps< typeof ColorPicker >;
+
+/**
+ * @deprecated
+ */
+type LegacyColor =
+	| string
+	| {
+			hex: string;
+			hsl: ColorFormats.HSL | ColorFormats.HSLA;
+			hsv: ColorFormats.HSV | ColorFormats.HSVA;
+			rgb: ColorFormats.RGB | ColorFormats.RGBA;
+			/**
+			 * @deprecated
+			 */
+			oldHue: number;
+			/**
+			 * @deprecated
+			 */
+			source: 'hex';
+			draftHex: string;
+			draftHsl: ColorFormats.HSL | ColorFormats.HSLA;
+			draftRgb: ColorFormats.RGB | ColorFormats.RGBA;
+	  };
+
+/**
+ * @deprecated
+ */
+export interface LegacyProps {
+	color: LegacyColor;
+	/**
+	 * @deprecated
+	 */
+	onChangeComplete: ( colors: LegacyColor ) => void;
+	/**
+	 * @deprecated
+	 */
+	oldHue: string;
+	className: string;
+	/**
+	 * @deprecated
+	 */
+	disableAlpha: boolean;
+}
+
+function isLegacyProps( props: any ): props is LegacyProps {
+	return typeof props.onChangeComplete !== 'undefined';
+}
+
+function getColorFromLegacyProps(
+	props: LegacyProps
+): ColorFormats.HSL | ColorFormats.HSLA {
+	if ( typeof props.color === 'string' ) {
+		return colorize( props.color ).toHsl();
+	}
+
+	return props.color.hsl;
+}
+
+function toHsv(
+	color: colorize.Instance
+): ColorFormats.HSV | ColorFormats.HSVA {
+	const { h, s, v, a } = color.toHsv();
+
+	return {
+		h: Math.round( h ),
+		s: Math.round( s * 100 ),
+		v: Math.round( v * 100 ),
+		a,
+	};
+}
+
+const transformHslToLegacyColor = memoize(
+	( hsla: ColorFormats.HSL | ColorFormats.HSLA ): LegacyColor => {
+		const color = colorize( hsla );
+		const rawHex = color.toHex();
+		const rgb = color.toRgb();
+		const hsv = toHsv( color );
+		const hsl = hsla;
+
+		const isTransparent = rawHex === '000000' && rgb.a === 0;
+
+		const hex = isTransparent ? 'transparent' : `#${ rawHex }`;
+
+		return {
+			hex,
+			rgb,
+			hsv,
+			hsl,
+			draftHex: hex.toLowerCase(),
+			draftHsl: hsl,
+			draftRgb: rgb,
+			source: 'hex',
+			oldHue: hsl.h,
+		};
+	}
+);
+
+export function useDeprecatedProps(
+	props: LegacyProps | ColorPickerProps
+): ColorPickerProps {
+	const onChange = useCallback(
+		( hsla: ColorFormats.HSL | ColorFormats.HSLA ) => {
+			if ( isLegacyProps( props ) ) {
+				return props.onChangeComplete(
+					transformHslToLegacyColor( hsla )
+				);
+			}
+
+			return props.onChange?.( hsla );
+		},
+		[
+			( props as LegacyProps ).onChangeComplete,
+			( props as ColorPickerProps ).onChange,
+		]
+	);
+
+	const color = useMemo( () => {
+		return isLegacyProps( props )
+			? getColorFromLegacyProps( props )
+			: props.color;
+	}, [ props.color ] );
+
+	const enableAlpha = useMemo( () => {
+		return isLegacyProps( props )
+			? ! props.disableAlpha
+			: props.enableAlpha;
+	}, [
+		( props as LegacyProps ).disableAlpha,
+		( props as ColorPickerProps ).enableAlpha,
+	] );
+
+	return {
+		...( isLegacyProps( props ) ? {} : props ),
+		onChange,
+		color,
+		enableAlpha,
+	};
+}

--- a/packages/components/src/ui/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/ui/color-picker/use-deprecated-props.ts
@@ -24,6 +24,7 @@ type ColorPickerProps = ComponentProps< typeof ColorPicker >;
 type LegacyColor =
 	| string
 	| {
+			color: colorize.Instance;
 			hex: string;
 			hsl: ColorFormats.HSL | ColorFormats.HSLA;
 			hsv: ColorFormats.HSV | ColorFormats.HSVA;
@@ -36,9 +37,6 @@ type LegacyColor =
 			 * @deprecated
 			 */
 			source: 'hex';
-			draftHex: string;
-			draftHsl: ColorFormats.HSL | ColorFormats.HSLA;
-			draftRgb: ColorFormats.RGB | ColorFormats.RGBA;
 	  };
 
 /**
@@ -65,7 +63,7 @@ function isLegacyProps( props: any ): props is LegacyProps {
 	return (
 		typeof props.onChangeComplete !== 'undefined' ||
 		typeof props.color === 'string' ||
-		typeof props.hex === 'string'
+		typeof props.color.hex === 'string'
 	);
 }
 
@@ -105,13 +103,11 @@ const transformHslToLegacyColor = memoize(
 		const hex = isTransparent ? 'transparent' : `#${ rawHex }`;
 
 		return {
+			color,
 			hex,
 			rgb,
 			hsv,
 			hsl,
-			draftHex: hex.toLowerCase(),
-			draftHsl: hsl,
-			draftRgb: rgb,
 			source: 'hex',
 			oldHue: hsl.h,
 		};

--- a/packages/components/src/ui/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/ui/color-picker/use-deprecated-props.ts
@@ -62,7 +62,11 @@ export interface LegacyProps {
 }
 
 function isLegacyProps( props: any ): props is LegacyProps {
-	return typeof props.onChangeComplete !== 'undefined';
+	return (
+		typeof props.onChangeComplete !== 'undefined' ||
+		typeof props.color === 'string' ||
+		typeof props.hex === 'string'
+	);
 }
 
 function getColorFromLegacyProps(

--- a/packages/components/src/ui/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/ui/color-picker/use-deprecated-props.ts
@@ -63,7 +63,7 @@ function isLegacyProps( props: any ): props is LegacyProps {
 	return (
 		typeof props.onChangeComplete !== 'undefined' ||
 		typeof props.color === 'string' ||
-		typeof props.color.hex === 'string'
+		typeof props.color?.hex === 'string'
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a `useDeprecatedProps` hook as well as a LegacyAdapter component that acts as a proxy for the new color picker and transforms the deprecated props into the new version of the props (while also allowing for the new props to be passed directly).

## How has this been tested?
Storybook. The existing story for the new color picker should continue to work (even though it is now using the LegacyAdapter). Likewise, the new story for the legacy adapter should work with all the features of the new color picker correctly working as well as the correct shape of the legacy color values being emitted in the "onChangeComplete" prop. Please refer to the `colorToState` in `components/src/color-picker/utils.js` to double check the shape of the color picker change object.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
