### PR TITLE
Fix menu item padding regression.

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -5,22 +5,16 @@
 	display: none;
 }
 
-// Forcing some space above the list of options in
-// the dropdown to visually balance them.
-.block-editor-media-replace-flow__options .components-popover__content > div {
-	padding-top: $grid-unit-20;
-}
-
 .block-editor-media-replace-flow__indicator {
 	margin-left: 4px;
 }
 
 .block-editor-media-flow__url-input {
 	border-top: $border-width solid $gray-900;
-	margin-top: $grid-unit-15;
-	margin-right: -$grid-unit-15;
-	margin-left: -$grid-unit-15;
-	padding: $grid-unit-15 $grid-unit-30 0;
+	margin-top: $grid-unit-10;
+	margin-right: -$grid-unit-10;
+	margin-left: -$grid-unit-10;
+	padding: $grid-unit-20;
 
 	.block-editor-media-replace-flow__image-url-label {
 		display: block;

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -1,10 +1,10 @@
 .block-editor-tool-selector__help {
 	margin-top: $grid-unit-10;
-	margin-left: -$grid-unit-15;
-	margin-right: -$grid-unit-15;
-	margin-bottom: -$grid-unit-15;
-	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
-	border-top: 1px solid $gray-300;
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+	margin-bottom: -$grid-unit-10;
+	padding: $grid-unit-20;
+	border-top: $border-width solid $gray-300;
 	color: $gray-700;
 	min-width: 280px;
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -61,25 +61,25 @@
 	}
 
 	.components-menu-group {
-		padding: $grid-unit-15;
+		padding: $grid-unit-10;
 		margin-top: 0;
 		margin-bottom: 0;
-		margin-left: -$grid-unit-15;
-		margin-right: -$grid-unit-15;
+		margin-left: -$grid-unit-10;
+		margin-right: -$grid-unit-10;
 
 		&:first-child {
-			margin-top: -$grid-unit-15;
+			margin-top: -$grid-unit-10;
 		}
 
 		&:last-child {
-			margin-bottom: -$grid-unit-15;
+			margin-bottom: -$grid-unit-10;
 		}
 	}
 
 	.components-menu-group + .components-menu-group {
 		margin-top: 0;
 		border-top: $border-width solid $gray-400;
-		padding: $grid-unit-15;
+		padding: $grid-unit-10;
 
 		.is-alternate & {
 			border-color: $gray-900;


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/34378#issuecomment-909837099. 

A change to simplify and unify dropdown menu item padding failed to accommodate further customizations done in other components. This caused a horizontal scrollbar to appear in some popovers. This PR follows up and hopefully catches the remaining issues. 

## How has this been tested?

Please test dropdown menus and elements that use the popover component across the board, but notably these three:

- The Tools panel
- The Image "Replace" dropdown

## Screenshots <!-- if applicable -->

The issue is fixed in these:

<img width="405" alt="Screenshot 2021-09-01 at 08 49 54" src="https://user-images.githubusercontent.com/1204802/131625992-011d8dd4-b556-4660-9395-6535d650c1b9.png">

<img width="333" alt="Screenshot 2021-09-01 at 08 51 05" src="https://user-images.githubusercontent.com/1204802/131625993-b8b5e537-8a5b-4391-af9a-5704811ee12a.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
