### PR TITLE
Make Test_Widget compatible with WP_Widget

### DIFF
--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -58,13 +58,16 @@ class Test_Widget extends WP_Widget {
 	 *
 	 * @param array $new_instance New settings for this instance as input by the user via
 	 *                            WP_Widget::form().
+	 * @param array $old_instance Old settings for this instance.
 	 *
 	 * @return array Settings to save or bool false to cancel saving.
 	 * @since 4.8.1
 	 */
-	public function update( $new_instance ) {
+	// @codingStandardsIgnoreStart
+	public function update( $new_instance, $old_instance ) {
+	// @codingStandardsIgnoreEnd
 		$instance          = array();
-		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( isset( $new_instance['title'] ) ? $new_instance['title'] : '' ) : '';
 		return $instance;
 	}
 }

--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -63,7 +63,7 @@ class Test_Widget extends WP_Widget {
 	 * @return array Settings to save or bool false to cancel saving.
 	 * @since 4.8.1
 	 */
-	// @codingStandardsIgnoreStart
+	// @codingStandardsIgnoreStart – to prevent phpcs from complaining about unused function argument.
 	public function update( $new_instance, $old_instance ) {
 	// @codingStandardsIgnoreEnd
 		$instance          = array();

--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -48,7 +48,7 @@ class Test_Widget extends WP_Widget {
 		?>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>">Title:</label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( isset( $instance['title'] ) ? $instance['title'] : '' ); ?>" />
 		</p>
 		<?php
 	}
@@ -67,7 +67,7 @@ class Test_Widget extends WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 	// @codingStandardsIgnoreEnd
 		$instance          = array();
-		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( isset( $new_instance['title'] ) ? $new_instance['title'] : '' ) : '';
+		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
 		return $instance;
 	}
 }


### PR DESCRIPTION
Today I noticed that running certains e2e tests locally logs the following errors:

```
  ● Widgets Customizer › should handle the inserter outer section

    Unexpected error in page content: Warning: Declaration of Test_Widget::update($new_instance) should be compatible with WP_Widget::update($new_instance, $old_instance) in /var/www/html/wp-content/plugins/gutenberg-test-plugins/class-test-widget.php on line 65

      at visitAdminPage (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/visit-admin-page.js:38:9)
          at runMicrotasks (<anonymous>)
      at Object.<anonymous> (specs/widgets/customizing-widgets.test.js:28:3
```

```
  ● Widgets Customizer › should move (inner) blocks to another sidebar

    Unexpected error in page content: Notice: Undefined index: title in /var/www/html/wp-content/plugins/gutenberg-test-plugins/class-test-widget.php on line 51

      at visitAdminPage (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/visit-admin-page.js:38:9)
          at runMicrotasks (<anonymous>)
      at Object.<anonymous> (specs/widgets/customizing-widgets.test.js:28:3)
```

Turns out that the signature of `Test_Widget::update` is indeed incompatible with `WP_Widget::update`. This PR adjusts class Test_Widget to fix these two problems.

