### PR TITLE
Scripts: Convert legacy entry point arguments for compatibility with webpack 5

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Bring back support for SVG files in CSS ([#34394](https://github.com/WordPress/gutenberg/pull/34394)). It wasn't correctly migrated when integrating webpack v5.
+-   Convert legacy entry point arguments supported in webpack 4 for compatibility with webpack 5 ([#34264](https://github.com/WordPress/gutenberg/pull/34264)).
 
 ## 18.0.0 (2021-08-23)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -88,9 +88,6 @@ const getLiveReloadPort = ( inputPort ) => {
 const config = {
 	mode,
 	target,
-	entry: {
-		index: path.resolve( process.cwd(), 'src', 'index.js' ),
-	},
 	output: {
 		filename: '[name].js',
 		path: path.resolve( process.cwd(), 'build' ),
@@ -250,4 +247,9 @@ if ( ! isProduction ) {
 	} );
 }
 
-module.exports = config;
+module.exports = ( env ) => ( {
+	...config,
+	entry: env.entries ?? {
+		index: path.resolve( process.cwd(), 'src', 'index.js' ),
+	},
+} );

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -7,6 +7,7 @@ const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
 const browserslist = require( 'browserslist' );
+const fs = require( 'fs' );
 const path = require( 'path' );
 
 /**
@@ -30,6 +31,21 @@ const mode = isProduction ? 'production' : 'development';
 let target = 'browserslist';
 if ( ! browserslist.findConfig( '.' ) ) {
 	target += ':' + fromConfigRoot( '.browserslistrc' );
+}
+let entry = {};
+if ( process.env.WP_ENTRY ) {
+	entry = JSON.parse( process.env.WP_ENTRY );
+} else {
+	[ 'index', 'view' ].forEach( ( entryName ) => {
+		const filepath = path.resolve(
+			process.cwd(),
+			'src',
+			`${ entryName }.js`
+		);
+		if ( fs.existsSync( filepath ) ) {
+			entry[ entryName ] = filepath;
+		}
+	} );
 }
 
 const cssLoaders = [
@@ -88,6 +104,7 @@ const getLiveReloadPort = ( inputPort ) => {
 const config = {
 	mode,
 	target,
+	entry,
 	output: {
 		filename: '[name].js',
 		path: path.resolve( process.cwd(), 'build' ),
@@ -247,9 +264,4 @@ if ( ! isProduction ) {
 	} );
 }
 
-module.exports = ( env ) => ( {
-	...config,
-	entry: env.entries || {
-		index: path.resolve( process.cwd(), 'src', 'index.js' ),
-	},
-} );
+module.exports = config;

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -249,7 +249,7 @@ if ( ! isProduction ) {
 
 module.exports = ( env ) => ( {
 	...config,
-	entry: env.entries ?? {
+	entry: env.entries || {
 		index: path.resolve( process.cwd(), 'src', 'index.js' ),
 	},
 } );

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -36,7 +36,7 @@ let entry = {};
 if ( process.env.WP_ENTRY ) {
 	entry = JSON.parse( process.env.WP_ENTRY );
 } else {
-	[ 'index', 'view' ].forEach( ( entryName ) => {
+	[ 'index' ].forEach( ( entryName ) => {
 		const filepath = path.resolve(
 			process.cwd(),
 			'src',

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -36,6 +36,8 @@ let entry = {};
 if ( process.env.WP_ENTRY ) {
 	entry = JSON.parse( process.env.WP_ENTRY );
 } else {
+	// By default the script checks if `src/index.js` exists and sets it as an entry point.
+	// In the future we should add similar handling for `src/script.js` and `src/view.js`.
 	[ 'index' ].forEach( ( entryName ) => {
 		const filepath = path.resolve(
 			process.cwd(),

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -131,13 +131,14 @@ const getWebpackArgs = () => {
 		// The following handles the support for multiple entry points in webpack, e.g.:
 		// `wp-scripts build one.js custom=./two.js` -> `webpack one=./one.js custom=./two.js`
 		webpackArgs = webpackArgs.reduce( ( args, cliArg ) => {
-			if (
-				getFileArgsFromCLI().includes( cliArg ) &&
-				! cliArg.includes( '=' )
-			) {
-				args.push( ...pathToEntry( cliArg ) );
-			} else {
+			if ( ! getFileArgsFromCLI().includes( cliArg ) ) {
 				args.push( cliArg );
+				return args;
+			}
+			if ( cliArg.includes( '=' ) ) {
+				args.push( '--env', 'entries.' + cliArg );
+			} else {
+				args.push( ...pathToEntry( cliArg ) );
 			}
 			return args;
 		}, [] );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,17 +1,7 @@
 /**
- * External dependencies
- */
-const { basename } = require( 'path' );
-
-/**
  * Internal dependencies
  */
-const {
-	getArgsFromCLI,
-	getFileArgsFromCLI,
-	hasArgInCLI,
-	hasFileArgInCLI,
-} = require( './cli' );
+const { getArgsFromCLI, hasArgInCLI } = require( './cli' );
 const { fromConfigRoot, fromProjectRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
 
@@ -104,43 +94,7 @@ const hasPostCSSConfig = () =>
  */
 const getWebpackArgs = () => {
 	// Gets all args from CLI without those prefixed with `--webpack`.
-	let webpackArgs = getArgsFromCLI( [ '--webpack' ] );
-
-	const hasWebpackOutputOption =
-		hasArgInCLI( '-o' ) || hasArgInCLI( '--output' );
-	if ( hasFileArgInCLI() && ! hasWebpackOutputOption ) {
-		/**
-		 * Converts a path to the entry format supported by webpack, e.g.:
-		 * `./entry-one.js` -> `entry-one=./entry-one.js`
-		 * `entry-two.js` -> `entry-two=./entry-two.js`
-		 *
-		 * @param {string} path The path provided.
-		 *
-		 * @return {string} The entry format supported by webpack.
-		 */
-		const pathToEntry = ( path ) => {
-			const entry = basename( path, '.js' );
-
-			if ( ! path.startsWith( './' ) ) {
-				path = './' + path;
-			}
-
-			return [ entry, path ].join( '=' );
-		};
-
-		// The following handles the support for multiple entry points in webpack, e.g.:
-		// `wp-scripts build one.js custom=./two.js` -> `webpack one=./one.js custom=./two.js`
-		webpackArgs = webpackArgs.map( ( cliArg ) => {
-			if (
-				getFileArgsFromCLI().includes( cliArg ) &&
-				! cliArg.includes( '=' )
-			) {
-				return pathToEntry( cliArg );
-			}
-
-			return cliArg;
-		} );
-	}
+	const webpackArgs = getArgsFromCLI( [ '--webpack' ] );
 
 	if ( ! hasWebpackConfig() ) {
 		webpackArgs.push( '--config', fromConfigRoot( 'webpack.config.js' ) );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -108,7 +108,11 @@ const getWebpackArgs = () => {
 
 	const hasWebpackOutputOption =
 		hasArgInCLI( '-o' ) || hasArgInCLI( '--output' );
-	if ( hasFileArgInCLI() && ! hasWebpackOutputOption ) {
+	if (
+		! hasWebpackOutputOption &&
+		! hasArgInCLI( '--entry' ) &&
+		hasFileArgInCLI()
+	) {
 		/**
 		 * Converts a legacy path to the entry pair supported by webpack, e.g.:
 		 * `./entry-one.js` -> `[ 'entry-one', './entry-one.js] ]`

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -130,7 +130,7 @@ const getWebpackArgs = () => {
 
 		const fileArgs = getFileArgsFromCLI();
 		if ( fileArgs.length > 0 ) {
-			// Filter out all CLI arguments that are file paths.
+			// Filters out all CLI arguments that are recognized as file paths.
 			const fileArgsToRemove = new Set( fileArgs );
 			webpackArgs = webpackArgs.filter( ( cliArg ) => {
 				if ( fileArgsToRemove.has( cliArg ) ) {
@@ -140,7 +140,7 @@ const getWebpackArgs = () => {
 				return true;
 			} );
 
-			// Convert all CLI arguments that are file paths to the `entry` format supported by webpack.
+			// Converts all CLI arguments that are file paths to the `entry` format supported by webpack.
 			// It is going to be consumed in the config through the WP_ENTRY global variable.
 			const entry = {};
 			fileArgs.forEach( ( fileArg ) => {


### PR DESCRIPTION
## Description
Fixes #34236.
Fixes #34239.

After upgrading to v18.0.0, we started getting an error when specifying the entry point file on the command line:

```bash
> wp-scripts build src/index.js                                                                                                  
                                                                                                                                                                                                                                                                  
[webpack-cli] Unknown command or entry 'index=./src/index.js'                                                                                                                                                                                                     
[webpack-cli] Run 'webpack --help' to see available commands and options                                                                                                                                                                                          
 ERROR  Command failed with exit code 2.  
```

Because `src/index.js` is the default, we could get around this problem by removing the command line argument, but I decided to investigate what was happening. 

It seems like the issue is caused by a breaking change from the upgrade to webpack v5. Looking at the documentation, [webpack v4 states](https://v4.webpack.js.org/api/cli/#usage-without-config-file) that custom/multiple entry points can be specified on the command line using `[name]=[file]` pairs. [The webpack v5 documentation](https://webpack.js.org/api/cli/#entry) doesn't have this option for command line entry points. One of the options it does show is simply the filenames listed as separate arguments.

This change removes the code that converted file arguments on the command line to the webpack v4 entry point format, so the arguments are passed as is to webpack v5.

## How has this been tested?

It's been a little tricky to test as I haven't been able to link the development version of the package with it's dependencies into our project in a way that will have the build process complete successfully. But I have been able to test that without this change, I get the above error, and with it, the error doesn't occur.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix - This allows entry points to be specified on the command line.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
