### PR TITLE
Replace tinycolor2 with colord on getMostReadableColor util. Add unit test.

### DIFF
--- a/packages/block-editor/src/components/colors/test/utils.js
+++ b/packages/block-editor/src/components/colors/test/utils.js
@@ -5,6 +5,7 @@ import {
 	getColorObjectByAttributeValues,
 	getColorObjectByColorValue,
 	getColorClassName,
+	getMostReadableColor,
 } from '../utils';
 
 describe( 'color utils', () => {
@@ -125,6 +126,46 @@ describe( 'color utils', () => {
 			expect( getColorClassName( 'background', '#abcdef' ) ).toBe(
 				'has-abcdef-background'
 			);
+		} );
+	} );
+
+	describe( 'getMostReadableColor', () => {
+		it( 'should return the most readable color', () => {
+			expect(
+				getMostReadableColor(
+					[
+						{
+							name: 'Red',
+							slug: 'red',
+							color: 'red',
+						},
+						{
+							name: 'Black',
+							slug: 'black',
+							color: 'black',
+						},
+					],
+					'#f3f3f3'
+				)
+			).toBe( 'black' );
+
+			expect(
+				getMostReadableColor(
+					[
+						{
+							name: 'C1',
+							slug: 'c1',
+							color: '#39373b',
+						},
+						{
+							name: 'C2',
+							slug: 'c2',
+							color: '#a25de6',
+						},
+					],
+					'#9853ff'
+				)
+			).toBe( '#39373b' );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { find, kebabCase, map } from 'lodash';
-import tinycolor from 'tinycolor2';
+import { find, kebabCase, maxBy } from 'lodash';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+import a11yPlugin from 'colord/plugins/a11y';
+
+extend( [ namesPlugin, a11yPlugin ] );
 
 /**
  * Provided an array of color objects as set by the theme or by the editor defaults,
@@ -72,7 +76,7 @@ export function getColorClassName( colorContextName, colorSlug ) {
  * @return {string} String with the color value of the most readable color.
  */
 export function getMostReadableColor( colors, colorValue ) {
-	return tinycolor
-		.mostReadable( colorValue, map( colors, 'color' ) )
-		.toHexString();
+	const colordColor = colord( colorValue );
+	return maxBy( colors, ( { color } ) => colordColor.contrast( color ) )
+		.color;
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/34286.
This PR replaces the tinycolor2 library with colord on the getMostReadableColor block editor util.
We are also adding some unit tests for this util given that the function did not had any tests.


## How has this been tested?
I verified the unit tests are passing.