### PR TITLE
Classic meta boxes modal

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -43,7 +43,6 @@ import Header from '../header';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
 import SettingsSidebar from '../sidebar/settings-sidebar';
-import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
 import { store as editPostStore } from '../../store';
@@ -85,7 +84,6 @@ function Layout( { styles } ) {
 		showIconLabels,
 		hasReducedUI,
 		showBlockBreadcrumbs,
-		isTemplateMode,
 		documentLabel,
 	} = useSelect( ( select ) => {
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
@@ -235,12 +233,6 @@ function Layout( { styles } ) {
 						) }
 						{ isRichEditingEnabled && mode === 'visual' && (
 							<VisualEditor styles={ styles } />
-						) }
-						{ ! isTemplateMode && (
-							<div className="edit-post-layout__metaboxes">
-								<MetaBoxes location="normal" />
-								<MetaBoxes location="advanced" />
-							</div>
 						) }
 						{ isMobileViewport && sidebarIsOpened && (
 							<ScrollLock />

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -17,6 +17,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
+import ClassicMetaBoxButton from '../meta-boxes';
 
 function TextEditor( { onExit, isRichEditingEnabled } ) {
 	return (
@@ -37,6 +38,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 			<div className="edit-post-text-editor__body">
 				<PostTitle />
 				<PostTextEditor />
+				<ClassicMetaBoxButton />
 			</div>
 		</div>
 	);

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -41,6 +41,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockInspectorButton from './block-inspector-button';
+import ClassicMetaBoxButton from '../meta-boxes';
 import { store as editPostStore } from '../../store';
 
 function MaybeIframe( {
@@ -234,6 +235,7 @@ export default function VisualEditor( { styles } ) {
 						) }
 						<RecursionProvider>
 							<BlockList __experimentalLayout={ layout } />
+							{ ! isTemplateMode && <ClassicMetaBoxButton /> }
 						</RecursionProvider>
 					</MaybeIframe>
 				</motion.div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This is one tasks we need to do before we can iframe the post content editor. See #33346.

Currently classic meta boxes (if there are any) are rendered below the post content and in the same scroll area as the post content. As a result, they pretty much feel as an extension of the post content.

When iframing the post content, the scrollable area move from the interface's content area to the styled post content area, which does _not_ include the classic meta boxes below it because they are editor UI, not content.

We cannot leave the classic meta boxes below the iframed post content, because it would mean having two scrollable areas.

We also cannot move the classic meta boxes into the iframe, because they're editor UI, not content. It's as if we'd move the meta boxes into the TinyMCE editor iframe. :)

The only solution we have is to remove the classic meta boxes either in a modal or a sidebar. A sidebar doesn't seem right, since these meta boxes have always been given a wider space. So a modal fits better.

The only thing left is to find a food space for a button to open this modal. There's a lot of places where we could put this.

* Maybe the top toolbar where also the buttons appear if you pin a plugin area.
* Maybe in the interface's footer (to the right of the block breadcrumbs), but that may be harder to find.
* Maybe we can just leave a button in place below the post content.

I picked the last option because it would allow people to easily find the meta boxes. It's in the same space they were before, but now you need to expand them with a button. Yes, the button is now in the iframed (styled) post content, but this should be fine compared to having all classic meta boxes embedded in the post content.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="1126" alt="Screenshot 2021-08-17 at 11 10 19" src="https://user-images.githubusercontent.com/4710635/129688980-7842f81f-699e-4144-aeb0-16e074b865d6.png">
<img width="1124" alt="Screenshot 2021-08-17 at 11 10 30" src="https://user-images.githubusercontent.com/4710635/129688986-f198b7a7-3cd0-4955-9a6a-0812ee7266a4.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
