### PR TITLE
RNmobile: Fix the cancel button on Block Variation Picker / Columns Block

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/style.native.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.native.scss
@@ -17,6 +17,8 @@
 .cancelButton {
 	color: $blue-wordpress;
 	font-size: 16px;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 }
 
 .cancelButtonDark {


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/34018 we refactored how we apply the padding the buttons in the navigation header. This Pr add the padding that we missed to add to the columns grid block.

## Description
Add padding to button to fix spacing. 

## How has this been tested?
iOS Simulator add the layout grid block notice that the cancel button has the correct padding applied.

## Screenshots <!-- if applicable -->
Before:
<img width="300" alt="Screen Shot 2021-08-23 at 4 22 31 PM" src="https://user-images.githubusercontent.com/115071/130531720-ef8bb9f7-fd98-4699-b9a7-51bf91ec1ec8.png">

After:
<img width="300" alt="Screen Shot 2021-08-23 at 4 20 50 PM" src="https://user-images.githubusercontent.com/115071/130531738-28268b76-8447-4580-a7df-4f1e641a3891.png">

Related
https://github.com/Automattic/block-experiments/pull/238

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
