### PR TITLE
Components: fix `ToggleGroupControlBackdrop` not updating size when `isAdaptiveWidth` prop changes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Fixed RTL styles in `Flex` component ([#33729](https://github.com/WordPress/gutenberg/pull/33729)).
 -   Fixed unit test errors caused by `CSS.supports` being called in a non-browser environment ([#34572](https://github.com/WordPress/gutenberg/pull/34572)).
+-   Fixed `ToggleGroupControl`'s backdrop not updating when changing the `isAdaptiveWidth` property ([#34595](https://github.com/WordPress/gutenberg/pull/34595)).
 
 ### Internal
 

--- a/packages/components/src/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/component.tsx
@@ -23,7 +23,7 @@ import {
 import { useUpdateEffect, useCx } from '../utils/hooks';
 import { View } from '../view';
 import BaseControl from '../base-control';
-import Backdrop from './toggle-group-control-backdrop';
+import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import type { ToggleGroupControlProps } from './types';
 import ToggleGroupControlContext from './toggle-group-control-context';
 import * as styles from './styles';
@@ -101,7 +101,7 @@ function ToggleGroupControl(
 					ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
 				>
 					{ resizeListener }
-					<Backdrop
+					<ToggleGroupControlBackdrop
 						{ ...radio }
 						containerRef={ containerRef }
 						containerWidth={ sizes.width }

--- a/packages/components/src/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/component.tsx
@@ -20,13 +20,13 @@ import {
 	useContextSystem,
 	WordPressComponentProps,
 } from '../ui/context';
+import { useUpdateEffect, useCx } from '../utils/hooks';
 import { View } from '../view';
 import BaseControl from '../base-control';
-import * as styles from './styles';
-import { useUpdateEffect, useCx } from '../utils/hooks';
 import Backdrop from './toggle-group-control-backdrop';
 import type { ToggleGroupControlProps } from './types';
 import ToggleGroupControlContext from './toggle-group-control-context';
+import * as styles from './styles';
 
 const noop = () => {};
 

--- a/packages/components/src/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/component.tsx
@@ -105,6 +105,7 @@ function ToggleGroupControl(
 						{ ...radio }
 						containerRef={ containerRef }
 						containerWidth={ sizes.width }
+						isAdaptiveWidth={ isAdaptiveWidth }
 					/>
 					{ children }
 				</RadioGroup>

--- a/packages/components/src/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -12,6 +12,7 @@ import { BackdropView } from './styles';
 function ToggleGroupControlBackdrop( {
 	containerRef,
 	containerWidth,
+	isAdaptiveWidth,
 	state,
 }: ToggleGroupControlBackdropProps ) {
 	const [ left, setLeft ] = useState( 0 );
@@ -43,7 +44,7 @@ function ToggleGroupControlBackdrop( {
 				setCanAnimate( true );
 			} );
 		}
-	}, [ canAnimate, containerRef, containerWidth, state ] );
+	}, [ canAnimate, containerRef, containerWidth, state, isAdaptiveWidth ] );
 
 	return (
 		<BackdropView

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -88,5 +88,6 @@ export type ToggleGroupControlButtonProps = {
 export type ToggleGroupControlBackdropProps = {
 	containerRef: MutableRefObject< HTMLElement | undefined >;
 	containerWidth?: number | null;
+	isAdaptiveWidth?: boolean;
 	state?: any;
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR fixes an issue occurring in `ToggleGroupControl` — the backdrop element, in charge of highlighting the selected element, doesn't currently update its size/position when the `isAdaptiveWidth` prop changes.

To fix this issue, this PR simply forwards the `isAdaptiveProp` from the parent `ToggleGroupControl` component to the `ToggleGroupControlBackdrop`, and it uses it as an additional dependency for the `useEffect` hook that recalculates the backdrop position/size.

Fixes #34587

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/1083581/132243574-a1a995fa-8de9-4878-9f73-f429af02a094.mp4 


After:

https://user-images.githubusercontent.com/1083581/132243586-d0ad8e8e-3d0d-49e4-acd4-7c6a8b79acfd.mp4 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
