### PR TITLE
Fix navigation menu submenu icon positioning.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -80,10 +80,13 @@
 	// Submenu indicator.
 	.wp-block-page-list__submenu-icon,
 	.wp-block-navigation-link__submenu-icon {
+		align-self: center;
 		height: inherit;
+		line-height: 0;
 		margin-left: 6px;
 
 		svg {
+			display: inline-block;
 			stroke: currentColor;
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #34016.

In the post editor, inherited line heights affect the positioning and sizing of sensitive items like in this case, the SVG indicating submenus. That caused it to look right in the post editor, not in the site editor:

<img width="653" alt="before" src="https://user-images.githubusercontent.com/1204802/130057606-8b118e7b-31cc-474b-a41f-d19c1f02f3e2.png">

This PR sets the line-height on the containing icon item to zero, making it identical between the two. Site editor:

<img width="550" alt="after, site editor" src="https://user-images.githubusercontent.com/1204802/130057658-cbd5914c-2eb4-4cd3-b79c-d3f07127345d.png">

Post editor:

<img width="807" alt="after, post editor" src="https://user-images.githubusercontent.com/1204802/130057667-cf433b80-8dee-448c-95df-bb450ad66bf2.png">


## How has this been tested?

Create a navigation item with a bunch of submenus, and verify they look the same in post and site editors.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
