### PR TITLE
Block Styles: Fix long strings of text without spaces overflow the block

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -14,7 +14,7 @@ $blocks-block__margin: 0.5em;
 	padding: calc(0.667em + 2px) calc(1.333em + 2px); // The extra 2px are added to size solids the same as the outline versions.
 	text-align: center;
 	text-decoration: none;
-	overflow-wrap: break-word;
+	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
 
 	&:hover,

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -21,6 +21,7 @@
 
 .wp-block-embed {
 	margin: 0 0 1em 0;
+	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 
 	// Supply caption styles to embeds, even if the theme hasn't opted in.
 	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -4,6 +4,9 @@ h3,
 h4,
 h5,
 h6 {
+	// Break long strings of text without spaces so they don't overflow the block.
+	overflow-wrap: break-word;
+
 	&.has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}

--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -1,4 +1,9 @@
-ol.has-background,
-ul.has-background {
-	padding: $block-bg-padding--v $block-bg-padding--h;
+ol,
+ul {
+	// Break long strings of text without spaces so they don't overflow the block.
+	overflow-wrap: break-word;
+
+	&.has-background {
+		padding: $block-bg-padding--v $block-bg-padding--h;
+	}
 }

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -28,6 +28,11 @@
 	font-style: normal;
 }
 
+p {
+	// Break long strings of text without spaces so they don't overflow the block.
+	overflow-wrap: break-word;
+}
+
 // Prevent the dropcap from breaking out of the box when a background is applied.
 p.has-drop-cap.has-background {
 	overflow: hidden;

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -2,6 +2,7 @@
 	margin: 0 0 1em 0;
 	padding: 3em 0;
 	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
+	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 
 	p,
 	blockquote,

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,4 +1,6 @@
 .wp-block-quote {
+	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
+
 	&.is-style-large,
 	&.is-large {
 		margin-bottom: 1em;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Currently, some of the themes set the `word-break: break-word;` or `overflow-wrap: break-word;` css to the heading block or paragraph block. For example, `Independent Publisher 2` sets `word-break: break-word` [here](https://github.com/Automattic/themes/blob/1ca042362f230f0169732d36fec2115179420acb/independent-publisher-2/style.css#L1191) to `.entry-content` and heading and paragraph inherit that property. However, some of the themes (Twenty Twenty-One, Blank Canvas and so on) don't set that property so that the multi-line strings without spaces make the pages broken and generate the horizontal scrollbar on mobile devices.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Create or Edit a post
2. Insert the following blocks
   * multi-line strings without spaces as one of following
     * heading
     * paragraph
     * heading or paragraph inside the cover block
     * button
     * list item
     * caption inside the embed video
     * caption inside the Pullquote or quote
3. Save and view the post on the new tab
3. Open Chrome Developer Tools and change to mobile view
4. Check the multi-line strings break the page and generate a horizontal scrollbar or not

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| <img width="300" src="https://user-images.githubusercontent.com/13596067/130409908-dad47ed2-e33f-44b5-a4af-77c241bdbcec.png" /> | <img width="300" src="https://user-images.githubusercontent.com/13596067/130409963-33c95c17-4ac8-41da-9df0-55c2cc0a553d.png" /> |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
