### PR TITLE
Add wide alignment control only if theme provides `layout.wideSize`

### DIFF
--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -160,8 +160,16 @@ export default {
 			return layout.alignments;
 		}
 
-		return layout.contentSize || layout.wideSize
-			? [ 'wide', 'full', 'left', 'center', 'right' ]
-			: [ 'left', 'center', 'right' ];
+		const alignments = [ 'left', 'center', 'right' ];
+
+		if ( layout.contentSize ) {
+			alignments.unshift( 'full' );
+		}
+
+		if ( layout.wideSize ) {
+			alignments.unshift( 'wide' );
+		}
+
+		return alignments;
 	},
 };


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34507

This PR makes it so the wide control is only shown if the theme provides a `layout.wideSize` and the full control is shown when the theme provides a `layout.wideSize` or `layout.contentSize`.