### PR TITLE
Remove extra props from Cover deprecations

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -63,15 +63,6 @@ const deprecated = [
 	{
 		attributes: {
 			...blockAttributes,
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
 			isRepeated: {
 				type: 'boolean',
 				default: false,
@@ -206,15 +197,6 @@ const deprecated = [
 	{
 		attributes: {
 			...blockAttributes,
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
 			minHeight: {
 				type: 'number',
 			},
@@ -312,15 +294,6 @@ const deprecated = [
 	{
 		attributes: {
 			...blockAttributes,
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
 			minHeight: {
 				type: 'number',
 			},

--- a/test/integration/fixtures/blocks/core__cover__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-4.json
@@ -12,9 +12,7 @@
 			"focalPoint": {
 				"x": "0.07",
 				"y": "0.07"
-			},
-			"title": "",
-			"contentAlign": "center"
+			}
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__cover__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-5.json
@@ -8,8 +8,6 @@
 			"hasParallax": false,
 			"dimRatio": 50,
 			"backgroundType": "image",
-			"title": "",
-			"contentAlign": "center",
 			"gradient": "midnight"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__cover__deprecated-6.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-6.json
@@ -8,8 +8,6 @@
 			"hasParallax": false,
 			"dimRatio": 40,
 			"backgroundType": "image",
-			"title": "",
-			"contentAlign": "center",
 			"isRepeated": false
 		},
 		"innerBlocks": [
@@ -44,8 +42,6 @@
 				"x": "0.50",
 				"y": "0.40"
 			},
-			"title": "",
-			"contentAlign": "center",
 			"isRepeated": false,
 			"minHeight": 48,
 			"minHeightUnit": "vw",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
While working on a different PR I noticed that there were some extra not needed attributes in some `Cover` block deprecations. This PR just removes them and updates the fixtures.
<!-- Please describe what you have changed or added -->

