### PR TITLE
[Block Editor]: Fix caret position on block merging

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -878,7 +878,8 @@ export function* mergeBlocks( firstBlockClientId, secondBlockClientId ) {
 				},
 			},
 			...blocksWithTheSameType.slice( 1 ),
-		]
+		],
+		0 // If we don't pass the `indexToSelect` it will default to the last block.
 	);
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1214,9 +1214,9 @@ function selectionHelper( state = {}, action ) {
 				return state;
 			}
 
-			const indexToSelect =
-				action.indexToSelect || action.blocks.length - 1;
-			const blockToSelect = action.blocks[ indexToSelect ];
+			const blockToSelect =
+				action.blocks[ action.indexToSelect ] ||
+				action.blocks[ action.blocks.length - 1 ];
 
 			if ( ! blockToSelect ) {
 				return {};

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2351,6 +2351,30 @@ describe( 'state', () => {
 			expect( state.selectionEnd ).toEqual( expected.selectionEnd );
 		} );
 
+		it( 'should replace the selected block when is explicitly passed (`indexToSelect`)', () => {
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
+			const action = {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'chicken' ],
+				blocks: [
+					{ clientId: 'rigas' },
+					{ clientId: 'chicken' },
+					{ clientId: 'wings' },
+				],
+				indexToSelect: 0,
+			};
+			const state = selection( original, action );
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					selectionStart: { clientId: 'rigas' },
+					selectionEnd: { clientId: 'rigas' },
+				} )
+			);
+		} );
+
 		it( 'should reset if replacing with empty set', () => {
 			const original = deepFreeze( {
 				selectionStart: { clientId: 'chicken' },

--- a/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
@@ -226,4 +226,52 @@ describe( 'splitting and merging blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	describe( 'test restore selection when merge produces more than one block', () => {
+		it( 'on forward delete', async () => {
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( 'hi' );
+			await insertBlock( 'List' );
+			await page.keyboard.type( 'item 1' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'item 2' );
+			await pressKeyTimes( 'ArrowUp', 2 );
+			await page.keyboard.press( 'Delete' );
+			await page.keyboard.type(
+				' caret is in first block and at the proper position. '
+			);
+			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:paragraph -->
+			<p>hi caret is in first block and at the proper position. item 1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>item 2</p>
+			<!-- /wp:paragraph -->"
+		` );
+		} );
+		it( 'on backspace', async () => {
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( 'hi' );
+			await insertBlock( 'List' );
+			await page.keyboard.type( 'item 1' );
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'item 2' );
+			await page.keyboard.press( 'ArrowUp' );
+			await pressKeyTimes( 'ArrowLeft', 6 );
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.type(
+				' caret is in first block and at the proper position. '
+			);
+			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:paragraph -->
+			<p>hi caret is in first block and at the proper position. item 1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>item 2</p>
+			<!-- /wp:paragraph -->"
+		` );
+		} );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
@@ -237,12 +237,11 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.type( 'item 2' );
 			await pressKeyTimes( 'ArrowUp', 2 );
 			await page.keyboard.press( 'Delete' );
-			await page.keyboard.type(
-				' caret is in first block and at the proper position. '
-			);
+			// Carret should be in the first block and at the proper position.
+			await page.keyboard.type( '-' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
 			"<!-- wp:paragraph -->
-			<p>hi caret is in first block and at the proper position. item 1</p>
+			<p>hi-item 1</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph -->
@@ -260,12 +259,11 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.press( 'ArrowUp' );
 			await pressKeyTimes( 'ArrowLeft', 6 );
 			await page.keyboard.press( 'Backspace' );
-			await page.keyboard.type(
-				' caret is in first block and at the proper position. '
-			);
+			// Carret should be in the first block and at the proper position.
+			await page.keyboard.type( '-' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
 			"<!-- wp:paragraph -->
-			<p>hi caret is in first block and at the proper position. item 1</p>
+			<p>hi-item 1</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/33986

This PR fixes a couple of issues. First there was a bug in the `selectionHelper` reducer (and specifically in `REPLACE_BLOCKS` action) where it wouldn't handle properly the zero(`0`) value passed for `indexToSelect`. Therefore it wasn't possible to select the fist block and would default to selecting the last one.

The second one is the linked issue, where the caret was misplaced to the start of the last block merged. If the merged two blocks would produce more than one block (through the transformation of blocks to the same type), the index for the final selected block was not passed to `replaceBlocks` which led to the default behavior of selecting the last created block.

## Note
The **merge** action I'm referring to is when we press `delete` while having the caret at the end of a block or press `backspace` when the caret is at the start of the block. Also noting that not all blocks are mergeable for obvious reasons.

## Testing instructions
1. In a page/post insert for example a `paragraph` and below a `list` with more than one items (this will produce more than one final blocks)
2. Test by placing the caret at the end of the paragraph text and press `delete`
3. Place the caret at the start of the first `list item` and press `escape`
4. Observe that the caret is preserved to the proper position