### PR TITLE
Global Styles: Add unit tests for edit site editor utils

### DIFF
--- a/packages/edit-site/src/components/editor/test/utils.js
+++ b/packages/edit-site/src/components/editor/test/utils.js
@@ -1,0 +1,146 @@
+/**
+ * Internal dependencies
+ */
+import { getPresetVariable, getValueFromVariable } from '../utils';
+
+describe( 'editor utils', () => {
+	const styles = {
+		version: 1,
+		settings: {
+			color: {
+				palette: {
+					theme: [
+						{
+							slug: 'primary',
+							color: '#007cba',
+							name: 'Primary',
+						},
+						{
+							slug: 'secondary',
+							color: '#006ba1',
+							name: 'Secondary',
+						},
+					],
+					user: [
+						{
+							slug: 'primary',
+							color: '#007cba',
+							name: 'Primary',
+						},
+						{
+							slug: 'secondary',
+							color: '#a65555',
+							name: 'Secondary',
+						},
+					],
+				},
+				custom: true,
+				customDuotone: true,
+				customGradient: true,
+				link: true,
+			},
+			custom: {
+				color: {
+					primary: 'var(--wp--preset--color--primary)',
+					secondary: 'var(--wp--preset--color--secondary)',
+				},
+			},
+		},
+		isGlobalStylesUserThemeJSON: true,
+	};
+
+	describe( 'getPresetVariable', () => {
+		const context = 'root';
+		const propertyName = 'color';
+		const value = '#007cba';
+
+		describe( 'when a provided global style (e.g. fontFamily, color,etc.) does not exist', () => {
+			it( 'returns the originally provided value', () => {
+				const actual = getPresetVariable(
+					styles,
+					context,
+					'fakePropertyName',
+					value
+				);
+				expect( actual ).toBe( value );
+			} );
+		} );
+
+		describe( 'when a global style is cleared by the user', () => {
+			it( 'returns an undefined preset variable', () => {
+				const actual = getPresetVariable(
+					styles,
+					context,
+					propertyName,
+					undefined
+				);
+				expect( actual ).toBe( undefined );
+			} );
+		} );
+
+		describe( 'when a global style is selected by the user', () => {
+			describe( 'and it is not a preset value (e.g. custom color)', () => {
+				it( 'returns the originally provided value', () => {
+					const customValue = '#6e4545';
+					const actual = getPresetVariable(
+						styles,
+						context,
+						propertyName,
+						customValue
+					);
+					expect( actual ).toBe( customValue );
+				} );
+			} );
+
+			describe( 'and it is a preset value', () => {
+				it( 'returns the preset variable', () => {
+					const actual = getPresetVariable(
+						styles,
+						context,
+						propertyName,
+						value
+					);
+					expect( actual ).toBe( 'var:preset|color|primary' );
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'getValueFromVariable', () => {
+		describe( 'when provided an invalid variable', () => {
+			it( 'returns the originally provided value', () => {
+				const actual = getValueFromVariable(
+					styles,
+					'root',
+					undefined
+				);
+
+				expect( actual ).toBe( undefined );
+			} );
+		} );
+
+		describe( 'when provided a preset variable', () => {
+			it( 'retrieves the correct preset value', () => {
+				const actual = getValueFromVariable(
+					styles,
+					'root',
+					'var:preset|color|primary'
+				);
+
+				expect( actual ).toBe( '#007cba' );
+			} );
+		} );
+
+		describe( 'when provided a custom variable', () => {
+			it( 'retrieves the correct custom value', () => {
+				const actual = getValueFromVariable(
+					styles,
+					'root',
+					'var(--wp--custom--color--secondary)'
+				);
+
+				expect( actual ).toBe( '#a65555' );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Adds unit tests to global styles utils in `packages/edit-site/src/components/editor/utils.js` for:
- `getPresetVariable()`
- `getValueFromVariable()`

**Note:**
This PR does not include tests for the `useSetting()` hook, which lives in the same utils file.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run `npm run test-unit packages/edit-site/src/components/editor/test/utils.js` in a terminal from within the Gutenberg repo

## Screenshots <!-- if applicable -->
### Before
<img width="1366" alt="Screen Shot 2021-08-30 at 4 27 07 PM" src="https://user-images.githubusercontent.com/5414230/131418492-7ade225c-8372-4076-be7d-76126fe88976.png">

### After
<img width="1358" alt="Screen Shot 2021-08-30 at 4 26 19 PM" src="https://user-images.githubusercontent.com/5414230/131418497-3742a053-41e3-4c0f-bb5c-bf9243c8ccc9.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Adds Tests

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
