### PR TITLE
Scripts: Add missing fallback for target in webpack 5 config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19001,6 +19001,7 @@
 			"requires": {
 				"@svgr/webpack": "^5.5.0",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
+				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
@@ -19010,6 +19011,7 @@
 				"@wordpress/stylelint-config": "file:packages/stylelint-config",
 				"babel-jest": "^26.6.3",
 				"babel-loader": "^8.2.2",
+				"browserslist": "^4.16.6",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -24,6 +24,10 @@
 -   The bundled `@svgr/webpack` dependency has been updated from requiring `^5.2.0` to requiring `^5.5.0` ([#33818](https://github.com/WordPress/gutenberg/pull/33818)).
 -   The bundled `webpack-bundle-analyzer` dependency has been updated from requiring `^4.2.0` to requiring `^4.4.2` ([#33818](https://github.com/WordPress/gutenberg/pull/33818)).
 
+### Bug Fixes
+
+-   Add missing fallback for target in webpack 5 config ([#34112](https://github.com/WordPress/gutenberg/pull/34112)),
+
 ## 17.1.0 (2021-07-29)
 
 ### Enhancements

--- a/packages/scripts/config/.browserslistrc
+++ b/packages/scripts/config/.browserslistrc
@@ -1,0 +1,1 @@
+extends @wordpress/browserslist-config

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -6,6 +6,7 @@ const LiveReloadPlugin = require( 'webpack-livereload-plugin' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
+const browserslist = require( 'browserslist' );
 const path = require( 'path' );
 
 /**
@@ -18,6 +19,7 @@ const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
  * Internal dependencies
  */
 const {
+	fromConfigRoot,
 	hasBabelConfig,
 	hasCssnanoConfig,
 	hasPostCSSConfig,
@@ -25,6 +27,10 @@ const {
 
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
+let target = 'browserslist';
+if ( ! browserslist.findConfig( '.' ) ) {
+	target += ':' + fromConfigRoot( '.browserslistrc' );
+}
 
 const cssLoaders = [
 	{
@@ -81,7 +87,7 @@ const getLiveReloadPort = ( inputPort ) => {
 
 const config = {
 	mode,
-	target: 'browserslist',
+	target,
 	entry: {
 		index: path.resolve( process.cwd(), 'src', 'index.js' ),
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@svgr/webpack": "^5.5.0",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
+		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
 		"@wordpress/eslint-plugin": "file:../eslint-plugin",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
@@ -43,6 +44,7 @@
 		"@wordpress/stylelint-config": "file:../stylelint-config",
 		"babel-jest": "^26.6.3",
 		"babel-loader": "^8.2.2",
+		"browserslist": "^4.16.6",
 		"chalk": "^4.0.0",
 		"check-node-version": "^4.1.0",
 		"clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow up for #33818.

Fixes the following error when using `@wordpress/scripts` without the browserslist config provided:
```
[webpack-cli] Error: No browserslist config found to handle the 'browserslist' target.
See https://github.com/browserslist/browserslist#queries for possible ways to provide a config.
The recommended way is to add a 'browserslist' key to your package.json and list supported browsers (resp. node.js versions).
You can also more options via the 'target' option: 'browserslist' / 'browserslist:env' / 'browserslist:query' / 'browserslist:path-to-config' / 'browserslist:path-to-config:env'
```

It adds a fallback when that happens.

Related webpack 5 docs:

https://webpack.js.org/configuration/target/#target

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

```bash
npx wp-create-block example --no-wp-scripts
rm .browserslistconfig
cd example
./node_modules/.bin/wp-scripts build
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
