### PR TITLE
[RNMobile] Mention the embed variant the preview of which is WIP

### DIFF
--- a/packages/block-library/src/embed/embed-no-preview.native.js
+++ b/packages/block-library/src/embed/embed-no-preview.native.js
@@ -73,11 +73,17 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 		postType === 'page' ? __( 'Preview page' ) : __( 'Preview post' );
 	const comingSoonDescription =
 		postType === 'page'
-			? __(
-					'We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the page.'
+			? sprintf(
+					__(
+						'We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page.'
+					),
+					label
 			  )
-			: __(
-					'We’re working hard on adding support for embed previews. In the meantime, you can preview the embedded content on the post.'
+			: sprintf(
+					__(
+						'We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the post.'
+					),
+					label
 			  );
 
 	function onOpenSheet() {
@@ -118,7 +124,10 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 					<BlockIcon icon={ icon } />
 					<Text style={ labelStyle }>{ label }</Text>
 					<Text style={ descriptionStyle }>
-						{ __( 'Embed previews not yet available' ) }
+						{ sprintf(
+							__( '%s previews not yet available' ),
+							label
+						) }
 					</Text>
 					<Text style={ styles.embed__action }>
 						{ previewButtonText.toUpperCase() }
@@ -154,7 +163,10 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 						/>
 					</View>
 					<Text style={ sheetTitleStyle }>
-						{ __( 'Embed block previews are coming soon' ) }
+						{ sprintf(
+							__( '%s block previews are coming soon' ),
+							label
+						) }
 					</Text>
 					<Text style={ sheetDescriptionStyle }>
 						{ comingSoonDescription }

--- a/packages/block-library/src/embed/embed-no-preview.native.js
+++ b/packages/block-library/src/embed/embed-no-preview.native.js
@@ -8,7 +8,7 @@ import { TouchableOpacity, TouchableWithoutFeedback, Text } from 'react-native';
  */
 import { View } from '@wordpress/primitives';
 
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { requestPreview } from '@wordpress/react-native-bridge';

--- a/packages/block-library/src/embed/embed-no-preview.native.js
+++ b/packages/block-library/src/embed/embed-no-preview.native.js
@@ -74,12 +74,14 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 	const comingSoonDescription =
 		postType === 'page'
 			? sprintf(
+					// translators: %s: embed block variant's label e.g: "Twitter".
 					__(
 						'We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page.'
 					),
 					label
 			  )
 			: sprintf(
+					// translators: %s: embed block variant's label e.g: "Twitter".
 					__(
 						'We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the post.'
 					),
@@ -125,6 +127,7 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 					<Text style={ labelStyle }>{ label }</Text>
 					<Text style={ descriptionStyle }>
 						{ sprintf(
+							// translators: %s: embed block variant's label e.g: "Twitter".
 							__( '%s previews not yet available' ),
 							label
 						) }
@@ -164,6 +167,7 @@ const EmbedNoPreview = ( { label, icon, isSelected, onPress } ) => {
 					</View>
 					<Text style={ sheetTitleStyle }>
 						{ sprintf(
+							// translators: %s: embed block variant's label e.g: "Twitter".
 							__( '%s block previews are coming soon' ),
 							label
 						) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
We are gradually adding support for inline previews and so, the message for the yet unsupported ones is now too general and perhaps confusing. So, this PR updates the copy to make the "WIP" messages more specific, by adding the embed variant name.

### Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3909

## How has this been tested?

By running the WPAndroid app (wasabiDebug) against Metro off [the gb-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3909) and testing out an embed block variant the previews of which are not yet supported.

## Changes

1. Change [inline preview placeholder message](https://github.com/WordPress/gutenberg/pull/34495/files#diff-3b12d9c3e20c206f7abc20197fd3ace518d6e9cfef03f70fbd73a68f487e3a60R128) to: `%s previews not yet available`
2. Change ["coming soon" bottomsheet title](https://github.com/WordPress/gutenberg/pull/34495/files#diff-3b12d9c3e20c206f7abc20197fd3ace518d6e9cfef03f70fbd73a68f487e3a60R167) to: `%s block previews are coming soon`
3. Change the [bottomsheet content message for posts](https://github.com/WordPress/gutenberg/pull/34495/files#diff-3b12d9c3e20c206f7abc20197fd3ace518d6e9cfef03f70fbd73a68f487e3a60R78) (and for [pages](https://github.com/WordPress/gutenberg/pull/34495/files#diff-3b12d9c3e20c206f7abc20197fd3ace518d6e9cfef03f70fbd73a68f487e3a60R84)) to: `We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page.`

## Screenshots

<img src="https://user-images.githubusercontent.com/1032913/131843424-6e4b7ded-fb6b-4a9d-99d3-b77b1d0d6f62.png" width="300px"/>


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
