### PR TITLE
Use resolveSelect instead of select in saveEntityRecord

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -348,7 +348,7 @@ export const saveEntityRecord = (
 	name,
 	record,
 	{ isAutosave = false, __unstableFetch = triggerFetch } = {}
-) => async ( { select, dispatch } ) => {
+) => async ( { select, resolveSelect, dispatch } ) => {
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
@@ -410,7 +410,7 @@ export const saveEntityRecord = (
 				// so the client just sends and receives objects.
 				const currentUser = select.getCurrentUser();
 				const currentUserId = currentUser ? currentUser.id : undefined;
-				const autosavePost = select.getAutosave(
+				const autosavePost = resolveSelect.getAutosave(
 					persistedRecord.type,
 					persistedRecord.id,
 					currentUserId


### PR DESCRIPTION
## Description

#33201 introduced a bug in the autosaving path of `saveEntityRecord`. The `getAutosave` call wants to fetch the autosave for the given post and wait until it's fetched. Therefore the call should use `resolveSelect` instead of `select`. Kudos to @jsnajdr for catching this in https://github.com/WordPress/gutenberg/pull/34501#discussion_r702619491.

## Test plan

.. todo .., we could use a new automated test here
