### PR TITLE
ToolsPanel: change icon from horizontal to vertical ellipsis

### DIFF
--- a/packages/components/src/tools-panel/tools-panel-header/component.js
+++ b/packages/components/src/tools-panel/tools-panel-header/component.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { check, moreHorizontal } from '@wordpress/icons';
+import { check, moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -32,7 +32,7 @@ const ToolsPanelHeader = ( props, forwardedRef ) => {
 		<h2 { ...headerProps } ref={ forwardedRef }>
 			{ header }
 			{ hasMenuItems && (
-				<DropdownMenu icon={ moreHorizontal } label={ menuLabel }>
+				<DropdownMenu icon={ moreVertical } label={ menuLabel }>
 					{ ( { onClose } ) => (
 						<>
 							<MenuGroup label={ __( 'Display options' ) }>


### PR DESCRIPTION
## Description

> One small thing as well: the ellipsis is vertical in recent global styles mockups, so we should update it here as well.

Citation: https://github.com/WordPress/gutenberg/issues/34257#issuecomment-904440778

This PR swaps the horizontal more menu item for the vertical variant.


## How has this been tested?
With 👀 

## Screenshots <!-- if applicable -->

**Before**
<img width="282" alt="Screen Shot 2021-08-30 at 9 56 49 am" src="https://user-images.githubusercontent.com/6458278/131269554-3993afdd-3970-4020-90da-21e9f37d0ac3.png">


**After**\
<img width="283" alt="Screen Shot 2021-08-30 at 9 57 36 am" src="https://user-images.githubusercontent.com/6458278/131269578-5d967d52-7530-43b1-a3c7-0ba2dc94e907.png">

## Types of changes
Non-breaking icon change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
