### PR TITLE
Consolidate the PATHS_WITH_MERGE constant to one instance

### DIFF
--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { PATHS_WITH_MERGE } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -47,13 +48,6 @@ const deprecatedFlags = {
 		return settings.enableCustomUnits;
 	},
 	'spacing.customPadding': ( settings ) => settings.enableCustomSpacing,
-};
-
-const PATHS_WITH_MERGE = {
-	'color.gradients': true,
-	'color.palette': true,
-	'typography.fontFamilies': true,
-	'typography.fontSizes': true,
 };
 
 /**

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { PATHS_WITH_MERGE } from '@wordpress/blocks';
+import { __EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -665,6 +665,10 @@ _Returns_
 
 -   `Array|string`: A list of blocks or a string, depending on `handlerMode`.
 
+### PATHS_WITH_MERGE
+
+Undocumented declaration.
+
 ### rawHandler
 
 Converts an HTML string to known blocks.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -665,10 +665,6 @@ _Returns_
 
 -   `Array|string`: A list of blocks or a string, depending on `handlerMode`.
 
-### PATHS_WITH_MERGE
-
-Undocumented declaration.
-
 ### rawHandler
 
 Converts an HTML string to known blocks.

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -125,7 +125,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	h6: 'h6',
 };
 
-export const PATHS_WITH_MERGE = {
+export const __EXPERIMENTAL_PATHS_WITH_MERGE = {
 	'color.duotone': true,
 	'color.gradients': true,
 	'color.palette': true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -126,7 +126,6 @@ export const __EXPERIMENTAL_ELEMENTS = {
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {
-	'color.duotone': true,
 	'color.gradients': true,
 	'color.palette': true,
 	'typography.fontFamilies': true,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -124,3 +124,11 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	h5: 'h5',
 	h6: 'h6',
 };
+
+export const PATHS_WITH_MERGE = {
+	'color.duotone': true,
+	'color.gradients': true,
+	'color.palette': true,
+	'typography.fontFamilies': true,
+	'typography.fontSizes': true,
+};

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -159,4 +159,5 @@ export { default as node } from './node';
 export {
 	__EXPERIMENTAL_STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS,
+	PATHS_WITH_MERGE,
 } from './constants';

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -159,5 +159,5 @@ export { default as node } from './node';
 export {
 	__EXPERIMENTAL_STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS,
-	PATHS_WITH_MERGE,
+	__EXPERIMENTAL_PATHS_WITH_MERGE,
 } from './constants';

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -6,7 +6,7 @@ import { get, find, forEach, camelCase, isString } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { PATHS_WITH_MERGE } from '@wordpress/blocks';
+import { __EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -6,6 +6,7 @@ import { get, find, forEach, camelCase, isString } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { PATHS_WITH_MERGE } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -90,13 +91,6 @@ function getPresetMetadataFromStyleProperty( styleProperty ) {
 	}
 	return getPresetMetadataFromStyleProperty.MAP[ styleProperty ];
 }
-
-const PATHS_WITH_MERGE = {
-	'color.gradients': true,
-	'color.palette': true,
-	'typography.fontFamilies': true,
-	'typography.fontSizes': true,
-};
 
 export function useSetting( path, blockName = '' ) {
 	const settings = useSelect( ( select ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
As suggested in https://github.com/WordPress/gutenberg/pull/34073#discussion_r699073788, this consolidates the two instances of PATHS_WITH_MERGE to one definition and moves it to the constants file.

## How has this been tested?
- Check that the block editor continues to load as before

## Types of changes
- Refactor

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
