### PR TITLE
Columns block: Enable blockGap and vertical margin support

### DIFF
--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -12,7 +12,6 @@ import { getBlockSupport } from '@wordpress/blocks';
 import InspectorControls from '../components/inspector-controls';
 import {
 	GapEdit,
-	getGapLabel,
 	hasGapSupport,
 	hasGapValue,
 	resetGap,
@@ -60,8 +59,6 @@ export function DimensionsPanel( props ) {
 		'__experimentalDefaultControls',
 	] );
 
-	const blockGapLabel = getGapLabel( props );
-
 	const createResetAllFilter = ( attribute ) => ( newAttributes ) => ( {
 		...newAttributes,
 		style: {
@@ -103,13 +100,13 @@ export function DimensionsPanel( props ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ () => hasGapValue( props ) }
-					label={ blockGapLabel }
+					label={ __( 'Block spacing' ) }
 					onDeselect={ () => resetGap( props ) }
 					resetAllFilter={ createResetAllFilter( 'blockGap' ) }
 					isShownByDefault={ defaultSpacingControls?.blockGap }
 					panelId={ props.clientId }
 				>
-					<GapEdit { ...props } label={ blockGapLabel } />
+					<GapEdit { ...props } />
 				</ToolsPanelItem>
 			) }
 		</InspectorControls>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -12,6 +12,7 @@ import { getBlockSupport } from '@wordpress/blocks';
 import InspectorControls from '../components/inspector-controls';
 import {
 	GapEdit,
+	getGapLabel,
 	hasGapSupport,
 	hasGapValue,
 	resetGap,
@@ -59,6 +60,8 @@ export function DimensionsPanel( props ) {
 		'__experimentalDefaultControls',
 	] );
 
+	const blockGapLabel = getGapLabel( props );
+
 	const createResetAllFilter = ( attribute ) => ( newAttributes ) => ( {
 		...newAttributes,
 		style: {
@@ -100,13 +103,13 @@ export function DimensionsPanel( props ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ () => hasGapValue( props ) }
-					label={ __( 'Block gap' ) }
+					label={ blockGapLabel }
 					onDeselect={ () => resetGap( props ) }
 					resetAllFilter={ createResetAllFilter( 'blockGap' ) }
 					isShownByDefault={ defaultSpacingControls?.blockGap }
 					panelId={ props.clientId }
 				>
-					<GapEdit { ...props } />
+					<GapEdit { ...props } label={ blockGapLabel } />
 				</ToolsPanelItem>
 			) }
 		</InspectorControls>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -98,7 +98,6 @@ export function DimensionsPanel( props ) {
 			) }
 			{ ! isGapDisabled && (
 				<ToolsPanelItem
-					className="single-column"
 					hasValue={ () => hasGapValue( props ) }
 					label={ __( 'Block spacing' ) }
 					onDeselect={ () => resetGap( props ) }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
-import { getBlockSupport, getBlockType } from '@wordpress/blocks';
+import { getBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
@@ -61,24 +61,6 @@ export function resetGap( { attributes = {}, setAttributes } ) {
 }
 
 /**
- * Get the label for the gap control, if handled by the block's
- * `__experimentalLabel` function via the `blockGap` context string.
- *
- * Falls back to a default string.
- *
- * @param {Object} props            Block props.
- * @param {Object} props.name       Block's name.
- * @param {Object} props.attributes Block's attributes.
- * @return {string} The label for the gap control.
- */
-export function getGapLabel( { name, attributes } ) {
-	const { __experimentalLabel: getLabel } = getBlockType( name );
-	const label = getLabel && getLabel( attributes, { context: 'blockGap' } );
-
-	return label || __( 'Block spacing' );
-}
-
-/**
  * Custom hook that checks if gap settings have been disabled.
  *
  * @param {string} name The name of the block.
@@ -98,9 +80,8 @@ export function useIsGapDisabled( { name: blockName } = {} ) {
  */
 export function GapEdit( props ) {
 	const {
-		attributes: { style },
 		clientId,
-		label,
+		attributes: { style },
 		setAttributes,
 	} = props;
 
@@ -151,7 +132,7 @@ export function GapEdit( props ) {
 		web: (
 			<>
 				<UnitControl
-					label={ label || __( 'Block spacing' ) }
+					label={ __( 'Block spacing' ) }
 					min={ 0 }
 					onChange={ onChange }
 					units={ units }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
-import { getBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport, getBlockType } from '@wordpress/blocks';
 import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
@@ -61,6 +61,24 @@ export function resetGap( { attributes = {}, setAttributes } ) {
 }
 
 /**
+ * Get the label for the gap control, if handled by the block's
+ * `__experimentalLabel` function via the `blockGap` context string.
+ *
+ * Falls back to a default string.
+ *
+ * @param {Object} props            Block props.
+ * @param {Object} props.name       Block's name.
+ * @param {Object} props.attributes Block's attributes.
+ * @return {string} The label for the gap control.
+ */
+export function getGapLabel( { name, attributes } ) {
+	const { __experimentalLabel: getLabel } = getBlockType( name );
+	const label = getLabel && getLabel( attributes, { context: 'blockGap' } );
+
+	return label || __( 'Block spacing' );
+}
+
+/**
  * Custom hook that checks if gap settings have been disabled.
  *
  * @param {string} name The name of the block.
@@ -80,8 +98,9 @@ export function useIsGapDisabled( { name: blockName } = {} ) {
  */
 export function GapEdit( props ) {
 	const {
-		clientId,
 		attributes: { style },
+		clientId,
+		label,
 		setAttributes,
 	} = props;
 
@@ -132,7 +151,7 @@ export function GapEdit( props ) {
 		web: (
 			<>
 				<UnitControl
-					label={ __( 'Block gap' ) }
+					label={ label || __( 'Block spacing' ) }
 					min={ 0 }
 					onChange={ onChange }
 					units={ units }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -133,6 +133,7 @@ export function GapEdit( props ) {
 			<>
 				<UnitControl
 					label={ __( 'Block spacing' ) }
+					__unstableInputWidth="80px"
 					min={ 0 }
 					onChange={ onChange }
 					units={ units }

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -21,6 +21,13 @@
 		"color": {
 			"gradients": true,
 			"link": true
+		},
+		"spacing": {
+			"blockGap": true,
+			"margin": [ "top", "bottom" ],
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-columns-editor",

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -79,6 +79,11 @@ export const settings = {
 			},
 		],
 	},
+	__experimentalLabel( _, { context } ) {
+		if ( context === 'blockGap' ) {
+			return __( 'Column spacing' );
+		}
+	},
 	deprecated,
 	edit,
 	save,

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -79,11 +79,6 @@ export const settings = {
 			},
 		],
 	},
-	__experimentalLabel( _, { context } ) {
-		if ( context === 'blockGap' ) {
-			return __( 'Column spacing' );
-		}
-	},
 	deprecated,
 	edit,
 	save,

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -10,6 +10,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -42,6 +43,22 @@ function useHasGap( { name, supports } ) {
 	const settings = useSetting( 'spacing.blockGap', name );
 
 	return settings && supports.includes( '--wp--style--block-gap' );
+}
+
+/**
+ * Get the label for the gap control, if handled by the block's
+ * `__experimentalLabel` function via the `blockGap` context string.
+ *
+ * Falls back to a default string.
+ *
+ * @param {string} name Block's name.
+ * @return {string} The label for the gap control.
+ */
+export function getGapLabel( name ) {
+	const { __experimentalLabel: getLabel } = getBlockType( name );
+	const label = getLabel && getLabel( {}, { context: 'blockGap' } );
+
+	return label || __( 'Block spacing' );
 }
 
 function filterValuesBySides( values, sides ) {
@@ -126,6 +143,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 		!! marginValues && Object.keys( marginValues ).length;
 
 	const gapValue = getStyle( name, '--wp--style--block-gap' );
+	const gapLabel = getGapLabel( name );
 
 	const setGapValue = ( newGapValue ) => {
 		setStyle( name, '--wp--style--block-gap', newGapValue );
@@ -181,12 +199,12 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ hasGapValue }
-					label={ __( 'Block gap' ) }
+					label={ gapLabel || __( 'Block spacing' ) }
 					onDeselect={ resetGapValue }
 					isShownByDefault={ true }
 				>
 					<UnitControl
-						label={ __( 'Block gap' ) }
+						label={ gapLabel || __( 'Block spacing' ) }
 						min={ 0 }
 						onChange={ setGapValue }
 						units={ units }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -179,7 +179,6 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 			) }
 			{ showGapControl && (
 				<ToolsPanelItem
-					className="single-column"
 					hasValue={ hasGapValue }
 					label={ __( 'Block spacing' ) }
 					onDeselect={ resetGapValue }
@@ -187,6 +186,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 				>
 					<UnitControl
 						label={ __( 'Block spacing' ) }
+						__unstableInputWidth="80px"
 						min={ 0 }
 						onChange={ setGapValue }
 						units={ units }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -10,7 +10,6 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
-import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -43,22 +42,6 @@ function useHasGap( { name, supports } ) {
 	const settings = useSetting( 'spacing.blockGap', name );
 
 	return settings && supports.includes( '--wp--style--block-gap' );
-}
-
-/**
- * Get the label for the gap control, if handled by the block's
- * `__experimentalLabel` function via the `blockGap` context string.
- *
- * Falls back to a default string.
- *
- * @param {string} name Block's name.
- * @return {string} The label for the gap control.
- */
-export function getGapLabel( name ) {
-	const { __experimentalLabel: getLabel } = getBlockType( name );
-	const label = getLabel && getLabel( {}, { context: 'blockGap' } );
-
-	return label || __( 'Block spacing' );
 }
 
 function filterValuesBySides( values, sides ) {
@@ -143,7 +126,6 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 		!! marginValues && Object.keys( marginValues ).length;
 
 	const gapValue = getStyle( name, '--wp--style--block-gap' );
-	const gapLabel = getGapLabel( name );
 
 	const setGapValue = ( newGapValue ) => {
 		setStyle( name, '--wp--style--block-gap', newGapValue );
@@ -199,12 +181,12 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ hasGapValue }
-					label={ gapLabel || __( 'Block spacing' ) }
+					label={ __( 'Block spacing' ) }
 					onDeselect={ resetGapValue }
 					isShownByDefault={ true }
 				>
 					<UnitControl
-						label={ gapLabel || __( 'Block spacing' ) }
+						label={ __( 'Block spacing' ) }
 						min={ 0 }
 						onChange={ setGapValue }
 						units={ units }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following on from #33991 and the Columns CSS change by @richtabor in https://github.com/WordPress/gutenberg/pull/34456, this PR opts the Columns block in to the gap block support control, and also the vertical margin control.

Adjusting block gap allows the user to adjust the space between columns blocks. Depending on where the columns block is placed, and whether or not the theme uses the Layout support, the adjusted block gap value can also change the gap between the selected block and blocks around it. To allow the user to tweak this, the margin control is added, so that the margin can be controlled separately to the gap on inner blocks.

***Up for discussion:*** which controls are good to display by default? Does it make sense to expose blockGap by default, but hide margin? Should we default to both? I'd love to hear feedback on what's best to expose here.

### Changes proposed

* Opt the Columns block in to using the blockGap support
* Opt the Columns block in to using the margin support for vertical margins
* Update the gap support label to `Block spacing`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Running TT1-Blocks theme, in the `theme.json` file, under `settings.spacing`, enable the `blockGap` and `customMargin` controls. For example, here's how that section of my `theme.json` file looks:

```
		"spacing": {
			"blockGap": true,
			"customPadding": true,
			"customMargin": true,
			"units": [
				"px",
				"em",
				"rem",
				"vh",
				"vw"
			]
		},
```

1. Add a Columns block to a post or page, and try out the blockGap control in the inspector controls.
2. Try adding the Columns block to different positions in a page or post, and adjust the blockGap value.
3. In the Dimensions panel, enable the Margin control, and try adjusting the margin to adjust the spacing around the block.
4. Test in the site editor

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14988353/132447637-a05f5e56-6f35-4d49-b6f4-044cc1ee9ad4.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested. (manually)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
