### PR TITLE
Bump jest-dev-server to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,53 +2819,6 @@
 				}
 			}
 		},
-		"@hapi/address": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
-			"dev": true
-		},
-		"@hapi/hoek": {
-			"version": "6.2.4",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-			"integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
-			"dev": true
-		},
-		"@hapi/joi": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-			"integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/address": "2.x.x",
-				"@hapi/hoek": "6.x.x",
-				"@hapi/marker": "1.x.x",
-				"@hapi/topo": "3.x.x"
-			}
-		},
-		"@hapi/marker": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-			"integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==",
-			"dev": true
-		},
-		"@hapi/topo": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-			"integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "8.x.x"
-			},
-			"dependencies": {
-				"@hapi/hoek": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-					"integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw==",
-					"dev": true
-				}
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -19021,7 +18974,7 @@
 				"filenamify": "^4.2.0",
 				"jest": "^26.6.3",
 				"jest-circus": "^26.6.3",
-				"jest-dev-server": "^4.4.0",
+				"jest-dev-server": "^5.0.3",
 				"jest-environment-node": "^26.6.2",
 				"markdownlint": "^0.23.1",
 				"markdownlint-cli": "^0.27.1",
@@ -19045,6 +18998,153 @@
 				"webpack-bundle-analyzer": "^4.4.2",
 				"webpack-cli": "^4.7.2",
 				"webpack-livereload-plugin": "^3.0.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"find-process": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
+					"integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0",
+						"commander": "^5.1.0",
+						"debug": "^4.1.1"
+					}
+				},
+				"jest-dev-server": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-5.0.3.tgz",
+					"integrity": "sha512-aJR3a5KdY18Lsz+VbREKwx2HM3iukiui+J9rlv9o6iYTwZCSsJazSTStcD9K1q0AIF3oA+FqLOKDyo/sc7+fJw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.1.1",
+						"cwd": "^0.10.0",
+						"find-process": "^1.4.4",
+						"prompts": "^2.4.1",
+						"spawnd": "^5.0.0",
+						"tree-kill": "^1.2.2",
+						"wait-on": "^5.3.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"prompts": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+					"integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+					"dev": true,
+					"requires": {
+						"kleur": "^3.0.3",
+						"sisteransi": "^1.0.5"
+					}
+				},
+				"rxjs": {
+					"version": "6.6.7",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+					"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
+				"signal-exit": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+					"dev": true
+				},
+				"sisteransi": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+					"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+					"dev": true
+				},
+				"spawnd": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-5.0.0.tgz",
+					"integrity": "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==",
+					"dev": true,
+					"requires": {
+						"exit": "^0.1.2",
+						"signal-exit": "^3.0.3",
+						"tree-kill": "^1.2.2",
+						"wait-port": "^0.2.9"
+					}
+				},
+				"tree-kill": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+					"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+					"dev": true
+				},
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				},
+				"wait-on": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.3.0.tgz",
+					"integrity": "sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==",
+					"dev": true,
+					"requires": {
+						"axios": "^0.21.1",
+						"joi": "^17.3.0",
+						"lodash": "^4.17.21",
+						"minimist": "^1.2.5",
+						"rxjs": "^6.6.3"
+					}
+				},
+				"wait-port": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.9.tgz",
+					"integrity": "sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"commander": "^3.0.2",
+						"debug": "^4.1.1"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"commander": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+							"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -28143,6 +28243,15 @@
 			"integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
 			"dev": true
 		},
+		"axios": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+			"integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.14.0"
+			}
+		},
 		"axobject-query": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -36559,45 +36668,6 @@
 				"find-file-up": "^0.1.2"
 			}
 		},
-		"find-process": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
-			"integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1",
-				"commander": "^2.11.0",
-				"debug": "^2.6.8"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -36665,6 +36735,12 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
 			}
+		},
+		"follow-redirects": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+			"integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -40845,78 +40921,6 @@
 					"requires": {
 						"is-number": "^7.0.0"
 					}
-				}
-			}
-		},
-		"jest-dev-server": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
-			"integrity": "sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==",
-			"dev": true,
-			"requires": {
-				"chalk": "^3.0.0",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.3",
-				"prompts": "^2.3.0",
-				"spawnd": "^4.4.0",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"tree-kill": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-					"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-					"dev": true
 				}
 			}
 		},
@@ -56428,26 +56432,6 @@
 			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
 			"dev": true
 		},
-		"spawnd": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
-			"integrity": "sha512-jLPOfB6QOEgMOQY15Z6+lwZEhH3F5ncXxIaZ7WHPIapwNNLyjrs61okj3VJ3K6tmP5TZ6cO0VAu9rEY4MD4YQg==",
-			"dev": true,
-			"requires": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.2",
-				"tree-kill": "^1.2.2",
-				"wait-port": "^0.2.7"
-			},
-			"dependencies": {
-				"tree-kill": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-					"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-					"dev": true
-				}
-			}
-		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -60204,78 +60188,6 @@
 			"dev": true,
 			"requires": {
 				"xml-name-validator": "^3.0.0"
-			}
-		},
-		"wait-on": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
-			"integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/joi": "^15.0.3",
-				"core-js": "^2.6.5",
-				"minimist": "^1.2.0",
-				"request": "^2.88.0",
-				"rx": "^4.1.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.11",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-					"dev": true
-				},
-				"rx": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-					"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-					"dev": true
-				}
-			}
-		},
-		"wait-port": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.7.tgz",
-			"integrity": "sha512-pJ6cSBIa0w1sDg4y/wXN4bmvhM9OneOvwdFHo647L2NShBi/oXG4lRaLic5cO1HaYGbUhEvratPfl/WMlIC+tg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"commander": "^3.0.2",
-				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"walker": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -59,7 +59,7 @@
 		"filenamify": "^4.2.0",
 		"jest": "^26.6.3",
 		"jest-circus": "^26.6.3",
-		"jest-dev-server": "^4.4.0",
+		"jest-dev-server": "^5.0.3",
 		"jest-environment-node": "^26.6.2",
 		"markdownlint": "^0.23.1",
 		"markdownlint-cli": "^0.27.1",


### PR DESCRIPTION


## Description
- Bumped `jest-dev-server` to v5
  Changelog: https://github.com/smooth-code/jest-puppeteer/blob/master/CHANGELOG.md#500-2021-04-16

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
