### PR TITLE
Block editor: add consolidated styles to store

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -149,7 +149,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'__experimentalStyles'                   => array(
 					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'mobile' ),
+					'context'     => array( 'mobile', 'post-editor' ),
 				),
 
 				'alignWide'                              => array(

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -91,6 +91,16 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'site-editor';
 	}
 
+	// Is it a block editor on site that supports block templates?
+	if (
+		is_callable( 'get_current_screen' ) &&
+		get_current_screen()->is_block_editor() &&
+		WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() &&
+		gutenberg_supports_block_templates()
+	) {
+		$context = 'post-editor';
+	}
+
 	if (
 		defined( 'REST_REQUEST' ) &&
 		REST_REQUEST &&
@@ -111,7 +121,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, $origin );
 
-	if ( 'mobile' === $context ) {
+	if ( 'mobile' === $context || 'post-editor' === $context ) {
 		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -81,6 +81,19 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 function gutenberg_experimental_global_styles_settings( $settings ) {
 	// Set what is the context for this data request.
 	$context = 'all';
+
+	// Is it a block editor on site that supports block templates?
+	if (
+		is_callable( 'get_current_screen' ) &&
+		get_current_screen()->is_block_editor() &&
+		function_exists( 'gutenberg_is_edit_site_page' ) &&
+		! gutenberg_is_edit_site_page( get_current_screen()->id ) &&
+		WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() &&
+		gutenberg_supports_block_templates()
+	) {
+		$context = 'post-editor';
+	}
+
 	if (
 		is_callable( 'get_current_screen' ) &&
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
@@ -89,16 +102,6 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		gutenberg_supports_block_templates()
 	) {
 		$context = 'site-editor';
-	}
-
-	// Is it a block editor on site that supports block templates?
-	if (
-		is_callable( 'get_current_screen' ) &&
-		get_current_screen()->is_block_editor() &&
-		WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() &&
-		gutenberg_supports_block_templates()
-	) {
-		$context = 'post-editor';
 	}
 
 	if (

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -554,6 +554,7 @@ _Properties_
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
 -   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
+-   _\_\_experimentalStyles_ `Array`: Array of objects consolidated styles from core, theme, and user origins.
 
 ### SkipToSelectedBlock
 

--- a/packages/block-editor/src/components/use-consolidated-styles/index.js
+++ b/packages/block-editor/src/components/use-consolidated-styles/index.js
@@ -9,18 +9,51 @@ import { useSelect } from '@wordpress/data';
 import { useBlockEditContext } from '../block-edit';
 import { store as blockEditorStore } from '../../store';
 
-export default function useConsolidatedStyles() {
+/**
+ * // TODO This is an example targeted at specific style properties. We could consolidate at the highest level, e.g., return a merged styles object for all in packages/block-editor/src/hooks/style.js
+ * Hook that retrieves consolidated styles from the block editor store,
+ * and merges them with incoming user styles for a particular property.
+ *
+ * @param  {Object} userStyles    User-selected styles from the editor.
+ * @param  {string} styleProperty Targets a specific property. If not passed then we return the entire merged object.
+ *
+ * @return {Object}               The merged user styles, or original user styles if no consolidated styles.
+ *
+ * @example
+ * ```js
+ * const consolidatedStyles = useConsolidatedStyles( props.attributes?.style, 'border' );
+ * ```
+ */
+export default function useConsolidatedStyles( userStyles, styleProperty ) {
 	const { name: blockName } = useBlockEditContext();
-	const consolidatedStyles = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const consolidatedBlockStyles =
-			getSettings().__experimentalStyles?.blocks || {};
 
+	const consolidatedStyles = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const consolidatedBlockStyles =
+				getSettings().__experimentalStyles?.blocks || {};
 
-		return consolidatedBlockStyles && consolidatedBlockStyles[ blockName ]
-			? consolidatedBlockStyles[ blockName ]
-			: null;
-	}, [] );
+			return consolidatedBlockStyles &&
+				consolidatedBlockStyles[ blockName ]
+				? consolidatedBlockStyles[ blockName ]
+				: undefined;
+		},
+		[ blockName, styleProperty ]
+	);
 
-	return consolidatedStyles;
+	if ( ! userStyles || ! styleProperty ) {
+		return userStyles;
+	}
+
+	if ( consolidatedStyles ) {
+		return {
+			...userStyles,
+			[ styleProperty ]: {
+				...consolidatedStyles[ styleProperty ],
+				...userStyles[ styleProperty ],
+			},
+		};
+	}
+
+	return userStyles;
 }

--- a/packages/block-editor/src/components/use-consolidated-styles/index.js
+++ b/packages/block-editor/src/components/use-consolidated-styles/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../block-edit';
+import { store as blockEditorStore } from '../../store';
+
+export default function useConsolidatedStyles() {
+	const { name: blockName } = useBlockEditContext();
+	const consolidatedStyles = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const consolidatedBlockStyles =
+			getSettings().__experimentalStyles?.blocks || {};
+
+
+		return consolidatedBlockStyles && consolidatedBlockStyles[ blockName ]
+			? consolidatedBlockStyles[ blockName ]
+			: null;
+	}, [] );
+
+	return consolidatedStyles;
+}

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import InspectorControls from '../components/inspector-controls';
 import useSetting from '../components/use-setting';
+import useConsolidatedStyles from '../components/use-consolidated-styles';
 import { BorderColorEdit } from './border-color';
 import { BorderRadiusEdit } from './border-radius';
 import { BorderStyleEdit } from './border-style';
@@ -38,6 +39,29 @@ export function BorderPanel( props ) {
 		useSetting( 'border.customWidth' ) &&
 		hasBorderSupport( props.name, 'width' );
 
+	// TODO
+	// This is an example targeted at border for now while testing.
+	// We could consolidate at the highest level: packages/block-editor/src/hooks/style.js
+	const consolidatedStyles = useConsolidatedStyles(
+		props.attributes?.style,
+		'border'
+	);
+
+	// TODO abstract this to the hook?
+	// TODO We'll have to revisit defaults here.
+	// E.g., if the user removes a value from the post editor, what does that mean?
+	// Do we automatically default to the global style value, or do we interpret empty as `0` for border width for example?
+	// At which point do we reinstate the global style value?
+	const mergedProps = {
+		...props,
+		attributes: {
+			...props.attributes,
+			style: {
+				...consolidatedStyles,
+			},
+		},
+	};
+
 	if ( isDisabled || ! isSupported ) {
 		return null;
 	}
@@ -51,12 +75,16 @@ export function BorderPanel( props ) {
 			>
 				{ ( isWidthSupported || isStyleSupported ) && (
 					<div className="block-editor-hooks__border-controls-row">
-						{ isWidthSupported && <BorderWidthEdit { ...props } /> }
-						{ isStyleSupported && <BorderStyleEdit { ...props } /> }
+						{ isWidthSupported && (
+							<BorderWidthEdit { ...mergedProps } />
+						) }
+						{ isStyleSupported && (
+							<BorderStyleEdit { ...mergedProps } />
+						) }
 					</div>
 				) }
-				{ isColorSupported && <BorderColorEdit { ...props } /> }
-				{ isRadiusSupported && <BorderRadiusEdit { ...props } /> }
+				{ isColorSupported && <BorderColorEdit { ...mergedProps } /> }
+				{ isRadiusSupported && <BorderRadiusEdit { ...mergedProps } /> }
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -28,6 +28,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
  * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
  * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
+ * @property {Array}         __experimentalStyles   				Array of objects consolidated styles from core, theme, and user origins.
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,
@@ -155,6 +156,7 @@ export const SETTINGS_DEFAULTS = {
 	__experimentalBlockPatterns: [],
 	__experimentalBlockPatternCategories: [],
 	__experimentalSpotlightEntityBlocks: [],
+	__experimentalStyles: [],
 
 	// gradients setting is not used anymore now defaults are passed from theme.json on the server and core has its own defaults.
 	// The setting is only kept for backward compatibility purposes.

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -77,6 +77,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
+				'__experimentalStyles',
 				'alignWide',
 				'allowedBlockTypes',
 				'bodyPlaceholder',


### PR DESCRIPTION
## What this PR does

This is an experimental PR meant to spark discussion and seek guidance only. 

It adds consolidated styles (global and theme styles) to the post editor store, and making it accessible to style block supports hooks.

At first, and just to test propositions/ideas, we're working with border styles in order to delay having to parse CSS vars in the consolidated style object. It might be that we can used merged consolidated styles for all properties.

![defaults-border](https://user-images.githubusercontent.com/6458278/130012708-57c2a454-1f45-4772-90d5-5927bc7ca11a.gif)

## Why would we want to do this? 

In the post editor, we can override global and theme styles for specific blocks using sidebar controls for padding, border, margin and so on.

We don't, however, know about the underlying style values – those set in global or theme styles – we're overriding. 

Sharing consolidated styles in the post editor would allow us to:

- fill default/empty controls values to indicate to the user the values they are overriding
- check for pre-defined values before we set defaults in the post editor. For example, we might like to set a default border style of `'solid'` if a user changes the border width value, but use any pre-defined border style value set in global styles or elsewhere.

For relevant context, see the comments in [border style default controls](https://github.com/WordPress/gutenberg/pull/34061#issuecomment-899578712) and related [discussions](https://github.com/WordPress/gutenberg/pull/31370#issuecomment-877969470).

## The objective

The PR seeks to answer the following questions:

1. Is it okay to add consolidated styles to the block editor store? Should we be adding anything else?
2. Are there valid use cases for doing so?
3. If yes to 1 and 2, what are the most reasonable steps forward?

Thank you!

