### PR TITLE
Add undo redo buttons in navigation editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18416,6 +18416,7 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/interface": "file:packages/interface",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
+				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/url": "file:packages/url",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -45,6 +45,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
+		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/url": "file:../url",

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { NavigableToolbar } from '@wordpress/block-editor';
 import { DropdownMenu } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { PinnedItems } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -10,6 +12,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import SaveButton from './save-button';
+import UndoButton from './undo-button';
+import RedoButton from './redo-button';
 import MenuSwitcher from '../menu-switcher';
 import { useMenuEntityProp } from '../../hooks';
 
@@ -21,6 +25,7 @@ export default function Header( {
 	isPending,
 	navigationPost,
 } ) {
+	const isMediumViewport = useViewportMatch( 'medium' );
 	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
 	let actionHeaderText;
 
@@ -39,9 +44,20 @@ export default function Header( {
 
 	return (
 		<div className="edit-navigation-header">
-			<h1 className="edit-navigation-header__title">
-				{ __( 'Navigation' ) }
-			</h1>
+			{ isMediumViewport && (
+				<div className="edit-navigation-header__toolbar-wrapper">
+					<h1 className="edit-navigation-header__title">
+						{ __( 'Navigation' ) }
+					</h1>
+					<NavigableToolbar
+						className="edit-navigation-header__toolbar"
+						aria-label={ __( 'Document tools' ) }
+					>
+						<UndoButton />
+						<RedoButton />
+					</NavigableToolbar>
+				</div>
+			) }
 			<h2 className="edit-navigation-header__subtitle">
 				{ isMenuSelected && decodeEntities( actionHeaderText ) }
 			</h2>

--- a/packages/edit-navigation/src/components/header/redo-button.js
+++ b/packages/edit-navigation/src/components/header/redo-button.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __, isRTL } from '@wordpress/i18n';
+import { ToolbarButton } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
+
+export default function RedoButton() {
+	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const { redo } = useDispatch( coreStore );
+	return (
+		<ToolbarButton
+			icon={ ! isRTL() ? redoIcon : undoIcon }
+			label={ __( 'Redo' ) }
+			shortcut={ displayShortcut.primaryShift( 'z' ) }
+			// If there are no undo levels we don't want to actually disable this
+			// button, because it will remove focus for keyboard users.
+			// See: https://github.com/WordPress/gutenberg/issues/3486
+			aria-disabled={ ! hasRedo }
+			onClick={ hasRedo ? redo : undefined }
+		/>
+	);
+}

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -5,10 +5,43 @@
 	padding: $grid-unit-15 $grid-unit-30 $grid-unit-15 20px;
 }
 
+.edit-navigation-header__toolbar-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 .edit-navigation-header__title {
 	font-size: 20px;
 	padding: 0;
 	margin: 0 20px 0 0;
+}
+
+.edit-navigation-header__toolbar {
+	border: none;
+
+	// The Toolbar component adds different styles to buttons, so we reset them
+	// here to the original button styles
+	// Specificity bump needed to offset https://github.com/WordPress/gutenberg/blob/8ea29cb04412c80c9adf7c1db0e816d6a0ac1232/packages/components/src/toolbar/style.scss#L76
+	> .components-button.has-icon.has-icon.has-icon,
+	> .components-dropdown > .components-button.has-icon.has-icon {
+		height: $button-size;
+		min-width: $button-size;
+		padding: 6px;
+
+		&.is-pressed {
+			background: $gray-900;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			outline: 1px solid transparent;
+		}
+
+		&::before {
+			display: none;
+		}
+	}
 }
 
 .edit-navigation-header__subtitle {

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -45,15 +45,10 @@
 }
 
 .edit-navigation-header__subtitle {
-	display: none;
+	display: block;
 	margin: 0;
 	font-size: 15px;
 	font-weight: normal;
-
-	// Only display on larger screens.
-	@include break-small() {
-		display: block;
-	}
 }
 
 .edit-navigation-header__actions {

--- a/packages/edit-navigation/src/components/header/undo-button.js
+++ b/packages/edit-navigation/src/components/header/undo-button.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __, isRTL } from '@wordpress/i18n';
+import { ToolbarButton } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { store as coreStore } from '@wordpress/core-data';
+
+export default function UndoButton() {
+	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const { undo } = useDispatch( coreStore );
+	return (
+		<ToolbarButton
+			icon={ ! isRTL() ? undoIcon : redoIcon }
+			label={ __( 'Undo' ) }
+			shortcut={ displayShortcut.primary( 'z' ) }
+			// If there are no undo levels we don't want to actually disable this
+			// button, because it will remove focus for keyboard users.
+			// See: https://github.com/WordPress/gutenberg/issues/3486
+			aria-disabled={ ! hasUndo }
+			onClick={ hasUndo ? undo : undefined }
+		/>
+	);
+}


### PR DESCRIPTION
## Description
Another iteration on the editor header to bring more consistency between this and the widgets screen.

Most of the code is lifted straight from widgets.

## How has this been tested?
1. Make some changes
2. Click undo
3. Click redo

It should work the same as using the shortcuts

## Screenshots <!-- if applicable -->
<img width="907" alt="Screenshot 2021-09-03 at 4 07 39 pm" src="https://user-images.githubusercontent.com/677833/131972647-4a123661-b619-4190-ad6e-4a1ace7a6d0f.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
