### PR TITLE
Initialize responsive modals with window onload event

### DIFF
--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -21,12 +21,6 @@ function navigationToggleModal( modal ) {
 	htmlElement.classList.toggle( 'has-modal-open' );
 }
 
-MicroModal.init( {
-	onShow: navigationToggleModal,
-	onClose: navigationToggleModal,
-	openClass: 'is-menu-open',
-} );
-
 // Open on click functionality.
 function closeSubmenus( element ) {
 	element
@@ -92,3 +86,12 @@ document.addEventListener( 'keyup', function ( event ) {
 		}
 	} );
 } );
+
+// Necessary for some themes such as TT1 Blocks, where
+// scripts could be loaded before the body.
+window.onload = () =>
+	MicroModal.init( {
+		onShow: navigationToggleModal,
+		onClose: navigationToggleModal,
+		openClass: 'is-menu-open',
+	} );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/33273

In TT1 blocks, scripts are loaded before the body, which means that trying to initialize Responsive Navigation menus in this theme doesn't work, as que markup is not present. Fixed by running the initialization script on the window's On Load event.

## How has this been tested?
1. Enable TT1 Blocks.
2. Create a Navigation Menu, and enable responsiveness.
3. The Burger button should appear, and it should toggle the responsive menu visibility both in the editor, and in the frontend.

## Screenshots <!-- if applicable -->

![Kapture 2021-09-03 at 15 46 31](https://user-images.githubusercontent.com/1157901/132058577-fe486f45-6c83-44d5-9f13-41d91d3f9766.gif)

## Types of changes
Bug fix.
