### PR TITLE
Build: Add Typescript extensions to watched files

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -62,7 +62,7 @@ function isSourceFile( filename ) {
 	const relativePath = path.relative( process.cwd(), filename );
 
 	return (
-		/\/src\/.+\.(js|json|scss)$/.test( relativePath ) &&
+		/\/src\/.+\.(js|json|scss|ts|tsx)$/.test( relativePath ) &&
 		! [
 			/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,
 			/.\.(spec|test)\.js$/,


### PR DESCRIPTION
Now that we have a few typescript files in the codebase we might want to have `dev` script rebuild when they are changed.

If there are any related typescript build changes we should make feel free to add them to the PR or suggest them and I'll do so.

## How has this been tested?
Changing a tsx file and noting the console logging the change and triggering a rebuild.

## Types of changes
New DX feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
