### PR TITLE
Add and apply a disabled picker button style

### DIFF
--- a/packages/components/src/unit-control/index.native.js
+++ b/packages/components/src/unit-control/index.native.js
@@ -43,6 +43,8 @@ function UnitControl( {
 	const pickerRef = useRef();
 	const anchorNodeRef = useRef();
 
+	const isPickerButtonEnabled = hasUnits( units ) && units?.length > 1;
+
 	const onPickerPresent = useCallback( () => {
 		if ( pickerRef?.current ) {
 			pickerRef.current.presentPicker();
@@ -55,8 +57,12 @@ function UnitControl( {
 		: initialPosition;
 
 	const unitButtonTextStyle = getStylesFromColorScheme(
-		styles.unitButtonText,
-		styles.unitButtonTextDark
+		isPickerButtonEnabled
+			? styles.unitButtonText
+			: styles.unitButtonTextDisabled,
+		isPickerButtonEnabled
+			? styles.unitButtonTextDark
+			: styles.unitButtonTextDisabledDark
 	);
 
 	/* translators: accessibility text. Inform about current unit value. %s: Current unit value. */
@@ -74,7 +80,7 @@ function UnitControl( {
 			</View>
 		);
 
-		if ( hasUnits( units ) && units?.length > 1 ) {
+		if ( isPickerButtonEnabled ) {
 			return (
 				<TouchableWithoutFeedback
 					onPress={ onPickerPresent }
@@ -118,7 +124,7 @@ function UnitControl( {
 		return (
 			<View style={ styles.unitMenu } ref={ anchorNodeRef }>
 				{ renderUnitButton }
-				{ hasUnits( units ) && units?.length > 1 ? (
+				{ isPickerButtonEnabled ? (
 					<Picker
 						ref={ pickerRef }
 						options={ units }

--- a/packages/components/src/unit-control/style.native.scss
+++ b/packages/components/src/unit-control/style.native.scss
@@ -6,6 +6,14 @@
 	color: $blue-30;
 }
 
+.unitButtonTextDisabled {
+	color: $gray-dark;
+}
+
+.unitButtonTextDisabledDark {
+	color: $white;
+}
+
 .unitButton {
 	padding-right: $grid-unit;
 	padding-left: $grid-unit;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3800 by updating the styling of the `UnitControl` unit button to look like a normal label when there is only a single unit option available (for example, "Pixel"). When this is the case the unit button is disabled and treated just as label and should only look like a label. 





## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
The easiest way to test is to either figure out a block that has a setting that uses `UnitControl` but only has a single unit to pick from, or to change the `isPickerButtonEnabled` `const` to return false like this:

```
const isPickerButtonEnabled = false;
```

1. Then add that block to the editor, click on the settings cog, and verify the color of the `unit` option in the `UnitControl`. The screenshots below are from the Column block for example. 
2. Also test that a block setting with multiple units available acts as a button that when tapped, opens the options to select a different unit (if you made changes to `isPickerButtonEnabled`, be sure to revert that change first). 

## Screenshots <!-- if applicable -->

Before | After
-- | --
![picker-enabled-ios](https://user-images.githubusercontent.com/5810477/129278288-dc4d09b9-f9e9-41d8-8070-0215ffb09a44.png)|![picker-disabled-ios](https://user-images.githubusercontent.com/5810477/129278294-924b459b-56eb-440f-b1c6-1328f519dda7.png)
![picker-enabled-ios-dark](https://user-images.githubusercontent.com/5810477/129278310-75971264-d97a-45e4-a6d1-d6a5d4745c22.png)|![picker-disabled-ios-dark](https://user-images.githubusercontent.com/5810477/129278315-4813f860-e3fa-45b4-b035-83fd1163fbbf.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Small styling changes that should not break anything. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
