### PR TITLE
Only capture toolbars on parent Nav block when not in vertical mode

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -158,7 +158,8 @@ function Navigation( {
 				isSelected
 					? InnerBlocks.DefaultAppender
 					: false,
-			__experimentalCaptureToolbars: true,
+			__experimentalCaptureToolbars:
+				attributes.orientation !== 'vertical',
 			// Template lock set to false here so that the Nav
 			// Block on the experimental menus screen does not
 			// inherit templateLock={ 'all' }.

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -158,6 +158,9 @@ function Navigation( {
 				isSelected
 					? InnerBlocks.DefaultAppender
 					: false,
+			// Ensure block toolbar is not too far removed from item
+			// being edited when in vertical mode.
+			// see: https://github.com/WordPress/gutenberg/pull/34615.
 			__experimentalCaptureToolbars:
 				attributes.orientation !== 'vertical',
 			// Template lock set to false here so that the Nav


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/34225 I described how capturing the nav _link_ block's toolbar on the parent Navigation block on the Navigation Editor screen causes the toolbar to be visually too far removed from the element the user is editing (see screencaptures below - they illustrate the issue).

This is only a problem when:

1. The Nav block is configured to be in "vertical" mode.
2. You add quite a few items to your navigation (I appreciate currently there is unwanted spacing between items in vertical mode but even if that were fixed the issue would still be in evidence eventually).

This PR looks to address this by only allowing the block toolbar to be "captured" if the Nav block is _not_ in vertical mode.

This is a "fix" for the Nav Editor _and_ the Nav block.

Closes https://github.com/WordPress/gutenberg/issues/34225

## How has this been tested?

#### On trunk

1. New Post.
2. Create Nav block in vertical mode.
3. Add _lots_ of items (at least enough to visually cause the bottom items to be "off screen" at the bottom of your monitor).
4. Now try editing some attributes (link/URL, bold, italic...etc) of the bottom-most items using the _block_ toolbar. You will see you have to do a lot of mouse movement as the toolbar is displayed on the parent Nav block which is likely to be pinned to the top of your screen.
5. Do the same with a Nav block in "horizontal" mode. Notice how the same problem does not exist.

#### On this PR

Repeat the steps above but this time notice how in "vertical" mode (only) the block toolbar is now displayed inline next to the block itself (default editor behaviour). This makes it lots easier to edit Nav link items.

Also validate that the "horizontal" behaviour is unchanged (ie: the toolbar is still captured in horizontal mode).


## Screenshots <!-- if applicable -->

#### Before
https://user-images.githubusercontent.com/444434/132318641-401e6d2d-6b2f-4038-a118-3577a055a596.mp4


#### After
https://user-images.githubusercontent.com/444434/132318645-a650bb3e-b15b-4ad9-8177-c4641e6c8224.mp4



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
