### PR TITLE
Async scheduling of batched updates

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -644,7 +644,8 @@ export function* __experimentalBatch( requests ) {
 		},
 	};
 	const resultPromises = [];
-	const awaitNextFrame = () => __unstableAwaitPromise( new Promise( window.requestAnimationFrame ) );
+	const awaitNextFrame = () =>
+		__unstableAwaitPromise( new Promise( window.requestAnimationFrame ) );
 	for ( const request of requests ) {
 		resultPromises.push( request( api ) );
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -656,6 +656,9 @@ export function* __experimentalBatch( requests ) {
 		// Each request( api ) is pretty fast, but when there's a lot of them it may block the browser for a few
 		// seconds. Let's split this long, blocking task into bite-sized pieces scheduled separately to give the
 		// browser a space for processing other tasks.
+		//
+		// Ideally this will be just a temporary fix and the blocking would not be an issue in the first place.
+		// Replacing redux-rungen usage with async thunks may help with that, see https://github.com/WordPress/gutenberg/pull/27276
 		yield awaitNextFrame();
 	}
 	const [ , ...results ] = yield __unstableAwaitPromise(

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -645,7 +645,7 @@ export function* __experimentalBatch( requests ) {
 	};
 	const resultPromises = [];
 	const awaitNextFrame = () =>
-		__unstableAwaitPromise( new Promise( window.requestAnimationFrame ) );
+		__unstableAwaitPromise( new Promise( resolve => window.requestAnimationFrame( () => resolve() ) ) );
 	for ( const request of requests ) {
 		resultPromises.push( request( api ) );
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -645,7 +645,11 @@ export function* __experimentalBatch( requests ) {
 	};
 	const resultPromises = [];
 	const awaitNextFrame = () =>
-		__unstableAwaitPromise( new Promise( resolve => window.requestAnimationFrame( () => resolve() ) ) );
+		__unstableAwaitPromise(
+			new Promise( ( resolve ) =>
+				window.requestAnimationFrame( () => resolve() )
+			)
+		);
 	for ( const request of requests ) {
 		resultPromises.push( request( api ) );
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -340,8 +340,13 @@ describe( '__experimentalBatch', () => {
 			),
 		};
 		const dispatch = () => actions;
+		// Run generator up to the last `yield awaitNextFrame( )`.
+		generator.next( dispatch )
+		generator.next();
+		generator.next();
+		const { value: awaitPromiseControl } = generator.next();
+
 		// Run generator up to `yield __unstableAwaitPromise( ... )`.
-		const { value: awaitPromiseControl } = generator.next( dispatch );
 		expect( actions.saveEntityRecord ).toHaveBeenCalledWith(
 			'root',
 			'widget',

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -341,7 +341,7 @@ describe( '__experimentalBatch', () => {
 		};
 		const dispatch = () => actions;
 		// Run generator up to the last `yield awaitNextFrame( )`.
-		generator.next( dispatch )
+		generator.next( dispatch );
 		generator.next();
 		generator.next();
 		const { value: awaitPromiseControl } = generator.next();


### PR DESCRIPTION
## Description

Calling `__experimentalBatch()` with a few dozens requests causes the UI to freeze like that:

![130773120-a0390dec-9620-48d4-9112-44a4aae2bd7a](https://user-images.githubusercontent.com/205419/130781299-8f8ad9d2-ae55-4d7b-b7d6-ddd6c96e58ae.gif)

This is because the saving state hinges on `isSavingEntityRecord()` which changes only once the appropriate redux actions are dispatched. Currently we do it in a blocking way like this:

```js
// this calls dispatch().saveEditedEntityRecord and such
const resultPromises = requests.map( ( request ) => request( api ) ); 
```

Which is fine for a small number of requests. Unfortunately, for many requests it takes some seconds:

```diff
+ console.time( "Before add requests" )
const resultPromises = requests.map( ( request ) => request( api ) );
+ console.timeEnd( "Before add requests" )
```

<img width="324" alt="Zrzut ekranu 2021-08-25 o 13 19 24" src="https://user-images.githubusercontent.com/205419/130781563-88cb70e2-e9e9-471c-b6fb-7cc1293d91b9.png">

In this PR I propose an async way of enqueuing updates. After every `request( api )` call, we await the next frame. This allows the browser to move on to other tasks, update the UI, switch to the "Saving..." state etc.

Note that this is a one-off fix for something that I believe is a symptom of using `redux-rungen` instead of `async/await`. I [explored refactoring that with](https://github.com/WordPress/gutenberg/pull/28389) @jsnajdr – it would make core-data async by default and potentially alleviate this problem. I'd love to pick up that work again – see https://github.com/WordPress/gutenberg/pull/33201.

## How has this been tested?

1. Go to the widgets editor
2. Add 50 widgets
3. Click "Update"
4. Confirm that it changes to "Saving..." pretty much immediately

## Types of changes
Bug fix (non-breaking change which fixes an issue)
