### PR TITLE
Support "any" step in NumberControl and RangeControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,9 +9,10 @@
 -   Changed `RangeControl` component to not apply `shiftStep` to inputs from its `<input type="range"/>` ([35020](https://github.com/WordPress/gutenberg/pull/35020)).
 -   Removed `isAction` prop from `Item`. The component will now rely on `onClick` to render as a `button` ([35152](https://github.com/WordPress/gutenberg/pull/35152)).
 
-### New Feature
+### New Features
 
 -   Add an experimental `Navigator` components ([#34904](https://github.com/WordPress/gutenberg/pull/34904)) as a replacement for the previous `Navigation` related components.
+-   Added support for `step="any"` in `NumberControl` and `RangeControl` ([#34542](https://github.com/WordPress/gutenberg/pull/34542)).
 
 ### Bug Fix
 

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -87,7 +87,7 @@ The maximum `value` allowed.
 
 -   Type: `Number`
 -   Required: No
--   Default: Infinity
+-   Default: `Infinity`
 
 ### min
 
@@ -95,7 +95,7 @@ The minimum `value` allowed.
 
 -   Type: `Number`
 -   Required: No
--   Default: -Infinity
+-   Default: `-Infinity`
 
 ### required
 

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -81,6 +81,22 @@ The position of the label (`top`, `side`, `bottom`, or `edge`).
 -   Type: `String`
 -   Required: No
 
+### max
+
+The maximum `value` allowed.
+
+-   Type: `Number`
+-   Required: No
+-   Default: Infinity
+
+### min
+
+The minimum `value` allowed.
+
+-   Type: `Number`
+-   Required: No
+-   Default: -Infinity
+
 ### required
 
 If `true` enforces a valid number within the control's min/max range. If `false` allows an empty string as a valid value.
@@ -99,8 +115,8 @@ Amount to increment by when the `SHIFT` key is held down. This shift value is a 
 
 ### step
 
-Amount to increment by when incrementing/decrementing.
+Amount by which the `value` is changed when incrementing/decrementing. It is also a factor in validation as `value` must be a multiple of `step` (offset by `min`, if specified) to be valid. Accepts the special string value `any` that voids the validation constraint and causes stepping actions to increment/decrement by `1`.
 
--   Type: `Number`
+-   Type: `Number | "any"`
 -   Required: No
 -   Default: `1`

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -41,7 +41,11 @@ export function NumberControl(
 	ref
 ) {
 	const baseStep = step === 'any' ? 1 : parseFloat( step );
-	const jumpStep = useJumpStep( { baseStep, shiftStep, isShiftStepEnabled } );
+	const jumpStep = useJumpStep( {
+		step: baseStep,
+		shiftStep,
+		isShiftStepEnabled,
+	} );
 
 	const baseValue = roundClamp( 0, min, max, baseStep );
 	const constrainValue = ( value, stepOverride ) => {

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -17,6 +17,7 @@ import { Input } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { composeStateReducers } from '../input-control/reducer/reducer';
 import { add, subtract, roundClamp } from '../utils/math';
+import { useJumpStep } from '../utils/hooks';
 import { isValueEmpty } from '../utils/values';
 
 export function NumberControl(
@@ -40,6 +41,8 @@ export function NumberControl(
 	ref
 ) {
 	const baseStep = step === 'any' ? 1 : parseFloat( step );
+	const jumpStep = useJumpStep( { baseStep, shiftStep, isShiftStepEnabled } );
+
 	const baseValue = roundClamp( 0, min, max, baseStep );
 	const constrainValue = ( value, stepOverride ) => {
 		// When step is "any" clamp the value, otherwise round and clamp it
@@ -176,7 +179,7 @@ export function NumberControl(
 			min={ min }
 			ref={ ref }
 			required={ required }
-			step={ step }
+			step={ jumpStep }
 			type={ typeProp }
 			value={ valueProp }
 			__unstableStateReducer={ composeStateReducers(

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -104,7 +104,8 @@ export function NumberControl(
 		 */
 		if ( type === inputControlActionTypes.DRAG && isDragEnabled ) {
 			const [ x, y ] = payload.delta;
-			const modifier = payload.shiftKey
+			const enableShift = payload.shiftKey && isShiftStepEnabled;
+			const modifier = enableShift
 				? parseFloat( shiftStep ) * baseStep
 				: baseStep;
 
@@ -139,7 +140,7 @@ export function NumberControl(
 
 				state.value = constrainValue(
 					add( currentValue, distance ),
-					payload.shiftKey ? modifier : null
+					enableShift ? modifier : null
 				);
 			}
 		}

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -17,7 +17,6 @@ import { Input } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { composeStateReducers } from '../input-control/reducer/reducer';
 import { add, subtract, roundClamp } from '../utils/math';
-import { useJumpStep } from '../utils/hooks';
 import { isValueEmpty } from '../utils/values';
 
 export function NumberControl(
@@ -40,17 +39,12 @@ export function NumberControl(
 	},
 	ref
 ) {
-	const baseStep = step === 'any' ? 1 : parseFloat( step );
-	const jumpStep = useJumpStep( {
-		step: baseStep,
-		shiftStep,
-		isShiftStepEnabled,
-	} );
-
+	const isStepAny = step === 'any';
+	const baseStep = isStepAny ? 1 : parseFloat( step );
 	const baseValue = roundClamp( 0, min, max, baseStep );
 	const constrainValue = ( value, stepOverride ) => {
 		// When step is "any" clamp the value, otherwise round and clamp it
-		return step === 'any'
+		return isStepAny
 			? Math.min( max, Math.max( min, value ) )
 			: roundClamp( value, min, max, stepOverride ?? baseStep );
 	};
@@ -183,7 +177,7 @@ export function NumberControl(
 			min={ min }
 			ref={ ref }
 			required={ required }
-			step={ jumpStep }
+			step={ step }
 			type={ typeProp }
 			value={ valueProp }
 			__unstableStateReducer={ composeStateReducers(

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -32,7 +32,7 @@ function Example() {
 		placeholder: text( 'placeholder', 0 ),
 		required: boolean( 'required', false ),
 		shiftStep: number( 'shiftStep', 10 ),
-		step: number( 'step', 1 ),
+		step: text( 'step', 1 ),
 	};
 
 	return (

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -170,6 +170,16 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '-4' );
 		} );
 
+		it( 'should increment while preserving the decimal value when `step` is “any”', () => {
+			render( <StatefulNumberControl value={ 866.5309 } step="any" /> );
+
+			const input = getInput();
+			input.focus();
+			fireKeyDown( { keyCode: UP } );
+
+			expect( input.value ).toBe( '867.5309' );
+		} );
+
 		it( 'should increment by shiftStep on key UP + shift press', () => {
 			render( <StatefulNumberControl value={ 5 } shiftStep={ 10 } /> );
 
@@ -178,6 +188,16 @@ describe( 'NumberControl', () => {
 			fireKeyDown( { keyCode: UP, shiftKey: true } );
 
 			expect( input.value ).toBe( '20' );
+		} );
+
+		it( 'should increment by shiftStep while preserving the decimal value when `step` is “any”', () => {
+			render( <StatefulNumberControl value={ 857.5309 } step="any" /> );
+
+			const input = getInput();
+			input.focus();
+			fireKeyDown( { keyCode: UP, shiftKey: true } );
+
+			expect( input.value ).toBe( '867.5309' );
 		} );
 
 		it( 'should increment by custom shiftStep on key UP + shift press', () => {
@@ -254,6 +274,16 @@ describe( 'NumberControl', () => {
 			expect( input.value ).toBe( '-6' );
 		} );
 
+		it( 'should decrement while preserving the decimal value when `step` is “any”', () => {
+			render( <StatefulNumberControl value={ 868.5309 } step="any" /> );
+
+			const input = getInput();
+			input.focus();
+			fireKeyDown( { keyCode: DOWN } );
+
+			expect( input.value ).toBe( '867.5309' );
+		} );
+
 		it( 'should decrement by shiftStep on key DOWN + shift press', () => {
 			render( <StatefulNumberControl value={ 5 } /> );
 
@@ -262,6 +292,16 @@ describe( 'NumberControl', () => {
 			fireKeyDown( { keyCode: DOWN, shiftKey: true } );
 
 			expect( input.value ).toBe( '0' );
+		} );
+
+		it( 'should decrement by shiftStep while preserving the decimal value when `step` is “any”', () => {
+			render( <StatefulNumberControl value={ 877.5309 } step="any" /> );
+
+			const input = getInput();
+			input.focus();
+			fireKeyDown( { keyCode: DOWN, shiftKey: true } );
+
+			expect( input.value ).toBe( '867.5309' );
 		} );
 
 		it( 'should decrement by custom shiftStep on key DOWN + shift press', () => {

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -272,7 +272,7 @@ The value to revert to if the Reset button is clicked (enabled by `allowReset`)
 
 #### showTooltip
 
-Forcing the Tooltip UI to show or hide.
+Forcing the Tooltip UI to show or hide. This is overriden to `false` when `step` is set to the special string value `any`.
 
 -   Type: `Boolean`
 -   Required: No
@@ -280,9 +280,9 @@ Forcing the Tooltip UI to show or hide.
 
 #### step
 
-The stepping interval between `min` and `max` values. Step is used both for user interface and validation purposes.
+The minimum amount by which `value` changes. It is also a factor in validation as `value` must be a multiple of `step` (offset by `min`) to be valid. Accepts the special string value `any` that voids the validation constraint and overrides both `withInputField` and `showTooltip` props to `false`.
 
--   Type: `Number`
+-   Type: `Number | "any"`
 -   Required: No
 -   Platform: Web
 
@@ -311,7 +311,7 @@ The current value of the range slider.
 
 #### withInputField
 
-Determines if the `input` number field will render next to the RangeControl.
+Determines if the `input` number field will render next to the RangeControl. This is overriden to `false` when `step` is set to the special string value `any`.
 
 -   Type: `Boolean`
 -   Required: No

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -77,6 +77,14 @@ function RangeControl(
 		initial: initialPosition,
 	} );
 	const isResetPendent = useRef( false );
+
+	if ( step === 'any' ) {
+		// The tooltip and number input field are hidden when the step is "any"
+		// because the decimals get too lengthy to fit well.
+		showTooltipProp = false;
+		withInputField = false;
+	}
+
 	const [ showTooltip, setShowTooltip ] = useState( showTooltipProp );
 	const [ isFocused, setIsFocused ] = useState( false );
 

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -44,6 +44,9 @@ function Marks( {
 	step = 1,
 	value = 0,
 } ) {
+	if ( step === 'any' ) {
+		step = 1;
+	}
 	const marksData = useMarks( { marks, min, max, step, value } );
 
 	return (

--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -43,7 +43,7 @@ const DefaultExample = () => {
 		max: number( 'max', 100 ),
 		min: number( 'min', 0 ),
 		showTooltip: boolean( 'showTooltip', false ),
-		step: number( 'step', 1 ),
+		step: text( 'step', 1 ),
 		railColor: text( 'railColor', null ),
 		trackColor: text( 'trackColor', null ),
 		withInputField: boolean( 'withInputField', true ),
@@ -79,6 +79,10 @@ export const InitialValueZero = () => {
 			value={ null }
 		/>
 	);
+};
+
+export const withAnyStep = () => {
+	return <RangeControlWithState label="Brightness" step="any" />;
 };
 
 export const withHelp = () => {
@@ -174,6 +178,10 @@ export const marks = () => {
 			<h2>Negative Range</h2>
 			<Range marks { ...rangeNegative } />
 			<Range marks={ marksWithNegatives } { ...rangeNegative } />
+
+			<h2>Any Step</h2>
+			<Range marks { ...{ ...stepInteger, step: 'any' } } />
+			<Range marks={ marksBase } { ...{ ...stepInteger, step: 'any' } } />
 		</Wrapper>
 	);
 };


### PR DESCRIPTION
Closes #34816 

Currently, `NumberControl` allows `step="any"` but attempting to use the arrow keys or dragging to change the value results in `NaN`. This PR fixes that.

Support in `RangeControl` presents a bit of a design challenge https://github.com/WordPress/gutenberg/pull/34542#issuecomment-921983454 and alternate ideas on resolving it are welcome.

## How has this been tested?
Unit tests and manually comparing behavior of `NumberControl` with behavior of an `input[type="number]` element using the same `step` values.

## Screenshots
### `NumberControl` support of "any" step with arrow keys and dragging
![number-control-any-step-and-shift-rounding](https://user-images.githubusercontent.com/9000376/132039811-9e425375-733b-4d91-85cf-f896a58e4079.gif)

### `RangeControl` switching between `step` of 1 and "any"

https://user-images.githubusercontent.com/9000376/134936903-30f3b1b0-1538-4878-bd9c-152493b7ed42.mp4

### `RangeControl` marks with "any" step
The mark handling code needed a tiny revision to treat `step="any"` as if the step was 1. While testing that I noticed that the styling for marks has regressed but it's a separate issue (#35153).

https://user-images.githubusercontent.com/9000376/134937266-1f8378af-495c-4e2b-92d7-122b1226ed41.mp4

## Types of changes
enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
