### PR TITLE
Fix Column bottom sheet Android close button

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/style.native.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.native.scss
@@ -27,4 +27,6 @@
 
 .closeIcon {
 	color: $gray;
+	margin-left: $grid-unit-20;
+	padding: $grid-unit-20;
 }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Column block: Fix Android close button alignment. [#34332]
 
 ## 1.60.0
 -   [**] Embed block: Add "Resize for smaller devices" setting. [#33654]


### PR DESCRIPTION
## Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3876

## Description
Apply required margin and padding to properly align Android close button in the Column block bottom sheet. Relates to https://github.com/WordPress/gutenberg/pull/34249.

## How has this been tested?
Performed the following on both Android and iOS.

1. Open the block editor. 
2. Add a Column block. 
3. **Expected:** The X/Cancel button is correctly aligned on the left side of the bottom sheet, and not flush with the left side of the screen. 

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| ![column-before-android](https://user-images.githubusercontent.com/438664/130978721-b5e5fd03-a2a0-4514-adab-abed17945b4f.jpg) | ![column-after-android](https://user-images.githubusercontent.com/438664/130978763-eef336a2-d729-45c1-a36c-c8152adc70f4.jpg) |
| ![column-before-ios](https://user-images.githubusercontent.com/438664/130978795-5d89f76c-bbb2-4f4c-9af3-5d867e9cc453.jpeg) | ![column-after-ios](https://user-images.githubusercontent.com/438664/130978795-5d89f76c-bbb2-4f4c-9af3-5d867e9cc453.jpeg) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
