### PR TITLE
Eslint plugin: Use @typescript-eslint/no-duplicate-imports in TS projects

### DIFF
--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -10,7 +10,6 @@ import type { Ref } from 'react';
  * Internal dependencies
  */
 import { contextConnect, useContextSystem } from '../ui/context';
-// eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import { DividerView } from './styles';
 import type { Props } from './types';

--- a/packages/components/src/heading/hook.ts
+++ b/packages/components/src/heading/hook.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { useContextSystem } from '../ui/context';
-// eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import type { Props as TextProps } from '../text/types';
 import { useText } from '../text';

--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -7,7 +7,6 @@ import { css } from '@emotion/react';
  * Internal dependencies
  */
 import { useContextSystem } from '../ui/context';
-// eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import { space } from '../ui/utils/space';
 import { useCx } from '../utils/hooks/use-cx';

--- a/packages/components/src/ui/shortcut/component.tsx
+++ b/packages/components/src/ui/shortcut/component.tsx
@@ -8,7 +8,6 @@ import type { Ref } from 'react';
  * Internal dependencies
  */
 import { useContextSystem, contextConnect } from '../context';
-// eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../context';
 import { View } from '../../view';
 

--- a/packages/components/src/ui/utils/create-component.tsx
+++ b/packages/components/src/ui/utils/create-component.tsx
@@ -9,7 +9,6 @@ import type { As } from 'reakit-utils/types';
  * Internal dependencies
  */
 import { contextConnect } from '../context';
-// eslint-disable-next-line no-duplicate-imports
 import type {
 	PolymorphicComponentProps,
 	PolymorphicComponentFromProps,

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -14,7 +14,6 @@ import { isValidElement } from '@wordpress/element';
  */
 import { getValidChildren } from '../ui/utils/get-valid-children';
 import { contextConnect, useContextSystem } from '../ui/context';
-// eslint-disable-next-line no-duplicate-imports
 import type { PolymorphicComponentProps } from '../ui/context';
 import { ZStackView, ZStackChildView } from './styles';
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-// eslint-disable-next-line no-duplicate-imports
 import type { HigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -8,7 +8,6 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-// eslint-disable-next-line no-duplicate-imports
 import type { SimpleHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -8,7 +8,6 @@ import type { ComponentType } from 'react';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-// eslint-disable-next-line no-duplicate-imports
 import type { PropInjectingHigherOrderComponent } from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
 

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -14,7 +14,6 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-// eslint-disable-next-line no-duplicate-imports
 import type { PropInjectingHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   Include `.jsx` extension when linting import statements in case TypeScript not present ([#33746](https://github.com/WordPress/gutenberg/pull/33746)).
+-   The recommended configuration will now respect `type` imports in TypeScript files ([#34055](https://github.com/WordPress/gutenberg/pull/34055)).
 
 ## 9.1.0 (2021-07-21)
 

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -39,11 +39,14 @@ if ( isPackageInstalled( 'typescript' ) ) {
 	};
 	config.extends.push( 'plugin:@typescript-eslint/eslint-recommended' );
 	config.ignorePatterns = [ '**/*.d.ts' ];
+	config.plugins = [ '@typescript-eslint' ];
 	config.overrides = [
 		{
 			files: [ '**/*.ts', '**/*.tsx' ],
 			parser: '@typescript-eslint/parser',
 			rules: {
+				'no-duplicate-imports': 'off',
+				'@typescript-eslint/no-duplicate-imports': 'error',
 				// Don't require redundant JSDoc types in TypeScript files.
 				'jsdoc/require-param-type': 'off',
 				'jsdoc/require-returns-type': 'off',

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -21,7 +21,6 @@ import {
 	useReducer,
 } from '@wordpress/element';
 import { defaultI18n } from '@wordpress/i18n';
-// eslint-disable-next-line no-duplicate-imports
 import type { I18n } from '@wordpress/i18n';
 interface I18nContextProps {
 	__: I18n[ '__' ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Update eslint plugin to use `@typescript-eslint/no-duplicate-imports` on TypeScript projects. This rule extends the base `eslint/no-duplicate-imports` rule and adds support for type-only import and export.

See https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-duplicate-imports.md

This allows importing types and exports from the same package without trowing an error. All files that import types today in Gutenberg adds a `// eslint-disable-next-line no-duplicate-imports` to avoid it. This PR fixes so these are no longer needed.

## How has this been tested?
Locally by running `npm run lint-js`

## Types of changes
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
