### PR TITLE
Post title: remove class from old div to fix alignment

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -156,10 +156,10 @@ describe( 'deleting all blocks', () => {
 		await page.keyboard.type( 'Paragraph' );
 		await clickOnBlockSettingsMenuRemoveBlockButton();
 
-		// There is a default block:
+		// There is a default block and post title:
 		expect(
 			await page.$$( '.block-editor-block-list__block' )
-		).toHaveLength( 1 );
+		).toHaveLength( 2 );
 
 		// But the effective saved content is still empty:
 		expect( await getEditedPostContent() ).toBe( '' );

--- a/packages/e2e-tests/specs/editor/various/block-mover.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-mover.test.js
@@ -16,7 +16,7 @@ describe( 'block mover', () => {
 		await page.keyboard.type( 'Second Paragraph' );
 
 		// Select a block so the block mover is rendered.
-		await page.focus( '.block-editor-block-list__block' );
+		await page.focus( '[data-type="core/paragraph"]' );
 
 		await showBlockToolbar();
 

--- a/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
@@ -193,10 +193,10 @@ describe( 'splitting and merging blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.press( 'Backspace' );
 
-		// There is a default block:
+		// There is a default block and post title:
 		expect(
 			await page.$$( '.block-editor-block-list__block' )
-		).toHaveLength( 1 );
+		).toHaveLength( 2 );
 
 		// But the effective saved content is still empty:
 		expect( await getEditedPostContent() ).toBe( '' );

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -5,7 +5,7 @@
 	flex-grow: 1;
 
 	// Post title.
-	.editor-post-title.editor-post-title__block {
+	.editor-post-title {
 		max-width: none;
 		line-height: $default-line-height;
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -168,7 +168,7 @@ export default function PostTitle() {
 	// The wp-block className is important for editor styles.
 	// This same block is used in both the visual and the code editor.
 	const className = classnames(
-		'wp-block editor-post-title editor-post-title__input rich-text',
+		'wp-block block-editor-block-list__block editor-post-title editor-post-title__input rich-text',
 		{
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -168,7 +168,7 @@ export default function PostTitle() {
 	// The wp-block className is important for editor styles.
 	// This same block is used in both the visual and the code editor.
 	const className = classnames(
-		'wp-block block-editor-block-list__block editor-post-title editor-post-title__input rich-text',
+		'wp-block wp-block-post-title block-editor-block-list__block editor-post-title editor-post-title__input rich-text',
 		{
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -168,7 +168,7 @@ export default function PostTitle() {
 	// The wp-block className is important for editor styles.
 	// This same block is used in both the visual and the code editor.
 	const className = classnames(
-		'wp-block editor-post-title editor-post-title__block editor-post-title__input rich-text',
+		'wp-block editor-post-title editor-post-title__input rich-text',
 		{
 			'is-selected': isSelected,
 			'is-focus-mode': isFocusMode,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #34479.

A div was removed in #34167. Instead of moving the class name to another div, we should just remove it as well. Also adds `block-editor-block-list__block` so some theme styles apply properly.

Note that the post title refactors prepare it for switching over to the post title _block_ eventually.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="1119" alt="Screenshot 2021-09-02 at 12 24 47" src="https://user-images.githubusercontent.com/4710635/131820415-c0233cc0-646a-4acc-8e87-e6492a274f85.png">
<img width="1121" alt="Screenshot 2021-09-02 at 12 33 56" src="https://user-images.githubusercontent.com/4710635/131820428-7b4828b8-4045-42df-ad53-037d9093f71a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
