### PR TITLE
Components: add reset timeout to ColorPicker's copy functionality.

### DIFF
--- a/packages/components/src/ui/color-picker/color-display.tsx
+++ b/packages/components/src/ui/color-picker/color-display.tsx
@@ -7,7 +7,7 @@ import colorize, { ColorFormats } from 'tinycolor2';
  * WordPress dependencies
  */
 import { useCopyToClipboard } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -114,6 +114,7 @@ export const ColorDisplay = ( {
 	enableAlpha,
 }: ColorDisplayProps ) => {
 	const [ copiedColor, setCopiedColor ] = useState< string | null >( null );
+	const copyTimer = useRef< number | undefined >();
 	const props = { color, enableAlpha };
 	const Component = getComponent( colorType );
 	const copyRef = useCopyToClipboard< HTMLDivElement >(
@@ -134,8 +135,25 @@ export const ColorDisplay = ( {
 				}
 			}
 		},
-		() => setCopiedColor( colorize( color ).toHex8String() )
+		() => {
+			if ( copyTimer.current ) {
+				clearTimeout( copyTimer.current );
+			}
+			setCopiedColor( colorize( color ).toHex8String() );
+			copyTimer.current = setTimeout( () => {
+				setCopiedColor( null );
+				copyTimer.current = undefined;
+			}, 3000 );
+		}
 	);
+	useEffect( () => {
+		// clear copyTimer on component unmount.
+		return () => {
+			if ( copyTimer.current ) {
+				clearTimeout( copyTimer.current );
+			}
+		};
+	}, [] );
 	return (
 		<Tooltip
 			content={


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/34289
This PR fixes the issue https://github.com/WordPress/gutenberg/issues/34289 by introducing a 3 seconds timer that resets the copied state allowing the user to copy the color again on the new color picker component after 3 seconds.


## How has this been tested?
I verified that the UI of the "Copy" button resets (allowing the user to click the button again) after 3 seconds from the previous button click/press and that the "Copy!" button keeps copying the value to the clipboard as before.
