### PR TITLE
Release workflow: only commit modified changelogs

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -79,8 +79,14 @@ jobs:
             - name: Commit the Changelog update
               run: |
                   git add changelog.txt
-                  git commit -m "Update Changelog for ${TAG#v}"
-                  git push --set-upstream origin "${{ matrix.branch }}"
+                  # Remove files that are not meant to be commited
+                  # ie. release_notes.txt created on the previous step.
+                  git clean -fd
+                  # Only attempt to commit changelog if it has been modified.
+                  if ! git diff-index --quiet HEAD --; then
+                    git commit -m "Update Changelog for ${TAG#v}"
+                    git push --set-upstream origin "${{ matrix.branch }}"
+                  fi
 
             - name: Upload Changelog artifact
               uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2


### PR DESCRIPTION
## Description
 
Checks if changelog.txt committed in the context of this workflow is different from the one in `trunk` and in the release branch. This makes it possible to re-run the workflow in order to re-try the upload of the plugin archive to the directory. Before, since attempting to create a commit without changes exits with an error, the upload step was being skipped ([eg. this retried run](https://github.com/WordPress/gutenberg/actions/runs/1144014656))

This would've allowed us to use the workflow in order to fix the [failure we faced when releasing Gutenberg v11.3.0](https://github.com/WordPress/gutenberg/runs/3363737920?check_suite_focus=true#step:8:406), where the SVN upload timed out; @youknowriad saved the day committing the plugin manually.

## How has this been tested?

[Tried these changes in a fork](https://github.com/vcanales/gutenberg/actions/runs/1151578457) (SVN Upload fails there because I purposefully did not configure secrets.)
1. First run updates the changelog correctly.
2. Subsequent re-runs don't attempt to commit unchanged files.
3. Upload step runs again every time.

