### PR TITLE
Fix linting error in trunk

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -7,7 +7,6 @@ import { v4 as uuid } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { controls } from '@wordpress/data';
 import { __unstableAwaitPromise } from '@wordpress/data-controls';
 import triggerFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';


### PR DESCRIPTION
A linting error was introduce from: https://github.com/WordPress/gutenberg/pull/34387. This PR just fixes that.