### PR TITLE
Clean theme data when switching themes in the customizer

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -530,4 +530,5 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 }
 
-add_action( 'setup_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -531,3 +531,4 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 }
 
 add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
+add_action( 'setup_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -530,5 +530,4 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 }
 
-add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );
 add_action( 'setup_theme', array( 'WP_Theme_JSON_Resolver_Gutenberg', 'clean_cached_data' ) );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34531
Related https://github.com/WordPress/gutenberg/pull/34704
Related https://meta.trac.wordpress.org/ticket/5818#comment:4

When we read the `theme.json` from the theme, we cache its data and only clean it upon certain actions, such as `switch_theme`. In the customizer, the user can dynamically switch themes, which appears not to use the `switch_theme`. We still have the `setup_theme` and specific ones such as `start_previewing_theme`.
