### PR TITLE
InspectorControls: Wrap block support slots in ToolsPanel

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -129,6 +129,11 @@ const BlockInspectorSingleBlock = ( {
 				</div>
 			) }
 			<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
+			<InspectorControls.Slot
+				__experimentalGroup="dimensions"
+				bubblesVirtually={ false }
+				label={ __( 'Dimensions' ) }
+			/>
 			<div>
 				<AdvancedControls bubblesVirtually={ bubblesVirtually } />
 			</div>

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { cleanEmptyObject } from '../../hooks/utils';
+
+export default function BlockSupportToolsPanel( { children, label, header } ) {
+	const { clientId, attributes } = useSelect( ( select ) => {
+		const { getBlockAttributes, getSelectedBlockClientId } = select(
+			blockEditorStore
+		);
+		const selectedBlockClientId = getSelectedBlockClientId();
+
+		return {
+			clientId: selectedBlockClientId,
+			attributes: getBlockAttributes( selectedBlockClientId ),
+		};
+	} );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const resetAll = ( resetFilters = [] ) => {
+		const { style } = attributes;
+		let newAttributes = { style };
+
+		resetFilters.forEach( ( resetFilter ) => {
+			newAttributes = {
+				...newAttributes,
+				...resetFilter( newAttributes ),
+			};
+		} );
+
+		// Enforce a cleaned style object.
+		newAttributes = {
+			...newAttributes,
+			style: cleanEmptyObject( newAttributes.style ),
+		};
+
+		updateBlockAttributes( clientId, newAttributes );
+	};
+
+	return (
+		<ToolsPanel
+			label={ label }
+			header={ header }
+			resetAll={ resetAll }
+			key={ clientId }
+			panelId={ clientId }
+		>
+			{ children }
+		</ToolsPanel>
+	);
+}

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -5,10 +5,14 @@ import { createSlotFill } from '@wordpress/components';
 
 const InspectorControlsDefault = createSlotFill( 'InspectorControls' );
 const InspectorControlsAdvanced = createSlotFill( 'InspectorAdvancedControls' );
+const InspectorControlsDimensions = createSlotFill(
+	'InspectorControlsDimensions'
+);
 
 const groups = {
 	default: InspectorControlsDefault,
 	advanced: InspectorControlsAdvanced,
+	dimensions: InspectorControlsDimensions,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -7,11 +7,13 @@ import warning from '@wordpress/warning';
 /**
  * Internal dependencies
  */
+import BlockSupportToolsPanel from './block-support-tools-panel';
 import groups from './groups';
 
 export default function InspectorControlsSlot( {
 	__experimentalGroup: group = 'default',
 	bubblesVirtually = true,
+	label,
 	...props
 } ) {
 	const Slot = groups[ group ]?.Slot;
@@ -24,6 +26,14 @@ export default function InspectorControlsSlot( {
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 	if ( ! hasFills ) {
 		return null;
+	}
+
+	if ( label ) {
+		return (
+			<BlockSupportToolsPanel group={ group } label={ label }>
+				<Slot { ...props } bubblesVirtually={ bubblesVirtually } />
+			</BlockSupportToolsPanel>
+		);
 	}
 
 	return <Slot { ...props } bubblesVirtually={ bubblesVirtually } />;

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
+import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
@@ -34,7 +31,6 @@ import {
 	resetPadding,
 	useIsPaddingDisabled,
 } from './padding';
-import { cleanEmptyObject } from './utils';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
@@ -63,62 +59,56 @@ export function DimensionsPanel( props ) {
 		'__experimentalDefaultControls',
 	] );
 
-	// Callback to reset all block support attributes controlled via this panel.
-	const resetAll = () => {
-		const { style } = props.attributes;
-
-		props.setAttributes( {
-			style: cleanEmptyObject( {
-				...style,
-				spacing: {
-					...style?.spacing,
-					blockGap: undefined,
-					margin: undefined,
-					padding: undefined,
-				},
-			} ),
-		} );
-	};
+	const createResetAllFilter = ( attribute ) => ( newAttributes ) => ( {
+		...newAttributes,
+		style: {
+			...newAttributes.style,
+			spacing: {
+				...newAttributes.style?.spacing,
+				[ attribute ]: undefined,
+			},
+		},
+	} );
 
 	return (
-		<InspectorControls key="dimensions">
-			<ToolsPanel
-				label={ __( 'Dimensions options' ) }
-				header={ __( 'Dimensions' ) }
-				resetAll={ resetAll }
-			>
-				{ ! isPaddingDisabled && (
-					<ToolsPanelItem
-						hasValue={ () => hasPaddingValue( props ) }
-						label={ __( 'Padding' ) }
-						onDeselect={ () => resetPadding( props ) }
-						isShownByDefault={ defaultSpacingControls?.padding }
-					>
-						<PaddingEdit { ...props } />
-					</ToolsPanelItem>
-				) }
-				{ ! isMarginDisabled && (
-					<ToolsPanelItem
-						hasValue={ () => hasMarginValue( props ) }
-						label={ __( 'Margin' ) }
-						onDeselect={ () => resetMargin( props ) }
-						isShownByDefault={ defaultSpacingControls?.margin }
-					>
-						<MarginEdit { ...props } />
-					</ToolsPanelItem>
-				) }
-				{ ! isGapDisabled && (
-					<ToolsPanelItem
-						className="single-column"
-						hasValue={ () => hasGapValue( props ) }
-						label={ __( 'Block gap' ) }
-						onDeselect={ () => resetGap( props ) }
-						isShownByDefault={ defaultSpacingControls?.blockGap }
-					>
-						<GapEdit { ...props } />
-					</ToolsPanelItem>
-				) }
-			</ToolsPanel>
+		<InspectorControls __experimentalGroup="dimensions">
+			{ ! isPaddingDisabled && (
+				<ToolsPanelItem
+					hasValue={ () => hasPaddingValue( props ) }
+					label={ __( 'Padding' ) }
+					onDeselect={ () => resetPadding( props ) }
+					resetAllFilter={ createResetAllFilter( 'padding' ) }
+					isShownByDefault={ defaultSpacingControls?.padding }
+					panelId={ props.clientId }
+				>
+					<PaddingEdit { ...props } />
+				</ToolsPanelItem>
+			) }
+			{ ! isMarginDisabled && (
+				<ToolsPanelItem
+					hasValue={ () => hasMarginValue( props ) }
+					label={ __( 'Margin' ) }
+					onDeselect={ () => resetMargin( props ) }
+					resetAllFilter={ createResetAllFilter( 'margin' ) }
+					isShownByDefault={ defaultSpacingControls?.margin }
+					panelId={ props.clientId }
+				>
+					<MarginEdit { ...props } />
+				</ToolsPanelItem>
+			) }
+			{ ! isGapDisabled && (
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ () => hasGapValue( props ) }
+					label={ __( 'Block gap' ) }
+					onDeselect={ () => resetGap( props ) }
+					resetAllFilter={ createResetAllFilter( 'blockGap' ) }
+					isShownByDefault={ defaultSpacingControls?.blockGap }
+					panelId={ props.clientId }
+				>
+					<GapEdit { ...props } />
+				</ToolsPanelItem>
+			) }
 		</InspectorControls>
 	);
 }

--- a/packages/components/src/tools-panel/tools-panel/hook.js
+++ b/packages/components/src/tools-panel/tools-panel/hook.js
@@ -22,6 +22,17 @@ export function useToolsPanel( props ) {
 	}, [ className ] );
 
 	const isResetting = useRef( false );
+	const wasResetting = isResetting.current;
+
+	// `isResetting` is cleared via this hook to effectively batch together
+	// the resetAll task. Without this, the flag is cleared after the first
+	// control updates and forces a rerender with subsequent controls then
+	// believing they need to reset, unfortunately using stale data.
+	useEffect( () => {
+		if ( wasResetting ) {
+			isResetting.current = false;
+		}
+	}, wasResetting );
 
 	// Allow panel items to register themselves.
 	const [ panelItems, setPanelItems ] = useState( [] );
@@ -103,12 +114,6 @@ export function useToolsPanel( props ) {
 		deregisterPanelItem,
 		isResetting: isResetting.current,
 	};
-
-	// Clean up isResetting after advising panel context we were resetting
-	// all controls. This lets panel items know to skip onDeselect callbacks.
-	if ( isResetting.current ) {
-		isResetting.current = false;
-	}
 
 	return {
 		...otherProps,

--- a/packages/components/src/tools-panel/tools-panel/hook.js
+++ b/packages/components/src/tools-panel/tools-panel/hook.js
@@ -32,7 +32,7 @@ export function useToolsPanel( props ) {
 		if ( wasResetting ) {
 			isResetting.current = false;
 		}
-	}, wasResetting );
+	}, [ wasResetting ] );
 
 	// Allow panel items to register themselves.
 	const [ panelItems, setPanelItems ] = useState( [] );

--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -140,11 +140,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	};
 
 	return (
-		<ToolsPanel
-			label={ __( 'Dimensions options' ) }
-			header={ __( 'Dimensions' ) }
-			resetAll={ resetAll }
-		>
+		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
 			{ showPaddingControl && (
 				<ToolsPanelItem
 					hasValue={ hasPaddingValue }


### PR DESCRIPTION
Depends on:
- https://github.com/WordPress/gutenberg/pull/34632

Related: 
- https://github.com/WordPress/gutenberg/pull/34069
- ~https://github.com/WordPress/gutenberg/pull/34063~
- https://github.com/WordPress/gutenberg/pull/34065

## Description

- Extends the work done in https://github.com/WordPress/gutenberg/pull/34069 to provide groups in `InspectorControls`.
- Adds a slot for the dimensions block support 
- Adds the new slot into the block inspector
- Wraps block support InspectorControl groups in a ToolsPanel. 
    - Does this via new component that handles the generation of `resetAll` function, getting block attributes from the store etc.
- Updates dimensions block support hook to inject its padding and margin controls via the hook

## How has this been tested?

1. Enable padding and margin support in theme.json
2. Opt into margin support for the group block ( we need two to properly test )
3. Edit a post, add a group block and select it
4. Confirm that the dimensions panel appears in the sidebar
5. Toggle the padding and margin controls on and off and ensure they display correctly
6. Set values for both padding and margin. Then test resetting them individually via the panel's menu
7. Set both values again before this time selecting "reset all" from the panel's menu
8. Ensure both values have been reset and the block has updated correctly. 

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/60436221/130033432-38ce5399-89a2-4939-be72-3737be950fd7.gif" width="400"/>

## Types of changes
New feature. Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
