### PR TITLE
Fix undo/redo 'trap' in navigation link block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -291,7 +291,10 @@ export default function NavigationLinkEdit( {
 	};
 	const { showSubmenuIcon } = context;
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { insertBlock } = useDispatch( blockEditorStore );
+	const {
+		insertBlock,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const listItemRef = useRef( null );
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
@@ -354,8 +357,10 @@ export default function NavigationLinkEdit( {
 		[ clientId ]
 	);
 
-	// Store the colors from context as attributes for rendering
-	useEffect( () => setAttributes( { isTopLevelLink } ), [ isTopLevelLink ] );
+	useEffect( () => {
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( { isTopLevelLink } );
+	}, [ isTopLevelLink ] );
 
 	/**
 	 * Insert a link block when submenu is added.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -358,6 +358,10 @@ export default function NavigationLinkEdit( {
 	);
 
 	useEffect( () => {
+		// This side-effect should not create an undo level as those should
+		// only be created via user interactions. Mark this change as
+		// not persistent to avoid undo level creation.
+		// See https://github.com/WordPress/gutenberg/issues/34564.
 		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { isTopLevelLink } );
 	}, [ isTopLevelLink ] );


### PR DESCRIPTION
## Description
Fixes #34564

There's some code in the navigation link block that calls `setAttribute` within a react effect. It causes a bug that means the user cannot click 'redo' after clicking 'undo'.

What happens here is hard to explain, but there is a good reason why this happens and an appropriate fix.

The best way to explain it is to first mention how the 'undo' feature generally works. If I click undo a few times as a user, but then make a change (type something in) I lose my ability to click 'redo'. Essentially what I just typed in becomes the new undo history. That's correct and how the feature has historically worked across various applications.

This react effect is causing the same thing. The user clicks undo a few times, the side effect triggers and the undo history is changed. The user is no longer able to click redo, but this time it wasn't caused by the user.

The appropriate fix seems to be to use `__unstableMarkNextChangeAsNotPersistent` to indicate that the attribute change shouldn't update the 'undo' history.

## How has this been tested?
1. Add x3 links to the Navigation.
2. Click Undo to revert the adding of the links.
3. Click Redo to restore the links.
4. Redo should work

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
