### PR TITLE
Try: Title block gap.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -44,8 +44,9 @@
 		margin-right: auto;
 
 		// Margins between the title and the first block, or appender, do not collapse.
-		// By explicitly setting this to zero, we avoid "double margin".
-		margin-bottom: 0;
+		// However in that support block gap, the first items in post content do not have a top margin.
+		// By leveraging the gap variable, with a fallback of zero, we handle both cases.
+		margin-bottom: var(--wp--style--block-gap, 0);
 	}
 }
 


### PR DESCRIPTION
## Description

When a theme uses block gap to space out blocks, there isn't meant to be a top-margin on the first block in post contents (except for a small bug, #34441).

Currently the post title has an explicit bottom margin of zero. This is set because it assumes blocks that have both top and bottom margins that rely on margin collapsing. But the title block is separate and margins don't collapse into it. In this layout, the zero margin on the title works to rely on the first block of the post content to have margins. 

So in themes that use block gap to space blocks out, the zero top margin means there's no space between title and content:

<img width="748" alt="Screenshot 2021-09-06 at 11 05 54" src="https://user-images.githubusercontent.com/1204802/132192376-e55be8d7-e0e4-4131-b3ff-678ac04ffc36.png">

<img width="886" alt="Screenshot 2021-09-06 at 11 15 44" src="https://user-images.githubusercontent.com/1204802/132192500-f1086976-52b4-445e-9840-a3dfe6fe52c1.png">

This PR changes that by leveraging the block gap CSS variable to set a bottom margin on the title block. It has zero as a fallback, for themes that do not use block gap:

<img width="671" alt="Screenshot 2021-09-06 at 11 09 50" src="https://user-images.githubusercontent.com/1204802/132192784-a7c22348-6c24-432b-9afc-e53434d7a1bb.png">

## How has this been tested?

- Test a classic theme in a post that features an empty image block, and verify the margin between title and content looks good.
- Test a block theme that uses gap in a post that features an empty image block, and verify the margin between title and content looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
