### PR TITLE
Data: Allow passing store definitions to controls

### DIFF
--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -87,7 +87,7 @@ export function* installBlockType( block ) {
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield controls.select(
-			blocksStore.name,
+			blocksStore,
 			'getBlockTypes'
 		);
 		if ( ! registeredBlocks.some( ( i ) => i.name === block.name ) ) {

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -93,7 +93,7 @@ describe( 'actions', () => {
 			expect( generator.next( [ block ] ).value ).toMatchObject( {
 				type: '@@data/DISPATCH',
 				actionName: 'createInfoNotice',
-				storeKey: noticesStore,
+				storeKey: noticesStore.name,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -161,7 +161,7 @@ describe( 'actions', () => {
 			expect( generator.next( [ inactiveBlock ] ).value ).toMatchObject( {
 				type: '@@data/DISPATCH',
 				actionName: 'createInfoNotice',
-				storeKey: noticesStore,
+				storeKey: noticesStore.name,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -211,7 +211,7 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toMatchObject( {
 				type: '@@data/DISPATCH',
 				actionName: 'createErrorNotice',
-				storeKey: noticesStore,
+				storeKey: noticesStore.name,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -300,7 +300,7 @@ describe( 'actions', () => {
 			expect( generator.throw( apiError ).value ).toMatchObject( {
 				type: '@@data/DISPATCH',
 				actionName: 'createErrorNotice',
-				storeKey: noticesStore,
+				storeKey: noticesStore.name,
 			} );
 
 			expect( generator.next() ).toEqual( {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Added a `batch` registry method to batch dispatch calls for performance reasons.
 -   Add a new migration for the persistence plugin to migrate edit-widgets preferences to the interface package. As part of this change deprecated migrations for the persistence plugin have been removed ([#33774](https://github.com/WordPress/gutenberg/pull/33774)).
+-   Update data controls to accept a data store definition as their first param in addition to a string-based store name value ([#34170](https://github.com/WordPress/gutenberg/pull/34170)).
 
 ## 6.0.0 (2021-07-29)
 

--- a/packages/data/src/controls.js
+++ b/packages/data/src/controls.js
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { createRegistryControl } from './factory';
+
+/** @typedef {import('./types').WPDataStore} WPDataStore */
 
 const SELECT = '@@data/SELECT';
 const RESOLVE_SELECT = '@@data/RESOLVE_SELECT';
@@ -13,9 +20,9 @@ const DISPATCH = '@@data/DISPATCH';
  * Note: This control synchronously returns the current selector value, triggering the
  * resolution, but not waiting for it.
  *
- * @param {string} storeKey     The key for the store the selector belongs to.
- * @param {string} selectorName The name of the selector.
- * @param {Array}  args         Arguments for the selector.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ * @param {string}             selectorName          The name of the selector.
+ * @param {Array}              args                  Arguments for the selector.
  *
  * @example
  * ```js
@@ -30,8 +37,15 @@ const DISPATCH = '@@data/DISPATCH';
  *
  * @return {Object} The control descriptor.
  */
-function select( storeKey, selectorName, ...args ) {
-	return { type: SELECT, storeKey, selectorName, args };
+function select( storeNameOrDefinition, selectorName, ...args ) {
+	return {
+		type: SELECT,
+		storeKey: isObject( storeNameOrDefinition )
+			? storeNameOrDefinition.name
+			: storeNameOrDefinition,
+		selectorName,
+		args,
+	};
 }
 
 /**
@@ -41,9 +55,9 @@ function select( storeKey, selectorName, ...args ) {
  * selectors that may have a resolver. In such case, it will return a `Promise` that resolves
  * after the selector finishes resolving, with the final result value.
  *
- * @param {string} storeKey     The key for the store the selector belongs to
- * @param {string} selectorName The name of the selector
- * @param {Array}  args         Arguments for the selector.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ * @param {string}             selectorName          The name of the selector
+ * @param {Array}              args                  Arguments for the selector.
  *
  * @example
  * ```js
@@ -58,16 +72,23 @@ function select( storeKey, selectorName, ...args ) {
  *
  * @return {Object} The control descriptor.
  */
-function resolveSelect( storeKey, selectorName, ...args ) {
-	return { type: RESOLVE_SELECT, storeKey, selectorName, args };
+function resolveSelect( storeNameOrDefinition, selectorName, ...args ) {
+	return {
+		type: RESOLVE_SELECT,
+		storeKey: isObject( storeNameOrDefinition )
+			? storeNameOrDefinition.name
+			: storeNameOrDefinition,
+		selectorName,
+		args,
+	};
 }
 
 /**
  * Dispatches a control action for triggering a registry dispatch.
  *
- * @param {string} storeKey   The key for the store the action belongs to
- * @param {string} actionName The name of the action to dispatch
- * @param {Array}  args       Arguments for the dispatch action.
+ * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+ * @param {string}             actionName            The name of the action to dispatch
+ * @param {Array}              args                  Arguments for the dispatch action.
  *
  * @example
  * ```js
@@ -82,8 +103,15 @@ function resolveSelect( storeKey, selectorName, ...args ) {
  *
  * @return {Object}  The control descriptor.
  */
-function dispatch( storeKey, actionName, ...args ) {
-	return { type: DISPATCH, storeKey, actionName, args };
+function dispatch( storeNameOrDefinition, actionName, ...args ) {
+	return {
+		type: DISPATCH,
+		storeKey: isObject( storeNameOrDefinition )
+			? storeNameOrDefinition.name
+			: storeNameOrDefinition,
+		actionName,
+		args,
+	};
 }
 
 export const controls = { select, resolveSelect, dispatch };

--- a/packages/edit-navigation/src/store/selectors.js
+++ b/packages/edit-navigation/src/store/selectors.js
@@ -44,7 +44,7 @@ export const getNavigationPostForMenu = createRegistrySelector(
 		if ( ! hasResolvedNavigationPost( state, menuId ) ) {
 			return null;
 		}
-		return select( coreStore.name ).getEditedEntityRecord(
+		return select( coreStore ).getEditedEntityRecord(
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId )
@@ -60,9 +60,7 @@ export const getNavigationPostForMenu = createRegistrySelector(
  */
 export const hasResolvedNavigationPost = createRegistrySelector(
 	( select ) => ( state, menuId ) => {
-		return select(
-			coreStore.name
-		).hasFinishedResolution( 'getEntityRecord', [
+		return select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
 			buildNavigationPostId( menuId ),
@@ -80,6 +78,6 @@ export const hasResolvedNavigationPost = createRegistrySelector(
 export const getMenuItemForClientId = createRegistrySelector(
 	( select ) => ( state, postId, clientId ) => {
 		const mapping = invert( state.mapping[ postId ] );
-		return select( coreStore.name ).getMenuItem( mapping[ clientId ] );
+		return select( coreStore ).getMenuItem( mapping[ clientId ] );
 	}
 );

--- a/packages/edit-navigation/src/store/test/selectors.js
+++ b/packages/edit-navigation/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
  * Internal dependencies
  */
 import {
@@ -33,7 +38,7 @@ describe( 'getNavigationPostForMenu', () => {
 
 		expect( getNavigationPostForMenu( 'state', menuId ) ).toBe( 'record' );
 
-		expect( registry.select ).toHaveBeenCalledWith( 'core' );
+		expect( registry.select ).toHaveBeenCalledWith( coreDataStore );
 		expect( getEditedEntityRecord ).toHaveBeenCalledWith(
 			NAVIGATION_POST_KIND,
 			NAVIGATION_POST_POST_TYPE,
@@ -62,7 +67,7 @@ describe( 'getNavigationPostForMenu', () => {
 
 		expect( getNavigationPostForMenu( 'state', menuId ) ).toBe( null );
 
-		expect( registry.select ).toHaveBeenCalledWith( 'core' );
+		expect( registry.select ).toHaveBeenCalledWith( coreDataStore );
 		expect( getEditedEntityRecord ).not.toHaveBeenCalled();
 
 		getNavigationPostForMenu.registry = defaultRegistry;
@@ -86,7 +91,7 @@ describe( 'hasResolvedNavigationPost', () => {
 
 		expect( hasResolvedNavigationPost( 'state', menuId ) ).toBe( true );
 
-		expect( registry.select ).toHaveBeenCalledWith( 'core' );
+		expect( registry.select ).toHaveBeenCalledWith( coreDataStore );
 		expect( hasFinishedResolution ).toHaveBeenCalledWith(
 			'getEntityRecord',
 			[
@@ -125,7 +130,7 @@ describe( 'getMenuItemForClientId', () => {
 			'menuItem'
 		);
 
-		expect( registry.select ).toHaveBeenCalledWith( 'core' );
+		expect( registry.select ).toHaveBeenCalledWith( coreDataStore );
 		expect( getMenuItem ).toHaveBeenCalledWith( '123' );
 
 		getMenuItemForClientId.registry = defaultRegistry;

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -30,7 +30,7 @@ import { store as editPostStore } from '.';
  */
 export function* openGeneralSidebar( name ) {
 	yield controls.dispatch(
-		interfaceStore.name,
+		interfaceStore,
 		'enableComplementaryArea',
 		editPostStore.name,
 		name
@@ -44,7 +44,7 @@ export function* openGeneralSidebar( name ) {
  */
 export function* closeGeneralSidebar() {
 	yield controls.dispatch(
-		interfaceStore.name,
+		interfaceStore,
 		'disableComplementaryArea',
 		editPostStore.name
 	);
@@ -174,7 +174,7 @@ export function* switchEditorMode( mode ) {
 
 	// Unselect blocks when we switch to the code editor.
 	if ( mode !== 'visual' ) {
-		yield controls.dispatch( blockEditorStore.name, 'clearSelectedBlock' );
+		yield controls.dispatch( blockEditorStore, 'clearSelectedBlock' );
 	}
 
 	const message =
@@ -191,14 +191,14 @@ export function* switchEditorMode( mode ) {
  */
 export function* togglePinnedPluginItem( pluginName ) {
 	const isPinned = yield controls.select(
-		interfaceStore.name,
+		interfaceStore,
 		'isItemPinned',
 		'core/edit-post',
 		pluginName
 	);
 
 	yield controls.dispatch(
-		interfaceStore.name,
+		interfaceStore,
 		isPinned ? 'unpinItem' : 'pinItem',
 		'core/edit-post',
 		pluginName
@@ -281,20 +281,14 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 		metaBoxesPerLocation,
 	};
 
-	const postType = yield controls.select(
-		editorStore.name,
-		'getCurrentPostType'
-	);
+	const postType = yield controls.select( editorStore, 'getCurrentPostType' );
 	if ( window.postboxes.page !== postType ) {
 		window.postboxes.add_postbox_toggles( postType );
 	}
 
-	let wasSavingPost = yield controls.select(
-		editorStore.name,
-		'isSavingPost'
-	);
+	let wasSavingPost = yield controls.select( editorStore, 'isSavingPost' );
 	let wasAutosavingPost = yield controls.select(
-		editorStore.name,
+		editorStore,
 		'isAutosavingPost'
 	);
 
@@ -303,7 +297,7 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 	//
 	// See: https://github.com/WordPress/WordPress/blob/5.1.1/wp-admin/includes/post.php#L2307-L2309
 	const hasActiveMetaBoxes = yield controls.select(
-		editPostStore.name,
+		editPostStore,
 		'hasMetaBoxes'
 	);
 
@@ -314,8 +308,8 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 
 	// Save metaboxes when performing a full save on the post.
 	saveMetaboxUnsubscribe = subscribe( () => {
-		const isSavingPost = select( editorStore.name ).isSavingPost();
-		const isAutosavingPost = select( editorStore.name ).isAutosavingPost();
+		const isSavingPost = select( editorStore ).isSavingPost();
+		const isAutosavingPost = select( editorStore ).isAutosavingPost();
 
 		// Save metaboxes on save completion, except for autosaves that are not a post preview.
 		const shouldTriggerMetaboxesSave =
@@ -329,7 +323,7 @@ export function* setAvailableMetaBoxesPerLocation( metaBoxesPerLocation ) {
 		wasAutosavingPost = isAutosavingPost;
 
 		if ( shouldTriggerMetaboxesSave ) {
-			dispatch( editPostStore.name ).requestMetaBoxUpdates();
+			dispatch( editPostStore ).requestMetaBoxUpdates();
 		}
 	} );
 }
@@ -351,7 +345,7 @@ export function* requestMetaBoxUpdates() {
 
 	// Additional data needed for backward compatibility.
 	// If we do not provide this data, the post will be overridden with the default values.
-	const post = yield controls.select( editorStore.name, 'getCurrentPost' );
+	const post = yield controls.select( editorStore, 'getCurrentPost' );
 	const additionalData = [
 		post.comment_status ? [ 'comment_status', post.comment_status ] : false,
 		post.ping_status ? [ 'ping_status', post.ping_status ] : false,
@@ -364,7 +358,7 @@ export function* requestMetaBoxUpdates() {
 		document.querySelector( '.metabox-base-form' )
 	);
 	const activeMetaBoxLocations = yield controls.select(
-		editPostStore.name,
+		editPostStore,
 		'getActiveMetaBoxLocations'
 	);
 	const formDataToMerge = [
@@ -398,9 +392,9 @@ export function* requestMetaBoxUpdates() {
 			body: formData,
 			parse: false,
 		} );
-		yield controls.dispatch( editPostStore.name, 'metaBoxUpdatesSuccess' );
+		yield controls.dispatch( editPostStore, 'metaBoxUpdatesSuccess' );
 	} catch {
-		yield controls.dispatch( editPostStore.name, 'metaBoxUpdatesFailure' );
+		yield controls.dispatch( editPostStore, 'metaBoxUpdatesFailure' );
 	}
 }
 
@@ -494,7 +488,7 @@ export function* __unstableSwitchToTemplateMode( newTemplate = false ) {
 	yield setIsEditingTemplate( true );
 
 	const isWelcomeGuideActive = yield controls.select(
-		editPostStore.name,
+		editPostStore,
 		'isFeatureActive',
 		'welcomeGuideTemplate'
 	);
@@ -524,7 +518,7 @@ export function* __unstableCreateTemplate( template ) {
 		'wp_template',
 		template
 	);
-	const post = yield controls.select( editorStore.name, 'getCurrentPost' );
+	const post = yield controls.select( editorStore, 'getCurrentPost' );
 
 	yield controls.dispatch(
 		coreStore,

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -54,7 +54,7 @@ export function* setTemplate( templateId, templateSlug ) {
 	const pageContext = { templateSlug };
 	if ( ! templateSlug ) {
 		const template = yield controls.resolveSelect(
-			coreStore.name,
+			coreStore,
 			'getEntityRecord',
 			'postType',
 			'wp_template',
@@ -78,7 +78,7 @@ export function* setTemplate( templateId, templateSlug ) {
  */
 export function* addTemplate( template ) {
 	const newTemplate = yield controls.dispatch(
-		coreStore.name,
+		coreStore,
 		'saveEntityRecord',
 		'postType',
 		'wp_template',
@@ -87,7 +87,7 @@ export function* addTemplate( template ) {
 
 	if ( template.content ) {
 		yield controls.dispatch(
-			coreStore.name,
+			coreStore,
 			'editEntityRecord',
 			'postType',
 			'wp_template',
@@ -160,7 +160,7 @@ export function setHomeTemplateId( homeTemplateId ) {
 export function* setPage( page ) {
 	if ( ! page.path && page.context?.postId ) {
 		const entity = yield controls.resolveSelect(
-			coreStore.name,
+			coreStore,
 			'getEntityRecord',
 			'postType',
 			page.context.postType || 'post',
@@ -170,7 +170,7 @@ export function* setPage( page ) {
 		page.path = getPathAndQueryString( entity.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
-		coreStore.name,
+		coreStore,
 		'__experimentalGetTemplateForLink',
 		page.path
 	);
@@ -198,7 +198,7 @@ export function* showHomepage() {
 		show_on_front: showOnFront,
 		page_on_front: frontpageId,
 	} = yield controls.resolveSelect(
-		coreStore.name,
+		coreStore,
 		'getEntityRecord',
 		'root',
 		'site'

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -373,7 +373,7 @@ export function setIsInserterOpened( value ) {
  */
 export function* closeGeneralSidebar() {
 	yield dispatch(
-		interfaceStore.name,
+		interfaceStore,
 		'disableComplementaryArea',
 		editWidgetsStoreName
 	);

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -119,7 +119,7 @@ export function* resetAutosave( newAutosave ) {
 
 	const postId = yield controls.select( STORE_NAME, 'getCurrentPostId' );
 	yield controls.dispatch(
-		coreStore.name,
+		coreStore,
 		'receiveAutosaves',
 		postId,
 		newAutosave
@@ -200,7 +200,7 @@ export function setupEditorState( post ) {
 export function* editPost( edits, options ) {
 	const { id, type } = yield controls.select( STORE_NAME, 'getCurrentPost' );
 	yield controls.dispatch(
-		coreStore.name,
+		coreStore,
 		'editEntityRecord',
 		'postType',
 		type,
@@ -236,7 +236,7 @@ export function* savePost( options = {} ) {
 	edits = {
 		id: previousRecord.id,
 		...( yield controls.select(
-			coreStore.name,
+			coreStore,
 			'getEntityRecordNonTransientEdits',
 			'postType',
 			previousRecord.type,
@@ -245,7 +245,7 @@ export function* savePost( options = {} ) {
 		...edits,
 	};
 	yield controls.dispatch(
-		coreStore.name,
+		coreStore,
 		'saveEntityRecord',
 		'postType',
 		previousRecord.type,
@@ -255,7 +255,7 @@ export function* savePost( options = {} ) {
 	yield __experimentalRequestPostUpdateFinish( options );
 
 	const error = yield controls.select(
-		coreStore.name,
+		coreStore,
 		'getLastEntitySaveError',
 		'postType',
 		previousRecord.type,
@@ -283,7 +283,7 @@ export function* savePost( options = {} ) {
 			previousPost: previousRecord,
 			post: updatedRecord,
 			postType: yield controls.resolveSelect(
-				coreStore.name,
+				coreStore,
 				'getPostType',
 				updatedRecord.type
 			),
@@ -300,7 +300,7 @@ export function* savePost( options = {} ) {
 		// considered for change detection.
 		if ( ! options.isAutosave ) {
 			yield controls.dispatch(
-				blockEditorStore.name,
+				blockEditorStore,
 				'__unstableMarkLastChangeAsPersistent'
 			);
 		}
@@ -317,7 +317,7 @@ export function* refreshPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		coreStore.name,
+		coreStore,
 		'getPostType',
 		postTypeSlug
 	);
@@ -340,7 +340,7 @@ export function* trashPost() {
 		'getCurrentPostType'
 	);
 	const postType = yield controls.resolveSelect(
-		coreStore.name,
+		coreStore,
 		'getPostType',
 		postTypeSlug
 	);
@@ -419,7 +419,7 @@ export function* autosave( { local = false, ...options } = {} ) {
  * @yield {Object} Action object.
  */
 export function* redo() {
-	yield controls.dispatch( coreStore.name, 'redo' );
+	yield controls.dispatch( coreStore, 'redo' );
 }
 
 /**
@@ -428,7 +428,7 @@ export function* redo() {
  * @yield {Object} Action object.
  */
 export function* undo() {
-	yield controls.dispatch( coreStore.name, 'undo' );
+	yield controls.dispatch( coreStore, 'undo' );
 }
 
 /**
@@ -608,7 +608,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 		);
 		const noChange =
 			( yield controls.select(
-				coreStore.name,
+				coreStore,
 				'getEditedEntityRecord',
 				'postType',
 				type,
@@ -616,7 +616,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 			) ).blocks === edits.blocks;
 		if ( noChange ) {
 			return yield controls.dispatch(
-				coreStore.name,
+				coreStore,
 				'__unstableCreateUndoLevel',
 				'postType',
 				type,
@@ -658,7 +658,7 @@ const getBlockEditorAction = ( name ) =>
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
 		} );
-		yield controls.dispatch( blockEditorStore.name, name, ...args );
+		yield controls.dispatch( blockEditorStore, name, ...args );
 	};
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to #34155.
Follow-up for #27548.

Updates data controls to accept a data store definition as their first param in addition to a string-based store name value. It aligns with the changes introduced in #27548 and is mostly for consistency.

Updated methods that can be imported from `@wordpress.data` with:

```js
import { controls } from '@wordpress/data';
```

- `select`
- `resolveSelect`
- `dispatch`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Unit and e2e tests should still pass.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
API enahcnement for `@wordpress/data` and controls.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
