### PR TITLE
Gallery block: add gap support

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -100,7 +100,13 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true
+		"align": true,
+		"spacing": {
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,6 +3,10 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
+	--gallery-block--gutter-size: var(
+		--wp--style--block-gap,
+		$blocks-block__margin
+	);
 	display: flex;
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,23 +3,24 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	--gallery-block--gutter-size: var(
-		--wp--style--block-gap,
-		$blocks-block__margin
-	);
+	--gallery-block--gutter-size:
+		var(
+			--wp--style--block-gap,
+			$grid-unit-20
+		);
 	display: flex;
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
 		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 var(--gallery-block--gutter-size, #{$grid-unit-20}) var(--gallery-block--gutter-size, #{$grid-unit-20}) 0;
+		margin: 0 var(--gallery-block--gutter-size) var(--gallery-block--gutter-size) 0;
 
 		&:last-of-type:not(#individual-image) {
 			margin-right: 0;
 		}
 
-		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
+		width: calc(50% - (var(--gallery-block--gutter-size) / 2));
 
 		&:nth-of-type(even) {
 			margin-right: 0;
@@ -98,11 +99,11 @@
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
-				margin-bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				margin-bottom: var(--gallery-block--gutter-size);
 			}
 
 			figcaption {
-				bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				bottom: var(--gallery-block--gutter-size);
 			}
 		}
 	}
@@ -133,14 +134,14 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
+				margin-right: var(--gallery-block--gutter-size);
+				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size) * #{math.div($i - 1, $i)}));
 
 			}
 
 			// Prevent collapsing margin while sibling is being dragged.
 			&.columns-#{$i} figure.wp-block-image:not(#individual-image).is-dragging ~ figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				margin-right: var(--gallery-block--gutter-size);
 			}
 		}
 		// Unset the right margin on every rightmost gallery item to ensure center balance.
@@ -152,7 +153,7 @@
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				margin-right: var(--gallery-block--gutter-size);
 				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
 			}
 			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,11 +3,7 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	--gallery-block--gutter-size:
-		var(
-			--wp--style--block-gap,
-			$grid-unit-20
-		);
+	--gallery-block--gutter-size: var(--wp--style--block-gap, $grid-unit-20);
 	display: flex;
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,24 +3,21 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	--gallery-block--gutter-size: var(--wp--style--block-gap, #{$grid-unit-20});
+	--gallery-block--gap: var(--wp--style--block-gap, #{$grid-unit-20});
 	display: flex;
+	gap: var(--gallery-block--gap);
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
 		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 var(--gallery-block--gutter-size) var(--gallery-block--gutter-size) 0;
+		margin: 0;
 
 		&:last-of-type:not(#individual-image) {
 			margin-right: 0;
 		}
 
-		width: calc(50% - (var(--gallery-block--gutter-size) / 2));
-
-		&:nth-of-type(even) {
-			margin-right: 0;
-		}
+		width: calc(50% - (var(--gallery-block--gap) / 2));
 	}
 
 	figure.wp-block-image {
@@ -95,11 +92,11 @@
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
-				margin-bottom: var(--gallery-block--gutter-size);
+				margin-bottom: var(--gallery-block--gap);
 			}
 
 			figcaption {
-				bottom: var(--gallery-block--gutter-size);
+				bottom: var(--gallery-block--gap);
 			}
 		}
 	}
@@ -122,7 +119,6 @@
 	}
 
 	&.columns-1 figure.wp-block-image:not(#individual-image) {
-		margin-right: 0;
 		width: 100%;
 	}
 
@@ -130,35 +126,21 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size);
-				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size) * #{math.div($i - 1, $i)}));
+				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gap) * #{math.div($i - 1, $i)}));
 
 			}
+		}
 
-			// Prevent collapsing margin while sibling is being dragged.
-			&.columns-#{$i} figure.wp-block-image:not(#individual-image).is-dragging ~ figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size);
-			}
-		}
-		// Unset the right margin on every rightmost gallery item to ensure center balance.
-		@for $column-count from 1 through 8 {
-			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type(#{ $column-count }n) {
-				margin-right: 0;
-			}
-		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size);
-				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
+				width: calc(33.33% - (var(--gallery-block--gap) * #{math.div(2, 3)}));
 			}
-			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
-				margin-right: 0;
-			}
+
 			// If only 2 child images use 2 columns.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
-				width: calc(50% - (var(--gallery-block--gutter-size, 16px) * 0.5));
+				width: calc(50% - (var(--gallery-block--gap) * 0.5));
 			}
 			// For a single image set to 100%.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,7 +3,7 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	--gallery-block--gutter-size: var(--wp--style--block-gap, $grid-unit-20);
+	--gallery-block--gutter-size: var(--wp--style--block-gap, #{$grid-unit-20});
 	display: flex;
 	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -94,6 +94,18 @@ function GalleryEdit( props ) {
 		blockEditorStore
 	);
 
+	// Remove the tools panel for v1 Gallery so we only have to support
+	// any new dimension settings, etc. for the new gallery format.
+	const toolsPanel = document.getElementsByClassName(
+		'components-tools-panel'
+	)[ 0 ];
+
+	useEffect( () => {
+		if ( toolsPanel && isSelected ) {
+			toolsPanel.style.display = 'none';
+		}
+	}, [ toolsPanel ] );
+
 	const {
 		imageSizes,
 		mediaUpload,

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -96,9 +96,9 @@ function GalleryEdit( props ) {
 
 	// Remove the tools panel for v1 Gallery so we only have to support
 	// any new dimension settings, etc. for the new gallery format.
-	const toolsPanel = document.getElementsByClassName(
-		'components-tools-panel'
-	)[ 0 ];
+	const toolsPanel = document.querySelector(
+		'.block-editor-block-inspector .components-tools-panel'
+	);
 
 	useEffect( () => {
 		if ( toolsPanel && isSelected ) {


### PR DESCRIPTION
## Description
Adds gap support to allow users to alter the space between images.

Fixes: #33582

## Testing

- Check out PR to local dev env and run in conjunction with `theme.json` enabled theme with `"blockGap": true,` set under `spacing`
- Enable the gallery experimental flag and add a gallery
- Adjust the gap setting in right panel and check that gap is adjusted in editor and frontend


## Screenshots 
![gap](https://user-images.githubusercontent.com/3629020/132272692-6f6fa9c5-3bdd-449f-84bb-d375d85607f3.gif)
