### PR TITLE
Fix duotone on fixed and repeated cover backgrounds

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -23,7 +23,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
-	backgroundImageStyles,
 	dimRatioToClass,
 	getPositionClassName,
 	isContentPositionCenter,
@@ -60,6 +59,148 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+			isRepeated: {
+				type: 'boolean',
+				default: false,
+			},
+			minHeight: {
+				type: 'number',
+			},
+			minHeightUnit: {
+				type: 'string',
+			},
+			gradient: {
+				type: 'string',
+			},
+			customGradient: {
+				type: 'string',
+			},
+			contentPosition: {
+				type: 'string',
+			},
+		},
+		save( { attributes } ) {
+			const {
+				backgroundType,
+				gradient,
+				contentPosition,
+				customGradient,
+				customOverlayColor,
+				dimRatio,
+				focalPoint,
+				hasParallax,
+				isRepeated,
+				overlayColor,
+				url,
+				id,
+				minHeight: minHeightProp,
+				minHeightUnit,
+			} = attributes;
+			const overlayColorClass = getColorClassName(
+				'background-color',
+				overlayColor
+			);
+			const gradientClass = __experimentalGetGradientClass( gradient );
+			const minHeight = minHeightUnit
+				? `${ minHeightProp }${ minHeightUnit }`
+				: minHeightProp;
+
+			const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
+			const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
+
+			const isImgElement = ! ( hasParallax || isRepeated );
+
+			const style = {
+				...( isImageBackground && ! isImgElement && url
+					? { backgroundImage: `url(${ url })` }
+					: {} ),
+				backgroundColor: ! overlayColorClass
+					? customOverlayColor
+					: undefined,
+				background:
+					customGradient && ! url ? customGradient : undefined,
+				minHeight: minHeight || undefined,
+			};
+
+			const objectPosition =
+				// prettier-ignore
+				focalPoint && isImgElement
+			? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
+			: undefined;
+
+			const classes = classnames(
+				dimRatioToClass( dimRatio ),
+				overlayColorClass,
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+					'is-repeated': isRepeated,
+					'has-background-gradient': gradient || customGradient,
+					[ gradientClass ]: ! url && gradientClass,
+					'has-custom-content-position': ! isContentPositionCenter(
+						contentPosition
+					),
+				},
+				getPositionClassName( contentPosition )
+			);
+
+			return (
+				<div { ...useBlockProps.save( { className: classes, style } ) }>
+					{ url &&
+						( gradient || customGradient ) &&
+						dimRatio !== 0 && (
+							<span
+								aria-hidden="true"
+								className={ classnames(
+									'wp-block-cover__gradient-background',
+									gradientClass
+								) }
+								style={
+									customGradient
+										? { background: customGradient }
+										: undefined
+								}
+							/>
+						) }
+					{ isImageBackground && isImgElement && url && (
+						<img
+							className={ classnames(
+								'wp-block-cover__image-background',
+								id ? `wp-image-${ id }` : null
+							) }
+							alt=""
+							src={ url }
+							style={ { objectPosition } }
+							data-object-fit="cover"
+							data-object-position={ objectPosition }
+						/>
+					) }
+					{ isVideoBackground && url && (
+						<video
+							className={ classnames(
+								'wp-block-cover__video-background',
+								'intrinsic-ignore'
+							) }
+							autoPlay
+							muted
+							loop
+							playsInline
+							src={ url }
+							style={ { objectPosition } }
+							data-object-fit="cover"
+							data-object-position={ objectPosition }
+						/>
+					) }
+					<div className="wp-block-cover__inner-container">
+						<InnerBlocks.Content />
+					</div>
+				</div>
+			);
+		},
+	},
 	{
 		attributes: {
 			...blockAttributes,
@@ -123,7 +264,10 @@ const deprecated = [
 			const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 			const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
-			const style = isImageBackground ? backgroundImageStyles( url ) : {};
+			const style =
+				isImageBackground && url
+					? { backgroundImage: `url(${ url })` }
+					: {};
 			const videoStyle = {};
 
 			if ( ! overlayColorClass ) {
@@ -248,8 +392,8 @@ const deprecated = [
 			const gradientClass = __experimentalGetGradientClass( gradient );
 
 			const style =
-				backgroundType === IMAGE_BACKGROUND_TYPE
-					? backgroundImageStyles( url )
+				backgroundType === IMAGE_BACKGROUND_TYPE && url
+					? { backgroundImage: `url(${ url })` }
 					: {};
 			if ( ! overlayColorClass ) {
 				style.backgroundColor = customOverlayColor;
@@ -354,8 +498,8 @@ const deprecated = [
 			const gradientClass = __experimentalGetGradientClass( gradient );
 
 			const style =
-				backgroundType === IMAGE_BACKGROUND_TYPE
-					? backgroundImageStyles( url )
+				backgroundType === IMAGE_BACKGROUND_TYPE && url
+					? { backgroundImage: `url(${ url })` }
 					: {};
 			if ( ! overlayColorClass ) {
 				style.backgroundColor = customOverlayColor;
@@ -448,8 +592,8 @@ const deprecated = [
 				overlayColor
 			);
 			const style =
-				backgroundType === IMAGE_BACKGROUND_TYPE
-					? backgroundImageStyles( url )
+				backgroundType === IMAGE_BACKGROUND_TYPE && url
+					? { backgroundImage: `url(${ url })` }
 					: {};
 			if ( ! overlayColorClass ) {
 				style.backgroundColor = customOverlayColor;
@@ -540,7 +684,7 @@ const deprecated = [
 				'background-color',
 				overlayColor
 			);
-			const style = backgroundImageStyles( url );
+			const style = url ? { backgroundImage: `url(${ url })` } : {};
 			if ( ! overlayColorClass ) {
 				style.backgroundColor = customOverlayColor;
 			}
@@ -605,7 +749,7 @@ const deprecated = [
 		},
 		save( { attributes } ) {
 			const { url, title, hasParallax, dimRatio, align } = attributes;
-			const style = backgroundImageStyles( url );
+			const style = url ? { backgroundImage: `url(${ url })` } : {};
 			const classes = classnames(
 				'wp-block-cover-image',
 				dimRatioToClass( dimRatio ),

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -56,7 +56,6 @@ import {
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
 	COVER_MIN_HEIGHT,
-	backgroundImageStyles,
 	dimRatioToClass,
 	isContentPositionCenter,
 	getPositionClassName,
@@ -394,21 +393,15 @@ function CoverEdit( {
 	const isImgElement = ! ( hasParallax || isRepeated );
 
 	const style = {
-		...( isImageBackground && ! isImgElement
-			? backgroundImageStyles( url )
-			: {
-					backgroundImage: gradientValue ? gradientValue : undefined,
-			  } ),
 		backgroundColor: overlayColor.color,
+		backgroundImage: gradientValue ? gradientValue : undefined,
 		minHeight: temporaryMinHeight || minHeightWithUnit || undefined,
 	};
 
-	const mediaStyle = {
-		objectPosition:
-			focalPoint && isImgElement
-				? mediaPosition( focalPoint )
-				: undefined,
-	};
+	const backgroundImage = ! isImgElement && url ? `url(${ url })` : undefined;
+	const backgroundPosition = focalPoint
+		? mediaPosition( focalPoint )
+		: undefined;
 
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
@@ -607,8 +600,6 @@ function CoverEdit( {
 			'is-dark-theme': isDark,
 			'has-background-dim': dimRatio !== 0,
 			'is-transient': isUploadingMedia,
-			'has-parallax': hasParallax,
-			'is-repeated': isRepeated,
 			[ overlayColor.class ]: overlayColor.class,
 			'has-background-gradient': gradientValue,
 			[ gradientClass ]: ! url && gradientClass,
@@ -618,6 +609,11 @@ function CoverEdit( {
 		},
 		getPositionClassName( contentPosition )
 	);
+
+	const backgroundClasses = classnames( {
+		'has-parallax': hasParallax,
+		'is-repeated': isRepeated,
+	} );
 
 	return (
 		<>
@@ -656,13 +652,24 @@ function CoverEdit( {
 						style={ { backgroundImage: gradientValue } }
 					/>
 				) }
+				{ url && isImageBackground && ! isImgElement && (
+					<div
+						ref={ isDarkElement }
+						role="img"
+						className={ classnames(
+							'wp-block-cover__image-background',
+							backgroundClasses
+						) }
+						style={ { backgroundImage, backgroundPosition } }
+					/>
+				) }
 				{ url && isImageBackground && isImgElement && (
 					<img
 						ref={ isDarkElement }
 						className="wp-block-cover__image-background"
 						alt=""
 						src={ url }
-						style={ mediaStyle }
+						style={ { objectPosition: backgroundPosition } }
 					/>
 				) }
 				{ url && isVideoBackground && (
@@ -673,7 +680,7 @@ function CoverEdit( {
 						muted
 						loop
 						src={ url }
-						style={ mediaStyle }
+						style={ { objectPosition: backgroundPosition } }
 					/>
 				) }
 				{ isUploadingMedia && <Spinner /> }

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -19,7 +19,6 @@ import {
 import {
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
-	backgroundImageStyles,
 	dimRatioToClass,
 	isContentPositionCenter,
 	getPositionClassName,
@@ -57,27 +56,22 @@ export default function save( { attributes } ) {
 	const isImgElement = ! ( hasParallax || isRepeated );
 
 	const style = {
-		...( isImageBackground && ! isImgElement
-			? backgroundImageStyles( url )
-			: {} ),
 		backgroundColor: ! overlayColorClass ? customOverlayColor : undefined,
-		background: customGradient && ! url ? customGradient : undefined,
+		backgroundImage: customGradient && ! url ? customGradient : undefined,
 		minHeight: minHeight || undefined,
 	};
 
-	const objectPosition =
-		// prettier-ignore
-		focalPoint && isImgElement
-			? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
-			: undefined;
+	const backgroundImage = ! isImgElement && url ? `url(${ url })` : undefined;
+	// prettier-ignore
+	const backgroundPosition = focalPoint
+		? `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`
+		: undefined;
 
 	const classes = classnames(
 		dimRatioToClass( dimRatio ),
 		overlayColorClass,
 		{
 			'has-background-dim': dimRatio !== 0,
-			'has-parallax': hasParallax,
-			'is-repeated': isRepeated,
 			'has-background-gradient': gradient || customGradient,
 			[ gradientClass ]: ! url && gradientClass,
 			'has-custom-content-position': ! isContentPositionCenter(
@@ -86,6 +80,11 @@ export default function save( { attributes } ) {
 		},
 		getPositionClassName( contentPosition )
 	);
+
+	const backgroundClasses = classnames( {
+		'has-parallax': hasParallax,
+		'is-repeated': isRepeated,
+	} );
 
 	return (
 		<div { ...useBlockProps.save( { className: classes, style } ) }>
@@ -103,7 +102,17 @@ export default function save( { attributes } ) {
 					}
 				/>
 			) }
-			{ isImageBackground && isImgElement && url && (
+			{ url && isImageBackground && ! isImgElement && (
+				<div
+					role="img"
+					className={ classnames(
+						'wp-block-cover__image-background',
+						backgroundClasses
+					) }
+					style={ { backgroundImage, backgroundPosition } }
+				/>
+			) }
+			{ url && isImageBackground && isImgElement && (
 				<img
 					className={ classnames(
 						'wp-block-cover__image-background',
@@ -111,12 +120,12 @@ export default function save( { attributes } ) {
 					) }
 					alt=""
 					src={ url }
-					style={ { objectPosition } }
+					style={ { objectPosition: backgroundPosition } }
 					data-object-fit="cover"
-					data-object-position={ objectPosition }
+					data-object-position={ backgroundPosition }
 				/>
 			) }
-			{ isVideoBackground && url && (
+			{ url && isVideoBackground && (
 				<video
 					className={ classnames(
 						'wp-block-cover__video-background',
@@ -127,9 +136,9 @@ export default function save( { attributes } ) {
 					loop
 					playsInline
 					src={ url }
-					style={ { objectPosition } }
+					style={ { objectPosition: backgroundPosition } }
 					data-object-fit="cover"
-					data-object-position={ objectPosition }
+					data-object-position={ backgroundPosition }
 				/>
 			) }
 			<div className="wp-block-cover__inner-container">

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -21,9 +21,6 @@ export const VIDEO_BACKGROUND_TYPE = 'video';
 export const COVER_MIN_HEIGHT = 50;
 export const COVER_MAX_HEIGHT = 1000;
 export const COVER_DEFAULT_HEIGHT = 300;
-export function backgroundImageStyles( url ) {
-	return url ? { backgroundImage: `url(${ url })` } : {};
-}
 export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 export function dimRatioToClass( ratio ) {

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,8 +1,6 @@
 .wp-block-cover-image,
 .wp-block-cover {
 	position: relative;
-	background-size: cover;
-	background-position: center center;
 	min-height: 430px;
 	width: 100%;
 	display: flex;
@@ -11,27 +9,6 @@
 	padding: 1em;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
-
-	&.has-parallax {
-		background-attachment: fixed;
-
-		// Mobile Safari does not support fixed background attachment properly.
-		// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
-		// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
-		@supports (-webkit-overflow-scrolling: touch) {
-			background-attachment: scroll;
-		}
-
-		// Remove the appearance of scrolling based on OS-level animation preferences.
-		@media (prefers-reduced-motion: reduce) {
-			background-attachment: scroll;
-		}
-	}
-
-	&.is-repeated {
-		background-repeat: repeat;
-		background-size: auto;
-	}
 
 	/**
 	 * Set a default background color for has-background-dim _unless_ it includes another
@@ -167,6 +144,7 @@
 	}
 
 	// Extra specificity for in edit mode where other styles would override it otherwise.
+	div.wp-block-cover__image-background,
 	img.wp-block-cover__image-background,
 	video.wp-block-cover__video-background {
 		position: absolute;
@@ -184,6 +162,32 @@
 		outline: none;
 		border: none;
 		box-shadow: none;
+	}
+
+	div.wp-block-cover__image-background {
+		background-size: cover;
+		background-position: center center;
+
+		&.has-parallax {
+			background-attachment: fixed;
+
+			// Mobile Safari does not support fixed background attachment properly.
+			// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+			// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+			@supports (-webkit-overflow-scrolling: touch) {
+				background-attachment: scroll;
+			}
+
+			// Remove the appearance of scrolling based on OS-level animation preferences.
+			@media (prefers-reduced-motion: reduce) {
+				background-attachment: scroll;
+			}
+		}
+
+		&.is-repeated {
+			background-repeat: repeat;
+			background-size: auto;
+		}
 	}
 }
 

--- a/test/integration/fixtures/blocks/core__cover__gradient.html
+++ b/test/integration/fixtures/blocks/core__cover__gradient.html
@@ -1,5 +1,5 @@
 <!-- wp:cover {"customGradient":"linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"} -->
-<div class="wp-block-cover has-background-dim has-background-gradient" style="background:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)">
+<div class="wp-block-cover has-background-dim has-background-gradient" style="background-image:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)">
 	<div class="wp-block-cover__inner-container">
 		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 		<p class="has-text-align-center has-large-font-size">Cover!</p>

--- a/test/integration/fixtures/blocks/core__cover__gradient.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient.json
@@ -26,6 +26,6 @@
 				"originalContent": "<p class=\"has-text-align-center has-large-font-size\">Cover!</p>"
 			}
 		],
-		"originalContent": "<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+		"originalContent": "<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background-image:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
 	}
 ]

--- a/test/integration/fixtures/blocks/core__cover__gradient.parsed.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient.parsed.json
@@ -19,9 +19,9 @@
 				]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background-image:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+			"\n<div class=\"wp-block-cover has-background-dim has-background-gradient\" style=\"background-image:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
 			null,
 			"\n\t</div>\n</div>\n"
 		]

--- a/test/integration/fixtures/blocks/core__cover__gradient.serialized.html
+++ b/test/integration/fixtures/blocks/core__cover__gradient.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:cover {"customGradient":"linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"} -->
-<div class="wp-block-cover has-background-dim has-background-gradient" style="background:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<div class="wp-block-cover has-background-dim has-background-gradient" style="background-image:linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size">Cover!</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #31662

The duotone filter should work with fixed and repeated backgrounds.

For duotone to be applied to an element, that element cannot contain child elements or the duotone will also be applied to the children, so the block markup had to change to accommodate that by having a separate `div` for the background to apply the duotone to.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a cover block
2. Set one of the duotone colors combinations
3. In the block settings, toggle on "Fixed Background" under Media Settings
4. In the block settings, toggle on "Repeated Background" under Media Settings

Since this is changing the saved markup, make sure deprecations work by creating a block prior to applying this PR and then upgrading the block.

## Screenshots <!-- if applicable -->

TODO

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Breaking change for the generated cover block markup.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
