### PR TITLE
Classic meta boxes: try tab

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -18,7 +18,7 @@ import {
 import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useRefEffect } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
 import { __, _x } from '@wordpress/i18n';
 import {
@@ -184,6 +184,24 @@ function Layout( { styles } ) {
 		return null;
 	};
 
+	const refEffect = useRefEffect( ( { ownerDocument } ) => {
+		const { defaultView } = ownerDocument;
+
+		function checkFocus() {
+			if ( ownerDocument.activeElement.nodeName !== 'IFRAME' ) {
+				return;
+			}
+
+			ownerDocument.activeElement.focus();
+		}
+
+		defaultView.addEventListener( 'blur', checkFocus );
+
+		return () => {
+			defaultView.removeEventListener( 'blur', checkFocus );
+		};
+	}, [] );
+
 	return (
 		<>
 			<FullscreenMode isActive={ isFullscreenActive } />
@@ -237,9 +255,20 @@ function Layout( { styles } ) {
 							<VisualEditor styles={ styles } />
 						) }
 						{ ! isTemplateMode && (
-							<div className="edit-post-layout__metaboxes">
-								<MetaBoxes location="normal" />
-								<MetaBoxes location="advanced" />
+							<div
+								className="edit-post-layout__metaboxes"
+								ref={ refEffect }
+							>
+								<Button
+									className="edit-post-sidebar__panel-tab"
+									tabIndex={ -1 }
+								>
+									{ __( 'Meta boxes' ) }
+								</Button>
+								<div className="edit-post-layout__metaboxes-container">
+									<MetaBoxes location="normal" />
+									<MetaBoxes location="advanced" />
+								</div>
 							</div>
 						) }
 						{ isMobileViewport && sidebarIsOpened && (

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,13 +1,32 @@
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
-}
-.edit-post-layout__metaboxes:not(:empty) {
-	border-top: $border-width solid $gray-300;
-	padding: 10px 0 10px;
-	clear: both;
 
-	.edit-post-meta-boxes-area {
-		margin: auto 20px;
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	top: 0;
+	z-index: 40;
+
+	.components-button.edit-post-sidebar__panel-tab {
+		background-color: #fff;
+	}
+
+	transform: translateY(calc(100% - 48px));
+
+	&:focus-within {
+		transform: translateY(0);
+	}
+
+	.edit-post-layout__metaboxes-container {
+		border-top: 1px solid #ddd;
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		top: 48px;
+		overflow: auto;
+		background: #fff;
 	}
 }
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -53,7 +53,12 @@ function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 				<WritingFlow
 					ref={ contentRef }
 					className="editor-styles-wrapper"
-					style={ { flex: '1', ...style } }
+					style={ {
+						flex: '1',
+						height: '100%',
+						overflow: 'auto',
+						...style,
+					} }
 					tabIndex={ -1 }
 				>
 					{ children }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -2,6 +2,7 @@
 	position: relative;
 	display: flex;
 	flex-flow: column;
+	height: 100%;
 
 	// Gray preview overlay (desktop/tablet/mobile) is intentionally not set on an element with scrolling content like
 	// interface-interface-skeleton__content. This causes graphical glitches (flashes of the background color)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

See #34105 for background.

![hidden-meta-boxes](https://user-images.githubusercontent.com/4710635/131640538-37bffa75-f4d4-4a8f-9eef-cb4938d414df.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
