### PR TITLE
wp-env: Document troubleshooting with `docker-compose down`.

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -169,7 +169,17 @@ $ wp-env destroy
 $ wp-env start
 ```
 
-### 7. Debug mode and inspecting the generated dockerfile.
+### 7. Manually nuke everything
+
+If you get Docker errors with `wp-env destroy`, then some containers may be stuck in a broken state. When that happens, removing them directly through Docker may be necessary.
+
+**⚠️ WARNING: This will permanently delete any posts, pages, media, etc. in the local WordPress installation.**
+
+```sh
+$ find ~/.wp-env -maxdepth 1 -type d -exec bash -c "cd '{}' && docker-compose down" \;
+```
+
+### 8. Debug mode and inspecting the generated dockerfile.
 
 `wp-env` uses docker behind the scenes. Inspecting the generated docker-compose file can help to understand what's going on.
 


### PR DESCRIPTION
I ran into a lot of unrecoverable errors while I was making changes to the `mappings` and `core` sections of a `.wp-env.json`, and none of the `wp-env` commands would run:

```
> yarn run wp-env destroy
yarn run v1.22.10
$ wp-env destroy
ℹ WARNING! This will remove Docker containers, volumes, and networks associated with the WordPress instance.
? Are you sure you want to continue? Yes
✖ Error while running docker-compose command.
Duplicate mount points: [/Users/iandunn/vhosts/localhost/wporg-news-2021/wordpress/env:/var/www/html/env:rw, /Users/iandunn/vhosts/localhost/wporg-news-2021/env:/var/www/html/env:rw]
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

`docker-compose down` was the only thing that worked for me.
