### PR TITLE
Prototype: merge block CSS with `theme.json` styles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, __experimentalStyle (border, color, spacing, typography), color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons
@@ -60,7 +60,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, spacing (blockGap, margin)
--	**Attributes:**
+-	**Attributes:** 
 
 ## Calendar
 
@@ -168,7 +168,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Supports:** align, ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Comments
 
@@ -204,7 +204,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Previous Page
 
@@ -420,7 +420,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Name:** core/nextpage
 -	**Category:** design
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Page List
 
@@ -528,7 +528,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Post Date
 
@@ -573,7 +573,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Name:** core/post-template
 -	**Category:** theme
 -	**Supports:** align, ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Post Terms
 
@@ -627,7 +627,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Name:** core/query-no-results
 -	**Category:** theme
 -	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Pagination
 
@@ -654,7 +654,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Previous Page
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, blockStyles (border, color, spacing, typography), color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, blockStyles (border, color, spacing, typography), color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, __experimentalStyle (border, color, spacing, typography), color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons
@@ -60,7 +60,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, spacing (blockGap, margin)
--	**Attributes:** 
+-	**Attributes:**
 
 ## Calendar
 
@@ -168,7 +168,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Supports:** align, ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Comments
 
@@ -204,7 +204,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Previous Page
 
@@ -420,7 +420,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Name:** core/nextpage
 -	**Category:** design
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Page List
 
@@ -528,7 +528,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Post Date
 
@@ -573,7 +573,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Name:** core/post-template
 -	**Category:** theme
 -	**Supports:** align, ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Post Terms
 
@@ -627,7 +627,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Name:** core/query-no-results
 -	**Category:** theme
 -	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Pagination
 
@@ -654,7 +654,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Previous Page
 

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -121,6 +121,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 	/**
 	 * When given an array, this will remove any keys with the name `//`.
 	 *
+	 * @param array The array to filter.
 	 * @return array The filtered array.
 	 */
 	private static function remove_JSON_comments( $array ) {

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -98,4 +98,37 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		return $with_theme_supports;
 	}
 
+	public static function get_block_data() {
+		$registry = WP_Block_Type_Registry::get_instance();
+		$blocks   = $registry->get_all_registered();
+		$config   = array( 'version' => 1 );
+		foreach( $blocks as $block_name => $block_type ) {
+			if ( isset( $block_type->supports['blockStyles'] ) ) {
+				$config['styles']['blocks'][ $block_name ] = $block_type->supports['blockStyles'];
+			}
+		}
+
+		// Core here means it's the lower level part of the styles chain.
+		// It can be a core or a third-party block.
+		return new WP_Theme_JSON( $config, 'core' );
+	}
+
+	public static function get_merged_data( $origin = 'custom' ) {
+		if ( is_array( $origin ) ) {
+			_deprecated_argument( __FUNCTION__, '5.9' );
+		}
+
+		$result = new WP_Theme_JSON_Gutenberg();
+		$result->merge( static::get_core_data() );
+		$result->merge( static::get_block_data() );
+		$result->merge( static::get_theme_data() );
+
+		if ( 'custom' === $origin ) {
+			$result->merge( static::get_user_data() );
+		}
+
+		return $result;
+	}
+
+
 }

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -121,7 +121,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 	/**
 	 * When given an array, this will remove any keys with the name `//`.
 	 *
-	 * @param array The array to filter.
+	 * @param array $array The array to filter.
 	 * @return array The filtered array.
 	 */
 	private static function remove_JSON_comments( $array ) {

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -98,6 +98,11 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		return $with_theme_supports;
 	}
 
+	/**
+	 * Gets the styles for blocks from the block.json file.
+	 *
+	 * @return WP_Theme_JSON object with the styles for each block.
+	 */
 	public static function get_block_data() {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -102,15 +102,26 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 		$config   = array( 'version' => 1 );
-		foreach( $blocks as $block_name => $block_type ) {
+		foreach ( $blocks as $block_name => $block_type ) {
 			if ( isset( $block_type->supports['blockStyles'] ) ) {
-				$config['styles']['blocks'][ $block_name ] = $block_type->supports['blockStyles'];
+				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->supports['blockStyles'] );
 			}
 		}
 
 		// Core here means it's the lower level part of the styles chain.
 		// It can be a core or a third-party block.
 		return new WP_Theme_JSON( $config, 'core' );
+	}
+
+	private static function removeJsonComments( $array ) {
+		unset( $array['//'] );
+		foreach ( $array as $k => $v ) {
+			if ( is_array( $v ) ) {
+				$array[ $k ] = static::removeJsonComments( $v );
+			}
+		}
+
+		return $array;
 	}
 
 	public static function get_merged_data( $origin = 'custom' ) {
@@ -122,7 +133,6 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$result->merge( static::get_core_data() );
 		$result->merge( static::get_block_data() );
 		$result->merge( static::get_theme_data() );
-
 		if ( 'custom' === $origin ) {
 			$result->merge( static::get_user_data() );
 		}

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -103,8 +103,8 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$blocks   = $registry->get_all_registered();
 		$config   = array( 'version' => 1 );
 		foreach ( $blocks as $block_name => $block_type ) {
-			if ( isset( $block_type->supports['blockStyles'] ) ) {
-				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->supports['blockStyles'] );
+			if ( isset( $block_type->supports['__experimentalStyle'] ) ) {
+				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->supports['__experimentalStyle'] );
 			}
 		}
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -92,6 +92,7 @@
 		"__experimentalSelector": ".wp-block-button__link",
 		"blockStyles": {
 			"border": {
+				"//": "100% causes an oval, but any explicit but really high value retains the pill shape.",
 				"radius": "9999px"
 			},
 			"color": {
@@ -104,6 +105,7 @@
 			},
 			"spacing": {
 				"padding": {
+					"//": "The extra 2px are added to size solids the same as the outline versions.",
 					"top": "calc(0.667em + 2px)",
 					"right": "calc(1.333em + 2px)",
 					"bottom": "calc(0.667em + 2px)",

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -89,22 +89,27 @@
 				"radius": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button__link"
-	},
-	"blockStyles": {
-		"border": {
-			"radius": "9999px"
-		},
-		"color": {
-			"text": "#fff",
-			"background": "#32373c"
-		},
-		"typography": {
-			"fontSize": "1.125em",
-			"textDecoration": "none"
-		},
-		"spacing": {
-			"padding": "calc(0.667em + 2px) calc(1.333em + 2px)"
+		"__experimentalSelector": ".wp-block-button__link",
+		"blockStyles": {
+			"border": {
+				"radius": "9999px"
+			},
+			"color": {
+				"text": "#fff",
+				"background": "#32373c"
+			},
+			"typography": {
+				"fontSize": "1.125em",
+				"textDecoration": "none"
+			},
+			"spacing": {
+				"padding": {
+					"top": "calc(0.667em + 2px)",
+					"right": "calc(1.333em + 2px)",
+					"bottom": "calc(0.667em + 2px)",
+					"left": "calc(1.333em + 2px)"
+				}
+			}
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -90,7 +90,7 @@
 			}
 		},
 		"__experimentalSelector": ".wp-block-button__link",
-		"blockStyles": {
+		"__experimentalStyle": {
 			"border": {
 				"//": "100% causes an oval, but any explicit but really high value retains the pill shape.",
 				"radius": "9999px"

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -91,6 +91,22 @@
 		},
 		"__experimentalSelector": ".wp-block-button__link"
 	},
+	"blockStyles": {
+		"border": {
+			"radius": "9999px"
+		},
+		"color": {
+			"text": "#fff",
+			"background": "#32373c"
+		},
+		"typography": {
+			"fontSize": "1.125em",
+			"textDecoration": "none"
+		},
+		"spacing": {
+			"padding": "calc(0.667em + 2px) calc(1.333em + 2px)"
+		}
+	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },
 		{ "name": "outline", "label": "Outline" }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -4,14 +4,9 @@ $blocks-block__margin: 0.5em;
 // Prefer the link selector instead of the regular button classname
 // to support the previous markup in addition to the new one.
 .wp-block-button__link {
-	color: $white;
-	background-color: #32373c;
-	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
-	font-size: 1.125em;
-	padding: calc(0.667em + 2px) calc(1.333em + 2px); // The extra 2px are added to size solids the same as the outline versions.
 	text-align: center;
 	text-decoration: none;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.


### PR DESCRIPTION
Implements https://github.com/WordPress/gutenberg/issues/33977

**I'd like feedback on the direction. Should we want to pursue this, I'd improve the implementation later**.

This PR experiments with moving parts of the CSS of the block to its `block.json` so it can be used to be merged with `theme.json` styles. The result of the merging will be (later in the chain overwrites the previous):

> core (theme.json) > block (block.json) > theme (theme.json) > user (styles coming from the global styles sidebar)

There're a few advantages to this approach:

- Block styles become easily configurable by the themes (via `theme.json`).
- We ship either block or theme styles, but not both.

I've noticed that many of the block styles are attached to classes (has-background, style variations, etc) so I presume, initially, we won't see a big reduction of CSS. It'll be a good first step to absorb more later (e.g.: [block variations](https://github.com/WordPress/gutenberg/issues/33232)).

## How to test

- Use the empty theme.
- Verify that the `global-styles-inline-css` embedded stylesheet in the frontend contains the following CSS coming from the `block.json`:

```css
.wp-block-button__link {
  background-color: #32373c;
  color: #fff;
  font-size: 1.125em;
  padding-top: calc(0.667em + 2px);
  padding-right: calc(1.333em + 2px);
  padding-bottom: calc(0.667em + 2px);
  padding-left: calc(1.333em + 2px);
}
```

- Add the following to the `theme.json` of the theme:

```json
"styles": {
  "blocks": {
    "core/button": {
      "color": {
        "text": "#000",
        "background": "#fff"
      }
    }
  }
}
```

- Verify that the `global-styles-inline-css` embedded stylesheet in the frontend contains the following CSS (colors come from the theme now):

```css
.wp-block-button__link {
  background-color: #fff;
  color: #000;
  font-size: 1.125em;
  padding-top: calc(0.667em + 2px);
  padding-right: calc(1.333em + 2px);
  padding-bottom: calc(0.667em + 2px);
  padding-left: calc(1.333em + 2px);
}
```
