### PR TITLE
RNMobile: Fix broken documentation link

### DIFF
--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,11 +380,11 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continious integration](docs/contributors/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continious integration](/docs/contributors/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
 
 ### Native mobile integration tests
 
-There is an ongoing effort to add integration tests to the native mobile project using the [`react-native-testing-library`](https://testing-library.com/docs/react-native-testing-library/intro/) library. A guide to writing integration tests can be found [here](native-mobile-integration-test-guide.md).
+There is an ongoing effort to add integration tests to the native mobile project using the [`react-native-testing-library`](https://testing-library.com/docs/react-native-testing-library/intro/) library. A guide to writing integration tests can be found [here](/docs/contributors/code/native-mobile-integration-test-guide.md).
 
 ## End-to-end Testing
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,7 +380,7 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continious integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
 
 ### Native mobile integration tests
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,7 +380,7 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](/packages/react-native-editor/__device-tests__/README.md).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [here](/packages/react-native-editor/__device-tests__/README.md).
 
 ### Native mobile integration tests
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,7 +380,7 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continious integration](/docs/contributors/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continious integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
 
 ### Native mobile integration tests
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,7 +380,7 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [here](/packages/react-native-editor/__device-tests__/README.md).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in [here](/packages/react-native-editor/__device-tests__/README.md).
 
 ### Native mobile integration tests
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -380,7 +380,7 @@ To locally run the tests in debug mode, follow these steps:
 
 ### Native mobile end-to-end tests
 
-Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](https://github.com/WordPress/gutenberg/tree/HEAD/packages/react-native-editor/__device-tests__).
+Contributors to Gutenberg will note that PRs include continuous integration E2E tests running the native mobile E2E tests on Android and iOS. For troubleshooting failed tests, check our guide on [native mobile tests in continuous integration](/docs/contributors/code/native-mobile.md#native-mobile-e2e-tests-in-continuous-integration). More information on running these tests locally can be found in the [relevant directory README.md](/packages/react-native-editor/__device-tests__/README.md).
 
 ### Native mobile integration tests
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2016,6 +2016,12 @@
 		"parent": "code"
 	},
 	{
+		"title": "React Native Integration Test Guide",
+		"slug": "native-mobile-integration-test-guide",
+		"markdown_source": "../docs/contributors/code/native-mobile-integration-test-guide.md",
+		"parent": "code"
+	},
+	{
 		"title": "Getting Started for the React Native based Mobile Gutenberg",
 		"slug": "getting-started-native-mobile",
 		"markdown_source": "../docs/contributors/code/getting-started-native-mobile.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -178,11 +178,13 @@
 			},
 			{ "docs/how-to-guides/accessibility.md": [] },
 			{ "docs/how-to-guides/internationalization.md": [] },
-			{ "docs/how-to-guides/widgets/README.md": [
-				{ "docs/how-to-guides/widgets/overview.md": [] },
-				{ "docs/how-to-guides/widgets/opting-out.md": [] },
-				{ "docs/how-to-guides/widgets/legacy-widget-block.md": [] }
-			] }
+			{
+				"docs/how-to-guides/widgets/README.md": [
+					{ "docs/how-to-guides/widgets/overview.md": [] },
+					{ "docs/how-to-guides/widgets/opting-out.md": [] },
+					{ "docs/how-to-guides/widgets/legacy-widget-block.md": [] }
+				]
+			}
 		]
 	},
 	{
@@ -318,6 +320,9 @@
 					{ "docs/contributors/code/managing-packages.md": [] },
 					{ "docs/contributors/code/release.md": [] },
 					{ "docs/contributors/code/native-mobile.md": [] },
+					{
+						"docs/contributors/code/native-mobile-integration-test-guide.md": []
+					},
 					{
 						"docs/contributors/code/getting-started-native-mobile.md": []
 					}


### PR DESCRIPTION
## Description

@mchowning reported that the new **React Native Integration Test Guide**'s link was broken in the Block Editor handbook (which is generated from this repo's `docs/` folder): see https://developer.wordpress.org/block-editor/contributors/code/#contributor-resources.

When adding this new doc in https://github.com/WordPress/gutenberg/pull/33833, I'd overlooked adding it to the `docs/manifest.json` file.

## How has this been tested?
Verify that this change follows the guideline in as outlined in [here](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/documentation#create-a-new-document).

After merging, expect the fix to be reflected in the Block Editor handbook ([after 15 minutes](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/documentation#block-editor-handbook-process)).

## Types of changes
- Doc fixes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
