### PR TITLE
Disable Xdebug by default unless specified by user

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Fix Xdebug installation code to ensure it would fail gracefully
+
 ## 4.0.3 (2021-04-29)
 
 ### Bug Fix

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -109,21 +109,21 @@ module.exports = async function initConfig( {
 function dockerFileContents( image, config ) {
 	// Don't install XDebug unless it is explicitly required
 	let shouldInstallXdebug = false;
-	
+
 	if ( config.xdebug !== 'off' ) {
 		if ( config.env.development.phpVersion ) {
 			const versionTokens = config.env.development.phpVersion.split( '.' );
 			const majorVersion = parseInt( versionTokens[ 0 ] );
 			const minorVersion = parseInt( versionTokens[ 1 ] );
-			
+
 			if ( isNaN( majorVersion ) || isNaN( minorVersion ) ) {
 				throw new Error( 'Something went wrong parsing the php version.' );
 			}
-			
+
 			// Xdebug 3 supports 7.2 and higher.
 			// Enable Xdebug for PHP >= 7.2.
 			const usingCompatiblePhpVersion = majorVersion > 7 && minorVersion >= 2;
-			
+
 			if ( usingCompatiblePhpVersion ) {
 				shouldInstallXdebug = true;
 			} else {
@@ -134,7 +134,7 @@ function dockerFileContents( image, config ) {
 			// which is supported by Xdebug 3.
 			shouldInstallXdebug = true;
 		}
-		
+
 	}
 
 	return `FROM ${ image }

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -119,9 +119,12 @@ function dockerFileContents( image, config ) {
 			if ( isNaN( majorVersion ) || isNaN( minorVersion ) ) {
 				throw new Error( 'Something went wrong parsing the php version.' );
 			}
-
-			// Disable Xdebug for PHP < 7.2. Xdebug 3 supports 7.2 and higher.
-			if ( majorVersion > 7 && minorVersion >= 2 ) {
+			
+			// Xdebug 3 supports 7.2 and higher.
+			// Enable Xdebug for PHP >= 7.2.
+			const usingCompatiblePhpVersion = majorVersion > 7 && minorVersion >= 2;
+			
+			if usingCompatiblePhpVersion {
 				shouldInstallXdebug = true;
 			} else {
 				throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -99,23 +99,21 @@ module.exports = async function initConfig( {
 };
 
 /**
- * Checks the configured PHP version 
+ * Checks the configured PHP version
  * against the minimum version supported by Xdebug
- * 
- * @param {WPConfig} config 
+ *
+ * @param {WPConfig} config
  * @return {boolean} Whether the PHP version is supported by Xdebug
  */
 function checkXdebugPhpCompatibility( config ) {
 	// By default, an undefined phpVersion uses the version on the docker image,
 	// which is supported by Xdebug 3.
-	let phpCompatibility = true;
+	const phpCompatibility = true;
 
 	// If PHP version is defined
 	// ensure it meets the Xdebug minimum compatibility requirment
 	if ( config.env.development.phpVersion ) {
-		const versionTokens = config.env.development.phpVersion.split(
-			'.'
-		);
+		const versionTokens = config.env.development.phpVersion.split( '.' );
 		const majorVer = parseInt( versionTokens[ 0 ] );
 		const minorVer = parseInt( versionTokens[ 1 ] );
 
@@ -148,7 +146,7 @@ function dockerFileContents( image, config ) {
 	let shouldInstallXdebug = false;
 
 	if ( config.xdebug !== 'off' ) {
-		const usingCompatiblePhp = checkXdebugPhpCompatibility(config);
+		const usingCompatiblePhp = checkXdebugPhpCompatibility( config );
 
 		if ( usingCompatiblePhp ) {
 			shouldInstallXdebug = true;

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -124,7 +124,7 @@ function dockerFileContents( image, config ) {
 			// Enable Xdebug for PHP >= 7.2.
 			const usingCompatiblePhpVersion = majorVersion > 7 && minorVersion >= 2;
 			
-			if usingCompatiblePhpVersion {
+			if ( usingCompatiblePhpVersion ) {
 				shouldInstallXdebug = true;
 			} else {
 				throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -103,7 +103,7 @@ module.exports = async function initConfig( {
  * against the minimum version supported by Xdebug
  * 
  * @param {WPConfig} config 
- * @return {bool} Whether the PHP version is supported by Xdebug
+ * @return {boolean} Whether the PHP version is supported by Xdebug
  */
 function checkXdebugPhpCompatibility( config ) {
 	// By default, an undefined phpVersion uses the version on the docker image,

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -111,8 +111,6 @@ function dockerFileContents( image, config ) {
 	let shouldInstallXdebug = false;
 	
 	if (config.xdebug !== 'off') {
-		// By default, an undefined phpVersion uses the version on the docker image,
-		// which is supported by Xdebug 3.
 		if ( config.env.development.phpVersion ) {
 			const versionTokens = config.env.development.phpVersion.split( '.' );
 			const majorVersion = parseInt( versionTokens[ 0 ] );
@@ -128,6 +126,10 @@ function dockerFileContents( image, config ) {
 			} else {
 				throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );
 			}
+		} else {
+			// By default, an undefined phpVersion uses the version on the docker image,
+			// which is supported by Xdebug 3.
+			shouldInstallXdebug = true;
 		}
 		
 	}

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -110,7 +110,7 @@ function dockerFileContents( image, config ) {
 	// Don't install XDebug unless it is explicitly required
 	let shouldInstallXdebug = false;
 	
-	if (config.xdebug !== 'off') {
+	if ( config.xdebug !== 'off' ) {
 		if ( config.env.development.phpVersion ) {
 			const versionTokens = config.env.development.phpVersion.split( '.' );
 			const majorVersion = parseInt( versionTokens[ 0 ] );

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -117,24 +117,21 @@ function dockerFileContents( image, config ) {
 			const minorVersion = parseInt( versionTokens[ 1 ] );
 
 			if ( isNaN( majorVersion ) || isNaN( minorVersion ) ) {
-				throw new Error( 'Something went wrong parsing the php version.' );
+				throw new Error( 'Something went wrong when parsing the PHP version.' );
 			}
 
-			// Xdebug 3 supports 7.2 and higher.
-			// Enable Xdebug for PHP >= 7.2.
-			const usingCompatiblePhpVersion = majorVersion > 7 && minorVersion >= 2;
+			// Xdebug 3 supports 7.2 and higher
+			// Ensure user has specified a compatible PHP version
+			const usingInompatiblePhpVersion = majorVersion < 7 || ( majorVersion === 7 && minorVersion < 2 );
 
-			if ( usingCompatiblePhpVersion ) {
-				shouldInstallXdebug = true;
-			} else {
+			if ( usingInompatiblePhpVersion ) {
 				throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );
 			}
-		} else {
-			// By default, an undefined phpVersion uses the version on the docker image,
-			// which is supported by Xdebug 3.
-			shouldInstallXdebug = true;
 		}
 
+		// By default, an undefined phpVersion uses the version on the docker image,
+		// which is supported by Xdebug 3.
+		shouldInstallXdebug = true;
 	}
 
 	return `FROM ${ image }

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -112,19 +112,23 @@ function dockerFileContents( image, config ) {
 
 	if ( config.xdebug !== 'off' ) {
 		if ( config.env.development.phpVersion ) {
-			const versionTokens = config.env.development.phpVersion.split( '.' );
+			const versionTokens = config.env.development.phpVersion.split(
+				'.'
+			);
 			const majorVersion = parseInt( versionTokens[ 0 ] );
 			const minorVersion = parseInt( versionTokens[ 1 ] );
 
 			if ( isNaN( majorVersion ) || isNaN( minorVersion ) ) {
-				throw new Error( 'Something went wrong when parsing the PHP version.' );
+				throw new Error(
+					'Something went wrong when parsing the PHP version.'
+				);
 			}
 
 			// Xdebug 3 supports 7.2 and higher
 			// Ensure user has specified a compatible PHP version
-			const usingInompatiblePhpVersion = majorVersion < 7 || ( majorVersion === 7 && minorVersion < 2 );
+			const inompatiblePhp = majorVersion < 7 || ( majorVersion === 7 && minorVersion < 2 );
 
-			if ( usingInompatiblePhpVersion ) {
+			if ( inompatiblePhp ) {
 				throw new Error( 'Cannot use XDebug 3 on PHP < 7.2.' );
 			}
 		}

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -150,7 +150,8 @@ function installXdebug( enableXdebug ) {
 
 	return `
 # Install Xdebug:
-RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN if [ -z "$(pecl list | grep xdebug)" ] ; then pecl install xdebug ; fi
+RUN docker-php-ext-enable xdebug
 RUN echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/php.ini
 RUN echo 'xdebug.mode=${ enableXdebug }' >> /usr/local/etc/php/php.ini
 RUN echo '${ clientDetectSettings }' >> /usr/local/etc/php/php.ini


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Currently, `wp-env` installs Xdebug regardless of whether the user has requested it. The only installation check is based on PHP version being 7.2+.

Xdebug shouldn't be installed unless specified by the user. Likewise, the Docker file should be more careful when running the `pecl install xdebug`  command, as [noted by @noahtallen](https://github.com/WordPress/gutenberg/pull/35667#issuecomment-953278245). 

The added complexity of the Xdebug installation is causing some other issues:

- https://github.com/WordPress/gutenberg/issues/30213
- https://github.com/WordPress/gutenberg/issues/27783
- https://github.com/WordPress/gutenberg/issues/34320

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
