### PR TITLE
[Mobile] - add CSS Unit parser to px 

### DIFF
--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -1,0 +1,103 @@
+const PIXELS_PER_INCH = 96;
+const ONE_PERCENT = 0.01;
+
+const defaults = {
+	ch: 8,
+	ex: 7.15625,
+	em: 16,
+	rem: 16,
+	in: PIXELS_PER_INCH,
+	cm: PIXELS_PER_INCH / 2.54,
+	mm: PIXELS_PER_INCH / 25.4,
+	pt: PIXELS_PER_INCH / 72,
+	pc: PIXELS_PER_INCH / 6,
+	px: 1,
+};
+
+function parseUnit( cssUnit ) {
+	const match = cssUnit
+		.trim()
+		.match(
+			/^(0?[-.]?\d+)(r?e[m|x]|v[h|w|min|max]+|p[x|t|c]|[c|m]m|%|in|ch)$/
+		);
+	return match
+		? { value: parseFloat( match[ 1 ] ) || match[ 1 ], unit: match[ 2 ] }
+		: { value: null, unit: undefined };
+}
+
+function parseUnitFunction( cssUnit ) {
+	// var regExp = /[min\(|max\(]([^()]*)\)/g;
+	// var matches = regExp.exec(cssUnit);
+	// let args = cssUnit.split( '/([(,),,])/' );
+	// const firstChunk = args[0].split( '(');
+	// args[0] = firstChunk[1];
+	// const lastChunk = args[args.length - 1 ].split(')');
+	// args[args.length - 1 ] = args[args.length - 1 ].split(')')[0];
+
+	const functionUnit = cssUnit.split( /[(),]/g ).filter( Boolean );
+	const units = functionUnit
+		.slice( 1 )
+		.map( ( unit ) => parseUnit( getPxFromCssUnit( unit ) ).value )
+		.filter( Boolean );
+
+	switch ( functionUnit[ 0 ] ) {
+		case 'min':
+			return { value: Math.min( ...units ), unit: 'px' };
+		case 'max':
+			return { value: Math.max( ...units ), unit: 'px' };
+	}
+	return null;
+}
+
+export function getPxFromCssUnit( cssUnit, options = {} ) {
+	let parsedUnit = parseUnit( cssUnit );
+
+	if ( ! parsedUnit.unit ) {
+		parsedUnit = parseUnitFunction( cssUnit );
+	}
+
+	const defaultProperties = {
+		fontSize: 16,
+		width: 375,
+		height: 812,
+		type: 'font',
+	};
+
+	const setOptions = Object.assign( {}, defaultProperties, options );
+
+	const relativeUnits = {
+		em: setOptions.fontSize,
+		rem: setOptions.fontSize,
+		vh: setOptions.height * ONE_PERCENT,
+		vw: setOptions.width * ONE_PERCENT,
+		vmin:
+			( setOptions.width < setOptions.height
+				? setOptions.width
+				: setOptions.height ) * ONE_PERCENT,
+		vmax:
+			( setOptions.width > setOptions.height
+				? setOptions.width
+				: setOptions.height ) * ONE_PERCENT,
+		'%':
+			( setOptions.type === 'font'
+				? setOptions.fontSize
+				: setOptions.width ) * ONE_PERCENT,
+	};
+
+	if ( relativeUnits[ parsedUnit.unit ] ) {
+		return (
+			( relativeUnits[ parsedUnit.unit ] * parsedUnit.value ).toFixed(
+				0
+			) + 'px'
+		);
+	}
+
+	if ( defaults[ parsedUnit.unit ] ) {
+		return (
+			( defaults[ parsedUnit.unit ] * parsedUnit.value ).toFixed( 0 ) +
+			'px'
+		);
+	}
+
+	return null;
+}

--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -10,6 +10,9 @@ function parseUnit( cssUnit ) {
 		.match(
 			/^(0?[-.]?\d+)(r?e[m|x]|v[h|w|min|max]+|p[x|t|c]|[c|m]m|%|in|ch|Q|lh)$/
 		);
+	if ( ! isNaN( cssUnit ) && ! isNaN( parseFloat( cssUnit ) ) ) {
+		return { value: parseFloat( cssUnit ), unit: 'px' };
+	}
 	return match
 		? { value: parseFloat( match[ 1 ] ) || match[ 1 ], unit: match[ 2 ] }
 		: { value: cssUnit, unit: undefined };
@@ -221,11 +224,6 @@ export function getPxFromCssUnit( cssUnit, options = {} ) {
 
 	if ( isMathExpression( cssUnit ) && ! parsedUnit.unit ) {
 		return evalMathExpression( cssUnit );
-	}
-
-	// shortcut
-	if ( parsedUnit.unit === 'px' ) {
-		return parsedUnit.value + parsedUnit.unit;
 	}
 
 	return convertParsedUnitToPx( parsedUnit, options );

--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -1,19 +1,9 @@
-const PIXELS_PER_INCH = 96;
-const ONE_PERCENT = 0.01;
-
-const defaults = {
-	ch: 8,
-	ex: 7.15625,
-	em: 16,
-	rem: 16,
-	in: PIXELS_PER_INCH,
-	cm: PIXELS_PER_INCH / 2.54,
-	mm: PIXELS_PER_INCH / 25.4,
-	pt: PIXELS_PER_INCH / 72,
-	pc: PIXELS_PER_INCH / 6,
-	px: 1,
-};
-
+/**
+ * Converts string to object { value, unit }.
+ *
+ * @param {string} cssUnit
+ * @return {Object} parsedUnit
+ */
 function parseUnit( cssUnit ) {
 	const match = cssUnit
 		.trim()
@@ -22,39 +12,149 @@ function parseUnit( cssUnit ) {
 		);
 	return match
 		? { value: parseFloat( match[ 1 ] ) || match[ 1 ], unit: match[ 2 ] }
-		: { value: null, unit: undefined };
+		: { value: cssUnit, unit: undefined };
+}
+/**
+ * Evaluate a math expression.
+ *
+ * @param {string} expression
+ * @return {number} evaluated expression.
+ */
+function calculate( expression ) {
+	return Function( `'use strict'; return (${ expression })` )();
 }
 
-function parseUnitFunction( cssUnit ) {
-	// var regExp = /[min\(|max\(]([^()]*)\)/g;
-	// var matches = regExp.exec(cssUnit);
-	// let args = cssUnit.split( '/([(,),,])/' );
-	// const firstChunk = args[0].split( '(');
-	// args[0] = firstChunk[1];
-	// const lastChunk = args[args.length - 1 ].split(')');
-	// args[args.length - 1 ] = args[args.length - 1 ].split(')')[0];
-
-	const functionUnit = cssUnit.split( /[(),]/g ).filter( Boolean );
+/**
+ * Calculates the css function value for the supported css functions such as max, min, clamp and calc.
+ *
+ * @param {string} functionUnitValue string should be in a particular format (for example min(12px,12px) ) no nested loops.
+ * @param {Object} options
+ * @return {string} unit containing the unit in PX.
+ */
+function getFunctionUnitValue( functionUnitValue, options ) {
+	if ( ! functionUnitValue ) {
+		return null;
+	}
+	const functionUnit = functionUnitValue.split( /[(),]/g ).filter( Boolean );
 	const units = functionUnit
 		.slice( 1 )
-		.map( ( unit ) => parseUnit( getPxFromCssUnit( unit ) ).value )
+		.map( ( unit ) => parseUnit( getPxFromCssUnit( unit, options ) ).value )
 		.filter( Boolean );
 
 	switch ( functionUnit[ 0 ] ) {
 		case 'min':
-			return { value: Math.min( ...units ), unit: 'px' };
+			return Math.min( ...units ) + 'px';
 		case 'max':
-			return { value: Math.max( ...units ), unit: 'px' };
+			return Math.max( ...units ) + 'px';
+		case 'clamp':
+			if ( units.length !== 3 ) {
+				return null;
+			}
+			if ( units[ 1 ] < units[ 0 ] ) {
+				return units[ 0 ] + 'px';
+			}
+			if ( units[ 1 ] > units[ 2 ] ) {
+				return units[ 2 ] + 'px';
+			}
+			return units[ 1 ] + 'px';
+		case 'calc':
+			return units[ 0 ] + 'px';
 	}
-	return null;
 }
 
-export function getPxFromCssUnit( cssUnit, options = {} ) {
-	let parsedUnit = parseUnit( cssUnit );
+/**
+ * Take a css function such as min, max, calc, clamp and returns parsedUnit
+ *
+ * @param {string} cssUnit
+ * @return {Object} parsedUnit object.
+ */
+function parseUnitFunction( cssUnit ) {
+	let matchFound = false;
+	while ( true ) {
+		const currentCssUnit = cssUnit;
 
-	if ( ! parsedUnit.unit ) {
-		parsedUnit = parseUnitFunction( cssUnit );
+		const regExps = [
+			/max\(([^()]*)\)/g,
+			/min\(([^()]*)\)/g,
+			/calc\(([^()]*)\)/g,
+			/clamp\(([^()]*)\)/g,
+		];
+		regExps.forEach( ( regExp ) => {
+			const matches = regExp.exec( cssUnit ) || [];
+			const functionUnitValue = getFunctionUnitValue( matches[ 0 ] );
+			if ( functionUnitValue ) {
+				matchFound = true;
+				cssUnit = cssUnit.replace( matches[ 0 ], functionUnitValue );
+			}
+		} );
+
+		// if the unit hasn't been modified
+		if ( cssUnit === currentCssUnit || parseFloat( cssUnit ) ) {
+			break;
+		}
 	}
+
+	if ( ! matchFound ) {
+		return cssUnit; // just return the value. We didn't find a match.
+	}
+
+	return parseUnit( cssUnit );
+}
+/**
+ * Return true if we think this is a math expression.
+ *
+ * @param {string} cssUnit the cssUnit value being evaluted.
+ * @return {boolean} Whether the cssUnit is a math expression.
+ */
+function isMathExpression( cssUnit ) {
+	for ( let i = 0; i < cssUnit.length; i++ ) {
+		if ( [ '+', '-', '/', '*' ].includes( cssUnit[ i ] ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+/**
+ * Evaluates the math expression and return a px value.
+ *
+ * @param {string} cssUnit the cssUnit value being evaluted.
+ * @return {string} return a converfted value to px.
+ */
+function evalMathExpression( cssUnit ) {
+	// Convert every part of the expression to px values.
+	const functionUnits = cssUnit.split( /[+-/*/]/g ).filter( Boolean );
+	functionUnits.forEach( ( unit ) => {
+		// standardize the unit to px and extract the value.
+		const parsedUnit = parseUnit( getPxFromCssUnit( unit ) );
+
+		cssUnit = cssUnit.replace( unit, parsedUnit.value );
+	} );
+
+	return calculate( cssUnit ).toFixed( 0 ) + 'px';
+}
+/**
+ * Convert a parsedUnit object to px value.
+ *
+ * @param {Object} parsedUnit
+ * @param {Object} options
+ * @return {string} or {null} returns the converted with in a px value format.
+ */
+function convertParsedUnitToPx( parsedUnit, options ) {
+	const PIXELS_PER_INCH = 96;
+	const ONE_PERCENT = 0.01;
+
+	const defaults = {
+		ch: 8,
+		ex: 7.15625,
+		em: 16,
+		rem: 16,
+		in: PIXELS_PER_INCH,
+		cm: PIXELS_PER_INCH / 2.54,
+		mm: PIXELS_PER_INCH / 25.4,
+		pt: PIXELS_PER_INCH / 72,
+		pc: PIXELS_PER_INCH / 6,
+		px: 1,
+	};
 
 	const defaultProperties = {
 		fontSize: 16,
@@ -100,4 +200,29 @@ export function getPxFromCssUnit( cssUnit, options = {} ) {
 	}
 
 	return null;
+}
+/**
+ * Returns the px value of a cssUnit.
+ *
+ * @param {string} cssUnit
+ * @param {string} options
+ * @return {string} returns the cssUnit value in a simple px format.
+ */
+export function getPxFromCssUnit( cssUnit, options = {} ) {
+	let parsedUnit = parseUnit( cssUnit );
+
+	if ( ! parsedUnit.unit ) {
+		parsedUnit = parseUnitFunction( cssUnit, options );
+	}
+
+	if ( isMathExpression( cssUnit ) && ! parsedUnit.unit ) {
+		return evalMathExpression( cssUnit );
+	}
+
+	// shortcut
+	if ( parsedUnit.unit === 'px' ) {
+		return parsedUnit.value + parsedUnit.unit;
+	}
+
+	return convertParsedUnitToPx( parsedUnit, options );
 }

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { getPxFromCssUnit } from '../parse-css-unit-to-px';
+
+describe( 'getPxFromCssUnit', () => {
+	// Absolute units
+	it( 'px return px unit', () => {
+		expect( getPxFromCssUnit( '25px' ) ).toBe( '25px' );
+	} );
+
+	it( 'cm return px unit', () => {
+		expect( getPxFromCssUnit( '1cm' ) ).toBe( '38px' );
+	} );
+
+	it( 'mm return px unit', () => {
+		expect( getPxFromCssUnit( '10mm' ) ).toBe( '38px' );
+	} );
+
+	it( 'in return px unit', () => {
+		expect( getPxFromCssUnit( '1in' ) ).toBe( '96px' );
+	} );
+
+	it( 'pt return px unit', () => {
+		expect( getPxFromCssUnit( '12pt' ) ).toBe( '16px' );
+	} );
+
+	it( 'pc return px unit', () => {
+		expect( getPxFromCssUnit( '1pc' ) ).toBe( '16px' );
+	} );
+
+	// Relative units
+	it( 'em return px unit', () => {
+		expect( getPxFromCssUnit( '2em', { fontSize: 10 } ) ).toBe( '20px' );
+	} );
+
+	it( 'rem return px unit', () => {
+		expect( getPxFromCssUnit( '2rem', { fontSize: 10 } ) ).toBe( '20px' );
+	} );
+
+	it( 'vw return px unit', () => {
+		expect( getPxFromCssUnit( '20vw', { width: 100 } ) ).toBe( '20px' );
+	} );
+
+	it( 'vh return px unit', () => {
+		expect( getPxFromCssUnit( '20vh', { height: 200 } ) ).toBe( '40px' );
+	} );
+
+	it( 'vmin return px unit', () => {
+		expect(
+			getPxFromCssUnit( '20vmin', { height: 200, width: 100 } )
+		).toBe( '20px' );
+	} );
+
+	it( 'vmax return px unit', () => {
+		expect(
+			getPxFromCssUnit( '20vmax', { height: 200, width: 100 } )
+		).toBe( '40px' );
+	} );
+
+	it( '% return px unit', () => {
+		expect(
+			getPxFromCssUnit( '120%', {
+				height: 200,
+				width: 100,
+				fontSize: 10,
+				type: 'font',
+			} )
+		).toBe( '12px' );
+	} );
+	// Function units
+	it( 'min() return px unit', () => {
+		expect( getPxFromCssUnit( 'min(20px, 25px)' ) ).toBe( '20px' );
+	} );
+
+	it( 'max() return px unit', () => {
+		expect( getPxFromCssUnit( 'max(20px, 25px)' ) ).toBe( '25px' );
+	} );
+} );

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -120,7 +120,7 @@ describe( 'getPxFromCssUnit', () => {
 		);
 	} );
 
-	it( 'test calcualte function return px unit', () => {
+	it( 'test calculate function return px unit', () => {
 		expect( getPxFromCssUnit( '10px + 25px' ) ).toBe( '35px' );
 	} );
 

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -72,8 +72,61 @@ describe( 'getPxFromCssUnit', () => {
 	it( 'min() return px unit', () => {
 		expect( getPxFromCssUnit( 'min(20px, 25px)' ) ).toBe( '20px' );
 	} );
+	it( 'min() function with many arguments return px unit', () => {
+		expect( getPxFromCssUnit( 'min(20px, 9px, 12pt, 25px)' ) ).toBe(
+			'9px'
+		);
+	} );
 
 	it( 'max() return px unit', () => {
 		expect( getPxFromCssUnit( 'max(20px, 25px)' ) ).toBe( '25px' );
+	} );
+
+	it( 'clamp() lower return px unit', () => {
+		expect( getPxFromCssUnit( 'clamp(10px, 9px, 25px)' ) ).toBe( '10px' );
+	} );
+
+	it( 'clamp() upper return px unit', () => {
+		expect( getPxFromCssUnit( 'clamp(10px, 35px, 25px)' ) ).toBe( '25px' );
+	} );
+
+	it( 'clamp() middle return px unit', () => {
+		expect( getPxFromCssUnit( 'clamp(10px, 15px, 25px)' ) ).toBe( '15px' );
+	} );
+
+	it( 'nested max min function return px unit', () => {
+		expect( getPxFromCssUnit( 'min(max(20px,25px), 35px)' ) ).toBe(
+			'25px'
+		);
+	} );
+
+	it( 'nested min max function return px unit', () => {
+		expect( getPxFromCssUnit( 'max(min(20px,25px), 35px)' ) ).toBe(
+			'35px'
+		);
+	} );
+
+	it( 'calcualte function return px unit', () => {
+		expect( getPxFromCssUnit( '10px + 25px' ) ).toBe( '35px' );
+	} );
+
+	it( 'test calc(10px + 25px) function return px unit', () => {
+		expect( getPxFromCssUnit( 'calc(10px + 25px)' ) ).toBe( '35px' );
+	} );
+
+	it( 'test calc(25px - 10px) function return px unit', () => {
+		expect( getPxFromCssUnit( 'calc(25px - 10px)' ) ).toBe( '15px' );
+	} );
+
+	it( 'test min(10px + 25px, 55pt) function return px unit', () => {
+		expect( getPxFromCssUnit( 'min(10px + 25px, 55pt)' ) ).toBe( '35px' );
+	} );
+
+	it( 'test calc(12vw * 10px) function return px unit', () => {
+		expect( getPxFromCssUnit( 'calc(12vw * 10px)' ) ).toBe( '450px' );
+	} );
+
+	it( 'test calc(42vw / 10px) function return px unit', () => {
+		expect( getPxFromCssUnit( 'calc(45vw / 10px)' ) ).toBe( '17px' );
 	} );
 } );

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -29,6 +29,10 @@ describe( 'getPxFromCssUnit', () => {
 		expect( getPxFromCssUnit( '1pc' ) ).toBe( '16px' );
 	} );
 
+	it( 'Q return px unit', () => {
+		expect( getPxFromCssUnit( '40Q' ) ).toBe( '38px' ); // 40 Q should be 1 cm
+	} );
+
 	// Relative units
 	it( 'em return px unit', () => {
 		expect( getPxFromCssUnit( '2em', { fontSize: 10 } ) ).toBe( '20px' );
@@ -58,6 +62,10 @@ describe( 'getPxFromCssUnit', () => {
 		).toBe( '40px' );
 	} );
 
+	it( 'lh return px unit', () => {
+		expect( getPxFromCssUnit( '20lh', { lineHeight: 2 } ) ).toBe( '40px' );
+	} );
+
 	it( '% return px unit', () => {
 		expect(
 			getPxFromCssUnit( '120%', {
@@ -68,6 +76,7 @@ describe( 'getPxFromCssUnit', () => {
 			} )
 		).toBe( '12px' );
 	} );
+
 	// Function units
 	it( 'min() return px unit', () => {
 		expect( getPxFromCssUnit( 'min(20px, 25px)' ) ).toBe( '20px' );
@@ -128,5 +137,37 @@ describe( 'getPxFromCssUnit', () => {
 
 	it( 'test calc(42vw / 10px) function return px unit', () => {
 		expect( getPxFromCssUnit( 'calc(45vw / 10px)' ) ).toBe( '17px' );
+	} );
+
+	it( 'test empty string', () => {
+		expect( getPxFromCssUnit( '' ) ).toBe( null );
+	} );
+
+	it( 'test undefined string', () => {
+		expect( getPxFromCssUnit( undefined ) ).toBe( null );
+	} );
+	it( 'test integer string', () => {
+		expect( getPxFromCssUnit( 123 ) ).toBe( '123px' );
+	} );
+
+	it( 'test float string', () => {
+		expect( getPxFromCssUnit( 123.456 ) ).toBe( '123px' );
+	} );
+
+	it( 'test text string', () => {
+		expect( getPxFromCssUnit( 'abc' ) ).toBe( null );
+	} );
+
+	it( 'test not non function return null', () => {
+		expect( getPxFromCssUnit( 'abc + num' ) ).toBe( null );
+	} );
+
+	it( 'test not a fishy function return null', () => {
+		expect( getPxFromCssUnit( 'console.log("howdy"); + 10px' ) ).toBe(
+			null
+		);
+	} );
+	it( 'test not a typo function return null', () => {
+		expect( getPxFromCssUnit( 'calc(12vw * 10px' ) ).toBe( null );
 	} );
 } );

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -5,68 +5,72 @@ import { getPxFromCssUnit } from '../parse-css-unit-to-px';
 
 describe( 'getPxFromCssUnit', () => {
 	// Absolute units
-	it( 'px return px unit', () => {
+	it( 'test px return px unit', () => {
 		expect( getPxFromCssUnit( '25px' ) ).toBe( '25px' );
 	} );
 
-	it( 'cm return px unit', () => {
+	it( 'test numeric float return px unit', () => {
+		expect( getPxFromCssUnit( '25.5' ) ).toBe( '26px' );
+	} );
+
+	it( 'test cm return px unit', () => {
 		expect( getPxFromCssUnit( '1cm' ) ).toBe( '38px' );
 	} );
 
-	it( 'mm return px unit', () => {
+	it( 'test mm return px unit', () => {
 		expect( getPxFromCssUnit( '10mm' ) ).toBe( '38px' );
 	} );
 
-	it( 'in return px unit', () => {
+	it( 'test in return px unit', () => {
 		expect( getPxFromCssUnit( '1in' ) ).toBe( '96px' );
 	} );
 
-	it( 'pt return px unit', () => {
+	it( 'test pt return px unit', () => {
 		expect( getPxFromCssUnit( '12pt' ) ).toBe( '16px' );
 	} );
 
-	it( 'pc return px unit', () => {
+	it( 'test pc return px unit', () => {
 		expect( getPxFromCssUnit( '1pc' ) ).toBe( '16px' );
 	} );
 
-	it( 'Q return px unit', () => {
+	it( 'test Q return px unit', () => {
 		expect( getPxFromCssUnit( '40Q' ) ).toBe( '38px' ); // 40 Q should be 1 cm
 	} );
 
 	// Relative units
-	it( 'em return px unit', () => {
+	it( 'test em return px unit', () => {
 		expect( getPxFromCssUnit( '2em', { fontSize: 10 } ) ).toBe( '20px' );
 	} );
 
-	it( 'rem return px unit', () => {
+	it( 'test rem return px unit', () => {
 		expect( getPxFromCssUnit( '2rem', { fontSize: 10 } ) ).toBe( '20px' );
 	} );
 
-	it( 'vw return px unit', () => {
+	it( 'test vw return px unit', () => {
 		expect( getPxFromCssUnit( '20vw', { width: 100 } ) ).toBe( '20px' );
 	} );
 
-	it( 'vh return px unit', () => {
+	it( 'test vh return px unit', () => {
 		expect( getPxFromCssUnit( '20vh', { height: 200 } ) ).toBe( '40px' );
 	} );
 
-	it( 'vmin return px unit', () => {
+	it( 'test vmin return px unit', () => {
 		expect(
 			getPxFromCssUnit( '20vmin', { height: 200, width: 100 } )
 		).toBe( '20px' );
 	} );
 
-	it( 'vmax return px unit', () => {
+	it( 'test vmax return px unit', () => {
 		expect(
 			getPxFromCssUnit( '20vmax', { height: 200, width: 100 } )
 		).toBe( '40px' );
 	} );
 
-	it( 'lh return px unit', () => {
+	it( 'test lh return px unit', () => {
 		expect( getPxFromCssUnit( '20lh', { lineHeight: 2 } ) ).toBe( '40px' );
 	} );
 
-	it( '% return px unit', () => {
+	it( 'test % return px unit', () => {
 		expect(
 			getPxFromCssUnit( '120%', {
 				height: 200,
@@ -78,49 +82,54 @@ describe( 'getPxFromCssUnit', () => {
 	} );
 
 	// Function units
-	it( 'min() return px unit', () => {
+	it( 'test min() return px unit', () => {
 		expect( getPxFromCssUnit( 'min(20px, 25px)' ) ).toBe( '20px' );
 	} );
-	it( 'min() function with many arguments return px unit', () => {
+
+	it( 'test min() function with many arguments return px unit', () => {
 		expect( getPxFromCssUnit( 'min(20px, 9px, 12pt, 25px)' ) ).toBe(
 			'9px'
 		);
 	} );
 
-	it( 'max() return px unit', () => {
+	it( 'test max() return px unit', () => {
 		expect( getPxFromCssUnit( 'max(20px, 25px)' ) ).toBe( '25px' );
 	} );
 
-	it( 'clamp() lower return px unit', () => {
+	it( 'test clamp() lower return px unit', () => {
 		expect( getPxFromCssUnit( 'clamp(10px, 9px, 25px)' ) ).toBe( '10px' );
 	} );
 
-	it( 'clamp() upper return px unit', () => {
+	it( 'test clamp() upper return px unit', () => {
 		expect( getPxFromCssUnit( 'clamp(10px, 35px, 25px)' ) ).toBe( '25px' );
 	} );
 
-	it( 'clamp() middle return px unit', () => {
+	it( 'test clamp() middle return px unit', () => {
 		expect( getPxFromCssUnit( 'clamp(10px, 15px, 25px)' ) ).toBe( '15px' );
 	} );
 
-	it( 'nested max min function return px unit', () => {
+	it( 'test nested max min function return px unit', () => {
 		expect( getPxFromCssUnit( 'min(max(20px,25px), 35px)' ) ).toBe(
 			'25px'
 		);
 	} );
 
-	it( 'nested min max function return px unit', () => {
+	it( 'test nested min max function return px unit', () => {
 		expect( getPxFromCssUnit( 'max(min(20px,25px), 35px)' ) ).toBe(
 			'35px'
 		);
 	} );
 
-	it( 'calcualte function return px unit', () => {
+	it( 'test calcualte function return px unit', () => {
 		expect( getPxFromCssUnit( '10px + 25px' ) ).toBe( '35px' );
 	} );
 
 	it( 'test calc(10px + 25px) function return px unit', () => {
 		expect( getPxFromCssUnit( 'calc(10px + 25px)' ) ).toBe( '35px' );
+	} );
+
+	it( 'test calc( number * cssUnit ) return px unit', () => {
+		expect( getPxFromCssUnit( 'calc( 2 * 20px)' ) ).toBe( '40px' );
 	} );
 
 	it( 'test calc(25px - 10px) function return px unit', () => {
@@ -167,6 +176,7 @@ describe( 'getPxFromCssUnit', () => {
 			null
 		);
 	} );
+
 	it( 'test not a typo function return null', () => {
 		expect( getPxFromCssUnit( 'calc(12vw * 10px' ) ).toBe( null );
 	} );


### PR DESCRIPTION
## Description
This PR adds a CSS unit parser that always returns a px value. 

Currently, we have a problem on the mobile side where when we receive a css unit and value we don't have a good way of using it. The new function `getPxFromCssUnit` take a css unit such as ( 2em, min( 50%, 23px), or clamp( 12px, 50vm, 2.3em ) ) and return a px value that then we can use in the mobile app editor and try to approximate the value to in the editor. 

This was done so that we are more easily able to convert units that are found in the theme.json file in a format that we can understand px values.

## How has this been tested?
The unit tests that are provided. 

## Types of changes
Adding a new utility function.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
