### PR TITLE
Spacing/Dimensions Supports: Separate spacing from dimensions for compatibility purposes

### DIFF
--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -2,6 +2,10 @@
 /**
  * Dimensions block support flag.
  *
+ * This does not include the `spacing` block support even though that visually
+ * appears under the "Dimensions" panel in the editor. It remains in its
+ * original `spacing.php` file for compatibility with core.
+ *
  * @package gutenberg
  */
 
@@ -21,10 +25,10 @@ function gutenberg_register_dimensions_support( $block_type ) {
 		return;
 	}
 
-	$has_spacing_support = gutenberg_block_has_support( $block_type, array( 'spacing' ), false );
+	$has_dimensions_support = gutenberg_block_has_support( $block_type, array( '__experimentalDimensions' ), false );
 	// Future block supports such as height & width will be added here.
 
-	if ( $has_spacing_support ) {
+	if ( $has_dimensions_support ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
@@ -38,79 +42,39 @@ function gutenberg_register_dimensions_support( $block_type ) {
  * @param WP_Block_Type $block_type       Block Type.
  * @param array         $block_attributes Block attributes.
  *
- * @return array Block spacing CSS classes and inline styles.
+ * @return array Block dimensions CSS classes and inline styles.
  */
 function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
-	$spacing_styles = gutenberg_apply_spacing_support( $block_type, $block_attributes );
-	// Future block supports such as height and width will be added here.
-
-	return $spacing_styles;
-}
-
-/**
- * Add CSS classes for block spacing to the incoming attributes array.
- * This will be applied to the block markup in the front-end.
- *
- * @param WP_Block_Type $block_type       Block Type.
- * @param array         $block_attributes Block attributes.
- *
- * @return array Block spacing CSS classes and inline styles.
- */
-function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
-	if ( gutenberg_skip_spacing_serialization( $block_type ) ) {
+	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
 		return array();
 	}
 
-	$has_padding_support = gutenberg_block_has_support( $block_type, array( 'spacing', 'padding' ), false );
-	$has_margin_support  = gutenberg_block_has_support( $block_type, array( 'spacing', 'margin' ), false );
-	$styles              = array();
+	$styles = array();
 
-	if ( $has_padding_support ) {
-		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
-
-		if ( is_array( $padding_value ) ) {
-			foreach ( $padding_value as $key => $value ) {
-				$styles[] = sprintf( 'padding-%s: %s;', $key, $value );
-			}
-		} elseif ( null !== $padding_value ) {
-			$styles[] = sprintf( 'padding: %s;', $padding_value );
-		}
-	}
-
-	if ( $has_margin_support ) {
-		$margin_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'margin' ), null );
-
-		if ( is_array( $margin_value ) ) {
-			foreach ( $margin_value as $key => $value ) {
-				$styles[] = sprintf( 'margin-%s: %s;', $key, $value );
-			}
-		} elseif ( null !== $margin_value ) {
-			$styles[] = sprintf( 'margin: %s;', $margin_value );
-		}
-	}
+	// Height support to be added in near future.
+	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
 }
 
 /**
- * Checks whether serialization of the current block's spacing properties should
- * occur.
+ * Checks whether serialization of the current block's dimensions properties
+ * should occur.
  *
  * @param WP_Block_type $block_type Block type.
  *
  * @return boolean Whether to serialize spacing support styles & classes.
  */
-function gutenberg_skip_spacing_serialization( $block_type ) {
-	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
-
-	return is_array( $spacing_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
-		$spacing_support['__experimentalSkipSerialization'];
+function gutenberg_skip_dimensions_serialization( $block_type ) {
+	$dimensions_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions' ), false );
+	return is_array( $dimensions_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $dimensions_support ) &&
+		$dimensions_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
-	'spacing', // This is deliberately `spacing` instead of `dimensions` for backwards compatibility.
+	'dimensions',
 	array(
 		'register_attribute' => 'gutenberg_register_dimensions_support',
 		'apply'              => 'gutenberg_apply_dimensions_support',

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -44,7 +44,7 @@ function gutenberg_register_dimensions_support( $block_type ) {
  *
  * @return array Block dimensions CSS classes and inline styles.
  */
-function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) {
+function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
 		return array();
 	}

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Spacing block support flag.
+ *
+ * For backwards compatibility with core, this remains separate to the
+ * dimensions.php block support despite both belonging under a single panel in
+ * the editor.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the style block attribute for block types that support it.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_spacing_support( $block_type ) {
+	$has_spacing_support = gutenberg_block_has_support( $block_type, array( 'spacing' ), false );
+
+	// Setup attributes and styles within that if needed.
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_spacing_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+}
+
+/**
+ * Add CSS classes for block spacing to the incoming attributes array.
+ * This will be applied to the block markup in the front-end.
+ *
+ * @param WP_Block_Type $block_type       Block Type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array Block spacing CSS classes and inline styles.
+ */
+function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
+	if ( gutenberg_skip_spacing_serialization( $block_type ) ) {
+		return array();
+	}
+
+	$has_padding_support = gutenberg_block_has_support( $block_type, array( 'spacing', 'padding' ), false );
+	$has_margin_support  = gutenberg_block_has_support( $block_type, array( 'spacing', 'margin' ), false );
+	$styles              = array();
+
+	if ( $has_padding_support ) {
+		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
+
+		if ( is_array( $padding_value ) ) {
+			foreach ( $padding_value as $key => $value ) {
+				$styles[] = sprintf( 'padding-%s: %s;', $key, $value );
+			}
+		} elseif ( null !== $padding_value ) {
+			$styles[] = sprintf( 'padding: %s;', $padding_value );
+		}
+	}
+
+	if ( $has_margin_support ) {
+		$margin_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'margin' ), null );
+
+		if ( is_array( $margin_value ) ) {
+			foreach ( $margin_value as $key => $value ) {
+				$styles[] = sprintf( 'margin-%s: %s;', $key, $value );
+			}
+		} elseif ( null !== $margin_value ) {
+			$styles[] = sprintf( 'margin: %s;', $margin_value );
+		}
+	}
+
+	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
+}
+
+/**
+ * Checks whether serialization of the current block's spacing properties should
+ * occur.
+ *
+ * @param WP_Block_type $block_type Block type.
+ *
+ * @return boolean Whether to serialize spacing support styles & classes.
+ */
+function gutenberg_skip_spacing_serialization( $block_type ) {
+	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
+
+	return is_array( $spacing_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
+		$spacing_support['__experimentalSkipSerialization'];
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'spacing',
+	array(
+		'register_attribute' => 'gutenberg_register_spacing_support',
+		'apply'              => 'gutenberg_apply_spacing_support',
+	)
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -128,5 +128,6 @@ require __DIR__ . '/block-supports/typography.php';
 require __DIR__ . '/block-supports/custom-classname.php';
 require __DIR__ . '/block-supports/border.php';
 require __DIR__ . '/block-supports/layout.php';
+require __DIR__ . '/block-supports/spacing.php';
 require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/32392

## Description

This PR addresses an issue of compatibility with core created by the renaming of spacing to dimensions support in [#32392](https://github.com/WordPress/gutenberg/pull/32392#discussion_r687501190).

- The previous version of `spacing.php` has been restored
- The `dimensions.php` server-side hook remains in place ready to accept [height](https://github.com/WordPress/gutenberg/pull/32499) and [width](https://github.com/WordPress/gutenberg/pull/32502) support
- No changes to the block.json or theme.json support keys have been made
   - `spacing` contains `padding` and `margin` support
       - block.json and theme.json both use the stabilised `spacing` key.
   - `dimensions` will contain `height`, `width`, and possibly min/max versions of those.
       - block.json uses an `__experimentalDimensions` key
       - theme.json uses a `dimensions` key

## How has this been tested?

- `npm run test-unit:watch packages/block-editor/src/hooks/test/style.js`
- `npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist --verbose --filter stylesheet /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-test.php'`
- Manually by:
    - opting into both padding and margin support under spacing for the group block
    - opting into both padding and margin support for the dynamic site tagline block
    - confirming dimensions hook is in place but takes no effect for the moment until the [height](https://github.com/WordPress/gutenberg/pull/32499) and [width](https://github.com/WordPress/gutenberg/pull/32502) supports add their application of styles within it

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
