### PR TITLE
Limit FSE admin notices to the Themes screen

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -27,7 +27,7 @@ function gutenberg_supports_block_templates() {
  * Show a notice when a Full Site Editing theme is used.
  */
 function gutenberg_full_site_editing_notice() {
-	if ( ! gutenberg_is_fse_theme() || get_current_screen()->base !== 'themes' ) {
+	if ( ! gutenberg_is_fse_theme() || 'themes' !== get_current_screen()->base ) {
 		return;
 	}
 	?>

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -27,7 +27,7 @@ function gutenberg_supports_block_templates() {
  * Show a notice when a Full Site Editing theme is used.
  */
 function gutenberg_full_site_editing_notice() {
-	if ( ! gutenberg_is_fse_theme() ) {
+	if ( ! gutenberg_is_fse_theme() || get_current_screen()->base !== 'themes' ) {
 		return;
 	}
 	?>


### PR DESCRIPTION
## Description
Currently, the Full Site Editing theme notice is displayed on every page and for every user. This can create noise and maybe even discourage theme users.

This PR updates conditional logic to only display a notice on the Themes screen.

Closes #33792.

## How has this been tested?
1. Install and activate TT1 Blocks.
2. FSE admin notices should be visible on the Themes screen.
3. Go to Dashboard or Settings; Page shouldn't display FSE notices. 

## Screenshots <!-- if applicable -->
![CleanShot 2021-08-27 at 15 58 38](https://user-images.githubusercontent.com/240569/131124160-8503adaa-1075-480b-9acb-a75e86194b8b.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
