### PR TITLE
Remove horizontal and vertical navigation block variations from inserter

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -8,7 +8,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"orientation": {
-			"type": "string"
+			"type": "string",
+			"default": "horizontal"
 		},
 		"textColor": {
 			"type": "string"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -150,7 +150,7 @@ function Navigation( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			orientation: attributes.orientation || 'horizontal',
+			orientation: attributes.orientation,
 			renderAppender:
 				( isImmediateParentOfSelectedBlock &&
 					! selectedBlockHasDescendants ) ||

--- a/packages/block-library/src/navigation/variations.js
+++ b/packages/block-library/src/navigation/variations.js
@@ -10,14 +10,14 @@ const variations = [
 		title: __( 'Navigation (horizontal)' ),
 		description: __( 'Links shown in a row.' ),
 		attributes: { orientation: 'horizontal' },
-		scope: [ 'inserter', 'transform' ],
+		scope: [ 'transform' ],
 	},
 	{
 		name: 'vertical',
 		title: __( 'Navigation (vertical)' ),
 		description: __( 'Links shown in a column.' ),
 		attributes: { orientation: 'vertical' },
-		scope: [ 'inserter', 'transform' ],
+		scope: [ 'transform' ],
 	},
 ];
 

--- a/packages/block-library/src/navigation/variations.js
+++ b/packages/block-library/src/navigation/variations.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 const variations = [
 	{
 		name: 'horizontal',
-		isDefault: true,
 		title: __( 'Navigation (horizontal)' ),
 		description: __( 'Links shown in a row.' ),
 		attributes: { orientation: 'horizontal' },

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+"<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"http://localhost:8889/?page_id=41\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} -->
@@ -36,16 +36,16 @@ exports[`Navigation Creating from existing Menus allows a navigation block to be
 <!-- /wp:navigation -->"
 `;
 
-exports[`Navigation Creating from existing Menus creates an empty navigation block when the selected existing menu is also empty 1`] = `"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} /-->"`;
+exports[`Navigation Creating from existing Menus creates an empty navigation block when the selected existing menu is also empty 1`] = `"<!-- wp:navigation /-->"`;
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+"<!-- wp:navigation -->
 <!-- wp:page-list {\\"isNavigationChild\\":true} /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+"<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
@@ -53,13 +53,13 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 `;
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+"<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation encodes URL when create block if needed 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+"<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"wordpress.org/шеллы\\",\\"url\\":\\"https://wordpress.org/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"お問い合わせ\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -4,6 +4,7 @@
 		"name": "core/navigation",
 		"isValid": true,
 		"attributes": {
+			"orientation": "horizontal",
 			"showSubmenuIcon": true,
 			"isResponsive": false
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"orientation":"horizontal","style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}}} -->
+<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->


### PR DESCRIPTION
## Description
This is a tiny PR to propose changing something that doesn't feel like a successful experiment:
<img width="315" alt="Screenshot 2021-09-07 at 4 28 55 pm" src="https://user-images.githubusercontent.com/677833/132311752-8e9ad3f8-f0a1-4e76-a7e0-33c6fb0b7922.png">

The horizontal/vertical variants being exposed in the inserter feels messy to me and makes the block library unnecessarily busy. This PR reduces the options to just the block itself (defaulting to horizontal):
<img width="316" alt="Screenshot 2021-09-07 at 4 28 21 pm" src="https://user-images.githubusercontent.com/677833/132312016-bae8dd77-e946-4209-a8b3-abab40157196.png">

The option to switch orientation is still available in the sidebar:
<img width="274" alt="Screenshot 2021-09-07 at 4 31 22 pm" src="https://user-images.githubusercontent.com/677833/132312169-05ac5c6e-0d68-46a6-b275-0d0130cd4063.png">

That piece of UI could be improved, but I think that's a separate change. There's probably also an opportunity to use patterns when setting up the block to dictate orientation, but for now I think it's fine to default to horizontal as the only inserter option.

## How has this been tested?
1. Try adding a navigation block
2. Only the 'Navigation' block itself should be available in the library.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
