### PR TITLE
Automated changelog: remove `Uncategorized` header in output and place items at top

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -673,11 +673,12 @@ async function getChangelog( settings ) {
 				return;
 			}
 
-			const shouldNest = featureName !== UNKNOWN_FEATURE_FALLBACK_NAME;
-
 			// Avoids double nesting such as "Documentation" feature under
 			// the "Documentation" section.
-			if ( group !== featureName && shouldNest ) {
+			if (
+				group !== featureName &&
+				featureName !== UNKNOWN_FEATURE_FALLBACK_NAME
+			) {
 				// Start new <ul> for the Feature group.
 				changelog += '#### ' + featureName + '\n';
 			}
@@ -688,7 +689,7 @@ async function getChangelog( settings ) {
 				entry = entry && entry.replace( `[${ featureName } - `, '[' );
 
 				// Add a new bullet point to the list.
-				changelog += shouldNest ? `  ${ entry }\n` : `${ entry }\n`;
+				changelog += `${ entry }\n`;
 			} );
 
 			// Close the <ul> for the Feature group.

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -711,7 +711,7 @@ async function getChangelog( settings ) {
 function sortFeatureGroups( featureGroups ) {
 	return Object.keys( featureGroups ).sort(
 		( featureAName, featureBName ) => {
-			// Sort "Unknown" to always be at the end
+			// Sort "uncategorized" items to *always* be at the top of the section
 			if ( featureAName === UNKNOWN_FEATURE_FALLBACK_NAME ) {
 				return -1;
 			} else if ( featureBName === UNKNOWN_FEATURE_FALLBACK_NAME ) {

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -673,9 +673,11 @@ async function getChangelog( settings ) {
 				return;
 			}
 
+			const shouldNest = featureName !== UNKNOWN_FEATURE_FALLBACK_NAME;
+
 			// Avoids double nesting such as "Documentation" feature under
 			// the "Documentation" section.
-			if ( group !== featureName ) {
+			if ( group !== featureName && shouldNest ) {
 				// Start new <ul> for the Feature group.
 				changelog += '#### ' + featureName + '\n';
 			}
@@ -686,7 +688,7 @@ async function getChangelog( settings ) {
 				entry = entry && entry.replace( `[${ featureName } - `, '[' );
 
 				// Add a new bullet point to the list.
-				changelog += `${ entry }\n`;
+				changelog += shouldNest ? `  ${ entry }\n` : `${ entry }\n`;
 			} );
 
 			// Close the <ul> for the Feature group.
@@ -711,9 +713,9 @@ function sortFeatureGroups( featureGroups ) {
 		( featureAName, featureBName ) => {
 			// Sort "Unknown" to always be at the end
 			if ( featureAName === UNKNOWN_FEATURE_FALLBACK_NAME ) {
-				return 1;
-			} else if ( featureBName === UNKNOWN_FEATURE_FALLBACK_NAME ) {
 				return -1;
+			} else if ( featureBName === UNKNOWN_FEATURE_FALLBACK_NAME ) {
+				return 1;
 			}
 
 			// Sort by greatest number of PRs in the group first.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/pull/33229#issuecomment-893320178 @youknowriad suggested we remove the `Uncategorized` _feature_ name from the auto-generated changelog and instead:

- Don't output a heading level
- Put those "uncategorized" items at the top of the given section.

This PR does this. Here is an example of the new output for a given section which I generated from the `11.3.0` Milestone:

```md
### Tools

- GitHub Templates: Format bug report template. ([33786](https://github.com/WordPress/gutenberg/pull/33786))
- GitHub Templates: Fix spacing in bug report template. ([33761](https://github.com/WordPress/gutenberg/pull/33761))
- Update bug issue template to use forms. ([33713](https://github.com/WordPress/gutenberg/pull/33713))

#### Testing
- Add search performance measure and make other measures more stable. ([33848](https://github.com/WordPress/gutenberg/pull/33848))
- E2E: Block Hierarchy Navigation wait for the column to be highlighted. ([33721](https://github.com/WordPress/gutenberg/pull/33721))

#### Build Tooling
- Scripts: Update webpack to v5 (try 2). ([33818](https://github.com/WordPress/gutenberg/pull/33818))

```



## How has this been tested?
Following testing instructions from https://github.com/WordPress/gutenberg/pull/33229.

The only difference here is that you should check that:

1. There is no `Uncategorized` feature heading in the output.
2. All the items that would have been under `Uncategozed` are now place at the top of each section and have no heading.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
