### PR TITLE
Block Editor: Migrate `lightBlockWrapper` support to `apiVersion` for blocks

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -51,10 +51,7 @@ export const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	if (
-		blockType.apiVersion > 1 ||
-		hasBlockSupport( blockType, 'lightBlockWrapper', false )
-	) {
+	if ( blockType.apiVersion > 1 ) {
 		return <Component { ...props } context={ context } />;
 	}
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -17,7 +17,6 @@ import {
 	getBlockType,
 	getSaveContent,
 	isUnmodifiedDefaultBlock,
-	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
@@ -110,9 +109,6 @@ function BlockListBlock( {
 	);
 
 	const blockType = getBlockType( name );
-	const lightBlockWrapper =
-		blockType?.apiVersion > 1 ||
-		hasBlockSupport( blockType, 'lightBlockWrapper', false );
 
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType?.getEditWrapperProps ) {
@@ -159,7 +155,7 @@ function BlockListBlock( {
 				</Block>
 			</>
 		);
-	} else if ( lightBlockWrapper ) {
+	} else if ( blockType?.apiVersion > 1 ) {
 		block = blockEdit;
 	} else {
 		block = <Block { ...wrapperProps }>{ blockEdit }</Block>;

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -11,7 +11,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	__unstableGetBlockProps as getBlockProps,
 	getBlockType,
-	hasBlockSupport,
 } from '@wordpress/blocks';
 import { useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -68,11 +67,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		index,
 		mode,
 		name,
+		blockApiVersion,
 		blockTitle,
 		isPartOfSelection,
 		adjustScrolling,
 		enableAnimation,
-		lightBlockWrapper,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -99,6 +98,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				index: getBlockIndex( clientId, rootClientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
+				blockApiVersion: blockType?.apiVersion || 1,
 				blockTitle: blockType?.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
@@ -106,9 +106,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				enableAnimation:
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
-				lightBlockWrapper:
-					blockType?.apiVersion > 1 ||
-					hasBlockSupport( blockType, 'lightBlockWrapper', false ),
 			};
 		},
 		[ clientId ]
@@ -139,7 +136,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	const blockEditContext = useBlockEditContext();
 	// Ensures it warns only inside the `edit` implementation for the block.
-	if ( ! lightBlockWrapper && clientId === blockEditContext.clientId ) {
+	if ( blockApiVersion < 2 && clientId === blockEditContext.clientId ) {
 		warning(
 			`Block type "${ name }" must support API version 2 or higher to work correctly with "useBlockProps" method.`
 		);

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-custom-class-name.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,9 +32,7 @@ export function useBlockCustomClassName( clientId ) {
 			}
 
 			const blockType = getBlockType( getBlockName( clientId ) );
-			const hasLightBlockWrapper =
-				blockType?.apiVersion > 1 ||
-				hasBlockSupport( blockType, 'lightBlockWrapper', false );
+			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 
 			if ( ! hasLightBlockWrapper ) {
 				return;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-default-class-name.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	hasBlockSupport,
-	getBlockType,
-	getBlockDefaultClassName,
-} from '@wordpress/blocks';
+import { getBlockType, getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -26,9 +22,7 @@ export function useBlockDefaultClassName( clientId ) {
 		( select ) => {
 			const name = select( blockEditorStore ).getBlockName( clientId );
 			const blockType = getBlockType( name );
-			const hasLightBlockWrapper =
-				blockType?.apiVersion > 1 ||
-				hasBlockSupport( blockType, 'lightBlockWrapper', false );
+			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 
 			if ( ! hasLightBlockWrapper ) {
 				return;

--- a/packages/block-editor/src/hooks/compat.js
+++ b/packages/block-editor/src/hooks/compat.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { hasBlockSupport } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
+
+function migrateLightBlockWrapper( settings ) {
+	const { apiVersion = 1 } = settings;
+	if (
+		apiVersion < 2 &&
+		hasBlockSupport( settings, 'lightBlockWrapper', false )
+	) {
+		settings.apiVersion = 2;
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/compat/migrateLightBlockWrapper',
+	migrateLightBlockWrapper
+);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './compat';
 import './align';
 import './anchor';
 import './custom-class-name';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './compat';
 import './align';
 import './anchor';
 import './custom-class-name';

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -18,7 +18,6 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
-	hasBlockSupport,
 } from './registration';
 import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
 import BlockContentProvider from '../block-content-provider';
@@ -118,14 +117,10 @@ export function getSaveElement(
 
 	let element = save( { attributes, innerBlocks } );
 
-	const hasLightBlockWrapper =
-		blockType.apiVersion > 1 ||
-		hasBlockSupport( blockType, 'lightBlockWrapper', false );
-
 	if (
 		isObject( element ) &&
 		hasFilter( 'blocks.getSaveContent.extraProps' ) &&
-		! hasLightBlockWrapper
+		! ( blockType.apiVersion > 1 )
 	) {
 		/**
 		 * Filters the props applied to the block save result element.


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for https://github.com/WordPress/gutenberg/pull/34346/files#r697287973:

> does `lightBlockWrapper` handling exist only for backward compatibility? I don't see it used with core blocks anymore. I see it referenced in multiple places in the block editor package. Could we set `apiVersion` to 2 in a hook during registration to simplify all those checks?

The change refactors code to no longer use `lightBlockWrapper` check for block types and instead migrates this removed `supports` field to `apiVersion` 2 if the version is lower than 2.

The rationale behind the proposed change is to simplify checks in the codebase.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

<img width="1002" alt="Screen Shot 2021-09-01 at 17 19 36" src="https://user-images.githubusercontent.com/699132/131699193-8eb0300f-90e7-44e8-bede-3fe5eaca4281.png">
<img width="1047" alt="Screen Shot 2021-09-01 at 17 22 13" src="https://user-images.githubusercontent.com/699132/131699202-602283d2-da16-4d8b-a224-b1403dc82170.png">

The most popular use case can be tested in the Browser Console:

```js
wp.blocks.registerBlockType( 'my/test-2', { title: 'Test', edit: function() { return 'Test' }, supports: { lightBlockWrapper: true } } );
```

## Types of changes
Code quality change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
