### PR TITLE
Migrate canUser resolver to thunks

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -27,7 +27,6 @@ import {
 	receiveEntityRecords,
 	receiveThemeSupports,
 	receiveEmbedPreview,
-	receiveUserPermission,
 } from './actions';
 import { getKindEntities, DEFAULT_ENTITY_KEY } from './entities';
 import { ifNotResolved, getNormalizedCommaSeparable } from './utils';
@@ -291,7 +290,7 @@ export function* getEmbedPreview( url ) {
  * @param {string}  resource REST resource to check, e.g. 'media' or 'posts'.
  * @param {?string} id       ID of the rest resource to check.
  */
-export function* canUser( action, resource, id ) {
+export const canUser = ( action, resource, id ) => async ( { dispatch } ) => {
 	const methods = {
 		create: 'POST',
 		read: 'GET',
@@ -308,7 +307,7 @@ export function* canUser( action, resource, id ) {
 
 	let response;
 	try {
-		response = yield apiFetch( {
+		response = await triggerFetch( {
 			path,
 			// Ideally this would always be an OPTIONS request, but unfortunately there's
 			// a bug in the REST API which causes the Allow header to not be sent on
@@ -336,8 +335,8 @@ export function* canUser( action, resource, id ) {
 
 	const key = compact( [ action, resource, id ] ).join( '/' );
 	const isAllowed = includes( allowHeader, method );
-	yield receiveUserPermission( key, isAllowed );
-}
+	dispatch.receiveUserPermission( key, isAllowed );
+};
 
 /**
  * Checks whether the current user can perform the given action on the given
@@ -347,16 +346,18 @@ export function* canUser( action, resource, id ) {
  * @param {string} name     Entity name.
  * @param {string} recordId Record's id.
  */
-export function* canUserEditEntityRecord( kind, name, recordId ) {
-	const entities = yield getKindEntities( kind );
+export const canUserEditEntityRecord = ( kind, name, recordId ) => async ( {
+	dispatch,
+} ) => {
+	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;
 	}
 
 	const resource = entity.__unstable_rest_base;
-	yield canUser( 'update', resource, recordId );
-}
+	await dispatch( canUser( 'update', resource, recordId ) );
+};
 
 /**
  * Request autosave data from the REST API.

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -16,10 +16,7 @@ import {
 	getAutosaves,
 	getCurrentUser,
 } from '../resolvers';
-import {
-	receiveEmbedPreview,
-	receiveCurrentUser,
-} from '../actions';
+import { receiveEmbedPreview, receiveCurrentUser } from '../actions';
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };


### PR DESCRIPTION
Builds on top of the thunks support added in #27276 and refactors just the parts of core-data required to make the `canUser` work (this PR is a minimal viable subset of #28389 with unit tests adjusted).

**Test plan:**

Confirm the automated tests pass

* Add a block title post as an admin, confirm it's saveable
* Add a block title post as an editor, confirm it's not saveable
 