### PR TITLE
Cover block: update Dimensions panel label to avoid duplicate

### DIFF
--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -294,7 +294,7 @@ function Controls( {
 				</PanelBody>
 			) : null }
 
-			<PanelBody>
+			<PanelBody title={ __( 'Dimensions' ) }>
 				<UnitControl
 					label={ __( 'Minimum height' ) }
 					min={ minHeightUnit === 'px' ? COVER_MIN_HEIGHT : 1 }

--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -294,7 +294,7 @@ function Controls( {
 				</PanelBody>
 			) : null }
 
-			<PanelBody title={ __( 'Dimensions' ) }>
+			<PanelBody>
 				<UnitControl
 					label={ __( 'Minimum height' ) }
 					min={ minHeightUnit === 'px' ? COVER_MIN_HEIGHT : 1 }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -138,7 +138,7 @@ function CoverHeightInput( {
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
-		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
+		<BaseControl id={ inputId }>
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange
@@ -536,7 +536,7 @@ function CoverEdit( {
 						</PanelRow>
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Dimensions' ) }>
+				<PanelBody title={ __( 'Minimum height' ) }>
 					<CoverHeightInput
 						value={ temporaryMinHeight || minHeight }
 						unit={ minHeightUnit }


### PR DESCRIPTION
## Description

The [dimensions panel](https://github.com/WordPress/gutenberg/pull/32392/files) is merged. 🎉 

It includes controls such as padding, margin and, soon, height, width and minimum width. 

The Cover block currently has padding support, so it now has a dimensions panel. 

But it also features an existing dimensions block, under which it has a minimum height control. 

All this means is that there are now two "Dimensions" blocks.

A couple of initiatives that address this issue are underway:

- https://github.com/WordPress/gutenberg/pull/34008 (which adds [min-height block supports](https://github.com/WordPress/gutenberg/pull/33970 ))
-  https://github.com/WordPress/gutenberg/pull/34065

These are still in progress.

So until we can come up with a definitive approach to replace the Cover block's existing Dimensions block, either by activating minimum heights block supports or via SlotFills or otherwise, let's update the copy to remove the duplicate labels before the next release.

**Dimensions** has become... wait for it... **Minimum height**. I'm open to ideas :) We don't need to fret about finding an overarching term since the minimum height control will be shifted to the dimensions ToolsPanel.

❗ I've also included screenshots for an optional change to the mobile copy (but not the changes in code). The duplication does not affect mobile for now, but it's an open question as to whether we change it everywhere to remain consistent or to leave out mobile copy changes.

## How has this been tested?
Eyeballing.

## Screenshots <!-- if applicable -->

Desktop!

Before | After
------------ | -------------
<img width="300" alt="Screen Shot 2021-08-17 at 2 23 54 pm" src="https://user-images.githubusercontent.com/6458278/129663446-acc45717-eed9-4026-860b-78757fe5c0ae.png"> | <img width="300" alt="Screen Shot 2021-08-17 at 2 13 57 pm" src="https://user-images.githubusercontent.com/6458278/129663600-15897804-e426-474d-b6eb-d920ca6cc84b.png">

Mobile!

Before | After
------------ | -------------
<img width="300" alt="Screen Shot 2021-08-17 at 2 19 33 pm" src="https://user-images.githubusercontent.com/6458278/129663455-87fae9f7-2000-4d79-a537-82548bc227fa.png"> | <img width="300" alt="Screen Shot 2021-08-17 at 1 58 37 pm" src="https://user-images.githubusercontent.com/6458278/129663613-4d9365c7-776d-4d00-adaa-cb20e2c47422.png">



## Types of changes
Copy changes.


