### PR TITLE
More work on the stability of the performance metrics

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -31,18 +31,18 @@ import {
 jest.setTimeout( 1000000 );
 
 describe( 'Post Editor Performance', () => {
-	it( 'Loading, typing and selecting blocks', async () => {
-		const traceFile = __dirname + '/trace.json';
-		let traceResults;
-		const results = {
-			load: [],
-			type: [],
-			focus: [],
-			inserterOpen: [],
-			inserterHover: [],
-			inserterSearch: [],
-		};
+	const results = {
+		load: [],
+		type: [],
+		focus: [],
+		inserterOpen: [],
+		inserterHover: [],
+		inserterSearch: [],
+	};
+	const traceFile = __dirname + '/trace.json';
+	let traceResults;
 
+	beforeAll( async () => {
 		const html = readFile(
 			join( __dirname, '../../assets/large-post.html' )
 		);
@@ -63,7 +63,30 @@ describe( 'Post Editor Performance', () => {
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		}, html );
 		await saveDraft();
+	} );
 
+	afterAll( async () => {
+		const resultsFilename = basename( __filename, '.js' ) + '.results.json';
+		writeFileSync(
+			join( __dirname, resultsFilename ),
+			JSON.stringify( results, null, 2 )
+		);
+		deleteFile( traceFile );
+	} );
+
+	beforeEach( async () => {
+		// Disable auto-save to avoid impacting the metrics.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/edit-post' )
+				.__experimentalUpdateLocalAutosaveInterval( 100000000000 );
+			window.wp.data
+				.dispatch( 'core/editor' )
+				.updateEditorSettings( { autosaveInterval: 100000000000 } );
+		} );
+	} );
+
+	it( 'Loading', async () => {
 		// Measuring loading time
 		let i = 5;
 		while ( i-- ) {
@@ -72,7 +95,77 @@ describe( 'Post Editor Performance', () => {
 			await page.waitForSelector( '.wp-block' );
 			results.load.push( new Date() - startTime );
 		}
+	} );
 
+	it( 'Typing', async () => {
+		// Measuring typing performance
+		await insertBlock( 'Paragraph' );
+		let i = 20;
+		await page.tracing.start( {
+			path: traceFile,
+			screenshots: false,
+			categories: [ 'devtools.timeline' ],
+		} );
+		while ( i-- ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// The timeout should be big enough to allow all async tasks tor run.
+			// And also to allow Rich Text to mark the change as persistent.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 2000 );
+			await page.keyboard.type( 'x' );
+		}
+		await page.tracing.stop();
+		traceResults = JSON.parse( readFile( traceFile ) );
+		const [
+			keyDownEvents,
+			keyPressEvents,
+			keyUpEvents,
+		] = getTypingEventDurations( traceResults );
+		if (
+			keyDownEvents.length === keyPressEvents.length &&
+			keyPressEvents.length === keyUpEvents.length
+		) {
+			// The first character typed triggers a longer time (isTyping change)
+			// It can impact the stability of the metric, so we exclude it.
+			for ( let j = 1; j < keyDownEvents.length; j++ ) {
+				results.type.push(
+					keyDownEvents[ j ] + keyPressEvents[ j ] + keyUpEvents[ j ]
+				);
+			}
+		}
+	} );
+
+	it( 'Selecting blocks', async () => {
+		// Measuring block selection performance
+		await createNewPost();
+		await page.evaluate( () => {
+			const { createBlock } = window.wp.blocks;
+			const { dispatch } = window.wp.data;
+			const blocks = window.lodash
+				.times( 1000 )
+				.map( () => createBlock( 'core/paragraph' ) );
+			dispatch( 'core/block-editor' ).resetBlocks( blocks );
+		} );
+		const paragraphs = await page.$$( '.wp-block' );
+		await page.tracing.start( {
+			path: traceFile,
+			screenshots: false,
+			categories: [ 'devtools.timeline' ],
+		} );
+		await paragraphs[ 0 ].click();
+		for ( let j = 1; j <= 10; j++ ) {
+			// Wait for the browser to be idle before starting the monitoring.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 1000 );
+			await paragraphs[ j ].click();
+		}
+		await page.tracing.stop();
+		traceResults = JSON.parse( readFile( traceFile ) );
+		const [ focusEvents ] = getSelectionEventDurations( traceResults );
+		results.focus = focusEvents;
+	} );
+
+	it( 'Opening the inserter', async () => {
 		// Measure time to open inserter
 		await page.waitForSelector( '.edit-post-layout' );
 		for ( let j = 0; j < 10; j++ ) {
@@ -90,7 +183,9 @@ describe( 'Post Editor Performance', () => {
 			}
 			await closeGlobalBlockInserter();
 		}
+	} );
 
+	it( 'Searching the inserter', async () => {
 		// Measure time to search the inserter and get results
 		await openGlobalBlockInserter();
 		for ( let j = 0; j < 10; j++ ) {
@@ -123,7 +218,9 @@ describe( 'Post Editor Performance', () => {
 			await page.keyboard.press( 'Backspace' );
 		}
 		await closeGlobalBlockInserter();
+	} );
 
+	it( 'Hovering Inserter Items', async () => {
 		// Measure inserter hover performance
 		const paragraphBlockItem =
 			'.block-editor-inserter__menu .editor-block-list-item-paragraph';
@@ -157,74 +254,5 @@ describe( 'Post Editor Performance', () => {
 			}
 		}
 		await closeGlobalBlockInserter();
-
-		// Measuring typing performance
-		await insertBlock( 'Paragraph' );
-		i = 20;
-		await page.tracing.start( {
-			path: traceFile,
-			screenshots: false,
-			categories: [ 'devtools.timeline' ],
-		} );
-		while ( i-- ) {
-			// Wait for the browser to be idle before starting the monitoring.
-			// eslint-disable-next-line no-restricted-syntax
-			await page.waitForTimeout( 200 );
-			await page.keyboard.type( 'x' );
-		}
-		await page.tracing.stop();
-		traceResults = JSON.parse( readFile( traceFile ) );
-		const [
-			keyDownEvents,
-			keyPressEvents,
-			keyUpEvents,
-		] = getTypingEventDurations( traceResults );
-		if (
-			keyDownEvents.length === keyPressEvents.length &&
-			keyPressEvents.length === keyUpEvents.length
-		) {
-			for ( let j = 0; j < keyDownEvents.length; j++ ) {
-				results.type.push(
-					keyDownEvents[ j ] + keyPressEvents[ j ] + keyUpEvents[ j ]
-				);
-			}
-		}
-
-		// Measuring block selection performance
-		await createNewPost();
-		await page.evaluate( () => {
-			const { createBlock } = window.wp.blocks;
-			const { dispatch } = window.wp.data;
-			const blocks = window.lodash
-				.times( 1000 )
-				.map( () => createBlock( 'core/paragraph' ) );
-			dispatch( 'core/block-editor' ).resetBlocks( blocks );
-		} );
-		const paragraphs = await page.$$( '.wp-block' );
-		await page.tracing.start( {
-			path: traceFile,
-			screenshots: false,
-			categories: [ 'devtools.timeline' ],
-		} );
-		await paragraphs[ 0 ].click();
-		for ( let j = 1; j <= 10; j++ ) {
-			// Wait for the browser to be idle before starting the monitoring.
-			// eslint-disable-next-line no-restricted-syntax
-			await page.waitForTimeout( 200 );
-			await paragraphs[ j ].click();
-		}
-		await page.tracing.stop();
-		traceResults = JSON.parse( readFile( traceFile ) );
-		const [ focusEvents ] = getSelectionEventDurations( traceResults );
-		results.focus = focusEvents;
-
-		const resultsFilename = basename( __filename, '.js' ) + '.results.json';
-		writeFileSync(
-			join( __dirname, resultsFilename ),
-			JSON.stringify( results, null, 2 )
-		);
-		deleteFile( traceFile );
-
-		expect( true ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
This PR improve our post editor performance test a bit:

 - Separate each metric into its own `it` call to be able to focus a metric easily using `it.only`
 - Tries to make the typing and selecting metrics more stable by increasing the timeout used to avoid having the lazy rendering and rich text persistence make the metric more random.