### PR TITLE
Widgets: fix should handle esc key events test

### DIFF
--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -694,13 +694,14 @@ describe( 'Widgets Customizer', () => {
 		// Expect pressing the Escape key to enter navigation mode,
 		// but not close the editor.
 		await page.keyboard.press( 'Escape' );
+
+		expect( console ).toHaveErrored( twentyTwentyError );
+
 		await expect( {
 			text: /^You are currently in navigation mode\./,
 			selector: '*[aria-live="polite"][aria-relevant="additions text"]',
 		} ).toBeFound();
 		await expect( paragraphBlock ).toBeVisible();
-
-		expect( console ).toHaveErrored( twentyTwentyError );
 	} );
 
 	it( 'should move (inner) blocks to another sidebar', async () => {


### PR DESCRIPTION
Testing to see if this stabilizes widgets E2E in CI.

https://github.com/WordPress/gutenberg/runs/3442206538
<img width="1117" alt="Screen Shot 2021-08-27 at 11 26 31 AM" src="https://user-images.githubusercontent.com/1270189/131172588-fb48433e-879a-4586-9f2b-f11a1eea5515.png">
