### PR TITLE
Block Editor: Add a way to absorb inspector controls from the parent

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -128,6 +128,10 @@ const BlockInspectorSingleBlock = ( {
 					</PanelBody>
 				</div>
 			) }
+			<InspectorControls.Slot
+				__experimentalGroup="parent"
+				bubblesVirtually={ bubblesVirtually }
+			/>
 			<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
 			<div>
 				<AdvancedControls bubblesVirtually={ bubblesVirtually } />

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -2,25 +2,22 @@
  * WordPress dependencies
  */
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
  */
-import useDisplayBlockControls from '../use-display-block-controls';
-import groups from './groups';
+import useInspectorControlsFill from './hook';
 
 export default function InspectorControlsFill( {
 	__experimentalGroup: group = 'default',
+	__experimentalExposeToChildren = false,
 	children,
 } ) {
-	const isDisplayed = useDisplayBlockControls();
-	const Fill = groups[ group ]?.Fill;
+	const Fill = useInspectorControlsFill(
+		group,
+		__experimentalExposeToChildren
+	);
 	if ( ! Fill ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
-		return null;
-	}
-	if ( ! isDisplayed ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/fill.native.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.native.js
@@ -8,27 +8,24 @@ import { View } from 'react-native';
  */
 import { Children } from '@wordpress/element';
 import { BottomSheetConsumer } from '@wordpress/components';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
  */
-import groups from './groups';
-import { useBlockEditContext } from '../block-edit/context';
 import { BlockSettingsButton } from '../block-settings';
+import useInspectorControlsFill from './hook';
 
 export default function InspectorControlsFill( {
-	children,
 	__experimentalGroup: group = 'default',
+	__experimentalExposeToChildren = false,
+	children,
 	...props
 } ) {
-	const { isSelected } = useBlockEditContext();
-	const Fill = groups[ group ]?.Fill;
+	const Fill = useInspectorControlsFill(
+		group,
+		__experimentalExposeToChildren
+	);
 	if ( ! Fill ) {
-		warning( `Unknown InspectorControl group "${ group }" provided.` );
-		return null;
-	}
-	if ( ! isSelected ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -5,10 +5,12 @@ import { createSlotFill } from '@wordpress/components';
 
 const InspectorControlsDefault = createSlotFill( 'InspectorControls' );
 const InspectorControlsAdvanced = createSlotFill( 'InspectorAdvancedControls' );
+const InspectorControlsParent = createSlotFill( 'InspectorControlsParent' );
 
 const groups = {
 	default: InspectorControlsDefault,
 	advanced: InspectorControlsAdvanced,
+	parent: InspectorControlsParent,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/inspector-controls/hook.js
+++ b/packages/block-editor/src/components/inspector-controls/hook.js
@@ -13,7 +13,7 @@ import { store as blockEditorStore } from '../../store';
 import { useBlockEditContext } from '../block-edit/context';
 import useDisplayBlockControls from '../use-display-block-controls';
 
-export default function useBlockControlsFill( group, exposeToChildren ) {
+export default function useInspectorControlsFill( group, exposeToChildren ) {
 	const isDisplayed = useDisplayBlockControls();
 	const { clientId } = useBlockEditContext();
 	const isParentDisplayed = useSelect(
@@ -36,7 +36,7 @@ export default function useBlockControlsFill( group, exposeToChildren ) {
 	);
 
 	if ( ! groups[ group ] ) {
-		warning( `Unknown BlockControls group "${ group }" provided.` );
+		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
 	}
 	if ( isDisplayed ) {

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -166,7 +166,7 @@ export function SocialLinksEdit( props ) {
 					) }
 				</ToolbarDropdownMenu>
 			</BlockControls>
-			<InspectorControls>
+			<InspectorControls __experimentalExposeToChildren>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open links in new tab' ) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Exploration for #26313.

> One apparent difficulty that has risen with more and more blocks leveraging child blocks for controls (Buttons, Social Icons, Navigation, etc) is a general lack of intuitiveness when it comes to modifying attributes of the parent. Example: changing the alignment of Buttons when editing a single Button; changing the color of Navigation (a parent block attribute) when editing a single Navigation Item.
To address this, I'd like to explore ideas around when and how the toolbar and sidebar controls of a parent block could be exposed on their children. There are many challenges around clarity to overcome. This should not be a default true property, since groupings like Group, Columns, Cover, etc, should not present this behaviour.

Complementary solution for #33955 that implements absorbing block controls.


I enabled this new functionality for the Social Icons block that has already opted-in for the experimental supports flag that exposed controls to the block's children blocks:

https://github.com/WordPress/gutenberg/blob/1971a3c205b56879683c2a9e426c4c3cdba805ac/packages/block-library/src/social-links/block.json#L44

Inspector controls get exposed by using the new prop in the code that defines inspector controls in the `edit` implementation:

```jsx
<InspectorControls __experimentalExposeToChildren>
   { ... }
</InspectorControls>
```

Controls are rendered in their own group `parent` that gets introduced to combine all parent controls together:

```jsx
<InspectorControls.Slot __experimentalGroup="parent" />
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

See the screencast:

https://user-images.githubusercontent.com/699132/130602553-7d6fcce4-a26f-4e7c-a375-51607c3943d9.mov

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New experimental feature (non-breaking change which adds functionality).
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
