### PR TITLE
Add ability to hide/disable the search box in the global block inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -23,6 +23,7 @@ function InserterLibrary( {
 	__experimentalInsertionIndex,
 	onSelect = noop,
 	shouldFocusBlock = false,
+	showSearch = true,
 } ) {
 	const destinationRootClientId = useSelect(
 		( select ) => {
@@ -45,6 +46,7 @@ function InserterLibrary( {
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 			shouldFocusBlock={ shouldFocusBlock }
+			showSearch={ showSearch }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -28,6 +28,7 @@ function InserterMenu( {
 	showInserterHelpPanel,
 	showMostUsedBlocks,
 	shouldFocusBlock = true,
+	showSearch = true,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
@@ -170,16 +171,18 @@ function InserterMenu( {
 			<div className="block-editor-inserter__main-area">
 				{ /* the following div is necessary to fix the sticky position of the search form */ }
 				<div className="block-editor-inserter__content">
-					<SearchControl
-						className="block-editor-inserter__search"
-						onChange={ ( value ) => {
-							if ( hoveredItem ) setHoveredItem( null );
-							setFilterValue( value );
-						} }
-						value={ filterValue }
-						label={ __( 'Search for blocks and patterns' ) }
-						placeholder={ __( 'Search' ) }
-					/>
+					{ showSearch && (
+						<SearchControl
+							className="block-editor-inserter__search"
+							onChange={ ( value ) => {
+								if ( hoveredItem ) setHoveredItem( null );
+								setFilterValue( value );
+							} }
+							value={ filterValue }
+							label={ __( 'Search for blocks and patterns' ) }
+							placeholder={ __( 'Search' ) }
+						/>
+					) }
 					{ !! filterValue && (
 						<InserterSearchResults
 							filterValue={ filterValue }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -19,6 +19,11 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
 function InserterMenu( {
 	rootClientId,
 	clientId,
@@ -166,8 +171,12 @@ function InserterMenu( {
 		[ blocksTab, patternsTab, reusableBlocksTab ]
 	);
 
+	const classes = classnames( 'block-editor-inserter__menu', {
+		'has-search': !! showSearch,
+	} );
+
 	return (
-		<div className="block-editor-inserter__menu">
+		<div className={ classes }>
 			<div className="block-editor-inserter__main-area">
 				{ /* the following div is necessary to fix the sticky position of the search form */ }
 				<div className="block-editor-inserter__content">

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -117,8 +117,7 @@ $block-inserter-tabs-height: 44px;
 
 	.components-tab-panel__tabs {
 		position: sticky;
-		// Computed based off the search input height and paddings
-		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
+		top: 0;
 		background: $white;
 		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tabs");
 		border-bottom: $border-width solid $gray-300;
@@ -137,6 +136,11 @@ $block-inserter-tabs-height: 44px;
 		position: relative;
 		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tab-content");
 	}
+}
+
+.block-editor-inserter__menu.has-search .block-editor-inserter__tabs .components-tab-panel__tabs {
+	// Computed based off the search input height and paddings
+	top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
 }
 
 .block-editor-inserter__panel-header {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/34619 we learnt that in certain circumstances it makes sense to disable the search feature UI from the global block inserter. For example, in the Nav Editor screen [the proposed addition of the global block inserter](https://github.com/WordPress/gutenberg/pull/34619) doesn't need a search as there are a _very_ limited number of blocks from which to choose

This PR 

1. extracts the changes made in https://github.com/WordPress/gutenberg/pull/34619/commits/be420123ae3144e87ba37dbfa6ed6baf043a9250 into a standalone PR. 
2. adds some styling conditionals to ensure the spacing required for the search UI is only applied _if_ the search is present/active.

As we default the search to `true` (active) this change should be fully backwards compatible with all existing usages.


## How has this been tested?

Tricky to test but perhaps:

1. Go to `packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js`.
2. Add `showSearch={false}` to the `<Library />` component.
3. Create a new Post.
4. Open global block inserter.
5. See there is no search and the UI is nicely aligned to the top with no space above the tabs.
6. Remove the prop.
7. Check the search is active by default and the UI looks as per `trunk`.
8. Check some other editor screens.



## Screenshots <!-- if applicable -->

This is how the feature appears when there is no search box

<img width="1278" alt="Screen Shot 2021-09-08 at 15 51 26" src="https://user-images.githubusercontent.com/444434/132532727-98b1d977-9ee6-4795-acda-486ef2824d67.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
