### PR TITLE
Fix subheadings from wrapping.

### DIFF
--- a/packages/components/src/menu-group/style.scss
+++ b/packages/components/src/menu-group/style.scss
@@ -18,4 +18,5 @@
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
+	white-space: nowrap;
 }


### PR DESCRIPTION
## Description

A recent change to remove a popover menu min width caused this:

<img width="185" alt="Screenshot 2021-08-26 at 10 30 56" src="https://user-images.githubusercontent.com/1204802/130929733-78cc41b2-58e2-45d1-8347-dc114efd7bbd.png">

This PR just prevents those subheadings from wrapping, fixing it:

<img width="196" alt="Screenshot 2021-08-26 at 10 31 54" src="https://user-images.githubusercontent.com/1204802/130929758-dda3ee75-fd9d-4fd9-89dc-37a7dc67d2f2.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
