### PR TITLE
Fix button block focus trap after a URL has been added

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -160,7 +160,10 @@ function URLPicker( {
 					bindGlobal
 					shortcuts={ {
 						[ rawShortcut.primary( 'k' ) ]: startEditing,
-						[ rawShortcut.primaryShift( 'k' ) ]: unlink,
+						[ rawShortcut.primaryShift( 'k' ) ]: () => {
+							unlink();
+							richTextRef.current?.focus();
+						},
 					} }
 				/>
 			) }

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -38,6 +38,36 @@ describe( 'Buttons', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'moves focus from the link editor back to the button when escape is pressed after the URL has been submitted', async () => {
+		// Regression: https://github.com/WordPress/gutenberg/issues/34307
+		await insertBlock( 'Buttons' );
+		await pressKeyWithModifier( 'primary', 'k' );
+		await page.waitForFunction(
+			() => !! document.activeElement.closest( '.block-editor-url-input' )
+		);
+		await page.keyboard.type( 'https://example.com' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForFunction(
+			() =>
+				document.activeElement ===
+				document.querySelector(
+					'.block-editor-link-control a[href="https://example.com"]'
+				)
+		);
+		await page.keyboard.press( 'Escape' );
+
+		// Focus should move from the link control to the button block's text.
+		await page.waitForFunction(
+			() =>
+				document.activeElement ===
+				document.querySelector( '[aria-label="Button text"]' )
+		);
+
+		// The link control should still be visible when a URL is set.
+		const linkControl = await page.$( '.block-editor-link-control' );
+		expect( linkControl ).toBeTruthy();
+	} );
+
 	it( 'can jump to the link editor using the keyboard shortcut', async () => {
 		await insertBlock( 'Buttons' );
 		await page.keyboard.type( 'WordPress' );


### PR DESCRIPTION
## Description
Fixes #34307

The button block unfortunately has a focus trap. I've reworked it to be more like the link format. Unfortunately it's quite a sizeable change. It might be worth looking at refactoring the delicate way focus and visibility for LinkControl works into a React hook if that's possible, so that the implementation can be shared across the codebase.

This is a bad enough bug that I'm suggesting it should be included in WordPress 5.8.1.

## How has this been tested?
1. Create a button block and enter text link
2. Open the link control toggle by using Ctrl+K or ⌘+K
3. Once the toggle opens, search a post or page in the search bar
4. Select a post or page using down arrow key
5. Use Enter to submit
6. Press escape, focus should move back to the RichText. The link control remains visible so that users can see what the URL is.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
