### PR TITLE
useDropZone: Ensure drag event targets HTMLElement

### DIFF
--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -73,17 +73,23 @@ export default function useDropZone( {
 			/**
 			 * Checks if an element is in the drop zone.
 			 *
-			 * @param {HTMLElement|null} elementToCheck
+			 * @param {EventTarget|null} targetToCheck
 			 *
 			 * @return {boolean} True if in drop zone, false if not.
 			 */
-			function isElementInZone( elementToCheck ) {
+			function isElementInZone( targetToCheck ) {
+				const { defaultView } = ownerDocument;
 				if (
-					! elementToCheck ||
-					! element.contains( elementToCheck )
+					! targetToCheck ||
+					! defaultView ||
+					! ( targetToCheck instanceof defaultView.HTMLElement ) ||
+					! element.contains( targetToCheck )
 				) {
 					return false;
 				}
+
+				/** @type {HTMLElement|null} */
+				let elementToCheck = targetToCheck;
 
 				do {
 					if ( elementToCheck.dataset.isDropZone ) {
@@ -155,11 +161,7 @@ export default function useDropZone( {
 				// leaving the drop zone, which means the `relatedTarget`
 				// (element that has been entered) should be outside the drop
 				// zone.
-				if (
-					isElementInZone(
-						/** @type {HTMLElement|null} */ ( event.relatedTarget )
-					)
-				) {
+				if ( isElementInZone( event.relatedTarget ) ) {
 					return;
 				}
 


### PR DESCRIPTION
Attempts to fix a TypeError that has been logged in the wild but is yet to be reproduced. In production builds, it manifests as `e.dataset is undefined`, pointing to the useDropZone hook. In addition:
* Don't cast FocusTarget instance to HTMLElement prior to calling isElementInZone.
* Perform type validations inside isElementInZone, then cast to HTMLElement.

## How has this been tested?
Should have no measure impact on regular usage.

## Types of changes
Code quality. Tentative bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
