### PR TITLE
Generate duotone preset classes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -274,8 +274,8 @@ function gutenberg_get_duotone_style( $selectors_group, $duotone_id ) {
 /**
  * Returns the markup for duotone filters.
  *
- * @param string $duotone_id
- * @param array $duotone_values
+ * @param string $duotone_id     UUID for the duotone filter.
+ * @param array  $duotone_values Duotone color values.
  * @return string The markup for the <svg> tag.
  */
 function gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values ) {
@@ -342,7 +342,7 @@ function get_duotone_color_values( $duotone_colors ) {
 /**
  * Output Duotone markup in the footer.
  *
- * @param $duotone_markup The markup for the SVG filer, and if necessary the style tag.
+ * @param string $duotone_markup The markup for the SVG filer, and if necessary the style tag.
  */
 function gutenberg_output_duotone_markup( $duotone_markup ) {
 	add_action(
@@ -391,9 +391,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		},
 		$selectors
 	);
-	$selectors_group = implode( ', ', $selectors_scoped );
+	$selectors_group  = implode( ', ', $selectors_scoped );
 
-	$duotone_markup = gutenberg_get_duotone_style( $selectors_group, $duotone_id );
+	$duotone_markup  = gutenberg_get_duotone_style( $selectors_group, $duotone_id );
 	$duotone_markup .= gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
 
 	if ( ! is_admin() ) {
@@ -435,11 +435,11 @@ function gutenberg_get_duotone_filter_id( $id ) {
 /**
  * Generates duotone markup from a settings array
  *
- * @param  array  $duotone_setting Block object.
+ * @param array $duotone_setting Block object.
  */
-function gutenberg_generate_duotone_filters_settings( $duotone_setting) {
+function gutenberg_generate_duotone_filters_settings( $duotone_setting ) {
 	$duotone_values = get_duotone_color_values( $duotone_setting['colors'] );
-	$duotone_id = gutenberg_get_duotone_filter_id( $duotone_setting['slug'] );
+	$duotone_id     = gutenberg_get_duotone_filter_id( $duotone_setting['slug'] );
 	$duotone_markup = gutenberg_get_duotone_svg_filters( $duotone_id, $duotone_values );
 	gutenberg_output_duotone_markup( $duotone_markup );
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -858,8 +858,8 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$theme_json_settings = $this->get_settings();
-		if( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) &&  ! empty( $theme_json_settings['color']['duotone'] ) ) {
-			foreach( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
+		if ( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) && ! empty( $theme_json_settings['color']['duotone'] ) ) {
+			foreach ( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
 				gutenberg_generate_duotone_filters_settings( $duotone_setting );
 			}
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -183,6 +183,18 @@ class WP_Theme_JSON_Gutenberg {
 			),
 		),
 		array(
+			'path'          => array( 'color', 'duotone' ),
+			'value_key'     => 'slug',
+			'css_var_infix' => 'duotone',
+			'value_format'  => 'url(#wp-duotone-%s)',
+			'classes'       => array(
+				array(
+					'class_suffix'  => 'duotone',
+					'property_name' => 'filter',
+				),
+			),
+		),
+		array(
 			'path'          => array( 'typography', 'fontSizes' ),
 			'value_key'     => 'size',
 			'css_var_infix' => 'font-size',
@@ -608,7 +620,14 @@ class WP_Theme_JSON_Gutenberg {
 				// see https://github.com/WordPress/gutenberg/issues/32347
 				// However, we need to make sure the generated class or css variable
 				// doesn't contain spaces.
-				$result[ preg_replace( '/\s+/', '-', $preset['slug'] ) ] = $preset[ $value_key ];
+				$result[ preg_replace( '/\s+/', '-', $preset['slug'] ) ] = is_array( $value_key )
+					? array_map(
+						function ( $key ) use ( $preset ) {
+							return $preset[ $key ];
+						},
+						$value_key
+					)
+					: $preset[ $value_key ];
 			}
 		}
 		return $result;
@@ -674,6 +693,12 @@ class WP_Theme_JSON_Gutenberg {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
 			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
 			foreach ( $preset_by_slug as $slug => $value ) {
+				if ( ! empty( $preset['value_format'] ) ) {
+					$value = vsprintf(
+						$preset['value_format'],
+						is_array( $value ) ? $value : array( $value )
+					);
+				}
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),
 					'value' => $value,
@@ -858,8 +883,8 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$theme_json_settings = $this->get_settings();
-		if ( ! empty( $theme_json_settings['color'] ) && ! empty( $theme_json_settings['color']['duotone'] ) && ! empty( $theme_json_settings['color']['duotone'] ) ) {
-			foreach ( $theme_json_settings['color']['duotone'] as $duotone_setting ) {
+		if ( isset( $theme_json_settings['color']['duotone']['theme'] ) ) {
+			foreach ( $theme_json_settings['color']['duotone']['theme'] as $duotone_setting ) {
 				gutenberg_generate_duotone_filters_settings( $duotone_setting );
 			}
 		}


### PR DESCRIPTION
Working off of @scruffian's branch for duotone to theme.json, this generates classes and CSS variables for duotone and tries to use them instead of the generated classnames.


See https://github.com/WordPress/gutenberg/pull/34073#issuecomment-909028869.

> It's a lot less CSS than what we do now, where we ship all this (note that classes aren't used anywhere and we use the custom properties to indirectly point to the filter):
> 
> ```css
> :root {
>   --wp--preset--duotone--dark-grayscale: url(#wp-duotone-filter-dark-grayscale);
>   --wp--preset--duotone--grayscale: url(#wp-duotone-filter-grayscale);
>   --wp--preset--duotone--purple-yellow: url(#wp-duotone-filter-purple-yellow);
>   --wp--preset--duotone--blue-red: url(#wp-duotone-filter-blue-red);
>   --wp--preset--duotone--midnight: url(#wp-duotone-filter-midnight);
>   --wp--preset--duotone--magenta-yellow: url(#wp-duotone-filter-magenta-yellow);
>   --wp--preset--duotone--purple-green: url(#wp-duotone-filter-purple-green);
>   --wp--preset--duotone--blue-orange: url(#wp-duotone-filter-blue-orange);
> }
> .wp-block-image img {
>   filter: var(--wp--preset--duotone--dark-grayscale);
> }
> .has-dark-grayscale-duotone {
>   filter: var(--wp--preset--duotone--dark-grayscale) !important;
> }
> .has-grayscale-duotone {
>   filter: var(--wp--preset--duotone--grayscale) !important;
> }
> .has-purple-yellow-duotone {
>   filter: var(--wp--preset--duotone--purple-yellow) !important;
> }
> .has-blue-red-duotone {
>   filter: var(--wp--preset--duotone--blue-red) !important;
> }
> .has-midnight-duotone {
>   filter: var(--wp--preset--duotone--midnight) !important;
> }
> .has-magenta-yellow-duotone {
>   filter: var(--wp--preset--duotone--magenta-yellow) !important;
> }
> .has-purple-green-duotone {
>   filter: var(--wp--preset--duotone--purple-green) !important;
> }
> .has-blue-orange-duotone {
>   filter: var(--wp--preset--duotone--blue-orange) !important;
> }  
> ```
