### PR TITLE
Fix block inserter scroll view height

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -202,7 +202,7 @@ function InserterMenu( {
 			}
 			hasNavigation
 			setMinHeightToMaxHeight={ showSearchForm }
-			contentStyle={ styles.list }
+			contentStyle={ styles[ 'inserter-menu__list' ] }
 			isFullScreen={ ! isIOS && showSearchForm }
 			allowDragIndicator={ true }
 		>
@@ -210,7 +210,7 @@ function InserterMenu( {
 				{ ( { listProps } ) => (
 					<TouchableHighlight
 						accessible={ false }
-						style={ styles[ 'inserter-tabs__wrapper' ] }
+						style={ styles[ 'inserter-menu__list-wrapper' ] }
 					>
 						{ ! showTabs || filterValue ? (
 							<InserterSearchResults

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -208,7 +208,10 @@ function InserterMenu( {
 		>
 			<BottomSheetConsumer>
 				{ ( { listProps } ) => (
-					<TouchableHighlight accessible={ false }>
+					<TouchableHighlight
+						accessible={ false }
+						style={ styles[ 'inserter-tabs__wrapper' ] }
+					>
 						{ ! showTabs || filterValue ? (
 							<InserterSearchResults
 								rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -8,7 +8,11 @@
 	color: $blue-30;
 }
 
-.list {
+.inserter-menu__list-wrapper {
+	flex: 1;
+}
+
+.inserter-menu__list {
 	padding-bottom: 20;
 	padding-top: 8;
 }

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -50,8 +50,7 @@
 }
 
 .inserter-tabs__wrapper {
-	overflow: hidden;
-	height: 100%;
+	flex: 1;
 }
 
 .inserter-tabs__container {


### PR DESCRIPTION
## Description
Leverages flex layout properties rather than explicit height to ensure the scroll view coordinates its height with its sibling elements.

## How has this been tested?
Tested block inserter search field on Android and iOS with and without reusable tabs.

## Screenshots <!-- if applicable -->
| Before | After | 
| - | - |
| ![inserter-height-incorrect](https://user-images.githubusercontent.com/438664/129913655-c0e0403d-066e-4ba8-9e8f-5c29e58dfe1f.jpg) | ![inserter-height-correct](https://user-images.githubusercontent.com/438664/129913680-89b51131-d857-455d-a8a0-27365f029259.jpg) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
