### PR TITLE
Documentation: fix typo in block gap docs

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -615,7 +615,6 @@ Each block declares which style properties it exposes via the [block supports me
 			"text": "value"
 		},
 		"spacing": {
-			"blockGap": "value",
 			"margin": {
 				"top": "value",
 				"right": "value",


### PR DESCRIPTION
Fix typo: block gap only works in the plugin, so it shouldn't be present in WordPress core docs.