### PR TITLE
Fix FlatList warning log from Columns block

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -262,8 +262,6 @@ export class BlockList extends Component {
 						{ flex: isRootList ? 1 : 0 },
 						! isRootList && styles.overflowVisible,
 					] }
-					horizontal={ horizontal }
-					numColumns={ 1 }
 					extraData={ this.getExtraData() }
 					scrollEnabled={ isRootList }
 					contentContainerStyle={ [

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -6,7 +6,6 @@
 
 .horizontalContentContainer {
 	flex-direction: row;
-	flex-wrap: wrap;
 	justify-content: flex-start;
 	align-items: stretch;
 	overflow: visible;

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -274,7 +274,7 @@ function ColumnsEditContainer( {
 						orientation={
 							columnsInRow > 1 ? 'horizontal' : undefined
 						}
-						horizontal={ true }
+						horizontal={ columnsInRow > 1 }
 						allowedBlocks={ ALLOWED_BLOCKS }
 						contentResizeMode="stretch"
 						onAddBlock={ onAddBlock }


### PR DESCRIPTION
## Description
Replace unsupported use of `flex-wrap` with dynamic setting of `horizontal` prop. The `horizontal` prop must be `false` to have the `numOfColumns` property take effect.

```
WARN  `flexWrap: 'wrap'` is not supported with the `VirtualizedList` components.Consider using `numColumns` with `FlatList` instead.
```

Related links:

- [FlatList Documentation `horizontal`](https://bit.ly/2UxBz3c)
- [Most recent Column block fix](https://git.io/J0prs)
- [Previous Column lock fix](https://git.io/J0prl)
- [Related Column block bug](https://git.io/J0pr8)
- [Original Column block implementation](https://git.io/J0prV)

## How has this been tested?

### Metro Server Logs
1. Load the editor. 
2. **Expected:** Observe the aforementioned warning no longer logs. 

### UI
1. Open the editor on a portrait phone.
2. Add a Column block. 
3. Select a default width. 
4. Tap the "+" button three times to add additional columns to the block. 
5. **Expected:** Five columns are visible and stacked vertically. 
6. Rotate the device to landscape orientation. 
7. **Expected:** Three columns are visible and side-by-side horizontally, before wrapping to an additional row with two columns. 

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/438664/130256616-125401b2-8959-4857-b82a-54b88f7de5a8.mov

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
