### PR TITLE
Cover: Move cover min-height into dimensions panel via SlotFill

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -24,6 +24,7 @@ import {
 	withNotices,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalBoxControl as BoxControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
 import {
@@ -536,20 +537,6 @@ function CoverEdit( {
 						</PanelRow>
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Dimensions' ) }>
-					<CoverHeightInput
-						value={ temporaryMinHeight || minHeight }
-						unit={ minHeightUnit }
-						onChange={ ( newMinHeight ) =>
-							setAttributes( { minHeight: newMinHeight } )
-						}
-						onUnitChange={ ( nextUnit ) =>
-							setAttributes( {
-								minHeightUnit: nextUnit,
-							} )
-						}
-					/>
-				</PanelBody>
 				<PanelColorGradientSettings
 					title={ __( 'Overlay' ) }
 					initialOpen={ true }
@@ -579,6 +566,30 @@ function CoverEdit( {
 						/>
 					) }
 				</PanelColorGradientSettings>
+			</InspectorControls>
+			<InspectorControls __experimentalGroup="dimensions">
+				<ToolsPanelItem
+					hasValue={ () => !! minHeight }
+					label={ __( 'Minimum height' ) }
+					onDeselect={ () =>
+						setAttributes( { minHeight: undefined } )
+					}
+					resetAllFilter={ () => ( { minHeight: undefined } ) }
+					isShownByDefault={ true }
+				>
+					<CoverHeightInput
+						value={ temporaryMinHeight || minHeight }
+						unit={ minHeightUnit }
+						onChange={ ( newMinHeight ) =>
+							setAttributes( { minHeight: newMinHeight } )
+						}
+						onUnitChange={ ( nextUnit ) =>
+							setAttributes( {
+								minHeightUnit: nextUnit,
+							} )
+						}
+					/>
+				</ToolsPanelItem>
 			</InspectorControls>
 		</>
 	);

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -582,6 +582,7 @@ function CoverEdit( {
 						minHeightUnit: undefined,
 					} ) }
 					isShownByDefault={ true }
+					panelId={ clientId }
 				>
 					<CoverHeightInput
 						value={ temporaryMinHeight || minHeight }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -572,9 +572,15 @@ function CoverEdit( {
 					hasValue={ () => !! minHeight }
 					label={ __( 'Minimum height' ) }
 					onDeselect={ () =>
-						setAttributes( { minHeight: undefined } )
+						setAttributes( {
+							minHeight: undefined,
+							minHeightUnit: undefined,
+						} )
 					}
-					resetAllFilter={ () => ( { minHeight: undefined } ) }
+					resetAllFilter={ () => ( {
+						minHeight: undefined,
+						minHeightUnit: undefined,
+					} ) }
 					isShownByDefault={ true }
 				>
 					<CoverHeightInput


### PR DESCRIPTION
Depends on: https://github.com/WordPress/gutenberg/pull/34157
Related: https://github.com/WordPress/gutenberg/pull/33970

## Description

- Moves the Cover block's `min-height` control into the dimensions block support panel.
- It wraps this control in a `ToolsPanelItem` component so it can also be reset via the `ToolsPanel` menu.

## How has this been tested?
Manually.

1. Edit a post, add separate group and cover blocks, select the cover block and add a background
2. There should only be one "Dimensions" panel in the sidebar
3. The `min-height` control should display by default under the "Dimensions" panel
4. Confirm the `min-height` control continues to function correctly when adjust
5. Confirm the `min-height` control behaves appropriately within the context of the `ToolsPanel` e.g. it can be reset etc.
6. With the Cover block selected select the Group block.
7. Ensure the `min-height` control does not appear in the Group block dimensions panel menu.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/129311172-4a916e49-c3a4-4136-ae10-6b9484a7baef.mp4

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
