### PR TITLE
Tools: Remove obsolete step that pushes tags in npm publishing flow

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -256,7 +256,7 @@ async function updatePackages(
 }
 
 /**
- * Push the local Git Changes and Tags to the remote repository.
+ * Push the local Git Changes the remote repository.
  *
  * @param {string} gitWorkingDirectoryPath Git working directory path.
  * @param {string} releaseBranch           Release branch name.
@@ -267,22 +267,14 @@ async function runPushGitChangesStep(
 	releaseBranch,
 	abortMessage
 ) {
-	await runStep(
-		'Pushing the release branch and the tag',
-		abortMessage,
-		async () => {
-			await askForConfirmation(
-				'The release branch and the tag are going to be pushed to the remote repository. Continue?',
-				true,
-				abortMessage
-			);
-			await git.pushBranchToOrigin(
-				gitWorkingDirectoryPath,
-				releaseBranch
-			);
-			await git.pushTagsToOrigin();
-		}
-	);
+	await runStep( 'Pushing the release branch', abortMessage, async () => {
+		await askForConfirmation(
+			'The release branch is going to be pushed to the remote repository. Continue?',
+			true,
+			abortMessage
+		);
+		await git.pushBranchToOrigin( gitWorkingDirectoryPath, releaseBranch );
+	} );
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I encountered the following error when executing `./bin/commander.js npm-next`:

```
he following error happened during the "Pushing the release branch and the tag" step:

 GitError: Pushing to github.com:WordPress/gutenberg.git
error: failed to push some refs to 'github.com:WordPress/gutenberg.git'
hint: Updates were rejected because the tag already exists in the remote.

    at GitExecutorChain.onFatalException (/Users/gziolo/Projects/gutenberg/node_modules/simple-git/src/lib/runners/git-executor-chain.js:65:87)
    at GitExecutorChain.<anonymous> (/Users/gziolo/Projects/gutenberg/node_modules/simple-git/src/lib/runners/git-executor-chain.js:56:28)
    at Generator.throw (<anonymous>)
    at rejected (/Users/gziolo/Projects/gutenberg/node_modules/simple-git/src/lib/runners/git-executor-chain.js:6:65)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  task: {
    commands: [ 'push', 'origin', '--tags', '--verbose', '--porcelain' ],
    format: 'utf-8',
    parser: [Function: parsePushResult]
  }
} 

Aborting! Make sure to push changes applied to WordPress release branch "wp/next" manually.
```

The fix would be the stops pushing tags from the branch since we aren't creating any tags. I have no idea why it errors in the first place but it works correctly with the changes applied to this branch.