### PR TITLE
Border Support: Fix check for displaying border support panel

### DIFF
--- a/packages/edit-site/src/components/sidebar/border-panel.js
+++ b/packages/edit-site/src/components/sidebar/border-panel.js
@@ -32,7 +32,7 @@ export function useHasBorderPanel( { supports, name } ) {
 		useHasBorderWidthControl( { supports, name } ),
 	];
 
-	return controls.every( Boolean );
+	return controls.some( Boolean );
 }
 
 function useHasBorderColorControl( { supports, name } ) {


### PR DESCRIPTION
## Description

Fixes problem where if only some border support features were opted into the border panel would not display within the Global Styles sidebar.

## How has this been tested?

1. Toggled off a single border support property for the pullquote block in `lib/theme.json` e.g. color
2. Confirmed no border panel displayed under Pullquote in the Global Styles sidebar's "By Block Type" tab.
3. Checked out this PR, refreshed and confirm that the border panel now displayed and still excluded the opted out of feature
4. Toggled feature back on and confirmed panel still displayed
5. Toggled all features off and confirmed panel no longer displayed

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
