### PR TITLE
Block Navigation List: do not show appender and avoid closing the modal on block select

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -11,6 +11,7 @@ import {
 	useMemo,
 	useRef,
 	useReducer,
+	forwardRef,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -48,15 +49,19 @@ const expanded = ( state, action ) => {
  * @param {boolean}  props.showOnlyCurrentHierarchy                 Flag to limit the list to the current hierarchy of blocks.
  * @param {boolean}  props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean}  props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
+ * @param {Object}   ref                                            Forwarded ref
  */
-export default function ListView( {
-	blocks,
-	showOnlyCurrentHierarchy,
-	onSelect = noop,
-	__experimentalFeatures,
-	__experimentalPersistentListViewFeatures,
-	...props
-} ) {
+function ListView(
+	{
+		blocks,
+		showOnlyCurrentHierarchy,
+		onSelect = noop,
+		__experimentalFeatures,
+		__experimentalPersistentListViewFeatures,
+		...props
+	},
+	ref
+) {
 	const { clientIdsTree, selectedClientIds } = useListViewClientIds(
 		blocks,
 		showOnlyCurrentHierarchy,
@@ -74,7 +79,7 @@ export default function ListView( {
 
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone();
 	const elementRef = useRef();
-	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef ] );
+	const treeGridRef = useMergeRefs( [ elementRef, dropZoneRef, ref ] );
 
 	const isMounted = useRef( false );
 	useEffect( () => {
@@ -144,3 +149,4 @@ export default function ListView( {
 		</>
 	);
 }
+export default forwardRef( ListView );

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -6,6 +6,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { useRef, useEffect, useState } from '@wordpress/element';
 
 export default function BlockNavigationList( {
 	clientId,
@@ -17,12 +18,21 @@ export default function BlockNavigationList( {
 		[ clientId ]
 	);
 
+	const listViewRef = useRef();
+	const [ minHeight, setMinHeight ] = useState( 300 );
+	useEffect( () => {
+		setMinHeight( listViewRef?.current?.clientHeight ?? 300 );
+	}, [] );
+
 	return (
-		<ListView
-			blocks={ blocks }
-			showBlockMovers
-			showNestedBlocks
-			__experimentalFeatures={ __experimentalFeatures }
-		/>
+		<div style={ { minHeight } }>
+			<ListView
+				ref={ listViewRef }
+				blocks={ blocks }
+				showBlockMovers
+				showNestedBlocks
+				__experimentalFeatures={ __experimentalFeatures }
+			/>
+		</div>
 	);
 }

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -20,7 +20,6 @@ export default function BlockNavigationList( {
 	return (
 		<ListView
 			blocks={ blocks }
-			showAppender
 			showBlockMovers
 			showNestedBlocks
 			__experimentalFeatures={ __experimentalFeatures }

--- a/packages/block-library/src/navigation/use-block-navigator.js
+++ b/packages/block-library/src/navigation/use-block-navigator.js
@@ -30,6 +30,7 @@ export default function useBlockNavigator( clientId, __experimentalFeatures ) {
 			onRequestClose={ () => {
 				setIsNavigationListOpen( false );
 			} }
+			shouldCloseOnClickOutside={ false }
 		>
 			<BlockNavigationList
 				clientId={ clientId }


### PR DESCRIPTION
This PR includes some small quality of life tweaks to the block navigation list modal. Changes here include:

* Not closing the modal on select.
* Avoiding modal close when dragging https://github.com/WordPress/gutenberg/issues/34254
* Removing the appender (since this was unreachable before and would make the inserter appear under the modal)
* Keeping the modal stable with a min-height. This avoids having the modal shift in size as we drag items.

#### After

https://user-images.githubusercontent.com/1270189/131001666-32e6858f-487d-4841-a5f0-a8c4f4b230c0.mp4

https://user-images.githubusercontent.com/1270189/131012186-48512720-e9f3-43dc-9162-cf9c5bfa6fb8.mp4

#### Before

https://user-images.githubusercontent.com/1270189/131002235-88c8feff-85ef-460d-9f09-04ec2771a11d.mp4

https://user-images.githubusercontent.com/1270189/131012139-53ceefa9-2bd0-44f5-85d3-a39844bc0fae.mp4

### Testing Instructions
 - Open an editor and add a navigation block with some links
 - Select the navigation block, then click on the "open block navigation" icon
<img width="723" alt="Screen Shot 2021-08-26 at 9 42 51 AM" src="https://user-images.githubusercontent.com/1270189/131002416-2ff88558-114b-4245-b0bf-a565d61f239d.png">

- Verify that trunk closes the modal on block item click
- Verify that this branch does not close the modal on block item click
- Verify that there are no drag regressions or regressions in the persistent list view
