### PR TITLE
Duotone: Make it possible to define duotone settings in theme.json

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -263,7 +263,7 @@ function gutenberg_get_duotone_style( $selectors_group, $duotone_id ) {
 	?>
 	<style>
 		<?php echo $selectors_group; ?> {
-			filter: url( <?php echo esc_url( '#' . $duotone_id ); ?> ) !important; <?php // We need !important to overide rules that come from theme.json. ?>
+			filter: url( <?php echo esc_url( '#' . $duotone_id ); ?> );
 		}
 	</style>
 	<?php
@@ -442,7 +442,7 @@ function gutenberg_render_duotone_filters_from_theme_json() {
 		foreach( $theme_json_settings['color']['duotone']['theme'] as $duotone_setting ) {
 			$duotone_values = get_duotone_color_values( $duotone_setting['colors'] );
 			$duotone_id = 'wp-duotone-filter-' . $duotone_setting['slug'];
-			$duotone_markup = gutenberg_get_dutone_svg_filters( $duotone_id, $duotone_values );
+			$duotone_markup = gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
 			gutenberg_output_duotone_markup( $duotone_markup );
 		}
 	}

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -382,7 +382,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	$duotone_values = get_duotone_color_values( $duotone_colors );
 
-	$duotone_id = 'wp-duotone-filter-' . uniqid();
+	$duotone_id = 'wp-duotone-' . uniqid();
 
 	$selectors        = explode( ',', $duotone_support );
 	$selectors_scoped = array_map(
@@ -438,10 +438,10 @@ function gutenberg_render_duotone_filters_from_theme_json() {
 	$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
 
 	$theme_json_settings = $theme_json->get_settings();
-	if( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) &&  ! empty( $theme_json_settings['color']['duotone']['theme'] ) ) {
-		foreach( $theme_json_settings['color']['duotone']['theme'] as $duotone_setting ) {
+	if( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) &&  ! empty( $theme_json_settings['color']['duotone'] ) ) {
+		foreach( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
 			$duotone_values = get_duotone_color_values( $duotone_setting['colors'] );
-			$duotone_id = 'wp-duotone-filter-' . $duotone_setting['slug'];
+			$duotone_id = 'wp-duotone-' . $duotone_setting['slug'];
 			$duotone_markup = gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
 			gutenberg_output_duotone_markup( $duotone_markup );
 		}

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -278,7 +278,7 @@ function gutenberg_get_duotone_style( $selectors_group, $duotone_id ) {
  * @param array $duotone_values
  * @return string The markup for the <svg> tag.
  */
-function gutenberg_get_dutone_svg_filters( $duotone_id, $duotone_values ) {
+function gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values ) {
 	ob_start();
 	?>
 

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -394,7 +394,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$selectors_group = implode( ', ', $selectors_scoped );
 
 	$duotone_markup = gutenberg_get_duotone_style( $selectors_group, $duotone_id );
-	$duotone_markup .= gutenberg_get_dutone_svg_filters( $duotone_id, $duotone_values );
+	$duotone_markup .= gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
 
 	if ( ! is_admin() ) {
 		gutenberg_output_duotone_markup( $duotone_markup );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -381,7 +381,6 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	$duotone_colors = $block['attrs']['style']['color']['duotone'];
 
 	$duotone_values = get_duotone_color_values( $duotone_colors );
-
 	$duotone_id = gutenberg_get_duotone_filter_id( uniqid() );
 
 	$selectors        = explode( ',', $duotone_support );
@@ -393,8 +392,12 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	);
 	$selectors_group = implode( ', ', $selectors_scoped );
 
-	$duotone_markup = gutenberg_get_duotone_style( $selectors_group, $duotone_id );
-	$duotone_markup .= gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
+	if ( 'unset' === $duotone_colors ) {
+		$duotone_markup = '<style>' . $selectors_group . '{ filter: unset; }</style>';
+	} else {
+		$duotone_markup = gutenberg_get_duotone_style( $selectors_group, $duotone_id );
+		$duotone_markup .= gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
+	}
 
 	if ( ! is_admin() ) {
 		gutenberg_output_duotone_markup( $duotone_markup );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -382,7 +382,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	$duotone_values = get_duotone_color_values( $duotone_colors );
 
-	$duotone_id = 'wp-duotone-' . uniqid();
+	$duotone_id = gutenberg_get_duotone_filter_id( uniqid() );
 
 	$selectors        = explode( ',', $duotone_support );
 	$selectors_scoped = array_map(
@@ -424,28 +424,22 @@ remove_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_duotone_support', 10, 2 );
 
 /**
- * Renders a the SVG and CSS to make duotone filters work.
+ * Returns the ID for the duotone filter
+ *
+ * @param string $id The ID of the filter.
  */
-function gutenberg_render_duotone_filters_from_theme_json() {
-	if (
-		! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
-		! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		return;
-	}
-
-
-	$settings = gutenberg_get_default_block_editor_settings();
-	$theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-
-	$theme_json_settings = $theme_json->get_settings();
-	if( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) &&  ! empty( $theme_json_settings['color']['duotone'] ) ) {
-		foreach( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
-			$duotone_values = get_duotone_color_values( $duotone_setting['colors'] );
-			$duotone_id = 'wp-duotone-' . $duotone_setting['slug'];
-			$duotone_markup = gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
-			gutenberg_output_duotone_markup( $duotone_markup );
-		}
-	}
+function gutenberg_get_duotone_filter_id( $id ) {
+	return 'wp-duotone-' . $id;
 }
 
-add_action( 'enqueue_block_assets', 'gutenberg_render_duotone_filters_from_theme_json' );
+/**
+ * Generates duotone markup from a settings array
+ *
+ * @param  array  $duotone_setting Block object.
+ */
+function gutenberg_generate_duotone_filters_settings( $duotone_setting) {
+	$duotone_values = get_duotone_color_values( $duotone_setting['colors'] );
+	$duotone_id = gutenberg_get_duotone_filter_id( $duotone_setting['slug'] );
+	$duotone_markup = gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
+	gutenberg_output_duotone_markup( $duotone_markup );
+}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -183,18 +183,6 @@ class WP_Theme_JSON_Gutenberg {
 			),
 		),
 		array(
-			'path'          => array( 'color', 'duotone' ),
-			'value_key'     => 'slug',
-			'css_var_infix' => 'duotone',
-			'value_format' => 'url(#wp-duotone-filter-%s)',
-			'classes'       => array(
-				array(
-					'class_suffix'  => 'duotone',
-					'property_name' => 'filter',
-				),
-			),
-		),
-		array(
 			'path'          => array( 'typography', 'fontSizes' ),
 			'value_key'     => 'size',
 			'css_var_infix' => 'font-size',
@@ -687,11 +675,6 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
-				if ( ! empty( $preset['value_format'] ) ) {
-					$value = vsprintf(
-						$preset['value_format'], is_array( $value ) ? $value : array( $value )
-					);
-				}
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),
 					'value' => $value,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -57,6 +57,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'color'      => array(
 			'background' => null,
+			'duotone'    => null,
 			'gradient'   => null,
 			'text'       => null,
 		),
@@ -182,6 +183,18 @@ class WP_Theme_JSON_Gutenberg {
 			),
 		),
 		array(
+			'path'          => array( 'color', 'duotone' ),
+			'value_key'     => 'slug',
+			'css_var_infix' => 'duotone',
+			'value_wrapper' => 'url(#wp-duotone-filter-$s)',
+			'classes'       => array(
+				array(
+					'class_suffix'  => 'duotone',
+					'property_name' => 'filter',
+				),
+			),
+		),
+		array(
 			'path'          => array( 'typography', 'fontSizes' ),
 			'value_key'     => 'size',
 			'css_var_infix' => 'font-size',
@@ -218,6 +231,7 @@ class WP_Theme_JSON_Gutenberg {
 		'border-width'               => array( 'border', 'width' ),
 		'border-style'               => array( 'border', 'style' ),
 		'color'                      => array( 'color', 'text' ),
+		'filter'                     => array( 'color', 'duotone' ),
 		'font-family'                => array( 'typography', 'fontFamily' ),
 		'font-size'                  => array( 'typography', 'fontSize' ),
 		'font-style'                 => array( 'typography', 'fontStyle' ),
@@ -609,6 +623,7 @@ class WP_Theme_JSON_Gutenberg {
 				$result[ preg_replace( '/\s+/', '-', $preset['slug'] ) ] = $preset[ $value_key ];
 			}
 		}
+
 		return $result;
 	}
 
@@ -672,6 +687,9 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
+				if ( ! empty( $preset['value_wrapper'] ) ) {
+					$value = str_replace( '$s', $value, $preset['value_wrapper'] );
+				}
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),
 					'value' => $value,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -611,7 +611,6 @@ class WP_Theme_JSON_Gutenberg {
 				$result[ preg_replace( '/\s+/', '-', $preset['slug'] ) ] = $preset[ $value_key ];
 			}
 		}
-
 		return $result;
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -186,7 +186,7 @@ class WP_Theme_JSON_Gutenberg {
 			'path'          => array( 'color', 'duotone' ),
 			'value_key'     => 'slug',
 			'css_var_infix' => 'duotone',
-			'value_wrapper' => 'url(#wp-duotone-filter-$s)',
+			'value_format' => 'url(#wp-duotone-filter-%s)',
 			'classes'       => array(
 				array(
 					'class_suffix'  => 'duotone',
@@ -687,8 +687,10 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
-				if ( ! empty( $preset['value_wrapper'] ) ) {
-					$value = str_replace( '$s', $value, $preset['value_wrapper'] );
+				if ( ! empty( $preset['value_format'] ) ) {
+					$value = vsprintf(
+						$preset['value_format'], is_array( $value ) ? $value : array( $value )
+					);
 				}
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -858,6 +858,13 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_rules .= self::compute_preset_classes( $node, $selector );
 		}
 
+		$theme_json_settings = $this->get_settings();
+		if( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) &&  ! empty( $theme_json_settings['color']['duotone'] ) ) {
+			foreach( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
+				gutenberg_generate_duotone_filters_settings( $duotone_setting );
+			}
+		}
+
 		return $block_rules . $preset_rules;
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -56,6 +56,7 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 
 	$settings = gutenberg_get_default_block_editor_settings();
 	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+
 	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
 	if ( empty( $stylesheet ) ) {
 		return;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -16,13 +16,13 @@
  */
 function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'all' ) {
 	// Check if we can use cached.
-	$can_use_cached = (
+	$can_use_cached = false; /*(
 		( 'all' === $type ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
 		! is_admin()
-	);
+	);*/
 
 	if ( $can_use_cached ) {
 		// Check if we have the styles already cached.
@@ -56,11 +56,12 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 
 	$settings = gutenberg_get_default_block_editor_settings();
 	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-
 	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
+
+	do_action( 'gutenberg_experimental_global_styles', $all );
 
 	if ( isset( wp_styles()->registered['global-styles'] ) ) {
 		wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -61,8 +61,6 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 		return;
 	}
 
-	do_action( 'gutenberg_experimental_global_styles', $all );
-
 	if ( isset( wp_styles()->registered['global-styles'] ) ) {
 		wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
 	} else {

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -76,7 +76,9 @@ function DuotoneFilter( { selector, id, values } ) {
 				filter: unset !important; /* We need !important to overide rules that come from theme.json.*/
 			}
 		`;
-		return ( <style dangerouslySetInnerHTML={ { __html: unsetStylesheet } } /> );
+		return (
+			<style dangerouslySetInnerHTML={ { __html: unsetStylesheet } } />
+		);
 	}
 
 	const stylesheet = `

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -68,7 +68,7 @@ export function getValuesFromColors( colors = [] ) {
 function DuotoneFilter( { selector, id, values } ) {
 	const stylesheet = `
 ${ selector } {
-	filter: url( #${ id } ) !important; // We need !important to overide rules that come from theme.json.
+	filter: url( #${ id } ) !important; /* We need !important to overide rules that come from theme.json.*/
 }
 `;
 

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -33,6 +33,10 @@ const EMPTY_ARRAY = [];
  * @return {Object} R, G, and B values.
  */
 export function getValuesFromColors( colors = [] ) {
+	if ( typeof colors === 'string' ) {
+		return colors;
+	}
+
 	const values = { r: [], g: [], b: [] };
 
 	colors.forEach( ( color ) => {
@@ -66,11 +70,19 @@ export function getValuesFromColors( colors = [] ) {
  * @return {WPElement} Duotone element.
  */
 function DuotoneFilter( { selector, id, values } ) {
+	if ( values === 'unset' ) {
+		const unsetStylesheet = `
+			${ selector } {
+				filter: unset !important; /* We need !important to overide rules that come from theme.json.*/
+			}
+		`;
+		return ( <style dangerouslySetInnerHTML={ { __html: unsetStylesheet } } /> );
+	}
+
 	const stylesheet = `
-${ selector } {
-	filter: url( #${ id } ) !important; /* We need !important to overide rules that come from theme.json.*/
-}
-`;
+		${ selector } {
+			filter: url( #${ id } ) !important; /* We need !important to overide rules that come from theme.json.*/
+	}`;
 
 	return (
 		<>

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -68,7 +68,7 @@ export function getValuesFromColors( colors = [] ) {
 function DuotoneFilter( { selector, id, values } ) {
 	const stylesheet = `
 ${ selector } {
-	filter: url( #${ id } );
+	filter: url( #${ id } ) !important; // We need !important to overide rules that come from theme.json.
 }
 `;
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -84,7 +84,8 @@
 		},
 		"__experimentalBorder": {
 			"radius": true
-		}
+		},
+		"__experimentalSelector": ".wp-block-image img"
 	},
 	"styles": [
 		{

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -128,6 +128,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {
+	'color.duotone': true,
 	'color.gradients': true,
 	'color.palette': true,
 	'typography.fontFamilies': true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -128,7 +128,6 @@ export const __EXPERIMENTAL_ELEMENTS = {
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {
-	'color.duotone': true,
 	'color.gradients': true,
 	'color.palette': true,
 	'typography.fontFamilies': true,

--- a/packages/components/src/duotone-picker/custom-duotone-bar.js
+++ b/packages/components/src/duotone-picker/custom-duotone-bar.js
@@ -12,10 +12,15 @@ import {
 const PLACEHOLDER_VALUES = [ '#333', '#CCC' ];
 
 export default function CustomDuotoneBar( { value, onChange } ) {
+	if ( typeof value === 'string' ) {
+		return null;
+	}
+
 	const hasGradient = !! value;
 	const values = hasGradient ? value : PLACEHOLDER_VALUES;
 	const background = getGradientFromCSSColors( values );
 	const controlPoints = getColorStopsFromColors( values );
+
 	return (
 		<CustomGradientBar
 			disableInserter

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -69,11 +69,19 @@ function DuotonePicker( {
 				);
 			} ) }
 			actions={
-				<CircularOptionPicker.ButtonAction
-					onClick={ () => onChange( undefined ) }
-				>
-					{ __( 'Clear' ) }
-				</CircularOptionPicker.ButtonAction>
+				<div>
+					<CircularOptionPicker.ButtonAction
+						onClick={ () => onChange( 'unset' ) }
+					>
+						{ __( 'Disable' ) }
+					</CircularOptionPicker.ButtonAction>
+
+					<CircularOptionPicker.ButtonAction
+						onClick={ () => onChange( undefined ) }
+					>
+						{ __( 'Clear' ) }
+					</CircularOptionPicker.ButtonAction>
+				</div>
 			}
 		>
 			{ ! disableCustomColors && ! disableCustomDuotone && (

--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -30,52 +30,65 @@ function DuotonePicker( {
 		() => getDefaultColors( colorPalette ),
 		[ colorPalette ]
 	);
+	const options = duotonePalette.map( ( { colors, slug, name } ) => {
+		const style = {
+			background: getGradientFromCSSColors( colors, '135deg' ),
+			color: 'transparent',
+		};
+		const tooltipText =
+			name ??
+			sprintf(
+				// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
+				__( 'Duotone code: %s' ),
+				slug
+			);
+		const label = name
+			? sprintf(
+					// translators: %s: The name of the option e.g: "Dark grayscale".
+					__( 'Duotone: %s' ),
+					name
+			  )
+			: tooltipText;
+		const isSelected = isEqual( colors, value );
+
+		return (
+			<CircularOptionPicker.Option
+				key={ slug }
+				value={ colors }
+				isSelected={ isSelected }
+				aria-label={ label }
+				tooltipText={ tooltipText }
+				style={ style }
+				onClick={ () => {
+					onChange( isSelected ? undefined : colors );
+				} }
+			/>
+		);
+	} );
+
+	// Add a disable duotone option.
+	const disableOption = (
+		<CircularOptionPicker.Option
+			key={ 'unset' }
+			value={ 'unset' }
+			isSelected={ value === 'unset' }
+			aria-label={ __( 'Disable duotone' ) }
+			tooltipText={ __( 'Disable duotone' ) }
+			style={ {
+				background: '#FFF url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\'><path d=\'M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zM3 12c0-5 4-9 9-9 2.2 0 4.3.8 5.8 2.2L5.2 17.8C3.8 16.3 3 14.2 3 12zm9 9c-2.4 0-4.5-.9-6.2-2.4L18.6 5.8C20.1 7.5 21 9.6 21 12c0 5-4 9-9 9z\' fill-rule=\'evenodd\' clip-rule=\'evenodd\' /></svg>" )',
+				color: 'transparent',
+			} }
+			onClick={ () => {
+				onChange( value === 'unset' ? undefined : 'unset' );
+			} }
+		/>
+	);
 
 	return (
 		<CircularOptionPicker
-			options={ duotonePalette.map( ( { colors, slug, name } ) => {
-				const style = {
-					background: getGradientFromCSSColors( colors, '135deg' ),
-					color: 'transparent',
-				};
-				const tooltipText =
-					name ??
-					sprintf(
-						// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
-						__( 'Duotone code: %s' ),
-						slug
-					);
-				const label = name
-					? sprintf(
-							// translators: %s: The name of the option e.g: "Dark grayscale".
-							__( 'Duotone: %s' ),
-							name
-					  )
-					: tooltipText;
-				const isSelected = isEqual( colors, value );
-
-				return (
-					<CircularOptionPicker.Option
-						key={ slug }
-						value={ colors }
-						isSelected={ isSelected }
-						aria-label={ label }
-						tooltipText={ tooltipText }
-						style={ style }
-						onClick={ () => {
-							onChange( isSelected ? undefined : colors );
-						} }
-					/>
-				);
-			} ) }
+			options={ [ disableOption, ...options ] }
 			actions={
 				<div>
-					<CircularOptionPicker.ButtonAction
-						onClick={ () => onChange( 'unset' ) }
-					>
-						{ __( 'Disable' ) }
-					</CircularOptionPicker.ButtonAction>
-
 					<CircularOptionPicker.ButtonAction
 						onClick={ () => onChange( undefined ) }
 					>

--- a/packages/components/src/duotone-picker/duotone-swatch.js
+++ b/packages/components/src/duotone-picker/duotone-swatch.js
@@ -6,6 +6,10 @@ import Swatch from '../swatch';
 import { getGradientFromCSSColors } from './utils';
 
 function DuotoneSwatch( { values } ) {
+	if ( typeof values === 'string' ) {
+		return <Swatch />;
+	}
+
 	return (
 		<Swatch
 			fill={ values && getGradientFromCSSColors( values, '135deg' ) }

--- a/packages/components/src/duotone-picker/utils.js
+++ b/packages/components/src/duotone-picker/utils.js
@@ -49,6 +49,10 @@ export function getDefaultColors( palette ) {
  * @return {string} CSS gradient string for the duotone swatch.
  */
 export function getGradientFromCSSColors( colors = [], angle = '90deg' ) {
+	if ( typeof colors === 'string' ) {
+		return null;
+	}
+
 	const l = 100 / colors.length;
 
 	const stops = colors
@@ -66,6 +70,10 @@ export function getGradientFromCSSColors( colors = [], angle = '90deg' ) {
  * @return {Object[]} Color stop information.
  */
 export function getColorStopsFromColors( colors ) {
+	if ( typeof colors === 'string' ) {
+		return null;
+	}
+
 	return colors.map( ( color, i ) => ( {
 		position: ( i * 100 ) / ( colors.length - 1 ),
 		color,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This allows users to apply a duotone filter to all image blocks. To make this possible, we need to output CSS variables and SVG filters for all the duotone filters in the theme.json file. Many of the changes in this PR are simply refactoring the duotone.php library into smaller reusable functions.

This is a fix for https://github.com/WordPress/gutenberg/issues/33642


## How has this been tested?
- Checkout this PR: https://github.com/Automattic/themes/pull/4406
- Switch to the Skatepark theme
- Your images should now have a red/black duotone filter applied.
- This should work in both the editor and the frontend.
- Duotone filters applied to images directly should continue to work as before

## Screenshots <!-- if applicable -->
Top section - duotone applied directly to the image.
Bottom section - duotone applied by the theme.
<img width="1439" alt="Screenshot 2021-08-13 at 15 17 57" src="https://user-images.githubusercontent.com/275961/129371023-26353f52-f1a0-4420-84ca-5c9eecc52612.png">


## Types of changes
<!-- New feature (non-breaking change which adds functionality) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
