### PR TITLE
Fix text-menu min widths.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -11,6 +11,8 @@
 	// Selector requires a lot of specificity to override base styles.
 	input[type="url"].block-editor-media-placeholder__url-input-field {
 		width: 100%;
+		min-width: 200px;
+
 		@include break-small() {
 			width: 300px;
 		}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   Removed a min-width from the `DropdownMenu` component, allowing the menu to accommodate thin contents like vertical tools menus ([#33995](https://github.com/WordPress/gutenberg/pull/33995)).
+
 ### Bug Fix
 
 -   Fixed RTL styles in `Flex` component ([#33729](https://github.com/WordPress/gutenberg/pull/33729)).

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -52,7 +52,10 @@
 }
 
 .components-menu-item__item {
+	// Provide a minimum width for text items in menus.
 	white-space: nowrap;
+	min-width: 160px;
+
 	margin-right: auto;
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
## Description

Fixes #34518. #33995 removed a min-width on popovers, causing some menus to be small.

This PR fixes the two issues found.

## How has this been tested?

Please test the Image block URL dropdown.

Please dropdown menus that feature the "menu item" component, including the "add existing" dropdown on the navigation block.


Before:

<img width="445" alt="Screenshot 2021-09-03 at 09 50 17" src="https://user-images.githubusercontent.com/1204802/131971060-0fec0804-5df9-4e0b-b0b7-fffc64df8934.png">

<img width="791" alt="Screenshot 2021-09-03 at 09 51 29" src="https://user-images.githubusercontent.com/1204802/131971073-fcf3eaad-b709-4005-bdea-ff06e8c7fb78.png">

After:

<img width="447" alt="Screenshot 2021-09-03 at 09 51 13" src="https://user-images.githubusercontent.com/1204802/131971086-d0f5769c-bb04-4a1e-ba0e-7e0ad69b99a7.png">

<img width="784" alt="Screenshot 2021-09-03 at 09 54 28" src="https://user-images.githubusercontent.com/1204802/131971089-b00e8e27-d575-42c4-89b9-6b141d793825.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
