### PR TITLE
Query Loop: Update Post Template sub-block icon

### DIFF
--- a/packages/block-library/src/post-template/index.js
+++ b/packages/block-library/src/post-template/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { loop } from '@wordpress/icons';
+import { layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	icon: loop,
+	icon: layout,
 	edit,
 	save,
 };


### PR DESCRIPTION
… instead of "loop"

fixes #33256

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR updates the Post Template sub-block's icon from `loop` to `layout`. Currently, the `loop` icon matches the `Query Loop` as shown below. The updated icon makes the List View and block toolbar UI less confusing

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Manually tested by creating a new post with a Query Loop block, and then viewed the Post Template sub block's icon in List View and on the block toolbar. In both cases it matches the`loop` icon.

After the change, I reloaded the post and confirmed the icon change is reflected, and now show the `layout` icon in both locations.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

![124744382-fce7e180-df1e-11eb-92ae-89cc33a7089d](https://user-images.githubusercontent.com/13856531/130257334-982127b0-425e-496d-896d-6f0acb5a864a.png)

## Types of changes
Small UI fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- N/A My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- N/A I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
