### PR TITLE
Global Styles: Fix per block text color customization for cover block

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -629,7 +629,7 @@ function CoverEdit( {
 		dimRatioToClass( dimRatio ),
 		{
 			'is-dark-theme': isDark,
-			'has-background-dim': dimRatio !== 0,
+			'has-background-dim': url && dimRatio !== 0,
 			'is-transient': isUploadingMedia,
 			'has-parallax': hasParallax,
 			'is-repeated': isRepeated,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -639,6 +639,7 @@ function CoverEdit( {
 			'has-custom-content-position': ! isContentPositionCenter(
 				contentPosition
 			),
+			'is-default-background-color': ! overlayColor.class,
 		},
 		getPositionClassName( contentPosition )
 	);

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -76,7 +76,7 @@ export default function save( { attributes } ) {
 		dimRatioToClass( dimRatio ),
 		overlayColorClass,
 		{
-			'has-background-dim': dimRatio !== 0,
+			'has-background-dim': url && dimRatio !== 0,
 			'has-parallax': hasParallax,
 			'is-repeated': isRepeated,
 			'has-background-gradient': gradient || customGradient,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -11,6 +11,7 @@
 	padding: 1em;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	color: $white;
 
 	&.has-parallax {
 		background-attachment: fixed;
@@ -104,7 +105,6 @@
 	.wp-block-cover__inner-container {
 		width: 100%;
 		z-index: z-index(".wp-block-cover__inner-container");
-		color: $white;
 	}
 
 	p,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -34,17 +34,7 @@
 		background-size: auto;
 	}
 
-	/**
-	 * Set a default background color for has-background-dim _unless_ it includes another
-	 * background-color class (e.g. has-green-background-color). The presence of another
-	 * background-color class implies that another style will provide the background color
-	 * for the overlay.
-	 *
-	 * See:
-	 *   - Issue with background color specificity: https://github.com/WordPress/gutenberg/issues/26545
-	 *   - Issue with alternative fix: https://github.com/WordPress/gutenberg/issues/26545
-	 */
-	&.has-background-dim:not([class*="-background-color"]) {
+	&.is-default-background-color {
 		background-color: $black;
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Partially fixes https://github.com/WordPress/gutenberg/issues/34150

## Description
<!-- Please describe what you have changed or added -->
Block level global styling for cover block text colors were being overridden by default colors. This was because, for global styles, we were setting styles on the top-level cover block element. The default text color, however, was being set on a child, (on the cover block inner container).

Since the text content's nearest ancestor was the inner container, it was inheriting the inner container's text color declarations instead of global styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate a block theme like `blockbase` or `mayland-blocks`
2. Activate the site editor
3. Navigate to the site editor
4. Insert a cover block onto the page and add text content
5. Open the global styles sidebar, and select the "By Block Type" menu tab
6. Unfold the Cover block-level global styles panel and select different text color options
7. Confirm that the text color options now change according to user customizations

## Screenshots <!-- if applicable -->
![2021-08-19 17 07 56](https://user-images.githubusercontent.com/5414230/130159411-7968c114-161c-447a-b1d3-02a652e9a550.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
