### PR TITLE
Create two-way data binding for ImageSizeControl

### DIFF
--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -30,17 +30,17 @@ export default function useDimensionHandler(
 	}, [ defaultWidth, defaultHeight ] );
 
 	// if custom values change, it means an outsider has resized the image using some other method (eg resize box)
-	// we should keep track of these values too. We need to parse them before comparing them as well as they can be strings.
+	// we should keep track of these values too. We need to parse customWidth as it can be a string.
 	useEffect( () => {
 		if (
 			customWidth !== undefined &&
-			Number.parseInt( customWidth ) !== Number.parseInt( defaultWidth )
+			Number.parseInt( customWidth ) !== Number.parseInt( currentWidth )
 		) {
 			setCurrentWidth( customWidth );
 		}
 		if (
 			customHeight !== undefined &&
-			Number.parseInt( customHeight ) !== Number.parseInt( defaultHeight )
+			Number.parseInt( customHeight ) !== Number.parseInt( currentHeight )
 		) {
 			setCurrentHeight( customHeight );
 		}

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -3,7 +3,7 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 
-export default function useDimensionHander(
+export default function useDimensionHandler(
 	customHeight,
 	customWidth,
 	defaultHeight,
@@ -28,6 +28,23 @@ export default function useDimensionHander(
 			setCurrentHeight( defaultHeight );
 		}
 	}, [ defaultWidth, defaultHeight ] );
+
+	// if custom values change, it means an outsider has resized the image using some other method (eg resize box)
+	// we should keep track of these values too. We need to parse them before comparing them as well as they can be strings.
+	useEffect( () => {
+		if (
+			customWidth !== undefined &&
+			Number.parseInt( customWidth ) !== Number.parseInt( defaultWidth )
+		) {
+			setCurrentWidth( customWidth );
+		}
+		if (
+			customHeight !== undefined &&
+			Number.parseInt( customHeight ) !== Number.parseInt( defaultHeight )
+		) {
+			setCurrentHeight( customHeight );
+		}
+	}, [ customWidth, customHeight ] );
 
 	const updateDimension = ( dimension, value ) => {
 		if ( dimension === 'width' ) {

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -29,8 +29,8 @@ export default function useDimensionHandler(
 		}
 	}, [ defaultWidth, defaultHeight ] );
 
-	// if custom values change, it means an outsider has resized the image using some other method (eg resize box)
-	// we should keep track of these values too. We need to parse customWidth as it can be a string.
+	// If custom values change, it means an outsider has resized the image using some other method (eg resize box)
+	// this keeps track of these values too. We need to parse before comparing; custom values can be strings.
 	useEffect( () => {
 		if (
 			customWidth !== undefined &&


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
`ImageSizeControl` uses `useDimensionHandler` hook to store image dimensions.

This hook accepts default values and custom values. It derives its state from them (custom values then fails over to default values). 

As common with derived state, a bug surfaces when custom values change, because the state remains outdated.

This commit observes custom values and updates the state when they're updated.

## How has this been tested?

Using a local wp instance.

1. Insert an image using the image block.
2. Resize it using the resize box.
3. Block control fields should update in real-time (on mouse up).





<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/17054134/132515727-2e067967-f159-4a80-88f1-e73bd4c92cd6.mov


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->


Fixes: https://github.com/Automattic/wp-calypso/issues/54800
