### PR TITLE
Remove the ENVIRONMENT_DIRECTORY env variable that was added to the performance jobs

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -150,19 +150,13 @@ async function setUpGitBranch( branch, environmentDirectory ) {
  *
  * @param {string} testSuite                Name of the tests set.
  * @param {string} performanceTestDirectory Path to the performance tests' clone.
- * @param {string} environmentDirectory     Path to the environment directory.
  *
  * @return {Promise<WPPerformanceResults>} Performance results for the branch.
  */
-async function runTestSuite(
-	testSuite,
-	performanceTestDirectory,
-	environmentDirectory
-) {
+async function runTestSuite( testSuite, performanceTestDirectory ) {
 	await runShellScript(
 		`npm run test-performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
-		performanceTestDirectory,
-		{ ENVIRONMENT_DIRECTORY: environmentDirectory }
+		performanceTestDirectory
 	);
 	const rawResults = await readJSONFile(
 		path.join(
@@ -306,8 +300,7 @@ async function runPerformanceTests( branches, options ) {
 				log( '        >> Running the test.' );
 				rawResults[ i ][ branch ] = await runTestSuite(
 					testSuite,
-					performanceTestDirectory,
-					environmentDirectory
+					performanceTestDirectory
 				);
 				log( '        >> Stopping the environment' );
 				await runShellScript(

--- a/packages/e2e-tests/jest.performance.config.js
+++ b/packages/e2e-tests/jest.performance.config.js
@@ -1,22 +1,7 @@
-/**
- * External dependencies
- */
-const path = require( 'path' );
-
-const { ENVIRONMENT_DIRECTORY = '<rootDir>' } = process.env;
-
 module.exports = {
 	...require( '@wordpress/scripts/config/jest-e2e.config' ),
 	testMatch: [ '**/performance/*.test.js' ],
 	setupFiles: [ '<rootDir>/config/gutenberg-phase.js' ],
-	moduleNameMapper: {
-		// Use different versions of e2e-test-utils for different environments
-		// rather than always using the latest.
-		[ `@wordpress\\/e2e-test-utils$` ]: path.join(
-			ENVIRONMENT_DIRECTORY,
-			'packages/e2e-test-utils/src'
-		),
-	},
 	setupFilesAfterEnv: [
 		'<rootDir>/config/setup-performance-test.js',
 		'@wordpress/jest-console',


### PR DESCRIPTION
This variable has been added recently in #33414 but it makes running the performance tests locally harder. (need to provide the variable).

**Testing instructions**

Run `npm run test-performance packages/e2e-tests/specs/performance/post-editor.test.js` locally or `npm run test-performance`. It should work without errors.

