### PR TITLE
Legacy widget's preview functionality is broken when the page is moved

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -634,8 +634,8 @@ describe( 'Widgets screen', () => {
 		// Wait for the Legacy Widget block's preview iframe to load.
 		const frame = await new Promise( ( resolve ) => {
 			const checkFrame = async ( candidateFrame ) => {
-				const url = await candidateFrame.url();
-				if ( url.includes( 'legacy-widget-preview' ) ) {
+				const title = await candidateFrame.title();
+				if ( 'Legacy Widget Preview' === title ) {
 					page.off( 'frameattached', checkFrame );
 					page.off( 'framenavigated', checkFrame );
 					resolve( candidateFrame );

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -634,13 +634,13 @@ describe( 'Widgets screen', () => {
 		// Wait for the Legacy Widget block's preview iframe to load.
 		const frame = await new Promise( ( resolve ) => {
 			const checkFrame = async () => {
-				const frameElements = await page.$$( 'iframe' );
-				for ( const frameElement in frameElements ) {
-					if ( frameElement.srcdoc ) {
-						page.off( 'frameattached', checkFrame );
-						page.off( 'framenavigated', checkFrame );
-						resolve( frameElement.contentFrame() );
-					}
+				const frameElement = await page.$(
+					'iframe.wp-block-legacy-widget__edit-preview-iframe'
+				);
+				if ( frameElement ) {
+					page.off( 'frameattached', checkFrame );
+					page.off( 'framenavigated', checkFrame );
+					resolve( frameElement.contentFrame() );
 				}
 			};
 			page.on( 'frameattached', checkFrame );

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -631,19 +631,10 @@ describe( 'Widgets screen', () => {
 
 		await page.reload();
 
-		// Wait for the Legacy Widget block's preview iframe to load.
-		const frame = await new Promise( ( resolve ) => {
-			const checkFrame = async ( candidateFrame ) => {
-				const title = await candidateFrame.title();
-				if ( 'Legacy Widget Preview' === title ) {
-					page.off( 'frameattached', checkFrame );
-					page.off( 'framenavigated', checkFrame );
-					resolve( candidateFrame );
-				}
-			};
-			page.on( 'frameattached', checkFrame );
-			page.on( 'framenavigated', checkFrame );
-		} );
+		const frameElement = await page.$(
+			'iframe.wp-block-legacy-widget__edit-preview-iframe'
+		);
+		const frame = frameElement.contentFrame();
 
 		// Expect to have search input.
 		await find(

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -631,10 +631,25 @@ describe( 'Widgets screen', () => {
 
 		await page.reload();
 
-		const frameElement = await page.$(
-			'iframe.wp-block-legacy-widget__edit-preview-iframe'
-		);
-		const frame = frameElement.contentFrame();
+		// Wait for the Legacy Widget block's preview iframe to load.
+		const frame = await new Promise( ( resolve ) => {
+			const checkFrame = async () => {
+				const frameElement = await page.$(
+					'iframe.wp-block-legacy-widget__edit-preview-iframe'
+				);
+				if (
+					frameElement &&
+					'wp-block-legacy-widget__edit-preview-iframe' ===
+						frameElement.className
+				) {
+					page.off( 'frameattached', checkFrame );
+					page.off( 'framenavigated', checkFrame );
+					resolve( frameElement.contentFrame() );
+				}
+			};
+			page.on( 'frameattached', checkFrame );
+			page.on( 'framenavigated', checkFrame );
+		} );
 
 		// Expect to have search input.
 		await find(

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -634,17 +634,13 @@ describe( 'Widgets screen', () => {
 		// Wait for the Legacy Widget block's preview iframe to load.
 		const frame = await new Promise( ( resolve ) => {
 			const checkFrame = async () => {
-				const frameElement = await page.$(
-					'iframe.wp-block-legacy-widget__edit-preview-iframe'
-				);
-				if (
-					frameElement &&
-					'wp-block-legacy-widget__edit-preview-iframe' ===
-						frameElement.className
-				) {
-					page.off( 'frameattached', checkFrame );
-					page.off( 'framenavigated', checkFrame );
-					resolve( frameElement.contentFrame() );
+				const frameElements = await page.$$( 'iframe' );
+				for ( const frameElement in frameElements ) {
+					if ( frameElement.srcdoc ) {
+						page.off( 'frameattached', checkFrame );
+						page.off( 'framenavigated', checkFrame );
+						resolve( frameElement.contentFrame() );
+					}
 				}
 			};
 			page.on( 'frameattached', checkFrame );

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -29,7 +29,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				method: 'POST',
 				signal: abortController?.signal,
 				data: {
-					id: idBase,
+					id_base: idBase,
 					instance,
 				},
 			} );

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -15,7 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
 export default function Preview( { idBase, instance, isVisible } ) {
 	const [ isLoaded, setIsLoaded ] = useState( false );
 	const [ srcDoc, setSrcDoc ] = useState( '' );
-	const [ isPreviewFetched, setIsPreviewFetched ] = useState( true );
+	const [ isPreviewFetched, setIsPreviewFetched ] = useState( false );
 
 	const abortController =
 		typeof window.AbortController === 'undefined'
@@ -36,13 +36,13 @@ export default function Preview( { idBase, instance, isVisible } ) {
 	}
 
 	useEffect( () => {
-		if ( ! isPreviewFetched ) {
+		if ( isPreviewFetched ) {
 			return;
 		}
 
 		fetchPreviewHTML( idBase, instance, abortController )
 			.then( ( response ) => {
-				setIsPreviewFetched( false );
+				setIsPreviewFetched( true );
 				setSrcDoc( response.preview );
 			} )
 			.catch( ( error ) => {

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -41,7 +41,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			} )
 			.catch( ( error ) => {
 				if ( 'AbortError' === error.name ) {
-					// We don't want to log abort "errors".
+					// We don't want to log aborted requests.
 					return;
 				}
 				throw error;

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -23,7 +23,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				: new window.AbortController();
 
 		async function fetchPreviewHTML() {
-			const restRoute = `/wp/v2/widget-types/${ idBase }/encode`;
+			const restRoute = `/wp/v2/widget-types/${ idBase }/render`;
 			return await apiFetch( {
 				path: restRoute,
 				method: 'POST',

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -6,10 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {useRefEffect} from '@wordpress/compose';
-import {useEffect, useState} from '@wordpress/element';
-import {Disabled, Placeholder, Spinner} from '@wordpress/components';
-import {__} from '@wordpress/i18n';
+import { useRefEffect } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
+import { Disabled, Placeholder, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 export default function Preview( { idBase, instance, isVisible } ) {

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -36,25 +36,23 @@ export default function Preview( { idBase, instance, isVisible } ) {
 	}
 
 	useEffect( () => {
-		if ( isPreviewFetched ) {
-			return;
+		if ( ! isPreviewFetched ) {
+			setIsPreviewFetched( true );
+			fetchPreviewHTML()
+				.then( ( response ) => {
+					setSrcDoc( response.preview );
+				} )
+				.catch( ( error ) => {
+					if ( error.name === 'AbortError' ) {
+						// We don't want to log abort errors.
+						return;
+					}
+					window.console.error(
+						`An error occurred while trying to fetch preview: ${ error.message }`,
+						error
+					);
+				} );
 		}
-
-		fetchPreviewHTML()
-			.then( ( response ) => {
-				setIsPreviewFetched( true );
-				setSrcDoc( response.preview );
-			} )
-			.catch( ( error ) => {
-				if ( error.name === 'AbortError' ) {
-					// We don't want to log abort errors.
-					return;
-				}
-				window.console.error(
-					`An error occurred while trying to fetch preview: ${ error.message }`,
-					error
-				);
-			} );
 
 		return () => {
 			if ( typeof abortController !== 'undefined' ) {

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -40,14 +40,11 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				setSrcDoc( response.preview );
 			} )
 			.catch( ( error ) => {
-				if ( error.name === 'AbortError' ) {
-					// We don't want to log abort errors.
+				if ( 'AbortError' === error.name ) {
+					// We don't want to log abort "errors".
 					return;
 				}
-				window.console.error(
-					`An error occurred while trying to fetch preview: ${ error.message }`,
-					error
-				);
+				throw error;
 			} );
 
 		return () => abortController?.abort();

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -29,7 +29,6 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				method: 'POST',
 				signal: abortController?.signal,
 				data: {
-					id_base: idBase,
 					instance,
 				},
 			} );

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -29,7 +29,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				method: 'POST',
 				signal: abortController?.signal,
 				data: {
-					id_base: idBase,
+					id: idBase,
 					instance,
 				},
 			} );

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -127,9 +127,6 @@ export default function Preview( { idBase, instance, isVisible } ) {
 						ref={ ref }
 						className="wp-block-legacy-widget__edit-preview-iframe"
 						title={ __( 'Legacy Widget Preview' ) }
-						// TODO: This chokes when the query param is too big.
-						// Ideally, we'd render a <ServerSideRender>. Maybe by
-						// rendering one in an iframe via a portal.
 						srcDoc={ srcDoc }
 						onLoad={ ( event ) => {
 							// To hide the scrollbars of the preview frame for some edge cases,

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -59,7 +59,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				abortController.abort();
 			}
 		};
-	} );
+	}, [] );
 
 	// Resize the iframe on either the load event, or when the iframe becomes visible.
 	const ref = useRefEffect(

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -40,7 +40,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			return;
 		}
 
-		fetchPreviewHTML( idBase, instance, abortController )
+		fetchPreviewHTML()
 			.then( ( response ) => {
 				setIsPreviewFetched( true );
 				setSrcDoc( response.preview );

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -28,9 +28,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				path: restRoute,
 				method: 'POST',
 				signal: abortController?.signal,
-				data: {
-					instance,
-				},
+				data: instance ? { instance } : {},
 			} );
 		}
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -6,10 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRefEffect } from '@wordpress/compose';
-import { useState, useEffect } from '@wordpress/element';
-import { Placeholder, Spinner, Disabled } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import {useRefEffect} from '@wordpress/compose';
+import {useEffect, useState} from '@wordpress/element';
+import {Disabled, Placeholder, Spinner} from '@wordpress/components';
+import {__} from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 export default function Preview( { idBase, instance, isVisible } ) {
@@ -23,7 +23,7 @@ export default function Preview( { idBase, instance, isVisible } ) {
 				: new window.AbortController();
 
 		async function fetchPreviewHTML() {
-			const restRoute = `/wp/v2/widget-types/${ idBase }/render`;
+			const restRoute = `/wp/v2/widget-types/${ idBase }/encode`;
 			return await apiFetch( {
 				path: restRoute,
 				method: 'POST',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Legacy Widget block has a preview function. However, it uses a relative URL.
`iframe` cannot load the widgets.php file when the code is no longer running from the /wp-admin/ URL.
This PR fixes that by using a REST API endpoint instead of the widgets.php file to fetch preview HTML. It doesn't depend on the admin URL.
Fixes #30049 

Based on #34230

## How has this been tested?
1. Go to Appearance -> Widgets page.
2. Click on the "plus sign" button at the very bottom of the page.
3. Add a `Legacy Widget` block.
4. Select `Meta` widget from the dropdown.
5. Click somewhere on the background of the page (not on the `Meta` widget itself). You should see a preview of the `Meta` widget now.
6. Open your browser's developer tools and find an `<iframe />` element with the `wp-block-legacy-widget__edit-preview-iframe`  class. Check its `srcdoc` attribute.

#### Expected result:
The `srcdoc` attribute of the `<iframe />` should contain html code of the preview.
Please see the screenshots section for reference.

## Screenshots <!-- if applicable -->
![Screenshot 2021-08-12 at 20 00 39](https://user-images.githubusercontent.com/43744263/129246203-e3734aba-d1fc-4ec1-b8e8-6d381e3d488d.png)
![Screenshot 2021-08-19 at 21 59 05](https://user-images.githubusercontent.com/43744263/130135924-2d876802-ac20-4b01-94ca-de47ddf48756.png)


## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
