### PR TITLE
Add contextual help text to the Scale property in featured image block.

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -40,10 +40,10 @@ const SCALE_OPTIONS = (
 
 const scaleHelp = {
 	cover: __(
-		'Image is sized to maintain its aspect ratio and cropped to fill the entire space.'
+		'Image is scaled and cropped to fill the entire space without being distorted.'
 	),
 	contain: __(
-		'Image is scaled to fill the space without clipping the content.'
+		'Image is scaled to fill the space without clipping nor distorting.'
 	),
 	fill: __(
 		'Image will be stretched and distorted to completely fill the space.'

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -41,6 +41,18 @@ const SCALE_OPTIONS = (
 	</>
 );
 
+const scaleHelp = {
+	cover: __(
+		'Image is sized to maintain its aspect ratio and cropped to fill the entire space.'
+	),
+	contain: __(
+		'Image is scaled to fill the space without clipping the content.'
+	),
+	fill: __(
+		'Image will be stretched and distorted to completely fill the space.'
+	),
+};
+
 const DimensionControls = ( {
 	attributes: { width, height, scale },
 	setAttributes,
@@ -98,6 +110,7 @@ const DimensionControls = ( {
 				<SegmentedControl
 					label={ scaleLabel }
 					value={ scale }
+					help={ scaleHelp[ scale ] }
 					onChange={ ( value ) => {
 						setAttributes( {
 							scale: value,

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -33,10 +33,7 @@ const SCALE_OPTIONS = (
 		/>
 		<SegmentedControlOption
 			value="fill"
-			label={ _x(
-				'Stretch',
-				'Scale option for Image dimension control'
-			) }
+			label={ _x( 'Fill', 'Scale option for Image dimension control' ) }
 		/>
 	</>
 );


### PR DESCRIPTION
Add some clarity over these options. Help text is contextual to the current chosen option.

![image](https://user-images.githubusercontent.com/548849/130036111-d8022701-3fc6-4386-95c2-bc3367539b05.png)

We have discussed before how these tools are a good place to inform and guide and not merely perform.