### PR TITLE
DateTime Component: Fix sizing of help info

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -12,6 +12,7 @@
 
 	.components-datetime__calendar-help {
 		padding: $grid-unit-20;
+		min-width: 260px;
 
 		h4 {
 			margin: 0;
@@ -46,6 +47,7 @@
 		height: 30px;
 		margin-top: 0;
 		margin-bottom: 0;
+		z-index: 1;
 	}
 }
 

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -47,7 +47,10 @@
 		height: 30px;
 		margin-top: 0;
 		margin-bottom: 0;
-		z-index: 1;
+	}
+
+	.components-button:focus {
+		z-index: z-index(".components-button {:focus or .is-primary}");
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR adds a couple of styling fixes to the DateTime component, to ensure that the help info view has an adequate minimum width, and that the focus styling on the Calendar Help button displays correctly.

* Add a minimum width to the calendar help view, since the popover's minimum width was removed in https://github.com/WordPress/gutenberg/pull/25218/
* Add a `z-index` to the buttons in the DateTime picker to ensure that when the Reset or Calender Help buttons are clicked/focused that the top border of the focus style is visible

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually, select the Publish date from the Status & visibility section in a post's settings panel.

1. Check that after clicking on the Calendar Help button, the border style of the button looks correct.
2. Check that the minimum width of the Calendar Help info area looks reasonable.

## Screenshots <!-- if applicable -->

| Calendar Help info area before | Calendar Help info area after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/131277615-55aec397-81af-4170-b57e-2d162e04ec29.png) | ![image](https://user-images.githubusercontent.com/14988353/131277629-2c90583c-62a1-49e3-a64d-5af02b4b804c.png) |

| Button focus style border visibility before | Button focus style border visibility after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/131277687-67004ef5-fb1b-4e26-89d9-4b6d0abb5600.png) | ![image](https://user-images.githubusercontent.com/14988353/131277702-85945765-e030-41a8-9442-82f9a36fd541.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested. (Manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
