### PR TITLE
block metadata documentation

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -73,7 +73,7 @@ It returns the registered block type (`WP_Block_Type`) on success or `false` on 
 **Example:**
 
 ```php
-register_block_type(
+register_block_type_from_metadata(
 	__DIR__ . '/notice',
 	array(
 		'render_callback' => 'render_block_core_notice',


### PR DESCRIPTION
I was searching and saw [this](https://github.com/WordPress/gutenberg/blob/dd5fd6b2466d33177d46dcdc0733abd0217e044a/packages/block-library/src/archives/index.php#L116) for archive block. but in the [documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#php-server-side) it's different.
So for a block which use `block.json` and registered with PHP `register_block_type` should be `register_block_type_from_metadata`