### PR TITLE
Add edit template part menu button

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -71,8 +71,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			onChange={ onChange }
 			useSubRegistry={ false }
 		>
-			<TemplatePartConverter />
 			<EditTemplatePartMenuButton />
+			<TemplatePartConverter />
 			<__experimentalLinkControl.ViewerFill>
 				{ useCallback(
 					( fillProps ) => (

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -27,6 +27,7 @@ import NavigateToLink from '../navigate-to-link';
 import { SidebarInspectorFill } from '../sidebar';
 import { store as editSiteStore } from '../../store';
 import BlockInspectorButton from './block-inspector-button';
+import EditTemplatePartMenuButton from '../edit-template-part-menu-button';
 
 const LAYOUT = {
 	type: 'default',
@@ -71,6 +72,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			useSubRegistry={ false }
 		>
 			<TemplatePartConverter />
+			<EditTemplatePartMenuButton />
 			<__experimentalLinkControl.ViewerFill>
 				{ useCallback(
 					( fillProps ) => (

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -21,18 +21,14 @@ export default function EditTemplatePartMenuButton() {
 		const block = select( blockEditorStore ).getSelectedBlock();
 
 		if ( block && isTemplatePart( block ) ) {
-			const templateParts =
-				select( coreStore ).getEntityRecords(
-					'postType',
-					'wp_template_part'
-				) || [];
+			const { theme, slug } = block.attributes;
 
-			const templatePart = templateParts.find(
-				( part ) =>
-					part.theme === block.attributes.theme &&
-					part.slug === block.attributes.slug
+			return select( coreStore ).getEntityRecord(
+				'postType',
+				'wp_template_part',
+				// Ideally this should be an official public API.
+				`${ theme }//${ slug }`
 			);
-			return templatePart;
 		}
 	}, [] );
 	const { setTemplatePart } = useDispatch( editSiteStore );

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	BlockSettingsMenuControls,
+} from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { MenuItem } from '@wordpress/components';
+import { isTemplatePart } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function EditTemplatePartMenuButton() {
+	const selectedTemplatePartId = useSelect( ( select ) => {
+		const { getSelectedBlockClientId, getBlock } = select(
+			blockEditorStore
+		);
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const block = getBlock( selectedBlockClientId );
+
+		if ( isTemplatePart( block ) ) {
+			const templateParts =
+				select( coreStore ).getEntityRecords(
+					'postType',
+					'wp_template_part'
+				) || [];
+
+			const templatePart = templateParts.find(
+				( part ) =>
+					part.theme === block.attributes.theme &&
+					part.slug === block.attributes.slug
+			);
+			return templatePart?.id;
+		}
+	}, [] );
+	const { setTemplatePart } = useDispatch( editSiteStore );
+
+	if ( ! selectedTemplatePartId ) {
+		return null;
+	}
+
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { onClose } ) => (
+				<MenuItem
+					onClick={ () => {
+						setTemplatePart( selectedTemplatePartId );
+						onClose();
+					} }
+				>
+					{ __( 'Edit template part' ) }
+				</MenuItem>
+			) }
+		</BlockSettingsMenuControls>
+	);
+}

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -52,7 +52,7 @@ export default function EditTemplatePartMenuButton() {
 				>
 					{
 						/* translators: %s: template part title */
-						sprintf( __( 'Edit "%s"' ), selectedTemplatePart.slug )
+						sprintf( __( 'Edit %s' ), selectedTemplatePart.slug )
 					}
 				</MenuItem>
 			) }

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -24,7 +24,7 @@ export default function EditTemplatePartMenuButton() {
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const block = getBlock( selectedBlockClientId );
 
-		if ( isTemplatePart( block ) ) {
+		if ( block && isTemplatePart( block ) ) {
 			const templateParts =
 				select( coreStore ).getEntityRecords(
 					'postType',

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -9,7 +9,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { MenuItem } from '@wordpress/components';
 import { isTemplatePart } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { store as editSiteStore } from '../../store';
 
 export default function EditTemplatePartMenuButton() {
-	const selectedTemplatePartId = useSelect( ( select ) => {
+	const selectedTemplatePart = useSelect( ( select ) => {
 		const { getSelectedBlockClientId, getBlock } = select(
 			blockEditorStore
 		);
@@ -36,12 +36,12 @@ export default function EditTemplatePartMenuButton() {
 					part.theme === block.attributes.theme &&
 					part.slug === block.attributes.slug
 			);
-			return templatePart?.id;
+			return templatePart;
 		}
 	}, [] );
 	const { setTemplatePart } = useDispatch( editSiteStore );
 
-	if ( ! selectedTemplatePartId ) {
+	if ( ! selectedTemplatePart ) {
 		return null;
 	}
 
@@ -50,11 +50,14 @@ export default function EditTemplatePartMenuButton() {
 			{ ( { onClose } ) => (
 				<MenuItem
 					onClick={ () => {
-						setTemplatePart( selectedTemplatePartId );
+						setTemplatePart( selectedTemplatePart.id );
 						onClose();
 					} }
 				>
-					{ __( 'Edit template part' ) }
+					{
+						/* translators: %s: template part title */
+						sprintf( __( 'Edit "%s"' ), selectedTemplatePart.slug )
+					}
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -18,11 +18,7 @@ import { store as editSiteStore } from '../../store';
 
 export default function EditTemplatePartMenuButton() {
 	const selectedTemplatePart = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlock } = select(
-			blockEditorStore
-		);
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const block = getBlock( selectedBlockClientId );
+		const block = select( blockEditorStore ).getSelectedBlock();
 
 		if ( block && isTemplatePart( block ) ) {
 			const templateParts =


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to https://github.com/WordPress/gutenberg/issues/33926. Addresses the following.

> Isolated template part editing should be accessible from the ellipsis menu in the Template Part toolbar.

Design is in https://github.com/WordPress/gutenberg/issues/29148#issuecomment-789679709 's video.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate tt1-block theme
2. Go to Site Editor
3. Click on a template part (Header for instance)
4. Click on the ellipsis menu in the block toolbar
5. There should be a "Edit template part" button
6. Click on the button navigate to the isolated template part editor

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/132634244-9238a047-2d43-4122-a363-99dcb540bcab.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
