### PR TITLE
[Components - ToggleGroupControl]: Update stories to use knobs

### DIFF
--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -28,9 +28,15 @@ export const _default = () => {
 	const [ alignState, setAlignState ] = useState( aligns[ 0 ] );
 	const label = text( 'Label', 'Toggle Group Control' );
 	const hideLabelFromVision = boolean( 'Hide label from vision', false );
-	const help = text( 'Help Text', 'This is the help text' );
-	const isBlock = boolean( 'Render as a (CSS) block element', true );
-
+	const isBlock = boolean(
+		'Render `ToggleGroupControl` as a (CSS) block element',
+		false
+	);
+	const help = text( 'Help Text' );
+	const isAdaptiveWidth = boolean(
+		'Render segments with equal widths',
+		false
+	);
 	return (
 		<View>
 			<ToggleGroupControl
@@ -40,6 +46,7 @@ export const _default = () => {
 				hideLabelFromVision={ hideLabelFromVision }
 				help={ help }
 				isBlock={ isBlock }
+				isAdaptiveWidth={ isAdaptiveWidth }
 			>
 				{ alignOptions }
 			</ToggleGroupControl>

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -28,27 +28,27 @@ const KNOBS_GROUPS = {
 export const _default = () => {
 	const [ alignState, setAlignState ] = useState( aligns[ 0 ] );
 	const label = text(
-		'Label',
+		`${ KNOBS_GROUPS.ToggleGroupControl }: label`,
 		'Toggle Group Control',
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 	const hideLabelFromVision = boolean(
-		'Hide label from vision',
+		`${ KNOBS_GROUPS.ToggleGroupControl }: hideLabelFromVision`,
 		false,
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 	const isBlock = boolean(
-		'Render `ToggleGroupControl` as a (CSS) block element',
+		`${ KNOBS_GROUPS.ToggleGroupControl }: isBlock (render as a css block element)`,
 		false,
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 	const help = text(
-		'Help Text',
+		`${ KNOBS_GROUPS.ToggleGroupControl }: help`,
 		undefined,
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 	const isAdaptiveWidth = boolean(
-		'Render segments with equal widths',
+		`${ KNOBS_GROUPS.ToggleGroupControl }: isAdaptiveWidth`,
 		false,
 		KNOBS_GROUPS.ToggleGroupControl
 	);
@@ -58,7 +58,7 @@ export const _default = () => {
 			key={ key }
 			value={ key }
 			label={ text(
-				'Label',
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }: label`,
 				key,
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
 			) }

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -20,23 +20,51 @@ export default {
 };
 
 const aligns = [ 'Left', 'Center', 'Right', 'Justify' ];
-const alignOptions = aligns.map( ( key ) => (
-	<ToggleGroupControlOption key={ key } value={ key } label={ key } />
-) );
+const KNOBS_GROUPS = {
+	ToggleGroupControl: 'ToggleGroupControl',
+	ToggleGroupControlOption: 'ToggleGroupControlOption',
+};
 
 export const _default = () => {
 	const [ alignState, setAlignState ] = useState( aligns[ 0 ] );
-	const label = text( 'Label', 'Toggle Group Control' );
-	const hideLabelFromVision = boolean( 'Hide label from vision', false );
+	const label = text(
+		'Label',
+		'Toggle Group Control',
+		KNOBS_GROUPS.ToggleGroupControl
+	);
+	const hideLabelFromVision = boolean(
+		'Hide label from vision',
+		false,
+		KNOBS_GROUPS.ToggleGroupControl
+	);
 	const isBlock = boolean(
 		'Render `ToggleGroupControl` as a (CSS) block element',
-		false
+		false,
+		KNOBS_GROUPS.ToggleGroupControl
 	);
-	const help = text( 'Help Text' );
+	const help = text(
+		'Help Text',
+		undefined,
+		KNOBS_GROUPS.ToggleGroupControl
+	);
 	const isAdaptiveWidth = boolean(
 		'Render segments with equal widths',
-		false
+		false,
+		KNOBS_GROUPS.ToggleGroupControl
 	);
+
+	const alignOptions = aligns.map( ( key, index ) => (
+		<ToggleGroupControlOption
+			key={ key }
+			value={ key }
+			label={ text(
+				'Label',
+				key,
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
+			) }
+		/>
+	) );
+
 	return (
 		<View>
 			<ToggleGroupControl

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { boolean, text } from '@storybook/addon-knobs';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -6,7 +11,6 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { __experimentalSpacer as Spacer } from '../../';
 import { ToggleGroupControl, ToggleGroupControlOption } from '../index';
 import { View } from '../../view';
 
@@ -22,46 +26,23 @@ const alignOptions = aligns.map( ( key ) => (
 
 export const _default = () => {
 	const [ alignState, setAlignState ] = useState( aligns[ 0 ] );
-	const label = 'Toggle Group Control';
+	const label = text( 'Label', 'Toggle Group Control' );
+	const hideLabelFromVision = boolean( 'Hide label from vision', false );
+	const help = text( 'Help Text', 'This is the help text' );
+	const isBlock = boolean( 'Render as a (CSS) block element', true );
 
 	return (
 		<View>
-			<Spacer>
-				<ToggleGroupControl
-					isBlock
-					onChange={ setAlignState }
-					value={ alignState }
-					label={ label }
-				>
-					{ alignOptions }
-				</ToggleGroupControl>
-			</Spacer>
-			<Spacer>
-				<ToggleGroupControl label={ label } value="horizontal">
-					<ToggleGroupControlOption
-						value="horizontal"
-						label="Horizontal"
-					/>
-					<ToggleGroupControlOption
-						value="vertical"
-						label="Vertical"
-					/>
-				</ToggleGroupControl>
-			</Spacer>
-			<Spacer>
-				<ToggleGroupControl
-					isAdaptiveWidth
-					label={ label }
-					value="long"
-					hideLabelFromVision={ true }
-				>
-					<ToggleGroupControlOption value="short" label="Short" />
-					<ToggleGroupControlOption
-						value="long"
-						label="Looooooooooooong"
-					/>
-				</ToggleGroupControl>
-			</Spacer>
+			<ToggleGroupControl
+				onChange={ setAlignState }
+				value={ alignState }
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+				help={ help }
+				isBlock={ isBlock }
+			>
+				{ alignOptions }
+			</ToggleGroupControl>
 		</View>
 	);
 };

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -29,7 +29,7 @@ export type ToggleGroupControlProps = Omit<
 	 *
 	 * @default false
 	 */
-	hideLabelFromVision: boolean;
+	hideLabelFromVision?: boolean;
 	/**
 	 * Determines if segments should be rendered with equal widths.
 	 *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR just updates the stories for `ToggleGroupControl` to use knobs for its properties. It's a follow up of: https://github.com/WordPress/gutenberg/pull/34017 and specifically [this comment](https://github.com/WordPress/gutenberg/pull/34017#discussion_r687588049).

## Testing instructions
1. `npm run storybook:dev`
2. Check `ToggleGroupControl` and change some properties from its knobs