### PR TITLE
Global Styles: consider theme supports to enqueue the styles

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1065,6 +1065,43 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Returns a filtered tree by the given base and property.
+	 * It keeps the version intact.
+	 *
+	 * @param string $base One of the top-level keys.
+	 * @param array $property The property to filter the object by.
+	 *
+	 * @return WP_Theme_JSON
+	 */
+	public function filter_by( $base = '', $property = array() ) {
+		// This object may have already processed presets with multiple origins.
+		// Instead of having to re-create one-by-one in a new object,
+		// we take that already processed data directly.
+		$new = clone $this;
+		$new->theme_json = array();
+		$new->theme_json['version'] = $this->theme_json['version'];
+
+		if ( $base === 'settings' ) {
+			$nodes = self::get_setting_nodes( $this->theme_json, self::get_blocks_metadata() );
+		} else if ( $base === 'styles' ) {
+			$nodes = self::get_style_nodes( $this->theme_json, self::get_blocks_metadata() );
+		} else {
+			// TODO: other top-level keys.
+		}
+
+		foreach ( $nodes as $metadata ) {
+			$path = array_merge( $metadata['path'], $property );
+			$node = _wp_array_get( $this->theme_json, $path );
+
+			if ( isset( $node ) ) {
+				_wp_array_set( $new->theme_json, $path, $node );
+			}
+		}
+
+		return $new;
+	}
+
+	/**
 	 * Merge new incoming data.
 	 *
 	 * @param WP_Theme_JSON $incoming Data to merge.


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/33924

We use the `theme.json` server code to output styles that were previously bundled in JavaScript packages, such as `block-library`. In removing the older CSS by those JavaScript packages we still have to support some use cases for classic themes.

This is what we have to do, depending on what the theme supports:

- with `theme.json`: everything stays the same
- without theme.json but link-color support: enqueue only the color vars (before this PR we enqueued everything)
- without theme.json and no editor-color-palette either: enqueue the color vars and classes (they were bundled by the `block-library` to all themes before https://github.com/WordPress/gutenberg/pull/33924)
- without theme.json and no editor-gradient-presets: enqueue the gradient vars and classes (they were bundled by the `block-library` to all themes before https://github.com/WordPress/gutenberg/pull/33924)

## TODO

- Add unit tests.
- Implement for top-level keys other than `settings` & `styles`.

## How to test

Link color: 

- Use the TwentyTwentyOne theme.
- Load the front-end and verify that the `global-styles-inline-css` only contains the CSS Custom Properties for the colors. In `trunk`, it has all the vars and classes.

Color:

- Use the TwentyTwentyOne theme.
- Remove the theme support for `editor-color-palette` in its `functions.php`.
- Load the front-end and verify that the `global-styles-inline-css` only contains the CSS Custom Properties and the classes for the colors.
- Load the editor and verify that it only has the default colors. Apply one to a block and publish. Verify that the color works in the editor and front-end.

Gradients:

- Use the TwentyTwentyOne theme.
- Undo the changes done before for colors.
- Remove the theme support for `editor-gradient-presets` in its `functions.php`.
- Load the front-end and verify that the `global-styles-inline-css` only contains the CSS Custom Properties and the classes for the gradients.
- Load the editor and verify that it only has the default gradients. Apply one to a block and publish. Verify that the color works in the editor and front-end.

Try a combination of the above and verify it works as expected (removing support for color palette & gradients should enqueue both, etc).
