### PR TITLE
Border controls: add base styles

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -93,6 +93,6 @@
 // The following sets baseline border styles with zero specificity such that
 // when a user begins to alter block borders via the block support UI they
 // see immediate visual changes.
-html :where(.wp-block) {
+html :where([class^="wp-block"]) {
 	border: 0 solid currentColor;
 }

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -93,6 +93,6 @@
 // The following sets baseline border styles with zero specificity such that
 // when a user begins to alter block borders via the block support UI they
 // see immediate visual changes.
-html :where([class^="wp-block"]) {
+html :where([class*="wp-block"]) {
 	border: 0 solid currentColor;
 }

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -89,3 +89,10 @@
 	width: auto;
 	z-index: 100000;
 }
+
+// The following sets baseline border styles with zero specificity such that
+// when a user begins to alter block borders via the block support UI they
+// see immediate visual changes.
+html :where(.wp-block) {
+	border: 0 solid currentColor;
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -62,6 +62,13 @@
 	font-size: 42px;
 }
 
+// The following sets baseline border styles with zero specificity such that
+// when a user begins to alter block borders via the block support UI they
+// see immediate visual changes.
+html :where(.wp-block) {
+	border: 0 solid currentColor;
+}
+
 /**
  * Editor Normalization Styles
  *

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -39,7 +39,6 @@
 			"__experimentalDefaultControls": {
 				"color": true,
 				"radius": true,
-				"style": true,
 				"width": true
 			}
 		},

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -53,7 +53,6 @@
 			"__experimentalDefaultControls": {
 				"color": true,
 				"radius": true,
-				"style": true,
 				"width": true
 			}
 		}

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -148,7 +148,6 @@
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
-				"style": true,
 				"width": true
 			}
 		},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
Requires #33743, #34061
<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
As we convert the border supports to use the new Tools Panel (#33743), it's necessary to think about what controls should be enabled as defaults for each block (#34061).

This PR is based on that work, and seeks to set some base styles for border in order to prevent needing to enable the border style as a default control. Without base styles, the user needs to actually select a style in order to see changes to other border attributes (color/width).

The approach taken here is to default to `border: 0 solid currentColor;`. We use the `:where` CSS selector to ensure 0 specificity, so that any values set by theme.json or global styles (or anywhere else for that matter) will override them correctly. 
This _should_ be safe to apply to all blocks, since the default width of `0` will prevent it from adding in visible borders where we don’t explicitly specify them in the theme/global styles etc. We’re also able to safely hide the border style control in the Border panel now.

This leaves us with one problem — you still need to set a width before setting a color or style.  In a further iteration we could attempt to set, say, a 1px default width when a color is selected; to avoid accidentally overriding theme/global styles we’d first need to explore accessing the merged styles from the editor. In the meantime, this solution allows us to hide the border style controls, prevents any [overriding of parent styles](https://github.com/WordPress/gutenberg/pull/31370#issuecomment-877969470), and the user is more likely to get immediate visual feedback when editing border controls than they were before.

## Testing
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Make sure you have #33743 and #34061!
Ensure that the border supports are switched on in your `theme.json`:
```
                 "border": {
			"customColor": true,
			"customRadius": true,
			"customStyle": true,
			"customWidth": true
		},
```

_Verify that border style is no longer a default control_
For each of the blocks that previously had border style enabled by default:
* Table
* Pullquote
* Group

Check that the Border controls appear in the ToolsPanel, and that border style is not displayed in the panel by default. 

_Verify the base styles are set_
* Create a new post and insert a Group block.
* Add a non-zero border width. You should immediately see a solid border of the appropriate width reflected in the editor, set to whatever your `currentColor` is
* Save and make sure you see the solid border on the frontend
* You should be able to change the style and color using the controls. *_Because style is not a default control, you will need to add it to the ToolsPanel using the `...` icon in order to make changes._ These should also reflect on the frontend

_Verify theme.json overrides base styles_
* Give the Group block some custom border styles in theme.json (but don't set width):
```
                            "core/group": {
				"border": {
					"color": "var(--wp--preset--color--dark-gray)"
				}
                              }
```
* Insert a new Group block. If you haven't set a width yet, you should not see a border.
* Adjust the width in the Border panel. You should immediately see a visible border, and the theme.json styles should override the base styles (so here we'd see a solid gray border)
* Verify the appearance on the frontend
* Verify that changes made through the Border panel override both the theme and the base styles

_Verify global styles override the base styles_
Repeat the above tests by setting some global styles for the Group block.
* For example, set a 2px width and a dotted style
* Insert a new Group block; you should immediately see the 2px dotted border in the `currentColor`


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
