### PR TITLE
Align labels on focal point picker position controls above the inputs

### DIFF
--- a/packages/components/src/focal-point-picker/controls.js
+++ b/packages/components/src/focal-point-picker/controls.js
@@ -60,7 +60,7 @@ function UnitControl( props ) {
 	return (
 		<BaseUnitControl
 			className="focal-point-picker__controls-position-unit-control"
-			labelPosition="side"
+			labelPosition="top"
 			max={ TEXTCONTROL_MAX }
 			min={ TEXTCONTROL_MIN }
 			unit="%"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #33563.

This PR relocates the 'Left' and 'Top' input labels on the Focal Point Picker to the top of the input field, rather than having them beside it.

With labels beside the inputs, the text can become longer when translated, which truncates the input field itself and making the value unreadable (see below for an example of Gutenberg in Spanish, where `Izquierda` is sufficiently long enough to cause the issue).

## How has this been tested?
Tested manually, I've added a Cover block to a new post before and after the change to confirm the new placement.

## Screenshots <!-- if applicable -->
Before:
![126246384-f2ed83cf-c2a0-4615-b1f1-61d59b37e9e3](https://user-images.githubusercontent.com/13856531/130287329-363fa454-a5c8-492c-9bd4-1446d0ac739f.png)

After:
<img width="275" alt="Screen Shot 2021-08-20 at 5 07 10 PM" src="https://user-images.githubusercontent.com/13856531/130294006-5e57d87b-7a66-418f-9c20-add7d22e87f7.png">

## Types of changes
UI Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- N/A My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- N/A I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
