### PR TITLE
[RNMobile] Fix missing block title of core/latest-posts block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -9,8 +9,7 @@ import { isEmpty } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
-import { coreBlocks } from '@wordpress/block-library';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { postList as icon } from '@wordpress/icons';
 import { InspectorControls } from '@wordpress/block-editor';
@@ -22,6 +21,7 @@ import {
 	RangeControl,
 	QueryControls,
 } from '@wordpress/components';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -189,13 +189,11 @@ class LatestPostsEdit extends Component {
 
 	render() {
 		const {
+			blockTitle,
 			getStylesFromColorScheme,
-			name,
 			openGeneralSidebar,
 			isSelected,
 		} = this.props;
-
-		const blockType = coreBlocks[ name ];
 
 		const blockStyle = getStylesFromColorScheme(
 			styles.latestPostBlock,
@@ -221,9 +219,7 @@ class LatestPostsEdit extends Component {
 				<View style={ blockStyle }>
 					{ isSelected && this.getInspectorControls() }
 					<Icon icon={ icon } { ...iconStyle } />
-					<Text style={ titleStyle }>
-						{ blockType.settings.title }
-					</Text>
+					<Text style={ titleStyle }>{ blockTitle }</Text>
 					<Text style={ styles.latestPostBlockSubtitle }>
 						{ __( 'CUSTOMIZE' ) }
 					</Text>
@@ -234,6 +230,12 @@ class LatestPostsEdit extends Component {
 }
 
 export default compose( [
+	withSelect( ( select, { name } ) => {
+		const blockType = select( blocksStore ).getBlockType( name );
+		return {
+			blockTitle: blockType?.title || name,
+		};
+	} ),
 	withDispatch( ( dispatch ) => {
 		const { openGeneralSidebar } = dispatch( 'core/edit-post' );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fetch the title of the block `core/latest-posts` from the block type instead of settings, which no longer provides this value ([reference](https://github.com/WordPress/gutenberg/pull/31120/files?file-filters%5B%5D=#diff-029fe180ab9a11b59f1789d639755bfc260d2aded3bedd6d0a0f15f0eba13fc4L18)).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Verify that the block's title is displayed

1. Open a post/page.
2. Tap on ➕ button.
3. Add `Latest Posts` block.
4. Observe that the block displays the `Latest Posts` icon and title.

### Verify that the block's title is translated

1. Change the device's language to a non-English one.
2. Open a post/page.
3. Tap on ➕ button.
4. Add `Latest Posts` block.
5. Observe that the block displays the `Latest Posts` title translated.

## Screenshots <!-- if applicable -->

English|Spanish
--|--
<img src=https://user-images.githubusercontent.com/14905380/129738714-5caba246-fa8a-4f1c-8797-3e5c57b9bc17.png>|<img src=https://user-images.githubusercontent.com/14905380/129738720-291b2562-ac56-4549-9ffa-a1f561d9b7ba.png>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
