### PR TITLE
Fix disabled blocks logical error on Widgets screen

### DIFF
--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -37,7 +37,7 @@ import {
 const disabledBlocks = [
 	'core/more',
 	'core/freeform',
-	...( ! ALLOW_REUSABLE_BLOCKS ? [ 'core/block' ] : [] ),
+	...( ALLOW_REUSABLE_BLOCKS ? [] : [ 'core/block' ] ),
 ];
 
 /**

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -37,7 +37,7 @@ import {
 const disabledBlocks = [
 	'core/more',
 	'core/freeform',
-	...( ! ALLOW_REUSABLE_BLOCKS && [ 'core/block' ] ),
+	...( ! ALLOW_REUSABLE_BLOCKS ? [ 'core/block' ] : [] ),
 ];
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
[As @draganescu has noticed](https://github.com/WordPress/gutenberg/pull/32761#discussion_r703704489) the logic which disables blocks in Widgets will throw an error if `ALLOW_REUSABLE_BLOCKS` is `true`. This is because the result of the expression was not always iterable.

This PR fixes that by ensuring the result of the expression is always iterable. 

## How has this been tested?

1. Open Widgets screen. Check there are no console errors and that you cannot use Resuable blocks.
2. Go to `packages/edit-widgets/src/constants.js` and change `ALLOW_REUSABLE_BLOCKS` to `true`.
3. Rebuild the Plugin.
4. Go to Widgets screen. Check there are no console errors and that you can use Resuable blocks.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
