### PR TITLE
Fix gray W menu color.

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -11,7 +11,7 @@
 		align-items: center;
 		align-self: stretch;
 		border: none;
-		background: #23282e; // WP-admin gray.
+		background: $gray-900;
 		color: $white;
 		border-radius: 0;
 		height: $header-height + $border-width;
@@ -38,7 +38,7 @@
 			bottom: 9px;
 			left: 9px;
 			border-radius: $radius-block-ui + $border-width + $border-width;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #23282e;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
 		}
 
 		// Hover color.

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -17,9 +17,10 @@
 	background: $gray-900;
 	border-radius: 0;
 	color: $white;
-	height: $header-height;
+	height: $header-height + $border-width;
 	width: $header-height;
 	z-index: 1;
+	margin-bottom: - $border-width;
 
 	&.has-icon {
 		min-width: $header-height;
@@ -44,7 +45,7 @@
 			bottom: 9px;
 			left: 9px;
 			border-radius: $radius-block-ui + $border-width + $border-width;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #23282e;
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
 		}
 
 		// Hover color.


### PR DESCRIPTION
## Description

From the department of subtleties, this PR makes a barely perceptible but still important change. Here's the post editor W menu:

<img width="105" alt="post editor" src="https://user-images.githubusercontent.com/1204802/130925182-cae3720a-a49d-47ac-a495-9878ab61d822.png">

Here's the site editor W menu:

<img width="131" alt="site editor" src="https://user-images.githubusercontent.com/1204802/130925197-6deb552a-c39b-4c75-89ad-2b1049c48fbb.png">

Spot the difference? Here's a zoomed version of the site editor menu:

![zoom](https://user-images.githubusercontent.com/1204802/130925238-5376a9b0-d072-4665-81f9-36c08b50a141.png)

Notice how there's a cold-gray halo, and how the black square does not overlap the gray border below.

This PR unifies the appearance of both, so they are both the same height, same color, and with no halo:

<img width="197" alt="after" src="https://user-images.githubusercontent.com/1204802/130925502-a47658c5-ee11-42d5-984e-5b456a6ed2e2.png">

![after-zoomed](https://user-images.githubusercontent.com/1204802/130925506-afeb55d8-5401-4354-a058-cd8d0a0c1def.png)

One thought this PR surfaces: it would be really nice if we could reduce the drift between the two editors, so improvements to one benefits the other, rather than all this code duplication going on.

## How has this been tested?

Please test that the post editor and site editor W menus look the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
