### PR TITLE
[Components - Segmented Control]: Use BaseControl as a wrapper and add `help` property

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -1,11 +1,15 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import {
 	PanelBody,
 	__experimentalUnitControl as UnitControl,
-	BaseControl,
 	Flex,
 	FlexItem,
 	__experimentalSegmentedControl as SegmentedControl,
@@ -60,32 +64,36 @@ const DimensionControls = ( {
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 	return (
 		<PanelBody title={ __( 'Dimensions' ) }>
-			<BaseControl>
-				<Flex justify="space-between">
-					<FlexItem>
-						<UnitControl
-							label={ __( 'Height' ) }
-							labelPosition="top"
-							value={ height || '' }
-							onChange={ ( nextHeight ) => {
-								onDimensionChange( 'height', nextHeight );
-							} }
-							units={ units }
-						/>
-					</FlexItem>
-					<FlexItem>
-						<UnitControl
-							label={ __( 'Width' ) }
-							labelPosition="top"
-							value={ width || '' }
-							onChange={ ( nextWidth ) => {
-								onDimensionChange( 'width', nextWidth );
-							} }
-							units={ units }
-						/>
-					</FlexItem>
-				</Flex>
-			</BaseControl>
+			<Flex
+				justify="space-between"
+				className={ classNames(
+					'block-library-post-featured-image-dimension-controls',
+					{ 'scale-control-is-visible': !! height }
+				) }
+			>
+				<FlexItem>
+					<UnitControl
+						label={ __( 'Height' ) }
+						labelPosition="top"
+						value={ height || '' }
+						onChange={ ( nextHeight ) => {
+							onDimensionChange( 'height', nextHeight );
+						} }
+						units={ units }
+					/>
+				</FlexItem>
+				<FlexItem>
+					<UnitControl
+						label={ __( 'Width' ) }
+						labelPosition="top"
+						value={ width || '' }
+						onChange={ ( nextWidth ) => {
+							onDimensionChange( 'width', nextWidth );
+						} }
+						units={ units }
+					/>
+				</FlexItem>
+			</Flex>
 			{ !! height && (
 				<SegmentedControl
 					label={ scaleLabel }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -60,55 +60,45 @@ const DimensionControls = ( {
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 	return (
 		<PanelBody title={ __( 'Dimensions' ) }>
-			<Flex justify="space-between">
-				<FlexItem>
-					<UnitControl
-						label={ __( 'Height' ) }
-						labelPosition="top"
-						value={ height || '' }
-						onChange={ ( nextHeight ) => {
-							onDimensionChange( 'height', nextHeight );
-						} }
-						units={ units }
-					/>
-				</FlexItem>
-				<FlexItem>
-					<UnitControl
-						label={ __( 'Width' ) }
-						labelPosition="top"
-						value={ width || '' }
-						onChange={ ( nextWidth ) => {
-							onDimensionChange( 'width', nextWidth );
-						} }
-						units={ units }
-					/>
-				</FlexItem>
-			</Flex>
-			{ !! height && (
-				<>
-					<BaseControl
-						aria-label={ scaleLabel }
-						className="block-library-post-featured-image-scale-controls"
-					>
-						<div>
-							<BaseControl.VisualLabel>
-								{ scaleLabel }
-							</BaseControl.VisualLabel>
-						</div>
-						<SegmentedControl
-							label={ scaleLabel }
-							value={ scale }
-							onChange={ ( value ) => {
-								setAttributes( {
-									scale: value,
-								} );
+			<BaseControl>
+				<Flex justify="space-between">
+					<FlexItem>
+						<UnitControl
+							label={ __( 'Height' ) }
+							labelPosition="top"
+							value={ height || '' }
+							onChange={ ( nextHeight ) => {
+								onDimensionChange( 'height', nextHeight );
 							} }
-							isBlock
-						>
-							{ SCALE_OPTIONS }
-						</SegmentedControl>
-					</BaseControl>
-				</>
+							units={ units }
+						/>
+					</FlexItem>
+					<FlexItem>
+						<UnitControl
+							label={ __( 'Width' ) }
+							labelPosition="top"
+							value={ width || '' }
+							onChange={ ( nextWidth ) => {
+								onDimensionChange( 'width', nextWidth );
+							} }
+							units={ units }
+						/>
+					</FlexItem>
+				</Flex>
+			</BaseControl>
+			{ !! height && (
+				<SegmentedControl
+					label={ scaleLabel }
+					value={ scale }
+					onChange={ ( value ) => {
+						setAttributes( {
+							scale: value,
+						} );
+					} }
+					isBlock
+				>
+					{ SCALE_OPTIONS }
+				</SegmentedControl>
 			) }
 		</PanelBody>
 	);

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -25,15 +25,3 @@ div[data-type="core/post-featured-image"] {
 		}
 	}
 }
-
-// TODO this is temp styles.
-.block-library-post-featured-image-scale-controls {
-	margin-top: $grid-unit-20;
-	.components-flex {
-		border: $border-width solid $gray-700;
-	}
-	button {
-		width: 100%;
-		display: block;
-	}
-}

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -25,3 +25,10 @@ div[data-type="core/post-featured-image"] {
 		}
 	}
 }
+
+.block-library-post-featured-image-dimension-controls {
+	margin-bottom: $grid-unit-10;
+	&.scale-control-is-visible {
+		margin-bottom: $grid-unit-20;
+	}
+}

--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -16,7 +16,7 @@ import {
 
 /**
  * @typedef Props
- * @property {string}                    id                    The id of the element to which labels and help text are being generated.
+ * @property {string}                    [id]                  The id of the element to which labels and help text are being generated.
  *                                                             That element should be passed as a child.
  * @property {import('react').ReactNode} help                  If this property is added, a help text will be
  *                                                             generated using help property as the content.

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -68,3 +68,8 @@ Callback when a segment is selected.
 -   Type: `string | number`
 
 The value of the `SegmentedControl`.
+### `help`
+
+-   Type: `ReactNode`
+
+If this property is added, a help text will be generated using help property as the content.

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -32,6 +32,14 @@ function Example() {
 
 Label for the form element.
 
+### `hideLabelFromVision`
+
+-   Type: `boolean`
+-   Required: No
+-   Default: `false`
+
+If true, the label will only be visible to screen readers.
+
 ### `baseId`
 
 -   Type: `string`
@@ -68,6 +76,7 @@ Callback when a segment is selected.
 -   Type: `string | number`
 
 The value of the `SegmentedControl`.
+
 ### `help`
 
 -   Type: `ReactNode`

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -80,5 +80,6 @@ The value of the `SegmentedControl`.
 ### `help`
 
 -   Type: `ReactNode`
+-   Required: No
 
 If this property is added, a help text will be generated using help property as the content.

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -40,13 +40,6 @@ Label for the form element.
 
 If true, the label will only be visible to screen readers.
 
-### `baseId`
-
--   Type: `string`
--   Required: No
-
-ID that will serve as a base for all the items IDs.
-
 ### `isAdaptiveWidth`
 
 -   Type: `boolean`

--- a/packages/components/src/segmented-control/component.tsx
+++ b/packages/components/src/segmented-control/component.tsx
@@ -10,7 +10,7 @@ import useResizeAware from 'react-resize-aware';
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useMemo } from '@wordpress/element';
-import { useMergeRefs, useInstanceId } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -29,12 +29,6 @@ import type { SegmentedControlProps } from './types';
 import SegmentedControlContext from './segmented-control-context';
 
 const noop = () => {};
-function useUniqueId( idProp?: string ) {
-	const instanceId = useInstanceId( SegmentedControl );
-	const id = `inspector-select-control-${ instanceId }`;
-
-	return idProp || id;
-}
 
 function SegmentedControl(
 	props: PolymorphicComponentProps< SegmentedControlProps, 'input' >,
@@ -45,7 +39,7 @@ function SegmentedControl(
 		baseId,
 		isAdaptiveWidth = false,
 		isBlock = false,
-		id: idProp,
+		id,
 		label,
 		hideLabelFromVision = false,
 		help,
@@ -58,7 +52,6 @@ function SegmentedControl(
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeAware();
 
-	const id = useUniqueId( idProp );
 	const radio = useRadioState( {
 		baseId: baseId || id,
 		state: value,
@@ -87,7 +80,7 @@ function SegmentedControl(
 		[ className, isBlock ]
 	);
 	return (
-		<BaseControl aria-label={ label } help={ help } id={ id }>
+		<BaseControl help={ help }>
 			<SegmentedControlContext.Provider
 				value={ { ...radio, isBlock: ! isAdaptiveWidth } }
 			>

--- a/packages/components/src/segmented-control/component.tsx
+++ b/packages/components/src/segmented-control/component.tsx
@@ -47,6 +47,7 @@ function SegmentedControl(
 		isBlock = false,
 		id: idProp,
 		label,
+		hideLabelFromVision = false,
 		help,
 		onChange = noop,
 		value,
@@ -83,16 +84,20 @@ function SegmentedControl(
 				'medium',
 				className
 			),
-		[ className ]
+		[ className, isBlock ]
 	);
 	return (
 		<BaseControl aria-label={ label } help={ help } id={ id }>
 			<SegmentedControlContext.Provider
 				value={ { ...radio, isBlock: ! isAdaptiveWidth } }
 			>
-				<div>
-					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
-				</div>
+				{ ! hideLabelFromVision && (
+					<div>
+						<BaseControl.VisualLabel>
+							{ label }
+						</BaseControl.VisualLabel>
+					</div>
+				) }
 				<RadioGroup
 					{ ...radio }
 					aria-label={ label }

--- a/packages/components/src/segmented-control/component.tsx
+++ b/packages/components/src/segmented-control/component.tsx
@@ -10,7 +10,7 @@ import useResizeAware from 'react-resize-aware';
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useMemo } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -36,10 +36,8 @@ function SegmentedControl(
 ) {
 	const {
 		className,
-		baseId,
 		isAdaptiveWidth = false,
 		isBlock = false,
-		id,
 		label,
 		hideLabelFromVision = false,
 		help,
@@ -51,9 +49,12 @@ function SegmentedControl(
 	const cx = useCx();
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeAware();
-
+	const baseId = useInstanceId(
+		SegmentedControl,
+		'segmented-control'
+	).toString();
 	const radio = useRadioState( {
-		baseId: baseId || id,
+		baseId,
 		state: value,
 	} );
 

--- a/packages/components/src/segmented-control/component.tsx
+++ b/packages/components/src/segmented-control/component.tsx
@@ -10,7 +10,7 @@ import useResizeAware from 'react-resize-aware';
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useMemo } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -21,6 +21,7 @@ import {
 	PolymorphicComponentProps,
 } from '../ui/context';
 import { View } from '../view';
+import BaseControl from '../base-control';
 import * as styles from './styles';
 import { useUpdateEffect, useCx } from '../utils/hooks';
 import Backdrop from './segmented-control-backdrop';
@@ -28,6 +29,12 @@ import type { SegmentedControlProps } from './types';
 import SegmentedControlContext from './segmented-control-context';
 
 const noop = () => {};
+function useUniqueId( idProp?: string ) {
+	const instanceId = useInstanceId( SegmentedControl );
+	const id = `inspector-select-control-${ instanceId }`;
+
+	return idProp || id;
+}
 
 function SegmentedControl(
 	props: PolymorphicComponentProps< SegmentedControlProps, 'input' >,
@@ -38,8 +45,9 @@ function SegmentedControl(
 		baseId,
 		isAdaptiveWidth = false,
 		isBlock = false,
-		id,
+		id: idProp,
 		label,
+		help,
 		onChange = noop,
 		value,
 		children,
@@ -49,6 +57,7 @@ function SegmentedControl(
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeAware();
 
+	const id = useUniqueId( idProp );
 	const radio = useRadioState( {
 		baseId: baseId || id,
 		state: value,
@@ -77,26 +86,31 @@ function SegmentedControl(
 		[ className ]
 	);
 	return (
-		<SegmentedControlContext.Provider
-			value={ { ...radio, isBlock: ! isAdaptiveWidth } }
-		>
-			<RadioGroup
-				{ ...radio }
-				aria-label={ label }
-				as={ View }
-				className={ classes }
-				{ ...otherProps }
-				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+		<BaseControl aria-label={ label } help={ help } id={ id }>
+			<SegmentedControlContext.Provider
+				value={ { ...radio, isBlock: ! isAdaptiveWidth } }
 			>
-				{ resizeListener }
-				<Backdrop
+				<div>
+					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
+				</div>
+				<RadioGroup
 					{ ...radio }
-					containerRef={ containerRef }
-					containerWidth={ sizes.width }
-				/>
-				{ children }
-			</RadioGroup>
-		</SegmentedControlContext.Provider>
+					aria-label={ label }
+					as={ View }
+					className={ classes }
+					{ ...otherProps }
+					ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+				>
+					{ resizeListener }
+					<Backdrop
+						{ ...radio }
+						containerRef={ containerRef }
+						containerWidth={ sizes.width }
+					/>
+					{ children }
+				</RadioGroup>
+			</SegmentedControlContext.Provider>
+		</BaseControl>
 	);
 }
 

--- a/packages/components/src/segmented-control/stories/index.js
+++ b/packages/components/src/segmented-control/stories/index.js
@@ -46,7 +46,12 @@ export const _default = () => {
 				</SegmentedControl>
 			</Spacer>
 			<Spacer>
-				<SegmentedControl isAdaptiveWidth label={ label } value="long">
+				<SegmentedControl
+					isAdaptiveWidth
+					label={ label }
+					value="long"
+					hideLabelFromVision={ true }
+				>
 					<SegmentedControlOption value="short" label="Short" />
 					<SegmentedControlOption
 						value="long"

--- a/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
@@ -188,7 +188,7 @@ exports[`SegmentedControl should render correctly 1`] = `
       class="medium components-segmented-control emotion-4 emotion-5"
       data-wp-c16t="true"
       data-wp-component="SegmentedControl"
-      id="segmented"
+      id="segmented-control-0"
       role="radiogroup"
     >
       <iframe
@@ -214,7 +214,7 @@ exports[`SegmentedControl should render correctly 1`] = `
           data-value="rigas"
           data-wp-c16t="true"
           data-wp-component="SegmentedControlOption"
-          id="segmented-0"
+          id="segmented-control-0-0"
           role="radio"
           tabindex="0"
         >
@@ -246,7 +246,7 @@ exports[`SegmentedControl should render correctly 1`] = `
           data-value="jack"
           data-wp-c16t="true"
           data-wp-component="SegmentedControlOption"
-          id="segmented-1"
+          id="segmented-control-0-1"
           role="radio"
           tabindex="-1"
         >

--- a/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/segmented-control/test/__snapshots__/index.js.snap
@@ -2,6 +2,19 @@
 
 exports[`SegmentedControl should render correctly 1`] = `
 .emotion-0 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+}
+
+.emotion-2 {
+  margin-bottom: calc(4px * 2);
+}
+
+.components-panel__row .emotion-2 {
+  margin-bottom: inherit;
+}
+
+.emotion-4 {
   background: #fff;
   border: 1px solid;
   border-color: #757575;
@@ -19,23 +32,23 @@ exports[`SegmentedControl should render correctly 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-0 {
+  .emotion-4 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-0:hover {
+.emotion-4:hover {
   border-color: #757575;
 }
 
-.emotion-0:focus-within {
+.emotion-4:focus-within {
   border-color: var( --wp-admin-theme-color-darker-10, #007cba);
   box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #00669b);
   outline: none;
   z-index: 1;
 }
 
-.emotion-2 {
+.emotion-6 {
   background: #1e1e1e;
   border-radius: 2px;
   box-shadow: transparent;
@@ -49,12 +62,12 @@ exports[`SegmentedControl should render correctly 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-2 {
+  .emotion-6 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-4 {
+.emotion-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -67,7 +80,7 @@ exports[`SegmentedControl should render correctly 1`] = `
   flex: 1;
 }
 
-.emotion-6 {
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -106,20 +119,20 @@ exports[`SegmentedControl should render correctly 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-6 {
+  .emotion-10 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-6::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-6:active {
+.emotion-10:active {
   background: #fff;
 }
 
-.emotion-7 {
+.emotion-11 {
   font-size: 13px;
   line-height: 1;
   position: absolute;
@@ -131,7 +144,7 @@ exports[`SegmentedControl should render correctly 1`] = `
   transform: translate( -50%, -50% );
 }
 
-.emotion-9 {
+.emotion-13 {
   font-size: 13px;
   font-weight: bold;
   height: 0;
@@ -139,7 +152,7 @@ exports[`SegmentedControl should render correctly 1`] = `
   visibility: hidden;
 }
 
-.emotion-11 {
+.emotion-15 {
   background: rgba(0, 0, 0, 0.1);
   height: calc( 100% - 4px - 4px );
   position: absolute;
@@ -152,94 +165,109 @@ exports[`SegmentedControl should render correctly 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-11 {
+  .emotion-15 {
     transition-duration: 0ms;
   }
 }
 
 <div
-  aria-label="Test Segmented Control"
-  class="medium components-segmented-control emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="SegmentedControl"
-  id="segmented"
-  role="radiogroup"
+  class="components-base-control emotion-0 emotion-1"
 >
-  <iframe
-    aria-hidden="true"
-    frameborder="0"
-    src="about:blank"
-    style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
-    tabindex="-1"
-  />
   <div
-    class="emotion-2 emotion-3"
-    role="presentation"
-    style="transform: translateX(0px); transition: none; width: 0px;"
-  />
-  <div
-    class="emotion-4 emotion-5"
-    data-active="false"
+    class="components-base-control__field emotion-2 emotion-3"
   >
-    <button
-      aria-checked="false"
-      aria-label="R"
-      class="emotion-6 components-segmented-control-option"
-      data-value="rigas"
-      data-wp-c16t="true"
-      data-wp-component="SegmentedControlOption"
-      id="segmented-0"
-      role="radio"
-      tabindex="0"
-    >
-      <div
-        class="emotion-7 emotion-8"
+    <div>
+      <span
+        class="components-base-control__label"
       >
-        R
-      </div>
-      <div
-        aria-hidden="true"
-        class="emotion-9 emotion-10"
-      >
-        R
-      </div>
-    </button>
+        Test Segmented Control
+      </span>
+    </div>
     <div
-      aria-hidden="true"
-      class="emotion-11 emotion-12"
-    />
-  </div>
-  <div
-    class="emotion-4 emotion-5"
-    data-active="false"
-  >
-    <button
-      aria-checked="false"
-      aria-label="J"
-      class="emotion-6 components-segmented-control-option"
-      data-value="jack"
+      aria-label="Test Segmented Control"
+      class="medium components-segmented-control emotion-4 emotion-5"
       data-wp-c16t="true"
-      data-wp-component="SegmentedControlOption"
-      id="segmented-1"
-      role="radio"
-      tabindex="-1"
+      data-wp-component="SegmentedControl"
+      id="segmented"
+      role="radiogroup"
     >
-      <div
-        class="emotion-7 emotion-8"
-      >
-        J
-      </div>
-      <div
+      <iframe
         aria-hidden="true"
-        class="emotion-9 emotion-10"
+        frameborder="0"
+        src="about:blank"
+        style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+        tabindex="-1"
+      />
+      <div
+        class="emotion-6 emotion-7"
+        role="presentation"
+        style="transform: translateX(0px); transition: none; width: 0px;"
+      />
+      <div
+        class="emotion-8 emotion-9"
+        data-active="false"
       >
-        J
+        <button
+          aria-checked="false"
+          aria-label="R"
+          class="emotion-10 components-segmented-control-option"
+          data-value="rigas"
+          data-wp-c16t="true"
+          data-wp-component="SegmentedControlOption"
+          id="segmented-0"
+          role="radio"
+          tabindex="0"
+        >
+          <div
+            class="emotion-11 emotion-12"
+          >
+            R
+          </div>
+          <div
+            aria-hidden="true"
+            class="emotion-13 emotion-14"
+          >
+            R
+          </div>
+        </button>
+        <div
+          aria-hidden="true"
+          class="emotion-15 emotion-16"
+        />
       </div>
-    </button>
-    <div
-      aria-hidden="true"
-      class="emotion-11 emotion-12"
-    />
+      <div
+        class="emotion-8 emotion-9"
+        data-active="false"
+      >
+        <button
+          aria-checked="false"
+          aria-label="J"
+          class="emotion-10 components-segmented-control-option"
+          data-value="jack"
+          data-wp-c16t="true"
+          data-wp-component="SegmentedControlOption"
+          id="segmented-1"
+          role="radio"
+          tabindex="-1"
+        >
+          <div
+            class="emotion-11 emotion-12"
+          >
+            J
+          </div>
+          <div
+            aria-hidden="true"
+            class="emotion-13 emotion-14"
+          >
+            J
+          </div>
+        </button>
+        <div
+          aria-hidden="true"
+          class="emotion-15 emotion-16"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/segmented-control/test/index.js
+++ b/packages/components/src/segmented-control/test/index.js
@@ -17,7 +17,7 @@ describe( 'SegmentedControl', () => {
 	);
 	it( 'should render correctly', () => {
 		const { container } = render(
-			<SegmentedControl baseId="segmented" label="Test Segmented Control">
+			<SegmentedControl label="Test Segmented Control">
 				{ options }
 			</SegmentedControl>
 		);
@@ -27,7 +27,6 @@ describe( 'SegmentedControl', () => {
 		const mockOnChange = jest.fn();
 		const { getByLabelText } = render(
 			<SegmentedControl
-				baseId="segmented"
 				value="jack"
 				onChange={ mockOnChange }
 				label="Test Segmented Control"

--- a/packages/components/src/segmented-control/types.ts
+++ b/packages/components/src/segmented-control/types.ts
@@ -25,6 +25,12 @@ export type SegmentedControlProps = Omit<
 	 */
 	label: string;
 	/**
+	 * If true, the label will only be visible to screen readers.
+	 *
+	 * @default false
+	 */
+	hideLabelFromVision: boolean;
+	/**
 	 * ID that will serve as a base for all the items IDs.
 	 *
 	 * @see https://reakit.io/docs/radio/#useradiostate

--- a/packages/components/src/segmented-control/types.ts
+++ b/packages/components/src/segmented-control/types.ts
@@ -31,12 +31,6 @@ export type SegmentedControlProps = Omit<
 	 */
 	hideLabelFromVision: boolean;
 	/**
-	 * ID that will serve as a base for all the items IDs.
-	 *
-	 * @see https://reakit.io/docs/radio/#useradiostate
-	 */
-	baseId?: string;
-	/**
 	 * Determines if segments should be rendered with equal widths.
 	 *
 	 * @default false

--- a/packages/components/src/segmented-control/types.ts
+++ b/packages/components/src/segmented-control/types.ts
@@ -54,6 +54,11 @@ export type SegmentedControlProps = Omit<
 	 * React children
 	 */
 	children: ReactNode;
+	/**
+	 * If this property is added, a help text will be generated
+	 * using help property as the content.
+	 */
+	help?: ReactNode;
 };
 
 export type SegmentedControlContextProps = RadioStateReturn & {


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR adds `BaseControl` built in the `SegmentedControl` component. I also added support for the help property if needed.

In this PR I have updated the sole usage in `PostFeaturedImage` block.

## Testing instructions
1. Insert `PostFeaturedImage` block and add a `height` in order for the scale options to be shown (SegmentedControl)
2. Observe that everything is as before and works properly
<!-- Please describe what you have changed or added -->

