### PR TITLE
Try: Simplify & polish heading levels.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -11,7 +11,6 @@
 @import "./freeform/editor.scss";
 @import "./gallery/editor.scss";
 @import "./group/editor.scss";
-@import "./heading/editor.scss";
 @import "./html/editor.scss";
 @import "./image/editor.scss";
 @import "./latest-posts/editor.scss";

--- a/packages/block-library/src/heading/editor.scss
+++ b/packages/block-library/src/heading/editor.scss
@@ -1,8 +1,0 @@
-// Remove padding in heading level control popover since the toolbar buttons already have padding.
-.block-library-heading-level-dropdown .components-popover__content {
-	min-width: auto;
-
-	> div {
-		padding: 0;
-	}
-}

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -4,7 +4,7 @@
 
 .components-dropdown__content {
 	.components-popover__content > div {
-		padding: $grid-unit-15;
+		padding: $grid-unit-10;
 	}
 
 	[role="menuitem"] {


### PR DESCRIPTION
## Description

Followup to #32926, this one tries to polish the heading level dropdown a little bit and simplify some code. The min width is no longer necessary, and the padding was too tight. Before:

<img width="485" alt="Screenshot 2021-08-30 at 10 52 20" src="https://user-images.githubusercontent.com/1204802/131313416-ea292d84-dfc2-4a98-87b0-47ebe19284cf.png">

<img width="457" alt="Screenshot 2021-08-30 at 10 52 23" src="https://user-images.githubusercontent.com/1204802/131313424-94312bf4-a741-4e73-b897-a1c6d7270f11.png">

This PR removes, and therefore unifies, some of the rules, and reduces the padding a bit to compensate:

<img width="467" alt="Screenshot 2021-08-30 at 10 46 58" src="https://user-images.githubusercontent.com/1204802/131313472-aefc62ae-0058-4b8c-9e47-abce17125456.png">

<img width="443" alt="Screenshot 2021-08-30 at 10 47 06" src="https://user-images.githubusercontent.com/1204802/131313478-1b681330-b469-40f8-95a0-09438c24bec6.png">

At first glance the vertical toolbar looks like it has too much padding at this point. But give it a moment, I think it works alright.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
