### PR TITLE
Try: Fix so submenus only take up space when visible.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -32,6 +32,9 @@
 			// We use important here because if the parent block is selected and submenus are present, they should always be visible.
 			visibility: visible !important;
 			opacity: 1 !important;
+			min-width: 200px !important;
+			height: auto !important;
+			width: auto !important;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -107,12 +107,15 @@
 		display: flex;
 		flex-direction: column;
 		align-items: normal;
-		min-width: 200px;
 
 		// Hide until hover or focus within.
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		visibility: hidden;
+
+		// Don't take up space when the menu is collapsed.
+		width: 0;
+		height: 0;
 
 		// Submenu items.
 		> .wp-block-navigation-item {
@@ -173,12 +176,18 @@
 	&:hover > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		opacity: 1;
+		width: auto;
+		height: auto;
+		min-width: 200px;
 	}
 
 	// Keep submenus open when focus is within.
 	&:focus-within > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		opacity: 1;
+		width: auto;
+		height: auto;
+		min-width: 200px;
 	}
 }
 


### PR DESCRIPTION
## Description

At the moment, navigation block dropdown menus are hidden using `visibility: hidden;`. This enables us to apply CSS animation, the alpha fade, when the menu becomes visible. The problem is that unlike `display: none;`, simply hiding an element using visibility doesn't remove it from the DOM, it's still there taking up space:

<img width="737" alt="Screenshot 2021-08-30 at 12 33 35" src="https://user-images.githubusercontent.com/1204802/131328386-dfa69e47-f676-48b0-aee4-2679a8228ef8.png">

Specifically when you have dropdown menus that nest deeply, this might cause a horizontal scrollbar to appear, even when the menu is supposed to be invisible. I'll come back to the horizontal scrollbar in a moment.

This PR fixes it so that when a submenu is meant to be invisible, it also doesn't take up space in the DOM, causing any scrollbars at all, at least until you actually open those submenus whether through hover or focus:

![after](https://user-images.githubusercontent.com/1204802/131328631-7912b92d-824e-44f5-b154-6208687a62ed.gif)

**About the scrollbar.** Horizontal scrollbars are not desirable. At the moment the navigation block doesn't have any built-in smarts to reverse the direction of submenus when bumping against screen edges, and until we've reached a more thorough point of stability with the block itself, it's probably not advisable to spend too much time making that happen. However there are multiple tools at a users disposal to mitigate and/or address such items. For example, if you justify right, menus open towards the left. If you justify space-between, the last item opens leftwards. 

So for now, this PR is not about avoiding a scrollbat per se — just to ensure that if it shows up, it shows up in context of the submenu that is causing it. 

## How has this been tested?

Create a menu with lots of nested submenus. Test that they appear the same as before. Please test menus with placeholder items nested in the editor as well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
