### PR TITLE
Make global styles available to all themes

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -799,8 +799,33 @@ class WP_Theme_JSON_Gutenberg {
 	 *     style-property-one: value;
 	 *   }
 	 *
-	 * Additionally, it'll also create new rulesets
-	 * as classes for each preset value such as:
+	 * @param array $style_nodes Nodes with styles.
+	 *
+	 * @return string The new stylesheet.
+	 */
+	private function get_block_classes( $style_nodes ) {
+		$block_rules = '';
+
+		foreach ( $style_nodes as $metadata ) {
+			if ( null === $metadata['selector'] ) {
+				continue;
+			}
+
+			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			$selector     = $metadata['selector'];
+			$declarations = self::compute_style_properties( $node );
+			$block_rules .= self::to_ruleset( $selector, $declarations );
+
+			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
+				$block_rules .= '.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }';
+			}
+		}
+
+		return $block_rules;
+	}
+
+	/**
+	 * Creates new rulesets as classes for each preset value such as:
 	 *
 	 *   .has-value-color {
 	 *     color: value;
@@ -821,30 +846,14 @@ class WP_Theme_JSON_Gutenberg {
 	 *   p.has-value-gradient-background {
 	 *     background: value;
 	 *   }
-	 *
-	 * @param array $style_nodes Nodes with styles.
+
 	 * @param array $setting_nodes Nodes with settings.
 	 *
 	 * @return string The new stylesheet.
 	 */
-	private function get_block_styles( $style_nodes, $setting_nodes ) {
-		$block_rules = '';
-		foreach ( $style_nodes as $metadata ) {
-			if ( null === $metadata['selector'] ) {
-				continue;
-			}
-
-			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
-			$selector     = $metadata['selector'];
-			$declarations = self::compute_style_properties( $node );
-			$block_rules .= self::to_ruleset( $selector, $declarations );
-
-			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
-				$block_rules .= '.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }';
-			}
-		}
-
+	private function get_preset_classes( $setting_nodes ) {
 		$preset_rules = '';
+
 		foreach ( $setting_nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
 				continue;
@@ -855,7 +864,7 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_rules .= self::compute_preset_classes( $node, $selector );
 		}
 
-		return $block_rules . $preset_rules;
+		return $preset_rules;
 	}
 
 	/**
@@ -1053,7 +1062,11 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the stylesheet that results of processing
 	 * the theme.json structure this object represents.
 	 *
-	 * @param string $type Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+	 * @param string $type Type of stylesheet. It accepts:
+	 *                     'all': css variables, block classes, preset classes. The default.
+	 *                     'block_styles': only block & preset classes.
+	 *                     'css_variables': only css variables.
+	 *                     'presets': only css variables and preset classes.
 	 * @return string Stylesheet.
 	 */
 	public function get_stylesheet( $type = 'all' ) {
@@ -1063,11 +1076,13 @@ class WP_Theme_JSON_Gutenberg {
 
 		switch ( $type ) {
 			case 'block_styles':
-				return $this->get_block_styles( $style_nodes, $setting_nodes );
+				return $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes );
 			case 'css_variables':
 				return $this->get_css_variables( $setting_nodes );
+			case 'presets':
+				return $this->get_css_variables( $setting_nodes ) . $this->get_preset_classes( $setting_nodes );
 			default:
-				return $this->get_css_variables( $setting_nodes ) . $this->get_block_styles( $style_nodes, $setting_nodes );
+				return $this->get_css_variables( $setting_nodes ) . $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes );
 		}
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -407,10 +407,17 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON_Gutenberg
 	 */
 	public static function get_merged_data( $settings = array(), $origin = 'user' ) {
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
-
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
+
+		if (
+			! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
+			! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
+		) {
+			return $result;
+		}
+
+		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
 		if ( 'user' === $origin ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -48,12 +48,6 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	if (
-		! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
-		! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		return;
-	}
-
 	$settings = gutenberg_get_default_block_editor_settings();
 	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,7 +10,7 @@
  * the corresponding stylesheet.
  *
  * @param WP_Theme_JSON_Gutenberg $tree Input tree.
- * @param string                  $type Type of stylesheet we want accepts 'all', 'block_styles', and 'css_variables'.
+ * @param string                  $type Type of stylesheet we want accepts 'all', 'block_styles', 'css_variables', and 'presets'.
  *
  * @return string Stylesheet.
  */
@@ -51,7 +51,11 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 	$settings = gutenberg_get_default_block_editor_settings();
 	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
 
-	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
+	$type = 'all';
+	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		$type = 'presets';
+	}
+	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all, $type );
 	if ( empty( $stylesheet ) ) {
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34328

This PR makes global styles available to all themes.

1. Themes without theme.json and no experimental-link-color support either: the stylesheet contains the core presets.
2. Themes without theme.json but experimental-link-color support: the stylesheet contains the core and theme presets.
3. Themes with theme.json: the stylesheet contains the core and theme presets, plus the result of merging core & theme styles.

## How to test

Activate **TT1-blocks**: a theme with `theme.json` support. Visit the front end. Check the content of `global-styles-inline-css` is:
- Both core & theme presets (classes and variables).
- The block gap styles ([see](https://github.com/WordPress/gutenberg/pull/34334#issuecomment-906498931)).
- The theme styles.

Activate the **TwentyTwentyOne** theme: a theme without theme.json but with `experimental-link-color` support. Visit the front end. Check the content of `global-styles-inline-css` is:
- Both core & theme presets (classes and variables).

Activate the **TwentyTwenty** theme: a theme without theme.json and no `experimental-link-color` support. Visit the front end. Check the content of `global-styles-inline-css` is:
- Core presets (classes & variables).

## Follow-ups

Remove the styles included here from the `block-library` package.