### PR TITLE
Gap block support: force gap change to cause the block to re-render (fix Safari issue)

### DIFF
--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -12,6 +12,7 @@ import {
 /**
  * Internal dependencies
  */
+import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
 import useSetting from '../components/use-setting';
 import { SPACING_SUPPORT_KEY } from './dimensions';
 import { cleanEmptyObject } from './utils';
@@ -79,6 +80,7 @@ export function useIsGapDisabled( { name: blockName } = {} ) {
  */
 export function GapEdit( props ) {
 	const {
+		clientId,
 		attributes: { style },
 		setAttributes,
 	} = props;
@@ -92,6 +94,8 @@ export function GapEdit( props ) {
 			'vw',
 		],
 	} );
+
+	const ref = useBlockRef( clientId );
 
 	if ( useIsGapDisabled( props ) ) {
 		return null;
@@ -109,6 +113,13 @@ export function GapEdit( props ) {
 		setAttributes( {
 			style: cleanEmptyObject( newStyle ),
 		} );
+
+		// In Safari, changing the `gap` CSS value on its own will not trigger the layout
+		// to be recalculated / re-rendered. To force the updated gap to re-render, here
+		// we replace the block's node with itself.
+		if ( ref.current ) {
+			ref.current.parentNode?.replaceChild( ref.current, ref.current );
+		}
 	};
 
 	return Platform.select( {

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -117,7 +117,13 @@ export function GapEdit( props ) {
 		// In Safari, changing the `gap` CSS value on its own will not trigger the layout
 		// to be recalculated / re-rendered. To force the updated gap to re-render, here
 		// we replace the block's node with itself.
-		if ( ref.current ) {
+		const isSafari =
+			window?.navigator.userAgent &&
+			window.navigator.userAgent.includes( 'Safari' ) &&
+			! window.navigator.userAgent.includes( 'Chrome ' ) &&
+			! window.navigator.userAgent.includes( 'Chromium ' );
+
+		if ( ref.current && isSafari ) {
 			ref.current.parentNode?.replaceChild( ref.current, ref.current );
 		}
 	};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

During testing of the block gap support in #33991 it was uncovered that updating the CSS value for `gap` on its own, doesn't appear to cause a layout to be recalculated / re-rendered by Safari desktop. Adjusting other CSS values at the same time appears to make Safari re-render (e.g. adjusting height or width). This means that in many cases when adjusting gap values in Safari, the block doesn't appear to update, until the user clicks away from that block.

To force the browser to re-render the block, in this PR we take a heavy-handed approach and replace the DOM node for the block that has opted-in to the blockGap support with itself when the gap value changes. The has a performance cost, but the hunch that I'm going with is that it's better for Safari to be able to render gap changes live when making changes to the gap value, than not at all.

***A note on implementation:*** I haven't used the `replace` method in the `@wordpress/dom` package, because that method removes and then appends to the parent node, which throws an error since here we're replace the node with itself, so `replaceChild` is a better fit. Also, I opted for replacement instead of hacking in a separate CSS update, to avoid having to register a `setTimeout`. Very happy to hear other ideas for workarounds if folks have them!

The issue this PR addresses appears to only be at play in Safari browser.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually, following the steps in #33991 to opt-in to blockGap support. Broadly that includes:

### Switch on the block gap support

1. Using TT1-Blocks theme, In your `theme.json` file, under `settings.spacing` add the `"blockGap": true` property. E.g. this is how my spacing settings look:

```
		"spacing": {
			"blockGap": true,
			"customPadding": true,
			"units": [
				"px",
				"em",
				"rem",
				"vh",
				"vw"
			]
		},
```

2. In `packages/block-library/src/buttons/block.json` add the `gap` "spacing" support. In my testing, the "supports" key of this file looks like this:

```
	"supports": {
		"anchor": true,
		"align": [ "wide", "full" ],
		"spacing": {
			"blockGap": true,
			"__experimentalDefaultControls": {
				"blockGap": true
			}
		}
	},
```

3. In `packages/block-library/src/buttons/style.scss` at line 8 add the following to set the gap styles:

```
	column-gap: var( --wp--style--block-gap, $blocks-block__margin );
	row-gap: var( --wp--style--block-gap, $blocks-block__margin );
```

4. Insert a Buttons block and a few buttons into a post, and try out the Gap control as in the screenshots below.

## Screenshots <!-- if applicable -->

In the below screenshots, this is a Buttons block added as the first block in a post, using the Safari browser.

| Before (styling only updates when you de-select the block) | After (styling updates live) |
| --- | --- |
| ![block-gap-safari-before-sml](https://user-images.githubusercontent.com/14988353/132173776-e5312ab4-9e2e-45d2-8292-7a9f20223577.gif) | ![block-gap-safari-after-sml](https://user-images.githubusercontent.com/14988353/132173825-644475bb-23bd-4c5c-8736-53504d12a1e9.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
