### PR TITLE
Update navigation editor to support new submenu block

### DIFF
--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -12,34 +12,34 @@ exports[`Navigation editor displays the first menu from the REST response when a
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"http://localhost:8889/?page_id=41\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"http://localhost:8889/?page_id=41\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
 <!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"page\\",\\"id\\":51,\\"url\\":\\"http://localhost:8889/?page_id=51\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-link -->
+<!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-link {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"page\\",\\"id\\":53,\\"url\\":\\"http://localhost:8889/?page_id=53\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"page\\",\\"id\\":56,\\"url\\":\\"http://localhost:8889/?page_id=56\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"page\\",\\"id\\":15,\\"url\\":\\"http://localhost:8889/?page_id=15\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"page\\",\\"id\\":45,\\"url\\":\\"http://localhost:8889/?page_id=45\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"page\\",\\"id\\":53,\\"url\\":\\"http://localhost:8889/?page_id=53\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"page\\",\\"id\\":56,\\"url\\":\\"http://localhost:8889/?page_id=56\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"page\\",\\"id\\":15,\\"url\\":\\"http://localhost:8889/?page_id=15\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"page\\",\\"id\\":45,\\"url\\":\\"http://localhost:8889/?page_id=45\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
 <!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"page\\",\\"id\\":27,\\"url\\":\\"http://localhost:8889/?page_id=27\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation-submenu -->
 
 <!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"page\\",\\"id\\":43,\\"url\\":\\"http://localhost:8889/?page_id=43\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"category\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"id\\":7,\\"url\\":\\"http://localhost:8889/?cat=7\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelLink\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"category\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"id\\":19,\\"url\\":\\"http://localhost:8889/?cat=19\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelLink\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"category\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"id\\":6,\\"url\\":\\"http://localhost:8889/?cat=6\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelLink\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"category\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"id\\":7,\\"url\\":\\"http://localhost:8889/?cat=7\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"category\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"id\\":19,\\"url\\":\\"http://localhost:8889/?cat=19\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"category\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"id\\":6,\\"url\\":\\"http://localhost:8889/?cat=6\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":false} -->
 <!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"category\\",\\"description\\":\\"Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora\\",\\"id\\":16,\\"url\\":\\"http://localhost:8889/?cat=16\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-link {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
 <!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://google.com\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-link -->
+<!-- /wp:navigation-submenu -->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -324,7 +324,7 @@ describe( 'Navigation editor', () => {
 
 		// Select a link block with nested links in a submenu.
 		const parentLinkXPath =
-			'//div[@aria-label="Block: Custom Link" and contains(.,"WordPress.org")]';
+			'//div[@aria-label="Block: Submenu" and contains(.,"WordPress.org")]';
 		const linkBlock = await page.waitForXPath( parentLinkXPath );
 		await linkBlock.click();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -322,7 +322,7 @@ describe( 'Navigation editor', () => {
 		] );
 		await visitNavigationEditor();
 
-		// Select a link block with nested links in a submenu.
+		// Select a submenu block with nested links in a submenu.
 		const parentLinkXPath =
 			'//div[@aria-label="Block: Submenu" and contains(.,"WordPress.org")]';
 		const linkBlock = await page.waitForXPath( parentLinkXPath );

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -108,7 +108,7 @@
 			position: absolute;
 			top: 15px;
 			left: 0;
-			padding: 0px;
+			padding: 0;
 			pointer-events: none;
 
 			svg {
@@ -120,8 +120,8 @@
 		}
 
 		// Point downwards when open.
-		.is-selected.has-child .wp-block-navigation-item__content .wp-block-navigation__submenu-icon svg,
-		.has-child-selected.has-child .wp-block-navigation-item__content .wp-block-navigation__submenu-icon svg {
+		.wp-block-navigation-submenu.is-selected > .wp-block-navigation-item__content > .wp-block-navigation__submenu-icon svg,
+		.wp-block-navigation-submenu.has-child-selected > .wp-block-navigation-item__content > .wp-block-navigation__submenu-icon svg {
 			transform: rotate(0deg);
 		}
 

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -147,7 +147,7 @@
 				background: transparent;
 				top: auto;
 				left: auto;
-				padding-left: $grid-unit-20;
+				padding-left: $grid-unit-20 + $grid-unit-05;
 				min-width: auto;
 				width: 100%;
 				border: none;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -30,8 +30,10 @@
 		font-family: $default-font;
 
 		// Increase specificity.
-		.wp-block-navigation-item {
+		.wp-block-navigation-item,
+		.wp-block-navigation-submenu {
 			display: block;
+			margin: $grid-unit-05 0 $grid-unit-05 0;
 
 			// Show submenus on click.
 			> .wp-block-navigation__submenu-container {
@@ -55,7 +57,8 @@
 
 			// Menu items.
 			// This needs high specificity to override inherited values.
-			&.wp-block-navigation-item.wp-block-navigation-item {
+			&.wp-block-navigation-item.wp-block-navigation-item,
+			&.wp-block-navigation-submenu .wp-block-navigation-submenu {
 				margin-right: 0;
 			}
 
@@ -103,27 +106,27 @@
 		// Submenu icon indicator.
 		.wp-block-navigation__submenu-icon {
 			position: absolute;
-			top: 6px;
+			top: 15px;
 			left: 0;
-			padding: 6px;
+			padding: 0px;
 			pointer-events: none;
 
 			svg {
 				// Point rightwards.
 				transform: rotate(-90deg);
-
 				transition: transform 0.2s ease;
 				@include reduce-motion("transition");
 			}
 		}
 
 		// Point downwards when open.
-		.is-selected.has-child > .wp-block-navigation__submenu-icon svg,
-		.has-child-selected.has-child > .wp-block-navigation__submenu-icon svg {
+		.is-selected.has-child .wp-block-navigation-item__content .wp-block-navigation__submenu-icon svg,
+		.has-child-selected.has-child .wp-block-navigation-item__content .wp-block-navigation__submenu-icon svg {
 			transform: rotate(0deg);
 		}
 
 		// Override inherited values to optimize menu items for the screen context.
+		.wp-block-navigation-submenu.has-child,
 		.wp-block-navigation-item.has-child {
 			cursor: default;
 			border-radius: $radius-block-ui;
@@ -137,7 +140,8 @@
 
 		// When editing a link with children, highlight the parent
 		// and adjust the spacing and submenu icon.
-		.wp-block-navigation-item.has-child.is-editing {
+		.wp-block-navigation-item.has-child.is-editing,
+		.wp-block-navigation-submenu.has-child.is-editing {
 			> .wp-block-navigation__container,
 			> .wp-block-navigation__submenu-container {
 				opacity: 1;
@@ -158,9 +162,13 @@
 			}
 		}
 
-		// Add buttons
+		// Appender styles
+		.block-list-appender {
+			margin: 0;
+		}
+
 		.block-editor-button-block-appender.block-list-appender__toggle {
-			margin: 0 0 0 $grid-unit-20;
+			margin: $grid-unit-05 0 $grid-unit-05 $grid-unit-30;
 			padding: 0;
 		}
 	}

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -33,7 +33,7 @@
 		.wp-block-navigation-item,
 		.wp-block-navigation-submenu {
 			display: block;
-			margin: $grid-unit-05 0 $grid-unit-05 0;
+			margin: $grid-unit-10 0;
 
 			// Show submenus on click.
 			> .wp-block-navigation__submenu-container {
@@ -133,7 +133,6 @@
 		}
 
 		// Override for deeply nested submenus.
-		.has-child .wp-block-navigation__container .wp-block-navigation__container,
 		.has-child .wp-block-navigation__container .wp-block-navigation__submenu-container {
 			left: auto;
 		}
@@ -141,7 +140,6 @@
 		// When editing a submenu with children, highlight the parent
 		// and adjust the spacing and submenu icon.
 		.wp-block-navigation-submenu.is-editing {
-			> .wp-block-navigation__container,
 			> .wp-block-navigation__submenu-container {
 				opacity: 1;
 				visibility: visible;
@@ -163,11 +161,16 @@
 
 		// Appender styles
 		.block-list-appender {
-			margin: 0;
+			// Make appender rows the same height as items and center the button vertically.
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			height: $grid-unit-50;
+			margin: $grid-unit-10 0;
 		}
 
 		.block-editor-button-block-appender.block-list-appender__toggle {
-			margin: $grid-unit-05 0 $grid-unit-05 $grid-unit-30;
+			margin: 0 0 0 $grid-unit-30;
 			padding: 0;
 		}
 	}

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -64,7 +64,6 @@
 
 			.wp-block-navigation-item__content.wp-block-navigation-item__content.wp-block-navigation-item__content {
 				padding: 0.5em 1em;
-				margin-bottom: 6px;
 				margin-right: 0;
 				border-radius: $radius-block-ui;
 

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -138,10 +138,9 @@
 			left: auto;
 		}
 
-		// When editing a link with children, highlight the parent
+		// When editing a submenu with children, highlight the parent
 		// and adjust the spacing and submenu icon.
-		.wp-block-navigation-item.has-child.is-editing,
-		.wp-block-navigation-submenu.has-child.is-editing {
+		.wp-block-navigation-submenu.is-editing {
 			> .wp-block-navigation__container,
 			> .wp-block-navigation__submenu-container {
 				opacity: 1;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -147,7 +147,7 @@
 				background: transparent;
 				top: auto;
 				left: auto;
-				padding-left: $grid-unit-15;
+				padding-left: $grid-unit-20;
 				min-width: auto;
 				width: 100%;
 				border: none;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -30,8 +30,7 @@
 		font-family: $default-font;
 
 		// Increase specificity.
-		.wp-block-navigation-item,
-		.wp-block-navigation-submenu {
+		.wp-block-navigation-item {
 			display: block;
 			margin: $grid-unit-10 0;
 
@@ -53,13 +52,6 @@
 
 			&.block-editor-block-list__block:not([contenteditable]):focus::after {
 				display: none;
-			}
-
-			// Menu items.
-			// This needs high specificity to override inherited values.
-			&.wp-block-navigation-item.wp-block-navigation-item,
-			&.wp-block-navigation-submenu .wp-block-navigation-submenu {
-				margin-right: 0;
 			}
 
 			.wp-block-navigation-item__content.wp-block-navigation-item__content.wp-block-navigation-item__content {

--- a/packages/edit-navigation/src/filters/disable-inserting-non-navigation-blocks.js
+++ b/packages/edit-navigation/src/filters/disable-inserting-non-navigation-blocks.js
@@ -8,7 +8,13 @@ import { addFilter } from '@wordpress/hooks';
 import { set } from 'lodash';
 
 function disableInsertingNonNavigationBlocks( settings, name ) {
-	if ( ! [ 'core/navigation', 'core/navigation-link' ].includes( name ) ) {
+	if (
+		! [
+			'core/navigation',
+			'core/navigation-link',
+			'core/navigation-submenu',
+		].includes( name )
+	) {
 		set( settings, [ 'supports', 'inserter' ], false );
 	}
 	return settings;

--- a/packages/edit-navigation/src/store/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/store/menu-items-to-blocks.js
@@ -65,12 +65,14 @@ function mapMenuItemsToBlocks( menuItems ) {
 			...nestedMapping,
 		};
 
+		// Create a submenu block when there are inner blocks, or just a link
+		// for a standalone item.
+		const itemBlockName = nestedBlocks?.length
+			? 'core/navigation-submenu'
+			: 'core/navigation-link';
+
 		// Create block with nested "innerBlocks".
-		const block = createBlock(
-			'core/navigation-link',
-			attributes,
-			nestedBlocks
-		);
+		const block = createBlock( itemBlockName, attributes, nestedBlocks );
 
 		// Create mapping for menuItem -> block
 		mapping[ menuItem.id ] = block.clientId;

--- a/packages/edit-navigation/src/store/test/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/store/test/menu-items-to-blocks.js
@@ -186,7 +186,7 @@ describe( 'converting menu items to blocks', () => {
 
 		expect( actual ).toEqual( [
 			expect.objectContaining( {
-				name: 'core/navigation-link',
+				name: 'core/navigation-submenu',
 				attributes: expect.objectContaining( {
 					label: 'Top Level',
 				} ),
@@ -199,13 +199,13 @@ describe( 'converting menu items to blocks', () => {
 						innerBlocks: [],
 					} ),
 					expect.objectContaining( {
-						name: 'core/navigation-link',
+						name: 'core/navigation-submenu',
 						attributes: expect.objectContaining( {
 							label: 'Child 2',
 						} ),
 						innerBlocks: [
 							expect.objectContaining( {
-								name: 'core/navigation-link',
+								name: 'core/navigation-submenu',
 								attributes: expect.objectContaining( {
 									label: 'Sub Child',
 								} ),

--- a/packages/edit-navigation/src/store/utils.js
+++ b/packages/edit-navigation/src/store/utils.js
@@ -156,7 +156,10 @@ export function computeCustomizedAttribute(
 
 		let attributes;
 
-		if ( block.name === 'core/navigation-link' ) {
+		if (
+			block.name === 'core/navigation-link' ||
+			block.name === 'core/navigation-submenu'
+		) {
 			attributes = blockAttributesToMenuItem( block.attributes );
 		} else {
 			attributes = {


### PR DESCRIPTION
Based on and merges into #33775

## Description
Updates the navigation editor to support the dropdown block.

The changes are:
- Add the 'core/navigation-submenu' block as a supported block in the nav editor's inserter
- When loading a menu and serializing from menu items to block, any menu item with children is now created as a 'core/navigation-submenu' block
- When saving blocks, save a 'core/navigation-submenu' block the same way as a 'core/navigation-link' block.
- Update nav editor's accordion styles to work with the new block classnames.
- Fixes a lot of the broken styles in the nav editor that have occurred as a result of changes to the nav block over the last few months.

## How has this been tested?
1. Create a nested menu in the old editor
2. Load it in the new editor, it should create submenu blocks, and everything should look similar to `trunk`.
3. Edit and save the menu in the new editor
4. Load the menu in the old editor, the menu should display normal menu items.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
