### PR TITLE
[Mobile] - Autocomplete - Show icons for embed suggestions

### DIFF
--- a/packages/components/src/autocomplete/autocompleter-ui.native.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.native.js
@@ -166,6 +166,9 @@ export function getAutoCompleterUI( autocompleter ) {
 										iconStyles,
 										isActive && activeIconStyles
 									);
+									const iconSource =
+										option?.value?.icon?.src ||
+										option?.value?.icon;
 
 									return (
 										<TouchableOpacity
@@ -187,11 +190,7 @@ export function getAutoCompleterUI( autocompleter ) {
 												}
 											>
 												<Icon
-													icon={
-														option?.value?.icon
-															?.src ||
-														option?.value?.icon
-													}
+													icon={ iconSource }
 													size={ 24 }
 													style={ iconStyle }
 												/>

--- a/packages/components/src/autocomplete/autocompleter-ui.native.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.native.js
@@ -188,7 +188,9 @@ export function getAutoCompleterUI( autocompleter ) {
 											>
 												<Icon
 													icon={
-														option?.value?.icon?.src
+														option?.value?.icon
+															?.src ||
+														option?.value?.icon
 													}
 													size={ 24 }
 													style={ iconStyle }


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3845

## Description
This PR fixes an issue where the slash inserter feature (autocomplete) is not showing some icons to the suggestions (for embeds). 

## How has this been tested?
- Open the app
- Type `/` into a Paragraph block
- Type a search term and **expect** to see icons for all of the suggestions
- E.g `VideoPress`,  `CloudUp`,  `Crowdsignal`

## Screenshots <!-- if applicable -->
Before|After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/129738346-459f580e-3315-49e8-87a2-2e4b6764cb0a.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/129738448-f11c92cc-62f6-415c-8a41-cfc39dba150e.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
