### PR TITLE
Letter Spacing: Group letter spacing correctly under typography supports

### DIFF
--- a/packages/block-editor/src/hooks/letter-spacing.js
+++ b/packages/block-editor/src/hooks/letter-spacing.js
@@ -14,7 +14,8 @@ import { cleanEmptyObject } from './utils';
  * Key within block settings' supports array indicating support for letter-spacing
  * e.g. settings found in `block.json`.
  */
-export const LETTER_SPACING_SUPPORT_KEY = '__experimentalLetterSpacing';
+export const LETTER_SPACING_SUPPORT_KEY =
+	'typography.__experimentalLetterSpacing';
 
 /**
  * Inspector control panel containing the letter-spacing options.

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -110,7 +110,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	letterSpacing: {
 		value: [ 'typography', 'letterSpacing' ],
-		support: [ '__experimentalLetterSpacing' ],
+		support: [ 'typography', '__experimentalLetterSpacing' ],
 	},
 	'--wp--style--block-gap': {
 		value: [ 'spacing', 'blockGap' ],


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/32577

## Description

Fixes issue where letter spacing support isn't correctly detected and results in letter spacing controls not being displayed.

## How has this been tested?

1. Replicated letter-spacing controls didn't show for the site tagline block in both post and site editors
2. Applied this PR, confirmed the site tagline block had letter-spacing controls in both editors and it worked.

## Screenshots

| Before | After |
|---|---|
| <img width="281" alt="Screen Shot 2021-09-03 at 11 07 26 am" src="https://user-images.githubusercontent.com/60436221/131936501-b7dfadbd-81ff-415f-afc1-b603b3223ed0.png"> | <img width="280" alt="Screen Shot 2021-09-03 at 11 08 54 am" src="https://user-images.githubusercontent.com/60436221/131936511-ed898610-1c31-4c2f-8181-78c9dd89dff4.png"> |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
