### PR TITLE
Fix NumberControl validation

### DIFF
--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -25,9 +25,11 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
+const passThrough = ( state: any ) => state;
+
 export function InputControl(
 	{
-		__unstableStateReducer: stateReducer = ( state ) => state,
+		__unstableStateReducer: stateReducer = passThrough,
 		__unstableInputWidth,
 		className,
 		disabled = false,

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -47,7 +47,7 @@ function InputField(
 		onValidate = noop,
 		size = 'default',
 		setIsFocused,
-		stateReducer = ( state: any ) => state,
+		stateReducer,
 		value: valueProp,
 		type,
 		...props
@@ -75,42 +75,42 @@ function InputField(
 		isPressEnterToChange,
 	} );
 
-	const { _event, value, isDragging, isDirty } = state;
-	const wasDirtyOnBlur = useRef( false );
+	const { _event, value, isDragging, isDirty, error } = state;
+	const wasPendentOnBlur = useRef( false );
 
 	const dragCursor = useDragCursor( isDragging, dragDirection );
 
 	/*
-	 * Handles synchronization of external and internal value state.
-	 * If not focused and did not hold a dirty value[1] on blur
-	 * updates the value from the props. Otherwise if not holding
-	 * a dirty value[1] propagates the value and event through onChange.
-	 * [1] value is only made dirty if isPressEnterToChange is true
+	 * Handles switching modes between controlled – while not focused – and
+	 * uncontrolled – while focused. Exceptions are made when the internal
+	 * value is either dirty or invalid. In such cases, the value does not
+	 * propagate while focused and the first render while not focused ignores
+	 * the value from props and instead propagates the internal value.
 	 */
 	useUpdateEffect( () => {
 		if ( valueProp === value ) {
 			return;
 		}
-		if ( ! isFocused && ! wasDirtyOnBlur.current ) {
+		if ( ! isFocused && ! wasPendentOnBlur.current ) {
 			update( valueProp, _event as SyntheticEvent );
-		} else if ( ! isDirty ) {
+		} else if ( ! isDirty && ! error ) {
 			onChange( value, {
 				event: _event as ChangeEvent< HTMLInputElement >,
 			} );
-			wasDirtyOnBlur.current = false;
+			wasPendentOnBlur.current = false;
 		}
-	}, [ value, isDirty, isFocused, valueProp ] );
+	}, [ value, isDirty, isFocused, valueProp, error ] );
 
 	const handleOnBlur = ( event: FocusEvent< HTMLInputElement > ) => {
 		onBlur( event );
 		setIsFocused?.( false );
 
 		/**
-		 * If isPressEnterToChange is set, this commits the value to
-		 * the onChange callback.
+		 * Commits the value in cases where it has not yet propagated. In case
+		 * of an error the commit will resolve the value before propagation.
 		 */
-		if ( isPressEnterToChange && isDirty ) {
-			wasDirtyOnBlur.current = true;
+		if ( isDirty || error ) {
+			wasPendentOnBlur.current = true;
 			handleOnCommit( event );
 		}
 	};

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -121,7 +121,7 @@ function InputField(
 	};
 
 	const validateAction = (
-		inputAction: (nextValue: string, event: SyntheticEvent) => void,
+		inputAction: ( nextValue: string, event: SyntheticEvent ) => void,
 		nextValue: string,
 		event: SyntheticEvent< HTMLInputElement >
 	) => {

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -120,20 +120,31 @@ function InputField(
 		setIsFocused?.( true );
 	};
 
+	const validateAction = (
+		inputAction: (nextValue: string, event: SyntheticEvent) => void,
+		nextValue: string,
+		event: SyntheticEvent< HTMLInputElement >
+	) => {
+		try {
+			onValidate( nextValue, event );
+			inputAction( nextValue, event );
+		} catch ( err ) {
+			invalidate( err, event );
+		}
+	};
+
 	const handleOnChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		const nextValue = event.target.value;
-		change( nextValue, event );
+		if ( isPressEnterToChange ) {
+			change( nextValue, event );
+		} else {
+			validateAction( change, nextValue, event );
+		}
 	};
 
 	const handleOnCommit = ( event: SyntheticEvent< HTMLInputElement > ) => {
 		const nextValue = event.currentTarget.value;
-
-		try {
-			onValidate( nextValue );
-			commit( nextValue, event );
-		} catch ( err ) {
-			invalidate( err, event );
-		}
+		validateAction( commit, nextValue, event );
 	};
 
 	const handleOnKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -7,7 +7,7 @@ import type { SyntheticEvent } from 'react';
 /**
  * WordPress dependencies
  */
-import { useReducer } from '@wordpress/element';
+import { useCallback, useReducer } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -166,8 +166,11 @@ export function useInputControlStateReducer(
 	stateReducer: StateReducer = initialStateReducer,
 	initialState: Partial< InputState > = initialInputControlState
 ) {
+	const reducer = useCallback( inputControlStateReducer( stateReducer ), [
+		stateReducer,
+	] );
 	const [ state, dispatch ] = useReducer< StateReducer >(
-		inputControlStateReducer( stateReducer ),
+		reducer,
 		mergeInitialState( initialState )
 	);
 

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -147,10 +147,12 @@ export function NumberControl(
 		}
 
 		/**
-		 * Handles commit (ENTER key press or on blur if isPressEnterToChange)
+		 * Handles ENTER key press or commits. The latter originates from blur
+		 * events or ENTER key presses when isPressEnterToChange is true).
 		 */
 		if (
-			type === inputControlActionTypes.PRESS_ENTER ||
+			( type === inputControlActionTypes.PRESS_ENTER &&
+				! state.isPressEnterToChange ) ||
 			type === inputControlActionTypes.COMMIT
 		) {
 			const applyEmptyValue = required === false && currentValue === '';
@@ -158,6 +160,22 @@ export function NumberControl(
 			state.value = applyEmptyValue
 				? currentValue
 				: constrainValue( currentValue );
+
+			state.error = null;
+		}
+
+		/**
+		 * Handles changes when isPressEnterToChange is false in order to skip
+		 * propagation of invalid values through onChange.
+		 */
+		if (
+			type === inputControlActionTypes.CHANGE &&
+			! state.isPressEnterToChange
+		) {
+			const { valid } = event.target.validity;
+			if ( ! valid ) {
+				state.error = 'invalid';
+			}
 		}
 
 		return state;

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -60,8 +60,26 @@ describe( 'NumberControl', () => {
 			const input = getInput();
 			input.focus();
 			fireEvent.change( input, { target: { value: 10 } } );
-
 			expect( spy ).toHaveBeenCalledWith( '10' );
+		} );
+
+		it( 'should not call onChange callback with invalid values', () => {
+			const spy = jest.fn();
+
+			render(
+				<NumberControl
+					value={ 5 }
+					min={ 2 }
+					max={ 10 }
+					onChange={ ( v ) => spy( v ) }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: 1 } } );
+			expect( input.value ).toBe( '1' );
+			expect( spy ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -78,8 +96,18 @@ describe( 'NumberControl', () => {
 			 * This is zero because the value has been adjusted to
 			 * respect the min/max range of the input.
 			 */
-
 			expect( input.value ).toBe( '0' );
+		} );
+
+		it( 'should clamp value within range on blur', () => {
+			render( <NumberControl value={ 0 } min={ -5 } max={ 5 } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: -10 } } );
+			input.blur();
+
+			expect( input.value ).toBe( '-5' );
 		} );
 
 		it( 'should parse to number value on ENTER keypress when required', () => {

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -129,7 +129,7 @@ function RangeControl(
 		onChange( nextValue );
 	};
 
-	const handleOnChange = ( nextValue ) => {
+	const handleOnInputNumberValidate = ( nextValue ) => {
 		nextValue = parseFloat( nextValue );
 		setValue( nextValue );
 		/*
@@ -288,7 +288,7 @@ function RangeControl(
 						max={ max }
 						min={ min }
 						onBlur={ handleOnInputNumberBlur }
-						onChange={ handleOnChange }
+						onValidate={ handleOnInputNumberValidate }
 						shiftStep={ shiftStep }
 						step={ step }
 						value={ inputSliderValue }


### PR DESCRIPTION
This includes two changes to `NumberControl` behavior:
* does not call `onChange` with invalid values
* clamps invalid values to within range on `blur`

The changed behaviors are covered by a couple of new unit tests. I'd manually verified the behavior before writing the tests and so was quite surprised that the unit tests would not pass. I never pinpointed the issue but, on a hunch, I tried memoizing the reducers used in `NumberControl` and `InputControl` and that got the tests passing as expected. Since it seems better to have the reducers stable (so they don't run twice per render) the reducer for `UnitControl` is also made so.

## How has this been tested?
Manually and unit tests. Part of the manual testing was 

## Types of changes
Bug fix: #33291

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
