### PR TITLE
Global Styles: enqueue styles later so theme css can load first

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -62,13 +62,17 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 		return;
 	}
 
+	// Dequeue and deregister global styles, if needed, to enqueue with a later priority.
+	// This lets theme styles load before on the default priority, so global styles
+	// user settings take prededence over theme settings and css.
 	if ( isset( wp_styles()->registered['global-styles'] ) ) {
-		wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
-	} else {
-		wp_register_style( 'global-styles', false, array(), true, true );
-		wp_add_inline_style( 'global-styles', $stylesheet );
-		wp_enqueue_style( 'global-styles' );
+		wp_dequeue_style( 'global-styles' );
+		wp_deregister_style( 'global-styles' );
 	}
+
+	wp_register_style( 'global-styles', false, array(), true, true );
+	wp_add_inline_style( 'global-styles', $stylesheet );
+	wp_enqueue_style( 'global-styles' );
 }
 
 /**
@@ -334,7 +338,8 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
-add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+// Enqueue on a later priority so theme styles on the default priority are enqueued first.
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets', 50 );
 
 // kses actions&filters.
 add_action( 'init', 'gutenberg_global_styles_kses_init' );


### PR DESCRIPTION
## Description

Deenqueues and deregisters the 'global-styles' asset enqueued by Core, and reenqueues it on a later priority.

This allows theme css enqueued on the default priority to load first, so that a user's Global Style settings take precedence over theme css (particularly in the case of equal css selector weight).

Fixes #34141

Example of conflicts with themes: https://github.com/Automattic/themes/issues/4435

## How has this been tested?

Ensure that Global styles is loaded after the theme css on the page.

## Screenshots <!-- if applicable -->

<img width="522" alt="Screen Shot 2021-08-18 at 14 09 34" src="https://user-images.githubusercontent.com/1699996/129958081-3100d76a-9e97-4944-84a1-653c4f09773b.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
