### PR TITLE
Fix post editor's API for pinning plugin items

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -514,15 +514,11 @@ _Returns_
 
 ### togglePinnedPluginItem
 
-Returns an action object used to toggle a plugin name flag.
+Triggers an action object used to toggle a plugin name flag.
 
 _Parameters_
 
 -   _pluginName_ `string`: Plugin name.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### togglePublishSidebar
 

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -185,17 +185,24 @@ export function* switchEditorMode( mode ) {
 }
 
 /**
- * Returns an action object used to toggle a plugin name flag.
+ * Triggers an action object used to toggle a plugin name flag.
  *
  * @param {string} pluginName Plugin name.
- *
- * @return {Object} Action object.
  */
-export function togglePinnedPluginItem( pluginName ) {
-	return {
-		type: 'TOGGLE_PINNED_PLUGIN_ITEM',
-		pluginName,
-	};
+export function* togglePinnedPluginItem( pluginName ) {
+	const isPinned = yield controls.select(
+		interfaceStore.name,
+		'isItemPinned',
+		'core/edit-post',
+		pluginName
+	);
+
+	yield controls.dispatch(
+		interfaceStore.name,
+		isPinned ? 'unpinItem' : 'pinItem',
+		'core/edit-post',
+		pluginName
+	);
 }
 
 /**

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -203,7 +203,7 @@ export function isFeatureActive( state, feature ) {
  * @return {boolean} Whether the plugin item is pinned.
  */
 export const isPluginItemPinned = createRegistrySelector(
-	( select ) => ( pluginName ) => {
+	( select ) => ( state, pluginName ) => {
 		return select( interfaceStore ).isItemPinned(
 			'core/edit-post',
 			pluginName


### PR DESCRIPTION
## Description
Something I noticed in passing, the `isPluginItemPinned` selector and  `togglePinnedPluginItem` actions in the post editor are broken. The selector has the wrong params, and the action has no matching reducer so doesn't do anything.

These APIs not used internally by any code, so they're really just kept as public APIs. It could also be an option to just delete them, though if a plugin is using them (https://www.wpdirectory.net/search/01FDE8F27RZMBXZWB15C75Q5JB) that would cause an error to be triggered.

## How has this been tested?
1. In the console run `wp.data.select( 'core/edit-post' ).isPluginItemPinned( 'myAwesomePlugin' );`, it should return the default `true` value first time
2. Run `wp.data.dispatch( 'core/edit-post' ).togglePinnedPluginItem( 'myAwesomePlugin' );` to toggle it off.
3. Run `wp.data.select( 'core/edit-post' ).isPluginItemPinned( 'myAwesomePlugin' );`, it should return `false`
4. Keep running the selectors and actions until you're happy that it works.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
