### PR TITLE
Copy Handler: only handle paste event once

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -130,6 +130,15 @@ export function useClipboardHandler() {
 			if ( event.type === 'cut' ) {
 				removeBlocks( selectedBlockClientIds );
 			} else if ( event.type === 'paste' ) {
+				if (
+					event.defaultPrevented &&
+					event.target.classList.contains(
+						'block-editor-rich-text__editable'
+					)
+				) {
+					// If event originated from rich text this was already handled in rich-text/use-paste-handler.js
+					return;
+				}
 				const {
 					__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
 				} = getSettings();

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -113,6 +113,7 @@ export function useClipboardHandler() {
 				return;
 			}
 
+			const eventDefaultPrevented = event.defaultPrevented;
 			event.preventDefault();
 
 			if ( event.type === 'copy' || event.type === 'cut' ) {
@@ -130,12 +131,8 @@ export function useClipboardHandler() {
 			if ( event.type === 'cut' ) {
 				removeBlocks( selectedBlockClientIds );
 			} else if ( event.type === 'paste' ) {
-				if (
-					event.target.classList.contains(
-						'block-editor-rich-text__editable'
-					)
-				) {
-					// If event originated from rich text this was already handled in rich-text/use-paste-handler.js
+				if ( eventDefaultPrevented ) {
+					// This was likely already handled in rich-text/use-paste-handler.js
 					return;
 				}
 				const {

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -131,7 +131,13 @@ export function useClipboardHandler() {
 			if ( event.type === 'cut' ) {
 				removeBlocks( selectedBlockClientIds );
 			} else if ( event.type === 'paste' ) {
-				if ( eventDefaultPrevented ) {
+				if (
+					eventDefaultPrevented ||
+					( event.cancelable === false &&
+						event.target.classList.contains(
+							'block-editor-rich-text__editable'
+						) )
+				) {
 					// This was likely already handled in rich-text/use-paste-handler.js
 					return;
 				}

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -131,7 +131,6 @@ export function useClipboardHandler() {
 				removeBlocks( selectedBlockClientIds );
 			} else if ( event.type === 'paste' ) {
 				if (
-					event.defaultPrevented &&
 					event.target.classList.contains(
 						'block-editor-rich-text__editable'
 					)

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -131,13 +131,7 @@ export function useClipboardHandler() {
 			if ( event.type === 'cut' ) {
 				removeBlocks( selectedBlockClientIds );
 			} else if ( event.type === 'paste' ) {
-				if (
-					eventDefaultPrevented ||
-					( event.cancelable === false &&
-						event.target.classList.contains(
-							'block-editor-rich-text__editable'
-						) )
-				) {
+				if ( eventDefaultPrevented ) {
 					// This was likely already handled in rich-text/use-paste-handler.js
 					return;
 				}

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -126,6 +126,7 @@ async function emulateClipboard( type ) {
 		document.activeElement.dispatchEvent(
 			new ClipboardEvent( _type, {
 				bubbles: true,
+				cancelable: true,
 				clipboardData: window._clipboardData,
 			} )
 		);

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -68,6 +68,18 @@ exports[`Copy/cut/paste of whole blocks should cut and paste individual blocks 2
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Copy/cut/paste of whole blocks should handle paste events once 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+<p>P</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->"
+`;
+
 exports[`Copy/cut/paste of whole blocks should respect inline copy in places like input fields and textareas 1`] = `
 "<!-- wp:shortcode -->
 [my-shortcode]

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Copy/cut/paste of whole blocks can copy group onto non textual element (image, spacer) 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+<p>P</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->"
+`;
+
 exports[`Copy/cut/paste of whole blocks should copy and paste individual blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>Here is a unique string so we can test copying.</p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Copy/cut/paste of whole blocks can copy group onto non textual element (image, spacer) 1`] = `
+exports[`Copy/cut/paste of whole blocks can copy group onto non textual element (image, spacer) 1`] = `""`;
+
+exports[`Copy/cut/paste of whole blocks can copy group onto non textual element (image, spacer) 2`] = `
 "<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->
@@ -68,7 +70,9 @@ exports[`Copy/cut/paste of whole blocks should cut and paste individual blocks 2
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Copy/cut/paste of whole blocks should handle paste events once 1`] = `
+exports[`Copy/cut/paste of whole blocks should handle paste events once 1`] = `""`;
+
+exports[`Copy/cut/paste of whole blocks should handle paste events once 2`] = `
 "<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -94,12 +94,14 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 	} );
 
 	it( 'should handle paste events once', async () => {
+		// Add group block with paragraph
 		await insertBlock( 'Group' );
 		await page.click( '.block-editor-button-block-appender' );
 		await page.click( '.editor-block-list-item-paragraph' );
 		await page.keyboard.type( 'P' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
+		// Cut group
 		await pressKeyWithModifier( 'primary', 'x' );
 		await page.keyboard.press( 'Enter' );
 
@@ -122,26 +124,32 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 			} );
 		} );
 
+		// Paste
 		await pressKeyWithModifier( 'primary', 'v' );
 
+		// Blocks should only be modified once, not twice with new clientIds on a single paste action
 		const blocksUpdated = await page.evaluate(
 			() => window.e2eTestPasteOnce
 		);
 
 		expect( blocksUpdated.length ).toEqual( 1 );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'can copy group onto non textual element (image, spacer)', async () => {
+		// Add group block with paragraph
 		await insertBlock( 'Group' );
 		await page.click( '.block-editor-button-block-appender' );
 		await page.click( '.editor-block-list-item-paragraph' );
 		await page.keyboard.type( 'P' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );
+		// Cut group
 		await pressKeyWithModifier( 'primary', 'x' );
 		await page.keyboard.press( 'Enter' );
+		// Insert a non textual element (a spacer)
 		await insertBlock( 'Spacer' );
-		//spacer is focused
+		// Spacer is focused
 		await page.evaluate( () => {
 			window.e2eTestPasteOnce = [];
 			let oldBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
@@ -163,6 +171,7 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 
 		await pressKeyWithModifier( 'primary', 'v' );
 
+		// Paste should be handled on non-textual elements and only handled once.
 		const blocksUpdated = await page.evaluate(
 			() => window.e2eTestPasteOnce
 		);

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -103,6 +103,8 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		// Cut group
 		await pressKeyWithModifier( 'primary', 'x' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		await page.keyboard.press( 'Enter' );
 
 		await page.evaluate( () => {
@@ -146,7 +148,10 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		// Cut group
 		await pressKeyWithModifier( 'primary', 'x' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
 		await page.keyboard.press( 'Enter' );
+
 		// Insert a non textual element (a spacer)
 		await insertBlock( 'Spacer' );
 		// Spacer is focused

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -92,4 +92,42 @@ describe( 'Copy/cut/paste of whole blocks', () => {
 		await pressKeyWithModifier( 'primary', 'v' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should handle paste events once', async () => {
+		await insertBlock( 'Group' );
+		await page.click( '.block-editor-button-block-appender' );
+		await page.click( '.editor-block-list-item-paragraph' );
+		await page.keyboard.type( 'P' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'x' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.evaluate( () => {
+			window.e2eTestPasteOnce = [];
+			let oldBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
+			wp.data.subscribe( () => {
+				const blocks = wp.data
+					.select( 'core/block-editor' )
+					.getBlocks();
+				if ( blocks !== oldBlocks ) {
+					window.e2eTestPasteOnce.push(
+						blocks.map( ( { clientId, name } ) => ( {
+							clientId,
+							name,
+						} ) )
+					);
+				}
+				oldBlocks = blocks;
+			} );
+		} );
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		const blocksUpdated = await page.evaluate(
+			() => window.e2eTestPasteOnce
+		);
+
+		expect( blocksUpdated.length ).toEqual( 1 );
+	} );
 } );


### PR DESCRIPTION
When copy and pasting blocks I noticed that we were dispatching two `REPLACE_BLOCKS` actions, causing state to be updated two times. I'm relatively sure that the second handling is unintentional when we only have one block selected. In the copy handler the event.target points to the old paragraph block instead of the newly inserted blocks.

https://user-images.githubusercontent.com/1270189/131576875-a284cc1b-5de6-4427-a6a4-e13babfccde1.mp4

https://user-images.githubusercontent.com/1270189/131576878-81069d0f-eb08-48c1-b2fb-c315deed0aee.mp4

The replace block actions are coming from:

https://github.com/WordPress/gutenberg/blob/01040b800ea02216bea5b5d78bbb6d272e5c8967/packages/block-editor/src/components/rich-text/use-paste-handler.js#L208

https://github.com/WordPress/gutenberg/blob/01040b800ea02216bea5b5d78bbb6d272e5c8967/packages/block-editor/src/components/copy-handler/index.js#L144-L149

### Testing Instructions

- Copy blocks that have innerBlocks. A quick way of doing this is dragging a block pattern and copying it.
- Start with a fresh empty post and paste the blocks
- Verify that blocks are inserted as expected, and only insert once. (the block clientIds do not change).
- Verify that no regressions are present (multi-select paste should work as expected).