### PR TITLE
Try: Fix navigation inherited underline

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -528,3 +528,13 @@
 html.has-modal-open {
 	overflow: hidden;
 }
+
+
+/**
+ * Child blocks.
+ */
+
+// Text decoration is inherited all the way down. Floating the item unsets it.
+.wp-block-navigation[style*="text-decoration"] .wp-block-search {
+	float: left;
+}


### PR DESCRIPTION
## Description

Fixes #34275. When you set an underline on a navigation block, that underline is inherited into child blocks as well. Before:

<img width="797" alt="Screenshot 2021-08-30 at 10 56 25" src="https://user-images.githubusercontent.com/1204802/131316223-a7f8cdec-38db-4d80-a59d-6da7e7e8ffa6.png">

After:

<img width="817" alt="Screenshot 2021-08-30 at 11 10 44" src="https://user-images.githubusercontent.com/1204802/131316236-be7e5d24-8131-4d9c-94d8-51b6f8a7c4e9.png">

The thing is, text decoration is by weirdly hard to unset. In fact it isn't meant to be unset at all. The fact that it gets unset using the `float` property is a bit of a curiosity. Nevertheless that fixes it.

I've placed the rule inside the navigation block based on the philosophy that the parent container should carry the responsibility of how it affects the children. But I wonder if the rule should be removed to the text-decoration component itself, somehow, so we have a more universal rule like perhaps the following:

```
// Text decoration is inherited all the way down. Floating the item unsets it.
[style*="text-decoration"] .wp-block-search {
	float: left;
}
```

At the same time, I'm not sure we can make this particular rule generic — not everything can survive being floated like this. And it works for the search block inside the navigation primarily because the nav block uses flex.

The alternative is to choose to not fix the original issue, since the CSS spec is responsible for text decoration propogating all the way down the tree. This might just mean we need to use that property more responsibly, perhaps even remove it from the navigation block entirely.

## How has this been tested?

Put a search block inside the navigation block and set underlines on the navigation block. Observe no ill side effects.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
