### PR TITLE
FSE: Add basic support for child themes

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -493,16 +493,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return string The whole file path or empty if the file doesn't exist.
 	 */
 	private static function get_file_path_from_theme( $file_name ) {
-		// This used to be a locate_template call.
-		// However, that method proved problematic
-		// due to its use of constants (STYLESHEETPATH)
-		// that threw errors in some scenarios.
-		//
-		// When the theme.json merge algorithm properly supports
-		// child themes, this should also fallback
-		// to the template path, as locate_template did.
 		$located   = '';
-		$candidate = get_stylesheet_directory() . '/' . $file_name;
+		$candidate = get_theme_file_path( $file_name );
 		if ( is_readable( $candidate ) ) {
 			$located = $candidate;
 		}

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -11,7 +11,7 @@
  * @return boolean Whether the current theme is an FSE theme or not.
  */
 function gutenberg_is_fse_theme() {
-	return is_readable( get_stylesheet_directory() . '/block-templates/index.html' );
+	return is_readable( get_theme_file_path( '/block-templates/index.html' ) );
 }
 
 /**

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -53,7 +53,7 @@ function render_block_core_template_part( $attributes ) {
 		} else {
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
-			$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
+			$template_part_file_path = get_theme_file_path( '/block-template-parts/' . $attributes['slug'] . '.html' );
 			if ( 0 === validate_file( $attributes['slug'] ) && file_exists( $template_part_file_path ) ) {
 				$content = _gutenberg_inject_theme_attribute_in_content( file_get_contents( $template_part_file_path ) );
 			}


### PR DESCRIPTION
## Description
Part of #25612.
Fixes #33959.
Fixes #33957.

Adds basic support for child themes in Full Site Editor/Global Styles.

### Features covered
* Block template and template parts file inheritance.
* The `theme.json` inheritance.

### Props
This is based on previous work by @aristath and @oandregal.

P.S. I'm not sure how we want to handle user-created templates and wasn't able to find any information. I would be happy to iterate on this PR or create a follow-up if anyone can point me in the right direction.

## How has this been tested?
1. Create TT1 Blocks child theme.

```
wp scaffold child-theme tt1-blocks-child --parent_theme=tt1-blocks --theme_name="TT1 Blocks Child"
``` 
2. Activate the child theme.
3. See that the "Site Editor" admin menu is visible.
4. Check that you can edit template files.
5. See that template and template parts are correctly rendered on the front-end.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
