### PR TITLE
Webpack: Fix watch on `.json` and `.php` files

### DIFF
--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -53,7 +53,10 @@ const baseConfig = {
 		] ),
 	},
 	watchOptions: {
-		ignored: [ '**/node_modules', '**/packages/*/src' ],
+		ignored: [
+			'**/node_modules',
+			'**/packages/*/src/**/*.{js,ts,tsx,scss}',
+		],
 		aggregateTimeout: 500,
 	},
 	devtool,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Only ignore watch on files in the src folder that are handled by the build script.

This fixes a bug where `.json` and `.php` files in blocks isn't copied in development mode.

Fixes #33993

## How has this been tested?
See steps in issue

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
