### PR TITLE
Code cleanup to the getBlock refactoring

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1215,11 +1215,11 @@ _Parameters_
 
 ### receiveBlocks
 
+> **Deprecated**
+
 Returns an action object used in signalling that blocks have been received.
 Unlike resetBlocks, these should be appended to the existing known set, not
 replacing.
-
-Todo: This should be deprecated
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -225,7 +225,7 @@ export default compose( [
 
 			const isReadOnly = getSettings().readOnly;
 
-			const { attributes, name } = getBlock( clientId );
+			const { attributes, name } = getBlock( clientId ) || {};
 			const { align } = attributes || {};
 			const parents = getBlockParents( clientId, true );
 			const hasParents = !! parents.length;

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -151,13 +151,18 @@ export function resetSelection(
  * Unlike resetBlocks, these should be appended to the existing known set, not
  * replacing.
  *
- * Todo: This should be deprecated
+ * @deprecated
  *
  * @param {Object[]} blocks Array of block objects.
  *
  * @return {Object} Action object.
  */
 export function receiveBlocks( blocks ) {
+	deprecated( 'wp.data.dispatch( "core/block-editor" ).receiveBlocks', {
+		since: '5.9',
+		alternative: 'resetBlocks or insertBlocks',
+	} );
+
 	return {
 		type: 'RECEIVE_BLOCKS',
 		blocks,


### PR DESCRIPTION
follow-up to #34241

See https://github.com/WordPress/gutenberg/pull/34241/files/a741d274102063971d85288633e8c3d058f1ffb3#diff-e7c866ee1322cae46d455c1089c531e9e0e95b49454c8a1334d48d16a7eb3df9