### PR TITLE
Dimensions Support: Switch dimensions block support back to using spacing key

### DIFF
--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -110,7 +110,7 @@ function gutenberg_skip_spacing_serialization( $block_type ) {
 
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
-	'dimensions',
+	'spacing', // This is deliberately `spacing` instead of `dimensions` for backwards compatibility.
 	array(
 		'register_attribute' => 'gutenberg_register_dimensions_support',
 		'apply'              => 'gutenberg_apply_dimensions_support',


### PR DESCRIPTION
## Description

This reverts the registration of dimensions block support back to using the `spacing` key. This is to ensure that it still aligns with the previous registration of block support within WordPress 5.8.

## How has this been tested?

- Ran `npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose --filter stylesheet /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php'`
- Ran `npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`
- Added padding via block supports to dynamic block e.g. site-tagline

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
