### PR TITLE
CustomSelectControl: Add describedBy fallback

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -81,10 +81,18 @@ export default function CustomSelectControl( {
 		stateReducer,
 	} );
 
-	const controlDescribedBy = describedBy
-		? describedBy
-		: // translators: %s: The selected option.
-		  sprintf( __( 'Currently selected: %s' ), selectedItem?.name );
+	function getDescribedBy() {
+		if ( describedBy ) {
+			return describedBy;
+		}
+
+		if ( ! selectedItem ) {
+			return __( 'No selection' );
+		}
+
+		// translators: %s: The selected option.
+		return sprintf( __( 'Currently selected: %s' ), selectedItem.name );
+	}
 
 	const menuProps = getMenuProps( {
 		className: 'components-custom-select-control__menu',
@@ -129,7 +137,7 @@ export default function CustomSelectControl( {
 					'aria-labelledby': undefined,
 					className: 'components-custom-select-control__button',
 					isSmall: true,
-					describedBy: controlDescribedBy,
+					describedBy: getDescribedBy(),
 				} ) }
 			>
 				{ itemToString( selectedItem ) }


### PR DESCRIPTION
## Description
Add "No selection" fallback `describedBy` text for `FontAppearanceControl` and `CustomSelectControl` components.

PR also converts ternary logic in the `CustomSelectControl` to a function since we avoid nested ternaries.

Fixes #34348.

## How has this been tested?
1. Install and activate the Quadrat theme.
2. Go the the "Site Editor."
3. The site editor shouldn't crash because of the JS error.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
