### PR TITLE
Re-enable Android e2e tests

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -15,9 +15,7 @@ concurrency:
 jobs:
     test:
         runs-on: macos-latest
-        # The false value below disables the test while we investigate a
-        # foundational error causing failures
-        if: ${{ false && (github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request') }}
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-initial-html]

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -39,9 +39,10 @@ jobs:
                   path: ~/.gradle/caches
                   key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
 
-            - uses: reactivecircus/android-emulator-runner@d2799957d660add41c61a5103e2fbb9e2889eb73 # v2.15.0
+            - uses: reactivecircus/android-emulator-runner@5de26e4bd23bf523e8a4b7f077df8bfb8e52b50e # v2.19.1
               with:
                   api-level: 28
+                  emulator-build: 7425822 # https://git.io/JE3jX
                   profile: pixel_xl
                   script: npm run native test:e2e:android:local ${{ matrix.native-test-name }}
 


### PR DESCRIPTION
## Description
Re-enable Android e2e tests that were disabled due to consistent failures caused by a foundational error. A  breakage within Android Studio emulators ([one](https://issuetracker.google.com/issues/191805460), [two](https://issuetracker.google.com/issues/191799887)) caused Gutenberg's Android e2e tests to fail with the following error. 

```
dyld: lazy symbol binding failed: Symbol not found: _preadv
  Referenced from: /Users/runner/Library/Android/sdk/emulator/qemu/darwin-x86_64/qemu-system-x86_64-headless
  Expected in: /usr/lib/libSystem.B.dylib
```
...which led to... 
```
adb: no devices/emulators found
```

This is relevant to the Gutenberg project through the [usage](https://github.com/WordPress/gutenberg/blob/2a4257a3b0aaa7c9554cc59d161b90c433b68501/.github/workflows/rnmobile-android-runner.yml#L44) of [`android-emulator-runner`](https://github.com/ReactiveCircus/android-emulator-runner). As a workaround, this project implemented the ability to [pin the emulator to a specific build ID](https://git.io/JE3jX). 

## How has this been tested?
Verify all CI tasks succeed.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Code quality improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
