### PR TITLE
ToolsPanel: switch to plus icon when no controls present in panel body

### DIFF
--- a/packages/components/src/tools-panel/context.ts
+++ b/packages/components/src/tools-panel/context.ts
@@ -18,6 +18,7 @@ export const ToolsPanelContext = createContext< ToolsPanelContextType >( {
 	registerPanelItem: noop,
 	deregisterPanelItem: noop,
 	flagItemCustomization: noop,
+	areAllOptionalControlsHidden: true,
 } );
 
 export const useToolsPanelContext = () =>

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -35,7 +35,10 @@ export const _default = () => {
 	return (
 		<PanelWrapperView>
 			<Panel>
-				<ToolsPanel label="Tools Panel" resetAll={ resetAll }>
+				<ToolsPanel
+					label="Tools Panel (default example)"
+					resetAll={ resetAll }
+				>
 					<ToolsPanelItem
 						className="single-column"
 						hasValue={ () => !! width }
@@ -92,7 +95,10 @@ export const WithOptionalItemsPlusIcon = () => {
 	return (
 		<PanelWrapperView>
 			<Panel>
-				<ToolsPanel label="Tools Panel" resetAll={ resetAll }>
+				<ToolsPanel
+					label="Tools Panel (with optional items only)"
+					resetAll={ resetAll }
+				>
 					<ToolsPanelItem
 						className="single-column"
 						hasValue={ () => !! width }

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -66,11 +66,57 @@ export const _default = () => {
 						hasValue={ () => !! minHeight }
 						label="Minimum height"
 						onDeselect={ () => setMinHeight( undefined ) }
+						isShownByDefault={ true }
 					>
 						<UnitControl
 							label="Minimum height"
 							value={ minHeight }
 							onChange={ ( next ) => setMinHeight( next ) }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</Panel>
+		</PanelWrapperView>
+	);
+};
+
+export const WithOptionalItemsPlusIcon = () => {
+	const [ height, setHeight ] = useState();
+	const [ width, setWidth ] = useState();
+
+	const resetAll = () => {
+		setHeight( undefined );
+		setWidth( undefined );
+	};
+
+	return (
+		<PanelWrapperView>
+			<Panel>
+				<ToolsPanel label="Tools Panel" resetAll={ resetAll }>
+					<ToolsPanelItem
+						className="single-column"
+						hasValue={ () => !! width }
+						label="Width"
+						onDeselect={ () => setWidth( undefined ) }
+						isShownByDefault={ false }
+					>
+						<UnitControl
+							label="Width"
+							value={ width }
+							onChange={ ( next ) => setWidth( next ) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						className="single-column"
+						hasValue={ () => !! height }
+						label="Height"
+						onDeselect={ () => setHeight( undefined ) }
+						isShownByDefault={ false }
+					>
+						<UnitControl
+							label="Height"
+							value={ height }
+							onChange={ ( next ) => setHeight( next ) }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -96,7 +96,7 @@ export const WithOptionalItemsPlusIcon = () => {
 		<PanelWrapperView>
 			<Panel>
 				<ToolsPanel
-					label="Tools Panel (with optional items only)"
+					label="Tools Panel (optional items only)"
 					resetAll={ resetAll }
 				>
 					<ToolsPanelItem

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -518,7 +518,7 @@ describe( 'ToolsPanel', () => {
 	} );
 
 	describe( 'panel header icon toggle', () => {
-		it( 'should continue to render shown by default item after it is toggled off via menu item', async () => {
+		it( 'should render appropriate icons for the dropdown menu', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>
 					<ToolsPanelItem { ...controlProps }>

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -146,7 +146,7 @@ const renderPanel = () => {
  */
 const openDropdownMenu = () => {
 	const menuButton = screen.getByRole( 'button', {
-		name: /show([\w\s]+)options/i,
+		name: /view([\w\s]+)options/i,
 	} );
 	fireEvent.click( menuButton );
 	return menuButton;
@@ -529,7 +529,7 @@ describe( 'ToolsPanel', () => {
 
 			// There are unactivated, optional menu items in the Tools Panel dropdown.
 			const optionsHiddenIcon = screen.getByRole( 'button', {
-				name: 'Show and add options',
+				name: 'View and add options',
 			} );
 
 			expect( optionsHiddenIcon ).toBeInTheDocument();
@@ -538,11 +538,11 @@ describe( 'ToolsPanel', () => {
 
 			// There are now NO unactivated, optional menu items in the Tools Panel dropdown.
 			expect(
-				screen.queryByRole( 'button', { name: 'Show and add options' } )
-			).toBeNull();
+				screen.queryByRole( 'button', { name: 'View and add options' } )
+			).not.toBeInTheDocument();
 
 			const optionsDisplayedIcon = screen.getByRole( 'button', {
-				name: 'Show options',
+				name: 'View options',
 			} );
 
 			expect( optionsDisplayedIcon ).toBeInTheDocument();

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -518,11 +518,22 @@ describe( 'ToolsPanel', () => {
 	} );
 
 	describe( 'panel header icon toggle', () => {
+		const optionalControls = {
+			attributes: { value: false },
+			hasValue: jest.fn().mockImplementation( () => {
+				return !! optionalControls.attributes.value;
+			} ),
+			label: 'Optional',
+			onDeselect: jest.fn(),
+			onSelect: jest.fn(),
+			isShownByDefault: false,
+		};
+
 		it( 'should render appropriate icons for the dropdown menu', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>
-					<ToolsPanelItem { ...controlProps }>
-						<div>Default control</div>
+					<ToolsPanelItem { ...optionalControls }>
+						<div>Optional control</div>
 					</ToolsPanelItem>
 				</ToolsPanel>
 			);
@@ -534,7 +545,7 @@ describe( 'ToolsPanel', () => {
 
 			expect( optionsHiddenIcon ).toBeInTheDocument();
 
-			await selectMenuItem( controlProps.label );
+			await selectMenuItem( optionalControls.label );
 
 			// There are now NO unactivated, optional menu items in the Tools Panel dropdown.
 			expect(

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -139,10 +139,17 @@ const renderPanel = () => {
 	);
 };
 
-// Helper to find the menu button and simulate a user click.
+/**
+ * Helper to find the menu button and simulate a user click.
+ *
+ * @return {HTMLElement} The menuButton.
+ */
 const openDropdownMenu = () => {
-	const menuButton = screen.getByLabelText( defaultProps.label );
+	const menuButton = screen.getByRole( 'button', {
+		name: /show([\w\s]+)options/i,
+	} );
 	fireEvent.click( menuButton );
+	return menuButton;
 };
 
 // Opens dropdown then selects the menu item by label before simulating a click.
@@ -212,7 +219,7 @@ describe( 'ToolsPanel', () => {
 		it( 'should render panel menu when at least one panel item', () => {
 			renderPanel();
 
-			const menuButton = screen.getByLabelText( defaultProps.label );
+			const menuButton = openDropdownMenu();
 			expect( menuButton ).toBeInTheDocument();
 		} );
 
@@ -507,6 +514,38 @@ describe( 'ToolsPanel', () => {
 			expect( items ).toHaveLength( 2 );
 			expect( items[ 0 ] ).toHaveTextContent( 'Item 1' );
 			expect( items[ 1 ] ).toHaveTextContent( 'Item 2' );
+		} );
+	} );
+
+	describe( 'panel header icon toggle', () => {
+		it( 'should continue to render shown by default item after it is toggled off via menu item', async () => {
+			render(
+				<ToolsPanel { ...defaultProps }>
+					<ToolsPanelItem { ...controlProps }>
+						<div>Default control</div>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			);
+
+			// There are unactivated, optional menu items in the Tools Panel dropdown.
+			const optionsHiddenIcon = screen.getByRole( 'button', {
+				name: 'Show and add options',
+			} );
+
+			expect( optionsHiddenIcon ).toBeInTheDocument();
+
+			await selectMenuItem( controlProps.label );
+
+			// There are now NO unactivated, optional menu items in the Tools Panel dropdown.
+			expect(
+				screen.queryByRole( 'button', { name: 'Show and add options' } )
+			).toBeNull();
+
+			const optionsDisplayedIcon = screen.getByRole( 'button', {
+				name: 'Show options',
+			} );
+
+			expect( optionsDisplayedIcon ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -7,7 +7,7 @@ import type { Ref } from 'react';
 /**
  * WordPress dependencies
  */
-import { check, reset, moreVertical } from '@wordpress/icons';
+import { check, reset, moreVertical, plus } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -118,6 +118,7 @@ const ToolsPanelHeader = (
 	const {
 		dropdownMenuClassName,
 		hasMenuItems,
+		hasSelectedMenuItems,
 		label: labelText,
 		menuItems,
 		resetAll,
@@ -137,7 +138,7 @@ const ToolsPanelHeader = (
 			{ labelText }
 			{ hasMenuItems && (
 				<DropdownMenu
-					icon={ moreVertical }
+					icon={ hasSelectedMenuItems ? moreVertical : plus }
 					label={ labelText }
 					menuProps={ { className: dropdownMenuClassName } }
 				>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -118,7 +118,7 @@ const ToolsPanelHeader = (
 	const {
 		dropdownMenuClassName,
 		hasMenuItems,
-		areOptionalControlsAvailableAndHidden,
+		areAllOptionalControlsHidden,
 		label: labelText,
 		menuItems,
 		resetAll,
@@ -132,10 +132,8 @@ const ToolsPanelHeader = (
 
 	const defaultItems = Object.entries( menuItems?.default || {} );
 	const optionalItems = Object.entries( menuItems?.optional || {} );
-	const dropDownMenuIcon = areOptionalControlsAvailableAndHidden
-		? plus
-		: moreVertical;
-	const dropDownMenuLabelText = areOptionalControlsAvailableAndHidden
+	const dropDownMenuIcon = areAllOptionalControlsHidden ? plus : moreVertical;
+	const dropDownMenuLabelText = areAllOptionalControlsHidden
 		? _x(
 				'View and add options',
 				'Button label to reveal tool panel options'

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -118,7 +118,7 @@ const ToolsPanelHeader = (
 	const {
 		dropdownMenuClassName,
 		hasMenuItems,
-		hasSelectedMenuItems,
+		areOptionalControlsHidden,
 		label: labelText,
 		menuItems,
 		resetAll,
@@ -138,7 +138,7 @@ const ToolsPanelHeader = (
 			{ labelText }
 			{ hasMenuItems && (
 				<DropdownMenu
-					icon={ hasSelectedMenuItems ? moreVertical : plus }
+					icon={ areOptionalControlsHidden ? plus : moreVertical }
 					label={ labelText }
 					menuProps={ { className: dropdownMenuClassName } }
 				>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -137,10 +137,10 @@ const ToolsPanelHeader = (
 		: moreVertical;
 	const dropDownMenuLabelText = areOptionalControlsAvailableAndHidden
 		? _x(
-				'Show and add options',
+				'View and add options',
 				'Button label to reveal tool panel options'
 		  )
-		: _x( 'Show options', 'Button label to reveal tool panel options' );
+		: _x( 'View options', 'Button label to reveal tool panel options' );
 
 	return (
 		<h2 { ...headerProps } ref={ forwardedRef }>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -118,7 +118,7 @@ const ToolsPanelHeader = (
 	const {
 		dropdownMenuClassName,
 		hasMenuItems,
-		areOptionalControlsHidden,
+		areOptionalControlsAvailableAndHidden,
 		label: labelText,
 		menuItems,
 		resetAll,
@@ -138,7 +138,11 @@ const ToolsPanelHeader = (
 			{ labelText }
 			{ hasMenuItems && (
 				<DropdownMenu
-					icon={ areOptionalControlsHidden ? plus : moreVertical }
+					icon={
+						areOptionalControlsAvailableAndHidden
+							? plus
+							: moreVertical
+					}
 					label={ labelText }
 					menuProps={ { className: dropdownMenuClassName } }
 				>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -8,7 +8,7 @@ import type { Ref } from 'react';
  * WordPress dependencies
  */
 import { check, reset, moreVertical, plus } from '@wordpress/icons';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -132,18 +132,23 @@ const ToolsPanelHeader = (
 
 	const defaultItems = Object.entries( menuItems?.default || {} );
 	const optionalItems = Object.entries( menuItems?.optional || {} );
+	const dropDownMenuIcon = areOptionalControlsAvailableAndHidden
+		? plus
+		: moreVertical;
+	const dropDownMenuLabelText = areOptionalControlsAvailableAndHidden
+		? _x(
+				'Show and add options',
+				'Button label to reveal tool panel options'
+		  )
+		: _x( 'Show options', 'Button label to reveal tool panel options' );
 
 	return (
 		<h2 { ...headerProps } ref={ forwardedRef }>
 			{ labelText }
 			{ hasMenuItems && (
 				<DropdownMenu
-					icon={
-						areOptionalControlsAvailableAndHidden
-							? plus
-							: moreVertical
-					}
-					label={ labelText }
+					icon={ dropDownMenuIcon }
+					label={ dropDownMenuLabelText }
 					menuProps={ { className: dropdownMenuClassName } }
 				>
 					{ ( { onClose = noop } ) => (

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -32,14 +32,14 @@ export function useToolsPanelHeader(
 	const {
 		menuItems,
 		hasMenuItems,
-		areOptionalControlsHidden,
+		areOptionalControlsAvailableAndHidden,
 	} = useToolsPanelContext();
 
 	return {
 		...otherProps,
 		dropdownMenuClassName,
 		hasMenuItems,
-		areOptionalControlsHidden,
+		areOptionalControlsAvailableAndHidden,
 		menuItems,
 		className: classes,
 	};

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -29,16 +29,17 @@ export function useToolsPanelHeader(
 		return cx( styles.DropdownMenu );
 	}, [] );
 
-	const { menuItems, hasMenuItems } = useToolsPanelContext();
-	const menuItemsArray = Object.entries( menuItems );
-	const hasSelectedMenuItems = menuItemsArray.some(
-		( [ , isSelected ] ) => isSelected
-	);
+	const {
+		menuItems,
+		hasMenuItems,
+		areOptionalControlsHidden,
+	} = useToolsPanelContext();
+
 	return {
 		...otherProps,
 		dropdownMenuClassName,
 		hasMenuItems,
-		hasSelectedMenuItems,
+		areOptionalControlsHidden,
 		menuItems,
 		className: classes,
 	};

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -30,11 +30,15 @@ export function useToolsPanelHeader(
 	}, [] );
 
 	const { menuItems, hasMenuItems } = useToolsPanelContext();
-
+	const menuItemsArray = Object.entries( menuItems );
+	const hasSelectedMenuItems = menuItemsArray.some(
+		( [ , isSelected ] ) => isSelected
+	);
 	return {
 		...otherProps,
 		dropdownMenuClassName,
 		hasMenuItems,
+		hasSelectedMenuItems,
 		menuItems,
 		className: classes,
 	};

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -32,14 +32,14 @@ export function useToolsPanelHeader(
 	const {
 		menuItems,
 		hasMenuItems,
-		areOptionalControlsAvailableAndHidden,
+		areAllOptionalControlsHidden,
 	} = useToolsPanelContext();
 
 	return {
 		...otherProps,
 		dropdownMenuClassName,
 		hasMenuItems,
-		areOptionalControlsAvailableAndHidden,
+		areAllOptionalControlsHidden,
 		menuItems,
 		className: classes,
 	};

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -92,27 +92,6 @@ export function useToolsPanel(
 		setMenuItems( items );
 	}, [ panelItems ] );
 
-	// Track whether optional controls, if any, are displayed or not.
-	// Default state is that all optional controls, if any, are hidden.
-	const [
-		areAllOptionalControlsHidden,
-		setAreAllOptionalControlsHidden,
-	] = useState( true );
-
-	// Where no optional menu items are active, we display a plus icon
-	// to indicate the presence of further menu items.
-	useEffect( () => {
-		if ( menuItems.optional ) {
-			const optionalMenuItemsArray = Object.entries( menuItems.optional );
-			const newValue =
-				optionalMenuItemsArray.length > 0 &&
-				! optionalMenuItemsArray.some(
-					( [ , isSelected ] ) => isSelected
-				);
-			setAreAllOptionalControlsHidden( newValue );
-		}
-	}, [ menuItems.optional ] );
-
 	// Force a menu item to be checked.
 	// This is intended for use with default panel items. They are displayed
 	// separately to optional items and have different display states,
@@ -129,6 +108,25 @@ export function useToolsPanel(
 			},
 		} );
 	};
+
+	// Whether all optional menu items are hidden or not must be tracked
+	// in order to later determine if the panel display is empty and handle
+	// conditional display of a plus icon to indicate the presence of further
+	// menu items.
+	const [
+		areAllOptionalControlsHidden,
+		setAreAllOptionalControlsHidden,
+	] = useState( false );
+
+	useEffect( () => {
+		if ( menuItems.optional ) {
+			const optionalItems = Object.entries( menuItems.optional );
+			const allControlsHidden =
+				optionalItems.length > 0 &&
+				! optionalItems.some( ( [ , isSelected ] ) => isSelected );
+			setAreAllOptionalControlsHidden( allControlsHidden );
+		}
+	}, [ menuItems.optional ] );
 
 	const cx = useCx();
 	const classes = useMemo( () => {

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -93,10 +93,11 @@ export function useToolsPanel(
 	}, [ panelItems ] );
 
 	// Track whether optional controls, if any, are displayed or not.
+	// Default state is that all optional controls, if any, are hidden.
 	const [
-		areOptionalControlsAvailableAndHidden,
-		setAreOptionalControlsAvailableAndHidden,
-	] = useState( false );
+		areAllOptionalControlsHidden,
+		setAreAllOptionalControlsHidden,
+	] = useState( true );
 
 	// Where no optional menu items are active, we display a plus icon
 	// to indicate the presence of further menu items.
@@ -108,7 +109,7 @@ export function useToolsPanel(
 				! optionalMenuItemsArray.some(
 					( [ , isSelected ] ) => isSelected
 				);
-			setAreOptionalControlsAvailableAndHidden( newValue );
+			setAreAllOptionalControlsHidden( newValue );
 		}
 	}, [ menuItems.optional ] );
 
@@ -223,7 +224,7 @@ export function useToolsPanel(
 		registerPanelItem,
 		deregisterPanelItem,
 		flagItemCustomization,
-		areOptionalControlsAvailableAndHidden,
+		areAllOptionalControlsHidden,
 		hasMenuItems: !! panelItems.length,
 		isResetting: isResetting.current,
 		shouldRenderPlaceholderItems,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -130,27 +130,6 @@ export function useToolsPanel(
 		} );
 	};
 
-	// Track whether all optional controls are displayed or not.
-	// If no optional controls are present, then none are hidden and this will
-	// be `false`.
-	const [
-		areAllOptionalControlsHidden,
-		setAreAllOptionalControlsHidden,
-	] = useState( false );
-
-	// We need to track whether any optional menu items are active to later
-	// determine whether the panel is currently empty and any inner wrapper
-	// should be hidden.
-	useEffect( () => {
-		if ( menuItems.optional ) {
-			const optionalItems = Object.entries( menuItems.optional );
-			const allControlsHidden =
-				optionalItems.length > 0 &&
-				! optionalItems.some( ( [ , isSelected ] ) => isSelected );
-			setAreAllOptionalControlsHidden( allControlsHidden );
-		}
-	}, [ menuItems.optional ] );
-
 	const cx = useCx();
 	const classes = useMemo( () => {
 		const hasDefaultMenuItems =

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -92,6 +92,26 @@ export function useToolsPanel(
 		setMenuItems( items );
 	}, [ panelItems ] );
 
+	// Track whether optional controls, if any, are displayed or not.
+	const [
+		areOptionalControlsHidden,
+		setAreOptionalControlsHidden,
+	] = useState( false );
+
+	// Where no optional menu items are active, we display a plus icon
+	// to indicate the presence of further menu items.
+	useEffect( () => {
+		if ( menuItems.optional ) {
+			const optionalMenuItemsArray = Object.entries( menuItems.optional );
+			const newValue =
+				optionalMenuItemsArray.length > 0 &&
+				! Object.entries( menuItems.optional ).some(
+					( [ , isSelected ] ) => isSelected
+				);
+			setAreOptionalControlsHidden( newValue );
+		}
+	}, [ menuItems.optional ] );
+
 	// Force a menu item to be checked.
 	// This is intended for use with default panel items. They are displayed
 	// separately to optional items and have different display states,
@@ -203,6 +223,7 @@ export function useToolsPanel(
 		registerPanelItem,
 		deregisterPanelItem,
 		flagItemCustomization,
+		areOptionalControlsHidden,
 		hasMenuItems: !! panelItems.length,
 		isResetting: isResetting.current,
 		shouldRenderPlaceholderItems,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -94,8 +94,8 @@ export function useToolsPanel(
 
 	// Track whether optional controls, if any, are displayed or not.
 	const [
-		areOptionalControlsHidden,
-		setAreOptionalControlsHidden,
+		areOptionalControlsAvailableAndHidden,
+		setAreOptionalControlsAvailableAndHidden,
 	] = useState( false );
 
 	// Where no optional menu items are active, we display a plus icon
@@ -105,10 +105,10 @@ export function useToolsPanel(
 			const optionalMenuItemsArray = Object.entries( menuItems.optional );
 			const newValue =
 				optionalMenuItemsArray.length > 0 &&
-				! Object.entries( menuItems.optional ).some(
+				! optionalMenuItemsArray.some(
 					( [ , isSelected ] ) => isSelected
 				);
-			setAreOptionalControlsHidden( newValue );
+			setAreOptionalControlsAvailableAndHidden( newValue );
 		}
 	}, [ menuItems.optional ] );
 
@@ -223,7 +223,7 @@ export function useToolsPanel(
 		registerPanelItem,
 		deregisterPanelItem,
 		flagItemCustomization,
-		areOptionalControlsHidden,
+		areOptionalControlsAvailableAndHidden,
 		hasMenuItems: !! panelItems.length,
 		isResetting: isResetting.current,
 		shouldRenderPlaceholderItems,

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -127,7 +127,7 @@ export type ToolsPanelContext = {
 	flagItemCustomization: ( label: string ) => void;
 	isResetting: boolean;
 	shouldRenderPlaceholderItems: boolean;
-	areAllOptionalControlsHidden?: boolean;
+	areAllOptionalControlsHidden: boolean;
 };
 
 export type ToolsPanelControlsGroupProps = {

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -127,6 +127,7 @@ export type ToolsPanelContext = {
 	flagItemCustomization: ( label: string ) => void;
 	isResetting: boolean;
 	shouldRenderPlaceholderItems: boolean;
+	areAllOptionalControlsHidden?: boolean;
 };
 
 export type ToolsPanelControlsGroupProps = {


### PR DESCRIPTION
**Depends on:** #34530 

Today we're swapping the ellipsis icon with a plus symbol when there are no selected controls within a ToolsPanel. 

<img width="1075" alt="Screen Shot 2021-08-17 at 8 03 46 pm" src="https://user-images.githubusercontent.com/6458278/129706647-d8973180-c461-4a55-9d1b-4ebb191a6923.png">

The [original suggestion](https://github.com/WordPress/gutenberg/pull/34060#issuecomment-899315955). Thank you!

The motivation is to provide a hint to users that they can add optional controls to the panel. 

"Optional" controls – introduced in https://github.com/WordPress/gutenberg/pull/34530 – are those not displayed by default, and whose visibility may be toggled.

Some known edge cases/considerations:

- When the ToolsPanel has children that are not rendered (and therefore selectable) in the panel menu. Not sure yet, but we might have to know whether there are children that not registered ToolsPanelItems.

Several ToolsPanels will therefore look something like this:

<img width="283" alt="Screen Shot 2021-08-17 at 8 18 38 pm" src="https://user-images.githubusercontent.com/6458278/129708985-8e14d439-fed6-4dbf-b0da-ea9f33f32559.png">

## Testing

1. Fire up this branch, and insert a group, cover or other block that has a dimensions ToolsPanel in the sidebar controls.
2. If there is no optional control present in the panel body, the plus icon should display in the ToolsPanel header. "Default" controls cannot be toggled and should have no effect on the icon.
3. Toggle controls on and off in the ToolsPanel menu. The ellipsis should show when there are controls present in the panel body.
4. Check that panel with only default controls, and no optional controls, always show the vertical dots icon.
5. Check the `aria-label` for both button states. They should reflect the label prop passed down to the dropdown component.


Run ` npm run test-unit packages/components/src/tools-panel/test/index.js` for glory!

## Screenshots 

https://user-images.githubusercontent.com/6458278/129707348-74654137-21f5-4bd4-bd8c-0e310333fda6.mp4

New view in storybook:

<img width="479" alt="Screen Shot 2021-09-15 at 10 40 03 pm" src="https://user-images.githubusercontent.com/6458278/133435708-fdca41ae-8750-46c9-a335-7d6f9764d8e5.png">



## What this PR does


## Types of changes

UI: Adding an icon to the ToolsPanel header.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
