### PR TITLE
Improve the getBlock and getBlocks performance

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -281,12 +281,6 @@ Returns all block objects for the current post being edited as an array in
 the order they appear in the post. Note that this will exclude child blocks
 of nested inner block controllers.
 
-Note: It's important to memoize this selector to avoid return a new instance
-on each call. We use the block cache state for each top-level block of the
-given clientID. This way, the selector only refreshes on changes to blocks
-associated with the given entity, and does not refresh when changes are made
-to blocks which are part of different inner block controllers.
-
 _Parameters_
 
 -   _state_ `Object`: Editor state.
@@ -1224,6 +1218,8 @@ _Parameters_
 Returns an action object used in signalling that blocks have been received.
 Unlike resetBlocks, these should be appended to the existing known set, not
 replacing.
+
+Todo: This should be deprecated
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -199,7 +199,7 @@ export default compose( [
 				isBlockInsertionPointVisible,
 				getSettings,
 				getBlockParents,
-				__unstableGetBlockWithoutInnerBlocks,
+				getBlock,
 			} = select( blockEditorStore );
 
 			const blockClientIds = getBlockOrder( rootClientId );
@@ -225,14 +225,11 @@ export default compose( [
 
 			const isReadOnly = getSettings().readOnly;
 
-			const block = __unstableGetBlockWithoutInnerBlocks( clientId );
-			const { attributes, name } = block || {};
+			const { attributes, name } = getBlock( clientId );
 			const { align } = attributes || {};
 			const parents = getBlockParents( clientId, true );
 			const hasParents = !! parents.length;
-			const parentBlock = hasParents
-				? __unstableGetBlockWithoutInnerBlocks( parents[ 0 ] )
-				: {};
+			const parentBlock = hasParents ? getBlock( parents[ 0 ] ) : {};
 			const { align: parentBlockAlignment } =
 				parentBlock?.attributes || {};
 			const { name: parentBlockName } = parentBlock || {};

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -194,9 +194,11 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		getBlockMode,
 		isSelectionEnabled,
 		getTemplateLock,
-		__unstableGetBlockWithoutInnerBlocks,
+		getBlock,
 	} = select( blockEditorStore );
-	const block = __unstableGetBlockWithoutInnerBlocks( clientId );
+	// This change is going to leak innerBlocks,
+	// so maybe keep the selector but change how it's computed.
+	const block = getBlock( clientId );
 	const isSelected = isBlockSelected( clientId );
 	const templateLock = getTemplateLock( rootClientId );
 	// The fallback to `{}` is a temporary fix.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -194,11 +194,9 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId } ) => {
 		getBlockMode,
 		isSelectionEnabled,
 		getTemplateLock,
-		getBlock,
+		__unstableGetBlockWithoutInnerBlocks,
 	} = select( blockEditorStore );
-	// This change is going to leak innerBlocks,
-	// so maybe keep the selector but change how it's computed.
-	const block = getBlock( clientId );
+	const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 	const isSelected = isBlockSelected( clientId );
 	const templateLock = getTemplateLock( rootClientId );
 	// The fallback to `{}` is a temporary fix.

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -305,7 +305,7 @@ export default compose( [
 			getBlockIndex,
 			getSettings,
 			isBlockSelected,
-			__unstableGetBlockWithoutInnerBlocks,
+			getBlock,
 			getSelectedBlockClientId,
 			getLowestCommonAncestorWithSelectedBlock,
 			getBlockParents,
@@ -315,7 +315,7 @@ export default compose( [
 		const order = getBlockIndex( clientId, rootClientId );
 		const isSelected = isBlockSelected( clientId );
 		const isInnerBlockSelected = hasSelectedInnerBlock( clientId );
-		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
+		const block = getBlock( clientId );
 		const { name, attributes, isValid } = block || {};
 
 		const blockType = getBlockType( name || 'core/missing' );

--- a/packages/block-editor/src/components/block-tools/block-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-popover.js
@@ -281,7 +281,7 @@ function wrapperSelector( select ) {
 		getSelectedBlockClientId,
 		getFirstMultiSelectedBlockClientId,
 		getBlockRootClientId,
-		__unstableGetBlockWithoutInnerBlocks,
+		getBlock,
 		getBlockParents,
 		__experimentalGetBlockListSettingsForBlocks,
 	} = select( blockEditorStore );
@@ -293,8 +293,7 @@ function wrapperSelector( select ) {
 		return;
 	}
 
-	const { name, attributes = {}, isValid } =
-		__unstableGetBlockWithoutInnerBlocks( clientId ) || {};
+	const { name, attributes = {}, isValid } = getBlock( clientId ) || {};
 	const blockParentsClientIds = getBlockParents( clientId );
 
 	// Get Block List Settings for all ancestors of the current Block clientId

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -54,15 +54,13 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 	const selected = useSelect(
 		( select ) => {
 			const {
-				__unstableGetBlockWithoutInnerBlocks,
+				getBlock,
 				getBlockIndex,
 				hasBlockMovingClientId,
 				getBlockListSettings,
 			} = select( blockEditorStore );
 			const index = getBlockIndex( clientId, rootClientId );
-			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
-				clientId
-			);
+			const { name, attributes } = getBlock( clientId );
 			const blockMovingMode = hasBlockMovingClientId();
 			return {
 				index,

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -125,7 +125,7 @@ function RichTextWrapper(
 			getSelectionEnd,
 			getSettings,
 			didAutomaticChange,
-			__unstableGetBlockWithoutInnerBlocks,
+			getBlock,
 			isMultiSelecting,
 			hasMultiSelection,
 		} = select( blockEditorStore );
@@ -149,8 +149,7 @@ function RichTextWrapper(
 			// If the block of this RichText is unmodified then it's a candidate for replacing when adding a new block.
 			// In order to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1126, let's blur on unmount in that case.
 			// This apparently assumes functionality the BlockHlder actually
-			const block =
-				clientId && __unstableGetBlockWithoutInnerBlocks( clientId );
+			const block = clientId && getBlock( clientId );
 			const shouldBlurOnUnmount =
 				block && isSelected && isUnmodifiedDefaultBlock( block );
 			extraProps = {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -151,6 +151,8 @@ export function resetSelection(
  * Unlike resetBlocks, these should be appended to the existing known set, not
  * replacing.
  *
+ * Todo: This should be deprecated
+ *
  * @param {Object[]} blocks Array of block objects.
  *
  * @return {Object} Action object.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -13,7 +13,6 @@ import {
 	isEqual,
 	isEmpty,
 	identity,
-	difference,
 	omitBy,
 	pickBy,
 } from 'lodash';
@@ -215,150 +214,195 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 	);
 }
 
-/**
- * Utility returning an object with an empty object value for each key.
- *
- * @param {Array} objectKeys Keys to fill.
- * @return {Object} Object filled with empty object as values for each clientId.
- */
-const fillKeysWithEmptyObject = ( objectKeys ) => {
-	return objectKeys.reduce( ( result, key ) => {
-		result[ key ] = {};
-		return result;
-	}, {} );
-};
+function buildBlockTree( state, blocks ) {
+	const result = {};
+	const stack = [ ...blocks ];
+	const flattenedBlocks = [ ...blocks ];
+	while ( stack.length ) {
+		const block = stack.shift();
+		stack.push( ...block.innerBlocks );
+		flattenedBlocks.push( ...block.innerBlocks );
+	}
+
+	for ( const block of flattenedBlocks ) {
+		result[ block.clientId ] = {
+			...state.byClientId[ block.clientId ],
+			attributes: state.attributes[ block.clientId ],
+			innerBlocks: block.innerBlocks.map(
+				( subBlock ) => result[ subBlock.clientId ]
+			),
+		};
+	}
+
+	return result;
+}
+
+function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
+	const clientIds = updatedClientIds.length
+		? [ ...updatedClientIds ]
+		: [ '' ];
+	for ( const clientId of updatedClientIds ) {
+		let current = clientId;
+		do {
+			// Should stop on controlled blocks.
+			current = state.parents[ current ];
+			if ( current !== undefined ) {
+				clientIds.push( current );
+			}
+		} while ( current !== undefined );
+	}
+
+	// To make sure the order of assignments doesn't matter,
+	// we first create empty objects and mutates the inner blocks later.
+	for ( const clientId of clientIds ) {
+		tree[ clientId ] = {
+			...tree[ clientId ],
+		};
+	}
+	//	console.log( clientIds, state.order );
+	for ( const clientId of clientIds ) {
+		tree[ clientId ].innerBlocks = ( state.order[ clientId ] || [] ).map(
+			( subClientId ) => tree[ subClientId ]
+		);
+	}
+
+	return tree;
+}
 
 /**
- * Higher-order reducer intended to compute a cache key for each block in the post.
- * A new instance of the cache key (empty object) is created each time the block object
- * needs to be refreshed (for any change in the block or its children).
+ * Higher-order reducer intended to compute full block objects key for each block in the post.
+ * This is a denormalization to optimize the performance of the getBlock selectors and avoid
+ * recomputing the block objects and avoid heavy memoization.
  *
  * @param {Function} reducer Original reducer function.
  *
  * @return {Function} Enhanced reducer function.
  */
-const withBlockCache = ( reducer ) => ( state = {}, action ) => {
+const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 	const newState = reducer( state, action );
 
 	if ( newState === state ) {
 		return state;
 	}
-	newState.cache = state.cache ? state.cache : {};
 
-	/**
-	 * For each clientId provided, traverses up parents, adding the provided clientIds
-	 * and each parent's clientId to the returned array.
-	 *
-	 * When calling this function consider that it uses the old state, so any state
-	 * modifications made by the `reducer` will not be present.
-	 *
-	 * @param {Array} clientIds an Array of block clientIds.
-	 *
-	 * @return {Array} The provided clientIds and all of their parent clientIds.
-	 */
-	const getBlocksWithParentsClientIds = ( clientIds ) => {
-		return clientIds.reduce( ( result, clientId ) => {
-			let current = clientId;
-			do {
-				result.push( current );
-				current = state.parents[ current ];
-			} while ( current && ! state.controlledInnerBlocks[ current ] );
-			return result;
-		}, [] );
-	};
-
+	newState.tree = state.tree ? state.tree : {};
 	switch ( action.type ) {
-		case 'RESET_BLOCKS':
-			newState.cache = mapValues(
-				flattenBlocks( action.blocks ),
-				() => ( {} )
-			);
-			break;
-		case 'RECEIVE_BLOCKS':
-		case 'INSERT_BLOCKS': {
-			const updatedBlockUids = keys( flattenBlocks( action.blocks ) );
-			if (
-				action.rootClientId &&
-				! state.controlledInnerBlocks[ action.rootClientId ]
-			) {
-				updatedBlockUids.push( action.rootClientId );
-			}
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( updatedBlockUids )
-				),
+		case 'RESET_BLOCKS': {
+			const subTree = buildBlockTree( newState, action.blocks );
+			newState.tree = {
+				...subTree,
+				// Root
+				'': {
+					innerBlocks: action.blocks.map(
+						( subBlock ) => subTree[ subBlock.clientId ]
+					),
+				},
 			};
 			break;
 		}
-		case 'UPDATE_BLOCK':
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( [ action.clientId ] )
-				),
-			};
-			break;
-		case 'UPDATE_BLOCK_ATTRIBUTES':
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( action.clientIds )
-				),
-			};
-			break;
-		case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-			const parentClientIds = fillKeysWithEmptyObject(
-				getBlocksWithParentsClientIds( action.replacedClientIds )
+		case 'RECEIVE_BLOCKS':
+		case 'INSERT_BLOCKS': {
+			const subTree = buildBlockTree( newState, action.blocks );
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				{
+					...newState.tree,
+					...subTree,
+				},
+				action.rootClientId ? [ action.rootClientId ] : []
 			);
-
-			newState.cache = {
-				...omit( newState.cache, action.replacedClientIds ),
-				...omit( parentClientIds, action.replacedClientIds ),
-				...fillKeysWithEmptyObject(
-					keys( flattenBlocks( action.blocks ) )
-				),
-			};
 			break;
+		}
+		case 'UPDATE_BLOCK':
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				{
+					...newState.tree,
+					[ action.clientId ]: {
+						...newState.byClientId[ action.clientId ],
+						attributes: newState.attributes[ action.clientId ],
+					},
+				},
+				[ action.clientId ]
+			);
+			break;
+		case 'UPDATE_BLOCK_ATTRIBUTES': {
+			const newSubTree = action.clientIds.reduce(
+				( result, clientId ) => {
+					result[ clientId ] = {
+						...newState.tree[ clientId ],
+						attributes: newState.attributes[ clientId ],
+					};
+					return result;
+				},
+				{}
+			);
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				{
+					...newState.tree,
+					...newSubTree,
+				},
+				action.clientIds
+			);
+			break;
+		}
+		case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
+			const subTree = buildBlockTree( newState, action.blocks );
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				{
+					...omit( newState.tree, action.replacedClientIds ),
+					...subTree,
+				},
+				action.blocks.map( ( b ) => b.clientId )
+			);
+			break;
+		}
 		case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-			newState.cache = {
-				...omit( newState.cache, action.removedClientIds ),
-				...fillKeysWithEmptyObject(
-					difference(
-						getBlocksWithParentsClientIds( action.clientIds ),
-						action.clientIds
-					)
-				),
-			};
+			const parentsOfRemovedBlocks = [];
+			for ( const clientId of action.clientIds ) {
+				if (
+					state.parents[ clientId ] &&
+					newState.byClientId[ state.parents[ clientId ] ]
+				) {
+					parentsOfRemovedBlocks.push( state.parents[ clientId ] );
+				}
+			}
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				omit( newState.tree, action.removedClientIds ),
+				parentsOfRemovedBlocks
+			);
 			break;
 		case 'MOVE_BLOCKS_TO_POSITION': {
-			const updatedBlockUids = [ ...action.clientIds ];
+			const updatedBlockUids = [];
 			if ( action.fromRootClientId ) {
 				updatedBlockUids.push( action.fromRootClientId );
 			}
 			if ( action.toRootClientId ) {
 				updatedBlockUids.push( action.toRootClientId );
 			}
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( updatedBlockUids )
-				),
-			};
+			if ( ! action.fromRootClientId || ! action.fromRootClientId ) {
+				updatedBlockUids.push( '' );
+			}
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				newState.tree,
+				updatedBlockUids
+			);
 			break;
 		}
 		case 'MOVE_BLOCKS_UP':
 		case 'MOVE_BLOCKS_DOWN': {
-			const updatedBlockUids = [];
-			if ( action.rootClientId ) {
-				updatedBlockUids.push( action.rootClientId );
-			}
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( updatedBlockUids )
-				),
-			};
+			const updatedBlockUids = [
+				action.rootClientId ? action.rootClientId : '',
+			];
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				newState.tree,
+				updatedBlockUids
+			);
 			break;
 		}
 		case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
@@ -371,12 +415,21 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 				} )
 			);
 
-			newState.cache = {
-				...newState.cache,
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( updatedBlockUids )
-				),
-			};
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				{
+					...newState.tree,
+					...updatedBlockUids.reduce( ( result, clientId ) => {
+						result[ clientId ] = {
+							...newState.byClientId[ clientId ],
+							attributes: newState.attributes[ clientId ],
+							innerBlocks: newState.tree[ clientId ].innerBlocks,
+						};
+						return result;
+					}, {} ),
+				},
+				updatedBlockUids
+			);
 		}
 	}
 
@@ -569,7 +622,7 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 		 *    new value was used, template parts would disappear from the editor
 		 *    whenever you try to undo a change in the top level entity.
 		 */
-		return {
+		const newState = {
 			...state,
 			byClientId: {
 				...omit( state.byClientId, visibleClientIds ),
@@ -590,14 +643,22 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 				...omit( state.parents, visibleClientIds ),
 				...mapBlockParents( action.blocks ),
 			},
-			cache: {
-				...omit( state.cache, visibleClientIds ),
-				...omit(
-					mapValues( flattenBlocks( action.blocks ), () => ( {} ) ),
-					controlledInnerBlocks
+		};
+
+		// This seem to be duplicated in withBlockTree,
+		// but both are needed according to unit tests
+		const subTree = buildBlockTree( newState, action.blocks );
+		newState.tree = {
+			...subTree,
+			// Root
+			'': {
+				innerBlocks: action.blocks.map(
+					( subBlock ) => subTree[ subBlock.clientId ]
 				),
 			},
 		};
+
+		return newState;
 	}
 
 	return reducer( state, action );
@@ -727,7 +788,7 @@ const withSaveReusableBlock = ( reducer ) => ( state, action ) => {
 export const blocks = flow(
 	combineReducers,
 	withSaveReusableBlock, // needs to be before withBlockCache
-	withBlockCache, // needs to be before withInnerBlocksRemoveCascade
+	withBlockTree, // needs to be before withInnerBlocksRemoveCascade
 	withInnerBlocksRemoveCascade,
 	withReplaceInnerBlocks, // needs to be after withInnerBlocksRemoveCascade
 	withBlockReset,
@@ -876,12 +937,14 @@ export const blocks = flow(
 			case 'RESET_BLOCKS':
 				return mapBlockOrder( action.blocks );
 
-			case 'RECEIVE_BLOCKS':
+			case 'RECEIVE_BLOCKS': {
+				const blockOrder = mapBlockOrder( action.blocks );
 				return {
 					...state,
-					...omit( mapBlockOrder( action.blocks ), '' ),
+					...omit( blockOrder, '' ),
+					'': ( state?.[ '' ] || [] ).concat( blockOrder ),
 				};
-
+			}
 			case 'INSERT_BLOCKS': {
 				const { rootClientId = '' } = action;
 				const subState = state[ rootClientId ] || [];

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -246,10 +246,16 @@ function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
 		do {
 			// Should stop on controlled blocks.
 			current = state.parents[ current ];
-			if ( current !== undefined ) {
+			if (
+				current !== undefined &&
+				! state.controlledInnerBlocks[ current ]
+			) {
 				clientIds.push( current );
 			}
-		} while ( current !== undefined );
+		} while (
+			current !== undefined &&
+			! state.controlledInnerBlocks[ current ]
+		);
 	}
 
 	// To make sure the order of assignments doesn't matter,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -141,6 +141,24 @@ export function getBlock( state, clientId ) {
 	return state.blocks.tree[ clientId ];
 }
 
+export const __unstableGetBlockWithoutInnerBlocks = createSelector(
+	( state, clientId ) => {
+		const block = state.blocks.byClientId[ clientId ];
+		if ( ! block ) {
+			return null;
+		}
+
+		return {
+			...block,
+			attributes: getBlockAttributes( state, clientId ),
+		};
+	},
+	( state, clientId ) => [
+		state.blocks.byClientId[ clientId ],
+		state.blocks.attributes[ clientId ],
+	]
+);
+
 /**
  * Returns all block objects for the current post being edited as an array in
  * the order they appear in the post. Note that this will exclude child blocks
@@ -158,58 +176,6 @@ export function getBlocks( state, rootClientId ) {
 			: 'controlled||' + rootClientId;
 	return state.blocks.tree[ treeKey ]?.innerBlocks || EMPTY_ARRAY;
 }
-
-/**
- * Similar to getBlock, except it will include the entire nested block tree as
- * inner blocks. The normal getBlock selector will exclude sections of the block
- * tree which belong to different entities.
- *
- * @param {Object} state    Editor state.
- * @param {string} clientId Client ID of the block to get.
- *
- * @return {Object} The block with all
- */
-export const __unstableGetBlockWithBlockTree = createSelector(
-	( state, clientId ) => {
-		const block = state.blocks.byClientId[ clientId ];
-		if ( ! block ) {
-			return null;
-		}
-
-		return {
-			...block,
-			attributes: getBlockAttributes( state, clientId ),
-			innerBlocks: __unstableGetBlockTree( state, clientId ),
-		};
-	},
-	( state ) => [
-		state.blocks.byClientId,
-		state.blocks.order,
-		state.blocks.attributes,
-	]
-);
-
-/**
- * Similar to getBlocks, except this selector returns the entire block tree
- * represented in the block-editor store from the given root regardless of any
- * inner block controllers.
- *
- * @param {Object}  state        Editor state.
- * @param {?string} rootClientId Optional root client ID of block list.
- *
- * @return {Object[]} Post blocks.
- */
-export const __unstableGetBlockTree = createSelector(
-	( state, rootClientId = '' ) =>
-		map( getBlockOrder( state, rootClientId ), ( clientId ) =>
-			__unstableGetBlockWithBlockTree( state, clientId )
-		),
-	( state ) => [
-		state.blocks.byClientId,
-		state.blocks.order,
-		state.blocks.attributes,
-	]
-);
 
 /**
  * Returns a stripped down block object containing only its client ID,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -152,7 +152,11 @@ export function getBlock( state, clientId ) {
  * @return {Object[]} Post blocks.
  */
 export function getBlocks( state, rootClientId ) {
-	return state.blocks.tree[ rootClientId || '' ]?.innerBlocks || EMPTY_ARRAY;
+	const treeKey =
+		! rootClientId || ! areInnerBlocksControlled( state, rootClientId )
+			? rootClientId || ''
+			: 'controlled||' + rootClientId;
+	return state.blocks.tree[ treeKey ]?.innerBlocks || EMPTY_ARRAY;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -290,11 +290,11 @@ export const getBlocksByClientId = createSelector(
 		map( castArray( clientIds ), ( clientId ) =>
 			getBlock( state, clientId )
 		),
-	( state ) => [
-		state.blocks.byClientId,
-		state.blocks.order,
-		state.blocks.attributes,
-	]
+	( state, clientIds ) =>
+		map(
+			castArray( clientIds ),
+			( clientId ) => state.blocks.tree[ clientId ]
+		)
 );
 
 /**

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, noop } from 'lodash';
+import { values, noop, omit } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -236,7 +236,8 @@ describe( 'state', () => {
 						chicken: '',
 						'chicken-child': 'chicken',
 					},
-					cache: {
+					tree: {
+						'': {},
 						chicken: {},
 						'chicken-child': {},
 					},
@@ -258,7 +259,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
+				expect( omit( state, [ 'tree' ] ) ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
@@ -289,14 +290,10 @@ describe( 'state', () => {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
 					},
-					cache: {
-						chicken: {},
-						[ newChildBlockId ]: {},
-					},
 					controlledInnerBlocks: {},
 				} );
-				expect( state.cache.chicken ).not.toBe(
-					existingState.cache.chicken
+				expect( state.tree.chicken ).not.toBe(
+					existingState.tree.chicken
 				);
 			} );
 
@@ -319,7 +316,10 @@ describe( 'state', () => {
 					parents: {
 						chicken: '',
 					},
-					cache: {
+					tree: {
+						'': {
+							innerBlocks: [],
+						},
 						chicken: {},
 					},
 					controlledInnerBlocks: {},
@@ -340,7 +340,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
+				expect( omit( state, [ 'tree' ] ) ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
@@ -371,15 +371,27 @@ describe( 'state', () => {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
 					},
-					cache: {
-						chicken: {},
-						[ newChildBlockId ]: {},
-					},
 					controlledInnerBlocks: {},
 				} );
-				expect( state.cache.chicken ).not.toBe(
-					existingState.cache.chicken
+				expect( state.tree.chicken ).not.toBe(
+					existingState.tree.chicken
 				);
+				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+					state.tree.chicken
+				);
+				expect( state.tree.chicken.innerBlocks[ 0 ] ).toBe(
+					state.tree[ newChildBlockId ]
+				);
+				expect( state.tree[ newChildBlockId ] ).toEqual( {
+					clientId: newChildBlockId,
+					innerBlocks: [],
+					isValid: true,
+					name: 'core/test-child-block',
+					attributes: {
+						attr: false,
+						attr2: 'perfect',
+					},
+				} );
 			} );
 
 			it( 'can replace multiple child blocks', () => {
@@ -421,11 +433,7 @@ describe( 'state', () => {
 						'chicken-child': 'chicken',
 						'chicken-child-2': 'chicken',
 					},
-					cache: {
-						chicken: {},
-						'chicken-child': {},
-						'chicken-child-2': {},
-					},
+					tree: {},
 					controlledInnerBlocks: {},
 				} );
 
@@ -455,7 +463,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
+				expect( omit( state, [ 'tree' ] ) ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
@@ -511,13 +519,30 @@ describe( 'state', () => {
 						[ newChildBlockId2 ]: 'chicken',
 						[ newChildBlockId3 ]: 'chicken',
 					},
-					cache: {
-						chicken: {},
-						[ newChildBlockId1 ]: {},
-						[ newChildBlockId2 ]: {},
-						[ newChildBlockId3 ]: {},
-					},
 					controlledInnerBlocks: {},
+				} );
+
+				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+					state.tree.chicken
+				);
+				expect( state.tree.chicken.innerBlocks[ 0 ] ).toBe(
+					state.tree[ newChildBlockId1 ]
+				);
+				expect( state.tree.chicken.innerBlocks[ 1 ] ).toBe(
+					state.tree[ newChildBlockId2 ]
+				);
+				expect( state.tree.chicken.innerBlocks[ 2 ] ).toBe(
+					state.tree[ newChildBlockId3 ]
+				);
+				expect( state.tree[ newChildBlockId1 ] ).toEqual( {
+					innerBlocks: [],
+					clientId: newChildBlockId1,
+					name: 'core/test-child-block',
+					isValid: true,
+					attributes: {
+						attr: false,
+						attr2: 'perfect',
+					},
 				} );
 			} );
 
@@ -556,10 +581,8 @@ describe( 'state', () => {
 						'chicken-child': 'chicken',
 						'chicken-grand-child': 'chicken-child',
 					},
-					cache: {
+					tree: {
 						chicken: {},
-						'chicken-child': {},
-						'chicken-grand-child': {},
 					},
 					controlledInnerBlocks: {},
 				} );
@@ -576,7 +599,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
+				expect( omit( state, [ 'tree' ] ) ).toEqual( {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
@@ -604,16 +627,12 @@ describe( 'state', () => {
 						chicken: '',
 						[ newChildBlockId ]: 'chicken',
 					},
-					cache: {
-						chicken: {},
-						[ newChildBlockId ]: {},
-					},
 					controlledInnerBlocks: {},
 				} );
 
-				// the cache key of the parent should be updated
-				expect( existingState.cache.chicken ).not.toBe(
-					state.cache.chicken
+				// the block object of the parent should be updated
+				expect( state.tree.chicken ).not.toBe(
+					existingState.tree.chicken
 				);
 			} );
 		} );
@@ -628,7 +647,7 @@ describe( 'state', () => {
 				parents: {},
 				isPersistentChange: true,
 				isIgnoredChange: false,
-				cache: {},
+				tree: {},
 				controlledInnerBlocks: {},
 			} );
 		} );
@@ -648,9 +667,13 @@ describe( 'state', () => {
 					'': [ 'bananas' ],
 					bananas: [],
 				} );
-				expect( state.cache ).toEqual( {
-					bananas: {},
+				expect( state.tree.bananas ).toEqual( {
+					clientId: 'bananas',
+					innerBlocks: [],
 				} );
+				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+					state.tree.bananas
+				);
 			} );
 		} );
 
@@ -673,10 +696,6 @@ describe( 'state', () => {
 				'': [ 'bananas' ],
 				apples: [],
 				bananas: [ 'apples' ],
-			} );
-			expect( state.cache ).toEqual( {
-				bananas: {},
-				apples: {},
 			} );
 		} );
 
@@ -710,12 +729,17 @@ describe( 'state', () => {
 				chicken: [],
 				ribs: [],
 			} );
-			expect( state.cache ).toEqual( {
-				chicken: {},
-				ribs: {},
+
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+				state.tree.chicken
+			);
+			expect( state.tree[ '' ].innerBlocks[ 1 ] ).toBe( state.tree.ribs );
+			expect( state.tree.chicken ).toEqual( {
+				clientId: 'chicken',
+				name: 'core/test-block',
+				attributes: {},
+				innerBlocks: [],
 			} );
-			// The cache key is the same because the block has not been modified.
-			expect( original.cache.chicken ).toBe( state.cache.chicken );
 		} );
 
 		it( 'should replace the block', () => {
@@ -754,10 +778,16 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				wings: '',
 			} );
-			expect( state.cache ).toEqual( {
-				wings: {},
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+				state.tree.wings
+			);
+			expect( state.tree.wings ).toEqual( {
+				clientId: 'wings',
+				name: 'core/freeform',
+				innerBlocks: [],
 			} );
 		} );
+
 		it( 'should replace the block and remove references to its inner blocks', () => {
 			const original = blocks( undefined, {
 				type: 'RESET_BLOCKS',
@@ -797,8 +827,13 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				wings: '',
 			} );
-			expect( state.cache ).toEqual( {
-				wings: {},
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+				state.tree.wings
+			);
+			expect( state.tree.wings ).toEqual( {
+				clientId: 'wings',
+				name: 'core/freeform',
+				innerBlocks: [],
 			} );
 		} );
 
@@ -813,21 +848,11 @@ describe( 'state', () => {
 				blocks: [ wrapperBlock ],
 			} );
 
-			const originalWrapperBlockCacheKey =
-				original.cache[ wrapperBlock.clientId ];
-
 			const state = blocks( original, {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ nestedBlock.clientId ],
 				blocks: [ replacementBlock ],
 			} );
-
-			const newWrapperBlockCacheKey =
-				state.cache[ wrapperBlock.clientId ];
-
-			expect( newWrapperBlockCacheKey ).not.toBe(
-				originalWrapperBlockCacheKey
-			);
 
 			expect( state.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
@@ -840,9 +865,15 @@ describe( 'state', () => {
 				[ replacementBlock.clientId ]: wrapperBlock.clientId,
 			} );
 
-			expect( state.cache ).toEqual( {
-				[ wrapperBlock.clientId ]: {},
-				[ replacementBlock.clientId ]: {},
+			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 0 ] ).toBe(
+				state.tree[ replacementBlock.clientId ]
+			);
+			expect( state.tree[ replacementBlock.clientId ] ).toEqual( {
+				clientId: replacementBlock.clientId,
+				name: 'core/test-block',
+				innerBlocks: [],
+				attributes: {},
+				isValid: true,
 			} );
 		} );
 
@@ -884,11 +915,8 @@ describe( 'state', () => {
 				'': [ 'chicken' ],
 				chicken: [],
 			} );
-			expect( replacedState.cache ).toEqual( {
-				chicken: {},
-			} );
-			expect( originalState.cache.chicken ).not.toBe(
-				replacedState.cache.chicken
+			expect( originalState.tree.chicken ).not.toBe(
+				replacedState.tree.chicken
 			);
 
 			const nestedBlock = {
@@ -963,11 +991,18 @@ describe( 'state', () => {
 			expect( state.attributes.chicken ).toEqual( {
 				content: 'ribs',
 			} );
-
-			expect( state.cache ).toEqual( {
-				chicken: {},
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+				state.tree.chicken
+			);
+			expect( state.tree.chicken ).toEqual( {
+				clientId: 'chicken',
+				name: 'core/test-block',
+				innerBlocks: [],
+				attributes: {
+					content: 'ribs',
+				},
+				isValid: true,
 			} );
-			expect( state.cache.chicken ).not.toBe( original.cache.chicken );
 		} );
 
 		it( 'should update the reusable block reference if the temporary id is swapped', () => {
@@ -1001,10 +1036,19 @@ describe( 'state', () => {
 			expect( state.attributes.chicken ).toEqual( {
 				ref: 3,
 			} );
-			expect( state.cache ).toEqual( {
-				chicken: {},
+
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
+				state.tree.chicken
+			);
+			expect( state.tree.chicken ).toEqual( {
+				clientId: 'chicken',
+				name: 'core/block',
+				isValid: false,
+				innerBlocks: [],
+				attributes: {
+					ref: 3,
+				},
 			} );
-			expect( state.cache.chicken ).not.toBe( original.cache.chicken );
 		} );
 
 		it( 'should move the block up', () => {
@@ -1031,8 +1075,11 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
-			expect( state.cache.ribs ).toBe( original.cache.ribs );
-			expect( state.cache.chicken ).toBe( original.cache.chicken );
+			expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe( state.tree.ribs );
+			expect( state.tree[ '' ].innerBlocks[ 1 ] ).toBe(
+				state.tree.chicken
+			);
+			expect( state.tree.chicken ).toBe( original.tree.chicken );
 		} );
 
 		it( 'should move the nested block up', () => {
@@ -1061,14 +1108,15 @@ describe( 'state', () => {
 				[ movedBlock.clientId ]: [],
 				[ siblingBlock.clientId ]: [],
 			} );
-			expect( state.cache[ wrapperBlock.clientId ] ).not.toBe(
-				original.cache[ wrapperBlock.clientId ]
+
+			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 0 ] ).toBe(
+				state.tree[ movedBlock.clientId ]
 			);
-			expect( state.cache[ movedBlock.clientId ] ).toBe(
-				original.cache[ movedBlock.clientId ]
+			expect( state.tree[ wrapperBlock.clientId ].innerBlocks[ 1 ] ).toBe(
+				state.tree[ siblingBlock.clientId ]
 			);
-			expect( state.cache[ siblingBlock.clientId ] ).toBe(
-				original.cache[ siblingBlock.clientId ]
+			expect( state.tree[ movedBlock.clientId ] ).toBe(
+				original.tree[ movedBlock.clientId ]
 			);
 		} );
 
@@ -1351,9 +1399,7 @@ describe( 'state', () => {
 			expect( state.attributes ).toEqual( {
 				ribs: {},
 			} );
-			expect( state.cache ).toEqual( {
-				ribs: {},
-			} );
+			expect( state.tree[ '' ].innerBlocks ).toHaveLength( 1 );
 		} );
 
 		it( 'should remove multiple blocks', () => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -228,19 +228,19 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 					},
-					cache: {
-						123: {},
+					tree: {
+						123: {
+							clientId: 123,
+							name: 'core/paragraph',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 					controlledInnerBlocks: {},
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).toEqual( {
-				clientId: 123,
-				name: 'core/paragraph',
-				attributes: {},
-				innerBlocks: [],
-			} );
+			expect( getBlock( state, 123 ) ).toBe( state.blocks.tree[ 123 ] );
 		} );
 
 		it( 'should return null if the block is not present in state', () => {
@@ -250,55 +250,19 @@ describe( 'selectors', () => {
 					attributes: {},
 					order: {},
 					parents: {},
-					cache: {},
+					tree: {
+						123: {
+							clientId: 123,
+							name: 'core/paragraph',
+							attributes: {},
+							innerBlocks: [],
+						},
+					},
 					controlledInnerBlocks: {},
 				},
 			};
 
 			expect( getBlock( state, 123 ) ).toBe( null );
-		} );
-
-		it( 'should include inner blocks', () => {
-			const state = {
-				blocks: {
-					byClientId: {
-						123: { clientId: 123, name: 'core/paragraph' },
-						456: { clientId: 456, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: {},
-						456: {},
-					},
-					order: {
-						'': [ 123 ],
-						123: [ 456 ],
-						456: [],
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-					cache: {
-						123: {},
-						456: {},
-					},
-					controlledInnerBlocks: {},
-				},
-			};
-
-			expect( getBlock( state, 123 ) ).toEqual( {
-				clientId: 123,
-				name: 'core/paragraph',
-				attributes: {},
-				innerBlocks: [
-					{
-						clientId: 456,
-						name: 'core/paragraph',
-						attributes: {},
-						innerBlocks: [],
-					},
-				],
-			} );
 		} );
 	} );
 
@@ -321,7 +285,23 @@ describe( 'selectors', () => {
 						123: '',
 						23: '',
 					},
-					cache: {
+					tree: {
+						'': {
+							innerBlocks: [
+								{
+									clientId: 123,
+									name: 'core/paragraph',
+									attributes: {},
+									innerBlocks: [],
+								},
+								{
+									clientId: 23,
+									name: 'core/heading',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						},
 						123: {},
 						23: {},
 					},
@@ -329,92 +309,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlocks( state ) ).toEqual( [
-				{
-					clientId: 123,
-					name: 'core/paragraph',
-					attributes: {},
-					innerBlocks: [],
-				},
-				{
-					clientId: 23,
-					name: 'core/heading',
-					attributes: {},
-					innerBlocks: [],
-				},
-			] );
-		} );
-		it( 'only returns a new value if the cache key of a direct child changes', () => {
-			const cacheRef = {};
-			const state = {
-				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-					},
-					attributes: {
-						23: {},
-					},
-					order: {
-						'': [ 23 ],
-					},
-					parents: {
-						23: '',
-					},
-					cache: {
-						23: cacheRef,
-					},
-					controlledInnerBlocks: {},
-				},
-			};
-			const oldBlocks = getBlocks( state );
-
-			const newStateSameCache = {
-				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-					},
-					attributes: {
-						23: {},
-					},
-					order: {
-						'': [ 23 ],
-					},
-					parents: {
-						23: '',
-					},
-					cache: {
-						23: cacheRef,
-					},
-					controlledInnerBlocks: {},
-				},
-			};
-			// Makes sure blocks are referentially equal if the cache key stays the same.
-			const newBlocks = getBlocks( newStateSameCache );
-			expect( oldBlocks ).toBe( newBlocks );
-
-			const newStateNewCache = {
-				blocks: {
-					byClientId: {
-						23: { clientId: 23, name: 'core/heading' },
-					},
-					attributes: {
-						23: {},
-					},
-					order: {
-						'': [ 23 ],
-					},
-					parents: {
-						23: '',
-					},
-					cache: {
-						23: {},
-					},
-					controlledInnerBlocks: {},
-				},
-			};
-			// Blocks are referentially different if the cache key changes.
-			const newBlocksNewCache = getBlocks( newStateNewCache );
-			expect( oldBlocks ).not.toBe( newBlocksNewCache );
+			expect( getBlocks( state ) ).toBe(
+				state.blocks.tree[ '' ].innerBlocks
+			);
 		} );
 	} );
 
@@ -963,6 +860,14 @@ describe( 'selectors', () => {
 						23: '',
 						123: '',
 					},
+					tree: {
+						23: {
+							clientId: 23,
+							name: 'core/heading',
+							attributes: {},
+							innerBlocks: [],
+						},
+					},
 				},
 				selection: {
 					selectionStart: {},
@@ -992,6 +897,14 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 						23: '',
+					},
+					tree: {
+						23: {
+							clientId: 23,
+							name: 'core/heading',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 				},
 				selection: {
@@ -1023,8 +936,13 @@ describe( 'selectors', () => {
 						123: '',
 						23: '',
 					},
-					cache: {
-						23: {},
+					tree: {
+						23: {
+							clientId: 23,
+							name: 'core/heading',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 					controlledInnerBlocks: {},
 				},
@@ -1034,12 +952,9 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getSelectedBlock( state ) ).toEqual( {
-				clientId: 23,
-				name: 'core/heading',
-				attributes: {},
-				innerBlocks: [],
-			} );
+			expect( getSelectedBlock( state ) ).toEqual(
+				getBlock( state, 23 )
+			);
 		} );
 	} );
 
@@ -2560,7 +2475,11 @@ describe( 'selectors', () => {
 					attributes: {},
 					order: {},
 					parents: {},
-					cache: {},
+					tree: {
+						'': {
+							innerBlocks: [],
+						},
+					},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2636,9 +2555,19 @@ describe( 'selectors', () => {
 						block3: '',
 						block4: '',
 					},
-					cache: {
-						block3: {},
-						block4: {},
+					tree: {
+						block3: {
+							clientId: 'block3',
+							name: 'core/test-block-a',
+							attributes: {},
+							innerBlocks: [],
+						},
+						block4: {
+							clientId: 'block4',
+							name: 'core/test-block-a',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 					controlledInnerBlocks: {},
 				},
@@ -2726,8 +2655,13 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 'block1' ],
 					},
-					cache: {
-						block1: {},
+					tree: {
+						block1: {
+							clientId: 'block1',
+							name: 'core/test-block-b',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 					controlledInnerBlocks: {},
 				},
@@ -2929,8 +2863,13 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 'block1' ],
 					},
-					cache: {
-						block1: {},
+					tree: {
+						block1: {
+							clientId: 'block1',
+							name: 'core/with-tranforms-c',
+							attributes: {},
+							innerBlocks: [],
+						},
 					},
 					controlledInnerBlocks: {},
 				},

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -10,11 +10,8 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function ConvertToRegularBlocks( { clientId } ) {
-	const { innerBlocks } = useSelect(
-		( select ) =>
-			select( blockEditorStore ).__unstableGetBlockWithBlockTree(
-				clientId
-			),
+	const innerBlocks = useSelect(
+		( select ) => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
 	);
 	const { replaceBlocks } = useDispatch( blockEditorStore );

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -10,10 +10,7 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function ConvertToRegularBlocks( { clientId } ) {
-	const innerBlocks = useSelect(
-		( select ) => select( blockEditorStore ).getBlocks( clientId ),
-		[ clientId ]
-	);
+	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
 	return (
@@ -21,7 +18,7 @@ export default function ConvertToRegularBlocks( { clientId } ) {
 			{ ( { onClose } ) => (
 				<MenuItem
 					onClick={ () => {
-						replaceBlocks( clientId, innerBlocks );
+						replaceBlocks( clientId, getBlocks( clientId ) );
 						onClose();
 					} }
 				>

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1395,13 +1395,6 @@ export const getBlock = getBlockEditorSelector( 'getBlock' );
 export const getBlocks = getBlockEditorSelector( 'getBlocks' );
 
 /**
- * @see __unstableGetBlockWithoutInnerBlocks in core/block-editor store.
- */
-export const __unstableGetBlockWithoutInnerBlocks = getBlockEditorSelector(
-	'__unstableGetBlockWithoutInnerBlocks'
-);
-
-/**
  * @see getClientIdsOfDescendants in core/block-editor store.
  */
 export const getClientIdsOfDescendants = getBlockEditorSelector(


### PR DESCRIPTION
The getBlock and getBlocks selector in the block-editor state represent one of our bottlenecks in terms of typing performance. It's important that they are as fast as possible.

In trunk we rely on a `cacheKey` stored in the reducer to indicate whether the block object need to be recomputed or not. I believe we can do a bit better and make everything simpler by denormalizing the block objects and computing them directly in the reducer. This means we can remove the memoization from these selectors and just return the cached values.