### PR TITLE
Navigation block: Add missing closing tag

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -267,7 +267,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks_html .= $inner_block->render();
 	}
 
-	if ( true === $is_list_open ) {
+	if ( $is_list_open ) {
 		$inner_blocks_html .= '</ul>';
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -267,6 +267,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks_html .= $inner_block->render();
 	}
 
+	if ( true === $is_list_open ) {
+		$inner_blocks_html .= '</ul>';
+	}
+
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
 
 	$wrapper_attributes = get_block_wrapper_attributes(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -256,11 +256,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$inner_blocks_html = '';
 	$is_list_open      = false;
 	foreach ( $inner_blocks as $inner_block ) {
-		if ( ( 'core/navigation-link' === $inner_block->name || 'core/home-link' === $inner_block->name ) && false === $is_list_open ) {
+		if ( ( 'core/navigation-link' === $inner_block->name || 'core/home-link' === $inner_block->name ) && ! $is_list_open ) {
 			$is_list_open       = true;
 			$inner_blocks_html .= '<ul class="wp-block-navigation__container">';
 		}
-		if ( 'core/navigation-link' !== $inner_block->name && 'core/home-link' !== $inner_block->name && true === $is_list_open ) {
+		if ( 'core/navigation-link' !== $inner_block->name && 'core/home-link' !== $inner_block->name && $is_list_open ) {
 			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}


### PR DESCRIPTION
## Description
The navigation block missing a closing `</ul>` in some cases. This PR adds the missing closing tag after the innerblocks are added if the list is still open. 

Fixes #34074

## How has this been tested?
- In trunk: Follow the steps in #34074 to add navigation block.
- Confirmed that the `</ul>` is missing.
- Switched to this branch and confirmed that the `</ul>` is added
- Tested with different items inside the navigation block.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
