### PR TITLE
Jest Preset: Restore the default setting for the `verbose` option

### DIFF
--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Restore the default setting for the `verbose` option. In effect, each test won't get reported during the run ([#34327](https://github.com/WordPress/gutenberg/pull/34327)).
+
 ## 7.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -26,5 +26,4 @@ module.exports = {
 	transform: {
 		'^.+\\.[jt]sx?$': require.resolve( 'babel-jest' ),
 	},
-	verbose: true,
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

According to the README file of the `@wordpress/jest-preset-default` package the [`verbose`](https://jestjs.io/docs/configuration#verbose-boolean) option should be disabled

> -   `verbose` - each individual test won't be reported during the run.

The full description in Jest:

> Default: `false`
> Indicates whether each individual test should be reported during the run. All errors will also still be shown on the bottom after execution. Note that if there is only one test file being run it will default to `true`.

### Before

<img width="679" alt="Screen Shot 2021-08-26 at 12 26 07" src="https://user-images.githubusercontent.com/699132/130947556-0aa3d72f-b22f-40e1-9500-ab492b6dfaf7.png">

### After

<img width="729" alt="Screen Shot 2021-08-26 at 12 29 07" src="https://user-images.githubusercontent.com/699132/130947537-ed99f2ef-67ef-4b94-a3c8-124c556ec76d.png">

The execution time is 4-5 times faster with this flag disabled so I have no idea why this setting was changed.