### PR TITLE
Accessibility improvement for font weight screen reader description

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -166,7 +166,8 @@ export default function FontAppearanceControl( props ) {
 	// Adjusts screen reader description based on styles or weights.
 	const getDescribedBy = () => {
 		if ( ! hasFontStyles ) {
-			return sprintf( // translators: %s: Currently selected font weight.
+			return sprintf(
+				// translators: %s: Currently selected font weight.
 				__( 'Currently selected font weight: %s' ),
 				currentSelection.name
 			);
@@ -181,10 +182,10 @@ export default function FontAppearanceControl( props ) {
 		}
 
 		return sprintf(
-		// translators: %s: Currently selected font appearance.
-		__( 'Currently selected font appearance: %s' ),
-		currentSelection.name
-	);
+			// translators: %s: Currently selected font appearance.
+			__( 'Currently selected font appearance: %s' ),
+			currentSelection.name
+		);
 	};
 
 	return (

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -163,12 +163,38 @@ export default function FontAppearanceControl( props ) {
 		return __( 'Appearance' );
 	};
 
+	// Adjusts screen reader description based on styles or weights.
+	const getDescribedBy = () => {
+		if ( ! hasFontStyles ) {
+			return sprintf(
+				// translators: %s: Currently selected font weight.
+				__( 'Currently selected font weight: %s' ),
+				currentSelection.name
+			);
+		}
+
+		if ( ! hasFontWeights ) {
+			return sprintf(
+				// translators: %s: Currently selected font style.
+				__( 'Currently selected font style: %s' ),
+				currentSelection.name
+			);
+		}
+
+		return sprintf(
+		// translators: %s: Currently selected font appearance.
+		__( 'Currently selected font appearance: %s' ),
+		currentSelection.name
+	);
+	};
+
 	return (
 		<fieldset className="components-font-appearance-control">
 			{ hasStylesOrWeights && (
 				<CustomSelectControl
 					className="components-font-appearance-control__select"
 					label={ getLabel() }
+					describedBy={ getDescribedBy() }
 					options={ selectOptions }
 					value={ currentSelection }
 					onChange={ ( { selectedItem } ) =>

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -166,8 +166,7 @@ export default function FontAppearanceControl( props ) {
 	// Adjusts screen reader description based on styles or weights.
 	const getDescribedBy = () => {
 		if ( ! hasFontStyles ) {
-			return sprintf(
-				// translators: %s: Currently selected font weight.
+			return sprintf( // translators: %s: Currently selected font weight.
 				__( 'Currently selected font weight: %s' ),
 				currentSelection.name
 			);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Add a function for custom description for currently selected font weight.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested on Windows using NVDA in Chrome and Firefox.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Quick Bug fix/improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
