### PR TITLE
Automated changelog - use nested headings for feature groups instead of indenting lists

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -677,7 +677,7 @@ async function getChangelog( settings ) {
 			// the "Documentation" section.
 			if ( group !== featureName ) {
 				// Start new <ul> for the Feature group.
-				changelog += '- ' + featureName + '\n';
+				changelog += '#### ' + featureName + '\n';
 			}
 
 			// Add a <li> for each PR in the Feature.
@@ -686,7 +686,7 @@ async function getChangelog( settings ) {
 				entry = entry && entry.replace( `[${ featureName } - `, '[' );
 
 				// Add a new bullet point to the list.
-				changelog += `  ${ entry }\n`;
+				changelog += `${ entry }\n`;
 			} );
 
 			// Close the <ul> for the Feature group.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/33719 it was decided that we should prefer nested heading levels over indenting lists for feature groupings.

This PR does that. Here's an example:

```md
### Various

#### Block Library
- Search Block: Removed components class from icon button and polished css. ([33961](https://github.com/WordPress/gutenberg/pull/33961))
- [Button Block]: Add padding block support. ([31774](https://github.com/WordPress/gutenberg/pull/31774))

#### Widgets Editor
- Try to fix flaky customizer inspector test 2nd try. ([33965](https://github.com/WordPress/gutenberg/pull/33965))
- Try to fix flaky customizer inspector test. ([33890](https://github.com/WordPress/gutenberg/pull/33890))

#### Block Editor
- Closing the block inserter decrements block type impressions. ([33906](https://github.com/WordPress/gutenberg/pull/33906))
- Enable rich previews for internal links. ([33086](https://github.com/WordPress/gutenberg/pull/33086))

```

Notice how the feature groups (`Block Editor`, `Widgets Editor`...etc) are all headings now and not lists.

## How has this been tested?

Run `npm run changelog -- --milestone="Gutenberg 11.2" --token=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN`.

Check the output uses nested headings not nested lists for feature groups.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
