### PR TITLE
Make nav editor links content-width instead of expanding

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -31,14 +31,14 @@
 
 		// Customize/zero out the gap.
 		.wp-block-navigation__container {
-			// This unsets flex.
-			display: block;
+			display: flex;
+			gap: 0;
 		}
 
 		// Increase specificity.
 		.wp-block-navigation-item {
 			display: block;
-			margin: $grid-unit-10 0;
+			margin: $grid-unit-05 0;
 
 			// Show submenus on click.
 			> .wp-block-navigation__submenu-container {
@@ -133,11 +133,6 @@
 			border-radius: $radius-block-ui;
 		}
 
-		// Use flex layout to calculate menu item length based on content.
-		.wp-block-navigation__container {
-			display: flex;
-		}
-
 		// Override for deeply nested submenus.
 		.has-child .wp-block-navigation__container .wp-block-navigation__submenu-container {
 			left: auto;
@@ -157,7 +152,8 @@
 				min-width: auto;
 				width: 100%;
 				border: none;
-				display: block;
+				display: flex;
+				align-items: flex-start;
 
 				&::before {
 					display: none;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -133,6 +133,11 @@
 			border-radius: $radius-block-ui;
 		}
 
+		// Use flex layout to calculate menu item length based on content.
+		.wp-block-navigation__container {
+			display: flex;
+		}
+
 		// Override for deeply nested submenus.
 		.has-child .wp-block-navigation__container .wp-block-navigation__submenu-container {
 			left: auto;


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/34036
Make sure Navigation Items don't expand their width within the Navigation Editor, when longer items are present.

## How has this been tested?
1. Go to Nav Editor, create items of different lengths.
2. Shorter items should stick to content-size instead of expanding.

## Screenshots <!-- if applicable -->

![Kapture 2021-09-08 at 12 12 03](https://user-images.githubusercontent.com/1157901/132536323-15875fb6-1c2e-45c8-9644-67bae9064ee9.gif)

## Types of changes
Bug fix.