### PR TITLE
Temporarily disable Puppeteer reduced motion emulation

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -240,9 +240,10 @@ beforeAll( async () => {
 	await trashAllPosts( 'wp_block' );
 	await setupBrowser();
 	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
-	await page.emulateMediaFeatures( [
-		{ name: 'prefers-reduced-motion', value: 'reduce' },
-	] );
+	// Doesn't play well with https://core.trac.wordpress.org/changeset/51677.
+	// await page.emulateMediaFeatures( [
+	// 	{ name: 'prefers-reduced-motion', value: 'reduce' },
+	// ] );
 } );
 
 afterEach( async () => {


### PR DESCRIPTION
## Description
Temporarily disables `prefers-reduced-motion` emulation in e2e tests by Puppeteer to unblock development. It looks like this doesn't play well with the latest Customizer [update](https://core.trac.wordpress.org/changeset/51677) or vice versa.

## How has this been tested?
E2E Tests should be passing
