### PR TITLE
Gallery Block: Get media data in a single request

### DIFF
--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -32,7 +32,7 @@ export default function useGetMedia( innerBlockImages ) {
 
 			return select( coreStore ).getMediaItems( {
 				include: imageIds.join( ',' ),
-				per_page: imageIds.length,
+				per_page: -1,
 			} );
 		},
 		[ innerBlockImages ]

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -29,23 +29,18 @@ export default function useGetMedia( innerBlockImages ) {
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;
 			}
-			const getMedia = select( coreStore ).getMedia;
-			const newImageMedia = imageIds.map( ( img ) => {
-				return getMedia( img );
+
+			return select( coreStore ).getMediaItems( {
+				include: imageIds.join( ',' ),
+				per_page: imageIds.length,
 			} );
-
-			if ( newImageMedia.some( ( img ) => ! img ) ) {
-				return currentImageMedia;
-			}
-
-			return newImageMedia;
 		},
 		[ innerBlockImages ]
 	);
 
 	if (
-		imageMedia?.length !== currentImageMedia.length ||
-		imageMedia.some(
+		imageMedia?.length !== currentImageMedia?.length ||
+		imageMedia?.some(
 			( newImage ) =>
 				! currentImageMedia.find(
 					( currentImage ) => currentImage.id === newImage.id


### PR DESCRIPTION
## Description
With recent Gallery block refactoring now, it's possible to request media data in a single call instead of N numbers of requests.

The small downside of this change is that it will fire a new request when a gallery item (Image block) is selected. But I think this still improves the initial load of image data.

Fixes #10994.

## How has this been tested?
1. Enable "Gallery block experiment" from Gutenberg > Experiments screen.
2. Make sure the gallery works as expected - adding, reordering, deleting images.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
