### PR TITLE
Automated Changelog: Rename "Editor" grouping to "Post Editor" to avoid ambiguity with other editors

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -123,7 +123,7 @@ const LABEL_FEATURE_MAPPING = {
 	'[Package] Icons': 'Icons',
 	'[Package] Block Editor': 'Block Editor',
 	'[Package] Block library': 'Block Library',
-	'[Package] Editor': 'Editor',
+	'[Package] Editor': 'Post Editor',
 	'[Package] Edit Widgets': 'Widgets Editor',
 	'[Package] Widgets Customizer': 'Widgets Editor',
 	'[Package] Components': 'Components',

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -76,7 +76,7 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 - Fix the site editor breaking in firefox. ([33896](https://github.com/WordPress/gutenberg/pull/33896))
 
 #### Post Editor
-- Safer isPreviewingPost check. ([33840](https://github.com/WordPress/gutenberg/pull/33840))
+- Editor: Safer isPreviewingPost check. ([33840](https://github.com/WordPress/gutenberg/pull/33840))
 
 #### Meta Boxes
 - Fix Safari 13 metaboxes from overlapping the content. ([33817](https://github.com/WordPress/gutenberg/pull/33817))

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -75,7 +75,7 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 #### Site Editor
 - Fix the site editor breaking in firefox. ([33896](https://github.com/WordPress/gutenberg/pull/33896))
 
-#### Editor
+#### Post Editor
 - Safer isPreviewingPost check. ([33840](https://github.com/WordPress/gutenberg/pull/33840))
 
 #### Meta Boxes
@@ -109,7 +109,7 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 #### Template Editor
 - Template Mode: Remove 'per_page' argument from the template data selector. ([33742](https://github.com/WordPress/gutenberg/pull/33742))
 
-#### Editor
+#### Post Editor
 - Refactor the HierarchicalTermSelector so that it does not cause unnecessary loading of terms. ([33418](https://github.com/WordPress/gutenberg/pull/33418))
 
 


### PR DESCRIPTION
## Description
Finishes and closes #33719.

This PR renames the `Editor` feature grouping to `Post Editor` to differentiate it from other Editors. 
```diff
- #### Editor
+ #### Post Editor
Safer isPreviewingPost check. ([33840](https://github.com/WordPress/gutenberg/pull/33840))
```
## How has this been tested?
The snapshot in the unit test got updated to reflect the latest changes.

Run `npm run changelog -- --milestone="Gutenberg 11.3"` and you should see the same changelog generated.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
