### PR TITLE
Fix responsive menu height regression.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -510,6 +510,8 @@
 		position: relative;
 		opacity: 1;
 		visibility: visible;
+		height: auto;
+		width: auto;
 
 		padding: 0 0 0 32px;
 		border: none;


### PR DESCRIPTION
## Description

#34382 fixed an issue so submenus did not take up space in the dom until actually opened. That caused an issue inside the mobile responsive menu, with a collapsing height:

<img width="543" alt="before" src="https://user-images.githubusercontent.com/1204802/131815796-390c377f-fc4f-465b-a85e-a06d8abdc8ac.png">

This PR fixes that:

<img width="542" alt="Screenshot 2021-09-02 at 11 01 52" src="https://user-images.githubusercontent.com/1204802/131815807-008fb2fb-63ef-4484-94e0-4df6b1e5fd83.png">


## How has this been tested?

Insert a navigation menu with nested items and toggle on responsiveness. Test at the mobile breakpoint and ensure all items are visible inside the overlay menu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
