### PR TITLE
Gallery block: fix bug with stalled upload when image size too large

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -16,7 +16,7 @@ figure.wp-block-gallery {
 		flex: 0 0 100%;
 	}
 
-	.components-form-file-upload {
+	> .components-form-file-upload {
 		flex-basis: 100%;
 	}
 	// @todo: this deserves a refactor, by being moved to the toolbar.

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -22,7 +22,6 @@ figure.wp-block-gallery {
 
 	.wp-block-image {
 		.components-notice.is-error {
-			padding-right: 12px;
 			display: block;
 		}
 		.components-notice__content {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -19,6 +19,22 @@ figure.wp-block-gallery {
 	> .components-form-file-upload {
 		flex-basis: 100%;
 	}
+
+	.wp-block-image {
+		.components-notice.is-error {
+			padding-right: 12px;
+			display: block;
+		}
+		.components-notice__content {
+			margin: 4px 0;
+		}
+		.components-notice__dismiss {
+			position: absolute;
+			top: 0;
+			right: 5px;
+		}
+	}
+
 	// @todo: this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder.is-appender {
 		.components-placeholder__label {

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -10,18 +10,13 @@ export default function useGetMedia( innerBlockImages ) {
 
 	const imageMedia = useSelect(
 		( select ) => {
-			if (
-				! innerBlockImages?.length ||
-				innerBlockImages.some(
-					( imageBlock ) => ! imageBlock.attributes.id
-				)
-			) {
+			if ( ! innerBlockImages?.length ) {
 				return currentImageMedia;
 			}
 
-			const imageIds = innerBlockImages.map(
-				( imageBlock ) => imageBlock.attributes.id
-			);
+			const imageIds = innerBlockImages
+				.map( ( imageBlock ) => imageBlock.attributes.id )
+				.filter( ( id ) => id !== undefined );
 
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -246,7 +246,7 @@ export function ImageEdit( {
 		} );
 	}
 
-	const isTemp = isTemporaryImage( id, url );
+	let isTemp = isTemporaryImage( id, url );
 
 	// Upload a temporary image on mount.
 	useEffect( () => {
@@ -264,6 +264,7 @@ export function ImageEdit( {
 				},
 				allowedTypes: ALLOWED_MEDIA_TYPES,
 				onError: ( message ) => {
+					isTemp = false;
 					noticeOperations.createErrorNotice( message );
 					setAttributes( {
 						src: undefined,


### PR DESCRIPTION
## Description
With the new gallery format of nested Image innerBlocks, if an Image upload failed due to file size no error is shown and the image gets stuck in an uploading state. This PR changes the status of the isTemp flag as part of the upload error to prevent the isTemp useEffect running again and overriding the error state.

Fixes: #10251

## To test

- Check out PR to local dev env and enable the gallery experimental flag
- Add a gallery block and try uploading images that are bigger that the max file size
- Check that correct error message shows for oversized images, and that the gallery image size selector loads still if some image uploads were successful
- Also check that upload individual image blocks still works as expected
- 

## Screenshots 

Before:
![before](https://user-images.githubusercontent.com/3629020/131279086-55e23fa6-82b3-4b71-b3aa-e0c93deec8f7.gif)

After:
![after](https://user-images.githubusercontent.com/3629020/131280542-b129b5f8-098b-4d14-9696-9102649f91a9.gif)



