### PR TITLE
Mobile - Allow disabling text and background color via theme.json

### DIFF
--- a/packages/block-editor/src/store/defaults.native.js
+++ b/packages/block-editor/src/store/defaults.native.js
@@ -13,6 +13,12 @@ const SETTINGS_DEFAULTS = {
 	__unstableGalleryWithImageBlocks: __DEV__,
 	alignWide: true,
 	supportsLayout: false,
+	__experimentalFeatures: {
+		color: {
+			text: true,
+			background: true,
+		},
+	},
 };
 
 export { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS };

--- a/packages/components/src/mobile/global-styles-context/test/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/utils.native.js
@@ -131,6 +131,8 @@ describe( 'getGlobalStyles', () => {
 					color: {
 						palette: RAW_FEATURES.color.palette,
 						gradients,
+						text: true,
+						background: true,
 					},
 					typography: {
 						fontSizes: RAW_FEATURES.typography.fontSizes,

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -203,6 +203,8 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 			color: {
 				palette: colors?.palette,
 				gradients,
+				text: features?.color?.text ?? true,
+				background: features?.color?.background ?? true,
 			},
 			typography: {
 				fontSizes: features?.typography?.fontSizes,


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/3929 

## Description
This fixes a regression introduced by https://github.com/WordPress/gutenberg/pull/34420, and adds default support for `text` and `background` color customization for standard themes and for block-based themes that can now enable/disable it from the `theme.json`

## How has this been tested?

### Test case 1 (standard theme)

- Open the app.
- Start a new post.
- Add a `Paragraph` block.
- Open the settings of the block.
- **Expect** to see the `Color` and `Background` settings.

### Test case 1 (block-based theme: Quadrat, TT1 blocks)

- Open the app.
- Start a new post.
- Add a `Paragraph` block.
- Open the settings of the block.
- **Expect** to see the `Color` and `Background` settings.

## Screenshots <!-- if applicable -->

Test case 1 Before |Test case 1 After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/132497429-83015ca2-0779-4c38-b9dc-15cae838a49d.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/132497436-001842e3-334d-4ffa-8afa-a087810e99f3.gif" width="200" /></kbd>

Test case 2 Before |Test case 2 After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/132497480-79e84575-8fbe-4ee1-bf1b-ff6df4ff3d73.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/132497483-429d5a86-ba90-4cc6-9ab3-56f468c96c84.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
