### PR TITLE
[Blocks]: Fix single block selection by holding `shift` key

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -165,7 +165,13 @@ export function useMultiSelection( clientId ) {
 
 				if ( event.shiftKey ) {
 					const blockSelectionStart = getBlockSelectionStart();
-					if ( blockSelectionStart !== clientId ) {
+					// Handle the case where we select a single block by
+					// holding the `shiftKey` and don't mark this action
+					// as multiselection.
+					if (
+						blockSelectionStart &&
+						blockSelectionStart !== clientId
+					) {
 						toggleRichText( node, false );
 						multiSelect( blockSelectionStart, clientId );
 						event.preventDefault();

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -10,6 +10,7 @@ import {
 	clickBlockToolbarButton,
 	clickButton,
 	clickMenuItem,
+	saveDraft,
 } from '@wordpress/e2e-test-utils';
 
 async function getSelectedFlatIndices() {
@@ -286,6 +287,28 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.up( 'Shift' );
 		await testNativeSelection();
 		expect( await getSelectedFlatIndices() ).toEqual( [ 2, 3 ] );
+	} );
+
+	// @see https://github.com/WordPress/gutenberg/issues/34118
+	it( 'should properly select a single block even if `shift` was held for the selection', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+
+		await saveDraft();
+		await page.reload();
+		await page.waitForSelector( '.edit-post-layout' );
+
+		await page.keyboard.down( 'Shift' );
+		await page.click( '[data-type="core/paragraph"]', { visible: true } );
+		await page.keyboard.up( 'Shift' );
+
+		await pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( 'new content' );
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>new content</p>
+		<!-- /wp:paragraph -->"
+	` );
 	} );
 
 	it( 'should select by dragging', async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/34118

If we have no block selected and select one by holding the `shift` key, it makes the block uneditable and there is no clear way to get it back to normal state.

This happened because when holding `shift` and clicking a block, we assumed there is already a block selected. Currently if you follow the testing instructions the blocks are not editable. In this PR the block is just selected.

## Testing instructions
1. Load a page with some blocks.
2. Without selecting anything before, hold `shift` key and `click` to a block (for example a paragraph which has richText support).
3. Try to edit the block.

