### PR TITLE
Unit Control: add some tests for getValidParsedUnit util method

### DIFF
--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -19,7 +19,7 @@ import { composeStateReducers } from '../input-control/reducer/reducer';
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
 import { CSS_UNITS, getParsedValue, getValidParsedUnit } from './utils';
-import { useControlledState } from '../utils/hooks';
+import { useControlledState, useUpdateEffect } from '../utils/hooks';
 
 function UnitControl(
 	{
@@ -52,6 +52,19 @@ function UnitControl(
 	const refParsedValue = useRef( null );
 
 	const classes = classnames( 'components-unit-control', className );
+
+	// Watch for incoming updates to the unit.
+	useUpdateEffect( () => {
+		if ( initialUnit !== unit ) {
+			const parsedUnitValue = getValidParsedUnit(
+				initialUnit,
+				units,
+				value,
+				unit
+			).join( '' );
+			setUnit( parsedUnitValue );
+		}
+	}, [ initialUnit ] );
 
 	const handleOnChange = ( next, changeProps ) => {
 		if ( next === '' ) {

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -19,7 +19,7 @@ import { composeStateReducers } from '../input-control/reducer/reducer';
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
 import { CSS_UNITS, getParsedValue, getValidParsedUnit } from './utils';
-import { useControlledState, useUpdateEffect } from '../utils/hooks';
+import { useControlledState } from '../utils/hooks';
 
 function UnitControl(
 	{
@@ -52,19 +52,6 @@ function UnitControl(
 	const refParsedValue = useRef( null );
 
 	const classes = classnames( 'components-unit-control', className );
-
-	// Watch for incoming updates to the unit.
-	useUpdateEffect( () => {
-		if ( initialUnit !== unit ) {
-			const parsedUnitValue = getValidParsedUnit(
-				initialUnit,
-				units,
-				value,
-				unit
-			).join( '' );
-			setUnit( parsedUnitValue );
-		}
-	}, [ initialUnit ] );
 
 	const handleOnChange = ( next, changeProps ) => {
 		if ( next === '' ) {

--- a/packages/components/src/unit-control/test/utils.js
+++ b/packages/components/src/unit-control/test/utils.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { filterUnitsWithSettings, useCustomUnits } from '../utils';
+import {
+	filterUnitsWithSettings,
+	useCustomUnits,
+	getValidParsedUnit,
+} from '../utils';
 
 describe( 'UnitControl utils', () => {
 	describe( 'useCustomUnits', () => {
@@ -58,6 +62,57 @@ describe( 'UnitControl utils', () => {
 			expect(
 				filterUnitsWithSettings( preferredUnits, availableUnits )
 			).toEqual( [] );
+		} );
+	} );
+
+	describe( 'getValidParsedUnit', () => {
+		it( 'should parse valid number and unit', () => {
+			const nextValue = '42px';
+
+			expect( getValidParsedUnit( nextValue ) ).toEqual( [ 42, 'px' ] );
+		} );
+
+		it( 'should return next value only where no known unit parsed', () => {
+			const nextValue = '365zz';
+
+			expect( getValidParsedUnit( nextValue ) ).toEqual( [
+				365,
+				undefined,
+			] );
+		} );
+
+		it( 'should return fallback value', () => {
+			const nextValue = 'thirteen';
+			const preferredUnits = [ { value: 'em' } ];
+			const fallbackValue = 13;
+
+			expect(
+				getValidParsedUnit( nextValue, preferredUnits, fallbackValue )
+			).toEqual( [ 13, 'em' ] );
+		} );
+
+		it( 'should return fallback unit', () => {
+			const nextValue = '911';
+			const fallbackUnit = '%';
+
+			expect(
+				getValidParsedUnit(
+					nextValue,
+					undefined,
+					undefined,
+					fallbackUnit
+				)
+			).toEqual( [ 911, '%' ] );
+		} );
+
+		it( 'should return first unit in preferred units collection as second fallback unit', () => {
+			const nextValue = 101;
+			const preferredUnits = [ { value: 'px' } ];
+
+			expect( getValidParsedUnit( nextValue, preferredUnits ) ).toEqual( [
+				101,
+				'px',
+			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description

This PR started out as an exploratory mission to coerce the UnitControl component to update the unit value based on incoming changes in the value.

So for example, if the unit is set to `px`, but the incoming value is `22em`, the component would parse and validate the new unit (`em`) and call `setUnit` to update the internal state. 

Hoorah!

Well, it turns out this was all a bit superfluous seeing that we can pass the updated unit value using the components `unit` prop. 🤦 

Still, along the way we added a few tests for `getValidParsedUnit()` so it seemed a shame to abandon them to the cloud, where they would linger, alone and forgotten, like a wet sock in a suburban laundromat.

## How has this been tested?

Run the tests:

```js
npm run test-unit packages/components/src/unit-control/test/utils.js
```

## Types of changes
Adding unit tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->

