### PR TITLE
Inserter: Prevent non-deterministic order of inserter items

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1640,8 +1640,8 @@ export const getInserterItems = createSelector(
 		} );
 		const sortedBlockTypes = [
 			...items.core,
-			...items.noncore,
 			...variations.core,
+			...items.noncore,
 			...variations.noncore,
 		];
 		return [ ...sortedBlockTypes, ...reusableBlockInserterItems ];

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1623,18 +1623,18 @@ export const getInserterItems = createSelector(
 		// the core blocks (usually by using the `init` action),
 		// thus affecting the display order.
 		// We don't sort reusable blocks as they are handled differently.
-		const toTyped = ( blocks, block ) => {
+		const groupByType = ( blocks, block ) => {
 			const { core, noncore } = blocks;
 			const type = block.name.startsWith( 'core/' ) ? core : noncore;
 
 			type.push( block );
 			return blocks;
 		};
-		const items = visibleBlockTypeInserterItems.reduce( toTyped, {
+		const items = visibleBlockTypeInserterItems.reduce( groupByType, {
 			core: [],
 			noncore: [],
 		} );
-		const variations = blockVariations.reduce( toTyped, {
+		const variations = blockVariations.reduce( groupByType, {
 			core: [],
 			noncore: [],
 		} );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1618,25 +1618,32 @@ export const getInserterItems = createSelector(
 				blockVariations.push( ...variations.map( variationMapper ) );
 			}
 		}
-		// Prioritize core blocks's display in inserter.
-		const prioritizeCoreBlocks = ( a, b ) => {
-			const coreBlockNamePrefix = 'core/';
-			const firstIsCoreBlock = a.name.startsWith( coreBlockNamePrefix );
-			const secondIsCoreBlock = b.name.startsWith( coreBlockNamePrefix );
-			if ( firstIsCoreBlock && secondIsCoreBlock ) {
-				return 0;
-			}
-			return firstIsCoreBlock && ! secondIsCoreBlock ? -1 : 1;
-		};
 		// Ensure core blocks are prioritized in the returned results,
 		// because third party blocks can be registered earlier than
 		// the core blocks (usually by using the `init` action),
 		// thus affecting the display order.
 		// We don't sort reusable blocks as they are handled differently.
+		const toTyped = ( blocks, block ) => {
+			const { core, noncore } = blocks;
+			const type = block.name.startsWith( 'core/' ) ? core : noncore;
+
+			type.push( block );
+			return blocks;
+		};
+		const items = visibleBlockTypeInserterItems.reduce( toTyped, {
+			core: [],
+			noncore: [],
+		} );
+		const variations = blockVariations.reduce( toTyped, {
+			core: [],
+			noncore: [],
+		} );
 		const sortedBlockTypes = [
-			...visibleBlockTypeInserterItems,
-			...blockVariations,
-		].sort( prioritizeCoreBlocks );
+			...items.core,
+			...items.noncore,
+			...variations.core,
+			...variations.noncore,
+		];
 		return [ ...sortedBlockTypes, ...reusableBlockInserterItems ];
 	},
 	( state, rootClientId ) => [

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3781,11 +3781,11 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			'core/block',
 			'core/test-block-a',
 			'core/test-block-with-variations',
+			'core/test-block-with-variations/variation-a',
+			'core/test-block-with-variations/variation-b',
 			'plugin/block-a',
 			'another-plugin/block-b',
 			'plugin/block-c-with-variations',
-			'core/test-block-with-variations/variation-a',
-			'core/test-block-with-variations/variation-b',
 			'plugin/block-c-with-variations/variation-a',
 			'plugin/block-c-with-variations/variation-b',
 		];

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3725,6 +3725,13 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			title: 'Another Plugin Block B',
 			icon: 'test',
 		} );
+		registerBlockType( 'plugin/block-c-with-variations', {
+			save() {},
+			category: 'text',
+			title: 'Plugin Block C with variations',
+			icon: 'test',
+			variations: [ { name: 'variation-a' }, { name: 'variation-b' } ],
+		} );
 		registerBlockType( 'core/block', {
 			save() {},
 			category: 'text',
@@ -3737,13 +3744,23 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 			icon: 'test',
 			keywords: [ 'testing' ],
 		} );
+		registerBlockType( 'core/test-block-with-variations', {
+			save() {},
+			category: 'text',
+			title: 'Core Block C with variations',
+			icon: 'test',
+			keywords: [ 'testing' ],
+			variations: [ { name: 'variation-a' }, { name: 'variation-b' } ],
+		} );
 	} );
 	afterEach( () => {
 		[
 			'plugin/block-a',
 			'another-plugin/block-b',
+			'plugin/block-c-with-variations',
 			'core/block',
 			'core/test-block-a',
+			'core/test-block-with-variations',
 		].forEach( unregisterBlockType );
 	} );
 	it( 'should prioritize core blocks by sorting them at the top of the returned list', () => {
@@ -3763,10 +3780,16 @@ describe( 'getInserterItems with core blocks prioritization', () => {
 		const expectedResult = [
 			'core/block',
 			'core/test-block-a',
+			'core/test-block-with-variations',
 			'plugin/block-a',
 			'another-plugin/block-b',
+			'plugin/block-c-with-variations',
+			'core/test-block-with-variations/variation-a',
+			'core/test-block-with-variations/variation-b',
+			'plugin/block-c-with-variations/variation-a',
+			'plugin/block-c-with-variations/variation-b',
 		];
-		expect( items.map( ( { name } ) => name ) ).toEqual( expectedResult );
+		expect( items.map( ( { id } ) => id ) ).toEqual( expectedResult );
 	} );
 } );
 


### PR DESCRIPTION
**This PR takes the changes created by @ttahmouch from PR https://github.com/WordPress/gutenberg/pull/34062, thanks for the help on this ❤️!**

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

We've noticed that using the function `Array.prototype.sort` can produce different results on the native version, actually on Android due to the use of [Hermes](https://hermesengine.dev/), it's generating a different list than iOS (which uses [`javascriptcore`](https://developer.apple.com/documentation/javascriptcore)). Per the documentation of the function, it looks like [the function itself is not stable until ES2019](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability) so it would be nice to figure out a replacement to prevent non-deterministic results.

Specifically, we've identified this issue in the `getInserterItems` selector ([reference](https://github.com/WordPress/gutenberg/blob/b77066b38ae7e7a8894b33f328ccfeedfd265c8f/packages/block-editor/src/store/selectors.js#L1636-L1639)), so a solution has been applied for this purpose by replacing the use of `sort` with the calculation of the core and non-core block lists using `reduce`. This directly affects the logic related to prioritizing core blocks' display in the inserter menu.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Unit test

Block variations case has been added to the unit test "getInserterItems with core blocks prioritization" to assure the proper order of blocks in the inserter menu.

### Web version

#### Verify that inserter items order match the production version

For this purpose, we can compare the current order of a WP.com site with a local instance of Gutenberg using the changes from this PR. 

1. Run Gutenberg locally using the changes from this PR.
2. Open a post/page.
3. Open the inserter menu by clicking on ➕ button located in the top toolbar.
<img width="300" alt="Screenshot 2021-08-16 at 19 35 19" src="https://user-images.githubusercontent.com/14905380/129605661-70bcafac-2e19-4222-9f81-d56a26f82bdd.png">

4. In a different tab, navigate to a WP.com site.
5. Open a post/page.
6. Open the inserter menu by clicking on ➕ button located in the top toolbar.
7. Compare both inserter menus (local instance and WP.com site) and verify that are displaying the inserter items in the same order.

**NOTE:** In a WP.com site the inserter menu shows more items than a local instance, however, the extra items should always be displayed at the end of the list.


Additionally, we should verify that the inserter menu displayed within the blocks matches the same order as the blocks are registered.

1. Run Gutenberg locally using the changes from this PR.
2. Open a post/page on incognito mode (**NOTE:** Incognito mode is required to prevent displaying suggested items).
3. Select a block and open the inserter menu by clicking on ➕ button.
<img width="300" alt="Screenshot 2021-08-16 at 19 35 14" src="https://user-images.githubusercontent.com/14905380/129605814-f4b7e1fa-87b8-4807-95ff-df9d997e3ccf.png">

4. Verify that the inserter items are sorted in the same order as the blocks are registered.
https://github.com/WordPress/gutenberg/blob/34fbec666d9b210e94df56246bc208da64d3ad10/packages/block-library/src/index.js#L119-L188

### Native version

Similar to the web version, we have to verify that the inserter items order remains the same as in the production version, in this case, we would need to use the iOS version because the Android one is not displaying the correct order. Additionally, we need to verify that both iOS and Android versions display the same order.

#### Verify that inserter items order match the production version

1. Download and install the last version of the WordPress app from the Appstore on an iOS device.
2. Open a post/page.
3. Open the inserter menu by tapping on ➕ button.
4. (On a different iOS device) Open the app and use the changes from this PR by connecting it to a local Metro server.
5. Open a post/page.
6. Open the inserter menu by tapping on ➕ button.
7. Compare both inserter menus (iOS production version and iOS local version) and verify that are displaying the inserter items in the same order.

### Verify IOS and Android match the inserter items order

1. Open the app on iOS.
2. Open a post/page.
3. Open the inserter menu by tapping on ➕ button.
4. (On an Android device) Open the app.
5. Open a post/page.
6. Open the inserter menu by tapping on ➕ button.
7. Compare both inserter menus (iOS and Android) and verify that are displaying the inserter items in the same order.
8. Verify that the inserter items are sorted in the same order as the blocks are registered.
https://github.com/WordPress/gutenberg/blob/947816e3d5867d8285f1151054d576b1d76811f1/packages/block-library/src/index.native.js#L237-L269

**NOTE:** The following blocks are not displayed in the inserter menu:
- `missing`
- `column`
- `classic`
- `button`
- `socialLink`
- `reusableBlock`

The block `core/search` is displayed at the bottom because it's being included as a core variant.
https://github.com/WordPress/gutenberg/blob/947816e3d5867d8285f1151054d576b1d76811f1/packages/block-library/src/search/variations.js#L6-L12

## Screenshots <!-- if applicable -->

iOS|Android
--|--
<img src=https://user-images.githubusercontent.com/14905380/129535026-048bb754-aa98-4ecb-a20e-c241db38870f.png>|<img src=https://user-images.githubusercontent.com/14905380/129535035-6f2954c3-b41c-41ec-aa6e-fc7ab3004a78.jpg>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
