### PR TITLE
Rich text - toTree - Add check in replacements before accessing its type

### DIFF
--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -287,7 +287,7 @@ export function toTree( {
 		}
 
 		if ( character === OBJECT_REPLACEMENT_CHARACTER ) {
-			if ( ! isEditableTree && replacements[ i ].type === 'script' ) {
+			if ( ! isEditableTree && replacements[ i ]?.type === 'script' ) {
 				pointer = append(
 					getParent( pointer ),
 					fromFormat( {


### PR DESCRIPTION
## Description
In the latest mobile release, we have a current crash for users that are pasting content that includes the `Object replacement character`. This PR adds a check for `replacements` before accessing its `type`.

## How has this been tested?
- Open the app
- Paste some content that includes that character for example from [here](https://charbase.com/fffc-unicode-object-replacement-character).
- Expect the app to not crash (red screen)

## Screenshots <!-- if applicable -->
Before|After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/129065655-8cd8e8c2-cba2-48ea-aebd-6a7907d33935.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/129065665-8967e182-c5b3-4b60-8a07-24d175d713ac.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
