### PR TITLE
Create Block: Add explict `save: save` within index.js

### DIFF
--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Code Quality: explictly specify `save: save` for consistency [#33613](https://github.com/WordPress/gutenberg/issues/33613)
+
 ## 1.3.0 (2021-07-21)
 
 ### Enhancement

--- a/packages/create-block-tutorial-template/templates/src/index.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/index.js.mustache
@@ -45,5 +45,5 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
 	 * @see ./save.js
 	 */
-	save,
+	save: save,
 } );

--- a/packages/create-block-tutorial-template/templates/src/index.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/index.js.mustache
@@ -3,6 +3,12 @@
  *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
  */
+
+/* eslint object-shorthand: [ "errors", "consistent" ] */
+
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Code Quality: explictly specify `save: save` for consistency [#33613](https://github.com/WordPress/gutenberg/issues/33613)
+
 ## 2.5.0 (2021-07-21)
 
 ### Enhancements

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -34,5 +34,5 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
 	 * @see ./save.js
 	 */
-	save,
+	save: save,
 } );

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -3,6 +3,12 @@
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
+
+/* eslint object-shorthand: [ "error", "consistent" ] */
+
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**


### PR DESCRIPTION

## Description

For consistency with other usage and edit function above, specify
the save property in the object we are assigning then simply allowing
the shorthand notation.

Fixes #33613

## How has this been tested?

Confirm the code will make no functional difference.

To test you can use: `npx @wordpress/create-block` and confirm the generated index.js shows `save: save`


## Types of changes

Code quality.

