### PR TITLE
Site title: Allow empty title in edit mode

### DIFF
--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -52,7 +52,7 @@ export default function SiteTitleEdit( {
 				tagName="a"
 				aria-label={ __( 'Site title text' ) }
 				placeholder={ __( 'Write site title…' ) }
-				value={ title || readOnlyTitle }
+				value={ title }
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When the value in the site title is empty the richtext has a fallback to the existing title. Remove the fallback so users can remove the currect site title before adding a new one.

Fixes #34244

## How has this been tested?
See steps in ticket

## Screenshots <!-- if applicable -->
### Before
![site-title-broken](https://user-images.githubusercontent.com/1415747/130693079-26c92dd8-84f0-40b2-a715-bf117c212eef.gif)

### After
![site-title-fixed](https://user-images.githubusercontent.com/1415747/130693093-cbe99929-2397-4328-9ec4-f7d8bef558db.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
