### PR TITLE
Add option to manual transform from the old gallery to new gallery format

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -36,6 +36,22 @@ import PatternTransformationsMenu from './pattern-transformations-menu';
 export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( blocks[ 0 ].clientId );
+
+	// The following method is needed to allow a manual transform from the old to new
+	// gallery block formats. It can be removed once old galleries are automatically
+	// migrated on edit.
+	const transformNewGalleryTitle = ( transform ) => {
+		{
+			if (
+				blockInformation.name === 'core/gallery' &&
+				transform.id === 'core/gallery'
+			) {
+				transform.title = __( 'New Gallery Format' );
+			}
+			return transform;
+		}
+	};
+
 	const {
 		possibleBlockTransformations,
 		hasBlockStyles,
@@ -73,7 +89,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 				possibleBlockTransformations: getBlockTransformItems(
 					blocks,
 					rootClientId
-				),
+				).map( transformNewGalleryTitle ),
 				hasBlockStyles: !! styles?.length,
 				icon: _icon,
 				blockTitle: getBlockType( firstBlockName ).title,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -52,6 +52,7 @@ export default function useBlockDisplayInformation( clientId ) {
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const blockTypeInfo = {
+				name: blockType.name,
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -129,6 +129,49 @@ addFilter(
 const transforms = {
 	from: [
 		{
+			// Allow transform to new gallery format if experimental flag enabled.
+			// can be removed once automatic migration of old galleries on edit is added.
+			type: 'block',
+			isMultiBlock: false,
+			blocks: [ 'core/gallery' ],
+			priority: 1,
+			isMatch( { ids } ) {
+				const settings = select( blockEditorStore ).getSettings();
+				return (
+					settings.__unstableGalleryWithImageBlocks && ids.length > 0
+				);
+			},
+			transform( { images, linkTo, sizeSlug } ) {
+				let link;
+				switch ( linkTo ) {
+					case 'post':
+						link = LINK_DESTINATION_ATTACHMENT;
+						break;
+					case 'file':
+						link = LINK_DESTINATION_MEDIA;
+						break;
+					default:
+						link = LINK_DESTINATION_NONE;
+						break;
+				}
+				const innerBlocks = images.map( ( image ) =>
+					createBlock( 'core/image', {
+						id: parseInt( image.id, 10 ),
+						url: image.url,
+						alt: image.alt,
+						caption: image.caption,
+						linkDestination: link,
+					} )
+				);
+
+				return createBlock(
+					'core/gallery',
+					{ sizeSlug, linkTo: link },
+					innerBlocks
+				);
+			},
+		},
+		{
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],


### PR DESCRIPTION
## Description
Fixes: #33486 Currently there is no way to transform a Gallery block in the old format to the new nested Image block format. An automatic migrate on edit, which would normally be added to deprecations on a block change, was not added in this instance in order to reduce the risk of releasing this breaking change to the Gallery block.

It would be good however to give users the option to manually transform individual galleries. This could be done by just adding the gallery transform which is part of this PR. This was included as part of the original PR, but it was thought that having a transform option of 'Gallery' in a Gallery transform menu was too confusing for users.

There isn't currently any way to pass a custom title to a transform, and this is a reasonably unique case so potentially not worth add this to the API, so this approach just adds a temporary mapping for this which can be removed once an automatic migration is added to a gallery deprecation.

Happy to explore a more permanent option of adding an optional `title` param to the transformations flow it that is thought to be a useful addition to the API.

## How has this been tested?

- Check out PR to local dev env
- Add a Gallery with gallery experiment flag off
- Turn on the gallery experiment flag and make sure there is now a transform to new gallery option on the gallery transform menu
- Check that the menu option works and that the menu option doesn't appear for the new gallery format.

## Screenshots 
![transform](https://user-images.githubusercontent.com/3629020/131610454-9ad68c7e-f758-4090-84a8-610130b545f7.gif)
