### PR TITLE
Add "controls" icon.

### DIFF
--- a/packages/icons/src/library/settings.js
+++ b/packages/icons/src/library/settings.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const settings = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M17 4h-2v4.5h2V7h3V5.5h-3V4zM4 5.5h9V7H4V5.5zm16 5.75h-9v1.5h9v-1.5zm-16 0h3V10h2v4.25H7v-1.5H4v-1.5zM9 17H4v1.5h5V17zm4 0h7v1.5h-7V20h-2v-4.25h2V17z" />
+		<Path d="M14.5 13.8c-1.1 0-2.1.7-2.4 1.8H4V17h8.1c.3 1 1.3 1.8 2.4 1.8s2.1-.7 2.4-1.8H20v-1.5h-3.1c-.3-1-1.3-1.7-2.4-1.7zM11.9 7c-.3-1-1.3-1.8-2.4-1.8S7.4 6 7.1 7H4v1.5h3.1c.3 1 1.3 1.8 2.4 1.8s2.1-.7 2.4-1.8H20V7h-8.1z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## Description

This ~adds a "controls"~ updates the "settings" icon, which is meant to toggle the display of additional controls in an interface. It is to be used with the updated color picker component:

<img width="535" alt="Screenshot 2021-08-19 at 12 06 18" src="https://user-images.githubusercontent.com/1204802/130051602-01affe27-ac05-40c0-8e27-e5bed0f614f6.png">

The new icon:

<img width="385" alt="controls-icon" src="https://user-images.githubusercontent.com/1204802/130051621-0c46695a-3d8a-4696-96bd-49c340ff2a1e.png">

## How has this been tested?

The settings icon is in use in the Query Loop block. Before:

<img width="319" alt="Screenshot 2021-08-19 at 12 24 16" src="https://user-images.githubusercontent.com/1204802/130053627-387899c8-d8c4-4265-9664-9efee6ad331f.png">

After:

<img width="343" alt="Screenshot 2021-08-19 at 12 26 03" src="https://user-images.githubusercontent.com/1204802/130053646-9606f21f-f4ff-4678-b75d-b20cf9c42bc3.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->


**Edit:** I realized that the icon is so close to the existing settings icon, that I ended up just replacing that. 