### PR TITLE
Try: Fix navigation responsive menu overlay z index.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -441,6 +441,7 @@
 			display: flex;
 			flex-direction: row;
 			position: relative;
+			z-index: 2;
 			background-color: inherit;
 
 			.wp-block-navigation__responsive-container-close {


### PR DESCRIPTION
## Description

Fixes #34161:

![overlay](https://user-images.githubusercontent.com/1204802/130435217-024f39c2-0397-419a-907a-4d0edb58a904.gif)

The responsive navigation feature adds extra containers and CSS classes, which changed the relative positioning hierarchy. 


## How has this been tested?

Add a cover block with a color overlay.
Add a navigation block with submenus above that.
Open the submenu and the dropdown menu should not be under the cover color overlay.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
