### PR TITLE
Replace tinycolor2 with colord on contrast checker.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18086,6 +18086,7 @@
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.3.1",
+				"colord": "^2.7.0",
 				"css-mediaquery": "^0.1.2",
 				"diff": "^4.0.2",
 				"dom-scroll-into-view": "^1.2.1",
@@ -18098,6 +18099,13 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.2",
 				"traverse": "^0.6.6"
+			},
+			"dependencies": {
+				"colord": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
+					"integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q=="
+				}
 			}
 		},
 		"@wordpress/block-library": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.3.1",
+		"colord": "^2.7.0",
 		"css-mediaquery": "^0.1.2",
 		"diff": "^4.0.2",
 		"dom-scroll-into-view": "^1.2.1",

--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import tinycolor from 'tinycolor2';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+import a11yPlugin from 'colord/plugins/a11y';
 
 /**
  * WordPress dependencies
@@ -11,14 +13,16 @@ import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
+extend( [ namesPlugin, a11yPlugin ] );
+
 function ContrastCheckerMessage( {
-	tinyBackgroundColor,
-	tinyTextColor,
+	colordBackgroundColor,
+	colordTextColor,
 	backgroundColor,
 	textColor,
 } ) {
 	const msg =
-		tinyBackgroundColor.getBrightness() < tinyTextColor.getBrightness()
+		colordBackgroundColor.brightness() < colordTextColor.brightness()
 			? __(
 					'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.'
 			  )
@@ -61,16 +65,16 @@ function ContrastChecker( {
 	) {
 		return null;
 	}
-	const tinyBackgroundColor = tinycolor(
+	const colordBackgroundColor = colord(
 		backgroundColor || fallbackBackgroundColor
 	);
-	const tinyTextColor = tinycolor( textColor || fallbackTextColor );
+	const colordTextColor = colord( textColor || fallbackTextColor );
 	const hasTransparency =
-		tinyBackgroundColor.getAlpha() !== 1 || tinyTextColor.getAlpha() !== 1;
+		colordBackgroundColor.alpha() !== 1 || colordTextColor.alpha() !== 1;
 
 	if (
 		hasTransparency ||
-		tinycolor.isReadable( tinyBackgroundColor, tinyTextColor, {
+		colordTextColor.isReadable( colordBackgroundColor, {
 			level: 'AA',
 			size:
 				isLargeText || ( isLargeText !== false && fontSize >= 24 )
@@ -85,8 +89,8 @@ function ContrastChecker( {
 		<ContrastCheckerMessage
 			backgroundColor={ backgroundColor }
 			textColor={ textColor }
-			tinyBackgroundColor={ tinyBackgroundColor }
-			tinyTextColor={ tinyTextColor }
+			colordBackgroundColor={ colordBackgroundColor }
+			colordTextColor={ colordTextColor }
 		/>
 	);
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/34286.
This PR replaces the tinycolor2 library with colord on the contrast checking component.


## How has this been tested?
I added a paragraph block and tried some text and background color combinations. I verified the contrast warnings appear when expected.