### PR TITLE
ToolsPanel: Update unchecked menu items to use empty icon to ensure enough whitespace

### DIFF
--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -22,6 +22,7 @@ export default {
 
 export const _default = () => {
 	const [ height, setHeight ] = useState();
+	const [ minHeight, setMinHeight ] = useState();
 	const [ width, setWidth ] = useState();
 
 	const resetAll = () => {
@@ -39,6 +40,18 @@ export const _default = () => {
 				>
 					<ToolsPanelItem
 						className="single-column"
+						hasValue={ () => !! width }
+						label="Width"
+						onDeselect={ () => setWidth( undefined ) }
+					>
+						<UnitControl
+							label="Width"
+							value={ width }
+							onChange={ ( next ) => setWidth( next ) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						className="single-column"
 						hasValue={ () => !! height }
 						label="Height"
 						onDeselect={ () => setHeight( undefined ) }
@@ -50,15 +63,14 @@ export const _default = () => {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						className="single-column"
-						hasValue={ () => !! width }
-						label="Width"
-						onDeselect={ () => setWidth( undefined ) }
+						hasValue={ () => !! minHeight }
+						label="Minimum height"
+						onDeselect={ () => setMinHeight( undefined ) }
 					>
 						<UnitControl
-							label="Width"
-							value={ width }
-							onChange={ ( next ) => setWidth( next ) }
+							label="Minimum height"
+							value={ minHeight }
+							onChange={ ( next ) => setMinHeight( next ) }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/components/src/tools-panel/tools-panel-header/component.js
+++ b/packages/components/src/tools-panel/tools-panel-header/component.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { check, moreVertical } from '@wordpress/icons';
+import { SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,6 +13,10 @@ import MenuGroup from '../../menu-group';
 import MenuItem from '../../menu-item';
 import { useToolsPanelHeader } from './hook';
 import { contextConnect } from '../../ui/context';
+
+const emptyIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></SVG>
+);
 
 const ToolsPanelHeader = ( props, forwardedRef ) => {
 	const {
@@ -41,7 +46,11 @@ const ToolsPanelHeader = ( props, forwardedRef ) => {
 										return (
 											<MenuItem
 												key={ label }
-												icon={ isSelected && check }
+												icon={
+													isSelected
+														? check
+														: emptyIcon
+												}
 												isSelected={ isSelected }
 												onClick={ () => {
 													toggleItem( label );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Noticed while testing https://github.com/WordPress/gutenberg/pull/34065:

In the ToolsPanel component, if a longer ToolsPanelItem label is used and the item is unchecked, then its label encroaches upon the visual space that the check icon takes up in the menu.

In this change, we add an empty icon for unchecked menu items to ensure that the space surrounding the unchecked item is reserved for the presence (or in this case absence) of the icon. It also helps ensure that the width of the display options popover is the same when all items are unchecked as when they're all checked.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Via Storybook:

```
npm run storybook:dev
```

Go to http://localhost:50240/?path=/story/components-experimental-toolspanel--default and experiment with checking and unchecking the panel items.

## Screenshots <!-- if applicable -->

With other items checked (note there isn't enough whitespace next to the third item):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/131295992-21a5269e-9304-4f22-88d4-041356348835.png) | ![image](https://user-images.githubusercontent.com/14988353/131296006-91003ac9-8829-4322-bcd7-53bab9a0ed82.png) |

With other items unchecked (note that in the before gif, the width of the popover is inconsistent between all items unchecked and one item checked)

| Before | After |
| --- | --- |
| ![tools-panel-menu-item-before-sml](https://user-images.githubusercontent.com/14988353/131296652-5ce48fc3-26d3-452e-aad1-8ebce247dc32.gif) | ![tools-panel-menu-item-after-sml](https://user-images.githubusercontent.com/14988353/131296688-7f55fcc0-4ec2-4c6b-a44b-9e0ef85c11d8.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
(non-breaking change which fixes a styling issue)

## Checklist:
- [x] My code is tested. (manually in Storybook)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
