### PR TITLE
Experiment: Try to change scope of classic auto margins.

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -1,7 +1,7 @@
 // Provide baseline auto margin for centering blocks.
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
-.editor-styles-wrapper .wp-block {
+.is-root-container > .wp-block {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
## Description

_This PR is mostly created for the discussion topic._

In classic themes, we have this rule to deal with:

```
.editor-styles-wrapper .wp-block {
	margin-left: auto;
	margin-right: auto;
}
```

It's been around for a while, and it exists to center blocks in a main column. Of course we've already encountered headaches with the specificity of this in nesting contexts, having to unset those margins. 

In #32659 I tried to replace that with this:

```
.editor-styles-wrapper :where(.wp-block) {
	margin-left: auto;
	margin-right: auto;
}
```

That works wonderfully in that it reduces the specificity of that rule to barely anything. The problem is that in themes, blocks like List or usually set `margin-left: 0;`, and there are commonly blanket rules that set the overall margin of `figure` to zero, which would both left align those blocks now that the specificity is reduced.

The reason I'm back here again, though, is that we've reached a bit of a crossroads with this rule, and how global styles works. Let me walk through an example. 

In the navigation block, you can insert menu items. These menu come with default margins: `margin: 0 2em 0 0;`, and the specificity of this rule is kept low enough that you can easily write out your own custom menu item margins in theme.json to override and configure. This works great in block themes.

However that same low specificity means that the auto margins win out, in this case, right-aligning the menu items:

<img width="789" alt="Screenshot 2021-08-27 at 13 40 18" src="https://user-images.githubusercontent.com/1204802/131122042-e54888f2-3753-4711-b9c0-79b594ca0fc9.png">

<img width="421" alt="Screenshot 2021-08-27 at 13 40 59" src="https://user-images.githubusercontent.com/1204802/131122056-135087bb-cac0-45f4-b6ca-b377fc27e555.png">

The problem is, we can't increase the specificity of the margin rule in the navigation block, without also having to change the specificity of rules output by global styles. It's a bit of an arms race.

Ultimately the solution to the navigation block might be to use `gap` instead of margins (#32367). But the challenge above is likely going to emerge in the future as more blocks are refactored to leverage global styles. Hence this draft PR, which changes the classic auto margin rule to this new selector: `.is-root-container > .wp-block`. In my brief testing, this works as intended. But I'm sure there's something I haven't thought of.