### PR TITLE
Refactor deleteEntityRecord to use thunks instead of generators

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -535,7 +535,7 @@ _Parameters_
 -   _recordId_ `string`: Record ID of the deleted entity.
 -   _query_ `?Object`: Special query parameters for the DELETE API call.
 -   _options_ `[Object]`: Delete options.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### editEntityRecord
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -69,7 +69,7 @@ _Parameters_
 -   _recordId_ `string`: Record ID of the deleted entity.
 -   _query_ `?Object`: Special query parameters for the DELETE API call.
 -   _options_ `[Object]`: Delete options.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a control descriptor.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### editEntityRecord
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -8,7 +8,7 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { controls } from '@wordpress/data';
-import { apiFetch, __unstableAwaitPromise } from '@wordpress/data-controls';
+import { __unstableAwaitPromise } from '@wordpress/data-controls';
 import triggerFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -162,16 +162,16 @@ export function receiveEmbedPreview( url, preview ) {
  * @param {Object}   [options]                 Delete options.
  * @param {Function} [options.__unstableFetch] Internal use only. Function to
  *                                             call instead of `apiFetch()`.
- *                                             Must return a control descriptor.
+ *                                             Must return a promise.
  */
-export function* deleteEntityRecord(
+export const deleteEntityRecord = (
 	kind,
 	name,
 	recordId,
 	query,
-	{ __unstableFetch = null } = {}
-) {
-	const entities = yield getKindEntities( kind );
+	{ __unstableFetch = triggerFetch } = {}
+) => async ( { dispatch } ) => {
+	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
 	let error;
 	let deletedRecord = false;
@@ -179,21 +179,19 @@ export function* deleteEntityRecord(
 		return;
 	}
 
-	const lock = yield controls.dispatch(
-		STORE_NAME,
-		'__unstableAcquireStoreLock',
+	const lock = await dispatch.__unstableAcquireStoreLock(
 		STORE_NAME,
 		[ 'entities', 'data', kind, name, recordId ],
 		{ exclusive: true }
 	);
 
 	try {
-		yield {
+		await dispatch( {
 			type: 'DELETE_ENTITY_RECORD_START',
 			kind,
 			name,
 			recordId,
-		};
+		} );
 
 		try {
 			let path = `${ entity.baseURL }/${ recordId }`;
@@ -202,40 +200,29 @@ export function* deleteEntityRecord(
 				path = addQueryArgs( path, query );
 			}
 
-			const options = {
+			deletedRecord = await __unstableFetch( {
 				path,
 				method: 'DELETE',
-			};
-			if ( __unstableFetch ) {
-				deletedRecord = yield __unstableAwaitPromise(
-					__unstableFetch( options )
-				);
-			} else {
-				deletedRecord = yield apiFetch( options );
-			}
+			} );
 
-			yield removeItems( kind, name, recordId, true );
+			await dispatch( removeItems( kind, name, recordId, true ) );
 		} catch ( _error ) {
 			error = _error;
 		}
 
-		yield {
+		await dispatch( {
 			type: 'DELETE_ENTITY_RECORD_FINISH',
 			kind,
 			name,
 			recordId,
 			error,
-		};
+		} );
 
 		return deletedRecord;
 	} finally {
-		yield controls.dispatch(
-			STORE_NAME,
-			'__unstableReleaseStoreLock',
-			lock
-		);
+		dispatch.__unstableReleaseStoreLock( lock );
 	}
-}
+};
 
 /**
  * Returns an action object that triggers an

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -186,7 +186,7 @@ export const deleteEntityRecord = (
 	);
 
 	try {
-		await dispatch( {
+		dispatch( {
 			type: 'DELETE_ENTITY_RECORD_START',
 			kind,
 			name,
@@ -210,7 +210,7 @@ export const deleteEntityRecord = (
 			error = _error;
 		}
 
-		await dispatch( {
+		dispatch( {
 			type: 'DELETE_ENTITY_RECORD_FINISH',
 			kind,
 			name,

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -49,46 +49,63 @@ describe( 'editEntityRecord', () => {
 } );
 
 describe( 'deleteEntityRecord', () => {
+	beforeEach( async () => {
+		apiFetch.mockReset();
+		jest.useFakeTimers();
+	} );
+
 	it( 'triggers a DELETE request for an existing record', async () => {
-		const post = 10;
+		const deletedRecord = { title: 'new post', id: 10 };
 		const entities = [
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
-		const fulfillment = deleteEntityRecord( 'postType', 'post', post );
 
-		// Trigger generator
-		fulfillment.next();
+		const dispatch = jest.fn();
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
 
-		// Acquire lock
-		expect( fulfillment.next( entities ).value.type ).toBe(
-			'@@data/DISPATCH'
-		);
+		// Provide response
+		apiFetch.mockImplementation( () => deletedRecord );
 
-		// Start
-		expect( fulfillment.next().value.type ).toEqual(
-			'DELETE_ENTITY_RECORD_START'
-		);
+		const result = await deleteEntityRecord(
+			'postType',
+			'post',
+			deletedRecord.id
+		)( { dispatch } );
 
-		// delete api call
-		const { value: apiFetchAction } = fulfillment.next();
-		expect( apiFetchAction.request ).toEqual( {
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/posts/10',
 			method: 'DELETE',
 		} );
 
-		expect( fulfillment.next().value.type ).toBe( 'REMOVE_ITEMS' );
 
-		expect( fulfillment.next().value.type ).toBe(
-			'DELETE_ENTITY_RECORD_FINISH'
-		);
-
-		// Release lock
-		expect( fulfillment.next().value.type ).toEqual( '@@data/DISPATCH' );
-
-		expect( fulfillment.next() ).toMatchObject( {
-			done: true,
-			value: undefined,
+		expect( dispatch ).toHaveBeenCalledTimes( 6 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'DELETE_ENTITY_RECORD_START',
+			kind: 'postType',
+			name: 'post',
+			recordId: 10,
 		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_ACQUIRE_LOCK',
+			},
+		] );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'DELETE_ENTITY_RECORD_FINISH',
+			kind: 'postType',
+			name: 'post',
+			recordId: 10,
+			error: undefined,
+		} );
+		expect( dispatch ).toHaveBeenCalledWith( [
+			{
+				type: 'MOCKED_RELEASE_LOCK',
+			},
+		] );
+
+		expect( result ).toBe( deletedRecord );
 	} );
 } );
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -60,7 +60,11 @@ describe( 'deleteEntityRecord', () => {
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 
-		const dispatch = jest.fn();
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
 		// Provide entities
 		dispatch.mockReturnValueOnce( entities );
 
@@ -79,19 +83,13 @@ describe( 'deleteEntityRecord', () => {
 			method: 'DELETE',
 		} );
 
-
-		expect( dispatch ).toHaveBeenCalledTimes( 6 );
+		expect( dispatch ).toHaveBeenCalledTimes( 4 );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'DELETE_ENTITY_RECORD_START',
 			kind: 'postType',
 			name: 'post',
 			recordId: 10,
 		} );
-		expect( dispatch ).toHaveBeenCalledWith( [
-			{
-				type: 'MOCKED_ACQUIRE_LOCK',
-			},
-		] );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'DELETE_ENTITY_RECORD_FINISH',
 			kind: 'postType',
@@ -99,11 +97,12 @@ describe( 'deleteEntityRecord', () => {
 			recordId: 10,
 			error: undefined,
 		} );
-		expect( dispatch ).toHaveBeenCalledWith( [
-			{
-				type: 'MOCKED_RELEASE_LOCK',
-			},
-		] );
+		expect( dispatch.__unstableAcquireStoreLock ).toHaveBeenCalledTimes(
+			1
+		);
+		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
+			1
+		);
 
 		expect( result ).toBe( deletedRecord );
 	} );


### PR DESCRIPTION
Builds on top of the thunks support added in #27276 and refactors just the parts of core-data required to make the `deleteEntityRecord` work (see #28389 from @jsnajdr).

**Test plan:**

* Confirm all the tests are green.
* Go to the widgets editor, delete a few widgets, click Update, confirm it worked as expected.
* Try anything else delete-related that comes to your mind.
 