### PR TITLE
Emulate reduced-motion in e2e tests

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Npm install and build
               run: |
                   npm ci
-                  FORCE_REDUCED_MOTION=true npm run build
+                  npm run build
 
             - name: Install WordPress
               run: |

--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -4,21 +4,11 @@
 import useMediaQuery from '../use-media-query';
 
 /**
- * Whether or not the user agent is Internet Explorer.
- *
- * @type {boolean}
- */
-const IS_IE =
-	typeof window !== 'undefined' &&
-	window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
-
-/**
  * Hook returning whether the user has a preference for reduced motion.
  *
  * @return {boolean} Reduced motion preference value.
  */
-const useReducedMotion = IS_IE
-	? () => true
-	: () => useMediaQuery( '(prefers-reduced-motion: reduce)' );
+const useReducedMotion = () =>
+	useMediaQuery( '(prefers-reduced-motion: reduce)' );
 
 export default useReducedMotion;

--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -17,9 +17,8 @@ const IS_IE =
  *
  * @return {boolean} Reduced motion preference value.
  */
-const useReducedMotion =
-	process.env.FORCE_REDUCED_MOTION || IS_IE
-		? () => true
-		: () => useMediaQuery( '(prefers-reduced-motion: reduce)' );
+const useReducedMotion = IS_IE
+	? () => true
+	: () => useMediaQuery( '(prefers-reduced-motion: reduce)' );
 
 export default useReducedMotion;

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Emulate `prefers-reduced-motion: reduce` [#34132](https://github.com/WordPress/gutenberg/pull/34132).
+
 ## 2.4.0 (2021-07-29)
 
 ### New Features

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -240,6 +240,9 @@ beforeAll( async () => {
 	await trashAllPosts( 'wp_block' );
 	await setupBrowser();
 	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
+	await page.emulateMediaFeatures( [
+		{ name: 'prefers-reduced-motion', value: 'reduce' },
+	] );
 } );
 
 afterEach( async () => {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -52,23 +52,10 @@ describe( 'Widgets screen', () => {
 	beforeAll( async () => {
 		// TODO: Ideally we can bundle our test theme directly in the repo.
 		await activateTheme( 'twentytwenty' );
-		// Reduced motion is needed to immediately show and dismiss the snackbars.
-		await page.emulateMediaFeatures( [
-			{
-				name: 'prefers-reduced-motion',
-				value: 'reduce',
-			},
-		] );
 		await deleteAllWidgets();
 	} );
 
 	afterAll( async () => {
-		await page.emulateMediaFeatures( [
-			{
-				name: 'prefers-reduced-motion',
-				value: 'no-preference',
-			},
-		] );
 		await activateTheme( 'twentytwentyone' );
 	} );
 

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -71,9 +71,6 @@ const plugins = [
 		'process.env.GUTENBERG_PHASE': JSON.stringify(
 			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
 		),
-		'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
-			process.env.FORCE_REDUCED_MOTION
-		),
 	} ),
 	new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,6 +1,5 @@
 interface Environment {
 	NODE_ENV: unknown;
-	FORCE_REDUCED_MOTION: boolean | undefined;
 }
 interface Process {
 	env: Environment;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Originally brought up in https://github.com/WordPress/gutenberg/pull/33317#discussion_r667744967. Emulate `prefers-reduced-motion: reduce` in e2e tests.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
E2E tests should pass

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
