### PR TITLE
Gallery block: Fix media placeholder height in site editor

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -45,7 +45,6 @@ figure.wp-block-gallery {
 	}
 	.block-editor-media-placeholder {
 		margin: 0;
-		height: 100%;
 
 		&::before {
 			box-shadow: 0 0 0 $border-width $white inset, 0 0 0 3px var(--wp-admin-theme-color) inset;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

While testing #34606, I noticed that the placeholder for adding media to an existing v1 gallery block (i.e. the non-experimental refactored gallery) was rendering too high vertically in the site editor, when the gallery block is inserted as a child of a template part.

This PR removes the `height: 100%` setting for the placeholder, and I haven't found any issues so far in removing it, but I'm not sure if there was a reason why it might be needed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually:

Without this PR applied and running TT1-blocks theme:

1. With the refactored gallery experiment switched off, open up the site editor
2. Select to edit a template part (e.g. the Footer) and insert a gallery block in the footer
3. Add a couple of images to the gallery block
4. Select the gallery block and notice that the placeholder is stretched too high vertically

* Apply this PR and repeat the above steps, and the placeholder should be the correct height
* Test with the refactored gallery and gallery blocks with no images in them, and ensure the placeholder still renders correctly

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/132444233-13f819c8-5f67-4164-b011-374301f21152.png) | ![image](https://user-images.githubusercontent.com/14988353/132444241-b94e14f9-20ec-4d66-b3a9-3526f4ecfee5.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
