### PR TITLE
Fix Buttons styling issue caused by Layout support being applied to blocks that have not opted in

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -88,8 +88,8 @@ function gutenberg_get_layout_style( $selector, $layout ) {
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_type        = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$support_layout    = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
-	$has_innner_blocks = count( $block['innerBlocks'] ) > 0;
-	if ( ! $support_layout && ! $has_innner_blocks ) {
+
+	if ( ! $support_layout ) {
 		return $block_content;
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -86,8 +86,8 @@ function gutenberg_get_layout_style( $selector, $layout ) {
  * @return string                Filtered block content.
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
-	$block_type        = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$support_layout    = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
+	$block_type     = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$support_layout = gutenberg_block_has_support( $block_type, array( '__experimentalLayout' ), false );
 
 	if ( ! $support_layout ) {
 		return $block_content;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -166,19 +166,12 @@ export const withInspectorControls = createHigherOrderComponent(
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { name, attributes, clientId } = props;
+		const { name, attributes } = props;
 		const supportLayout = hasBlockSupport( name, layoutBlockSupportKey );
 		const id = useInstanceId( BlockListBlock );
 		const defaultLayout = useSetting( 'layout' ) || {};
-		const hasInnerBlocks = useSelect(
-			( select ) => {
-				const { getBlockCount } = select( blockEditorStore );
-				return getBlockCount( clientId ) > 0;
-			},
-			[ clientId ]
-		);
 		const element = useContext( BlockList.__unstableElementContext );
-		const shouldRenderLayoutStyles = supportLayout || hasInnerBlocks;
+		const shouldRenderLayoutStyles = supportLayout;
 		const { layout = {} } = attributes;
 		const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 		const className = classnames( props?.className, {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This is a follow on from https://github.com/WordPress/gutenberg/pull/33812 to address a regression for the styling of the Buttons block. In that PR, the logic to skip the Layout support was updated to check that the Layout support isn't enabled and that the block doesn't have inner blocks. This means that blocks that haven't opted-in, but do have inner blocks will skip this check and have the container class applied, causing a styling issue for the Buttons block, which is laid out horizontally by default.

In this PR, I've reverted the check back to just checking if the Layout support is enabled (I tried switching it to an `||` check, but that introduced further issues with the Group block not getting the styling it needed). There could be a better approach to this, but it _seems_ to fix the issue so far CC: @youknowriad 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Before applying this PR, in TT1-blocks theme, I added a Buttons block with multiple buttons to a post and viewed on the front end of my site. I noticed the styling regression in the screenshots below.

After applying this PR, the styling issue is no longer present, and the Buttons block no longer has the container class added.

## Screenshots <!-- if applicable -->

Note that in the before image, the container class is added, and because the Buttons block hasn't opted in to the Layout, the default layout style gets applied ([this CSS rule](https://github.com/WordPress/gutenberg/blob/3e645c4693023fb7dd08e3feb36c82d5968c0c98/lib/block-supports/layout.php#L66)), which affects the top margin on all but the first Button block.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/130160972-d22992d5-696f-4844-8be7-d8d915067b6d.png) | ![image](https://user-images.githubusercontent.com/14988353/130161168-a5651179-606e-4741-be4f-7bd488e81824.png) | 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
