### PR TITLE
Remove extraction of raw values in saveEntityRecords

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, get, isEqual, find } from 'lodash';
+import { castArray, isEqual, find } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -425,8 +425,7 @@ export const saveEntityRecord = (
 						if (
 							[ 'title', 'excerpt', 'content' ].includes( key )
 						) {
-							// Edits should be the "raw" attribute values.
-							acc[ key ] = get( data[ key ], 'raw', data[ key ] );
+							acc[ key ] = data[ key ];
 						}
 						return acc;
 					},
@@ -461,12 +460,7 @@ export const saveEntityRecord = (
 									key
 								)
 							) {
-								// Edits should be the "raw" attribute values.
-								acc[ key ] = get(
-									newRecord[ key ],
-									'raw',
-									newRecord[ key ]
-								);
+								acc[ key ] = newRecord[ key ];
 							} else if ( key === 'status' ) {
 								// Status is only persisted in autosaves when going from
 								// "auto-draft" to "draft".
@@ -477,11 +471,7 @@ export const saveEntityRecord = (
 										: persistedRecord.status;
 							} else {
 								// These properties are not persisted in autosaves.
-								acc[ key ] = get(
-									persistedRecord[ key ],
-									'raw',
-									persistedRecord[ key ]
-								);
+								acc[ key ] = persistedRecord[ key ];
 							}
 							return acc;
 						},


### PR DESCRIPTION
## Description

Related to https://github.com/WordPress/gutenberg/issues/34449 

Removes the extraction of `.raw` values from the API request body and API response in saveEntityRecord. Both the API and `core-data` handle the wrapped format without any issues and so 

## How has this been tested?
1. Confirm all the tests pass
2. Open the new post editor, type in something, wait until it autosaves, inspect the API request and the redux store in dev tools and confirm that the request was handled correctly and the data was stored just as expected
3. Ditto for an existing post

You may also run this in your devtools to force an autosave: `window.wp.data.dispatch( 'core/editor' ).autosave()`