### PR TITLE
Remove some low impact APIs that were deprecated on WP 5.3

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -68,22 +68,6 @@ _Related_
 
 -   getAdjacentBlockClientId in core/block-editor store.
 
-### getAutosave
-
-> **Deprecated** since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector from the '@wordpress/core-data' package.
-
-Returns the current autosave, or null if one is not set (i.e. if the post
-has yet to be autosaved, or has been saved or published since the last
-autosave).
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
-
-_Returns_
-
--   `?Object`: Current autosave, if exists.
-
 ### getAutosaveAttribute
 
 > **Deprecated** since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector from the '@wordpress/core-data' package and access properties on the returned autosave object using getPostRawValue.
@@ -189,21 +173,6 @@ _Related_
 _Related_
 
 -   getBlockSelectionStart in core/block-editor store.
-
-### getBlocksForSerialization
-
-> **Deprecated** since Gutenberg 6.2.0.
-
-Returns a set of blocks which are to be used in consideration of the post's
-generated save content.
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
-
-_Returns_
-
--   `WPBlock[]`: Filtered set of blocks for save.
 
 ### getClientIdsOfDescendants
 
@@ -626,20 +595,6 @@ _Related_
 _Related_
 
 -   getTemplateLock in core/block-editor store.
-
-### hasAutosave
-
-> **Deprecated** since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector from the '@wordpress/core-data' package and check for a truthy value.
-
-Returns the true if there is an existing autosave, otherwise false.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `boolean`: Whether there is an existing autosave.
 
 ### hasChangedContent
 
@@ -1314,21 +1269,6 @@ _Related_
 _Related_
 
 -   replaceBlocks in core/block-editor store.
-
-### resetAutosave
-
-> **Deprecated** since 5.6. Callers should use the `receiveAutosaves( postId, autosave )` selector from the '@wordpress/core-data' package.
-
-Returns an action object used in signalling that the latest autosave of the
-post has been received, by initialization or autosave.
-
-_Parameters_
-
--   _newAutosave_ `Object`: Autosave post object.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### resetBlocks
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Breaking changes
 
-- Removed the deprecated position and menuLable from the DropdownMenu component.
-- Removed the deprecated onClickOutside prop from the Popover component.
+-   Removed the deprecated `position` and `menuLabel` from the `DropdownMenu` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
+-   Removed the deprecated `onClickOutside` prop from the `Popover` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
 
 ## 17.0.0 (2021-09-09)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Removed the deprecated position and menuLable from the DropdownMenu component.
+- Removed the deprecated onClickOutside prop from the Popover component.
+
 ## 17.0.0 (2021-09-09)
 
 ### Breaking Change

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -8,7 +8,6 @@ import { flatMap, isEmpty, isFunction } from 'lodash';
  * WordPress dependencies
  */
 import { DOWN } from '@wordpress/keycodes';
-import deprecated from '@wordpress/deprecated';
 import { menu } from '@wordpress/icons';
 
 /**
@@ -45,25 +44,8 @@ function DropdownMenu( {
 	menuProps,
 	disableOpenOnArrowDown = false,
 	text,
-	// The following props exist for backward compatibility.
-	menuLabel,
-	position,
 	noIcons,
 } ) {
-	if ( menuLabel ) {
-		deprecated( '`menuLabel` prop in `DropdownComponent`', {
-			since: '5.3',
-			alternative: '`menuProps` object and its `aria-label` property',
-		} );
-	}
-
-	if ( position ) {
-		deprecated( '`position` prop in `DropdownComponent`', {
-			since: '5.3',
-			alternative: '`popoverProps` object and its `position` property',
-		} );
-	}
-
 	if ( isEmpty( controls ) && ! isFunction( children ) ) {
 		return null;
 	}
@@ -79,7 +61,6 @@ function DropdownMenu( {
 	const mergedPopoverProps = mergeProps(
 		{
 			className: 'components-dropdown-menu__popover',
-			position,
 		},
 		popoverProps
 	);
@@ -140,7 +121,7 @@ function DropdownMenu( {
 			renderContent={ ( props ) => {
 				const mergedMenuProps = mergeProps(
 					{
-						'aria-label': menuLabel || label,
+						'aria-label': label,
 						className: classnames(
 							'components-dropdown-menu__menu',
 							{ 'no-icons': noIcons }

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -8,7 +8,6 @@ import { Platform } from 'react-native';
  * WordPress dependencies
  */
 import { DOWN } from '@wordpress/keycodes';
-import deprecated from '@wordpress/deprecated';
 import { BottomSheet, PanelBody } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { menu } from '@wordpress/icons';
@@ -43,24 +42,7 @@ function DropdownMenu( {
 	label,
 	popoverProps,
 	toggleProps,
-	// The following props exist for backward compatibility.
-	menuLabel,
-	position,
 } ) {
-	if ( menuLabel ) {
-		deprecated( '`menuLabel` prop in `DropdownComponent`', {
-			alternative: '`menuProps` object and its `aria-label` property',
-			plugin: 'Gutenberg',
-		} );
-	}
-
-	if ( position ) {
-		deprecated( '`position` prop in `DropdownComponent`', {
-			alternative: '`popoverProps` object and its `position` property',
-			plugin: 'Gutenberg',
-		} );
-	}
-
 	if ( isEmpty( controls ) && ! isFunction( children ) ) {
 		return null;
 	}
@@ -76,7 +58,6 @@ function DropdownMenu( {
 	const mergedPopoverProps = mergeProps(
 		{
 			className: 'components-dropdown-menu__popover',
-			position,
 		},
 		popoverProps
 	);

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -14,7 +14,6 @@ import {
 	forwardRef,
 } from '@wordpress/element';
 import { getRectangleFromRange } from '@wordpress/dom';
-import deprecated from '@wordpress/deprecated';
 import {
 	useViewportMatch,
 	useResizeObserver,
@@ -250,7 +249,6 @@ const Popover = (
 		getAnchorRect,
 		expandOnMobile,
 		animate = true,
-		onClickOutside,
 		onFocusOutside,
 		__unstableStickyBoundaryElement,
 		__unstableSlotName = SLOT_NAME,
@@ -488,20 +486,6 @@ const Popover = (
 		// not three props that potentially do the same thing.
 		if ( type === 'focus-outside' && onFocusOutside ) {
 			onFocusOutside( event );
-		} else if ( type === 'focus-outside' && onClickOutside ) {
-			// Simulate MouseEvent using FocusEvent#relatedTarget as emulated click target.
-			const clickEvent = new window.MouseEvent( 'click' );
-
-			Object.defineProperty( clickEvent, 'target', {
-				get: () => event.relatedTarget,
-			} );
-
-			deprecated( 'Popover onClickOutside prop', {
-				since: '5.3',
-				alternative: 'onFocusOutside',
-			} );
-
-			onClickOutside( clickEvent );
 		} else if ( onClose ) {
 			onClose();
 		}

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Removed the deprecated resetAutosave action.
+- Removed the deprecated getAutosave, hasAutosave and getBlockForSerialization selectors.
 ## 11.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Breaking changes
 
-- Removed the deprecated resetAutosave action.
-- Removed the deprecated getAutosave, hasAutosave and getBlockForSerialization selectors.
+-   Removed the deprecated `resetAutosave` action ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
+-   Removed the deprecated `getAutosave`, `hasAutosave` and `getBlockForSerialization` selectors ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
+
 ## 11.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -101,34 +101,6 @@ export function resetPost( post ) {
 }
 
 /**
- * Returns an action object used in signalling that the latest autosave of the
- * post has been received, by initialization or autosave.
- *
- * @deprecated since 5.6. Callers should use the `receiveAutosaves( postId, autosave )`
- * 			   selector from the '@wordpress/core-data' package.
- *
- * @param {Object} newAutosave Autosave post object.
- *
- * @return {Object} Action object.
- */
-export function* resetAutosave( newAutosave ) {
-	deprecated( 'resetAutosave action (`core/editor` store)', {
-		since: '5.3',
-		alternative: 'receiveAutosaves action (`core` store)',
-	} );
-
-	const postId = yield controls.select( STORE_NAME, 'getCurrentPostId' );
-	yield controls.dispatch(
-		coreStore,
-		'receiveAutosaves',
-		postId,
-		newAutosave
-	);
-
-	return { type: '__INERT__' };
-}
-
-/**
  * Action for dispatching that a post update request has started.
  *
  * @param {Object} options

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	find,
-	get,
-	has,
-	isString,
-	pick,
-	mapValues,
-	includes,
-	some,
-} from 'lodash';
+import { find, get, has, isString, includes, some } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -19,7 +10,6 @@ import createSelector from 'rememo';
 import {
 	getFreeformContentHandlerName,
 	getDefaultBlockName,
-	isUnmodifiedDefaultBlock,
 	__unstableSerializeAndClean,
 } from '@wordpress/blocks';
 import { isInTheFuture, getDate } from '@wordpress/date';
@@ -679,63 +669,6 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 );
 
 /**
- * Returns the current autosave, or null if one is not set (i.e. if the post
- * has yet to be autosaved, or has been saved or published since the last
- * autosave).
- *
- * @deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )`
- * 			   selector from the '@wordpress/core-data' package.
- *
- * @param {Object} state Editor state.
- *
- * @return {?Object} Current autosave, if exists.
- */
-export const getAutosave = createRegistrySelector( ( select ) => ( state ) => {
-	deprecated( "`wp.data.select( 'core/editor' ).getAutosave()`", {
-		since: '5.3',
-		alternative:
-			"`wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
-	} );
-
-	const postType = getCurrentPostType( state );
-	const postId = getCurrentPostId( state );
-	const currentUserId = get( select( coreStore ).getCurrentUser(), [ 'id' ] );
-	const autosave = select( coreStore ).getAutosave(
-		postType,
-		postId,
-		currentUserId
-	);
-	return mapValues( pick( autosave, AUTOSAVE_PROPERTIES ), getPostRawValue );
-} );
-
-/**
- * Returns the true if there is an existing autosave, otherwise false.
- *
- * @deprecated since 5.6. Callers should use the `getAutosave( postType, postId, userId )` selector
- *             from the '@wordpress/core-data' package and check for a truthy value.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} Whether there is an existing autosave.
- */
-export const hasAutosave = createRegistrySelector( ( select ) => ( state ) => {
-	deprecated( "`wp.data.select( 'core/editor' ).hasAutosave()`", {
-		since: '5.3',
-		alternative:
-			"`!! wp.data.select( 'core' ).getAutosave( postType, postId, userId )`",
-	} );
-
-	const postType = getCurrentPostType( state );
-	const postId = getCurrentPostId( state );
-	const currentUserId = get( select( coreStore ).getCurrentUser(), [ 'id' ] );
-	return !! select( coreStore ).getAutosave(
-		postType,
-		postId,
-		currentUserId
-	);
-} );
-
-/**
  * Return true if the post being edited is being scheduled. Preferring the
  * unsaved status values.
  *
@@ -973,42 +906,6 @@ export function getSuggestedPostFormat( state ) {
 		default:
 			return null;
 	}
-}
-
-/**
- * Returns a set of blocks which are to be used in consideration of the post's
- * generated save content.
- *
- * @deprecated since Gutenberg 6.2.0.
- *
- * @param {Object} state Editor state.
- *
- * @return {WPBlock[]} Filtered set of blocks for save.
- */
-export function getBlocksForSerialization( state ) {
-	deprecated( '`core/editor` getBlocksForSerialization selector', {
-		since: '5.3',
-		alternative: 'getEditorBlocks',
-		hint: 'Blocks serialization pre-processing occurs at save time',
-	} );
-
-	const blocks = state.editor.present.blocks.value;
-
-	// WARNING: Any changes to the logic of this function should be verified
-	// against the implementation of isEditedPostEmpty, which bypasses this
-	// function for performance' sake, in an assumption of this current logic
-	// being irrelevant to the optimized condition of emptiness.
-
-	// A single unmodified default block is assumed to be equivalent to an
-	// empty post.
-	const isSingleUnmodifiedDefaultBlock =
-		blocks.length === 1 && isUnmodifiedDefaultBlock( blocks[ 0 ] );
-
-	if ( isSingleUnmodifiedDefaultBlock ) {
-		return [];
-	}
-
-	return blocks;
 }
 
 /**


### PR DESCRIPTION
This PR removes some old APIs that have a low impact and that were deprecated in 5.3.

 - menuLabel prop in Dropdown menu: without it, the Dropdown menu still works, it just might render a slightly different aria label.
 - position prop: the Dropdown menu still works without it but might have a different position. 
 - onClickOutside for Popover component: the component still works without it, it might not close when you click outside it.
 
I also removed some selectors and actions from the 'core/editor' store after checking that it has no impact based on a wpdirectory.net

There are still other APIs that were deprecated on 5.3 that I decided against removing for now because of their potential impact (we could consider removal in future WP major versions):

 - The TextColumns block
 - The move from `wp.editor` to `wp.blockEditor` for some components, selectors and actions
 - the `wp.components.ServerSideRender` component.

What do you think of my arbitrations here?