### PR TITLE
Global Styles: Fix block-level global styles color panels

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -24,7 +24,8 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	backgroundColor: {
 		value: [ 'color', 'background' ],
-		support: [ 'color' ],
+		support: [ 'color', 'background' ],
+		requiresOptOut: true,
 	},
 	borderColor: {
 		value: [ 'border', 'color' ],
@@ -50,7 +51,8 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	color: {
 		value: [ 'color', 'text' ],
-		support: [ 'color' ],
+		support: [ 'color', 'text' ],
+		requiresOptOut: true,
 	},
 	linkColor: {
 		value: [ 'elements', 'link', 'color', 'text' ],

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { set, get, mergeWith, mapValues, setWith, clone } from 'lodash';
+import { set, get, has, mergeWith, mapValues, setWith, clone } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -72,10 +72,29 @@ export const useGlobalStylesReset = () => {
 	];
 };
 
+const shouldExtractKey = ( name, supports ) => {
+	// Opting out means that, for certain support keys, blocks have to explicitly
+	// set the support value false. If the key is unset, we still extract it.
+	const blockHasNotOptedOut =
+		STYLE_PROPERTY[ name ].requiresOptOut &&
+		has( supports, STYLE_PROPERTY[ name ].support[ 0 ] ) &&
+		get( supports, STYLE_PROPERTY[ name ].support ) !== false;
+
+	const blockHasAllowedSupportKey =
+		! STYLE_PROPERTY[ name ].requiresOptOut &&
+		get( supports, STYLE_PROPERTY[ name ].support, false );
+
+	return blockHasAllowedSupportKey || blockHasNotOptedOut;
+};
+
 const extractSupportKeys = ( supports ) => {
 	const supportKeys = [];
 	Object.keys( STYLE_PROPERTY ).forEach( ( name ) => {
-		if ( get( supports, STYLE_PROPERTY[ name ].support, false ) ) {
+		if ( ! STYLE_PROPERTY[ name ].support ) {
+			return;
+		}
+
+		if ( shouldExtractKey( name, supports ) ) {
 			supportKeys.push( name );
 		}
 	} );

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -72,21 +72,6 @@ export const useGlobalStylesReset = () => {
 	];
 };
 
-const shouldExtractKey = ( name, supports ) => {
-	// Opting out means that, for certain support keys, blocks have to explicitly
-	// set the support value false. If the key is unset, we still extract it.
-	const blockHasNotOptedOut =
-		STYLE_PROPERTY[ name ].requiresOptOut &&
-		has( supports, STYLE_PROPERTY[ name ].support[ 0 ] ) &&
-		get( supports, STYLE_PROPERTY[ name ].support ) !== false;
-
-	const blockHasAllowedSupportKey =
-		! STYLE_PROPERTY[ name ].requiresOptOut &&
-		get( supports, STYLE_PROPERTY[ name ].support, false );
-
-	return blockHasAllowedSupportKey || blockHasNotOptedOut;
-};
-
 const extractSupportKeys = ( supports ) => {
 	const supportKeys = [];
 	Object.keys( STYLE_PROPERTY ).forEach( ( name ) => {
@@ -94,8 +79,20 @@ const extractSupportKeys = ( supports ) => {
 			return;
 		}
 
-		if ( shouldExtractKey( name, supports ) ) {
-			supportKeys.push( name );
+		// Opting out means that, for certain support keys like background color,
+		// blocks have to explicitly set the support value false. If the key is
+		// unset, we still enable it.
+		if ( STYLE_PROPERTY[ name ].requiresOptOut ) {
+			if (
+				has( supports, STYLE_PROPERTY[ name ].support[ 0 ] ) &&
+				get( supports, STYLE_PROPERTY[ name ].support ) !== false
+			) {
+				return supportKeys.push( name );
+			}
+		}
+
+		if ( get( supports, STYLE_PROPERTY[ name ].support, false ) ) {
+			return supportKeys.push( name );
 		}
 	} );
 	return supportKeys;

--- a/packages/edit-site/src/components/editor/test/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/test/global-styles-provider.js
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+/**
+ * Internal dependencies
+ */
+import GlobalStylesProvider, {
+	useGlobalStylesContext,
+} from '../global-styles-provider';
+
+const settings = {
+	styles: [
+		{
+			css: 'body {\n\tmargin: 0;\n\tpadding: 0;\n}',
+			baseURL: 'http://localhost:4759/ponyfill.css',
+		},
+	],
+	__experimentalGlobalStylesBaseStyles: {},
+};
+
+const generateCoverBlockType = ( colorSupports ) => {
+	return {
+		name: 'core/cover',
+		supports: {
+			color: colorSupports,
+		},
+	};
+};
+
+const FakeCmp = () => {
+	const globalStylesContext = useGlobalStylesContext();
+	const coverBlockSupports =
+		globalStylesContext.blocks[ 'core/cover' ].supports;
+
+	return <div supports={ coverBlockSupports }></div>;
+};
+
+const generateWrapper = () => {
+	return mount(
+		<GlobalStylesProvider
+			baseStyles={ settings.__experimentalGlobalStylesBaseStyles }
+		>
+			<FakeCmp />
+		</GlobalStylesProvider>
+	);
+};
+
+describe( 'global styles provider', () => {
+	beforeAll( () => {
+		dispatch( 'core/edit-site' ).updateSettings( settings );
+	} );
+
+	// afterEach( () => {
+	// 	dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+	// } );
+
+	describe( 'when a block enables color support', () => {
+		it( 'automatically enables text color and background color supports', () => {
+			act( () => {
+				dispatch( 'core/blocks' ).addBlockTypes(
+					generateCoverBlockType( { link: true } )
+				);
+			} );
+
+			const wrapper = generateWrapper();
+			const actual = wrapper
+				.findWhere( ( ele ) => Boolean( ele.prop( 'supports' ) ) )
+				.prop( 'supports' );
+			expect( actual ).toContain( 'backgroundColor' );
+			expect( actual ).toContain( 'color' );
+
+			act( () => {
+				dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+			} );
+		} );
+
+		describe( 'and both text color and background color support are disabled', () => {
+			it( 'disables text color and background color support', () => {
+				act( () => {
+					dispatch( 'core/blocks' ).addBlockTypes(
+						generateCoverBlockType( {
+							text: false,
+							background: false,
+						} )
+					);
+				} );
+
+				const wrapper = generateWrapper();
+				const actual = wrapper
+					.findWhere( ( ele ) => Boolean( ele.prop( 'supports' ) ) )
+					.prop( 'supports' );
+				expect( actual ).not.toContain( 'backgroundColor' );
+				expect( actual ).not.toContain( 'color' );
+
+				act( () => {
+					dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+				} );
+			} );
+		} );
+
+		describe( 'and text color and background color supports are omitted', () => {
+			it( 'still enables text color and background color supports', () => {
+				act( () => {
+					dispatch( 'core/blocks' ).addBlockTypes(
+						generateCoverBlockType( { link: true } )
+					);
+				} );
+
+				const wrapper = generateWrapper();
+				const actual = wrapper
+					.findWhere( ( ele ) => Boolean( ele.prop( 'supports' ) ) )
+					.prop( 'supports' );
+				expect( actual ).toContain( 'backgroundColor' );
+				expect( actual ).toContain( 'color' );
+
+				act( () => {
+					dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/packages/edit-site/src/components/editor/test/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/test/global-styles-provider.js
@@ -58,10 +58,6 @@ describe( 'global styles provider', () => {
 		dispatch( 'core/edit-site' ).updateSettings( settings );
 	} );
 
-	// afterEach( () => {
-	// 	dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
-	// } );
-
 	describe( 'when a block enables color support', () => {
 		it( 'automatically enables text color and background color supports', () => {
 			act( () => {

--- a/packages/edit-site/src/components/editor/test/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/test/global-styles-provider.js
@@ -59,22 +59,27 @@ describe( 'global styles provider', () => {
 	} );
 
 	describe( 'when a block enables color support', () => {
-		it( 'automatically enables text color and background color supports', () => {
-			act( () => {
-				dispatch( 'core/blocks' ).addBlockTypes(
-					generateCoverBlockType( { link: true } )
-				);
-			} );
+		describe( 'and disables background color support', () => {
+			it( 'still enables text color support', () => {
+				act( () => {
+					dispatch( 'core/blocks' ).addBlockTypes(
+						generateCoverBlockType( {
+							link: true,
+							background: false,
+						} )
+					);
+				} );
 
-			const wrapper = generateWrapper();
-			const actual = wrapper
-				.findWhere( ( ele ) => Boolean( ele.prop( 'supports' ) ) )
-				.prop( 'supports' );
-			expect( actual ).toContain( 'backgroundColor' );
-			expect( actual ).toContain( 'color' );
+				const wrapper = generateWrapper();
+				const actual = wrapper
+					.findWhere( ( ele ) => Boolean( ele.prop( 'supports' ) ) )
+					.prop( 'supports' );
+				expect( actual ).not.toContain( 'backgroundColor' );
+				expect( actual ).toContain( 'color' );
 
-			act( () => {
-				dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+				act( () => {
+					dispatch( 'core/blocks' ).removeBlockTypes( 'core/cover' );
+				} );
 			} );
 		} );
 
@@ -103,7 +108,7 @@ describe( 'global styles provider', () => {
 		} );
 
 		describe( 'and text color and background color supports are omitted', () => {
-			it( 'still enables text color and background color supports', () => {
+			it( 'still enables both text color and background color supports', () => {
 				act( () => {
 					dispatch( 'core/blocks' ).addBlockTypes(
 						generateCoverBlockType( { link: true } )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Background color and text color are opt-out block supports. That is to say, they're enabled if there's a support key for _any_ color unless the block opts-out from them explicitly. For example, the paragraph block only specifies support for link colors.

https://github.com/WordPress/gutenberg/blob/ac41a59a2ce33cce69c4a6374a6dc759888d0ce1/packages/block-library/src/paragraph/block.json#L35-L37

The global styles paragraph color panel, however, still displays **both** text and background color supports. This behavior is desired and expected.

<img width="1279" alt="Screen Shot 2021-08-25 at 4 00 24 AM" src="https://user-images.githubusercontent.com/5414230/130779301-05a363ea-52f6-4906-82b3-9ba6b9616dcd.png">

The issue is that global styles UI panels aren't respecting blocks explicitly opting out of text and background color supports. The cover block is a specific example.

https://github.com/WordPress/gutenberg/blob/599b60d2cc8b26b9bc2141305cfe5e07b23dab88/packages/block-library/src/cover/block.json#L73-L77

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate block theme (blockbases, mayland-blocks, etc.)
2. Enable site editor
3. Navigate to site editor
4. Open global styles sidebar
5. Confirm that there are background and text color options in the cover block panel
6. Apply this PR
7. Confirm that there are no longer background and text color option in the cover block panel
8. Verify that panels for other block-level global styles in the sidebar still render as expected

## Screenshots <!-- if applicable -->
### Before
![2021-08-25 04 07 56](https://user-images.githubusercontent.com/5414230/130780185-22fc7442-64d6-48c1-a2f1-4050b26fe206.gif)

### After
![2021-08-25 04 06 59](https://user-images.githubusercontent.com/5414230/130780055-cc8a6bca-d2d2-4bf8-aba7-1ea3bed8b1d0.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix. Potentially addresses https://github.com/WordPress/gutenberg/issues/34150

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
