### PR TITLE
Allow disabling `text` and `background` color via `theme.json`

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -222,13 +222,15 @@ The settings section has the following structure:
 			"customWidth": false
 		},
 		"color": {
+			"background": true,
 			"custom": true,
 			"customDuotone": true,
 			"customGradient": true,
 			"duotone": [],
 			"gradients": [],
 			"link": false,
-			"palette": []
+			"palette": [],
+			"text": true
 		},
 		"custom": {},
 		"layout": {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -85,6 +85,7 @@ class WP_Theme_JSON_Gutenberg {
 			'customWidth'  => null,
 		),
 		'color'      => array(
+			'background'     => null,
 			'custom'         => null,
 			'customDuotone'  => null,
 			'customGradient' => null,
@@ -92,6 +93,7 @@ class WP_Theme_JSON_Gutenberg {
 			'gradients'      => null,
 			'link'           => null,
 			'palette'        => null,
+			'text'           => null,
 		),
 		'custom'     => null,
 		'layout'     => array(

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -2,6 +2,7 @@
 	"version": 1,
 	"settings": {
 		"color": {
+			"background": true,
 			"palette": [
 				{
 					"name": "Black",
@@ -171,7 +172,8 @@
 			"custom": true,
 			"customDuotone": true,
 			"customGradient": true,
-			"link": false
+			"link": false,
+			"text": true
 		},
 		"typography": {
 			"dropCap": true,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -222,6 +222,8 @@ export function ColorEdit( props ) {
 	const areCustomSolidsEnabled = useSetting( 'color.custom' );
 	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
 	const isLinkEnabled = useSetting( 'color.link' );
+	const isTextEnabled = useSetting( 'color.text' );
+	const isBackgroundEnabled = useSetting( 'color.background' );
 
 	// Shouldn't be needed but right now the ColorGradientsPanel
 	// can trigger both onChangeColor and onChangeBackground
@@ -242,9 +244,11 @@ export function ColorEdit( props ) {
 		( solids.length > 0 || areCustomSolidsEnabled );
 	const hasTextColor =
 		hasTextColorSupport( blockName ) &&
+		isTextEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
 	const hasBackgroundColor =
 		hasBackgroundColorSupport( blockName ) &&
+		isBackgroundEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
 	const hasGradientColor =
 		hasGradientSupport( blockName ) &&

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -34,6 +34,12 @@ export default function ColorPanel( {
 		'color.customGradient',
 		name
 	);
+	const isLinkEnabled = useSetting( 'color.link', name );
+
+	const hasLinkColor =
+		supports.includes( 'linkColor' ) &&
+		isLinkEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled );
 
 	const settings = [];
 
@@ -88,7 +94,7 @@ export default function ColorPanel( {
 		} );
 	}
 
-	if ( supports.includes( 'linkColor' ) ) {
+	if ( hasLinkColor ) {
 		const color = getStyle( name, 'linkColor' );
 		const userColor = getStyle( name, 'linkColor', 'user' );
 		settings.push( {

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -27,10 +27,13 @@ export default function ColorPanel( {
 	getSetting,
 	setSetting,
 } ) {
-	const colors = useSetting( 'color.palette', name );
-	const disableCustomColors = ! useSetting( 'color.custom', name );
+	const solids = useSetting( 'color.palette', name );
 	const gradients = useSetting( 'color.gradients', name );
-	const disableCustomGradients = ! useSetting( 'color.customGradient', name );
+	const areCustomSolidsEnabled = useSetting( 'color.custom', name );
+	const areCustomGradientsEnabled = useSetting(
+		'color.customGradient',
+		name
+	);
 
 	const settings = [];
 
@@ -99,10 +102,10 @@ export default function ColorPanel( {
 		<PanelColorGradientSettings
 			title={ __( 'Color' ) }
 			settings={ settings }
-			colors={ colors }
+			colors={ solids }
 			gradients={ gradients }
-			disableCustomColors={ disableCustomColors }
-			disableCustomGradients={ disableCustomGradients }
+			disableCustomColors={ ! areCustomSolidsEnabled }
+			disableCustomGradients={ ! areCustomGradientsEnabled }
 		>
 			<ColorPalettePanel
 				key={ 'color-palette-panel-' + name }

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -50,6 +50,9 @@ export default function ColorPanel( {
 		supports.includes( 'backgroundColor' ) &&
 		isBackgroundEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasGradientColor =
+		supports.includes( 'background' ) &&
+		( gradients.length > 0 || areCustomGradientsEnabled );
 
 	const settings = [];
 
@@ -80,7 +83,7 @@ export default function ColorPanel( {
 	}
 
 	let gradientSettings = {};
-	if ( supports.includes( 'background' ) ) {
+	if ( hasGradientColor ) {
 		const gradient = getStyle( name, 'background' );
 		const userGradient = getStyle( name, 'background', 'user' );
 		gradientSettings = {
@@ -93,10 +96,7 @@ export default function ColorPanel( {
 		}
 	}
 
-	if (
-		supports.includes( 'background' ) ||
-		supports.includes( 'backgroundColor' )
-	) {
+	if ( hasBackgroundColor || hasGradientColor ) {
 		settings.push( {
 			...backgroundSettings,
 			...gradientSettings,
@@ -114,6 +114,7 @@ export default function ColorPanel( {
 			clearable: color === userColor,
 		} );
 	}
+
 	return (
 		<PanelColorGradientSettings
 			title={ __( 'Color' ) }

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -35,15 +35,25 @@ export default function ColorPanel( {
 		name
 	);
 	const isLinkEnabled = useSetting( 'color.link', name );
+	const isTextEnabled = useSetting( 'color.text', name );
+	const isBackgroundEnabled = useSetting( 'color.background', name );
 
 	const hasLinkColor =
 		supports.includes( 'linkColor' ) &&
 		isLinkEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasTextColor =
+		supports.includes( 'color' ) &&
+		isTextEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled );
+	const hasBackgroundColor =
+		supports.includes( 'backgroundColor' ) &&
+		isBackgroundEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled );
 
 	const settings = [];
 
-	if ( supports.includes( 'color' ) ) {
+	if ( hasTextColor ) {
 		const color = getStyle( name, 'color' );
 		const userColor = getStyle( name, 'color', 'user' );
 		settings.push( {
@@ -55,7 +65,7 @@ export default function ColorPanel( {
 	}
 
 	let backgroundSettings = {};
-	if ( supports.includes( 'backgroundColor' ) ) {
+	if ( hasBackgroundColor ) {
 		const backgroundColor = getStyle( name, 'backgroundColor' );
 		const userBackgroundColor = getStyle( name, 'backgroundColor', 'user' );
 		backgroundSettings = {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34414

## Description 

This also fixes the logic to show the subcomponents of the color panel:

- **link** is enabled when all these conditions are met:
  - the block supports it
  - the theme supports it (it's false by default)
  - either the presets contain some solid value or the custom colors can be used

- **text** is enabled when all these conditions are met:
  - the block supports it
  - the theme supports it (it's true by default)
  - either the presets contain some solid value or the custom colors can be used.

- **background** is enabled when all these conditions are met:
  - the block supports it
  - the theme supports it (it's true by default)
  - either the presets contain some solid value or the custom colors can be used

- **gradients** is enabled when all these conditions are met:
  - the block supports it
  - either the presets contain some solid value or the custom colors can be used

As per https://github.com/WordPress/gutenberg/issues/34414 we don't need a specific key for gradients.

## How to test

- Using the empty theme, verify that the theme can disable the text, background, and link independently.

```
{
  "version": 1,
  "settings": {
    "color": {
      "background": true / false,
      "link": true / false,
      "text": true / false,
    }
  }
}
```

- Also verify not providing any value works as expected. In this case, text & background should be enabled but link should be disabled.