### PR TITLE
Fix social links deprecation

### DIFF
--- a/packages/block-library/src/social-links/deprecated.js
+++ b/packages/block-library/src/social-links/deprecated.js
@@ -78,6 +78,11 @@ const deprecated = [
 				type: 'string',
 			},
 		},
+		supports: {
+			align: [ 'left', 'center', 'right' ],
+			anchor: true,
+			__experimentalExposeControlsToChildren: true,
+		},
 		isEligible: ( { layout } ) => ! layout,
 		migrate: migrateWithLayout,
 		save( props ) {


### PR DESCRIPTION
Follow up on: https://github.com/WordPress/gutenberg/pull/34493

I had missed the `supports` field in the new deprecation of the block. It should now work properly.


Regarding: https://github.com/WordPress/gutenberg/pull/34493#issuecomment-914801396 

@aaronrobertshaw can you verify that now this is working properly?

