### PR TITLE
Rn/add/modified style hook

### DIFF
--- a/packages/block-editor/src/components/inserter/no-results.native.js
+++ b/packages/block-editor/src/components/inserter/no-results.native.js
@@ -1,35 +1,29 @@
 /**
  * External dependencies
  */
-import { View, Text } from 'react-native';
+import { View, Text, useColorScheme } from 'react-native';
 
 /**
  * WordPress dependencies
  */
-import { usePreferredColorSchemeStyle } from '@wordpress/compose';
+import { useModifiedStyle } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import styles from './style.scss';
+import baseStyles from './style.scss';
 
 function InserterNoResults() {
+	const isDark = useColorScheme() === 'dark';
+	const styles = useModifiedStyle( baseStyles, {
+		dark: [ isDark ],
+	} );
 	const {
 		'inserter-search-no-results__container': containerStyle,
-		'inserter-search-no-results__text-primary': textPrimaryBaseStyle,
-		'inserter-search-no-results__text-primary--dark': textPrimaryDarkStyle,
-		'inserter-search-no-results__text-secondary': textSecondaryBaseStyle,
-		'inserter-search-no-results__text-secondary--dark': textSecondaryDarkStyle,
+		'inserter-search-no-results__text-primary': textPrimaryStyle,
+		'inserter-search-no-results__text-secondary': textSecondaryStyle,
 	} = styles;
-	const textPrimaryStyle = usePreferredColorSchemeStyle(
-		textPrimaryBaseStyle,
-		textPrimaryDarkStyle
-	);
-	const textSecondaryStyle = usePreferredColorSchemeStyle(
-		textSecondaryBaseStyle,
-		textSecondaryDarkStyle
-	);
 
 	return (
 		<View>

--- a/packages/components/src/search-control/index.native.js
+++ b/packages/components/src/search-control/index.native.js
@@ -15,7 +15,7 @@ import {
  * WordPress dependencies
  */
 import { useState, useRef, useEffect } from '@wordpress/element';
-import { useModifiedStyle } from '@wordpress/compose';
+import { createModifiedStyleHook } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Button, Gridicons } from '@wordpress/components';
 import {
@@ -39,6 +39,8 @@ for ( const selector in platformStyles ) {
 		...platformStyles[ selector ],
 	};
 }
+
+const useModifiedStyle = createModifiedStyleHook( baseStyles );
 
 function SearchControl( {
 	value,
@@ -67,7 +69,7 @@ function SearchControl( {
 		};
 	}, [] );
 
-	const styles = useModifiedStyle( baseStyles, {
+	const styles = useModifiedStyle( {
 		active: [ isActive ],
 		dark: [ isDark ],
 		'active-dark': [ isActive, isDark ],

--- a/packages/compose/src/hooks/use-modified-style/README.md
+++ b/packages/compose/src/hooks/use-modified-style/README.md
@@ -1,0 +1,64 @@
+# `useModifiedStyle`
+
+`useModifiedStyle` is a hook that maps a dependency array to a modified style rules . The style selectors
+should follow the BEM naming convention. The styles are only recaculated when the the mapped dependencies change.
+
+## Parameters
+
+### `style`
+
+-   Type: `object`
+
+A static style object.
+
+### `modifierStates`
+
+-   Type: `object`
+
+An object of modifier dependencies. The keys are the modifier portion of the BEM selector, and the
+values are an array of dependencies to used to enable the modifier. The modifier is enabled if every mapped dependency is truthy.
+
+## Return Object
+
+The hook returns an object where the keys are the `block__element` portion of the BEM selector and the values are the merged style properties.
+
+## Usage
+
+`./styles.scss`
+
+```css
+.my-component__container {
+	color: grey;
+}
+.my-component__container--active {
+	color: red;
+}
+
+.my-component__button {
+	font-family: comic-sans;
+}
+.my-component__button--active {
+	font-weight: bold;
+}
+```
+
+```jsx
+import { useModifiedStyle } from '@wordpress/compose';
+import { baseStyles } from './styles';
+
+const myComponent = ({isActive}) => {
+  const styles = useModifiedStyle( baseStyles, { 'active': [ isActive ] });
+
+  const {
+		'my-component__container': containerStyle
+    'my-component__button': buttonStyle
+  } = styles;
+
+  return (
+    <div style={containerStyle} >
+      <buttton style={buttonStyle} />
+    </div>
+  )
+
+}
+```

--- a/packages/compose/src/hooks/use-modified-style/README.md
+++ b/packages/compose/src/hooks/use-modified-style/README.md
@@ -1,7 +1,7 @@
 # `useModifiedStyle`
 
-`useModifiedStyle` is a hook that maps a dependency array to a modified style rules . The style selectors
-should follow the BEM naming convention. The styles are only recaculated when the the mapped dependencies change.
+`useModifiedStyle` is a hook that maps a dependency array to modified style rules. The style selectors
+should follow the BEM naming convention. The styles are only recalculated when the mapped dependencies change.
 
 ## Parameters
 
@@ -16,7 +16,7 @@ A static style object.
 -   Type: `object`
 
 An object of modifier dependencies. The keys are the modifier portion of the BEM selector, and the
-values are an array of dependencies to used to enable the modifier. The modifier is enabled if every mapped dependency is truthy.
+values are an array of dependencies to be used to enable the modifier. The modifier is enabled if every mapped dependency is truthy.
 
 ## Return Object
 
@@ -56,7 +56,7 @@ const myComponent = ({isActive}) => {
 
   return (
     <div style={containerStyle} >
-      <buttton style={buttonStyle} />
+      <button style={buttonStyle} />
     </div>
   )
 

--- a/packages/compose/src/hooks/use-modified-style/index.js
+++ b/packages/compose/src/hooks/use-modified-style/index.js
@@ -1,0 +1,122 @@
+// @ts-nocheck
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Pluck the modified styles by matching the modifier in the selector name.
+ * The style selectors should follow the BEM naming convetion e.g.
+ *    block__element--modifier
+ * The return styles are keyed by the block_element only.
+ *
+ * @example
+ * ```
+ * selectModifiedStyles(
+ *   {
+ *    'block__element': { width: '10px' },
+ *    'block__element--narrow': { width: '1px' },
+ *    'block__element--wide': {width: '100px'}
+ *   },
+ *   'wide'
+ * );
+ * // returns { block_element': { width: '100px' } }
+ * ```
+ *
+ * @param {Object} styles
+ * @param {string} modifier - the base modifier without the `--` prefix
+ *
+ * @return {Object} - Subset of styles based on the modifier
+ */
+function selectModifiedStyles( styles, modifier ) {
+	const modifierSelectors = Object.keys( styles ).filter( ( selector ) =>
+		selector.match( `--${ modifier }$` )
+	);
+
+	return modifierSelectors.reduce( ( modifiedStyles, modifierSelector ) => {
+		const blockElementSelector = modifierSelector.split( '--' )[ 0 ];
+		modifiedStyles[ blockElementSelector ] = styles[ modifierSelector ];
+		return modifiedStyles;
+	}, {} );
+}
+
+/**
+ * Updates a styles object with modified styles if the update conditions are met.
+ *
+ * @example
+ *
+ * ```
+ * updateStyles(
+ *  {
+ *    'block__element-A' : { width: '10px' },
+ *    'block__element-B' : { 'font-family': 'Comic Sans' },
+ *    'block__element-C' : { visibility : 'hidden' }
+ *  },
+ *  {
+ *    'block__element-A' : { height: '10px' },
+ *    'block__element-B' : { 'font-family' : 'Helvetica' },
+ *    'block__element-Z' : { 'z-index' : 2147483647 }
+ *  },
+ *  [ true, true ]
+ * );
+ * // returns
+ * // {
+ * //   'block_element-A' : { width: '10px', height: '10px' },
+ * //   'block-element-B' : { 'font-family' : 'Helvetica' },
+ * //   'block-element-C' : { visibility : 'hidden' }
+ * // }
+ * ```
+ * @param {Object} styles
+ * @param {Object} styleUpdates
+ * @param {Array<boolean>} updateConditions - Boolean conditions on when to apply updates
+ *
+ * @return {Object} - Updated styles object
+ */
+function updateStyles( styles, styleUpdates, updateConditions ) {
+	// Test if the modifier conditions are met
+	const shouldUpdate = updateConditions.every( ( should ) => should );
+
+	if ( shouldUpdate ) {
+		Object.keys( styleUpdates ).forEach( ( selector ) => {
+			styles[ selector ] = {
+				...styles[ selector ],
+				...styleUpdates[ selector ],
+			};
+		} );
+	}
+	return styles;
+}
+
+function useModifiedStyle( baseStyles, modifiers ) {
+	// Memoize the modifier selectors
+	const modifierSelectors = useMemo( () => {
+		return Object.keys( modifiers );
+	}, [] );
+
+	// Memoize the modified styles
+	const modifiedStyles = useMemo( () => {
+		const _modifiedStyles = {};
+		for ( const modifier in modifiers ) {
+			_modifiedStyles[ modifier ] = selectModifiedStyles(
+				baseStyles,
+				modifier
+			);
+		}
+		return _modifiedStyles;
+	}, [] );
+
+	const futureStyles = { ...baseStyles };
+
+	// Apply the modifiers to the future styles
+	modifierSelectors.forEach( ( modifier ) => {
+		updateStyles(
+			futureStyles,
+			modifiedStyles[ modifier ],
+			modifiers[ modifier ]
+		);
+	} );
+
+	return futureStyles;
+}
+
+export default useModifiedStyle;

--- a/packages/compose/src/hooks/use-modified-style/index.js
+++ b/packages/compose/src/hooks/use-modified-style/index.js
@@ -44,6 +44,15 @@ function mergeStyles( styles, styleUpdates ) {
 	);
 }
 
+/**
+ * Hook to get the modified styles based on the modifier.
+ * The styles are only updated when there is a change to the modifierStates.
+ * Updating the baseStyles will not trigger a recalculation of the styles.
+ *
+ * @param {Object} baseStyles
+ * @param {Object} modifierStates
+ * @return {Object} - The modified styles
+ */
 function useModifiedStyle( baseStyles, modifierStates ) {
 	const [ styles, setStyles ] = useState( baseStyles );
 	const modifiers = Object.keys( modifierStates );
@@ -64,7 +73,7 @@ function useModifiedStyle( baseStyles, modifierStates ) {
 	}, [] );
 
 	// Convert the modified states to string to satisfy the equality check.
-	const modifiedStatesString = Object.values( modifierStates ).toString();
+	const modifiedStatesString = JSON.stringify( modifierStates );
 	useEffect( () => {
 		const enabledModifiers = ( modifier ) =>
 			isModifierEnabled( modifier, modifierStates );
@@ -79,6 +88,13 @@ function useModifiedStyle( baseStyles, modifierStates ) {
 	return styles;
 }
 
+/**
+ * Factory function for useModifiedStyle hook.
+ * The returned hook accepts the modifier states.
+ *
+ * @param {Object} baseStyles
+ * @return {Function} - Hook function
+ */
 export function createModifiedStyleHook( baseStyles ) {
 	return ( modifierStates ) => useModifiedStyle( baseStyles, modifierStates );
 }

--- a/packages/compose/src/hooks/use-modified-style/index.js
+++ b/packages/compose/src/hooks/use-modified-style/index.js
@@ -79,4 +79,8 @@ function useModifiedStyle( baseStyles, modifierStates ) {
 	return styles;
 }
 
+export function createModifiedStyleHook( baseStyles ) {
+	return ( modifierStates ) => useModifiedStyle( baseStyles, modifierStates );
+}
+
 export default useModifiedStyle;

--- a/packages/compose/src/hooks/use-modified-style/index.js
+++ b/packages/compose/src/hooks/use-modified-style/index.js
@@ -70,7 +70,7 @@ function useModifiedStyle( baseStyles, modifierStates ) {
 			isModifierEnabled( modifier, modifierStates );
 		const activeModifiers = modifiers.filter( enabledModifiers );
 		const updatedStyles = activeModifiers.reduce( updateStyles, {
-			...styles,
+			...baseStyles,
 		} );
 
 		setStyles( updatedStyles );

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -30,3 +30,4 @@ export { default as usePreferredColorSchemeStyle } from './hooks/use-preferred-c
 export { default as useResizeObserver } from './hooks/use-resize-observer';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
+export { default as useModifiedStyle } from './hooks/use-modified-style';

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -30,4 +30,7 @@ export { default as usePreferredColorSchemeStyle } from './hooks/use-preferred-c
 export { default as useResizeObserver } from './hooks/use-resize-observer';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
-export { default as useModifiedStyle } from './hooks/use-modified-style';
+export {
+	createModifiedStyleHook,
+	default as useModifiedStyle,
+} from './hooks/use-modified-style';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds a `useModifiedStyle` hook to generate dependency driven styles. The hook accepts a style object and object with the interface: 
```
{
 'modifier' : [{dependencies}]
}
```

The modifier should be the same modifier used in the BEM formatted styles. If every dependency is truthy, the hook will merge the modified styles into the base styles. Styles are only recreated when any of the dependency values change. Changes to the base style or modifier keys will not trigger a recalculation.

Example:
all styles
```css
.block__element {
   font-family: 'comic-sans';
   font-size: 16px;
}
.block__element--active {
   font-size: 32px;
   color: "#FF00FF";
}
```

```js

const [ isActive, setActive ] = useState(false );
const styles = useModifiedStye( allStyles, { active:  [ isActive ] }

/** styles initialized with: 
 * { fontFamily:' 'comic-sans', fontSize: 16 }
 */

function onClick() {
 setActive(true) 
 /**
  * styles becomes:
  *  { fontFamily: 'comic-sans', fontSize 32, color: '#FF00FF' }
  */
}
```

To apply compound modifications, use kabab modifiers e.g. 
`.block__element__active-dark` 

```
const styles = useModifiedStyle( allStyles, { 'active-dark': [ isActive, isDark ] } )
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This PR includes replacing the modified style handlers used for the inserter search with the `useModifiedStyle` hook
To test:
1. Open the demo app
2. Open the inserter
3. Verify the inactive inserter search looks correct in both light and dark themes
4. Activate the search by tapping on the search input
5. Verify the active inserter search looks correct in both light and dark themes
6. Add a query that produces no results i.e. an arbitrary string of 5 or 6 characters
7. Verify the no results view looks correct in both light and dark themes

** Note: There are known issues switching between light and dark themes on Android. it is best to restart the demo/editor when testing the theme styles on Android.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Adds a new hook for handling style changes that are bound to state updates
- Updates the `SearchControl` and `InserterNoResults` components to use the new hook.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
