### PR TITLE
Gallery block: Fix problem with overflowing captions on new gallery block format

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -52,9 +52,9 @@
 			font-size: $default-font-size;
 			left: 0;
 			margin-bottom: 0;
-			max-height: 100%;
+			max-height: 38%;
 			overflow: auto;
-			padding: 40px 10px 9px;
+			padding: 0 0 8px;
 			position: absolute;
 			text-align: center;
 			width: 100%;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -58,6 +58,7 @@
 			position: absolute;
 			text-align: center;
 			width: 100%;
+			box-sizing: border-box;
 
 			img {
 				display: inline;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -52,9 +52,9 @@
 			font-size: $default-font-size;
 			left: 0;
 			margin-bottom: 0;
-			max-height: 38%;
+			max-height: 60%;
 			overflow: auto;
-			padding: 0 0 8px;
+			padding: 0 8px 8px;
 			position: absolute;
 			text-align: center;
 			width: 100%;


### PR DESCRIPTION
## Description
Currently very long captions cause the  the caption  to overflow outside the image. 

This PR also implements [the suggestion here](https://github.com/WordPress/gutenberg/issues/7963#issuecomment-627612937) by @mapk to try and give a better indication that the caption is scrollable and also to stop long captions covering the whole image. This could be handled in a different PR if there are differing views on whether this is a good approach to this problem or not.

## To test

- Check out PR to local dev env and enable Gallery experiment
- Add a gallery block and make sure long captions do not overflow the image and are scrollable 

## Screenshots 

Before:
<img width="699" alt="Screen Shot 2021-08-31 at 3 18 55 PM" src="https://user-images.githubusercontent.com/3629020/131436257-16bda76b-e316-412e-b328-363652d8c939.png">

After:
![after](https://user-images.githubusercontent.com/3629020/131436330-ee89321f-43c8-4719-a7f9-8bf32e4bd7f6.gif)



