### PR TITLE
Components: Guide: replace global shortcut event handlers with local ones

### DIFF
--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -9,12 +9,12 @@ import classnames from 'classnames';
 import { useState, useEffect, Children } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
+import { LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import Modal from '../modal';
-import KeyboardShortcuts from '../keyboard-shortcuts';
 import Button from '../button';
 import PageControl from './page-control';
 import FinishButton from './finish-button';
@@ -66,15 +66,14 @@ export default function Guide( {
 			className={ classnames( 'components-guide', className ) }
 			contentLabel={ contentLabel }
 			onRequestClose={ onFinish }
+			onKeyDown={ ( event ) => {
+				if ( event.keyCode === LEFT ) {
+					goBack();
+				} else if ( event.keyCode === RIGHT ) {
+					goForward();
+				}
+			} }
 		>
-			<KeyboardShortcuts
-				key={ currentPage }
-				shortcuts={ {
-					left: goBack,
-					right: goForward,
-				} }
-			/>
-
 			<div className="components-guide__container">
 				<div className="components-guide__page">
 					{ pages[ currentPage ].image }

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -51,6 +51,7 @@ export default function Modal( {
 	overlayClassName,
 	className,
 	contentLabel,
+	onKeyDown,
 } ) {
 	const ref = useRef();
 	const instanceId = useInstanceId( Modal );
@@ -124,6 +125,7 @@ export default function Modal( {
 				aria-describedby={ aria.describedby }
 				tabIndex="-1"
 				{ ...( shouldCloseOnClickOutside ? focusOutsideProps : {} ) }
+				onKeyDown={ onKeyDown }
 			>
 				<div className={ 'components-modal__content' } role="document">
 					<div className="components-modal__header">


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related: #34498 and #34500.

`KeyboardShortcuts` adds event handles globally, while these handlers could simply be added locally instead.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
