### PR TITLE
Enable flex on nav container to fix space between.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -338,6 +338,7 @@
 	// Horizontal layout
 	display: flex;
 	flex-wrap: wrap;
+	flex: 1;
 }
 
 // Vertical layout


### PR DESCRIPTION
## Description

Fixes #34056.

When there are only few items in a menu, space-between won't take up the full space as the container for items itself collapses. This fixes that by allowing it to flex.

Before:

<img width="742" alt="Screenshot 2021-08-24 at 09 09 42" src="https://user-images.githubusercontent.com/1204802/130573102-4cdaa55a-5894-4ec5-adc1-f2880d6e7b02.png">

After:

<img width="711" alt="Screenshot 2021-08-24 at 09 09 52" src="https://user-images.githubusercontent.com/1204802/130573108-59f8f8c3-5cb6-4959-b0f3-0ade1e3bfbef.png">


## How has this been tested?

Insert a menu  with 2 items, and apply space between. They should be spaced-between in editor and frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
