### PR TITLE
[RNmobile] Fix  iOS inserter search focus issue

### DIFF
--- a/packages/components/src/search-control/index.native.js
+++ b/packages/components/src/search-control/index.native.js
@@ -121,7 +121,9 @@ function SearchControl( {
 		const keyboardHideSubscription = Keyboard.addListener(
 			'keyboardDidHide',
 			() => {
-				onCancel();
+				if ( ! isIOS ) {
+					onCancel();
+				}
 			}
 		);
 		return () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This fixes an issue where the inserter search input losses focus immediately when tapped. 
The issue is iOS only.

Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3877

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Open up the inserter on an iOS device with a hardware keyboard connected or on a sim with the `Connect Hardware Keyboard` option selected.
- Finger tap on the inserter search input
- The Inserter Search input should stay focused

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
#34278 introduced a fix for cases when the inserter search was active and the keyboard is manually closed on Android. This left the inserter in an active state when , with the keyboard closed, should return to an inactive state.

This changes that flow to apply to Android only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
