### PR TITLE
Allow zero values for theme.json styles

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -549,7 +549,7 @@ class WP_Theme_JSON_Gutenberg {
 			$value = self::get_property_value( $styles, $value_path );
 
 			// Skip if empty and not "0" or value represents array of longhand values.
-			$missing_value = empty( $value ) && ! is_numeric( $value );
+			$has_missing_value = empty( $value ) && ! is_numeric( $value );
 			if ( $missing_value || is_array( $value ) ) {
 				continue;
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -548,8 +548,9 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( self::PROPERTIES_METADATA as $css_property => $value_path ) {
 			$value = self::get_property_value( $styles, $value_path );
 
-			// Skip if empty or value represents array of longhand values.
-			if ( empty( $value ) || is_array( $value ) ) {
+			// Skip if empty and not "0" or value represents array of longhand values.
+			$missing_value = empty( $value ) && ! is_numeric( $value );
+			if ( $missing_value || is_array( $value ) ) {
 				continue;
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -550,7 +550,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Skip if empty and not "0" or value represents array of longhand values.
 			$has_missing_value = empty( $value ) && ! is_numeric( $value );
-			if ( $missing_value || is_array( $value ) ) {
+			if ( $has_missing_value || is_array( $value ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/34240

## Description

This PR fixes the check performed when generating theme.json styles so that it allows `0` values.

- Theme.json style generation was skipping any value that `empty()` returned `true` for. 
- This effectively filtered out any `0` or `"0"` style values but allowed `"0px"`.

## How has this been tested?
Issue replication steps: https://github.com/WordPress/gutenberg/issues/34240

- Add this to the empty theme:
```json
	"styles": {
		"blocks": {
			"core/button": {
				"border": {
					"radius": "0",
					"color": "red",
					"style": "solid",
					"width": "6px"
				}
			}
		}		
	}
```
- Create a new post that contains a button.
- Confirm that in both frontend and editor the buttons have rounded corners.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="385" alt="Screen Shot 2021-08-24 at 11 45 15 am" src="https://user-images.githubusercontent.com/60436221/130542417-a93ba4b2-8632-46c0-9b5d-6892a29e2497.png"> | <img width="350" alt="Screen Shot 2021-08-24 at 11 45 24 am" src="https://user-images.githubusercontent.com/60436221/130542432-9e67fe7e-7613-435e-b855-74cbf5c94729.png"> |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
