### PR TITLE
[RNMobile] Use Flexbox for Inserter Menu tabs on mobile

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -204,7 +204,10 @@ function InserterMenu( {
 		>
 			<BottomSheetConsumer>
 				{ ( { listProps } ) => (
-					<TouchableHighlight accessible={ false }>
+					<TouchableHighlight
+						accessible={ false }
+						style={ { flex: 1 } }
+					>
 						{ ! showTabs || filterValue ? (
 							<InserterSearchResults
 								rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -51,13 +51,12 @@
 
 .inserter-tabs__wrapper {
 	overflow: hidden;
+	height: 100%;
 }
 
 .inserter-tabs__container {
 	height: 100%;
 	width: 100%;
-}
-
-.inserter-tabs__item {
-	position: absolute;
+	flex: 1;
+	flex-direction: row;
 }

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -51,7 +51,7 @@
 
 .inserter-tabs__wrapper {
 	overflow: hidden;
-	height: 100%;
+	flex: 1;
 }
 
 .inserter-tabs__container {

--- a/packages/block-editor/src/components/inserter/tabs.native.js
+++ b/packages/block-editor/src/components/inserter/tabs.native.js
@@ -100,13 +100,7 @@ function InserterTabs( {
 		>
 			<Animated.View style={ containerStyle }>
 				{ tabs.map( ( { component: TabComponent }, index ) => (
-					<View
-						key={ `tab-${ index }` }
-						style={ [
-							styles[ 'inserter-tabs__item' ],
-							{ left: index * wrapperWidth },
-						] }
-					>
+					<View key={ `tab-${ index }` }>
 						<TabComponent
 							rootClientId={ rootClientId }
 							onSelect={ onSelect }


### PR DESCRIPTION

## Description
This refactors the inserter tabs to use flexbox for positioning.  This is needed to remove the absolute positioning which prevents scrolling the block list when the inserter is fullscreen ( h/t @dcalhoun for the flexbox suggestion) 

Foundation change set for #34124 

## How has this been tested?
- Visit a site with resuseable blocks on the WP mobile app (iOS/Android)
- Open the mobile editor on any post.
- Press the inserter menu '+' 
- Try switching the Inserter tabs between 'Blocks' and 'Reusable'
- The tabs should update as expected.



## Types of changes
Replaces the `absolute` positioning with flexbox row in the InseterTab component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
