### PR TITLE
Rich text: replace global event handlers with local ones

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -42,10 +42,13 @@ import { useInputRules } from './use-input-rules';
 import { useEnter } from './use-enter';
 import { useFormatTypes } from './use-format-types';
 import { useRemoveBrowserShortcuts } from './use-remove-browser-shortcuts';
+import { useShortcuts } from './use-shortcuts';
+import { useInputEvents } from './use-input-events';
 import FormatEdit from './format-edit';
 import { getMultilineTag, getAllowedFormats } from './utils';
 
-export const keyboardShortcutContext = createContext( new Set() );
+export const keyboardShortcutContext = createContext();
+export const inputEventContext = createContext();
 
 /**
  * Removes props used for the native version of RichText so that they are not
@@ -253,13 +256,10 @@ function RichTextWrapper(
 	useMarkPersistent( { html: adjustedValue, value } );
 
 	const keyboardShortcuts = useRef( new Set() );
+	const inputEvents = useRef( new Set() );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;
-
-		for ( const keyboardShortcut of keyboardShortcuts.current ) {
-			keyboardShortcut( event );
-		}
 
 		if ( event.defaultPrevented ) {
 			return;
@@ -307,13 +307,15 @@ function RichTextWrapper(
 				<keyboardShortcutContext.Provider
 					value={ keyboardShortcuts.current }
 				>
-					<FormatEdit
-						value={ value }
-						onChange={ onChange }
-						onFocus={ onFocus }
-						formatTypes={ formatTypes }
-						forwardedRef={ anchorRef }
-					/>
+					<inputEventContext.Provider value={ inputEvents.current }>
+						<FormatEdit
+							value={ value }
+							onChange={ onChange }
+							onFocus={ onFocus }
+							formatTypes={ formatTypes }
+							forwardedRef={ anchorRef }
+						/>
+					</inputEventContext.Provider>
 				</keyboardShortcutContext.Provider>
 			) }
 			{ isSelected && hasFormats && (
@@ -341,6 +343,8 @@ function RichTextWrapper(
 						onReplace,
 					} ),
 					useRemoveBrowserShortcuts(),
+					useShortcuts( keyboardShortcuts ),
+					useInputEvents( inputEvents ),
 					useUndoAutomaticChange(),
 					usePasteHandler( {
 						isSelected,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -300,14 +300,10 @@ function RichTextWrapper(
 	const TagName = tagName;
 	const content = (
 		<>
-			{ isSelected &&
-				children &&
-				children( { value, onChange, onFocus } ) }
 			{ isSelected && (
-				<keyboardShortcutContext.Provider
-					value={ keyboardShortcuts.current }
-				>
-					<inputEventContext.Provider value={ inputEvents.current }>
+				<keyboardShortcutContext.Provider value={ keyboardShortcuts }>
+					<inputEventContext.Provider value={ inputEvents }>
+						{ children && children( { value, onChange, onFocus } ) }
 						<FormatEdit
 							value={ value }
 							onChange={ onChange }

--- a/packages/block-editor/src/components/rich-text/input-event.js
+++ b/packages/block-editor/src/components/rich-text/input-event.js
@@ -21,9 +21,9 @@ export function __unstableRichTextInputEvent( { inputType, onInput } ) {
 			}
 		}
 
-		callbacks.add( callback );
+		callbacks.current.add( callback );
 		return () => {
-			callbacks.delete( callback );
+			callbacks.current.delete( callback );
 		};
 	}, [ inputType ] );
 

--- a/packages/block-editor/src/components/rich-text/input-event.js
+++ b/packages/block-editor/src/components/rich-text/input-event.js
@@ -1,30 +1,31 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useEffect, useContext, useRef } from '@wordpress/element';
 
-export class __unstableRichTextInputEvent extends Component {
-	constructor() {
-		super( ...arguments );
+/**
+ * Internal dependencies
+ */
+import { inputEventContext } from './';
 
-		this.onInput = this.onInput.bind( this );
-	}
+export function __unstableRichTextInputEvent( { inputType, onInput } ) {
+	const callbacks = useContext( inputEventContext );
+	const onInputRef = useRef();
+	onInputRef.current = onInput;
 
-	onInput( event ) {
-		if ( event.inputType === this.props.inputType ) {
-			this.props.onInput();
+	useEffect( () => {
+		function callback( event ) {
+			if ( event.inputType === inputType ) {
+				onInputRef.current();
+				event.preventDefault();
+			}
 		}
-	}
 
-	componentDidMount() {
-		document.addEventListener( 'input', this.onInput, true );
-	}
+		callbacks.add( callback );
+		return () => {
+			callbacks.delete( callback );
+		};
+	}, [ inputType ] );
 
-	componentWillUnmount() {
-		document.removeEventListener( 'input', this.onInput, true );
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }

--- a/packages/block-editor/src/components/rich-text/shortcut.js
+++ b/packages/block-editor/src/components/rich-text/shortcut.js
@@ -22,9 +22,9 @@ export function RichTextShortcut( { character, type, onUse } ) {
 			}
 		}
 
-		keyboardShortcuts.add( callback );
+		keyboardShortcuts.current.add( callback );
 		return () => {
-			keyboardShortcuts.delete( callback );
+			keyboardShortcuts.current.delete( callback );
 		};
 	}, [ character, type ] );
 

--- a/packages/block-editor/src/components/rich-text/shortcut.js
+++ b/packages/block-editor/src/components/rich-text/shortcut.js
@@ -1,17 +1,32 @@
 /**
  * WordPress dependencies
  */
-import { useKeyboardShortcut } from '@wordpress/compose';
-import { rawShortcut } from '@wordpress/keycodes';
+import { isKeyboardEvent } from '@wordpress/keycodes';
+import { useEffect, useContext, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { keyboardShortcutContext } from './';
 
 export function RichTextShortcut( { character, type, onUse } ) {
-	const callback = () => {
-		onUse();
-		return false;
-	};
-	useKeyboardShortcut( rawShortcut[ type ]( character ), callback, {
-		bindGlobal: true,
-	} );
+	const keyboardShortcuts = useContext( keyboardShortcutContext );
+	const onUseRef = useRef();
+	onUseRef.current = onUse;
+
+	useEffect( () => {
+		function callback( event ) {
+			if ( isKeyboardEvent[ type ]( event, character ) ) {
+				onUseRef.current();
+				event.preventDefault();
+			}
+		}
+
+		keyboardShortcuts.add( callback );
+		return () => {
+			keyboardShortcuts.delete( callback );
+		};
+	}, [ character, type ] );
 
 	return null;
 }

--- a/packages/block-editor/src/components/rich-text/use-input-events.js
+++ b/packages/block-editor/src/components/rich-text/use-input-events.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+export function useInputEvents( inputEvents ) {
+	return useRefEffect( ( element ) => {
+		function onInput( event ) {
+			for ( const keyboardShortcut of inputEvents.current ) {
+				keyboardShortcut( event );
+			}
+		}
+
+		element.addEventListener( 'input', onInput );
+		return () => {
+			element.removeEventListener( 'input', onInput );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/rich-text/use-shortcuts.js
+++ b/packages/block-editor/src/components/rich-text/use-shortcuts.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+export function useShortcuts( keyboardShortcuts ) {
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			for ( const keyboardShortcut of keyboardShortcuts.current ) {
+				keyboardShortcut( event );
+			}
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Similar to #32323 and #33633.

Replaces global event handlers for keydown and input components used in the format library with local ones.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
