### PR TITLE
Combobox Component: Only force expanded state if the input has focus

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -62,6 +62,7 @@ function ComboboxControl( {
 		currentOption || null
 	);
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ inputHasFocus, setInputHasFocus ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const inputContainer = useRef();
 
@@ -139,7 +140,12 @@ function ComboboxControl( {
 		}
 	};
 
+	const onBlur = () => {
+		setInputHasFocus( false );
+	};
+
 	const onFocus = () => {
+		setInputHasFocus( true );
 		setIsExpanded( true );
 		onFilterValueChange( '' );
 		setInputValue( '' );
@@ -153,7 +159,9 @@ function ComboboxControl( {
 		const text = event.value;
 		setInputValue( text );
 		onFilterValueChange( text );
-		setIsExpanded( true );
+		if ( inputHasFocus ) {
+			setIsExpanded( true );
+		}
 	};
 
 	const handleOnReset = () => {
@@ -228,6 +236,7 @@ function ComboboxControl( {
 										: null
 								}
 								onFocus={ onFocus }
+								onBlur={ onBlur }
 								isExpanded={ isExpanded }
 								selectedSuggestionIndex={ matchingSuggestions.indexOf(
 									selectedSuggestion


### PR DESCRIPTION
## Description

When using the combobox control, I found an odd case where browser autocomplete would change the input value and leave it in this state:

![Screenshot 2021-08-16 at 17 40 49](https://user-images.githubusercontent.com/90977/129599413-9d228ad2-20ed-4357-b6dc-1ce62e6b3520.png)

The component does not have focus, yet the view is expanded. It stays this way until clicked. To prevent this, we can track whether or not the input has focus, and only force the expanded state if true. 

## How has this been tested?
I tested locally with WooCommerce Blocks Checkout, importing from this package and testing autocomplete before and after.

## Screenshots 

Using autocomplete, without interacting with the combobox component, this is before:

![Screenshot 2021-08-16 at 17 40 49](https://user-images.githubusercontent.com/90977/129599413-9d228ad2-20ed-4357-b6dc-1ce62e6b3520.png)

And this is after:

![Screenshot 2021-08-16 at 17 42 22](https://user-images.githubusercontent.com/90977/129599792-52e36fd8-6057-4ee1-9000-38df5b9d0768.png)

## Types of changes
This is a bug fix. I realise this one will be more difficult to test because there is no autocomplete on Storybook for this component. cc @nerrad 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
