### PR TITLE
Try disabling async mode provider around selected block in ListView

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -33,6 +33,7 @@ import { store as blockEditorStore } from '../../store';
 export default function ListViewBlock( {
 	block,
 	isSelected,
+	isDragged,
 	isBranchSelected,
 	isLastOfSelectedBranch,
 	onClick,
@@ -48,20 +49,9 @@ export default function ListViewBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
-	const { isDragging, blockParents } = useSelect(
+	const blockParents = useSelect(
 		( select ) => {
-			const {
-				isBlockBeingDragged,
-				isAncestorBeingDragged,
-				getBlockParents,
-			} = select( blockEditorStore );
-
-			return {
-				isDragging:
-					isBlockBeingDragged( clientId ) ||
-					isAncestorBeingDragged( clientId ),
-				blockParents: getBlockParents( clientId ),
-			};
+			return select( blockEditorStore ).getBlockParents( clientId );
 		},
 		[ clientId ]
 	);
@@ -128,7 +118,7 @@ export default function ListViewBlock( {
 		'is-last-of-selected-branch':
 			withExperimentalPersistentListViewFeatures &&
 			isLastOfSelectedBranch,
-		'is-dragging': isDragging,
+		'is-dragging': isDragged,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -6,6 +6,8 @@ import { map, compact } from 'lodash';
 /**
  * WordPress dependencies
  */
+
+import { AsyncModeProvider } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -94,7 +96,8 @@ export default function ListViewBranch( props ) {
 				};
 
 				return (
-					<Fragment key={ clientId }>
+					// Make updates to the selected block synchronous.
+					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						<ListViewBlock
 							block={ block }
 							onClick={ selectBlockWithClientId }
@@ -129,7 +132,7 @@ export default function ListViewBranch( props ) {
 								path={ updatedPath }
 							/>
 						) }
-					</Fragment>
+					</AsyncModeProvider>
 				);
 			} ) }
 			{ hasAppender && (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -8,7 +8,6 @@ import { map, compact } from 'lodash';
  */
 
 import { AsyncModeProvider } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -6,8 +6,7 @@ import { map, compact } from 'lodash';
 /**
  * WordPress dependencies
  */
-
-import { AsyncModeProvider } from '@wordpress/data';
+import { AsyncModeProvider, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,6 +15,7 @@ import ListViewBlock from './block';
 import ListViewAppender from './appender';
 import { isClientIdSelected } from './utils';
 import { useListViewContext } from './context';
+import { store as blockEditorStore } from '../../store';
 
 export default function ListViewBranch( props ) {
 	const {
@@ -32,6 +32,10 @@ export default function ListViewBranch( props ) {
 		isBranchSelected = false,
 		isLastOfBranch = false,
 	} = props;
+
+	const draggedBlockClientIds = useSelect( ( select ) =>
+		select( blockEditorStore ).getDraggedBlockClientIds()
+	);
 
 	const isTreeRoot = ! parentBlockClientId;
 	const filteredBlocks = compact( blocks );
@@ -94,9 +98,17 @@ export default function ListViewBranch( props ) {
 					}
 				};
 
+				// Make updates to the selected or dragged blocks synchronous,
+				// but asynchronous for any other block.
+				const isAsynchronous =
+					! draggedBlockClientIds.includes( clientId ) &&
+					! isSelected;
+
 				return (
-					// Make updates to the selected block synchronous.
-					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
+					<AsyncModeProvider
+						key={ clientId }
+						value={ isAsynchronous }
+					>
 						<ListViewBlock
 							block={ block }
 							onClick={ selectBlockWithClientId }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -62,7 +62,11 @@ function ListView(
 	},
 	ref
 ) {
-	const { clientIdsTree, selectedClientIds } = useListViewClientIds(
+	const {
+		clientIdsTree,
+		selectedClientIds,
+		draggedClientIds,
+	} = useListViewClientIds(
 		blocks,
 		showOnlyCurrentHierarchy,
 		__experimentalPersistentListViewFeatures
@@ -116,6 +120,8 @@ function ListView(
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			isTreeGridMounted: isMounted.current,
+			draggedClientIds,
+			selectedClientIds,
 			expandedState,
 			expand,
 			collapse,
@@ -124,6 +130,8 @@ function ListView(
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			isMounted.current,
+			draggedClientIds,
+			selectedClientIds,
 			expandedState,
 			expand,
 			collapse,
@@ -147,7 +155,6 @@ function ListView(
 					<ListViewBranch
 						blocks={ clientIdsTree }
 						selectBlock={ selectEditorBlock }
-						selectedBlockClientIds={ selectedClientIds }
 						{ ...props }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -4,7 +4,7 @@
 
 import { useMergeRefs } from '@wordpress/compose';
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { AsyncModeProvider, useDispatch } from '@wordpress/data';
 import {
 	useCallback,
 	useEffect,
@@ -131,7 +131,7 @@ function ListView(
 	);
 
 	return (
-		<>
+		<AsyncModeProvider value={ true }>
 			<ListViewDropIndicator
 				listViewRef={ elementRef }
 				blockDropTarget={ blockDropTarget }
@@ -152,7 +152,7 @@ function ListView(
 					/>
 				</ListViewContext.Provider>
 			</TreeGrid>
-		</>
+		</AsyncModeProvider>
 	);
 }
 export default forwardRef( ListView );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -86,18 +86,24 @@ function ListView(
 		isMounted.current = true;
 	}, [] );
 
-	const expand = ( clientId ) => {
-		if ( ! clientId ) {
-			return;
-		}
-		setExpandedState( { type: 'expand', clientId } );
-	};
-	const collapse = ( clientId ) => {
-		if ( ! clientId ) {
-			return;
-		}
-		setExpandedState( { type: 'collapse', clientId } );
-	};
+	const expand = useCallback(
+		( clientId ) => {
+			if ( ! clientId ) {
+				return;
+			}
+			setExpandedState( { type: 'expand', clientId } );
+		},
+		[ setExpandedState ]
+	);
+	const collapse = useCallback(
+		( clientId ) => {
+			if ( ! clientId ) {
+				return;
+			}
+			setExpandedState( { type: 'collapse', clientId } );
+		},
+		[ setExpandedState ]
+	);
 	const expandRow = ( row ) => {
 		expand( row?.dataset?.block );
 	};

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -10,25 +10,6 @@ import { useSelect } from '@wordpress/data';
 import { isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
 
-const useListViewSelectedClientIds = (
-	__experimentalPersistentListViewFeatures
-) =>
-	useSelect(
-		( select ) => {
-			const {
-				getSelectedBlockClientId,
-				getSelectedBlockClientIds,
-			} = select( blockEditorStore );
-
-			if ( __experimentalPersistentListViewFeatures ) {
-				return getSelectedBlockClientIds();
-			}
-
-			return getSelectedBlockClientId();
-		},
-		[ __experimentalPersistentListViewFeatures ]
-	);
-
 const useListViewClientIdsTree = (
 	blocks,
 	selectedClientIds,
@@ -76,13 +57,32 @@ export default function useListViewClientIds(
 	showOnlyCurrentHierarchy,
 	__experimentalPersistentListViewFeatures
 ) {
-	const selectedClientIds = useListViewSelectedClientIds(
-		__experimentalPersistentListViewFeatures
+	const { selectedClientIds, draggedClientIds } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getSelectedBlockClientIds,
+				getDraggedBlockClientIds,
+			} = select( blockEditorStore );
+
+			if ( __experimentalPersistentListViewFeatures ) {
+				return {
+					selectedClientIds: getSelectedBlockClientIds(),
+					draggedClientIds: getDraggedBlockClientIds(),
+				};
+			}
+
+			return {
+				selectedClientIds: getSelectedBlockClientId(),
+				draggedClientIds: getDraggedBlockClientIds(),
+			};
+		},
+		[ __experimentalPersistentListViewFeatures ]
 	);
 	const clientIdsTree = useListViewClientIdsTree(
 		blocks,
 		selectedClientIds,
 		showOnlyCurrentHierarchy
 	);
-	return { clientIdsTree, selectedClientIds };
+	return { clientIdsTree, selectedClientIds, draggedClientIds };
 }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -15,7 +15,7 @@ import {
 	EditorSnackbars,
 	store as editorStore,
 } from '@wordpress/editor';
-import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -173,11 +173,7 @@ function Layout( { styles } ) {
 			return <InserterSidebar />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
-			return (
-				<AsyncModeProvider value="true">
-					<ListViewSidebar />
-				</AsyncModeProvider>
-			);
+			return <ListViewSidebar />;
 		}
 		return null;
 	};

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
-import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	SlotFillProvider,
 	Popover,
@@ -169,11 +169,7 @@ function Editor( { initialSettings, onError } ) {
 			return <InserterSidebar />;
 		}
 		if ( isListViewOpen ) {
-			return (
-				<AsyncModeProvider value="true">
-					<ListViewSidebar />
-				</AsyncModeProvider>
-			);
+			return <ListViewSidebar />;
 		}
 		return null;
 	};


### PR DESCRIPTION
## Description
Tries the suggestion in this comment to solve the slow updates in List View - https://github.com/WordPress/gutenberg/pull/34477#issuecomment-911712891.

The problem seems to be that the main selector used to build the ListViewTree is wrapped in `<AsyncModeProvider value={ true }>`. This PR moves the AsyncModeProvider into an inner part of the ListView component so that this is no longer the case. Each block and its nested block is also wrapped in a `<AsyncModeProvider>` with the select block being synchronous and unselected blocks being asynchronous.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
