### PR TITLE
Remove duplicated `useValidAlignment` hook

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -125,9 +125,6 @@ export const withToolbarControls = createHigherOrderComponent(
 			getBlockSupport( blockName, 'align' ),
 			hasBlockSupport( blockName, 'alignWide', true )
 		);
-		const validAlignments = useAvailableAlignments(
-			blockAllowedAlignments
-		);
 
 		const updateAlignment = ( nextAlign ) => {
 			if ( ! nextAlign ) {
@@ -142,12 +139,12 @@ export const withToolbarControls = createHigherOrderComponent(
 
 		return (
 			<>
-				{ validAlignments.length > 0 && (
+				{ blockAllowedAlignments.length > 0 && (
 					<BlockControls group="block" __experimentalExposeToChildren>
 						<BlockAlignmentControl
 							value={ props.attributes.align }
 							onChange={ updateAlignment }
-							controls={ validAlignments }
+							controls={ blockAllowedAlignments }
 						/>
 					</BlockControls>
 				) }


### PR DESCRIPTION
The `BlockAlignmentControl` already validates the alignment controls that should be visible according to the theme support using the same hook.