### PR TITLE
ToolsPanel: Allow SlotFill injection of panel items

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -141,6 +141,7 @@ export { default as ToolbarItem } from './toolbar-item';
 export {
 	ToolsPanel as __experimentalToolsPanel,
 	ToolsPanelItem as __experimentalToolsPanelItem,
+	ToolsPanelContext as __experimentalToolsPanelContext,
 } from './tools-panel';
 export { default as Tooltip } from './tooltip';
 export {

--- a/packages/components/src/tools-panel/index.js
+++ b/packages/components/src/tools-panel/index.js
@@ -1,2 +1,3 @@
 export { default as ToolsPanel } from './tools-panel';
 export { default as ToolsPanelItem } from './tools-panel-item';
+export { ToolsPanelContext } from './context';

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import { ToolsPanel, ToolsPanelItem } from '../';
 import Panel from '../../panel';
 import UnitControl from '../../unit-control';
+import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 
 export default {
 	title: 'Components (Experimental)/ToolsPanel',
@@ -76,7 +77,103 @@ export const _default = () => {
 	);
 };
 
+const { Fill, Slot } = createSlotFill( 'ToolsPanelSlot' );
+
+const ToolsPanelItems = ( { children } ) => {
+	return <Fill>{ children }</Fill>;
+};
+ToolsPanelItems.Slot = Slot;
+
+const panelId = 'unique-tools-panel-id';
+
+export const WithSlotFillItems = () => {
+	const [ attributes, setAttributes ] = useState( {} );
+	const { width, height } = attributes;
+
+	const resetAll = ( resetFilters = [] ) => {
+		let newAttributes = {};
+
+		resetFilters.forEach( ( resetFilter ) => {
+			newAttributes = {
+				...newAttributes,
+				...resetFilter( newAttributes ),
+			};
+		} );
+
+		setAttributes( newAttributes );
+	};
+
+	const updateAttribute = ( name, value ) => {
+		setAttributes( {
+			...attributes,
+			[ name ]: value,
+		} );
+	};
+
+	return (
+		<SlotFillProvider>
+			<ToolsPanelItems>
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ () => !! width }
+					label="Injected Width"
+					onDeselect={ () => updateAttribute( 'width', undefined ) }
+					resetAllFilter={ () => ( { width: undefined } ) }
+					panelId={ panelId }
+				>
+					<UnitControl
+						label="Injected Width"
+						value={ width }
+						onChange={ ( next ) =>
+							updateAttribute( 'width', next )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ () => !! height }
+					label="Injected Height"
+					onDeselect={ () => updateAttribute( 'height', undefined ) }
+					resetAllFilter={ () => ( { height: undefined } ) }
+					panelId={ panelId }
+				>
+					<UnitControl
+						label="Injected Height"
+						value={ height }
+						onChange={ ( next ) =>
+							updateAttribute( 'height', next )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					hasValue={ () => true }
+					label="Item for alternate panel"
+					onDeselect={ () => undefined }
+					resetAllFilter={ () => undefined }
+					panelId={ 'intended-for-another-panel-via-shared-slot' }
+				>
+					<p>
+						This panel item will not be displayed in the demo as its
+						panelId does not match the panel being rendered.
+					</p>
+				</ToolsPanelItem>
+			</ToolsPanelItems>
+			<PanelWrapperView>
+				<Panel>
+					<ToolsPanel
+						label="Tools Panel With SlotFill Items"
+						resetAll={ resetAll }
+						panelId={ panelId }
+					>
+						<ToolsPanelItems.Slot />
+					</ToolsPanel>
+				</Panel>
+			</PanelWrapperView>
+		</SlotFillProvider>
+	);
+};
+
 const PanelWrapperView = styled.div`
-	max-width: 250px;
+	max-width: 260px;
 	font-size: 13px;
 `;

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -28,16 +28,13 @@ export const _default = () => {
 	const resetAll = () => {
 		setHeight( undefined );
 		setWidth( undefined );
+		setMinHeight( undefined );
 	};
 
 	return (
 		<PanelWrapperView>
 			<Panel>
-				<ToolsPanel
-					header="Tools Panel"
-					label="Display options"
-					resetAll={ resetAll }
-				>
+				<ToolsPanel label="Tools Panel" resetAll={ resetAll }>
 					<ToolsPanelItem
 						className="single-column"
 						hasValue={ () => !! width }

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -77,13 +77,7 @@ export const _default = () => {
 	);
 };
 
-const { Fill, Slot } = createSlotFill( 'ToolsPanelSlot' );
-
-const ToolsPanelItems = ( { children } ) => {
-	return <Fill>{ children }</Fill>;
-};
-ToolsPanelItems.Slot = Slot;
-
+const { Fill: ToolsPanelItems, Slot } = createSlotFill( 'ToolsPanelSlot' );
 const panelId = 'unique-tools-panel-id';
 
 export const WithSlotFillItems = () => {
@@ -165,7 +159,7 @@ export const WithSlotFillItems = () => {
 						resetAll={ resetAll }
 						panelId={ panelId }
 					>
-						<ToolsPanelItems.Slot />
+						<Slot />
 					</ToolsPanel>
 				</Panel>
 			</PanelWrapperView>

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -320,6 +320,22 @@ describe( 'ToolsPanel', () => {
 			expect( altControlProps.onSelect ).not.toHaveBeenCalled();
 			expect( altControlProps.onDeselect ).not.toHaveBeenCalled();
 		} );
+
+		// This confirms the internal `isResetting` state when resetting all
+		// controls does not prevent subsequent individual reset requests.
+		// i.e. onDeselect callbacks are called correctly after a resetAll.
+		it( 'should call onDeselect after previous reset all', async () => {
+			renderPanel();
+
+			await selectMenuItem( 'Reset all' ); // Initial control is displayed by default.
+			await selectMenuItem( controlProps.label ); // Re-display control.
+
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+
+			await selectMenuItem( controlProps.label ); // Reset control.
+
+			expect( controlProps.onDeselect ).toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'grouped panel items within custom components', () => {

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -12,8 +12,7 @@ const resetAll = jest.fn();
 
 // Default props for the tools panel.
 const defaultProps = {
-	header: 'Panel header',
-	label: 'Display options',
+	label: 'Panel header',
 	resetAll,
 };
 
@@ -231,9 +230,9 @@ describe( 'ToolsPanel', () => {
 			expect( menuItems[ 1 ] ).toHaveAttribute( 'aria-checked', 'false' );
 		} );
 
-		it( 'should render panel header', () => {
+		it( 'should render panel label as header text', () => {
 			renderPanel();
-			const header = screen.getByText( defaultProps.header );
+			const header = screen.getByText( defaultProps.label );
 
 			expect( header ).toBeInTheDocument();
 		} );
@@ -316,6 +315,10 @@ describe( 'ToolsPanel', () => {
 			await selectMenuItem( 'Reset all' );
 
 			expect( resetAll ).toHaveBeenCalledTimes( 1 );
+			expect( controlProps.onSelect ).not.toHaveBeenCalled();
+			expect( controlProps.onDeselect ).not.toHaveBeenCalled();
+			expect( altControlProps.onSelect ).not.toHaveBeenCalled();
+			expect( altControlProps.onDeselect ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/components/src/tools-panel/tools-panel-header/README.md
+++ b/packages/components/src/tools-panel/tools-panel-header/README.md
@@ -18,17 +18,12 @@ This component is generated automatically by its parent
 
 ## Props
 
-### `header`: `string`
+### `label`: `string`
 
-Text to be displayed within the panel header.
+Text to be displayed within the panel header. It is also passed along as the
+`label` for the panel header's `DropdownMenu`.
 
 -   Required: Yes
-
-### `menuLabel`: `string`
-
-This is passed along as the `label` for the panel header's `DropdownMenu`.
-
--   Required: No
 
 ### `resetAll`: `function`
 

--- a/packages/components/src/tools-panel/tools-panel-header/README.md
+++ b/packages/components/src/tools-panel/tools-panel-header/README.md
@@ -28,7 +28,7 @@ Text to be displayed within the panel header. It is also passed along as the
 ### `resetAll`: `function`
 
 The `resetAll` prop provides the callback to execute when the "Reset all" menu
-item is selected. It's purpose is to facilitate resetting any control values
+item is selected. Its purpose is to facilitate resetting any control values
 for items contained within this header's panel.
 
 -   Required: Yes

--- a/packages/components/src/tools-panel/tools-panel-header/component.js
+++ b/packages/components/src/tools-panel/tools-panel-header/component.js
@@ -16,23 +16,22 @@ import { contextConnect } from '../../ui/context';
 const ToolsPanelHeader = ( props, forwardedRef ) => {
 	const {
 		hasMenuItems,
-		header,
+		label: labelText,
 		menuItems,
-		menuLabel,
 		resetAll,
 		toggleItem,
 		...headerProps
 	} = useToolsPanelHeader( props );
 
-	if ( ! header ) {
+	if ( ! labelText ) {
 		return null;
 	}
 
 	return (
 		<h2 { ...headerProps } ref={ forwardedRef }>
-			{ header }
+			{ labelText }
 			{ hasMenuItems && (
-				<DropdownMenu icon={ moreVertical } label={ menuLabel }>
+				<DropdownMenu icon={ moreVertical } label={ labelText }>
 					{ ( { onClose } ) => (
 						<>
 							<MenuGroup label={ __( 'Display options' ) }>

--- a/packages/components/src/tools-panel/tools-panel-item/README.md
+++ b/packages/components/src/tools-panel/tools-panel-item/README.md
@@ -18,6 +18,13 @@ for how to use `ToolsPanelItem`.
 
 ## Props
 
+### `hasValue`: `function`
+
+This is called when building the `ToolsPanel` menu to determine the item's
+initial checked state.
+
+-   Required: Yes
+
 ### `isShownByDefault`: `boolean`
 
 This prop identifies the current item as being displayed by default. This means
@@ -37,3 +44,33 @@ determine if the panel item should be displayed.
 A panel item's `label` should be unique among all items within a single panel.
 
 -   Required: Yes
+
+### `onDeselect`: `function`
+
+Called when this item is deselected in the `ToolsPanel` menu. This is normally
+used to reset the panel item control's value.
+
+-   Required: No
+
+### `onSelect`: `function`
+
+A callback to take action when this item is selected in the `ToolsPanel` menu.
+
+-   Required: No
+
+### `panelId`: `string`
+
+This prop can be set to a ID representing a unique `ToolsPanel`. Before
+attempting to register with a panel, each item will ensure that it belongs to
+the current panel. This avoids issues when sharing SlotFills to inject items
+into a panel.
+
+-   Required: No
+
+### `resetAllFilter`: `function`
+
+A `ToolsPanel` will collect each item's `resetAllFilter` and pass an array of
+these function through to the panel's `resetAll` callback. They can then be
+iterated over to perform additional tasks for items injected via SlotFills.
+
+-   Required: No

--- a/packages/components/src/tools-panel/tools-panel-item/README.md
+++ b/packages/components/src/tools-panel/tools-panel-item/README.md
@@ -6,7 +6,7 @@ implementation subject to drastic and breaking changes.
 </div>
 <br />
 
-This component acts a wrapper and controls the display of items to be contained
+This component acts as a wrapper and controls the display of items to be contained
 within a ToolsPanel. An item is displayed if it is flagged as a default control
 or the corresponding panel menu item, provided via context, is toggled on for
 this item.
@@ -37,7 +37,7 @@ panel's menu.
 
 The supplied label is dual purpose.
 It is used as:
-1. the human readable label for the panel's dropdown menu
+1. the human-readable label for the panel's dropdown menu
 2. a key to locate the corresponding item in the panel's menu context to
 determine if the panel item should be displayed.
 
@@ -60,17 +60,16 @@ A callback to take action when this item is selected in the `ToolsPanel` menu.
 
 ### `panelId`: `string`
 
-This prop can be set to a ID representing a unique `ToolsPanel`. Before
-attempting to register with a panel, each item will ensure that it belongs to
-the current panel. This avoids issues when sharing SlotFills to inject items
-into a panel.
+Panel items will ensure they are only registering with their intended panel by
+comparing the `panelId` props set on both the item and the panel itself. This
+allows items to be injected from a shared source.
 
 -   Required: No
 
 ### `resetAllFilter`: `function`
 
 A `ToolsPanel` will collect each item's `resetAllFilter` and pass an array of
-these function through to the panel's `resetAll` callback. They can then be
-iterated over to perform additional tasks for items injected via SlotFills.
+these functions through to the panel's `resetAll` callback. They can then be
+iterated over to perform additional tasks.
 
 -   Required: No

--- a/packages/components/src/tools-panel/tools-panel-item/hook.js
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.js
@@ -18,6 +18,8 @@ export function useToolsPanelItem( props ) {
 		hasValue,
 		isShownByDefault,
 		label,
+		panelId,
+		resetAllFilter,
 		onDeselect = () => undefined,
 		onSelect = () => undefined,
 		...otherProps
@@ -29,19 +31,25 @@ export function useToolsPanelItem( props ) {
 	} );
 
 	const {
+		panelId: currentPanelId,
 		menuItems,
 		registerPanelItem,
 		deregisterPanelItem,
+		isResetting,
 	} = useToolsPanelContext();
 
 	// Registering the panel item allows the panel to include it in its
 	// automatically generated menu and determine its initial checked status.
 	useEffect( () => {
-		registerPanelItem( {
-			hasValue,
-			isShownByDefault,
-			label,
-		} );
+		if ( currentPanelId === panelId ) {
+			registerPanelItem( {
+				hasValue,
+				isShownByDefault,
+				label,
+				resetAllFilter,
+				panelId,
+			} );
+		}
 
 		return () => deregisterPanelItem( label );
 	}, [] );
@@ -56,6 +64,10 @@ export function useToolsPanelItem( props ) {
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.
 	useEffect( () => {
+		if ( isResetting ) {
+			return;
+		}
+
 		if ( isMenuItemChecked && ! isValueSet && ! wasMenuItemChecked ) {
 			onSelect();
 		}
@@ -63,7 +75,7 @@ export function useToolsPanelItem( props ) {
 		if ( ! isMenuItemChecked && wasMenuItemChecked ) {
 			onDeselect();
 		}
-	}, [ isMenuItemChecked, wasMenuItemChecked, isValueSet ] );
+	}, [ isMenuItemChecked, wasMenuItemChecked, isValueSet, isResetting ] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -50,11 +50,7 @@ export function DimensionPanel( props ) {
 	};
 
 	return (
-		<ToolsPanel
-			header={ __( 'Dimensions' ) }
-			label={ __( 'Dimensions options' ) }
-			resetAll={ resetAll }
-		>
+		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
 			{ ! isPaddingDisabled && (
 				<ToolsPanelItem
 					hasValue={ () => hasPaddingValue( props ) }
@@ -73,19 +69,22 @@ export function DimensionPanel( props ) {
 
 ### `label`: `string`
 
-The label for the panel's dropdown menu.
+Text to be displayed within the panel's header and as the aria label for the
+panel's dropdown menu.
 
 - Required: Yes
+
+### `panelId`: `function`
+
+The `panelId` is passed through the `ToolsPanelContext` to panel items. This is
+be used to ensure items injected via SlotFills are only registered for their
+intended panels.
+
+- Required: No
 
 ### `resetAll`: `function`
 
 A function to call when the `Reset all` menu option is selected. This is passed
 through to the panel's header component.
-
-- Required: Yes
-
-### `header`: `string`
-
-Text to be displayed within the panel's header.
 
 - Required: Yes

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -69,16 +69,16 @@ export function DimensionPanel( props ) {
 
 ### `label`: `string`
 
-Text to be displayed within the panel's header and as the aria label for the
+Text to be displayed within the panel's header and as the aria-label for the
 panel's dropdown menu.
 
 - Required: Yes
 
 ### `panelId`: `function`
 
-The `panelId` is passed through the `ToolsPanelContext` to panel items. This is
-be used to ensure items injected via SlotFills are only registered for their
-intended panels.
+If a `panelId` is set, it is passed through the `ToolsPanelContext` and used
+to restrict panel items. Only items with a matching `panelId` will be able
+to register themselves with this panel.
 
 - Required: No
 

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -69,7 +69,7 @@ export function DimensionPanel( props ) {
 
 ### `label`: `string`
 
-Text to be displayed within the panel's header and as the aria-label for the
+Text to be displayed within the panel's header and as the `aria-label` for the
 panel's dropdown menu.
 
 - Required: Yes

--- a/packages/components/src/tools-panel/tools-panel/component.js
+++ b/packages/components/src/tools-panel/tools-panel/component.js
@@ -10,7 +10,6 @@ import { contextConnect } from '../../ui/context';
 const ToolsPanel = ( props, forwardedRef ) => {
 	const {
 		children,
-		header,
 		label,
 		panelContext,
 		resetAllItems,
@@ -22,8 +21,7 @@ const ToolsPanel = ( props, forwardedRef ) => {
 		<View { ...toolsPanelProps } ref={ forwardedRef }>
 			<ToolsPanelContext.Provider value={ panelContext }>
 				<ToolsPanelHeader
-					header={ header }
-					menuLabel={ label }
+					label={ label }
 					resetAll={ resetAllItems }
 					toggleItem={ toggleItem }
 				/>

--- a/packages/components/src/tools-panel/tools-panel/hook.js
+++ b/packages/components/src/tools-panel/tools-panel/hook.js
@@ -23,12 +23,6 @@ export function useToolsPanel( props ) {
 
 	const isResetting = useRef( false );
 
-	useEffect( () => {
-		if ( isResetting.current ) {
-			isResetting.current = false;
-		}
-	}, [ isResetting ] );
-
 	// Allow panel items to register themselves.
 	const [ panelItems, setPanelItems ] = useState( [] );
 
@@ -109,6 +103,12 @@ export function useToolsPanel( props ) {
 		deregisterPanelItem,
 		isResetting: isResetting.current,
 	};
+
+	// Clean up isResetting after advising panel context we were resetting
+	// all controls. This lets panel items know to skip onDeselect callbacks.
+	if ( isResetting.current ) {
+		isResetting.current = false;
+	}
 
 	return {
 		...otherProps,

--- a/packages/components/src/tools-panel/tools-panel/hook.js
+++ b/packages/components/src/tools-panel/tools-panel/hook.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import { useContextSystem } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
 
 export function useToolsPanel( props ) {
-	const { className, resetAll, ...otherProps } = useContextSystem(
+	const { className, resetAll, panelId, ...otherProps } = useContextSystem(
 		props,
 		'ToolsPanel'
 	);
@@ -20,6 +20,14 @@ export function useToolsPanel( props ) {
 	const classes = useMemo( () => {
 		return cx( styles.ToolsPanel, className );
 	}, [ className ] );
+
+	const isResetting = useRef( false );
+
+	useEffect( () => {
+		if ( isResetting.current ) {
+			isResetting.current = false;
+		}
+	}, [ isResetting ] );
 
 	// Allow panel items to register themselves.
 	const [ panelItems, setPanelItems ] = useState( [] );
@@ -31,13 +39,31 @@ export function useToolsPanel( props ) {
 	// Panels need to deregister on unmount to avoid orphans in menu state.
 	// This is an issue when panel items are being injected via SlotFills.
 	const deregisterPanelItem = ( label ) => {
-		setPanelItems( ( items ) =>
-			items.filter( ( item ) => item.label !== label )
-		);
+		// When switching selections between components injecting matching
+		// controls, e.g. both panels have a "padding" control, the
+		// deregistration of the first panel doesn't occur until after the
+		// registration of the next.
+		const index = panelItems.findIndex( ( item ) => item.label === label );
+
+		if ( index !== -1 ) {
+			setPanelItems( ( items ) => items.splice( index, 1 ) );
+		}
 	};
 
 	// Manage and share display state of menu items representing child controls.
 	const [ menuItems, setMenuItems ] = useState( {} );
+
+	const getResetAllFilters = () => {
+		const filters = [];
+
+		panelItems.forEach( ( item ) => {
+			if ( item.resetAllFilter ) {
+				filters.push( item.resetAllFilter );
+			}
+		} );
+
+		return filters;
+	};
 
 	// Setup menuItems state as panel items register themselves.
 	useEffect( () => {
@@ -62,7 +88,8 @@ export function useToolsPanel( props ) {
 	// Resets display of children and executes resetAll callback if available.
 	const resetAllItems = () => {
 		if ( typeof resetAll === 'function' ) {
-			resetAll();
+			isResetting.current = true;
+			resetAll( getResetAllFilters() );
 		}
 
 		// Turn off display of all non-default items.
@@ -75,7 +102,13 @@ export function useToolsPanel( props ) {
 		setMenuItems( resetMenuItems );
 	};
 
-	const panelContext = { menuItems, registerPanelItem, deregisterPanelItem };
+	const panelContext = {
+		panelId,
+		menuItems,
+		registerPanelItem,
+		deregisterPanelItem,
+		isResetting: isResetting.current,
+	};
 
 	return {
 		...otherProps,


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/34157
- https://github.com/WordPress/gutenberg/pull/34065
- https://github.com/WordPress/gutenberg/pull/34530
- https://github.com/WordPress/gutenberg/pull/34063
- https://github.com/WordPress/gutenberg/pull/34069

## Description

This updates the `ToolsPanel` component to support injection of panel items via a SlotFill.  The changes to the `ToolsPanel` here have been separated from https://github.com/WordPress/gutenberg/pull/34157.

#### Changes include:
- Exporting `ToolsPanelContext` so it can be passed via slots' `fillProps`
- Merges the `label` and `header` props for the `ToolsPanel`
- Updates readmes
- Fixes issues that arise when panel items are added via a shared slot 
    - e.g. items possibly still being in the slot's fills when changing block selections and the panel effectively changing
- Add ability to supply filters to the `resetAll` callback allowing injected panel item controls to reset whatever they need

## How has this been tested?

- Ensured tests are passing, including updated test for merged props:
    - `npm run test-unit packages/components/src/tools-panel/test`
- Manually through the storybook: 
    - `npm run storybook:dev`
    - http://localhost:50240/?path=/story/components-experimental-toolspanel--default
- Manually within the block editor, adding a group block and its "dimensions" panel

## Screenshots <!-- if applicable -->

![ToolsPanelPostSlotFillUpdates](https://user-images.githubusercontent.com/60436221/132454586-70965a98-b91f-479b-8bcb-19a6dc66438c.gif)


## Types of changes
Enhancement. Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
