### PR TITLE
[WIP] Refactor/gallery to nested image blocks bug fix

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -99,7 +99,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				index: getBlockIndex( clientId, rootClientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
-				blockTitle: blockType.title,
+				blockTitle: blockType?.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
 					isSelected || isFirstMultiSelectedBlock( clientId ),
@@ -107,7 +107,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
 				lightBlockWrapper:
-					blockType.apiVersion > 1 ||
+					blockType?.apiVersion > 1 ||
 					hasBlockSupport( blockType, 'lightBlockWrapper', false ),
 			};
 		},

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
@@ -25,9 +25,9 @@ export function useBlockCustomClassName( clientId ) {
 			const { getBlockName, getBlockAttributes } = select(
 				blockEditorStore
 			);
-			const { className } = getBlockAttributes( clientId );
+			const attributes = getBlockAttributes( clientId );
 
-			if ( ! className ) {
+			if ( ! attributes?.className ) {
 				return;
 			}
 
@@ -40,7 +40,7 @@ export function useBlockCustomClassName( clientId ) {
 				return;
 			}
 
-			return className;
+			return attributes.className;
 		},
 		[ clientId ]
 	);

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
@@ -27,7 +27,7 @@ export function useBlockDefaultClassName( clientId ) {
 			const name = select( blockEditorStore ).getBlockName( clientId );
 			const blockType = getBlockType( name );
 			const hasLightBlockWrapper =
-				blockType.apiVersion > 1 ||
+				blockType?.apiVersion > 1 ||
 				hasBlockSupport( blockType, 'lightBlockWrapper', false );
 
 			if ( ! hasLightBlockWrapper ) {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -603,7 +603,7 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
  * @return {boolean} Whether the given block is a reusable block.
  */
 export function isReusableBlock( blockOrType ) {
-	return blockOrType.name === 'core/block';
+	return blockOrType?.name === 'core/block';
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes: #34098, but this is PR is really just to highlight where the exceptions are being thrown, rather than as a final solution to the problem.

It seems that the issue is that under certain circumstances there is a race condition that causes the `useBlockProps` of an Image block to still run after the Image block it is attached to has been deleted by a call to `replaceInnerBlocks`. 

A better solution would be to prevent the offending calls being made once a block has been deleted, but I haven't found a way to do that yet, so open to ideas on that. 

## To test
1. Follow steps in #34098 to reproduce the error
1. Check out this PR and repeat steps and console exceptions should be gone

## Screenshots 

See #34098

## Types of changes

Adds optional chaining operators to prevent exceptions if useBlockProps runs after related block deleted.
