### PR TITLE
Use ESM JSON imports instead of adhoc json imports

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -156,8 +156,7 @@ if ( files.length ) {
 	} );
 
 	stream.push( null );
-	stream = stream.pipe( createStyleEntryTransform() )
-
+	stream = stream.pipe( createStyleEntryTransform() );
 } else {
 	const bar = new ProgressBar( 'Build Progress: [:bar] :percent', {
 		width: 30,

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -145,45 +145,6 @@ function createStyleEntryTransform() {
 	} );
 }
 
-/**
- * Returns a stream transform which maps an individual block.json to the
- * index.js that imports it. Presently, babel resolves the import of json
- * files by inlining them as a JavaScript primitive in the importing file.
- * This transform ensures the importing file is rebuilt.
- *
- * @return {Transform} Stream transform instance.
- */
-function createBlockJsonEntryTransform() {
-	const blocks = new Set();
-
-	return new Transform( {
-		objectMode: true,
-		async transform( file, encoding, callback ) {
-			const matches = /block-library[\/\\]src[\/\\](.*)[\/\\]block.json$/.exec(
-				file
-			);
-			const blockName = matches ? matches[ 1 ] : undefined;
-
-			// Only block.json files in the block-library folder are subject to this transform.
-			if ( ! blockName ) {
-				this.push( file );
-				callback();
-				return;
-			}
-
-			// Only operate once per block, assuming entries are common.
-			if ( blockName && blocks.has( blockName ) ) {
-				callback();
-				return;
-			}
-
-			blocks.add( blockName );
-			this.push( file.replace( 'block.json', 'index.js' ) );
-			callback();
-		},
-	} );
-}
-
 let onFileComplete = () => {};
 
 let stream;
@@ -195,9 +156,8 @@ if ( files.length ) {
 	} );
 
 	stream.push( null );
-	stream = stream
-		.pipe( createStyleEntryTransform() )
-		.pipe( createBlockJsonEntryTransform() );
+	stream = stream.pipe( createStyleEntryTransform() )
+
 } else {
 	const bar = new ProgressBar( 'Build Progress: [:bar] :percent', {
 		width: 30,

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -108,7 +108,7 @@ It returns the registered block type (`WPBlock`) on success or `undefined` on fa
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 registerBlockType( metadata, {
 	edit: Edit,
@@ -548,7 +548,7 @@ In JavaScript, you can use `registerBlockType` method from `@wordpress/blocks` p
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 registerBlockType( metadata, {
 	edit: Edit,

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -108,7 +108,7 @@ It returns the registered block type (`WPBlock`) on success or `undefined` on fa
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 registerBlockType( metadata, {
 	edit: Edit,
@@ -548,7 +548,7 @@ In JavaScript, you can use `registerBlockType` method from `@wordpress/blocks` p
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 registerBlockType( metadata, {
 	edit: Edit,

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,41 @@
 				}
 			}
 		},
+		"@babel/eslint-parser": {
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.0.tgz",
+			"integrity": "sha512-+gSPtjSBxOZz4Uh8Ggqu7HbfpB8cT1LwW0DnVVLZEJvzXauiD0Di3zszcBkRmfGGrLdYeHUwcflG7i3tr9kQlw==",
+			"dev": true,
+			"requires": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/generator": {
 			"version": "7.13.9",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
@@ -18669,10 +18704,10 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
+				"@babel/eslint-parser": "^7.15.0",
 				"@typescript-eslint/eslint-plugin": "^4.15.0",
 				"@typescript-eslint/parser": "^4.15.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
-				"babel-eslint": "^10.1.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^7.1.0",
 				"eslint-plugin-import": "^2.23.4",
@@ -28212,38 +28247,6 @@
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
 			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
 		},
-		"babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"dependencies": {
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.20.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-					"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.2.0",
-						"path-parse": "^1.0.6"
-					}
-				}
-			}
-		},
 		"babel-jest": {
 			"version": "26.6.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -35384,12 +35387,6 @@
 					"dev": true
 				}
 			}
-		},
-		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-			"dev": true
 		},
 		"espree": {
 			"version": "7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,23 @@
 				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
+		"@babel/plugin-syntax-import-assertions": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.14.5.tgz",
+			"integrity": "sha512-bCaGuphEinZeNtIUohltvmShQbiABsKVpg/tivRLJpAZUkHIJTtzTBjV/kOik1QZhS+G3QXVoajUlpOMOXO7vA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/plugin-syntax-import-meta": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -17949,6 +17966,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.13.10",
+				"@babel/plugin-syntax-import-assertions": "^7.14.5",
 				"@babel/plugin-transform-react-jsx": "^7.12.7",
 				"@babel/plugin-transform-runtime": "^7.13.10",
 				"@babel/preset-env": "^7.13.10",
@@ -19022,7 +19040,7 @@
 				"cssnano": "^5.0.7",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^7.17.0",
+				"eslint": "^7.32.0",
 				"eslint-plugin-markdown": "^2.2.0",
 				"expect-puppeteer": "^4.4.0",
 				"filenamify": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2331,19 +2331,18 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-			"integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+			"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
-				"lodash": "^4.17.19",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -2361,9 +2360,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -2376,12 +2375,12 @@
 					"dev": true
 				},
 				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "^0.20.2"
 					}
 				},
 				"ignore": {
@@ -2419,9 +2418,9 @@
 					"dev": true
 				},
 				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				}
 			}
@@ -2882,6 +2881,40 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
@@ -34036,29 +34069,32 @@
 			}
 		},
 		"eslint": {
-			"version": "7.17.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
-			"integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@eslint/eslintrc": "^0.2.2",
+				"@babel/code-frame": "7.12.11",
+				"@eslint/eslintrc": "^0.4.3",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"enquirer": "^2.3.5",
+				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^2.1.0",
 				"eslint-visitor-keys": "^2.0.0",
 				"espree": "^7.3.1",
-				"esquery": "^1.2.0",
+				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^6.0.0",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
-				"globals": "^12.1.0",
+				"glob-parent": "^5.1.2",
+				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
@@ -34066,7 +34102,7 @@
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
-				"lodash": "^4.17.19",
+				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.0.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
@@ -34075,15 +34111,54 @@
 				"semver": "^7.2.1",
 				"strip-ansi": "^6.0.0",
 				"strip-json-comments": "^3.1.0",
-				"table": "^6.0.4",
+				"table": "^6.0.9",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"cross-spawn": {
@@ -34098,9 +34173,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -34115,6 +34190,18 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
 				"eslint-scope": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -34126,32 +34213,21 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-					"dev": true,
-					"requires": {
-						"estraverse": "^5.2.0"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-							"dev": true
-						}
-					}
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
 				},
 				"glob-parent": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
@@ -34169,18 +34245,30 @@
 					}
 				},
 				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "^0.20.2"
 					}
 				},
 				"ignore": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 					"dev": true
 				},
 				"levn": {
@@ -34240,6 +34328,28 @@
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 					"dev": true
 				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
 				"strip-ansi": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -34255,6 +34365,34 @@
 					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 					"dev": true
 				},
+				"table": {
+					"version": "6.7.1",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+					"integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^8.0.1",
+						"lodash.clonedeep": "^4.5.0",
+						"lodash.truncate": "^4.4.2",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "8.6.2",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+							"integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"json-schema-traverse": "^1.0.0",
+								"require-from-string": "^2.0.2",
+								"uri-js": "^4.2.2"
+							}
+						}
+					}
+				},
 				"type-check": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -34265,9 +34403,9 @@
 					}
 				},
 				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				},
 				"which": {
@@ -35290,9 +35428,9 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -36213,9 +36351,9 @@
 			}
 		},
 		"file-entry-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-			"integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
@@ -45442,6 +45580,12 @@
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
 		"lodash.omitby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
@@ -45489,6 +45633,12 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+		},
+		"lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"dev": true
 		},
 		"lodash.union": {
 			"version": "4.6.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -90,7 +90,7 @@ _Example:_
 @@ -43,7 +43,6 @@
                 "check-node-version": "^4.1.0",
                 "cross-spawn": "^5.1.0",
-                "eslint": "^7.1.0",
+                "eslint": "^7.32.0",
 -               "jest": "^26.6.3",
                 "minimist": "^1.2.0",
                 "npm-package-json-lint": "^3.6.0",

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -70,6 +70,7 @@ module.exports = ( api ) => {
 			require.resolve( '@babel/preset-typescript' ),
 		],
 		plugins: [
+			require.resolve( '@babel/plugin-syntax-import-assertions' ),
 			require.resolve( '@wordpress/warning/babel-plugin' ),
 			[
 				require.resolve( '@wordpress/babel-plugin-import-jsx-pragma' ),

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -30,6 +30,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@babel/core": "^7.13.10",
+		"@babel/plugin-syntax-import-assertions": "^7.14.5",
 		"@babel/plugin-transform-react-jsx": "^7.12.7",
 		"@babel/plugin-transform-runtime": "^7.13.10",
 		"@babel/preset-env": "^7.13.10",

--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -6,7 +6,8 @@ import { archive as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+// eslint-disable-next-line
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -6,7 +6,6 @@ import { archive as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-// eslint-disable-next-line
 import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -8,7 +8,7 @@ import { audio as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -8,7 +8,7 @@ import { audio as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -6,7 +6,7 @@ import { symbol as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -6,7 +6,7 @@ import { symbol as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -9,7 +9,7 @@ import { button as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -9,7 +9,7 @@ import { button as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -10,7 +10,7 @@ import { buttons as icon } from '@wordpress/icons';
 import deprecated from './deprecated';
 import transforms from './transforms';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import variations from './variations';
 

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -10,7 +10,7 @@ import { buttons as icon } from '@wordpress/icons';
 import deprecated from './deprecated';
 import transforms from './transforms';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import variations from './variations';
 

--- a/packages/block-library/src/buttons/transforms.js
+++ b/packages/block-library/src/buttons/transforms.js
@@ -7,7 +7,7 @@ import { __unstableCreateElement as createElement } from '@wordpress/rich-text';
 /**
  * Internal dependencies
  */
-import { name } from './block.json';
+import { name } from './block.json' assert { type: 'json' };;
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/buttons/transforms.js
+++ b/packages/block-library/src/buttons/transforms.js
@@ -7,7 +7,7 @@ import { __unstableCreateElement as createElement } from '@wordpress/rich-text';
 /**
  * Internal dependencies
  */
-import { name } from './block.json' assert { type: 'json' };;
+import { name } from './block.json' assert { type: 'json' };
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -6,7 +6,7 @@ import { calendar as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -6,7 +6,7 @@ import { calendar as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -6,7 +6,7 @@ import { category as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -6,7 +6,7 @@ import { category as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -8,7 +8,7 @@ import { code as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -8,7 +8,7 @@ import { code as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -8,7 +8,7 @@ import { column as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -8,7 +8,7 @@ import { column as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -9,7 +9,7 @@ import { columns as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import variations from './variations';
 import transforms from './transforms';

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -9,7 +9,7 @@ import { columns as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import variations from './variations';
 import transforms from './transforms';

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -9,7 +9,7 @@ import { cover as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -9,7 +9,7 @@ import { cover as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/embed/deprecated.js
+++ b/packages/block-library/src/embed/deprecated.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/embed/deprecated.js
+++ b/packages/block-library/src/embed/deprecated.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -3,7 +3,7 @@
  */
 import edit from './edit';
 import save from './save';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import transforms from './transforms';
 import variations from './variations';
 import deprecated from './deprecated';

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -3,7 +3,7 @@
  */
 import edit from './edit';
 import save from './save';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import transforms from './transforms';
 import variations from './variations';
 import deprecated from './deprecated';

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -6,7 +6,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { name: EMBED_BLOCK } = metadata;
 

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -6,7 +6,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { name: EMBED_BLOCK } = metadata;
 

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -23,7 +23,7 @@ import {
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { name: DEFAULT_EMBED_BLOCK } = metadata;
 

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -23,7 +23,7 @@ import {
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { name: DEFAULT_EMBED_BLOCK } = metadata;
 

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -8,7 +8,7 @@ import { file as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -8,7 +8,7 @@ import { file as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -7,7 +7,7 @@ import { classic as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/freeform/index.js
+++ b/packages/block-library/src/freeform/index.js
@@ -7,7 +7,7 @@ import { classic as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -8,7 +8,7 @@ import { gallery as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit-wrapper';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -10,7 +10,7 @@ import { group as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -10,7 +10,7 @@ import { group as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -14,7 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -14,7 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -7,7 +7,7 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from './shared';
-import { name } from './block.json';
+import { name } from './block.json' assert { type: 'json' };;
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -7,7 +7,7 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from './shared';
-import { name } from './block.json' assert { type: 'json' };;
+import { name } from './block.json' assert { type: 'json' };
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/home-link/index.js
+++ b/packages/block-library/src/home-link/index.js
@@ -7,7 +7,7 @@ import { home } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/home-link/index.js
+++ b/packages/block-library/src/home-link/index.js
@@ -7,7 +7,7 @@ import { home } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -8,7 +8,7 @@ import { html as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -8,7 +8,7 @@ import { html as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -9,7 +9,7 @@ import { image as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -9,7 +9,7 @@ import { image as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -6,7 +6,7 @@ import { comment as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -6,7 +6,7 @@ import { comment as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/latest-posts/deprecated.js
+++ b/packages/block-library/src/latest-posts/deprecated.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { attributes } = metadata;
 

--- a/packages/block-library/src/latest-posts/deprecated.js
+++ b/packages/block-library/src/latest-posts/deprecated.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { attributes } = metadata;
 

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -8,7 +8,7 @@ import { postList as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { name } = metadata;
 export { metadata, name };

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -8,7 +8,7 @@ import { postList as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { name } = metadata;
 export { metadata, name };

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -7,7 +7,7 @@ import { list as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -7,7 +7,7 @@ import { list as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -7,7 +7,7 @@ import { login as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { name } = metadata;
 export { metadata, name };

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -7,7 +7,7 @@ import { login as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { name } = metadata;
 export { metadata, name };

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -9,7 +9,7 @@ import { mediaAndText as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -9,7 +9,7 @@ import { mediaAndText as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -7,7 +7,7 @@ import { getBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -7,7 +7,7 @@ import { getBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -7,7 +7,7 @@ import { more as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -7,7 +7,7 @@ import { more as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -47,7 +47,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { ItemSubmenuIcon } from './icons';
-import { name } from './block.json' assert { type: 'json' };;
+import { name } from './block.json' assert { type: 'json' };
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link' ];
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -47,7 +47,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { ItemSubmenuIcon } from './icons';
-import { name } from './block.json';
+import { name } from './block.json' assert { type: 'json' };;
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link' ];
 

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -9,7 +9,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 import { enhanceNavigationLinkVariations } from './hooks';

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -9,7 +9,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 import { enhanceNavigationLinkVariations } from './hooks';

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -7,7 +7,7 @@ import { navigation as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 import deprecated from './deprecated';

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -7,7 +7,7 @@ import { navigation as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 import deprecated from './deprecated';

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -7,7 +7,7 @@ import { pageBreak as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -7,7 +7,7 @@ import { pageBreak as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -6,7 +6,7 @@ import { pages as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit.js';
 
 const { name } = metadata;

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -6,7 +6,7 @@ import { pages as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit.js';
 
 const { name } = metadata;

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -14,7 +14,7 @@ import { paragraph as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -14,7 +14,7 @@ import { paragraph as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -6,7 +6,7 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { name } from './block.json' assert { type: 'json' };;
+import { name } from './block.json' assert { type: 'json' };
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -6,7 +6,7 @@ import { createBlock, getBlockAttributes } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { name } from './block.json';
+import { name } from './block.json' assert { type: 'json' };;
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 /**

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 /**

--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 /**

--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 /**

--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -6,7 +6,7 @@ import { postContent as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comment-content/index.js
+++ b/packages/block-library/src/post-comment-content/index.js
@@ -6,7 +6,7 @@ import { postContent as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -6,7 +6,7 @@ import { postDate as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -6,7 +6,7 @@ import { postDate as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comment/index.js
+++ b/packages/block-library/src/post-comment/index.js
@@ -6,7 +6,7 @@ import { comment as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/post-comment/index.js
+++ b/packages/block-library/src/post-comment/index.js
@@ -6,7 +6,7 @@ import { comment as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -6,7 +6,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -6,7 +6,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments-form/index.js
+++ b/packages/block-library/src/post-comments-form/index.js
@@ -6,7 +6,7 @@ import { postCommentsForm as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments-form/index.js
+++ b/packages/block-library/src/post-comments-form/index.js
@@ -6,7 +6,7 @@ import { postCommentsForm as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments-link/index.js
+++ b/packages/block-library/src/post-comments-link/index.js
@@ -6,7 +6,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments-link/index.js
+++ b/packages/block-library/src/post-comments-link/index.js
@@ -6,7 +6,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments/index.js
+++ b/packages/block-library/src/post-comments/index.js
@@ -6,7 +6,7 @@ import { postComments as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-comments/index.js
+++ b/packages/block-library/src/post-comments/index.js
@@ -6,7 +6,7 @@ import { postComments as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -6,7 +6,7 @@ import { postContent as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -6,7 +6,7 @@ import { postContent as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -6,7 +6,7 @@ import { postDate as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -6,7 +6,7 @@ import { postDate as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -6,7 +6,7 @@ import { postExcerpt as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -6,7 +6,7 @@ import { postExcerpt as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -6,7 +6,7 @@ import { postFeaturedImage as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -6,7 +6,7 @@ import { postFeaturedImage as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/post-template/index.js
+++ b/packages/block-library/src/post-template/index.js
@@ -6,7 +6,7 @@ import { loop } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/post-template/index.js
+++ b/packages/block-library/src/post-template/index.js
@@ -6,7 +6,7 @@ import { loop } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -6,7 +6,7 @@ import { postTitle as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -6,7 +6,7 @@ import { postTitle as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -8,7 +8,7 @@ import { preformatted as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -8,7 +8,7 @@ import { preformatted as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -9,7 +9,7 @@ import { pullquote as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -9,7 +9,7 @@ import { pullquote as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/query-pagination-next/index.js
+++ b/packages/block-library/src/query-pagination-next/index.js
@@ -6,7 +6,7 @@ import { queryPaginationNext as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination-next/index.js
+++ b/packages/block-library/src/query-pagination-next/index.js
@@ -6,7 +6,7 @@ import { queryPaginationNext as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination-numbers/index.js
+++ b/packages/block-library/src/query-pagination-numbers/index.js
@@ -6,7 +6,7 @@ import { queryPaginationNumbers as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination-numbers/index.js
+++ b/packages/block-library/src/query-pagination-numbers/index.js
@@ -6,7 +6,7 @@ import { queryPaginationNumbers as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination-previous/index.js
+++ b/packages/block-library/src/query-pagination-previous/index.js
@@ -6,7 +6,7 @@ import { queryPaginationPrevious as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination-previous/index.js
+++ b/packages/block-library/src/query-pagination-previous/index.js
@@ -6,7 +6,7 @@ import { queryPaginationPrevious as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -6,7 +6,7 @@ import { queryPagination as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -6,7 +6,7 @@ import { queryPagination as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 

--- a/packages/block-library/src/query-title/index.js
+++ b/packages/block-library/src/query-title/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/query-title/index.js
+++ b/packages/block-library/src/query-title/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -7,7 +7,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import save from './save';
 import variations from './variations';

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -7,7 +7,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import save from './save';
 import variations from './variations';

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -9,7 +9,7 @@ import { quote as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -9,7 +9,7 @@ import { quote as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/rss/index.js
+++ b/packages/block-library/src/rss/index.js
@@ -6,7 +6,7 @@ import { rss as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/rss/index.js
+++ b/packages/block-library/src/rss/index.js
@@ -6,7 +6,7 @@ import { rss as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -6,7 +6,7 @@ import { search as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/search/index.js
+++ b/packages/block-library/src/search/index.js
@@ -6,7 +6,7 @@ import { search as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import variations from './variations';
 

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -7,7 +7,7 @@ import { separator as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -7,7 +7,7 @@ import { separator as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -9,7 +9,7 @@ import { shortcode as icon } from '@wordpress/icons';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 
 const { name } = metadata;
 

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -9,7 +9,7 @@ import { shortcode as icon } from '@wordpress/icons';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 
 const { name } = metadata;
 

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -6,7 +6,7 @@ import { siteLogo as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -6,7 +6,7 @@ import { siteLogo as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import icon from './icon';
 

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import icon from './icon';
 

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -6,7 +6,7 @@ import { mapMarker as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -6,7 +6,7 @@ import { mapMarker as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -7,7 +7,7 @@ import { share as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import variations from './variations';
 
 const { name } = metadata;

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -7,7 +7,7 @@ import { share as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import variations from './variations';
 
 const { name } = metadata;

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -8,7 +8,7 @@ import { share as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -8,7 +8,7 @@ import { share as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -7,7 +7,7 @@ import { resizeCornerNE as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -7,7 +7,7 @@ import { resizeCornerNE as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 
 const { name } = metadata;

--- a/packages/block-library/src/table-of-contents/index.js
+++ b/packages/block-library/src/table-of-contents/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import icon from './icon';
 

--- a/packages/block-library/src/table-of-contents/index.js
+++ b/packages/block-library/src/table-of-contents/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import icon from './icon';
 

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -9,7 +9,7 @@ import { blockTable as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -9,7 +9,7 @@ import { blockTable as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -6,7 +6,7 @@ import { tag as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -6,7 +6,7 @@ import { tag as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -14,7 +14,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import { enhanceTemplatePartVariations } from './variations';
 

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -14,7 +14,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import { enhanceTemplatePartVariations } from './variations';
 

--- a/packages/block-library/src/term-description/index.js
+++ b/packages/block-library/src/term-description/index.js
@@ -6,7 +6,7 @@ import { termDescription as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/term-description/index.js
+++ b/packages/block-library/src/term-description/index.js
@@ -6,7 +6,7 @@ import { termDescription as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -9,7 +9,7 @@ import { verse as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -9,7 +9,7 @@ import { verse as icon } from '@wordpress/icons';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -8,7 +8,7 @@ import { video as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -8,7 +8,7 @@ import { video as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/edit-widgets/src/blocks/widget-area/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/edit-widgets/src/blocks/widget-area/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 
 const { name } = metadata;

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -1,5 +1,8 @@
 module.exports = {
-	parser: 'babel-eslint',
+	parser: '@babel/eslint-parser',
+	parserOptions: {
+		importAssertions: true,
+	},
 	extends: [
 		require.resolve( './jsx-a11y.js' ),
 		require.resolve( './custom.js' ),

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,10 +31,10 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@babel/eslint-parser": "^7.15.0",
 		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
-		"babel-eslint": "^10.1.0",
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^7.1.0",
 		"eslint-plugin-import": "^2.23.4",

--- a/packages/react-native-editor/.eslintrc.js
+++ b/packages/react-native-editor/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
-	parser: 'babel-eslint',
+	parser: '@babel/eslint-parser',
+	parserOptions: {
+		classProperties: true,
+	},
 	env: {
 		browser: true,
 		'jest/globals': true,

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -53,7 +53,7 @@
 		"cssnano": "^5.0.7",
 		"cwd": "^0.10.0",
 		"dir-glob": "^3.0.1",
-		"eslint": "^7.17.0",
+		"eslint": "^7.32.0",
 		"eslint-plugin-markdown": "^2.2.0",
 		"expect-puppeteer": "^4.4.0",
 		"filenamify": "^4.2.0",

--- a/packages/widgets/src/blocks/legacy-widget/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/index.js
@@ -6,7 +6,7 @@ import { widget as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json';
+import metadata from './block.json' assert { type: 'json' };;
 import edit from './edit';
 import transforms from './transforms';
 

--- a/packages/widgets/src/blocks/legacy-widget/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/index.js
@@ -6,7 +6,7 @@ import { widget as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import metadata from './block.json' assert { type: 'json' };;
+import metadata from './block.json' assert { type: 'json' };
 import edit from './edit';
 import transforms from './transforms';
 


### PR DESCRIPTION
Related to #36142 and #36716.

For some time now, we've been using a custom JSON import to load block metadata in JS. Now that JSON modules [are being standardized](https://github.com/tc39/proposal-json-modules), we should switch to the standard syntax which would allow us to avoid lockin.

This seems to work well aside eslint. I was not able to make eslint work without issues here. Any help would be appreciated.