### PR TITLE
Try: Hide theme-provided underlines when menu item is in setup state.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -81,6 +81,11 @@
 .wp-block-navigation-link__placeholder {
 	position: relative;
 
+	// While in a placeholder state, hide any underlines the theme might add.
+	text-decoration: none !important;
+	box-shadow: none !important;
+	background-image: none !important;
+
 	// Draw a wavy underline.
 	.wp-block-navigation-link__placeholder-text {
 		$blur: 10%;


### PR DESCRIPTION
## Description

Navigation items that do not link anywhere (and therefore won't show up on the published frontend) are denoted with a grammar-like wavy underline. You click the item to select a page, to fix the problem.

Only, some themes also provide their own underlines, which an conflict with that:

<img width="581" alt="Screenshot 2021-09-02 at 09 47 46" src="https://user-images.githubusercontent.com/1204802/131805073-1e4db4bd-f71e-41eb-ada7-087d001e1064.png">

This PR fixes that by unstyling those before applying the wavy underline:

<img width="763" alt="Screenshot 2021-09-02 at 09 51 35" src="https://user-images.githubusercontent.com/1204802/131805108-40ab4e68-f86f-4172-82a3-dbc412be1197.png">

## How has this been tested?

Add a navigation menu, insert a page link item, then don't select a page. Deselect the block and you should see a wavy underline, only, under the item.

You can test in TT1 Blocks where submenu items have dotted underlines on hover. In this branch they shouldn't.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
