### PR TITLE
Dimensions Panel: add padding tool as default for blocks where this is common setting

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -26,7 +26,10 @@
 			"link": true
 		},
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -58,7 +58,10 @@
 		"align": true,
 		"html": false,
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
 		},
 		"color": {
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -24,7 +24,10 @@
 			"link": true
 		},
 		"spacing": {
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
 		},
 		"__experimentalBorder": {
 			"color": true,


### PR DESCRIPTION
## Description
Currently blocks that support the `{spacing: { padding: true}}` do not show the option by default in the Dimensions panel. Now there is an `__experimentalDefaultControls` there are some blocks that could benefit from exposing this option by default to make it more obvious to users.

This PR adds the default option to 3 of the 7 core blocks that currently support the padding option:

- Button
- Group
- Columns

These seem to be the blocks where users are most likely to be looking for an option to modify padding.

The other four blocks that currently support padding, but don't seem as likely to need padding adjustments always visible are:

- Cover
- Site-tagline
- Site-title
- Verse

## Testing

Check out this PR to local dev env
Add a Button, Group, Column block and check that padding displays by default in the Dimensions panel

## Screenshots 

Before:
<img width="875" alt="Screen Shot 2021-08-12 at 2 27 19 PM" src="https://user-images.githubusercontent.com/3629020/129129091-a4cbd441-69a2-41f9-acbc-36a6b172e625.png">

After:
<img width="872" alt="Screen Shot 2021-08-12 at 2 26 00 PM" src="https://user-images.githubusercontent.com/3629020/129128993-158ede06-6c6c-4d68-86c6-8a4b2048e3f4.png">


