### PR TITLE
Gallery block: add toolbar button to convert old galleries to new format

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -206,3 +206,15 @@ figure.wp-block-gallery {
 	// Some themes give all <ul> default margin instead of padding.
 	margin: 0;
 }
+
+.wp-block-update-gallery-modal {
+	max-width: 400px;
+	.wp-block-update-gallery-modal-buttons {
+		display: flex;
+		justify-content: flex-end;
+	
+		.components-button {
+			margin-left: $grid-unit-15;
+		}
+	}
+}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -212,7 +212,7 @@ figure.wp-block-gallery {
 	.wp-block-update-gallery-modal-buttons {
 		display: flex;
 		justify-content: flex-end;
-	
+
 		.components-button {
 			margin-left: $grid-unit-15;
 		}

--- a/packages/block-library/src/gallery/v1/convert-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/convert-gallery-modal.js
@@ -1,0 +1,101 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LINK_DESTINATION_ATTACHMENT,
+	LINK_DESTINATION_NONE,
+	LINK_DESTINATION_MEDIA,
+} from './constants';
+
+export const convertGallery = ( {
+	clientId,
+	getBlock,
+	replaceBlocks,
+} ) => () => {
+	let link;
+	const {
+		attributes: { sizeSlug, linkTo, images, caption },
+	} = getBlock( clientId );
+
+	switch ( linkTo ) {
+		case 'post':
+			link = LINK_DESTINATION_ATTACHMENT;
+			break;
+		case 'file':
+			link = LINK_DESTINATION_MEDIA;
+			break;
+		default:
+			link = LINK_DESTINATION_NONE;
+			break;
+	}
+	const innerBlocks = images.map( ( image ) =>
+		createBlock( 'core/image', {
+			id: parseInt( image.id, 10 ),
+			url: image.url,
+			alt: image.alt,
+			caption: image.caption,
+			linkDestination: link,
+		} )
+	);
+
+	replaceBlocks(
+		clientId,
+		createBlock(
+			'core/gallery',
+			{ sizeSlug, linkTo: link, caption },
+			innerBlocks
+		)
+	);
+};
+
+export default function ConvertGalleryModal( { onClose, clientId } ) {
+	const { getBlock } = useSelect( blockEditorStore );
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	return (
+		<Modal
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ onClose }
+			title={ __( 'Convert to new gallery format' ) }
+			className={ 'wp-block-convert-gallery-modal' }
+			aria={ {
+				describedby: 'wp-block-convert-gallery-modal__description',
+			} }
+		>
+			<p id={ 'wp-block-convert-gallery-modal__description' }>
+				{ __(
+					'You can convert this gallery block to a new format which provides more flexibility, like adding custom links, or custom styles, to individual images.'
+				) }
+			</p>
+			<p id={ 'wp-block-convert-gallery-modal__description' }>
+				{ __(
+					'There is no option to convert it back to the old format, so if you do not like the new format once converted just leave the post/page without saving.'
+				) }
+			</p>
+			<div className="wp-block-convert-gallery-modal-buttons">
+				<Button isTertiary onClick={ onClose }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					isPrimary
+					onClick={ convertGallery( {
+						replaceBlocks,
+						getBlock,
+						clientId,
+						createBlock,
+					} ) }
+				>
+					{ __( 'Convert' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -53,7 +53,7 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
 } from './constants';
-import ConvertGalleryModal from './convert-gallery-modal';
+import UpdateGalleryModal from './update-gallery-modal';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -414,9 +414,9 @@ function GalleryEdit( props ) {
 		/>
 	);
 
-	const [ isConvertOpen, setConvertOpen ] = useState( false );
-	const openConvertModal = () => setConvertOpen( true );
-	const closeConvertModal = () => setConvertOpen( false );
+	const [ isUpdateOpen, setUpdateOpen ] = useState( false );
+	const openUpdateModal = () => setUpdateOpen( true );
+	const closeUpdateModal = () => setUpdateOpen( false );
 
 	const blockProps = useBlockProps();
 
@@ -467,19 +467,19 @@ function GalleryEdit( props ) {
 				</PanelBody>
 			</InspectorControls>
 			{ __unstableGalleryWithImageBlocks && (
-				<BlockControls group="block">
+				<BlockControls group="other">
 					<ToolbarButton
-						onClick={ openConvertModal }
-						title={ __( 'Convert' ) }
-						label={ __( 'Convert to new gallery format' ) }
+						onClick={ openUpdateModal }
+						title={ __( 'Update' ) }
+						label={ __( 'Update to the new gallery format' ) }
 					>
-						{ __( 'Convert' ) }
+						{ __( 'Update' ) }
 					</ToolbarButton>
 				</BlockControls>
 			) }
-			{ isConvertOpen && (
-				<ConvertGalleryModal
-					onClose={ closeConvertModal }
+			{ isUpdateOpen && (
+				<UpdateGalleryModal
+					onClose={ closeUpdateModal }
 					clientId={ clientId }
 				/>
 			) }

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -24,8 +24,10 @@ import {
 	ToggleControl,
 	withNotices,
 	RangeControl,
+	ToolbarButton,
 } from '@wordpress/components';
 import {
+	BlockControls,
 	MediaPlaceholder,
 	InspectorControls,
 	useBlockProps,
@@ -51,6 +53,7 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
 } from './constants';
+import ConvertGalleryModal from './convert-gallery-modal';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -99,10 +102,13 @@ function GalleryEdit( props ) {
 		mediaUpload,
 		getMedia,
 		wasBlockJustInserted,
+		__unstableGalleryWithImageBlocks,
 	} = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 
 		return {
+			__unstableGalleryWithImageBlocks:
+				settings.__unstableGalleryWithImageBlocks,
 			imageSizes: settings.imageSizes,
 			mediaUpload: settings.mediaUpload,
 			getMedia: select( coreStore ).getMedia,
@@ -408,6 +414,10 @@ function GalleryEdit( props ) {
 		/>
 	);
 
+	const [ isConvertOpen, setConvertOpen ] = useState( false );
+	const openConvertModal = () => setConvertOpen( true );
+	const closeConvertModal = () => setConvertOpen( false );
+
 	const blockProps = useBlockProps();
 
 	if ( ! hasImages ) {
@@ -456,6 +466,23 @@ function GalleryEdit( props ) {
 					) }
 				</PanelBody>
 			</InspectorControls>
+			{ __unstableGalleryWithImageBlocks && (
+				<BlockControls group="block">
+					<ToolbarButton
+						onClick={ openConvertModal }
+						title={ __( 'Convert' ) }
+						label={ __( 'Convert to new gallery format' ) }
+					>
+						{ __( 'Convert' ) }
+					</ToolbarButton>
+				</BlockControls>
+			) }
+			{ isConvertOpen && (
+				<ConvertGalleryModal
+					onClose={ closeConvertModal }
+					clientId={ clientId }
+				/>
+			) }
 			{ noticeUI }
 			<Gallery
 				{ ...props }

--- a/packages/block-library/src/gallery/v1/update-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/update-gallery-modal.js
@@ -16,7 +16,7 @@ import {
 	LINK_DESTINATION_MEDIA,
 } from './constants';
 
-export const convertGallery = ( {
+export const updateGallery = ( {
 	clientId,
 	getBlock,
 	replaceBlocks,
@@ -57,43 +57,44 @@ export const convertGallery = ( {
 	);
 };
 
-export default function ConvertGalleryModal( { onClose, clientId } ) {
+export default function UpdateGalleryModal( { onClose, clientId } ) {
 	const { getBlock } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	return (
 		<Modal
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
-			title={ __( 'Convert to new gallery format' ) }
-			className={ 'wp-block-convert-gallery-modal' }
+			title={ __( 'Update to new gallery format' ) }
+			className={ 'wp-block-update-gallery-modal' }
 			aria={ {
-				describedby: 'wp-block-convert-gallery-modal__description',
+				describedby: 'wp-block-update-gallery-modal__description',
 			} }
 		>
-			<p id={ 'wp-block-convert-gallery-modal__description' }>
+			<p id={ 'wp-block-update-gallery-modal__description' }>
 				{ __(
-					'You can convert this gallery block to a new format which provides more flexibility, like adding custom links, or custom styles, to individual images.'
+					'Updating to the new format adds the ability to add custom links or styles to individual images in the gallery, and makes it easier to add or move images around.'
 				) }
 			</p>
-			<p id={ 'wp-block-convert-gallery-modal__description' }>
+			<p>
 				{ __(
-					'There is no option to convert it back to the old format, so if you do not like the new format once converted just leave the post/page without saving.'
+					'There is no option to convert it back to the old format, so if there are problems with the new format once updated just leave the post/page without saving.'
 				) }
 			</p>
-			<div className="wp-block-convert-gallery-modal-buttons">
+
+			<div className="wp-block-update-gallery-modal-buttons">
 				<Button isTertiary onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
 					isPrimary
-					onClick={ convertGallery( {
+					onClick={ updateGallery( {
 						replaceBlocks,
 						getBlock,
 						clientId,
 						createBlock,
 					} ) }
 				>
-					{ __( 'Convert' ) }
+					{ __( 'Update' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/packages/block-library/src/gallery/v1/update-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/update-gallery-modal.js
@@ -64,7 +64,7 @@ export default function UpdateGalleryModal( { onClose, clientId } ) {
 		<Modal
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
-			title={ __( 'Update to new gallery format' ) }
+			title={ __( 'Update gallery' ) }
 			className={ 'wp-block-update-gallery-modal' }
 			aria={ {
 				describedby: 'wp-block-update-gallery-modal__description',
@@ -72,7 +72,7 @@ export default function UpdateGalleryModal( { onClose, clientId } ) {
 		>
 			<p id={ 'wp-block-update-gallery-modal__description' }>
 				{ __(
-					'Updating to the new format adds the ability to add custom links or styles to individual images in the gallery, and makes it easier to add or move images around.'
+					'Updating to the new format adds the ability to use custom links or styles on individual images in the gallery, and makes it easier to add or move them around.'
 				) }
 			</p>
 

--- a/packages/block-library/src/gallery/v1/update-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/update-gallery-modal.js
@@ -75,11 +75,6 @@ export default function UpdateGalleryModal( { onClose, clientId } ) {
 					'Updating to the new format adds the ability to add custom links or styles to individual images in the gallery, and makes it easier to add or move images around.'
 				) }
 			</p>
-			<p>
-				{ __(
-					'There is no option to convert it back to the old format, so if there are problems with the new format once updated just leave the post/page without saving.'
-				) }
-			</p>
 
 			<div className="wp-block-update-gallery-modal-buttons">
 				<Button isTertiary onClick={ onClose }>


### PR DESCRIPTION
## Description
Adds an 'Update' button to any galleries in the old format to allow conversion to the new innerBlocks format.

The reason for doing this rather than adding a transformation is because a straight transformation is confusing in the transform menu, as it shows transform Gallery -> Gallery, which gives user no indication of what that means. This PR introduces a modal that can provide some explanation to the user.

## To Test

- Check out PR to local dev env
- Add a gallery block while gallery experiment flag is disabled, and make sure there is no `Update` button showing
- Enable the gallery block experimental flag and reload the post with the gallery block you added
- An `Update` button should now show, and when clicked will show a modal that allows conversion to the new gallery format  - be brave and click it, and see if the block is converted correctly

## Screenshots 
![update](https://user-images.githubusercontent.com/3629020/132416016-2b1e259e-615b-4669-9bd9-27a7cee3ca53.gif)

