### PR TITLE
Border Controls: Add placeholders and base styles

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -149,7 +149,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'__experimentalStyles'                   => array(
 					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'mobile' ),
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor', 'mobile' ),
 				),
 
 				'alignWide'                              => array(

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -111,9 +111,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, $origin );
 
-	if ( 'mobile' === $context ) {
-		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
-	}
+	$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
 
 	if ( 'site-editor' === $context ) {
 		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -111,7 +111,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, $origin );
 
-	$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
+	if ( 'site-editor' !== $context ) {
+		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
+	}
 
 	if ( 'site-editor' === $context ) {
 		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );

--- a/packages/block-editor/src/components/border-radius-control/all-input-control.js
+++ b/packages/block-editor/src/components/border-radius-control/all-input-control.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import {
+	__experimentalParseUnit as parseUnit,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -9,11 +12,22 @@ import { __ } from '@wordpress/i18n';
  */
 import { getAllValue, hasMixedValues, hasDefinedValues } from './utils';
 
-export default function AllInputControl( { onChange, values, ...props } ) {
+export default function AllInputControl( {
+	onChange,
+	values,
+	defaults,
+	...props
+} ) {
 	const allValue = getAllValue( values );
 	const hasValues = hasDefinedValues( values );
-	const isMixed = hasValues && hasMixedValues( values );
-	const allPlaceholder = isMixed ? __( 'Mixed' ) : null;
+	const isMixedValues = hasValues && hasMixedValues( values );
+
+	const [ allDefault ] = parseUnit( getAllValue( defaults ) );
+	const isMixedDefaults =
+		hasDefinedValues( defaults ) && hasMixedValues( defaults );
+
+	const isMixed = isMixedValues || ( ! hasValues && isMixedDefaults );
+	const allPlaceholder = isMixed ? __( 'Mixed' ) : allDefault;
 
 	return (
 		<UnitControl

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -42,12 +42,20 @@ const MAX_BORDER_RADIUS_VALUES = {
  * @param {Object}   props          Component props.
  * @param {Function} props.onChange Callback to handle onChange.
  * @param {Object}   props.values   Border radius values.
+ * @param {Object}   props.defaults Border radius default values.
  *
  * @return {WPElement}              Custom border radius control.
  */
-export default function BorderRadiusControl( { onChange, values } ) {
+export default function BorderRadiusControl( { onChange, values, defaults } ) {
+	const isMixedValues =
+		hasDefinedValues( values ) && hasMixedValues( values );
+	const isMixedDefaults =
+		hasDefinedValues( defaults ) && hasMixedValues( defaults );
 	const [ isLinked, setIsLinked ] = useState(
-		! hasDefinedValues( values ) || ! hasMixedValues( values )
+		! (
+			isMixedValues ||
+			( ! hasDefinedValues( values ) && isMixedDefaults )
+		)
 	);
 
 	const units = useCustomUnits( {
@@ -58,6 +66,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 	const step = unitConfig?.step || 1;
 
 	const [ allValue ] = parseUnit( getAllValue( values ) );
+	const [ allDefault ] = parseUnit( getAllValue( defaults ) );
 
 	const toggleLinked = () => setIsLinked( ! isLinked );
 
@@ -74,6 +83,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 						<AllInputControl
 							className="components-border-radius-control__unit-control"
 							values={ values }
+							defaults={ defaults }
 							min={ MIN_BORDER_RADIUS_VALUE }
 							onChange={ onChange }
 							unit={ unit }
@@ -81,7 +91,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 						/>
 						<RangeControl
 							className="components-border-radius-control__range-control"
-							value={ allValue }
+							value={ allValue || allDefault }
 							min={ MIN_BORDER_RADIUS_VALUE }
 							max={ MAX_BORDER_RADIUS_VALUES[ unit ] }
 							initialPosition={ 0 }
@@ -95,6 +105,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 						min={ MIN_BORDER_RADIUS_VALUE }
 						onChange={ onChange }
 						values={ values || DEFAULT_VALUES }
+						defaults={ defaults }
 						units={ units }
 					/>
 				) }

--- a/packages/block-editor/src/components/border-radius-control/input-controls.js
+++ b/packages/block-editor/src/components/border-radius-control/input-controls.js
@@ -1,8 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import {
+	__experimentalParseUnit as parseUnit,
+	__experimentalUnitControl as UnitControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getValuesObject } from './utils';
 
 const CORNERS = {
 	topLeft: __( 'Top left' ),
@@ -14,6 +22,7 @@ const CORNERS = {
 export default function BoxInputControls( {
 	onChange,
 	values: valuesProp,
+	defaults: defaultsProp,
 	...props
 } ) {
 	const createHandleOnChange = ( corner ) => ( next ) => {
@@ -27,16 +36,9 @@ export default function BoxInputControls( {
 		} );
 	};
 
-	// For shorthand style & backwards compatibility, handle flat string value.
-	const values =
-		typeof valuesProp !== 'string'
-			? valuesProp
-			: {
-					topLeft: valuesProp,
-					topRight: valuesProp,
-					bottomLeft: valuesProp,
-					bottomRight: valuesProp,
-			  };
+	// For shorthand style & backwards compatibility, handle flat string values.
+	const values = getValuesObject( valuesProp );
+	const defaults = getValuesObject( defaultsProp );
 
 	// Controls are wrapped in tooltips as visible labels aren't desired here.
 	return (
@@ -47,6 +49,7 @@ export default function BoxInputControls( {
 					key={ key }
 					aria-label={ label }
 					value={ values[ key ] }
+					placeholder={ parseUnit( defaults[ key ] )[ 0 ] }
 					onChange={ createHandleOnChange( key ) }
 				/>
 			) ) }

--- a/packages/block-editor/src/components/border-radius-control/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/utils.js
@@ -74,6 +74,24 @@ export function getAllValue( values = {} ) {
 }
 
 /**
+ * For shorthand style & backwards compatibility, takes the radius values
+ * and handles flat string value.
+ *
+ * @param {string} values Radius values.
+ * @return {Object}       Radius values in longhand object form.
+ */
+export function getValuesObject( values = {} ) {
+	return typeof values !== 'string'
+		? values
+		: {
+				topLeft: values,
+				topRight: values,
+				bottomLeft: values,
+				bottomRight: values,
+		  };
+}
+
+/**
  * Checks to determine if values are mixed.
  *
  * @param {Object} values Radius values.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -147,3 +147,4 @@ export { default as __experimentalUseNoRecursiveRenders } from './use-no-recursi
 
 export { default as BlockEditorProvider } from './provider';
 export { default as useSetting } from './use-setting';
+export { default as __experimentalUseStyle } from './use-style';

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -15,7 +15,11 @@ import {
 	isLineHeightDefined,
 } from './utils';
 
-export default function LineHeightControl( { value: lineHeight, onChange } ) {
+export default function LineHeightControl( {
+	value: lineHeight,
+	onChange,
+	placeholder = BASE_DEFAULT_VALUE,
+} ) {
 	const isDefined = isLineHeightDefined( lineHeight );
 
 	const handleOnKeyDown = ( event ) => {
@@ -70,7 +74,7 @@ export default function LineHeightControl( { value: lineHeight, onChange } ) {
 				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnChange }
 				label={ __( 'Line height' ) }
-				placeholder={ BASE_DEFAULT_VALUE }
+				placeholder={ placeholder }
 				step={ STEP }
 				type="number"
 				value={ value }

--- a/packages/block-editor/src/components/use-style/index.js
+++ b/packages/block-editor/src/components/use-style/index.js
@@ -7,13 +7,14 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useBlockEditContext } from '../block-edit';
 import { store as blockEditorStore } from '../../store';
-import { getResolvedStyleVariable } from '../../utils/style-variable-resolution';
+import { getValueFromVariable } from '../../utils/style-variable-resolution';
 
 /**
  * Hook that retrieves the global styles of a block.
@@ -31,22 +32,20 @@ import { getResolvedStyleVariable } from '../../utils/style-variable-resolution'
 export default function useStyle( path ) {
 	const { name: blockName } = useBlockEditContext();
 
-	const setting = useSelect(
-		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
-			const settingsForBlock = get( settings, [
-				'__experimentalStyles',
-				'blocks',
-				blockName,
-			] );
-			return getResolvedStyleVariable(
-				settings.__experimentalFeatures,
-				blockName,
-				get( settingsForBlock, path )
-			);
-		},
-		[ blockName, path ]
-	);
-
-	return setting;
+	const settings = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings();
+	}, [] );
+	const settingsForBlock = get( settings, [
+		'__experimentalStyles',
+		'blocks',
+		blockName,
+	] );
+	const value = get( settingsForBlock, path );
+	return useMemo( () => {
+		return getValueFromVariable(
+			settings.__experimentalFeatures,
+			blockName,
+			value
+		);
+	}, [ settings.__experimentalFeatures, blockName, value ] );
 }

--- a/packages/block-editor/src/components/use-style/index.js
+++ b/packages/block-editor/src/components/use-style/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../block-edit';
+import { store as blockEditorStore } from '../../store';
+import { getResolvedStyleVariable } from '../../utils/style-variable-resolution';
+
+/**
+ * Hook that retrieves the global styles of a block.
+ * It works with nested objects using by finding the value at path.
+ *
+ * @param {string|Array} path The path to the setting.
+ *
+ * @return {any} Returns the style value defined for the path.
+ *
+ * @example
+ * ```js
+ * const backgroundColor = useStyle( 'color.background' );
+ * ```
+ */
+export default function useStyle( path ) {
+	const { name: blockName } = useBlockEditContext();
+
+	const setting = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			const settingsForBlock = get( settings, [
+				'__experimentalStyles',
+				'blocks',
+				blockName,
+			] );
+			return getResolvedStyleVariable(
+				settings.__experimentalFeatures,
+				blockName,
+				get( settingsForBlock, path )
+			);
+		},
+		[ blockName, path ]
+	);
+
+	return setting;
+}

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -54,8 +54,9 @@ export function BorderColorEdit( props ) {
 	const { style: borderStyle } = style?.border || {};
 	const defaultBorderStyle = useStyle( [ 'border', 'style' ] );
 	const defaultBorderColor = useStyle( [ 'border', 'color' ] );
+
 	const [ colorValue, setColorValue ] = useState(
-		borderColor || style?.border?.color || defaultBorderColor
+		borderColor || style?.border?.color
 	);
 
 	const onChangeColor = ( value ) => {
@@ -91,7 +92,7 @@ export function BorderColorEdit( props ) {
 	return (
 		<ColorGradientControl
 			label={ __( 'Color' ) }
-			colorValue={ colorValue }
+			colorValue={ colorValue || defaultBorderColor }
 			colors={ colors }
 			gradients={ undefined }
 			disableCustomColors={ disableCustomColors }

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -56,7 +56,11 @@ export function BorderColorEdit( props ) {
 	const defaultBorderColor = useStyle( [ 'border', 'color' ] );
 
 	const [ colorValue, setColorValue ] = useState(
-		borderColor || style?.border?.color
+		getColorObjectByAttributeValues(
+			colors,
+			borderColor,
+			style?.border?.color
+		)?.color
 	);
 
 	const onChangeColor = ( value ) => {

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -3,6 +3,7 @@
  */
 import BorderRadiusControl from '../components/border-radius-control';
 import { cleanEmptyObject } from './utils';
+import useStyle from '../components/use-style';
 
 /**
  * Inspector control panel containing the border radius related configuration.
@@ -16,6 +17,8 @@ export function BorderRadiusEdit( props ) {
 		attributes: { style },
 		setAttributes,
 	} = props;
+
+	const defaultBorderRadius = useStyle( [ 'border', 'radius' ] );
 
 	const onChange = ( newRadius ) => {
 		let newStyle = {
@@ -36,6 +39,7 @@ export function BorderRadiusEdit( props ) {
 	return (
 		<BorderRadiusControl
 			values={ style?.border?.radius }
+			defaults={ defaultBorderRadius }
 			onChange={ onChange }
 		/>
 	);

--- a/packages/block-editor/src/hooks/border-style.js
+++ b/packages/block-editor/src/hooks/border-style.js
@@ -3,6 +3,7 @@
  */
 import BorderStyleControl from '../components/border-style-control';
 import { cleanEmptyObject } from './utils';
+import useStyle from '../components/use-style';
 
 /**
  * Inspector control for configuring border style property.
@@ -16,6 +17,8 @@ export const BorderStyleEdit = ( props ) => {
 		attributes: { style },
 		setAttributes,
 	} = props;
+
+	const defaultBorderStyle = useStyle( [ 'border', 'style' ] );
 
 	const onChange = ( newBorderStyle ) => {
 		const newStyleAttributes = {
@@ -31,7 +34,7 @@ export const BorderStyleEdit = ( props ) => {
 
 	return (
 		<BorderStyleControl
-			value={ style?.border?.style }
+			value={ style?.border?.style || defaultBorderStyle }
 			onChange={ onChange }
 		/>
 	);

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	__experimentalParseUnit as parseUnit,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
@@ -36,7 +37,9 @@ export const BorderWidthEdit = ( props ) => {
 	const [ colorSelection, setColorSelection ] = useState();
 
 	const defaultBorderStyle = useStyle( [ 'border', 'style' ] );
-	const defaultBorderWidth = useStyle( [ 'border', 'width' ] );
+	const [ defaultBorderWidth ] = parseUnit(
+		useStyle( [ 'border', 'width' ] )
+	);
 
 	// Temporarily track previous border color & style selections to be able to
 	// restore them when border width changes from zero value.

--- a/packages/block-editor/src/hooks/border-width.js
+++ b/packages/block-editor/src/hooks/border-width.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { cleanEmptyObject } from './utils';
 import useSetting from '../components/use-setting';
+import useStyle from '../components/use-style';
 
 const MIN_BORDER_WIDTH = 0;
 
@@ -33,6 +34,9 @@ export const BorderWidthEdit = ( props ) => {
 		style?.border || {};
 	const [ styleSelection, setStyleSelection ] = useState();
 	const [ colorSelection, setColorSelection ] = useState();
+
+	const defaultBorderStyle = useStyle( [ 'border', 'style' ] );
+	const defaultBorderWidth = useStyle( [ 'border', 'width' ] );
 
 	// Temporarily track previous border color & style selections to be able to
 	// restore them when border width changes from zero value.
@@ -81,6 +85,12 @@ export const BorderWidthEdit = ( props ) => {
 			newStyle.border.style = styleSelection;
 		}
 
+		if ( ! hasZeroWidth && borderStyle === undefined ) {
+			newStyle.border.style = defaultBorderStyle
+				? defaultBorderStyle
+				: 'solid';
+		}
+
 		// Restore previous border color selection if width is no longer zero
 		// and current border color is undefined.
 		if ( ! hasZeroWidth && borderColor === undefined ) {
@@ -106,6 +116,7 @@ export const BorderWidthEdit = ( props ) => {
 	return (
 		<UnitControl
 			value={ width }
+			placeholder={ defaultBorderWidth }
 			label={ __( 'Width' ) }
 			min={ MIN_BORDER_WIDTH }
 			onChange={ onChange }

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -9,6 +9,7 @@ import { hasBlockSupport } from '@wordpress/blocks';
 import LineHeightControl from '../components/line-height-control';
 import { cleanEmptyObject } from './utils';
 import useSetting from '../components/use-setting';
+import useStyle from '../components/use-style';
 
 export const LINE_HEIGHT_SUPPORT_KEY = 'typography.lineHeight';
 
@@ -24,6 +25,7 @@ export function LineHeightEdit( props ) {
 		attributes: { style },
 	} = props;
 	const isDisabled = useIsLineHeightDisabled( props );
+	const defaultLineHeight = useStyle( [ 'typography', 'lineHeight' ] );
 
 	if ( isDisabled ) {
 		return null;
@@ -45,6 +47,7 @@ export function LineHeightEdit( props ) {
 		<LineHeightControl
 			value={ style?.typography?.lineHeight }
 			onChange={ onChange }
+			placeholder={ defaultLineHeight }
 		/>
 	);
 }

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,3 +1,7 @@
 export { default as transformStyles } from './transform-styles';
 export * from './theme';
 export * from './block-variation-transforms';
+export {
+	getResolvedStyleVariable as __experimentalGetResolvedStyleVariable,
+	getPresetVariableRepresentingAValue as __experimentalGetPresetVariableRepresentingAValue,
+} from './style-variable-resolution';

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -2,6 +2,6 @@ export { default as transformStyles } from './transform-styles';
 export * from './theme';
 export * from './block-variation-transforms';
 export {
-	getResolvedStyleVariable as __experimentalGetResolvedStyleVariable,
-	getPresetVariableRepresentingAValue as __experimentalGetPresetVariableRepresentingAValue,
+	getValueFromVariable as __experimentalGetValueFromVariable,
+	getPresetVariableFromValue as __experimentalGetPresetVariableFromValue,
 } from './style-variable-resolution';

--- a/packages/block-editor/src/utils/style-variable-resolution.js
+++ b/packages/block-editor/src/utils/style-variable-resolution.js
@@ -126,7 +126,7 @@ export function getResolvedStyleVariable( features, context, variable ) {
 			.slice( CSS_REFERENCE_PREFIX.length, -CSS_REFERENCE_SUFFIX.length )
 			.split( '--' );
 	} else {
-		// Value is raw.
+		// We don't know how to parse the value: either is raw of uses complex CSS such as `calc(1px * var(--wp--variable) )`
 		return variable;
 	}
 

--- a/packages/block-editor/src/utils/style-variable-resolution.js
+++ b/packages/block-editor/src/utils/style-variable-resolution.js
@@ -1,0 +1,180 @@
+/**
+ * External dependencies
+ */
+import { get, find, isString, kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __EXPERIMENTAL_PRESET_METADATA as PRESET_METADATA } from '@wordpress/blocks';
+
+const STYLE_PROPERTIES_TO_CSS_VAR_INFIX = {
+	linkColor: 'color',
+	backgroundColor: 'color',
+	background: 'gradient',
+};
+
+function findInPresetsBy(
+	features,
+	context,
+	presetPath,
+	presetProperty,
+	presetValueValue
+) {
+	// Block presets take priority above root level presets.
+	const orderedPresetsByOrigin = [
+		get( features, [ 'blocks', context, ...presetPath ] ),
+		get( features, presetPath ),
+	];
+	for ( const presetByOrigin of orderedPresetsByOrigin ) {
+		if ( presetByOrigin ) {
+			// Preset origins ordered by priority.
+			const origins = [ 'user', 'theme', 'core' ];
+			for ( const origin of origins ) {
+				const presets = presetByOrigin[ origin ];
+				if ( presets ) {
+					const presetObject = find(
+						presets,
+						( preset ) =>
+							preset[ presetProperty ] === presetValueValue
+					);
+					if ( presetObject ) {
+						if ( presetProperty === 'slug' ) {
+							return presetObject;
+						}
+						// if there is a highest priority preset with the same slug but different value the preset we found was overwritten and should be ignored.
+						const highestPresetObjectWithSameSlug = findInPresetsBy(
+							features,
+							context,
+							presetPath,
+							'slug',
+							presetObject.slug
+						);
+						if (
+							highestPresetObjectWithSameSlug[
+								presetProperty
+							] === presetObject[ presetProperty ]
+						) {
+							return presetObject;
+						}
+						return undefined;
+					}
+				}
+			}
+		}
+	}
+}
+
+function getValueFromPresetVariable(
+	features,
+	blockName,
+	variable,
+	[ presetType, slug ]
+) {
+	const metadata = find( PRESET_METADATA, [ 'cssVarInfix', presetType ] );
+	if ( ! metadata ) {
+		return variable;
+	}
+
+	const presetObject = findInPresetsBy(
+		features,
+		blockName,
+		metadata.path,
+		'slug',
+		slug
+	);
+
+	if ( presetObject ) {
+		const { valueKey } = metadata;
+		const result = presetObject[ valueKey ];
+		return getResolvedStyleVariable( features, blockName, result );
+	}
+
+	return variable;
+}
+
+function getValueFromCustomVariable( features, blockName, variable, path ) {
+	const result =
+		get( features, [ 'blocks', blockName, 'custom', ...path ] ) ??
+		get( features, [ 'custom', ...path ] );
+	if ( ! result ) {
+		return variable;
+	}
+	// A variable may reference another variable so we need recursion until we find the value.
+	return getResolvedStyleVariable( features, blockName, result );
+}
+
+export function getResolvedStyleVariable( features, context, variable ) {
+	if ( ! variable || ! isString( variable ) ) {
+		return variable;
+	}
+	const INTERNAL_REFERENCE_PREFIX = 'var:';
+	const CSS_REFERENCE_PREFIX = 'var(--wp--';
+	const CSS_REFERENCE_SUFFIX = ')';
+
+	let parsedVar;
+
+	if ( variable.startsWith( INTERNAL_REFERENCE_PREFIX ) ) {
+		parsedVar = variable
+			.slice( INTERNAL_REFERENCE_PREFIX.length )
+			.split( '|' );
+	} else if (
+		variable.startsWith( CSS_REFERENCE_PREFIX ) &&
+		variable.endsWith( CSS_REFERENCE_SUFFIX )
+	) {
+		parsedVar = variable
+			.slice( CSS_REFERENCE_PREFIX.length, -CSS_REFERENCE_SUFFIX.length )
+			.split( '--' );
+	} else {
+		// Value is raw.
+		return variable;
+	}
+
+	const [ type, ...path ] = parsedVar;
+	if ( type === 'preset' ) {
+		return getValueFromPresetVariable( features, context, variable, path );
+	}
+	if ( type === 'custom' ) {
+		return getValueFromCustomVariable( features, context, variable, path );
+	}
+	return variable;
+}
+
+export function getPresetVariableRepresentingAValue(
+	features,
+	context,
+	propertyName,
+	value
+) {
+	if ( ! value ) {
+		return value;
+	}
+
+	const cssVarInfix =
+		STYLE_PROPERTIES_TO_CSS_VAR_INFIX[ propertyName ] ||
+		kebabCase( propertyName );
+
+	const metadata = find( PRESET_METADATA, [ 'cssVarInfix', cssVarInfix ] );
+	if ( ! metadata ) {
+		// The property doesn't have preset data
+		// so the value should be returned as it is.
+		return value;
+	}
+	const { valueKey, path } = metadata;
+
+	const presetObject = findInPresetsBy(
+		features,
+		context,
+		path,
+		valueKey,
+		value
+	);
+
+	if ( ! presetObject ) {
+		// Value wasn't found in the presets,
+		// so it must be a custom value.
+		return value;
+	}
+
+	return `var:preset|${ cssVarInfix }|${ presetObject.slug }`;
+}

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -33,7 +33,13 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		},
 		"__experimentalLayout": true
 	},

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -37,7 +37,6 @@
 			"__experimentalDefaultControls": {
 				"color": true,
 				"radius": true,
-				"style": true,
 				"width": true
 			}
 		},

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -126,3 +126,45 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	h5: 'h5',
 	h6: 'h6',
 };
+
+export const __EXPERIMENTAL_PRESET_METADATA = [
+	{
+		path: [ 'color', 'palette' ],
+		valueKey: 'color',
+		cssVarInfix: 'color',
+		classes: [
+			{ classSuffix: 'color', propertyName: 'color' },
+			{
+				classSuffix: 'background-color',
+				propertyName: 'background-color',
+			},
+			{
+				classSuffix: 'border-color',
+				propertyName: 'border-color',
+			},
+		],
+	},
+	{
+		path: [ 'color', 'gradients' ],
+		valueKey: 'gradient',
+		cssVarInfix: 'gradient',
+		classes: [
+			{
+				classSuffix: 'gradient-background',
+				propertyName: 'background',
+			},
+		],
+	},
+	{
+		path: [ 'typography', 'fontSizes' ],
+		valueKey: 'size',
+		cssVarInfix: 'font-size',
+		classes: [ { classSuffix: 'font-size', propertyName: 'font-size' } ],
+	},
+	{
+		path: [ 'typography', 'fontFamilies' ],
+		valueKey: 'fontFamily',
+		cssVarInfix: 'font-family',
+		classes: [],
+	},
+];

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -159,4 +159,5 @@ export { default as node } from './node';
 export {
 	__EXPERIMENTAL_STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS,
+	__EXPERIMENTAL_PRESET_METADATA,
 } from './constants';

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -22,8 +22,8 @@ import {
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	__experimentalGetResolvedStyleVariable as getResolvedStyleVariable,
-	__experimentalGetPresetVariableRepresentingAValue as getPresetVariableRepresentingAValue,
+	__experimentalGetValueFromVariable as getValueFromVariable,
+	__experimentalGetPresetVariableFromValue as getPresetVariableFromValue,
 } from '@wordpress/block-editor';
 
 /**
@@ -258,7 +258,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 
 				if ( origin === 'theme' ) {
 					const value = get( themeStyles?.styles, path );
-					return getResolvedStyleVariable(
+					return getValueFromVariable(
 						themeStyles.settings,
 						context,
 						value
@@ -271,7 +271,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					// We still need to use merged styles here because the
 					// presets used to resolve user variable may be defined a
 					// layer down ( core, theme, or user ).
-					return getResolvedStyleVariable(
+					return getValueFromVariable(
 						mergedStyles.settings,
 						context,
 						value
@@ -279,7 +279,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				}
 
 				const value = get( mergedStyles?.styles, path );
-				return getResolvedStyleVariable(
+				return getValueFromVariable(
 					mergedStyles.settings,
 					context,
 					value
@@ -302,7 +302,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				set(
 					newStyles,
 					propertyPath,
-					getPresetVariableRepresentingAValue(
+					getPresetVariableFromValue(
 						mergedStyles.settings,
 						context,
 						propertyName,
@@ -337,6 +337,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				},
 			],
 			__experimentalFeatures: mergedStyles.settings,
+			__experimentalStyles: mergedStyles.styles,
 		} );
 	}, [ blocks, mergedStyles ] );
 

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -272,7 +272,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					// presets used to resolve user variable may be defined a
 					// layer down ( core, theme, or user ).
 					return getResolvedStyleVariable(
-						mergedStyles.setting,
+						mergedStyles.settings,
 						context,
 						value
 					);

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -16,10 +16,15 @@ import {
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
+	__EXPERIMENTAL_PRESET_METADATA as PRESET_METADATA,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	__experimentalGetResolvedStyleVariable as getResolvedStyleVariable,
+	__experimentalGetPresetVariableRepresentingAValue as getPresetVariableRepresentingAValue,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,9 +33,6 @@ import {
 	ROOT_BLOCK_NAME,
 	ROOT_BLOCK_SELECTOR,
 	ROOT_BLOCK_SUPPORTS,
-	getValueFromVariable,
-	getPresetVariable,
-	PRESET_METADATA,
 } from './utils';
 import { toCustomProperties, toStyles } from './global-styles-renderer';
 import { store as editSiteStore } from '../../store';
@@ -256,7 +258,11 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 
 				if ( origin === 'theme' ) {
 					const value = get( themeStyles?.styles, path );
-					return getValueFromVariable( themeStyles, context, value );
+					return getResolvedStyleVariable(
+						themeStyles.settings,
+						context,
+						value
+					);
 				}
 
 				if ( origin === 'user' ) {
@@ -265,11 +271,19 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 					// We still need to use merged styles here because the
 					// presets used to resolve user variable may be defined a
 					// layer down ( core, theme, or user ).
-					return getValueFromVariable( mergedStyles, context, value );
+					return getResolvedStyleVariable(
+						mergedStyles.setting,
+						context,
+						value
+					);
 				}
 
 				const value = get( mergedStyles?.styles, path );
-				return getValueFromVariable( mergedStyles, context, value );
+				return getResolvedStyleVariable(
+					mergedStyles.settings,
+					context,
+					value
+				);
 			},
 			setStyle: ( context, propertyName, newValue ) => {
 				const newContent = { ...userStyles };
@@ -288,8 +302,8 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				set(
 					newStyles,
 					propertyPath,
-					getPresetVariable(
-						mergedStyles,
+					getPresetVariableRepresentingAValue(
+						mergedStyles.settings,
 						context,
 						propertyName,
 						newValue

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -20,12 +20,13 @@ import {
 import {
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 	__EXPERIMENTAL_ELEMENTS as ELEMENTS,
+	__EXPERIMENTAL_PRESET_METADATA as PRESET_METADATA,
 } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { PRESET_METADATA, ROOT_BLOCK_SELECTOR } from './utils';
+import { ROOT_BLOCK_SELECTOR } from './utils';
 
 function compileStyleValue( uncompiledValue ) {
 	const VARIABLE_REFERENCE_PREFIX = 'var:';

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get  } from 'lodash';
+import { get } from 'lodash';
 /**
  * WordPress dependencies
  */

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { get, find, forEach, camelCase, isString } from 'lodash';
+import { get  } from 'lodash';
 /**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
@@ -28,69 +29,6 @@ export const ROOT_BLOCK_SUPPORTS = [
 	'textTransform',
 ];
 
-export const PRESET_METADATA = [
-	{
-		path: [ 'color', 'palette' ],
-		valueKey: 'color',
-		cssVarInfix: 'color',
-		classes: [
-			{ classSuffix: 'color', propertyName: 'color' },
-			{
-				classSuffix: 'background-color',
-				propertyName: 'background-color',
-			},
-			{
-				classSuffix: 'border-color',
-				propertyName: 'border-color',
-			},
-		],
-	},
-	{
-		path: [ 'color', 'gradients' ],
-		valueKey: 'gradient',
-		cssVarInfix: 'gradient',
-		classes: [
-			{
-				classSuffix: 'gradient-background',
-				propertyName: 'background',
-			},
-		],
-	},
-	{
-		path: [ 'typography', 'fontSizes' ],
-		valueKey: 'size',
-		cssVarInfix: 'font-size',
-		classes: [ { classSuffix: 'font-size', propertyName: 'font-size' } ],
-	},
-	{
-		path: [ 'typography', 'fontFamilies' ],
-		valueKey: 'fontFamily',
-		cssVarInfix: 'font-family',
-		classes: [],
-	},
-];
-
-const STYLE_PROPERTIES_TO_CSS_VAR_INFIX = {
-	linkColor: 'color',
-	backgroundColor: 'color',
-	background: 'gradient',
-};
-
-function getPresetMetadataFromStyleProperty( styleProperty ) {
-	if ( ! getPresetMetadataFromStyleProperty.MAP ) {
-		getPresetMetadataFromStyleProperty.MAP = {};
-		PRESET_METADATA.forEach( ( { cssVarInfix }, index ) => {
-			getPresetMetadataFromStyleProperty.MAP[ camelCase( cssVarInfix ) ] =
-				PRESET_METADATA[ index ];
-		} );
-		forEach( STYLE_PROPERTIES_TO_CSS_VAR_INFIX, ( value, key ) => {
-			getPresetMetadataFromStyleProperty.MAP[ key ] =
-				getPresetMetadataFromStyleProperty.MAP[ value ];
-		} );
-	}
-	return getPresetMetadataFromStyleProperty.MAP[ styleProperty ];
-}
-
 const PATHS_WITH_MERGE = {
 	'color.gradients': true,
 	'color.palette': true,
@@ -109,160 +47,4 @@ export function useSetting( path, blockName = '' ) {
 		return result.user ?? result.theme ?? result.core;
 	}
 	return result;
-}
-
-function findInPresetsBy(
-	styles,
-	context,
-	presetPath,
-	presetProperty,
-	presetValueValue
-) {
-	// Block presets take priority above root level presets.
-	const orderedPresetsByOrigin = [
-		get( styles, [ 'settings', 'blocks', context, ...presetPath ] ),
-		get( styles, [ 'settings', ...presetPath ] ),
-	];
-	for ( const presetByOrigin of orderedPresetsByOrigin ) {
-		if ( presetByOrigin ) {
-			// Preset origins ordered by priority.
-			const origins = [ 'user', 'theme', 'core' ];
-			for ( const origin of origins ) {
-				const presets = presetByOrigin[ origin ];
-				if ( presets ) {
-					const presetObject = find(
-						presets,
-						( preset ) =>
-							preset[ presetProperty ] === presetValueValue
-					);
-					if ( presetObject ) {
-						if ( presetProperty === 'slug' ) {
-							return presetObject;
-						}
-						// if there is a highest priority preset with the same slug but different value the preset we found was overwritten and should be ignored.
-						const highestPresetObjectWithSameSlug = findInPresetsBy(
-							styles,
-							context,
-							presetPath,
-							'slug',
-							presetObject.slug
-						);
-						if (
-							highestPresetObjectWithSameSlug[
-								presetProperty
-							] === presetObject[ presetProperty ]
-						) {
-							return presetObject;
-						}
-						return undefined;
-					}
-				}
-			}
-		}
-	}
-}
-
-export function getPresetVariable( styles, context, propertyName, value ) {
-	if ( ! value ) {
-		return value;
-	}
-
-	const metadata = getPresetMetadataFromStyleProperty( propertyName );
-	if ( ! metadata ) {
-		// The property doesn't have preset data
-		// so the value should be returned as it is.
-		return value;
-	}
-	const { valueKey, path, cssVarInfix } = metadata;
-
-	const presetObject = findInPresetsBy(
-		styles,
-		context,
-		path,
-		valueKey,
-		value
-	);
-
-	if ( ! presetObject ) {
-		// Value wasn't found in the presets,
-		// so it must be a custom value.
-		return value;
-	}
-
-	return `var:preset|${ cssVarInfix }|${ presetObject.slug }`;
-}
-
-function getValueFromPresetVariable(
-	styles,
-	blockName,
-	variable,
-	[ presetType, slug ]
-) {
-	presetType = camelCase( presetType );
-	const metadata = getPresetMetadataFromStyleProperty( presetType );
-	if ( ! metadata ) {
-		return variable;
-	}
-
-	const presetObject = findInPresetsBy(
-		styles,
-		blockName,
-		metadata.path,
-		'slug',
-		slug
-	);
-
-	if ( presetObject ) {
-		const { valueKey } = metadata;
-		const result = presetObject[ valueKey ];
-		return getValueFromVariable( styles, blockName, result );
-	}
-
-	return variable;
-}
-
-function getValueFromCustomVariable( styles, blockName, variable, path ) {
-	const result =
-		get( styles, [ 'settings', 'blocks', blockName, 'custom', ...path ] ) ??
-		get( styles, [ 'settings', 'custom', ...path ] );
-	if ( ! result ) {
-		return variable;
-	}
-	// A variable may reference another variable so we need recursion until we find the value.
-	return getValueFromVariable( styles, blockName, result );
-}
-
-export function getValueFromVariable( styles, blockName, variable ) {
-	if ( ! variable || ! isString( variable ) ) {
-		return variable;
-	}
-
-	let parsedVar;
-	const INTERNAL_REFERENCE_PREFIX = 'var:';
-	const CSS_REFERENCE_PREFIX = 'var(--wp--';
-	const CSS_REFERENCE_SUFFIX = ')';
-	if ( variable.startsWith( INTERNAL_REFERENCE_PREFIX ) ) {
-		parsedVar = variable
-			.slice( INTERNAL_REFERENCE_PREFIX.length )
-			.split( '|' );
-	} else if (
-		variable.startsWith( CSS_REFERENCE_PREFIX ) &&
-		variable.endsWith( CSS_REFERENCE_SUFFIX )
-	) {
-		parsedVar = variable
-			.slice( CSS_REFERENCE_PREFIX.length, -CSS_REFERENCE_SUFFIX.length )
-			.split( '--' );
-	} else {
-		// Value is raw.
-		return variable;
-	}
-
-	const [ type, ...path ] = parsedVar;
-	if ( type === 'preset' ) {
-		return getValueFromPresetVariable( styles, blockName, variable, path );
-	}
-	if ( type === 'custom' ) {
-		return getValueFromCustomVariable( styles, blockName, variable, path );
-	}
-	return variable;
 }

--- a/packages/edit-site/src/components/sidebar/border-panel.js
+++ b/packages/edit-site/src/components/sidebar/border-panel.js
@@ -123,7 +123,7 @@ export default function BorderPanel( {
 			{ hasBorderColor && (
 				<ColorGradientControl
 					label={ __( 'Color' ) }
-					value={ borderColor }
+					colorValue={ borderColor }
 					colors={ colors }
 					gradients={ undefined }
 					disableCustomColors={ disableCustomColors }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -72,6 +72,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalBlockDirectory',
 				'__experimentalBlockPatternCategories',
 				'__experimentalBlockPatterns',
+				'__experimentalStyles',
 				'__experimentalFeatures',
 				'__experimentalGlobalStylesBaseStyles',
 				'__experimentalGlobalStylesUserEntityId',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Depends on:
* #34178
* #33743
* #34061
* #34467

Alternative approach to #34131

## Description
<!-- Please describe what you have changed or added -->
As we convert the border supports to use the new Tools Panel (#33743) and configure default controls for each block (#34061), we want to prevent needing to enable border style as a default. This was previously done because the style needs to be selected in order for changes to color or width to make visible changes in the editor.

This PR makes use of the addition of an API to access global styles in the block editor (#34178) to solve this problem, and also add placeholders/defaults for each of the border attributes.

Changes:
* When a width or color is selected, the `solid` style will be automatically applied if none is selected/available from global styles
* Values from global styles are applied as placeholders for each border attribute

At the moment this PR also includes a fix for a bug in the border color control, to correctly check selected presets and display the selected color in the color indicator. Since this could be merged separately I also have a PR here with just those changes broken out: https://github.com/WordPress/gutenberg/pull/34467

## Notes
* This has a lot of dependencies. The changes can be viewed most easily compared against the #34178 branch. It can be rebased on #33743 to get the ToolsPanel. It may be easier to review after at least one of those is merged.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've tested this with just #34178, and also rebased on top of #33743 which converts the panel to the new ToolsPanel. It should work in both cases. I used the Group block to test.

* Test behavior of the placeholders for each of `width / style / color / radius` in the editor
    * Set values in your `theme.json`, something like this:
    ```
            "core/group": {
				"border": {
					"radius": {
						"topLeft": "20px",
						"topRight": "30px",
						"bottomLeft": "15px",
						"bottomRight": "45px"
					},
					"width": "2px",
					"color": "var(--wp--preset--color--dark-gray)",
					"style": "dashed"
				}
			}
		}
    ```
    * Set values in Global styles from the Site Editor --> By Block Type --> Group panel
    * Verify that the merged styles appear as placeholders in the Border panel for a Group block inserted in the editor
            
* Test the panel in Global styles to make sure it continues to function
    * Styles set in the theme should appear as placeholders in the Global styles panel

* Test setting a width or color when the style is not set
    * If style is not set, and there is no default value from global styles, a solid style should be automatically applied

## Screenshots <!-- if applicable -->

Placeholders:
![border-panel-defaults](https://user-images.githubusercontent.com/63313398/131898730-d05c4785-ea93-4b99-856f-afe2ed8c86fa.gif)

Automatically setting border style when color/width selected:
![auto-set-border-style](https://user-images.githubusercontent.com/63313398/131898772-575f924a-804f-4a1b-a974-1a0f8a7d8303.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
