### PR TITLE
[RNMobile] Blur inserter search when keyboard closes

### DIFF
--- a/packages/components/src/search-control/index.native.js
+++ b/packages/components/src/search-control/index.native.js
@@ -8,6 +8,7 @@ import {
 	TouchableOpacity,
 	Platform,
 	useColorScheme,
+	Keyboard,
 } from 'react-native';
 
 /**
@@ -116,12 +117,18 @@ function SearchControl( {
 		setCurrentStyles( futureStyles );
 	}, [ isActive, isDark ] );
 
-	useEffect(
-		() => () => {
+	useEffect( () => {
+		const keyboardHideSubscription = Keyboard.addListener(
+			'keyboardDidHide',
+			() => {
+				onCancel();
+			}
+		);
+		return () => {
 			clearTimeout( onCancelTimer.current );
-		},
-		[]
-	);
+			keyboardHideSubscription.remove();
+		};
+	}, [] );
 
 	const {
 		'search-control__container': containerStyle,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This blurs the inserter search input when the keyboard is manually closed.

Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3871

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Start the mobile demo app on a device with a dismissible keyboard*
- Open the inserter 
- Press on the inserter search
- Expect the keyboard to open
- Close the keyboard
- Expect the search input to lose focus
- Press on the inserter search again
- Expect the keyboard to open as expected 

(* while this change is not platform specific, the iOS devices tested did not have a way to close the keyboard outside of using the existing cancel flows )

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/744755/130722649-aca5f01e-95ce-4e72-91dd-0c7a78c34c2d.mp4


_Pixel 5, Android 11_

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Adds Keyboard listener to the mobile search control component 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
