### PR TITLE
MenuItem: Add right padding for unchecked radio and checkbox items

### DIFF
--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -2,6 +2,13 @@
 .components-menu-item__button.components-button {
 	width: 100%;
 
+	&[role="menuitemradio"],
+	&[role="menuitemcheckbox"] {
+		.components-menu-item__item:only-child {
+			padding-right: $grid-unit-60;
+		}
+	}
+
 	.components-menu-items__item-icon {
 		margin-right: -2px; // This optically balances the icon.
 		margin-left: $grid-unit-30;

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -5,6 +5,8 @@
 	&[role="menuitemradio"],
 	&[role="menuitemcheckbox"] {
 		.components-menu-item__item:only-child {
+			// Ensure unchecked items have clearance for consistency
+			// with checked items containing an icon or shortcut.
 			padding-right: $grid-unit-60;
 		}
 	}

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -22,6 +22,7 @@ export default {
 
 export const _default = () => {
 	const [ height, setHeight ] = useState();
+	const [ minHeight, setMinHeight ] = useState();
 	const [ width, setWidth ] = useState();
 
 	const resetAll = () => {
@@ -39,6 +40,18 @@ export const _default = () => {
 				>
 					<ToolsPanelItem
 						className="single-column"
+						hasValue={ () => !! width }
+						label="Width"
+						onDeselect={ () => setWidth( undefined ) }
+					>
+						<UnitControl
+							label="Width"
+							value={ width }
+							onChange={ ( next ) => setWidth( next ) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						className="single-column"
 						hasValue={ () => !! height }
 						label="Height"
 						onDeselect={ () => setHeight( undefined ) }
@@ -50,15 +63,14 @@ export const _default = () => {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						className="single-column"
-						hasValue={ () => !! width }
-						label="Width"
-						onDeselect={ () => setWidth( undefined ) }
+						hasValue={ () => !! minHeight }
+						label="Minimum height"
+						onDeselect={ () => setMinHeight( undefined ) }
 					>
 						<UnitControl
-							label="Width"
-							value={ width }
-							onChange={ ( next ) => setWidth( next ) }
+							label="Minimum height"
+							value={ minHeight }
+							onChange={ ( next ) => setMinHeight( next ) }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
[Based on this suggestion](https://github.com/WordPress/gutenberg/pull/34375#issuecomment-908415069), this is an alternative to #34375 with the goal of ensuring consistent width of the dropdown menu items between checked and unchecked states.

This PR adds right padding to checkbox and radio dropdown menu items that are only children — that is, they do not have icons or shortcuts.

The goal is to ensure that the padding is accounted for in the menu item's unchecked state, so that when it is checked, the menu item takes up the same amount of room visually. It also ensures that unchecked menu items do not encroach upon the space used by icons to denote checked status.

The expected behaviour is most notable with the ToolsPanel when we add a longer menu item to it, so this PR also includes an update to the ToolsPanel story, for testing. See screenshots below:

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually using Storybook:

```
npm run storybook:dev
```

Go to http://localhost:50240/?path=/story/components-experimental-toolspanel--default and experiment with checking and unchecking the panel items.

## Screenshots <!-- if applicable -->

With other items checked (note there isn't enough whitespace next to the third item):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/131295992-21a5269e-9304-4f22-88d4-041356348835.png) | ![image](https://user-images.githubusercontent.com/14988353/131296006-91003ac9-8829-4322-bcd7-53bab9a0ed82.png) |

With other items unchecked (note that in the before gif, the width of the popover is inconsistent between all items unchecked and one item checked)

| Before | After |
| --- | --- |
| ![tools-panel-menu-item-before-sml](https://user-images.githubusercontent.com/14988353/131296652-5ce48fc3-26d3-452e-aad1-8ebce247dc32.gif) | ![tools-panel-menu-item-after-sml](https://user-images.githubusercontent.com/14988353/131296688-7f55fcc0-4ec2-4c6b-a44b-9e0ef85c11d8.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
(non-breaking change which fixes a styling issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
