### PR TITLE
Remove redundant css selector

### DIFF
--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -20,7 +20,7 @@ export default function saveWithInnerBlocks( { attributes } ) {
 
 	const { caption, columns, imageCrop } = attributes;
 
-	const className = classnames( 'blocks-gallery-grid', 'has-nested-images', {
+	const className = classnames( 'has-nested-images', {
 		[ `columns-${ columns }` ]: columns !== undefined,
 		[ `columns-default` ]: columns === undefined,
 		'is-cropped': imageCrop,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -2,7 +2,7 @@
 @import "./deprecated.scss";
 
 // Styles for current version of gallery block.
-.wp-block-gallery.blocks-gallery-grid.has-nested-images {
+.wp-block-gallery.has-nested-images {
 	display: flex;
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()


### PR DESCRIPTION
## Description
Removes redundant css selector to reduce specificity for theme/plugin authors trying to override gallery styles

Fixes: #34276

## To test

- Check out PR to local dev env
- Add a gallery without gallery experiment enabled, make sure it displays as expected in editor and front end
- Turn on the gallery experiment and add another gallery and ensure that it also displays correctly in editor and front end

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.