### PR TITLE
Components: CustomGradientBar: replace global shortcut event handlers with local ones

### DIFF
--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -10,6 +10,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import { plus } from '@wordpress/icons';
 import Button from '../button';
 import ColorPicker from '../color-picker';
 import Dropdown from '../dropdown';
-import KeyboardShortcuts from '../keyboard-shortcuts';
 import { VisuallyHidden } from '../visually-hidden';
 
 import {
@@ -36,46 +36,11 @@ import {
 	KEYBOARD_CONTROL_POINT_VARIATION,
 } from './constants';
 
-function ControlPointKeyboardMove( { value: position, onChange, children } ) {
-	const shortcuts = {
-		right( event ) {
-			// Stop propagation of the key press event to avoid focus moving
-			// to another editor area.
-			event.stopPropagation();
-			const newPosition = clampPercent(
-				position + KEYBOARD_CONTROL_POINT_VARIATION
-			);
-			onChange( newPosition );
-		},
-		left( event ) {
-			// Stop propagation of the key press event to avoid focus moving
-			// to another editor area.
-			event.stopPropagation();
-			const newPosition = clampPercent(
-				position - KEYBOARD_CONTROL_POINT_VARIATION
-			);
-			onChange( newPosition );
-		},
-	};
-
-	return (
-		<KeyboardShortcuts shortcuts={ shortcuts }>
-			{ children }
-		</KeyboardShortcuts>
-	);
-}
-
-function ControlPointButton( {
-	isOpen,
-	position,
-	color,
-	onChange,
-	...additionalProps
-} ) {
+function ControlPointButton( { isOpen, position, color, ...additionalProps } ) {
 	const instanceId = useInstanceId( ControlPointButton );
 	const descriptionId = `components-custom-gradient-picker__control-point-button-description-${ instanceId }`;
 	return (
-		<ControlPointKeyboardMove value={ position } onChange={ onChange }>
+		<>
 			<Button
 				aria-label={ sprintf(
 					// translators: %1$s: gradient position e.g: 70, %2$s: gradient color code e.g: rgb(52,121,151).
@@ -104,7 +69,7 @@ function ControlPointButton( {
 					'Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
 				) }
 			</VisuallyHidden>
-		</ControlPointKeyboardMove>
+		</>
 	);
 }
 
@@ -208,18 +173,40 @@ function ControlPoints( {
 									);
 								}
 							} }
+							onKeyDown={ ( event ) => {
+								if ( event.keyCode === LEFT ) {
+									// Stop propagation of the key press event to avoid focus moving
+									// to another editor area.
+									event.stopPropagation();
+									onChange(
+										updateControlPointPosition(
+											controlPoints,
+											index,
+											clampPercent(
+												point.position -
+													KEYBOARD_CONTROL_POINT_VARIATION
+											)
+										)
+									);
+								} else if ( event.keyCode === RIGHT ) {
+									// Stop propagation of the key press event to avoid focus moving
+									// to another editor area.
+									event.stopPropagation();
+									onChange(
+										updateControlPointPosition(
+											controlPoints,
+											index,
+											clampPercent(
+												point.position +
+													KEYBOARD_CONTROL_POINT_VARIATION
+											)
+										)
+									);
+								}
+							} }
 							isOpen={ isOpen }
 							position={ point.position }
 							color={ point.color }
-							onChange={ ( newPosition ) => {
-								onChange(
-									updateControlPointPosition(
-										controlPoints,
-										index,
-										newPosition
-									)
-								);
-							} }
 						/>
 					) }
 					renderContent={ ( { onClose } ) => (


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related: #34498, #34500, #34503.

KeyboardShortcuts adds event handles globally, while these handlers could simply be added locally instead.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
