### PR TITLE
Block Editor: Rename experimental prop used in `BlockControls`

### DIFF
--- a/packages/block-editor/src/components/block-controls/fill.js
+++ b/packages/block-editor/src/components/block-controls/fill.js
@@ -21,9 +21,12 @@ export default function BlockControlsFill( {
 	group = 'default',
 	controls,
 	children,
-	__experimentalExposeToChildren = false,
+	__experimentalShareWithChildBlocks = false,
 } ) {
-	const Fill = useBlockControlsFill( group, __experimentalExposeToChildren );
+	const Fill = useBlockControlsFill(
+		group,
+		__experimentalShareWithChildBlocks
+	);
 	if ( ! Fill ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -12,7 +12,7 @@ import { store as blockEditorStore } from '../../store';
 import { useBlockEditContext } from '../block-edit/context';
 import useDisplayBlockControls from '../use-display-block-controls';
 
-export default function useBlockControlsFill( group, exposeToChildren ) {
+export default function useBlockControlsFill( group, shareWithChildBlocks ) {
 	const isDisplayed = useDisplayBlockControls();
 	const { clientId } = useBlockEditContext();
 	const isParentDisplayed = useSelect(
@@ -22,7 +22,7 @@ export default function useBlockControlsFill( group, exposeToChildren ) {
 			);
 			const { hasBlockSupport } = select( blocksStore );
 			return (
-				exposeToChildren &&
+				shareWithChildBlocks &&
 				hasBlockSupport(
 					getBlockName( clientId ),
 					'__experimentalExposeControlsToChildren',
@@ -31,7 +31,7 @@ export default function useBlockControlsFill( group, exposeToChildren ) {
 				hasSelectedInnerBlock( clientId )
 			);
 		},
-		[ exposeToChildren, clientId ]
+		[ shareWithChildBlocks, clientId ]
 	);
 
 	if ( isDisplayed ) {

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -140,7 +140,10 @@ export const withToolbarControls = createHigherOrderComponent(
 		return (
 			<>
 				{ blockAllowedAlignments.length > 0 && (
-					<BlockControls group="block" __experimentalExposeToChildren>
+					<BlockControls
+						group="block"
+						__experimentalShareWithChildBlocks
+					>
 						<BlockAlignmentControl
 							value={ props.attributes.align }
 							onChange={ updateAlignment }

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -140,7 +140,7 @@ function DuotonePanel( { attributes, setAttributes } ) {
 	}
 
 	return (
-		<BlockControls group="block" __experimentalExposeToChildren>
+		<BlockControls group="block" __experimentalShareWithChildBlocks>
 			<DuotoneControl
 				duotonePalette={ duotonePalette }
 				colorPalette={ colorPalette }

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -44,7 +44,7 @@ export default {
 			return null;
 		}
 		return (
-			<BlockControls group="block" __experimentalExposeToChildren>
+			<BlockControls group="block" __experimentalShareWithChildBlocks>
 				<FlexLayoutJustifyContentControl
 					layout={ layout }
 					onChange={ onChange }

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -70,7 +70,7 @@ function ButtonsEdit( {
 
 	return (
 		<>
-			<BlockControls group="block" __experimentalExposeToChildren>
+			<BlockControls group="block" __experimentalShareWithChildBlocks>
 				<JustifyContentControl
 					allowedControls={ justifyControls }
 					value={ contentJustification }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Let's rename the experimental prop `exposeToChildren` to `shareWithChildBlocks` used in `BlockControls`. It should help to clarify the intended behavior of this feature. In particular it should make it clear that block controls are shared only with inner blocks that are children of the block where `BlockControls` are defined.

Aside: the old name may sound strange for native speakers, which I didn't realize until @talldan brought it to my attention. Thank you 💯 