### PR TITLE
Fix vertical page list.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -338,13 +338,14 @@
 	// Horizontal layout
 	display: flex;
 	flex-wrap: wrap;
+}
 
-	// Vertical layout
-	.is-vertical & {
-		display: block;
-		flex-direction: column;
-		align-items: flex-start;
-	}
+// Vertical layout
+.is-vertical .wp-block-page-list, // Page list.
+.is-vertical .wp-block-navigation__container {
+	display: block;
+	flex-direction: column;
+	align-items: flex-start;
 }
 
 // Justification.


### PR DESCRIPTION
## Description

Fixes #34217.

Before:

<img width="1155" alt="editor" src="https://user-images.githubusercontent.com/1204802/130433901-cd5c4678-c225-4adb-bc78-3c31834c2bec.png">

<img width="881" alt="frontend" src="https://user-images.githubusercontent.com/1204802/130433903-afae9ce2-e02f-4be3-8f18-c0618cbcf8c6.png">

After, frontend (editor is the same):

<img width="954" alt="Screenshot 2021-08-23 at 12 36 30" src="https://user-images.githubusercontent.com/1204802/130433918-cf61015a-e1c6-4cfe-8396-f10080b29784.png">

## How has this been tested?

Insert a vertical navigation menu, click "add all pages", and verify frontend and backend are the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
