### PR TITLE
Fix navigation editor missing appender not showing appender when no blocks selected

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/button-block-appender.js
+++ b/packages/block-editor/src/components/inner-blocks/button-block-appender.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import BaseButtonBlockAppender from '../button-block-appender';
@@ -9,9 +14,13 @@ export const ButtonBlockAppender = ( {
 	showSeparator,
 	isFloating,
 	onAddBlock,
+	isToggle,
 } ) => {
 	return (
 		<BaseButtonBlockAppender
+			className={ classnames( {
+				'block-list-appender__toggle': isToggle,
+			} ) }
 			rootClientId={ clientId }
 			showSeparator={ showSeparator }
 			isFloating={ isFloating }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -14,7 +14,6 @@ import {
 	Platform,
 } from '@wordpress/element';
 import {
-	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	JustifyToolbar,
@@ -100,10 +99,14 @@ function Navigation( {
 	setOverlayBackgroundColor,
 	overlayTextColor,
 	setOverlayTextColor,
+
+	// These props are used by the navigation editor to override specific
+	// navigation block settings.
 	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
 	hasColorSettings = true,
 	customPlaceholder: CustomPlaceholder = null,
+	customAppender: CustomAppender = null,
 } ) {
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -145,6 +148,15 @@ function Navigation( {
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
+	// When the block is selected itself or has a top level item selected that
+	// doesn't itself have children, show the standard appender. Else show no
+	// appender.
+	const appender =
+		isSelected ||
+		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants )
+			? undefined
+			: false;
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -152,12 +164,8 @@ function Navigation( {
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
 			orientation: attributes.orientation,
-			renderAppender:
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasDescendants ) ||
-				isSelected
-					? InnerBlocks.DefaultAppender
-					: false,
+			renderAppender: CustomAppender || appender,
+
 			// Ensure block toolbar is not too far removed from item
 			// being edited when in vertical mode.
 			// see: https://github.com/WordPress/gutenberg/pull/34615.

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -315,6 +315,22 @@ describe( 'Navigation editor', () => {
 		expect( await getSerializedBlocks() ).toMatchSnapshot();
 	} );
 
+	it( 'shows the trailing block appender within the navigation block when no blocks are selected', async () => {
+		await setUpResponseMocking( [
+			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
+			...getMenuItemMocks( { GET: menuItemsFixture } ),
+		] );
+		await visitNavigationEditor();
+
+		const selectedBlocks = await page.$$( '.wp-block.is-selected' );
+		expect( selectedBlocks.length ).toBe( 0 );
+
+		const blockListAppender = await page.$(
+			'.block-list-appender button[aria-label="Add block"]'
+		);
+		expect( blockListAppender ).toBeTruthy();
+	} );
+
 	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
 		await setUpResponseMocking( [
 			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -165,7 +165,7 @@
 		}
 	}
 
-	// Override behavior that hides the navigation block's appender when it's selected.
+	// Override behavior that hides the navigation block's appender when it's deselected.
 	.block-editor-block-list__block:not(.is-selected):not(.has-child-selected):not(.block-editor-block-list__layout) {
 		.block-editor-block-list__layout > .block-list-appender .block-list-appender__toggle {
 			opacity: unset;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -164,4 +164,12 @@
 			padding: 0;
 		}
 	}
+
+	// Override behavior that hides the navigation block's appender when it's selected.
+	.block-editor-block-list__block:not(.is-selected):not(.has-child-selected):not(.block-editor-block-list__layout) {
+		.block-editor-block-list__layout > .block-list-appender .block-list-appender__toggle {
+			opacity: unset;
+			transform: unset;
+		}
+	}
 }

--- a/packages/edit-navigation/src/filters/add-navigation-editor-custom-appender.js
+++ b/packages/edit-navigation/src/filters/add-navigation-editor-custom-appender.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+function CustomAppender() {
+	return <InnerBlocks.ButtonBlockAppender isToggle />;
+}
+
+const addNavigationEditorCustomAppender = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		if ( props.name !== 'core/navigation' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return <BlockEdit { ...props } customAppender={ CustomAppender } />;
+	},
+	'withNavigationEditorCustomAppender'
+);
+
+export default () =>
+	addFilter(
+		'editor.BlockEdit',
+		'core/edit-navigation/with-navigation-editor-custom-appender',
+		addNavigationEditorCustomAppender
+	);

--- a/packages/edit-navigation/src/filters/add-navigation-editor-custom-appender.js
+++ b/packages/edit-navigation/src/filters/add-navigation-editor-custom-appender.js
@@ -1,12 +1,59 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 function CustomAppender() {
 	return <InnerBlocks.ButtonBlockAppender isToggle />;
+}
+
+function EnhancedNavigationBlock( { blockEdit: BlockEdit, ...props } ) {
+	const clientId = props.clientId;
+	const {
+		noBlockSelected,
+		isSelected,
+		isImmediateParentOfSelectedBlock,
+		selectedBlockHasDescendants,
+	} = useSelect(
+		( select ) => {
+			const {
+				getClientIdsOfDescendants,
+				hasSelectedInnerBlock,
+				getSelectedBlockClientId,
+			} = select( blockEditorStore );
+			const _isImmediateParentOfSelectedBlock = hasSelectedInnerBlock(
+				clientId,
+				false
+			);
+			const selectedBlockId = getSelectedBlockClientId();
+			const _selectedBlockHasDescendants = !! getClientIdsOfDescendants( [
+				selectedBlockId,
+			] )?.length;
+
+			return {
+				isSelected: selectedBlockId === clientId,
+				noBlockSelected: ! selectedBlockId,
+				isImmediateParentOfSelectedBlock: _isImmediateParentOfSelectedBlock,
+				selectedBlockHasDescendants: _selectedBlockHasDescendants,
+			};
+		},
+		[ clientId ]
+	);
+
+	const customAppender =
+		noBlockSelected ||
+		isSelected ||
+		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants )
+			? CustomAppender
+			: false;
+
+	return <BlockEdit { ...props } customAppender={ customAppender } />;
 }
 
 const addNavigationEditorCustomAppender = createHigherOrderComponent(
@@ -15,7 +62,8 @@ const addNavigationEditorCustomAppender = createHigherOrderComponent(
 			return <BlockEdit { ...props } />;
 		}
 
-		return <BlockEdit { ...props } customAppender={ CustomAppender } />;
+		// Use a separate component so that `useSelect` only run on the navigation block.
+		return <EnhancedNavigationBlock blockEdit={ BlockEdit } { ...props } />;
 	},
 	'withNavigationEditorCustomAppender'
 );

--- a/packages/edit-navigation/src/filters/add-navigation-editor-placeholder.js
+++ b/packages/edit-navigation/src/filters/add-navigation-editor-placeholder.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import BlockPlaceholder from '../components/block-placeholder';
 
 const addNavigationEditorPlaceholder = createHigherOrderComponent(

--- a/packages/edit-navigation/src/filters/index.js
+++ b/packages/edit-navigation/src/filters/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import addNavigationEditorCustomAppender from './add-navigation-editor-custom-appender';
 import addNavigationEditorPlaceholder from './add-navigation-editor-placeholder';
 import addMenuNameEditor from './add-menu-name-editor';
 import disableInsertingNonNavigationBlocks from './disable-inserting-non-navigation-blocks';
@@ -10,6 +11,7 @@ import removeSettingsUnsupportedFeatures from './remove-settings-unsupported-fea
 export const addFilters = (
 	shouldAddDisableInsertingNonNavigationBlocksFilter
 ) => {
+	addNavigationEditorCustomAppender();
 	addNavigationEditorPlaceholder();
 	addMenuNameEditor();
 	if ( shouldAddDisableInsertingNonNavigationBlocksFilter ) {


### PR DESCRIPTION
## Description
Fixes #31276

This fix is frustratingly complex.

The main problem is that the navigation block has its own custom logic for appender visibility, which conflicts with the desired behavior for the navigation editor.

The secondary problem is that even without the navigation block's custom logic, the block editor's default appender wouldn't be displayed anyway. When all blocks are deselected the block editor would usually show an appender at the root level, but not if that root level is a locked template, which is the case in the navigation editor.

This PR fixes things by supplying a completely custom appender implementation to the Navigation Block—yet another place where the block is being extend by the editor.

But at least with this situation, the navigation editor is in complete control of when the appender is shown, and this logic can be changed to whatever is desired now, even the appearance of the appender could be changed.

## How has this been tested?
1. Create a menu and choose 'Start blank'
2. Deselect the nav block

Expected: the appender should still be visible

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
