### PR TITLE
Migrate getEntityRecords resolver to thunks

### DIFF
--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -2,6 +2,9 @@
  * WordPress dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import triggerFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
 
 /**
  * Internal dependencies
@@ -117,69 +120,97 @@ describe( 'getEntityRecords', () => {
 		},
 	];
 
-	it( 'yields with requested post type', async () => {
-		const fulfillment = getEntityRecords( 'root', 'postType' );
+	beforeEach( async () => {
+		triggerFetch.mockReset();
+		jest.useFakeTimers();
+	} );
 
-		// Trigger generator
-		fulfillment.next();
+	it( 'dispatches the requested post type', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( ENTITIES );
 
-		// Provide entities and acquire lock
-		fulfillment.next( ENTITIES );
+		// Provide response
+		triggerFetch.mockImplementation( () => POST_TYPES );
 
-		// trigger apiFetch
-		const { value: apiFetchAction } = fulfillment.next();
+		await getEntityRecords( 'root', 'postType' )( { dispatch } );
 
-		expect( apiFetchAction.request ).toEqual( {
+		// Fetch request should have been issued
+		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/types?context=edit',
 		} );
-		// Provide response and trigger action
-		const { value: received } = fulfillment.next( POST_TYPES );
-		expect( received ).toEqual(
-			receiveEntityRecords(
-				'root',
-				'postType',
-				Object.values( POST_TYPES ),
-				{}
-			)
+
+		// The record should have been received
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'root',
+			'postType',
+			Object.values( POST_TYPES ),
+			{}
 		);
 	} );
 
 	it( 'Uses state locks', async () => {
-		const fulfillment = getEntityRecords( 'root', 'postType' );
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( ENTITIES );
 
-		// Repeat the steps from `yields with requested post type` test
-		fulfillment.next();
-		// Provide entities and acquire lock
-		expect( fulfillment.next( ENTITIES ).value.type ).toEqual(
-			'@@data/DISPATCH'
+		// Provide response
+		triggerFetch.mockImplementation( () => POST_TYPES );
+
+		await getEntityRecords( 'root', 'postType' )( { dispatch } );
+
+		// Fetch request should have been issued
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/types?context=edit',
+		} );
+
+		// The record should have been received
+		expect(
+			dispatch.__unstableAcquireStoreLock
+		).toHaveBeenCalledWith(
+			'core',
+			[ 'entities', 'data', 'root', 'postType' ],
+			{ exclusive: false }
 		);
-		fulfillment.next();
-		fulfillment.next( POST_TYPES );
-
-		// Resolve specific entity records
-		fulfillment.next();
-		fulfillment.next();
-
-		// Release lock
-		expect( fulfillment.next().value.type ).toEqual( '@@data/DISPATCH' );
+		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
+			1
+		);
 	} );
 
 	it( 'marks specific entity records as resolved', async () => {
-		const fulfillment = getEntityRecords( 'root', 'postType' );
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( ENTITIES );
 
-		// Repeat the steps from `yields with requested post type` test
-		fulfillment.next();
-		fulfillment.next( ENTITIES );
-		fulfillment.next();
-		fulfillment.next( POST_TYPES );
+		// Provide response
+		triggerFetch.mockImplementation( () => POST_TYPES );
 
-		// It should mark the entity record that has an ID as resolved
-		expect( fulfillment.next().value ).toEqual( {
+		await getEntityRecords( 'root', 'postType' )( { dispatch } );
+
+		// Fetch request should have been issued
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/types?context=edit',
+		} );
+
+		// The record should have been received
+		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'START_RESOLUTIONS',
 			selectorName: 'getEntityRecord',
 			args: [ [ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ] ],
 		} );
-		expect( fulfillment.next().value ).toEqual( {
+		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'FINISH_RESOLUTIONS',
 			selectorName: 'getEntityRecord',
 			args: [ [ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ] ],


### PR DESCRIPTION
Builds on top of the thunks support added in #27276 and refactors just the parts of core-data required to make the `getEntityRecords` work (this PR is a minimal viable subset of #28389).

**Test plan:**

Confirm the automated tests pass

* Edit a post and save it, confirm it worked as expected 
* Add a `blog title` block, edit it, save the post and related entities
* Play the widgets editor, add new widgets, update the existing ones
* Anything else that comes to your mind
 