### PR TITLE
Border controls: add defaults in the ToolPanel

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -79,7 +79,10 @@
 		},
 		"__experimentalBorder": {
 			"radius": true,
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"radius": true
+			}
 		},
 		"__experimentalSelector": ".wp-block-button__link"
 	},

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -35,7 +35,11 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true
+			"style": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"color": true
+			}
 		},
 		"color": {
 			"text": true,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -35,7 +35,13 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		},
 		"__experimentalLayout": true
 	},

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -84,7 +84,10 @@
 			"background": false
 		},
 		"__experimentalBorder": {
-			"radius": true
+			"radius": true,
+			"__experimentalDefaultControls": {
+				"radius": true
+			}
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -49,7 +49,13 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-pullquote-editor",

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -3,6 +3,7 @@
 	padding: 3em 0;
 	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
+	box-sizing: border-box;
 
 	p,
 	blockquote,

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -49,7 +49,11 @@
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true
+			}
 		},
 		"html": false
 	},

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -49,10 +49,12 @@
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,
+			"width": true,
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"color": true,
-				"radius": true
+				"radius": true,
+				"width": true
 			}
 		},
 		"html": false

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -103,6 +103,7 @@ export default function SearchEdit( {
 	}, [ insertedInNavigationBlock ] );
 	const borderRadius = style?.border?.radius;
 	const borderColor = style?.border?.color;
+	const borderWidth = style?.border?.width;
 	const borderProps = useBorderProps( attributes );
 
 	// Check for old deprecated numerical border radius. Done as a separate
@@ -388,6 +389,7 @@ export default function SearchEdit( {
 	const getWrapperStyles = () => {
 		const styles = {
 			borderColor,
+			borderWidth: isButtonPositionInside ? borderWidth : undefined,
 		};
 
 		const isNonZeroBorderRadius = parseInt( borderRadius, 10 ) !== 0;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -197,9 +197,10 @@ function styles_for_block_core_search( $attributes ) {
 
 	// Add border width styles.
 	$has_border_width = ! empty( $attributes['style']['border']['width'] );
-	$border_width     = $attributes['style']['border']['width'];
 
 	if ( $has_border_width ) {
+		$border_width = $attributes['style']['border']['width'];
+
 		if ( $is_button_inside ) {
 			$wrapper_styles[] = sprintf( 'border-width: %s;', esc_attr( $border_width ) );
 		} else {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -33,7 +33,6 @@ function render_block_core_search( $attributes ) {
 	$use_icon_button  = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
 	$show_input       = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'] ) ? false : true;
 	$show_button      = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
-	$label_markup     = '';
 	$input_markup     = '';
 	$button_markup    = '';
 	$inline_styles    = styles_for_block_core_search( $attributes );
@@ -178,9 +177,11 @@ function classnames_for_block_core_search( $attributes ) {
  * @return array Style HTML attribute.
  */
 function styles_for_block_core_search( $attributes ) {
-	$wrapper_styles = array();
-	$button_styles  = array();
-	$input_styles   = array();
+	$wrapper_styles   = array();
+	$button_styles    = array();
+	$input_styles     = array();
+	$is_button_inside = ! empty( $attributes['buttonPosition'] ) &&
+		'button-inside' === $attributes['buttonPosition'];
 
 	// Add width styles.
 	$has_width   = ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] );
@@ -194,15 +195,25 @@ function styles_for_block_core_search( $attributes ) {
 		);
 	}
 
+	// Add border width styles.
+	$has_border_width = ! empty( $attributes['style']['border']['width'] );
+	$border_width     = $attributes['style']['border']['width'];
+
+	if ( $has_border_width ) {
+		if ( $is_button_inside ) {
+			$wrapper_styles[] = sprintf( 'border-width: %s;', esc_attr( $border_width ) );
+		} else {
+			$button_styles[] = sprintf( 'border-width: %s;', esc_attr( $border_width ) );
+			$input_styles[]  = sprintf( 'border-width: %s;', esc_attr( $border_width ) );
+		}
+	}
+
 	// Add border radius styles.
 	$has_border_radius = ! empty( $attributes['style']['border']['radius'] );
 
 	if ( $has_border_radius ) {
 		$default_padding = '4px';
 		$border_radius   = $attributes['style']['border']['radius'];
-		// Apply wrapper border radius if button placed inside.
-		$is_button_inside = ! empty( $attributes['buttonPosition'] ) &&
-			'button-inside' === $attributes['buttonPosition'];
 
 		if ( is_array( $border_radius ) ) {
 			// Apply styles for individual corner border radii.
@@ -255,9 +266,7 @@ function styles_for_block_core_search( $attributes ) {
 	$has_border_color = ! empty( $attributes['style']['border']['color'] );
 
 	if ( $has_border_color ) {
-		$border_color     = $attributes['style']['border']['color'];
-		$is_button_inside = ! empty( $attributes['buttonPosition'] ) &&
-			'button-inside' === $attributes['buttonPosition'];
+		$border_color = $attributes['style']['border']['color'];
 
 		// Apply wrapper border color if button placed inside.
 		if ( $is_button_inside ) {

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -145,7 +145,12 @@
 			"__experimentalSkipSerialization": true,
 			"color": true,
 			"style": true,
-			"width": true
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"style": true,
+				"width": true
+			}
 		},
 		"__experimentalSelector": ".wp-block-table > table"
 	},

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -127,6 +127,7 @@
 		th,
 		td {
 			border-width: inherit;
+			border-style: inherit;
 		}
 	}
 }


### PR DESCRIPTION
Requires 
- https://github.com/WordPress/gutenberg/pull/33743

## Description

Lots of blocks are already taking advantage of border supports, but have they heard about the new [ToolsPanel](https://github.com/WordPress/gutenberg/pull/32392)?

This PR is based on https://github.com/WordPress/gutenberg/pull/33743, which switches border supports to the ToolsPanel, and sets which border properties are displayed in the ToolsPanel by default.

## Testing
Ensure that border supports are switched on in theme.json

```
		"border": {
			"customColor": true,
			"customRadius": true,
			"customStyle": true,
			"customWidth": true
		},
```

Create a new post and insert the follow blocks:

- Code
- Table
- Search
- Pullquote
- Image
- Group
- Buttons

For each block check that:

1. The Border controls appear in the ToolsPanel and,
2. The properties defined under `__experimentalDefaultControls` in the block's `block.json` are displayed in the panel by default.

For the Search Block, make sure:

1. The editor and frontend output is the same. Check various block styles (button inside, no button etc) cdcdd1f3152ee4c375d2dea5417c62bc365160fd

For the Table Block, observe that:
1. Adding a width maintains an initial border style 863a76fd5683d113bf67a962d1996ec56f2382ab

For the Pullquote Block, ensure that:
1. Adding a border width doesn't make the container bleed outside the post content column. 456b52342a187f2767c3579634bc4d70fca71cd7

Check in several themes.


## Screenshots 

<img width="500" alt="Screen Shot 2021-08-13 at 2 21 09 pm" src="https://user-images.githubusercontent.com/6458278/129304457-66b342b4-1eec-47fb-a2d0-b6af06b5019c.png">

## Types of changes

Turning on existing default panel features for border supports.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
