### PR TITLE
Margin block supports: show by default in site title and site tagline

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -18,7 +18,10 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": true
+			}
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -24,7 +24,10 @@
 		},
 		"spacing": {
 			"padding": true,
-			"margin": true
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": true
+			}
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
## Description

A PR to make margin controls display by default in the Dimensions ToolsPanel controls for site title and site tagline blocks.

Both these blocks already have margin supports. They are, at the time of writing, the only do that have.

Using the utterly tremendous `__experimentalDefaultControls` we can decide which controls we'd like to show, and which to leave collapsed.

## Testing

Turn on some Lo-Fi beats.

Spin up this branch.

Insert site title and site tagline blocks, and make sure that the Dimensions control show in the sidebar and that the margin controls are visible by default.

![margin-support-default](https://user-images.githubusercontent.com/6458278/129300362-e87f3dd0-733f-461d-8b0f-30753037dbd4.gif)

## Types of changes
Turning on existing default panel features for two blocks.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
