### PR TITLE
Keep Navigation Editor snackbar from overflowing notices.

### DIFF
--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -1,7 +1,7 @@
 .edit-navigation-notices__snackbar-list {
 	position: fixed;
-	bottom: 20px;
-	margin-left: 20px;
+	bottom: 0;
+	padding: 20px;
 }
 
 .edit-navigation-notices__notice-list {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes https://github.com/WordPress/gutenberg/issues/31182
Fix overflowing snack bar on the navigation editor mobile view. 

## How has this been tested?
1. Save the Navigation (CTRL/CMD + S will force this so that you don't have to make changes to test.)
2. Notice should be contained within the editor, centered.

## Screenshots <!-- if applicable -->

| Mobile | Desktop |
| -- | -- |
| ![Kapture 2021-09-08 at 13 12 18](https://user-images.githubusercontent.com/1157901/132546183-b4d1797d-3ef0-494d-8fa6-e6a91c18cfd3.gif) | <img width="1552" alt="image" src="https://user-images.githubusercontent.com/1157901/132546110-49348484-3d0f-479b-b1a3-beca46b9622c.png"> |
