### PR TITLE
Components: Expose `useSlot` from `createSlotFill` call

### DIFF
--- a/packages/block-editor/src/components/block-controls/slot.js
+++ b/packages/block-editor/src/components/block-controls/slot.js
@@ -5,7 +5,6 @@ import { useContext } from '@wordpress/element';
 import {
 	__experimentalToolbarContext as ToolbarContext,
 	ToolbarGroup,
-	__experimentalUseSlot as useSlot,
 } from '@wordpress/components';
 
 /**
@@ -14,11 +13,10 @@ import {
 import groups from './groups';
 
 export default function BlockControlsSlot( { group = 'default', ...props } ) {
+	const { Slot, useSlot } = groups[ group ];
 	const accessibleToolbarState = useContext( ToolbarContext );
-	const Slot = groups[ group ].Slot;
-	const slot = useSlot( Slot.__unstableName );
+	const slot = useSlot();
 	const hasFills = Boolean( slot.fills && slot.fills.length );
-
 	if ( ! hasFills ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -8,10 +8,7 @@ import {
 	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
-import {
-	PanelBody,
-	__experimentalUseSlot as useSlot,
-} from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -27,6 +24,8 @@ import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
+
+const useAdvancedControlsSlot = InspectorAdvancedControls.__unstableUseSlot;
 
 const BlockInspector = ( {
 	showNoBlockSelectedMessage = true,
@@ -128,18 +127,15 @@ const BlockInspectorSingleBlock = ( {
 			) }
 			<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
 			<div>
-				<AdvancedControls
-					slotName={ InspectorAdvancedControls.slotName }
-					bubblesVirtually={ bubblesVirtually }
-				/>
+				<AdvancedControls bubblesVirtually={ bubblesVirtually } />
 			</div>
 			<SkipToSelectedBlock key="back" />
 		</div>
 	);
 };
 
-const AdvancedControls = ( { slotName, bubblesVirtually } ) => {
-	const slot = useSlot( slotName );
+const AdvancedControls = ( { bubblesVirtually } ) => {
+	const slot = useAdvancedControlsSlot();
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {

--- a/packages/block-editor/src/components/block-toolbar/slot-fill.js
+++ b/packages/block-editor/src/components/block-toolbar/slot-fill.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+export default createSlotFill( 'block-toolbar' );

--- a/packages/block-editor/src/components/block-tools/back-compat.js
+++ b/packages/block-editor/src/components/block-tools/back-compat.js
@@ -10,6 +10,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import InsertionPoint, { InsertionPointOpenRef } from './insertion-point';
 import BlockPopover from './block-popover';
+import blockToolbarSlotFill from '../block-toolbar/slot-fill';
 
 export default function BlockToolsBackCompat( { children } ) {
 	const openRef = useContext( InsertionPointOpenRef );
@@ -25,8 +26,8 @@ export default function BlockToolsBackCompat( { children } ) {
 	} );
 
 	return (
-		<InsertionPoint __unstablePopoverSlot="block-toolbar">
-			<BlockPopover __unstablePopoverSlot="block-toolbar" />
+		<InsertionPoint __unstablePopoverSlotFill={ blockToolbarSlotFill }>
+			<BlockPopover __unstablePopoverSlotFill={ blockToolbarSlotFill } />
 			{ children }
 		</InsertionPoint>
 	);

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -52,7 +52,7 @@ function BlockPopover( {
 	isValid,
 	isEmptyDefaultBlock,
 	capturingClientId,
-	__unstablePopoverSlot,
+	__unstablePopoverSlotFill,
 	__unstableContentRef,
 } ) {
 	const {
@@ -208,7 +208,7 @@ function BlockPopover( {
 			__unstableStickyBoundaryElement={ stickyBoundaryElement }
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the the default popover slot).
-			__unstableSlotName={ __unstablePopoverSlot || null }
+			__unstableSlotFill={ __unstablePopoverSlotFill || null }
 			__unstableBoundaryParent
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ node }
@@ -322,7 +322,7 @@ function wrapperSelector( select ) {
 }
 
 export default function WrappedBlockPopover( {
-	__unstablePopoverSlot,
+	__unstablePopoverSlotFill,
 	__unstableContentRef,
 } ) {
 	const selected = useSelect( wrapperSelector, [] );
@@ -351,7 +351,7 @@ export default function WrappedBlockPopover( {
 			isValid={ isValid }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
 			capturingClientId={ capturingClientId }
-			__unstablePopoverSlot={ __unstablePopoverSlot }
+			__unstablePopoverSlotFill={ __unstablePopoverSlotFill }
 			__unstableContentRef={ __unstableContentRef }
 		/>
 	);

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -18,6 +18,7 @@ import InsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
 import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
+import blockToolbarSlotFill from '../block-toolbar/slot-fill';
 import { usePopoverScroll } from './use-popover-scroll';
 
 /**
@@ -124,7 +125,7 @@ export default function BlockTools( {
 				<BlockPopover __unstableContentRef={ __unstableContentRef } />
 				{ /* Used for the inline rich text toolbar. */ }
 				<Popover.Slot
-					name="block-toolbar"
+					Slot={ blockToolbarSlotFill.Slot }
 					ref={ usePopoverScroll( __unstableContentRef ) }
 				/>
 				{ children }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -28,7 +28,7 @@ import { usePopoverScroll } from './use-popover-scroll';
 export const InsertionPointOpenRef = createContext();
 
 function InsertionPointPopover( {
-	__unstablePopoverSlot,
+	__unstablePopoverSlotFill,
 	__unstableContentRef,
 } ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
@@ -215,7 +215,7 @@ function InsertionPointPopover( {
 			className="block-editor-block-list__insertion-point-popover"
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the the default popover slot).
-			__unstableSlotName={ __unstablePopoverSlot || null }
+			__unstableSlotFill={ __unstablePopoverSlotFill || null }
 		>
 			<div
 				ref={ ref }
@@ -256,7 +256,7 @@ function InsertionPointPopover( {
 
 export default function InsertionPoint( {
 	children,
-	__unstablePopoverSlot,
+	__unstablePopoverSlotFill,
 	__unstableContentRef,
 } ) {
 	const isVisible = useSelect( ( select ) => {
@@ -267,7 +267,7 @@ export default function InsertionPoint( {
 		<InsertionPointOpenRef.Provider value={ useRef( false ) }>
 			{ isVisible && (
 				<InsertionPointPopover
-					__unstablePopoverSlot={ __unstablePopoverSlot }
+					__unstablePopoverSlotFill={ __unstablePopoverSlotFill }
 					__unstableContentRef={ __unstableContentRef }
 				/>
 			) }

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.js
@@ -12,7 +12,7 @@ import {
 import { useBlockEditContext } from '../block-edit/context';
 
 const name = 'InspectorAdvancedControls';
-const { Fill, Slot } = createSlotFill( name );
+const { Fill, Slot, useSlot } = createSlotFill( name );
 
 function InspectorAdvancedControls( { children } ) {
 	const { isSelected } = useBlockEditContext();
@@ -23,8 +23,8 @@ function InspectorAdvancedControls( { children } ) {
 	) : null;
 }
 
-InspectorAdvancedControls.slotName = name;
 InspectorAdvancedControls.Slot = Slot;
+InspectorAdvancedControls.__unstableUseSlot = useSlot;
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-advanced-controls/README.md

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -7,6 +7,7 @@ import { Popover, ToolbarGroup } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockControls from '../block-controls';
+import blockToolbarSlotFill from '../block-toolbar/slot-fill';
 import FormatToolbar from './format-toolbar';
 
 const FormatToolbarContainer = ( { inline, anchorRef } ) => {
@@ -19,7 +20,7 @@ const FormatToolbarContainer = ( { inline, anchorRef } ) => {
 				focusOnMount={ false }
 				anchorRef={ anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"
-				__unstableSlotName="block-toolbar"
+				__unstableSlotFill={ blockToolbarSlotFill }
 			>
 				<div className="block-editor-rich-text__inline-format-toolbar-group">
 					<ToolbarGroup>

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -164,7 +164,6 @@ export {
 	Slot,
 	Fill,
 	Provider as SlotFillProvider,
-	useSlot as __experimentalUseSlot,
 } from './slot-fill';
 export { default as __experimentalStyleProvider } from './style-provider';
 export { ZStack as __experimentalZStack } from './z-stack';

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -29,15 +29,15 @@ import { close } from '@wordpress/icons';
 import { computePopoverPosition, offsetIframe } from './utils';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
-import { Slot, Fill, useSlot } from '../slot-fill';
+import { createSlotFill } from '../slot-fill';
 import { getAnimateClassName } from '../animate';
 
 /**
- * Name of slot in which popover should fill.
+ * The default SlotFill that popover uses.
  *
- * @type {string}
+ * @type {Object}
  */
-const SLOT_NAME = 'Popover';
+const defaultSlotFill = createSlotFill( 'Popover' );
 
 function computeAnchorRect(
 	anchorRefFallback,
@@ -253,7 +253,7 @@ const Popover = (
 		onClickOutside,
 		onFocusOutside,
 		__unstableStickyBoundaryElement,
-		__unstableSlotName = SLOT_NAME,
+		__unstableSlotFill = defaultSlotFill,
 		__unstableObserveElement,
 		__unstableBoundaryParent,
 		__unstableForcePosition,
@@ -263,12 +263,13 @@ const Popover = (
 	},
 	ref
 ) => {
+	const { Fill, useSlot } = __unstableSlotFill;
 	const anchorRefFallback = useRef( null );
 	const contentRef = useRef( null );
 	const containerRef = useRef();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ animateOrigin, setAnimateOrigin ] = useState();
-	const slot = useSlot( __unstableSlotName );
+	const slot = useSlot();
 	const isExpanded = expandOnMobile && isMobileViewport;
 	const [ containerResizeListener, contentSize ] = useResizeObserver();
 	noArrow = isExpanded || noArrow;
@@ -566,7 +567,7 @@ const Popover = (
 	);
 
 	if ( slot.ref ) {
-		content = <Fill name={ __unstableSlotName }>{ content }</Fill>;
+		content = <Fill>{ content }</Fill>;
 	}
 
 	if ( anchorRef || anchorRect ) {
@@ -578,15 +579,8 @@ const Popover = (
 
 const PopoverContainer = forwardRef( Popover );
 
-function PopoverSlot( { name = SLOT_NAME }, ref ) {
-	return (
-		<Slot
-			bubblesVirtually
-			name={ name }
-			className="popover-slot"
-			ref={ ref }
-		/>
-	);
+function PopoverSlot( { Slot = defaultSlotFill.Slot }, ref ) {
+	return <Slot bubblesVirtually className="popover-slot" ref={ ref } />;
 }
 
 PopoverContainer.Slot = forwardRef( PopoverSlot );

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -49,12 +49,10 @@ export function createSlotFill( name ) {
 
 	const SlotComponent = ( props ) => <Slot name={ name } { ...props } />;
 	SlotComponent.displayName = name + 'Slot';
-	SlotComponent.__unstableName = name;
 
 	return {
 		Fill: FillComponent,
 		Slot: SlotComponent,
+		useSlot: () => useSlot( name ),
 	};
 }
-
-export { useSlot };

--- a/packages/edit-post/src/components/header/main-dashboard-button/index.js
+++ b/packages/edit-post/src/components/header/main-dashboard-button/index.js
@@ -1,28 +1,23 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalUseSlot as useSlot,
-	createSlotFill,
-} from '@wordpress/components';
+import { createSlotFill } from '@wordpress/components';
 
-const slotName = '__experimentalMainDashboardButton';
+const { Fill: MainDashboardButton, Slot, useSlot } = createSlotFill(
+	'__experimentalMainDashboardButton'
+);
 
-const { Fill, Slot: MainDashboardButtonSlot } = createSlotFill( slotName );
-
-const MainDashboardButton = Fill;
-
-const Slot = ( { children } ) => {
-	const slot = useSlot( slotName );
+const MainDashboardButtonSlot = ( { children } ) => {
+	const slot = useSlot();
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {
 		return children;
 	}
 
-	return <MainDashboardButtonSlot bubblesVirtually />;
+	return <Slot bubblesVirtually />;
 };
 
-MainDashboardButton.Slot = Slot;
+MainDashboardButton.Slot = MainDashboardButtonSlot;
 
 export default MainDashboardButton;

--- a/packages/edit-site/src/components/main-dashboard-button/index.js
+++ b/packages/edit-site/src/components/main-dashboard-button/index.js
@@ -1,19 +1,16 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalUseSlot as useSlot,
-	createSlotFill,
-} from '@wordpress/components';
+import { createSlotFill } from '@wordpress/components';
 
-const slotName = '__experimentalMainDashboardButton';
-
-const { Fill, Slot: MainDashboardButtonSlot } = createSlotFill( slotName );
+const { Fill, Slot: MainDashboardButtonSlot, useSlot } = createSlotFill(
+	'__experimentalMainDashboardButton'
+);
 
 const MainDashboardButton = Fill;
 
 const Slot = ( { children } ) => {
-	const slot = useSlot( slotName );
+	const slot = useSlot();
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

It's an experiment to avoid exposing a global `useSlot` from `@wordpress/components`. Instead, we would have `useSlot` bound to the create SlotFill pair when using `createSlotFill` helper.

The branch has some bugs I didn't explore in detail, but I would treat it only as an example for the public API changes for now.

I'm thinking about the alternative approach as well closer to how `createContext` and `useContext` in React work. 