### PR TITLE
i18n: Add context to 'none' strings for better translations

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -169,7 +169,10 @@ function AudioEdit( {
 							{ value: '', label: __( 'Browser default' ) },
 							{ value: 'auto', label: __( 'Auto' ) },
 							{ value: 'metadata', label: __( 'Metadata' ) },
-							{ value: 'none', label: _x( 'None', '"Preload" value' ) },
+							{
+								value: 'none',
+								label: _x( 'None', '"Preload" value' ),
+							},
 						] }
 					/>
 				</PanelBody>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -20,7 +20,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
@@ -157,7 +157,7 @@ function AudioEdit( {
 						checked={ loop }
 					/>
 					<SelectControl
-						label={ __( 'Preload' ) }
+						label={ _x( 'Preload', 'noun; Audio block parameter' ) }
 						value={ preload || '' }
 						// `undefined` is required for the preload attribute to be unset.
 						onChange={ ( value ) =>
@@ -169,7 +169,7 @@ function AudioEdit( {
 							{ value: '', label: __( 'Browser default' ) },
 							{ value: 'auto', label: __( 'Auto' ) },
 							{ value: 'metadata', label: __( 'Metadata' ) },
-							{ value: 'none', label: __( 'None' ) },
+							{ value: 'none', label: _x( 'None', '"Preload" value' ) },
 						] }
 					/>
 				</PanelBody>

--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -197,7 +197,10 @@ function AudioEdit( {
 							checked={ loop }
 						/>
 						<SelectControl
-							label={ _x( 'Preload', 'noun; Audio block parameter' ) }
+							label={ _x(
+								'Preload',
+								'noun; Audio block parameter'
+							) }
 							value={ preload || '' }
 							// `undefined` is required for the preload attribute to be unset.
 							onChange={ ( value ) =>
@@ -209,7 +212,10 @@ function AudioEdit( {
 								{ value: '', label: __( 'Browser default' ) },
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },
-								{ value: 'none', label: _x( 'None', '"Preload" value' ) },
+								{
+									value: 'none',
+									label: _x( 'None', '"Preload" value' ),
+								},
 							] }
 							hideCancelButton={ true }
 						/>

--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -26,7 +26,7 @@ import {
 	MediaUploadProgress,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { audio as icon, replace } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -197,7 +197,7 @@ function AudioEdit( {
 							checked={ loop }
 						/>
 						<SelectControl
-							label={ __( 'Preload' ) }
+							label={ _x( 'Preload', 'noun; Audio block parameter' ) }
 							value={ preload || '' }
 							// `undefined` is required for the preload attribute to be unset.
 							onChange={ ( value ) =>
@@ -209,7 +209,7 @@ function AudioEdit( {
 								{ value: '', label: __( 'Browser default' ) },
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },
-								{ value: 'none', label: __( 'None' ) },
+								{ value: 'none', label: _x( 'None', '"Preload" value' ) },
 							] }
 							hideCancelButton={ true }
 						/>

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -6,7 +6,7 @@ import { View, AccessibilityInfo, Platform, Text } from 'react-native';
  * WordPress dependencies
  */
 import { withInstanceId, compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	RichText,
 	InspectorControls,
@@ -136,7 +136,7 @@ class ButtonEdit extends Component {
 			},
 			linkRel: {
 				label: __( 'Link Rel' ),
-				placeholder: __( 'None' ),
+				placeholder: _x( 'None', 'Link rel attribute value placeholder' ),
 			},
 		};
 

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -136,7 +136,10 @@ class ButtonEdit extends Component {
 			},
 			linkRel: {
 				label: __( 'Link Rel' ),
-				placeholder: _x( 'None', 'Link rel attribute value placeholder' ),
+				placeholder: _x(
+					'None',
+					'Link rel attribute value placeholder'
+				),
 			},
 		};
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -24,7 +24,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
-import { __,  _x, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { View } from '@wordpress/primitives';
@@ -57,7 +57,10 @@ const MAX_COLUMNS = 8;
 const linkOptions = [
 	{ value: LINK_DESTINATION_ATTACHMENT, label: __( 'Attachment Page' ) },
 	{ value: LINK_DESTINATION_MEDIA, label: __( 'Media File' ) },
-	{ value: LINK_DESTINATION_NONE, label: _x( 'None', 'Media item link option' ) },
+	{
+		value: LINK_DESTINATION_NONE,
+		label: _x( 'None', 'Media item link option' ),
+	},
 ];
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -24,7 +24,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __,  _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { View } from '@wordpress/primitives';
@@ -57,7 +57,7 @@ const MAX_COLUMNS = 8;
 const linkOptions = [
 	{ value: LINK_DESTINATION_ATTACHMENT, label: __( 'Attachment Page' ) },
 	{ value: LINK_DESTINATION_MEDIA, label: __( 'Media File' ) },
-	{ value: LINK_DESTINATION_NONE, label: __( 'None' ) },
+	{ value: LINK_DESTINATION_NONE, label: _x( 'None', 'Media item link option' ) },
 ];
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -42,7 +42,7 @@ import {
 	BlockStyles,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { getProtocol, hasQueryArg } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
@@ -121,7 +121,7 @@ export class ImageEdit extends Component {
 			},
 			linkRel: {
 				label: __( 'Link Rel' ),
-				placeholder: __( 'None' ),
+				placeholder: _x( 'None', 'Link rel attribute value placeholder' ),
 			},
 		};
 	}

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -121,7 +121,10 @@ export class ImageEdit extends Component {
 			},
 			linkRel: {
 				label: __( 'Link Rel' ),
-				placeholder: _x( 'None', 'Link rel attribute value placeholder' ),
+				placeholder: _x(
+					'None',
+					'Link rel attribute value placeholder'
+				),
 			},
 		};
 	}

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { ToggleControl, SelectControl } from '@wordpress/components';
 import { useMemo, useCallback, Platform } from '@wordpress/element';
 
 const options = [
 	{ value: 'auto', label: __( 'Auto' ) },
 	{ value: 'metadata', label: __( 'Metadata' ) },
-	{ value: 'none', label: __( 'None' ) },
+	{ value: 'none', label: _x( 'None', 'Preload value' ) },
 ];
 
 const VideoSettings = ( { setAttributes, attributes } ) => {

--- a/packages/components/src/dimension-control/sizes.js
+++ b/packages/components/src/dimension-control/sizes.js
@@ -10,7 +10,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Finds the correct size object from the provided sizes
@@ -26,23 +26,23 @@ export const findSizeBySlug = ( sizes, slug ) =>
 
 export default [
 	{
-		name: __( 'None' ),
+		name: _x( 'None', 'Size of a UI element' ),
 		slug: 'none',
 	},
 	{
-		name: __( 'Small' ),
+		name: _x( 'Small', 'Size of a UI element' ),
 		slug: 'small',
 	},
 	{
-		name: __( 'Medium' ),
+		name: _x( 'Medium', 'Size of a UI element' ),
 		slug: 'medium',
 	},
 	{
-		name: __( 'Large' ),
+		name: _x( 'Large', 'Size of a UI element' ),
 		slug: 'large',
 	},
 	{
-		name: __( 'Extra Large' ),
+		name: _x( 'Extra Large', 'Size of a UI element' ),
 		slug: 'xlarge',
 	},
 ];


### PR DESCRIPTION
## Description

This is a revival of https://github.com/WordPress/gutenberg/pull/22095 which adds context to "None" strings, which can, depending on the context, be translated differently in languages other than English.

This changeset replaces `__( 'None' )` occurrences with `_x( 'None', 'Some context )`, as well as implementing other suggestions made by reviewers in https://github.com/WordPress/gutenberg/pull/22095. 

Props to @audrasjb for the original PR.

Grazie! Thank you! Danke! Xièxie! Shukran!

## Types of changes
Non-breaking i18n change

## Testing

Check syntax and context comprehensibility

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
