### PR TITLE
Add default editor styles applied to themes without theme.json and without editor styles

### DIFF
--- a/lib/compat/wordpress-5.9/default-editor-styles.php
+++ b/lib/compat/wordpress-5.9/default-editor-styles.php
@@ -24,9 +24,11 @@ function gutenberg_extend_block_editor_settings_with_default_editor_styles( $set
 
 	// Remove the default font addition from Core Code.
 	$styles_without_core_styles = array();
-	foreach ( $settings['styles'] as $style ) {
-		if ( 'core' !== $style['__unstableType'] ) {
-			$styles_without_core_styles[] = $style;
+	if ( isset( $settings['styles'] ) ) {
+		foreach ( $settings['styles'] as $style ) {
+			if ( 'core' !== $style['__unstableType'] ) {
+				$styles_without_core_styles[] = $style;
+			}
 		}
 	}
 	$settings['styles'] = $styles_without_core_styles;

--- a/lib/compat/wordpress-5.9/default-editor-styles.php
+++ b/lib/compat/wordpress-5.9/default-editor-styles.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Loads the default editor styles.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Load the default editor styles.
+ * These styles are used if the "no theme styles" options is triggered
+ * or on themes without their own editor styles.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_block_editor_settings_with_default_editor_styles( $settings ) {
+	$default_editor_styles_file      = gutenberg_dir_path() . 'build/block-editor/default-editor-styles.css';
+	$settings['defaultEditorStyles'] = array(
+		array(
+			'css' => file_get_contents( $default_editor_styles_file ),
+		),
+	);
+
+	// Remove the default font addition from Core Code.
+	$styles_without_core_styles = array();
+	foreach ( $settings['styles'] as $style ) {
+		if ( 'core' !== $style['__unstableType'] ) {
+			$styles_without_core_styles[] = $style;
+		}
+	}
+	$settings['styles'] = $styles_without_core_styles;
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_settings_with_default_editor_styles' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -142,7 +142,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 		// Reset existing global styles.
 		$styles_without_existing_global_styles = array();
-		foreach ( $settings['styles'] as $key => $style ) {
+		foreach ( $settings['styles'] as $style ) {
 			if ( ! isset( $style['__unstableType'] ) || 'globalStyles' !== $style['__unstableType'] ) {
 				$styles_without_existing_global_styles[] = $style;
 			}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -141,15 +141,17 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		}
 
 		// Reset existing global styles.
+		$styles_without_existing_global_styles = array();
 		foreach ( $settings['styles'] as $key => $style ) {
-			if ( isset( $style['__unstableType'] ) && 'globalStyles' === $style['__unstableType'] ) {
-				unset( $settings['styles'][ $key ] );
+			if ( ! isset( $style['__unstableType'] ) || 'globalStyles' !== $style['__unstableType'] ) {
+				$styles_without_existing_global_styles[] = $style;
 			}
 		}
 
 		// Add the new ones.
-		$settings['styles'][] = $css_variables;
-		$settings['styles'][] = $block_styles;
+		$styles_without_existing_global_styles[] = $css_variables;
+		$styles_without_existing_global_styles[] = $block_styles;
+		$settings['styles']                      = $styles_without_existing_global_styles;
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.

--- a/lib/load.php
+++ b/lib/load.php
@@ -83,6 +83,7 @@ require_once __DIR__ . '/widgets-page.php';
 require __DIR__ . '/compat.php';
 require __DIR__ . '/compat/wordpress-5.8/index.php';
 require __DIR__ . '/compat/wordpress-5.8.1/index.php';
+require __DIR__ . '/compat/wordpress-5.9/default-editor-styles.php';
 require __DIR__ . '/utils.php';
 require __DIR__ . '/editor-settings.php';
 

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -68,6 +68,7 @@ export default function EditorStyles( { styles } ) {
 		() => transformStyles( styles, EDITOR_STYLES_SELECTOR ),
 		[ styles ]
 	);
+
 	return (
 		<>
 			{ /* Use an empty style element to have a document reference,

--- a/packages/block-editor/src/default-editor-styles.scss
+++ b/packages/block-editor/src/default-editor-styles.scss
@@ -1,0 +1,9 @@
+body {
+	font-family: $default-font;
+	line-height: 1.5;
+	--wp--style--block-gap: 1.5em;
+}
+
+p {
+	line-height: 2;
+}

--- a/packages/block-editor/src/default-editor-styles.scss
+++ b/packages/block-editor/src/default-editor-styles.scss
@@ -13,7 +13,7 @@ body {
 }
 
 p {
-	line-height: 2;
+	line-height: 1.8;
 }
 
 .editor-post-title__block {

--- a/packages/block-editor/src/default-editor-styles.scss
+++ b/packages/block-editor/src/default-editor-styles.scss
@@ -1,9 +1,24 @@
+/**
+ * Default editor styles.
+ *
+ * These styles are shown if a theme does not register its own editor style,
+ * a theme.json file, or has toggled off "Use theme styles" in preferences.
+ */
+
 body {
 	font-family: $default-font;
+	font-size: 18px;
 	line-height: 1.5;
-	--wp--style--block-gap: 1.5em;
+	--wp--style--block-gap: 2em;
 }
 
 p {
 	line-height: 2;
+}
+
+.editor-post-title__block {
+	margin-top: 2em;
+	margin-bottom: 1em;
+	font-size: 2.5em;
+	font-weight: 800;
 }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -156,7 +156,9 @@ function Editor( {
 	] );
 
 	const styles = useMemo( () => {
-		return hasThemeStyles ? settings.styles : [];
+		return hasThemeStyles && settings.styles?.length
+			? settings.styles
+			: settings.defaultEditorStyles;
 	}, [ settings, hasThemeStyles ] );
 
 	if ( ! post ) {


### PR DESCRIPTION
closes #34397 

This PR adds some default editor styles for themes that don't style the editor at all:

 - don't have editor styles
 - don't have a theme.json file

They also apply to all themes when you uncheck "use theme styles" in the preferences.

**Testing instructions**

Check with a variety of themes:

 - It should not impact themes with editors tyles
 - It should apply to themes without editor styles
 - It should apply to all themes when you uncheck "use theme styles".