### PR TITLE
General Interface: Make permalinks documentation URL translatable

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -95,7 +95,9 @@ function PostLink( {
 					/>
 					<p>
 						{ __( 'The last part of the URL.' ) }{ ' ' }
-						<ExternalLink href="https://wordpress.org/support/article/writing-posts/#post-field-descriptions">
+						<ExternalLink
+							href={ __( 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions' ) }
+						>
 							{ __( 'Read about permalinks' ) }
 						</ExternalLink>
 					</p>

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -96,7 +96,9 @@ function PostLink( {
 					<p>
 						{ __( 'The last part of the URL.' ) }{ ' ' }
 						<ExternalLink
-							href={ __( 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions' ) }
+							href={ __(
+								'https://wordpress.org/support/article/writing-posts/#post-field-descriptions'
+							) }
 						>
 							{ __( 'Read about permalinks' ) }
 						</ExternalLink>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The "Read about permalinks" links are not properly i18n enabled, so they all jump to the English documentation.
All "Read about permalinks" in the inspector of the editor are linked to https://wordpress.org/support/article/writing-posts/#post-field-descriptions in English. I would like to be able to jump to the documentation for each language.

https://core.trac.wordpress.org/ticket/54001

There is a document that has been translated into Japanese, so the link should be to the document in the same language, not English.

Example:

English
https://wordpress.org/support/article/writing-posts/#post-field-descriptions

Japanese
https://ja.wordpress.org/support/article/writing-posts/#%e3%83%91%e3%83%bc%e3%83%9e%e3%83%aa%e3%83%b3%e3%82%af

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
