### PR TITLE
Blocks: Register block when invalid value provided for the icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18112,7 +18112,6 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
-				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"hpq": "^1.3.0",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Backward Compatibility
+
+-   Register a block even when an invalid value provided for the icon setting ([#34350](https://github.com/WordPress/gutenberg/pull/34350)).
+
 ## 11.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -40,7 +40,6 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
-		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
 		"hpq": "^1.3.0",

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -1,3 +1,5 @@
+export const BLOCK_ICON_DEFAULT = 'block-default';
+
 /**
  * Array of valid keys in a block type settings deprecation object.
  *

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -25,14 +25,13 @@ import {
 import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
-import { blockDefault } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import i18nBlockSchema from './i18n-block.json';
 import { isValidIcon, normalizeIconObject } from './utils';
-import { DEPRECATED_ENTRY_KEYS } from './constants';
+import { BLOCK_ICON_DEFAULT, DEPRECATED_ENTRY_KEYS } from './constants';
 import { store as blocksStore } from '../store';
 
 /**
@@ -265,7 +264,7 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 
 	settings = {
 		name,
-		icon: blockDefault,
+		icon: BLOCK_ICON_DEFAULT,
 		keywords: [],
 		attributes: {},
 		providesContext: {},

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -10,7 +10,6 @@ import { noop, get, omit, pick } from 'lodash';
  */
 import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
-import { blockDefault as blockIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -36,7 +35,7 @@ import {
 	serverSideBlockDefinitions,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '../registration';
-import { DEPRECATED_ENTRY_KEYS } from '../constants';
+import { BLOCK_ICON_DEFAULT, DEPRECATED_ENTRY_KEYS } from '../constants';
 import { store as blocksStore } from '../../store';
 
 describe( 'blocks', () => {
@@ -121,9 +120,7 @@ describe( 'blocks', () => {
 			expect( console ).not.toHaveErrored();
 			expect( block ).toEqual( {
 				name: 'my-plugin/fancy-block-4',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -268,9 +265,7 @@ describe( 'blocks', () => {
 				name: 'core/test-block-with-defaults',
 				title: 'block title',
 				category: 'text',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -301,9 +296,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'text',
 					title: 'block title',
-					icon: {
-						src: blockIcon,
-					},
+					icon: { src: BLOCK_ICON_DEFAULT },
 					attributes: {
 						ok: {
 							type: 'boolean',
@@ -338,9 +331,7 @@ describe( 'blocks', () => {
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -371,9 +362,7 @@ describe( 'blocks', () => {
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {
 					fontSize: 'fontSize',
@@ -410,9 +399,7 @@ describe( 'blocks', () => {
 				save: expect.any( Function ),
 				title: 'block title',
 				category: 'widgets',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -636,9 +623,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'text',
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -723,7 +708,7 @@ describe( 'blocks', () => {
 								...omit(
 									{
 										name,
-										icon: blockIcon,
+										icon: BLOCK_ICON_DEFAULT,
 										attributes: {},
 										providesContext: {},
 										usesContext: [],
@@ -960,9 +945,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'text',
 					title: 'block title',
-					icon: {
-						src: blockIcon,
-					},
+					icon: { src: BLOCK_ICON_DEFAULT },
 					attributes: {},
 					providesContext: {},
 					usesContext: [],
@@ -979,9 +962,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'text',
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -1059,9 +1040,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'text',
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -1085,9 +1064,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'text',
 				title: 'block title',
-				icon: {
-					src: blockIcon,
-				},
+				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
 				providesContext: {},
 				usesContext: [],
@@ -1118,9 +1095,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'text',
 					title: 'block title',
-					icon: {
-						src: blockIcon,
-					},
+					icon: { src: BLOCK_ICON_DEFAULT },
 					attributes: {},
 					providesContext: {},
 					usesContext: [],
@@ -1135,9 +1110,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'text',
 					title: 'block title',
-					icon: {
-						src: blockIcon,
-					},
+					icon: { src: BLOCK_ICON_DEFAULT },
 					attributes: {},
 					providesContext: {},
 					usesContext: [],

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -14,6 +14,7 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
+import { BLOCK_ICON_DEFAULT } from './constants';
 import { getBlockType, getDefaultBlockName } from './registration';
 import { createBlock } from './factory';
 
@@ -89,6 +90,7 @@ export function isValidIcon( icon ) {
  * @return {WPBlockTypeIconDescriptor} Object describing the icon.
  */
 export function normalizeIconObject( icon ) {
+	icon = icon || BLOCK_ICON_DEFAULT;
 	if ( isValidIcon( icon ) ) {
 		return { src: icon };
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #18894.

> Before WordPress 5.3, it was possible to register a block type using an empty string or null value for `icon`. This would result in the block type using the default 'block' icon.
> 
> In WordPress 5.3, a block type registered with `icon: ''` or `icon: null` will trigger this warning:
> 
> ![image](https://user-images.githubusercontent.com/36432/70078093-f19c3980-15b6-11ea-96fe-04c73c29126d.png)
> 
> The early return statement added in https://github.com/WordPress/gutenberg/commit/1a7255fb751f1bf519968330c8ca5fcda740c1e5#diff-bcd12caf7289c956a519c4cd8f3f363eR144-R150 causes the block type to not be registered.
> 
> My expectation is that a block type with `icon: ''` or `icon: null` would be registered with a default icon.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I successfully registered and inserted a block with the icon field set to `icon: null` and `icon: ''`. I confirmed that the default block icon was used.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue). Backward compatibility.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
