### PR TITLE
[RNMobile] Fixes unsupported block crash

### DIFF
--- a/packages/block-editor/src/components/block-icon/index.native.js
+++ b/packages/block-editor/src/components/block-icon/index.native.js
@@ -17,6 +17,8 @@ import styles from './style.scss';
 
 export function BlockIcon( {
 	icon,
+	fill,
+	size,
 	showColors = false,
 	getStylesFromColorScheme,
 } ) {
@@ -29,10 +31,13 @@ export function BlockIcon( {
 	const renderedIcon = (
 		<Icon
 			icon={ icon && icon.src ? icon.src : icon }
-			{ ...getStylesFromColorScheme(
-				styles.iconPlaceholder,
-				styles.iconPlaceholderDark
-			) }
+			{ ...( fill && { fill } ) }
+			{ ...( size && { size } ) }
+			{ ...( ! fill &&
+				getStylesFromColorScheme(
+					styles.iconPlaceholder,
+					styles.iconPlaceholderDark
+				) ) }
 		/>
 	);
 	const style = showColors

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { getBlockType } from '@wordpress/blocks';
+import { BlockIcon } from '@wordpress/block-editor';
 
 /**
  * External dependencies
@@ -58,11 +59,13 @@ const BlockSelectionButton = ( {
 							/>
 						</View>,
 					] }
-				<Icon
-					size={ 24 }
-					icon={ blockInformation?.icon?.src }
-					fill={ styles.icon.color }
-				/>
+				{ blockInformation?.icon && (
+					<BlockIcon
+						size={ 24 }
+						icon={ blockInformation.icon }
+						fill={ styles.icon.color }
+					/>
+				) }
 				<Text
 					maxFontSizeMultiplier={ 1.25 }
 					ellipsizeMode="tail"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3910

This PR fixes a bug introduced with https://github.com/WordPress/gutenberg/pull/34350 causing the mobile application to crash when an unsupported block is tapped.

The issue was happening in the Floating Toolbar, it was using the `Icon` component and now uses the `BlockIcon` wrapper.

Some changes were done to `BlockIcon` to support some new props.

## How has this been tested?

### Test case 1
1. Create a post/page with an unsupported block on the web
2. Run metro and open the app
3. Open the post created in (1)
4. Tap on the unsupported block
5. **Verify** that the app does not crash

### Test case 2
1. Open the app
2. Add a Group block and nest some blocks inside
3. Check the Floating Toolbar has the same functionality as before and the color/size are shown correctly. Test both on Light and Dark mode.

### Test case 3
1. Open the app
2. Add a block that uses `BlockIcon` e.g. `Audio`
3. Expect the placeholder icon to be rendered as it was before: colors (light/dark, size)

## Screenshots

|Before|After|
|---|---|
<kbd><img width="250" src="https://user-images.githubusercontent.com/304044/131846170-639e4170-1276-4441-acba-af58234be522.gif" /></kbd>|<kbd><img width="250" src="https://user-images.githubusercontent.com/304044/131846061-9bc9df4a-8df0-4a81-b534-e2d8aa7ec496.gif" /></kbd>|

|FloatingBar|Icon placeholder|
|---|---|
<kbd><img width="250" src="https://user-images.githubusercontent.com/4885740/131856147-662d48a1-377b-4da8-bbf1-13f5d8d9a341.png" /></kbd>|<kbd><img width="250" src="https://user-images.githubusercontent.com/4885740/131856157-03e95bc9-ca7c-4b4c-b23a-e34cfafcd552.png" /></kbd>|

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
