### PR TITLE
Font Appearance Control: Fix error in global styles for Site Title in TT1-Blocks

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -144,11 +144,12 @@ export default function FontAppearanceControl( props ) {
 	}, [ props.options ] );
 
 	// Find current selection by comparing font style & weight against options.
-	const currentSelection = selectOptions.find(
-		( option ) =>
-			option.style.fontStyle === fontStyle &&
-			option.style.fontWeight === fontWeight
-	);
+	const currentSelection =
+		selectOptions.find(
+			( option ) =>
+				option.style.fontStyle === fontStyle &&
+				option.style.fontWeight === fontWeight
+		) || selectOptions[ 0 ];
 
 	// Adjusts field label in case either styles or weights are disabled.
 	const getLabel = () => {
@@ -165,6 +166,10 @@ export default function FontAppearanceControl( props ) {
 
 	// Adjusts screen reader description based on styles or weights.
 	const getDescribedBy = () => {
+		if ( ! currentSelection ) {
+			return __( 'No selected font appearance' );
+		}
+
 		if ( ! hasFontStyles ) {
 			return sprintf(
 				// translators: %s: Currently selected font weight.

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -144,12 +144,11 @@ export default function FontAppearanceControl( props ) {
 	}, [ props.options ] );
 
 	// Find current selection by comparing font style & weight against options.
-	const currentSelection =
-		selectOptions.find(
-			( option ) =>
-				option.style.fontStyle === fontStyle &&
-				option.style.fontWeight === fontWeight
-		) || selectOptions[ 0 ];
+	const currentSelection = selectOptions.find(
+		( option ) =>
+			option.style.fontStyle === fontStyle &&
+			option.style.fontWeight === fontWeight
+	);
 
 	// Adjusts field label in case either styles or weights are disabled.
 	const getLabel = () => {

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -77,14 +77,14 @@ export default function CustomSelectControl( {
 		onSelectedItemChange,
 		...( typeof _selectedItem !== 'undefined' && _selectedItem !== null
 			? { selectedItem: _selectedItem }
-			: undefined ),
+			: { selectedItem: '' } ),
 		stateReducer,
 	} );
 
 	const controlDescribedBy = describedBy
 		? describedBy
 		: // translators: %s: The selected option.
-		  sprintf( __( 'Currently selected: %s' ), selectedItem.name );
+		  sprintf( __( 'Currently selected: %s' ), selectedItem?.name );
 
 	const menuProps = getMenuProps( {
 		className: 'components-custom-select-control__menu',

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -77,7 +77,7 @@ export default function CustomSelectControl( {
 		onSelectedItemChange,
 		...( typeof _selectedItem !== 'undefined' && _selectedItem !== null
 			? { selectedItem: _selectedItem }
-			: { selectedItem: '' } ),
+			: undefined ),
 		stateReducer,
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

***Update: while this PR is merged, and resolves the fatal that was being thrown, the `downshift` error thrown in the console hasn't been resolved. I've [opened up a separate issue](https://github.com/WordPress/gutenberg/issues/34524) to track that, and will look into a fix next week***

---

While testing global styles using the TT1 Blocks theme, which sets a font weight but not a font style in its `theme.json` file, I noticed that selecting the Site Title block within global styles currently throws a fatal in the editor (see screenshots below).

This appears to be because the `getDescribedBy` function attempted to get the `.name` property on the `currentSelection` object, which starts out being undefined when running with this theme.

The fix I've gone for is to set the current selection to the first option (Default) if none are available rather than letting `currentSelection` being undefined. This also resolves a warning thrown by `downshift` if the `CustomSelectControl` receives an undefined value for the current selection.

There might be a better way of handling the current or default value when the theme provides a mix between undefined and a real value for the appearance (as in TT1-Blocks), but for the moment at least, this seems to resolve the fatal, and the Site Title block can be customised within global styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

These are the steps I used to test:

* Before applying this PR, run the TT1-Blocks theme on your test site
* Open up the site editor
* Open up the global styles sidebar, and attempt to edit the Site Title block's styles
* See the error thrown below
* (For further testing) comment out the `|| selectOptions[0]` in this PR and see that `downshift` throws an error (the below screenshot) when switching between Default and a style in the Appearance control.

With this PR applied:

* The above steps appear to work, with no errors thrown
* Try switching between a variety of font appearance values and check that it looks correct in the site editor

## Screenshots <!-- if applicable -->

Fatal thrown when selecting the Site Title block within global styles:

![site-title-global-styles-fatal-sml](https://user-images.githubusercontent.com/14988353/131950925-b90df10f-c957-4f1e-ad70-247c8ebd42e0.gif)

Error from `downshift` if we just resolve the issue with the `.name` in `getDescribedBy`:

![image](https://user-images.githubusercontent.com/14988353/131950992-ac2b97d0-4c83-423a-8010-01b3472586d2.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested. (Manually)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
