### PR TITLE
Update navigation editor placeholder

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -103,6 +103,7 @@ function Navigation( {
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
 	hasColorSettings = true,
+	customPlaceholder: CustomPlaceholder = null,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -163,7 +164,7 @@ function Navigation( {
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
 			__experimentalLayout: LAYOUT,
-			placeholder,
+			placeholder: ! CustomPlaceholder ? placeholder : undefined,
 		}
 	);
 
@@ -200,9 +201,13 @@ function Navigation( {
 	} );
 
 	if ( isPlaceholderShown ) {
+		const PlaceholderComponent = CustomPlaceholder
+			? CustomPlaceholder
+			: NavigationPlaceholder;
+
 		return (
 			<div { ...blockProps }>
-				<NavigationPlaceholder
+				<PlaceholderComponent
 					onCreate={ ( blocks, selectNavigationBlock ) => {
 						setIsPlaceholderShown( false );
 						updateInnerBlocks( blocks );

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -48,7 +48,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
 		const selectNavigationBlock = true;
 		onCreate( blocks, selectNavigationBlock );
-	} );
+	}, [ menuItems, menuItemsToBlocks, onCreate ] );
 
 	const onCreateFromMenu = () => {
 		// If we have menu items, create the block right away.

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -4,7 +4,7 @@ exports[`Navigation editor allows creation of a menu when there are existing men
 
 exports[`Navigation editor allows creation of a menu when there are no current menu items 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
-<!-- wp:page-list {\\"isNavigationChild\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"My page\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://example.com/1\\",\\"isTopLevelLink\\":true} /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -193,7 +193,18 @@ describe( 'Navigation editor', () => {
 				POST: menuPostResponse,
 			} ),
 			...getMenuItemMocks( { GET: [] } ),
-			...getPagesMocks( { GET: [ {} ] } ), // mock a single page
+			...getPagesMocks( {
+				GET: [
+					{
+						type: 'page',
+						id: 1,
+						link: 'https://example.com/1',
+						title: {
+							rendered: 'My page',
+						},
+					},
+				],
+			} ),
 		] );
 
 		await page.keyboard.type( 'Main Menu' );
@@ -354,7 +365,7 @@ describe( 'Navigation editor', () => {
 		);
 		await navBlock.click();
 		const startEmptyButton = await page.waitForXPath(
-			'//button[.="Start empty"]'
+			'//button[.="Start blank"]'
 		);
 		await startEmptyButton.click();
 

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -1,0 +1,185 @@
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import {
+	Placeholder,
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Spinner,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import {
+	forwardRef,
+	useCallback,
+	useState,
+	useEffect,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { store as navigationStore } from '../../store';
+import { useMenuEntityProp } from '../../hooks';
+import useNavigationEntities from './use-navigation-entities';
+import menuItemsToBlocks from './menu-items-to-blocks';
+
+/**
+ * Convert pages to blocks.
+ *
+ * @param {Object[]} pages An array of pages.
+ *
+ * @return {WPBlock[]} An array of blocks.
+ */
+function convertPagesToBlocks( pages ) {
+	if ( ! pages?.length ) {
+		return null;
+	}
+
+	return pages.map( ( { title, type, link: url, id } ) =>
+		createBlock( 'core/navigation-link', {
+			type,
+			id,
+			url,
+			label: ! title.rendered ? __( '(no title)' ) : title.rendered,
+			opensInNewTab: false,
+		} )
+	);
+}
+
+function BlockPlaceholder( { onCreate }, ref ) {
+	const [ selectedMenu, setSelectedMenu ] = useState();
+	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
+
+	const selectedMenuId = useSelect( ( select ) =>
+		select( navigationStore ).getSelectedMenuId()
+	);
+	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
+
+	const {
+		isResolvingPages,
+		menus,
+		isResolvingMenus,
+		menuItems,
+		hasResolvedMenuItems,
+		pages,
+		hasPages,
+		hasMenus,
+	} = useNavigationEntities( selectedMenu );
+
+	const isLoading = isResolvingPages || isResolvingMenus;
+
+	const createFromMenu = useCallback( () => {
+		const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
+		const selectNavigationBlock = true;
+		onCreate( blocks, selectNavigationBlock );
+	} );
+
+	const onCreateFromMenu = () => {
+		// If we have menu items, create the block right away.
+		if ( hasResolvedMenuItems ) {
+			createFromMenu();
+			return;
+		}
+
+		// Otherwise, create the block when resolution finishes.
+		setIsCreatingFromMenu( true );
+	};
+
+	const onCreateEmptyMenu = () => {
+		onCreate( [] );
+	};
+
+	const onCreateAllPages = () => {
+		const blocks = convertPagesToBlocks( pages );
+		const selectNavigationBlock = true;
+		onCreate( blocks, selectNavigationBlock );
+	};
+
+	useEffect( () => {
+		// If the user selected a menu but we had to wait for menu items to
+		// finish resolving, then create the block once resolution finishes.
+		if ( isCreatingFromMenu && hasResolvedMenuItems ) {
+			createFromMenu();
+			setIsCreatingFromMenu( false );
+		}
+	}, [ isCreatingFromMenu, hasResolvedMenuItems ] );
+
+	const toggleProps = {
+		variant: 'tertiary',
+	};
+
+	return (
+		<Placeholder
+			className="wp-block-placeholder"
+			label={ menuName }
+			instructions={ __(
+				'This menu is empty. You can start blank and choose what to add,' +
+					' add your existing pages, or add the content of another menu.'
+			) }
+		>
+			<div className="wp-block-placeholder__controls">
+				{ isLoading && (
+					<div ref={ ref }>
+						<Spinner />
+					</div>
+				) }
+				{ ! isLoading && (
+					<div ref={ ref } className="wp-block-placeholder__actions">
+						<Button
+							variant="tertiary"
+							onClick={ onCreateEmptyMenu }
+						>
+							{ __( 'Start blank' ) }
+						</Button>
+						{ hasPages ? (
+							<Button
+								variant={ hasMenus ? 'tertiary' : 'primary' }
+								onClick={ onCreateAllPages }
+							>
+								{ __( 'Add all pages' ) }
+							</Button>
+						) : undefined }
+						{ hasMenus ? (
+							<DropdownMenu
+								text={ __( 'Copy existing menu' ) }
+								icon={ chevronDown }
+								toggleProps={ toggleProps }
+							>
+								{ ( { onClose } ) => (
+									<MenuGroup>
+										{ menus.map( ( menu ) => {
+											return (
+												<MenuItem
+													onClick={ () => {
+														setSelectedMenu(
+															menu.id
+														);
+														onCreateFromMenu();
+													} }
+													onClose={ onClose }
+													key={ menu.id }
+												>
+													{ menu.name }
+												</MenuItem>
+											);
+										} ) }
+									</MenuGroup>
+								) }
+							</DropdownMenu>
+						) : undefined }
+					</div>
+				) }
+			</div>
+		</Placeholder>
+	);
+}
+
+export default forwardRef( BlockPlaceholder );

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -52,6 +52,9 @@ function convertPagesToBlocks( pages ) {
 	);
 }
 
+const TOGGLE_PROPS = { variant: 'tertiary' };
+const POPOVER_PROPS = { position: 'bottom center' };
+
 function BlockPlaceholder( { onCreate }, ref ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
@@ -108,10 +111,6 @@ function BlockPlaceholder( { onCreate }, ref ) {
 		}
 	}, [ isCreatingFromMenu, hasResolvedMenuItems ] );
 
-	const toggleProps = {
-		variant: 'tertiary',
-	};
-
 	const selectableMenus = menus?.filter(
 		( menu ) => menu.id !== selectedMenuId
 	);
@@ -120,21 +119,24 @@ function BlockPlaceholder( { onCreate }, ref ) {
 
 	return (
 		<Placeholder
-			className="wp-block-placeholder"
+			className="edit-navigation-block-placeholder"
 			label={ menuName }
 			instructions={ __(
 				'This menu is empty. You can start blank and choose what to add,' +
 					' add your existing pages, or add the content of another menu.'
 			) }
 		>
-			<div className="wp-block-placeholder__controls">
+			<div className="edit-navigation-block-placeholder__controls">
 				{ isLoading && (
 					<div ref={ ref }>
 						<Spinner />
 					</div>
 				) }
 				{ ! isLoading && (
-					<div ref={ ref } className="wp-block-placeholder__actions">
+					<div
+						ref={ ref }
+						className="edit-navigation-block-placeholder__actions"
+					>
 						<Button
 							variant="tertiary"
 							onClick={ onCreateEmptyMenu }
@@ -153,7 +155,8 @@ function BlockPlaceholder( { onCreate }, ref ) {
 							<DropdownMenu
 								text={ __( 'Copy existing menu' ) }
 								icon={ chevronDown }
-								toggleProps={ toggleProps }
+								toggleProps={ TOGGLE_PROPS }
+								popoverProps={ POPOVER_PROPS }
 							>
 								{ ( { onClose } ) => (
 									<MenuGroup>

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -155,22 +155,27 @@ function BlockPlaceholder( { onCreate }, ref ) {
 							>
 								{ ( { onClose } ) => (
 									<MenuGroup>
-										{ menus.map( ( menu ) => {
-											return (
-												<MenuItem
-													onClick={ () => {
-														setSelectedMenu(
-															menu.id
-														);
-														onCreateFromMenu();
-													} }
-													onClose={ onClose }
-													key={ menu.id }
-												>
-													{ menu.name }
-												</MenuItem>
-											);
-										} ) }
+										{ menus
+											.filter(
+												( menu ) =>
+													menu.id !== selectedMenuId
+											)
+											.map( ( menu ) => {
+												return (
+													<MenuItem
+														onClick={ () => {
+															setSelectedMenu(
+																menu.id
+															);
+															onCreateFromMenu();
+														} }
+														onClose={ onClose }
+														key={ menu.id }
+													>
+														{ menu.name }
+													</MenuItem>
+												);
+											} ) }
 									</MenuGroup>
 								) }
 							</DropdownMenu>

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
 import { createBlock } from '@wordpress/blocks';
 import {
 	Placeholder,

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -116,6 +116,12 @@ function BlockPlaceholder( { onCreate }, ref ) {
 		variant: 'tertiary',
 	};
 
+	const selectableMenus = menus?.filter(
+		( menu ) => menu.id !== selectedMenuId
+	);
+
+	const hasSelectableMenus = !! selectableMenus?.length;
+
 	return (
 		<Placeholder
 			className="wp-block-placeholder"
@@ -147,7 +153,7 @@ function BlockPlaceholder( { onCreate }, ref ) {
 								{ __( 'Add all pages' ) }
 							</Button>
 						) : undefined }
-						{ hasMenus ? (
+						{ hasSelectableMenus ? (
 							<DropdownMenu
 								text={ __( 'Copy existing menu' ) }
 								icon={ chevronDown }
@@ -155,27 +161,22 @@ function BlockPlaceholder( { onCreate }, ref ) {
 							>
 								{ ( { onClose } ) => (
 									<MenuGroup>
-										{ menus
-											.filter(
-												( menu ) =>
-													menu.id !== selectedMenuId
-											)
-											.map( ( menu ) => {
-												return (
-													<MenuItem
-														onClick={ () => {
-															setSelectedMenu(
-																menu.id
-															);
-															onCreateFromMenu();
-														} }
-														onClose={ onClose }
-														key={ menu.id }
-													>
-														{ menu.name }
-													</MenuItem>
-												);
-											} ) }
+										{ selectableMenus.map( ( menu ) => {
+											return (
+												<MenuItem
+													onClick={ () => {
+														setSelectedMenu(
+															menu.id
+														);
+														onCreateFromMenu();
+													} }
+													onClose={ onClose }
+													key={ menu.id }
+												>
+													{ menu.name }
+												</MenuItem>
+											);
+										} ) }
 									</MenuGroup>
 								) }
 							</DropdownMenu>

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -13,7 +13,6 @@ import {
 	MenuItem,
 	Spinner,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import {
 	forwardRef,
 	useCallback,
@@ -26,8 +25,7 @@ import { chevronDown } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { store as navigationStore } from '../../store';
-import { useMenuEntityProp } from '../../hooks';
+import { useMenuEntityProp, useSelectedMenuId } from '../../hooks';
 import useNavigationEntities from './use-navigation-entities';
 import menuItemsToBlocks from './menu-items-to-blocks';
 
@@ -58,9 +56,7 @@ function BlockPlaceholder( { onCreate }, ref ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
 
-	const selectedMenuId = useSelect( ( select ) =>
-		select( navigationStore ).getSelectedMenuId()
-	);
+	const [ selectedMenuId ] = useSelectedMenuId();
 	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
 
 	const {

--- a/packages/edit-navigation/src/components/block-placeholder/index.js
+++ b/packages/edit-navigation/src/components/block-placeholder/index.js
@@ -76,7 +76,7 @@ function BlockPlaceholder( { onCreate }, ref ) {
 		const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
 		const selectNavigationBlock = true;
 		onCreate( blocks, selectNavigationBlock );
-	} );
+	}, [ menuItems, menuItemsToBlocks, onCreate ] );
 
 	const onCreateFromMenu = () => {
 		// If we have menu items, create the block right away.

--- a/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
@@ -9,6 +9,11 @@ import { sortBy } from 'lodash';
 import { createBlock } from '@wordpress/blocks';
 
 /**
+ * Internal dependencies
+ */
+import { menuItemToBlockAttributes } from '../../store/utils';
+
+/**
  * Convert a flat menu item structure to a nested blocks structure.
  *
  * @param {Object[]} menuItems An array of menu items.
@@ -23,6 +28,8 @@ export default function menuItemsToBlocks( menuItems ) {
 	const menuTree = createDataTree( menuItems );
 	return mapMenuItemsToBlocks( menuTree );
 }
+
+/** @typedef {import('../..store/utils').WPNavMenuItem} WPNavMenuItem */
 
 /**
  * A recursive function that maps menu item nodes to blocks.
@@ -69,87 +76,6 @@ function mapMenuItemsToBlocks( menuItems ) {
 	return {
 		innerBlocks,
 		mapping,
-	};
-}
-
-/**
- * A WP nav_menu_item object.
- * For more documentation on the individual fields present on a menu item please see:
- * https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/nav-menu.php#L789
- *
- * Changes made here should also be mirrored in packages/edit-navigation/src/store/utils.js.
- *
- * @typedef WPNavMenuItem
- *
- * @property {Object} title       stores the raw and rendered versions of the title/label for this menu item.
- * @property {Array}  xfn         the XFN relationships expressed in the link of this menu item.
- * @property {Array}  classes     the HTML class attributes for this menu item.
- * @property {string} attr_title  the HTML title attribute for this menu item.
- * @property {string} object      The type of object originally represented, such as 'category', 'post', or 'attachment'.
- * @property {string} object_id   The DB ID of the original object this menu item represents, e.g. ID for posts and term_id for categories.
- * @property {string} description The description of this menu item.
- * @property {string} url         The URL to which this menu item points.
- * @property {string} type        The family of objects originally represented, such as 'post_type' or 'taxonomy'.
- * @property {string} target      The target attribute of the link element for this menu item.
- */
-
-/**
- * Convert block attributes to menu item.
- *
- * @param {WPNavMenuItem} menuItem the menu item to be converted to block attributes.
- * @return {Object} the block attributes converted from the WPNavMenuItem item.
- */
-function menuItemToBlockAttributes( {
-	title: menuItemTitleField,
-	xfn,
-	classes,
-	// eslint-disable-next-line camelcase
-	attr_title,
-	object,
-	// eslint-disable-next-line camelcase
-	object_id,
-	description,
-	url,
-	type: menuItemTypeField,
-	target,
-} ) {
-	// For historical reasons, the `core/navigation-link` variation type is `tag`
-	// whereas WP Core expects `post_tag` as the `object` type.
-	// To avoid writing a block migration we perform a conversion here.
-	// See also inverse equivalent in `blockAttributesToMenuItem`.
-	if ( object && object === 'post_tag' ) {
-		object = 'tag';
-	}
-
-	return {
-		label: menuItemTitleField?.rendered || '',
-		...( object?.length && {
-			type: object,
-		} ),
-		kind: menuItemTypeField?.replace( '_', '-' ) || 'custom',
-		url: url || '',
-		...( xfn?.length &&
-			xfn.join( ' ' ).trim() && {
-				rel: xfn.join( ' ' ).trim(),
-			} ),
-		...( classes?.length &&
-			classes.join( ' ' ).trim() && {
-				className: classes.join( ' ' ).trim(),
-			} ),
-		...( attr_title?.length && {
-			title: attr_title,
-		} ),
-		// eslint-disable-next-line camelcase
-		...( object_id &&
-			'custom' !== object && {
-				id: object_id,
-			} ),
-		...( description?.length && {
-			description,
-		} ),
-		...( target === '_blank' && {
-			opensInNewTab: true,
-		} ),
 	};
 }
 

--- a/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
@@ -6,12 +6,6 @@ import { sortBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
-/**
- * WordPress dependencies
- */
 import { createBlock } from '@wordpress/blocks';
 
 /**

--- a/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import { sortBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Convert a flat menu item structure to a nested blocks structure.
+ *
+ * @param {Object[]} menuItems An array of menu items.
+ *
+ * @return {WPBlock[]} An array of blocks.
+ */
+export default function menuItemsToBlocks( menuItems ) {
+	if ( ! menuItems ) {
+		return null;
+	}
+
+	const menuTree = createDataTree( menuItems );
+	return mapMenuItemsToBlocks( menuTree );
+}
+
+/**
+ * A recursive function that maps menu item nodes to blocks.
+ *
+ * @param {WPNavMenuItem[]} menuItems An array of WPNavMenuItem items.
+ * @return {Object} Object containing innerBlocks and mapping.
+ */
+function mapMenuItemsToBlocks( menuItems ) {
+	let mapping = {};
+
+	// The menuItem should be in menu_order sort order.
+	const sortedItems = sortBy( menuItems, 'menu_order' );
+
+	const innerBlocks = sortedItems.map( ( menuItem ) => {
+		const attributes = menuItemToBlockAttributes( menuItem );
+
+		// If there are children recurse to build those nested blocks.
+		const {
+			innerBlocks: nestedBlocks = [], // alias to avoid shadowing
+			mapping: nestedMapping = {}, // alias to avoid shadowing
+		} = menuItem.children?.length
+			? mapMenuItemsToBlocks( menuItem.children )
+			: {};
+
+		// Update parent mapping with nested mapping.
+		mapping = {
+			...mapping,
+			...nestedMapping,
+		};
+
+		// Create block with nested "innerBlocks".
+		const block = createBlock(
+			'core/navigation-link',
+			attributes,
+			nestedBlocks
+		);
+
+		// Create mapping for menuItem -> block
+		mapping[ menuItem.id ] = block.clientId;
+
+		return block;
+	} );
+
+	return {
+		innerBlocks,
+		mapping,
+	};
+}
+
+/**
+ * A WP nav_menu_item object.
+ * For more documentation on the individual fields present on a menu item please see:
+ * https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/nav-menu.php#L789
+ *
+ * Changes made here should also be mirrored in packages/edit-navigation/src/store/utils.js.
+ *
+ * @typedef WPNavMenuItem
+ *
+ * @property {Object} title       stores the raw and rendered versions of the title/label for this menu item.
+ * @property {Array}  xfn         the XFN relationships expressed in the link of this menu item.
+ * @property {Array}  classes     the HTML class attributes for this menu item.
+ * @property {string} attr_title  the HTML title attribute for this menu item.
+ * @property {string} object      The type of object originally represented, such as 'category', 'post', or 'attachment'.
+ * @property {string} object_id   The DB ID of the original object this menu item represents, e.g. ID for posts and term_id for categories.
+ * @property {string} description The description of this menu item.
+ * @property {string} url         The URL to which this menu item points.
+ * @property {string} type        The family of objects originally represented, such as 'post_type' or 'taxonomy'.
+ * @property {string} target      The target attribute of the link element for this menu item.
+ */
+
+/**
+ * Convert block attributes to menu item.
+ *
+ * @param {WPNavMenuItem} menuItem the menu item to be converted to block attributes.
+ * @return {Object} the block attributes converted from the WPNavMenuItem item.
+ */
+function menuItemToBlockAttributes( {
+	title: menuItemTitleField,
+	xfn,
+	classes,
+	// eslint-disable-next-line camelcase
+	attr_title,
+	object,
+	// eslint-disable-next-line camelcase
+	object_id,
+	description,
+	url,
+	type: menuItemTypeField,
+	target,
+} ) {
+	// For historical reasons, the `core/navigation-link` variation type is `tag`
+	// whereas WP Core expects `post_tag` as the `object` type.
+	// To avoid writing a block migration we perform a conversion here.
+	// See also inverse equivalent in `blockAttributesToMenuItem`.
+	if ( object && object === 'post_tag' ) {
+		object = 'tag';
+	}
+
+	return {
+		label: menuItemTitleField?.rendered || '',
+		...( object?.length && {
+			type: object,
+		} ),
+		kind: menuItemTypeField?.replace( '_', '-' ) || 'custom',
+		url: url || '',
+		...( xfn?.length &&
+			xfn.join( ' ' ).trim() && {
+				rel: xfn.join( ' ' ).trim(),
+			} ),
+		...( classes?.length &&
+			classes.join( ' ' ).trim() && {
+				className: classes.join( ' ' ).trim(),
+			} ),
+		...( attr_title?.length && {
+			title: attr_title,
+		} ),
+		// eslint-disable-next-line camelcase
+		...( object_id &&
+			'custom' !== object && {
+				id: object_id,
+			} ),
+		...( description?.length && {
+			description,
+		} ),
+		...( target === '_blank' && {
+			opensInNewTab: true,
+		} ),
+	};
+}
+
+/**
+ * Creates a nested, hierarchical tree representation from unstructured data that
+ * has an inherent relationship defined between individual items.
+ *
+ * For example, by default, each element in the dataset should have an `id` and
+ * `parent` property where the `parent` property indicates a relationship between
+ * the current item and another item with a matching `id` properties.
+ *
+ * This is useful for building linked lists of data from flat data structures.
+ *
+ * @param {Array}  dataset  linked data to be rearranged into a hierarchical tree based on relational fields.
+ * @param {string} id       the property which uniquely identifies each entry within the array.
+ * @param {*}      relation the property which identifies how the current item is related to other items in the data (if at all).
+ * @return {Array} a nested array of parent/child relationships
+ */
+function createDataTree( dataset, id = 'id', relation = 'parent' ) {
+	const hashTable = Object.create( null );
+	const dataTree = [];
+
+	for ( const data of dataset ) {
+		hashTable[ data[ id ] ] = {
+			...data,
+			children: [],
+		};
+	}
+	for ( const data of dataset ) {
+		if ( data[ relation ] ) {
+			hashTable[ data[ relation ] ].children.push(
+				hashTable[ data[ id ] ]
+			);
+		} else {
+			dataTree.push( hashTable[ data[ id ] ] );
+		}
+	}
+
+	return dataTree;
+}

--- a/packages/edit-navigation/src/components/block-placeholder/style.scss
+++ b/packages/edit-navigation/src/components/block-placeholder/style.scss
@@ -1,0 +1,42 @@
+.wp-block-placeholder {
+	// The navigation editor already has a border around content.
+	// Hide the placeholder's border. Requires extra specificity.
+	&.wp-block-placeholder {
+		box-shadow: none;
+	}
+
+	// Show placeholder instructions when it's a medium size.
+	&.is-medium .components-placeholder__instructions {
+		display: block;
+	}
+
+	// Display buttons in a column when placeholder is small.
+	.wp-block-placeholder__actions {
+		display: flex;
+		flex-direction: column;
+
+		.components-button {
+			margin-bottom: $grid-unit-15;
+			margin-right: 0;
+
+			// Avoid bottom margin on the dropdown since it makes the
+			// menu anchor itself too far away from the button.
+			&.components-dropdown-menu__toggle {
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	@include break-medium() {
+		.wp-block-placeholder__actions {
+			flex-direction: row;
+		}
+
+		// Change the default button margin. Again use extra specificity.
+		&.wp-block-placeholder.is-medium .components-button {
+			margin-bottom: 0;
+			margin-right: $grid-unit-15;
+		}
+	}
+
+}

--- a/packages/edit-navigation/src/components/block-placeholder/style.scss
+++ b/packages/edit-navigation/src/components/block-placeholder/style.scss
@@ -1,8 +1,13 @@
-.wp-block-placeholder {
+.edit-navigation-block-placeholder {
 	// The navigation editor already has a border around content.
 	// Hide the placeholder's border. Requires extra specificity.
-	&.wp-block-placeholder {
+	&.edit-navigation-block-placeholder {
 		box-shadow: none;
+		background: transparent;
+
+		@include break-medium() {
+			margin: -$grid-unit-20 0;
+		}
 	}
 
 	// Show placeholder instructions when it's a medium size.
@@ -11,29 +16,36 @@
 	}
 
 	// Display buttons in a column when placeholder is small.
-	.wp-block-placeholder__actions {
+	.edit-navigation-block-placeholder__actions {
 		display: flex;
 		flex-direction: column;
+		align-items: flex-start;
 
 		.components-button {
-			margin-bottom: $grid-unit-15;
+			margin-bottom: $grid-unit-05;
 			margin-right: 0;
 
 			// Avoid bottom margin on the dropdown since it makes the
 			// menu anchor itself too far away from the button.
 			&.components-dropdown-menu__toggle {
 				margin-bottom: 0;
+
+				svg {
+					// Make the spacing inside the left of the button match the
+					// spacing inside the right of the button.
+					margin-left: -6px;
+				}
 			}
 		}
 	}
 
 	@include break-medium() {
-		.wp-block-placeholder__actions {
+		.edit-navigation-block-placeholder__actions {
 			flex-direction: row;
 		}
 
 		// Change the default button margin. Again use extra specificity.
-		&.wp-block-placeholder.is-medium .components-button {
+		&.edit-navigation-block-placeholder.is-medium .components-button {
 			margin-bottom: 0;
 			margin-right: $grid-unit-15;
 		}

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -1,0 +1,142 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * @typedef {Object} NavigationEntitiesData
+ * @property {Array|undefined} pages                - a collection of WP Post entity objects of post type "Page".
+ * @property {boolean}         isResolvingPages     - indicates whether the request to fetch pages is currently resolving.
+ * @property {boolean}         hasResolvedPages     - indicates whether the request to fetch pages has finished resolving.
+ * @property {Array|undefined} menus                - a collection of Menu entity objects.
+ * @property {boolean}         isResolvingMenus     - indicates whether the request to fetch menus is currently resolving.
+ * @property {boolean}         hasResolvedMenus     - indicates whether the request to fetch menus has finished resolving.
+ * @property {Array|undefined} menusItems           - a collection of Menu Item entity objects for the current menuId.
+ * @property {boolean}         hasResolvedMenuItems - indicates whether the request to fetch menuItems has finished resolving.
+ * @property {boolean}         hasPages             - indicates whether there is currently any data for pages.
+ * @property {boolean}         hasMenus             - indicates whether there is currently any data for menus.
+ */
+
+/**
+ * Manages fetching and resolution state for all entities required
+ * for the Navigation block.
+ *
+ * @param {number} menuId the menu for which to retrieve menuItem data.
+ * @return { NavigationEntitiesData } the entity data.
+ */
+export default function useNavigationEntities( menuId ) {
+	return {
+		...usePageEntities(),
+		...useMenuEntities(),
+		...useMenuItemEntities( menuId ),
+	};
+}
+
+function useMenuEntities() {
+	const { menus, isResolvingMenus, hasResolvedMenus } = useSelect(
+		( select ) => {
+			const { getMenus, isResolving, hasFinishedResolution } = select(
+				coreStore
+			);
+
+			const menusParameters = [ { per_page: -1 } ];
+
+			return {
+				menus: getMenus( ...menusParameters ),
+				isResolvingMenus: isResolving( 'getMenus', menusParameters ),
+				hasResolvedMenus: hasFinishedResolution(
+					'getMenus',
+					menusParameters
+				),
+			};
+		},
+		[]
+	);
+
+	return {
+		menus,
+		isResolvingMenus,
+		hasResolvedMenus,
+		hasMenus: !! ( hasResolvedMenus && menus?.length ),
+	};
+}
+
+function useMenuItemEntities( menuId ) {
+	const { menuItems, hasResolvedMenuItems } = useSelect(
+		( select ) => {
+			const { getMenuItems, hasFinishedResolution } = select( coreStore );
+
+			const hasSelectedMenu = menuId !== undefined;
+			const menuItemsParameters = hasSelectedMenu
+				? [
+						{
+							menus: menuId,
+							per_page: -1,
+						},
+				  ]
+				: undefined;
+
+			return {
+				menuItems: hasSelectedMenu
+					? getMenuItems( ...menuItemsParameters )
+					: undefined,
+				hasResolvedMenuItems: hasSelectedMenu
+					? hasFinishedResolution(
+							'getMenuItems',
+							menuItemsParameters
+					  )
+					: false,
+			};
+		},
+		[ menuId ]
+	);
+
+	return {
+		menuItems,
+		hasResolvedMenuItems,
+	};
+}
+
+function usePageEntities() {
+	const { pages, isResolvingPages, hasResolvedPages } = useSelect(
+		( select ) => {
+			const {
+				getEntityRecords,
+				isResolving,
+				hasFinishedResolution,
+			} = select( coreStore );
+
+			const pagesParameters = [
+				'postType',
+				'page',
+				{
+					parent: 0,
+					order: 'asc',
+					orderby: 'id',
+					per_page: -1,
+				},
+			];
+
+			return {
+				pages: getEntityRecords( ...pagesParameters ) || null,
+				isResolvingPages: isResolving(
+					'getEntityRecords',
+					pagesParameters
+				),
+				hasResolvedPages: hasFinishedResolution(
+					'getEntityRecords',
+					pagesParameters
+				),
+			};
+		},
+		[]
+	);
+
+	return {
+		pages,
+		isResolvingPages,
+		hasResolvedPages,
+		hasPages: !! ( hasResolvedPages && pages?.length ),
+	};
+}

--- a/packages/edit-navigation/src/filters/add-navigation-editor-placeholder.js
+++ b/packages/edit-navigation/src/filters/add-navigation-editor-placeholder.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import BlockPlaceholder from '../components/block-placeholder';
+
+const addNavigationEditorPlaceholder = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		if ( props.name !== 'core/navigation' ) {
+			return <BlockEdit { ...props } />;
+		}
+		return (
+			<BlockEdit { ...props } customPlaceholder={ BlockPlaceholder } />
+		);
+	},
+	'withNavigationEditorPlaceholder'
+);
+
+export default () =>
+	addFilter(
+		'editor.BlockEdit',
+		'core/edit-navigation/with-navigation-editor-placeholder',
+		addNavigationEditorPlaceholder
+	);

--- a/packages/edit-navigation/src/filters/index.js
+++ b/packages/edit-navigation/src/filters/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import addNavigationEditorPlaceholder from './add-navigation-editor-placeholder';
 import addMenuNameEditor from './add-menu-name-editor';
 import disableInsertingNonNavigationBlocks from './disable-inserting-non-navigation-blocks';
 import removeEditUnsupportedFeatures from './remove-edit-unsupported-features';
@@ -9,6 +10,7 @@ import removeSettingsUnsupportedFeatures from './remove-settings-unsupported-fea
 export const addFilters = (
 	shouldAddDisableInsertingNonNavigationBlocksFilter
 ) => {
+	addNavigationEditorPlaceholder();
 	addMenuNameEditor();
 	if ( shouldAddDisableInsertingNonNavigationBlocksFilter ) {
 		disableInsertingNonNavigationBlocks();

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -8,6 +8,7 @@ $navigation-editor-spacing-top: $grid-unit-50 * 2;
 }
 
 @import "./components/add-menu/style.scss";
+@import "./components/block-placeholder/style.scss";
 @import "../../interface/src/style.scss";
 @import "./components/editor/style.scss";
 @import "./components/error-boundary/style.scss";


### PR DESCRIPTION
## Description
Fixes #33999
Fixes #23953
Fixes #30745

Updates the navigation editor's block placeholder when creating a new navigation block.

Implementation wise, this doesn't feel ideal. There was a lot of discussion on #23953 about a possible implementation that didn't affect the navigation block. When I started looking at this, I discovered the no matter what we do, the navigation block's current placeholder 'preview' needed to be disabled somehow as it always showed on block deselection:
<img width="444" alt="Screenshot 2021-09-06 at 3 49 11 pm" src="https://user-images.githubusercontent.com/677833/132179939-e133285a-449d-400c-9a01-e390c1cc233f.png">

I found it was equally as simple to disable this via a filter as it was to pass a replacement placeholder component into the block. So this is what I chose as the simplest approach.

Ultimately, this is an important piece for the navigation editor, and I think it's good to prioritise this as much as possible.

A problem with this change is that this now exposes the issue described in https://github.com/WordPress/gutenberg/issues/31276 even more after clicking 'Start blank' and deselecting the block, so I'll start looking at that next.

## How has this been tested?
It has existing e2e tests that have been updated.

1. Enable the navigation editor experiment
2. Visit the new screen
3. Create a new menu
4. See and use the placeholder

## Screenshots <!-- if applicable -->
<img width="859" alt="Screenshot 2021-09-06 at 3 59 36 pm" src="https://user-images.githubusercontent.com/677833/132181606-0c2e9c9c-37e2-486a-acb0-35f90ecd9b03.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
