### PR TITLE
Add getFilename method to the url package

### DIFF
--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -10,7 +10,7 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { getPath } from '@wordpress/url';
+import { getFilename } from '@wordpress/url';
 
 const transforms = {
 	from: [
@@ -71,11 +71,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/image' ],
 			transform: ( attributes ) => {
-				const filename = getPath( attributes.url )?.split( '/' ).pop();
-
 				return createBlock( 'core/file', {
 					href: attributes.url,
-					fileName: attributes.caption || filename,
+					fileName: attributes.caption || getFilename( attributes.url ),
 					textLinkHref: attributes.url,
 					id: attributes.id,
 					anchor: attributes.anchor,

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -73,7 +73,8 @@ const transforms = {
 			transform: ( attributes ) => {
 				return createBlock( 'core/file', {
 					href: attributes.url,
-					fileName: attributes.caption || getFilename( attributes.url ),
+					fileName:
+						attributes.caption || getFilename( attributes.url ),
 					textLinkHref: attributes.url,
 					id: attributes.id,
 					anchor: attributes.anchor,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, filter, map, last, pick, includes } from 'lodash';
+import { get, filter, map, pick, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
-import { getPath } from '@wordpress/url';
+import { getFilename } from '@wordpress/url';
 import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -48,13 +48,6 @@ import { isExternalImage } from './edit';
  * Module constants
  */
 import { MIN_SIZE, ALLOWED_MEDIA_TYPES } from './constants';
-
-function getFilename( url ) {
-	const path = getPath( url );
-	if ( path ) {
-		return last( path.split( '/' ) );
-	}
-}
 
 export default function Image( {
 	temporaryURL,

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -24,6 +24,7 @@ import {
 import { upload, media } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { getFilename } from '@wordpress/url';
 
 const ALLOWED_TYPES = [ 'text/vtt' ];
 
@@ -99,9 +100,7 @@ function TrackList( { tracks, onEditPress } ) {
 
 function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 	const { src = '', label = '', srcLang = '', kind = DEFAULT_KIND } = track;
-	const fileName = src.startsWith( 'blob:' )
-		? ''
-		: src.substring( src.lastIndexOf( '/' ) + 1 );
+	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
 		<NavigableMenu>
 			<div className="block-library-video-tracks-editor__single-track-editor">

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -132,6 +132,25 @@ _Returns_
 
 -   `string|void`: The authority part of the URL.
 
+### getFilename
+
+Returns the filename part of the URL.
+
+_Usage_
+
+```js
+const filename1 = getFilename( 'http://localhost:8080/this/is/a/test.jpg' ); // 'test.jpg'
+const filename2 = getFilename( '/this/is/a/test.png' ); // 'test.png'
+```
+
+_Parameters_
+
+-   _url_ `string`: The full URL.
+
+_Returns_
+
+-   `string|void`: The filename part of the URL.
+
 ### getFragment
 
 Returns the fragment part of the URL.

--- a/packages/url/src/get-filename.js
+++ b/packages/url/src/get-filename.js
@@ -1,0 +1,25 @@
+/**
+ * Returns the filename part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @example
+ * ```js
+ * const filename1 = getFilename( 'http://localhost:8080/this/is/a/test.jpg' ); // 'test.jpg'
+ * const filename2 = getFilename( '/this/is/a/test.png' ); // 'test.png'
+ * ```
+ *
+ * @return {string|void} The filename part of the URL.
+ */
+export function getFilename( url ) {
+	let filename;
+	try {
+		filename = new URL( url, 'http://example.com' ).pathname
+			.split( '/' )
+			.pop();
+	} catch ( error ) {}
+
+	if ( filename ) {
+		return filename;
+	}
+}

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -22,3 +22,4 @@ export { safeDecodeURI } from './safe-decode-uri';
 export { safeDecodeURIComponent } from './safe-decode-uri-component';
 export { filterURLForDisplay } from './filter-url-for-display';
 export { cleanForSlug } from './clean-for-slug';
+export { getFilename } from './get-filename';

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -29,6 +29,7 @@ import {
 	filterURLForDisplay,
 	cleanForSlug,
 	getQueryArgs,
+	getFilename,
 } from '../';
 import wptData from './fixtures/wpt-data';
 
@@ -240,6 +241,7 @@ describe( 'isValidPath', () => {
 		expect( isValidPath( 'relative/path' ) ).toBe( true );
 		expect( isValidPath( 'slightly/longer/path/' ) ).toBe( true );
 		expect( isValidPath( 'path/with/percent%20encoding' ) ).toBe( true );
+		expect( isValidPath( '/' ) ).toBe( true );
 	} );
 
 	it( 'returns false if the path is invalid', () => {
@@ -249,6 +251,42 @@ describe( 'isValidPath', () => {
 		expect( isValidPath( 'path/with/number/symbol#' ) ).toBe( false );
 		expect( isValidPath( 'path/with/question/mark?' ) ).toBe( false );
 		expect( isValidPath( ' path/with/padding ' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getFilename', () => {
+	it( 'returns the filename part of the URL', () => {
+		expect( getFilename( 'https://wordpress.org/image.jpg' ) ).toBe(
+			'image.jpg'
+		);
+		expect(
+			getFilename( 'https://wordpress.org/image.jpg?query=test' )
+		).toBe( 'image.jpg' );
+		expect( getFilename( 'https://wordpress.org/image.jpg#anchor' ) ).toBe(
+			'image.jpg'
+		);
+		expect(
+			getFilename( 'http://localhost:8080/a/path/to/an/image.jpg' )
+		).toBe( 'image.jpg' );
+		expect( getFilename( '/path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
+		expect( getFilename( 'path/to/an/image.jpg' ) ).toBe( 'image.jpg' );
+		expect( getFilename( '/image.jpg' ) ).toBe( 'image.jpg' );
+		expect( getFilename( 'image.jpg' ) ).toBe( 'image.jpg' );
+	} );
+
+	it( 'returns undefined when the provided value does not contain a filename', () => {
+		expect( getFilename( 'http://localhost:8080/' ) ).toBe( undefined );
+		expect( getFilename( 'http://localhost:8080/a/path/' ) ).toBe(
+			undefined
+		);
+		expect( getFilename( 'http://localhost:8080/?query=test' ) ).toBe(
+			undefined
+		);
+		expect( getFilename( 'http://localhost:8080/#anchor' ) ).toBe(
+			undefined
+		);
+		expect( getFilename( 'a/path/' ) ).toBe( undefined );
+		expect( getFilename( '/' ) ).toBe( undefined );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following on from feedback in https://github.com/WordPress/gutenberg/pull/34256#pullrequestreview-737443717 this code quality improvement PR adds in a `getFilename` method to the `url` package, and updates a few ad hoc approaches in the codebase that extract a filename from a url to use this method instead. Kudos @Mamaduka for the suggestion.

Instead of using `getPath` as a dependency, this method follows the pattern used in `getQueryString` of using the URL constructor — this allows `getFilename` to treat a file at root level in an absolute path as a valid filename, which isn't supported by `getPath` (since it doesn't include a slash for the root level).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 1. Running tests locally

```
npm run test-unit -- --testPathPattern packages/url/src/test/index.js
```

### 2. Test image block includes alt text within the editor that includes the filename

Add an image block and upload or add an image. Inspect the image element within the editor, and the `alt` text should reference the filename:

![image](https://user-images.githubusercontent.com/14988353/130901247-88127afa-95de-4e21-bfbc-9194d5bfe85a.png)

### 3. Convert an image block to a File block and check that it uses the filename

Convert the image to a File block, and the file name should be used as the File block's label:

![image](https://user-images.githubusercontent.com/14988353/130901618-3474cab3-0d72-418b-abc9-98e729d14c63.png)

### 4. Add a track file to a video block and check that the filename is used

1. Create a text file with the extension `.vtt`.
2. Add a video block and upload a video.
3. From the toolbar, select the Text Tracks button, and then click Upload underneath Add Tracks
4. Select your test `.vtt` file
5. The UI should show the correct filename: 

![image](https://user-images.githubusercontent.com/14988353/130901545-c047f958-e91f-42c4-898d-895f70573723.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Non-breaking change, code quality improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
