### PR TITLE
Core Data: getEntityRecords return items even if some included IDs don't exist

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -38,15 +38,7 @@ function getQueriedItemsUncached( state, query ) {
 	} = getQueryParts( query );
 	let itemIds;
 
-	if ( Array.isArray( include ) && ! stableKey ) {
-		// If the parsed query yields a set of IDs, but otherwise no filtering,
-		// it's safe to consider targeted item IDs as the include set. This
-		// doesn't guarantee that those objects have been queried, which is
-		// accounted for below in the loop `null` return.
-		itemIds = include;
-		// TODO: Avoid storing the empty stable string in reducer, since it
-		// can be computed dynamically here always.
-	} else if ( state.queries?.[ context ]?.[ stableKey ] ) {
+	if ( state.queries?.[ context ]?.[ stableKey ] ) {
 		itemIds = state.queries[ context ][ stableKey ];
 	}
 
@@ -67,8 +59,9 @@ function getQueriedItemsUncached( state, query ) {
 			continue;
 		}
 
+		// Having a target item ID doesn't guarantee that this object has been queried.
 		if ( ! state.items[ context ]?.hasOwnProperty( itemId ) ) {
-			continue;
+			return null;
 		}
 
 		const item = state.items[ context ][ itemId ];

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -68,7 +68,7 @@ function getQueriedItemsUncached( state, query ) {
 		}
 
 		if ( ! state.items[ context ]?.hasOwnProperty( itemId ) ) {
-			return null;
+			continue;
 		}
 
 		const item = state.items[ context ][ itemId ];


### PR DESCRIPTION
## Description
Makes response single source of truth for `itemIds`.

~~I couldn't find context for the original logic of aborting the loop and returning `null.` The original code was introduced in #19498.~~

Fixes #28429.

## How has this been tested?
Make sure unit tests are passing for the core data package:

```
npm run test-unit packages/core-data/src/**/test
```

Run the following code in the browser console:
```
wp.data.select('core').getEntityRecords('taxonomy', 'post_tag', { include: [ /* Tag IDs */ ] });
```
Replace `include` the existing Tag IDs and one non-existing. 

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
