### PR TITLE
[RNMobile] Update userAgent override to be string instead of array

### DIFF
--- a/packages/react-native-editor/src/globals.js
+++ b/packages/react-native-editor/src/globals.js
@@ -59,7 +59,7 @@ if ( ! global.window.matchMedia ) {
 	} );
 }
 
-global.window.navigator.userAgent = [];
+global.window.navigator.userAgent = global.window.navigator.userAgent ?? '';
 
 // Leverages existing console polyfill from react-native
 global.nativeLoggingHook = nativeLoggingHook;


### PR DESCRIPTION
## Description

This fixes issues that arise because the JSDOM user agent was incorrectly overridden to be an empty array, instead of an empty string. Third-party libraries and code which queried the user agent errored out when they encountered the wrong type (expected string, got array). 

Related:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/3880

## How has this been tested?

Run the native mobile demo app and ensure it runs correctly.

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
