### PR TITLE
Memoize entity records selectors properly

### DIFF
--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -134,40 +134,63 @@ export function getEntity( state, kind, name ) {
  *
  * @return {Object?} Record.
  */
-export function getEntityRecord( state, kind, name, key, query ) {
-	const queriedState = get( state.entities.data, [
-		kind,
-		name,
-		'queriedData',
-	] );
-	if ( ! queriedState ) {
-		return undefined;
-	}
-	const context = query?.context ?? 'default';
-
-	if ( query === undefined ) {
-		// If expecting a complete item, validate that completeness.
-		if ( ! queriedState.itemIsComplete[ context ]?.[ key ] ) {
+export const getEntityRecord = createSelector(
+	( state, kind, name, key, query ) => {
+		const queriedState = get( state.entities.data, [
+			kind,
+			name,
+			'queriedData',
+		] );
+		if ( ! queriedState ) {
 			return undefined;
 		}
+		const context = query?.context ?? 'default';
 
-		return queriedState.items[ context ][ key ];
-	}
+		if ( query === undefined ) {
+			// If expecting a complete item, validate that completeness.
+			if ( ! queriedState.itemIsComplete[ context ]?.[ key ] ) {
+				return undefined;
+			}
 
-	const item = queriedState.items[ context ]?.[ key ];
-	if ( item && query._fields ) {
-		const filteredItem = {};
-		const fields = getNormalizedCommaSeparable( query._fields );
-		for ( let f = 0; f < fields.length; f++ ) {
-			const field = fields[ f ].split( '.' );
-			const value = get( item, field );
-			set( filteredItem, field, value );
+			return queriedState.items[ context ][ key ];
 		}
-		return filteredItem;
-	}
 
-	return item;
-}
+		const item = queriedState.items[ context ]?.[ key ];
+		if ( item && query._fields ) {
+			const filteredItem = {};
+			const fields = getNormalizedCommaSeparable( query._fields );
+			for ( let f = 0; f < fields.length; f++ ) {
+				const field = fields[ f ].split( '.' );
+				const value = get( item, field );
+				set( filteredItem, field, value );
+			}
+			return filteredItem;
+		}
+
+		return item;
+	},
+	( state, kind, name, recordId, query ) => {
+		const context = query?.context ?? 'default';
+		return [
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'items',
+				context,
+				recordId,
+			] ),
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'itemIsComplete',
+				context,
+				recordId,
+			] ),
+		];
+	}
+);
 
 /**
  * Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
@@ -221,7 +244,27 @@ export const getRawEntityRecord = createSelector(
 			}, {} )
 		);
 	},
-	( state ) => [ state.entities.data ]
+	( state, kind, name, recordId, query ) => {
+		const context = query?.context ?? 'default';
+		return [
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'items',
+				context,
+				recordId,
+			] ),
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'itemIsComplete',
+				context,
+				recordId,
+			] ),
+		];
+	}
 );
 
 /**
@@ -408,7 +451,10 @@ export const getEntityRecordNonTransientEdits = createSelector(
 			return acc;
 		}, {} );
 	},
-	( state ) => [ state.entities.config, state.entities.data ]
+	( state, kind, name, recordId ) => [
+		state.entities.config,
+		get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+	]
 );
 
 /**
@@ -446,7 +492,28 @@ export const getEditedEntityRecord = createSelector(
 		...getRawEntityRecord( state, kind, name, recordId ),
 		...getEntityRecordEdits( state, kind, name, recordId ),
 	} ),
-	( state ) => [ state.entities.data ]
+	( state, kind, name, recordId, query ) => {
+		const context = query?.context ?? 'default';
+		return [
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'items',
+				context,
+				recordId,
+			] ),
+			get( state.entities.data, [
+				kind,
+				name,
+				'queriedData',
+				'itemIsComplete',
+				context,
+				recordId,
+			] ),
+			get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+		];
+	}
 );
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -247,6 +247,7 @@ export const getRawEntityRecord = createSelector(
 	( state, kind, name, recordId, query ) => {
 		const context = query?.context ?? 'default';
 		return [
+			state.entities.config,
 			get( state.entities.data, [
 				kind,
 				name,
@@ -495,6 +496,7 @@ export const getEditedEntityRecord = createSelector(
 	( state, kind, name, recordId, query ) => {
 		const context = query?.context ?? 'default';
 		return [
+			state.entities.config,
 			get( state.entities.data, [
 				kind,
 				name,


### PR DESCRIPTION
Extracted from #32106 

the current getTemplate selector calls in the `Editor` component are causing the rerendering of the whole editor while typing, this should improve it. I'm not sure whether this will have an impact on the "typing" metric but personally I did notice some calls in the trace related to this.