### PR TITLE
Update bug form to use drop downs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a bug with the WordPress block editor or Gutenberg plugin
-title: '<title>'
+title: ''
 body:
     - type: markdown
       attributes:
@@ -56,8 +56,8 @@ body:
           description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
           multiple: true
           options:
-             - Yes
-             - No
+             - 'Yes'
+             - 'No'
    
     - type: dropdown
       id: plugins
@@ -65,6 +65,6 @@ body:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
           multiple: true
           options:
-             - Yes
-             - No
+             - 'Yes'
+             - 'No'
         

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -59,7 +59,7 @@ body:
              - Yes
              - No
    
-   - type: dropdown
+    - type: dropdown
       id: plugins
       attributes:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -49,10 +49,22 @@ body:
       validations:
           required: false
           
-    - type: checkboxes
+    - type: dropdown
+      id: existing
       attributes:
-          label: Pre-checks
-          description: Please check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues and make sure the bug is not related to another plugin.
+          label: Please confirm that you have searched existing issues in the repo.
+          description: You can do this by searching https://github.com/WordPress/gutenberg/issues and making sure the bug is not related to another plugin.
+          multiple: true
           options:
-              - label: I have searched the existing issues.
-              - label: I have tested with all plugins deactivated except Gutenberg.
+             - Yes
+             - No
+   
+   - type: dropdown
+      id: plugins
+      attributes:
+          label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
+      multiple: true
+          options:
+             - Yes
+             - No
+        

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -58,6 +58,8 @@ body:
           options:
              - 'Yes'
              - 'No'
+      validations:
+          required: true
    
     - type: dropdown
       id: plugins
@@ -67,4 +69,5 @@ body:
           options:
              - 'Yes'
              - 'No'
-        
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -63,7 +63,7 @@ body:
       id: plugins
       attributes:
           label: Please confirm that you have tested with all plugins deactivated except Gutenberg.
-      multiple: true
+          multiple: true
           options:
              - Yes
              - No


### PR DESCRIPTION
## Description

This is a minor change that removes the checkboxes since that causes a todo list functionality to be triggered in the UI, making it hard for contributors to keep track of what's happening.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

## Types of changes

Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
