### PR TITLE
Revert "[RNMobile] Use Flexbox for Inserter Menu tabs on mobile"

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -204,10 +204,7 @@ function InserterMenu( {
 		>
 			<BottomSheetConsumer>
 				{ ( { listProps } ) => (
-					<TouchableHighlight
-						accessible={ false }
-						style={ { flex: 1 } }
-					>
+					<TouchableHighlight accessible={ false }>
 						{ ! showTabs || filterValue ? (
 							<InserterSearchResults
 								rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -51,12 +51,13 @@
 
 .inserter-tabs__wrapper {
 	overflow: hidden;
-	flex: 1;
 }
 
 .inserter-tabs__container {
 	height: 100%;
 	width: 100%;
-	flex: 1;
-	flex-direction: row;
+}
+
+.inserter-tabs__item {
+	position: absolute;
 }

--- a/packages/block-editor/src/components/inserter/tabs.native.js
+++ b/packages/block-editor/src/components/inserter/tabs.native.js
@@ -100,7 +100,13 @@ function InserterTabs( {
 		>
 			<Animated.View style={ containerStyle }>
 				{ tabs.map( ( { component: TabComponent }, index ) => (
-					<View key={ `tab-${ index }` }>
+					<View
+						key={ `tab-${ index }` }
+						style={ [
+							styles[ 'inserter-tabs__item' ],
+							{ left: index * wrapperWidth },
+						] }
+					>
 						<TabComponent
 							rootClientId={ rootClientId }
 							onSelect={ onSelect }


### PR DESCRIPTION
This reverts commit c238f4324354a4a87293fe83ff1268ce7889e1c2.

Switching to flexbox for the Inserter menu tabs breaks the menu unless the [Inserter search is enabled](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/menu.native.js#L41)

These changes are required to allow the Inserter menu to go [fullscreen on Android](https://github.com/WordPress/gutenberg/issues/34124) but we can introduce the change set when the [Inserter search](https://github.com/WordPress/gutenberg/pull/34129) is enabled. 
 
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
- Disable Dev mode on the demo mobile app 
- Try opening the Inserter menu
- Expect the inserter menu to have the expected height and not be empty.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
