### PR TITLE
Disable  "block-nav-menus" feature for the purposes of removing the "experimental" status on the Navigation Editor

### DIFF
--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -41,7 +41,10 @@ function gutenberg_navigation_init( $hook ) {
 	$settings = array_merge(
 		gutenberg_get_default_block_editor_settings(),
 		array(
-			'blockNavMenus' => get_theme_support( 'block-nav-menus' ),
+			'blockNavMenus' => false,
+			// We should uncomment the line below when the block-nav-menus feature becomes stable.
+			// @see https://github.com/WordPress/gutenberg/issues/34265.
+			/*'blockNavMenus' => get_theme_support( 'block-nav-menus' ),*/
 		)
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -152,7 +152,10 @@ add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_block_nav_menu_item', 
  * @return array Updated menu items, sorted by each menu item's menu order.
  */
 function gutenberg_remove_block_nav_menu_items( $menu_items ) {
-	if ( current_theme_supports( 'block-nav-menus' ) ) {
+	// We should uncomment the line below when the block-nav-menus feature becomes stable.
+	// @see https://github.com/WordPress/gutenberg/issues/34265.
+	/*if ( current_theme_supports( 'block-nav-menus' ) ) {*/
+	if ( false ) {
 		return $menu_items;
 	}
 
@@ -246,7 +249,10 @@ function gutenberg_convert_menu_items_to_blocks(
  * @return string|null Nav menu output to short-circuit with.
  */
 function gutenberg_output_block_nav_menu( $output, $args ) {
-	if ( ! current_theme_supports( 'block-nav-menus' ) ) {
+	// We should uncomment the line below when the block-nav-menus feature becomes stable.
+	// @see https://github.com/WordPress/gutenberg/issues/34265.
+	/*if ( ! current_theme_supports( 'block-nav-menus' ) ) {*/
+	if ( true ) {
 		return null;
 	}
 

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -41,6 +41,8 @@ Moreover, when the navigation is rendered on the front of the site the system co
 
 ### Block-based Mode
 
+**Important**: block-based mode has been temporarily ***disabled*** until it becomes stable. So, if a theme declares support for the `block-nav-menus` feature it will not affect the frontend.
+
 If desired, themes are able to opt into _rendering_ complete block-based menus using the Navigation Editor. This allows for arbitrarily complex navigation block structures to be used in an existing theme whilst still ensuring the navigation data is still _saved_ to the existing (post type powered) Menus system.
 
 Themes can opt into this behaviour by declaring:


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
For the purposes of removing the "experimental" status on the Navigation Editor, we agreed we would disable the theme opt-in from the screen until core developers have had enough time to improve the feature. That means no additional blocks.
Fixes https://github.com/WordPress/gutenberg/issues/34265.

## Steps to test this PR.
1. Enable support for the `block-nav-menus` feature.
If you theme doesn't support this feature you can "enable" it programmatically by modifying the [plugins/gutenberg/lib/navigation-page.php](https://github.com/WordPress/gutenberg/blob/trunk/lib/navigation-page.php#L31) file.
To do so go to that file and add this line
```php
get_theme_support( 'block-nav-menus' );
```
at the very beginning of the `gutenberg_navigation_init`'s function body ([around line 31](https://github.com/WordPress/gutenberg/blob/trunk/lib/navigation-page.php#L31)).
2. Go to the Gutenberg ->Navigation Editor -> Experiments page.
3. Enable the `Enable Navigation screen` setting, save the changes.
![Screenshot 2021-09-01 at 21 23 06](https://user-images.githubusercontent.com/43744263/131731477-a91f6765-6bbd-4dbf-96f6-690ce4bfa9ef.png)
4. Go to the Gutenberg -> Navigation page.
5. Create a new menu.
6. Click on the "Start empty" link.
![Screenshot 2021-09-01 at 21 28 24](https://user-images.githubusercontent.com/43744263/131732502-9495084f-fcdf-4cc4-b6c9-bd7a6c11e35e.png)
7. Click on the plus sign.
Expected result:
Make sure you only see "regular" menu items like those on the screenshot below:
![Screenshot 2021-09-01 at 21 28 30](https://user-images.githubusercontent.com/43744263/131734347-cbf1ccbc-85b8-422a-8c5f-87c294874017.png)
You *shouldn't* see block menu items, like `Social Links` block on the screenshot below:
![Screenshot 2021-09-01 at 21 50 36](https://user-images.githubusercontent.com/43744263/131735038-75627e06-6abd-4d8d-8ebb-c7d916d14c4c.png)

## Types of changes
New feature / Breaking change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
