### PR TITLE
Prevent useConstrainedTabbing from stealing focus from elements with tabindex="-1"

### DIFF
--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -54,12 +54,10 @@ function useConstrainedTabbing() {
 				event.preventDefault();
 				/** @type {HTMLElement} */ ( firstTabbable ).focus();
 				/*
-				 * When pressing Tab and none of the tabbables has focus, the keydown
-				 * event happens on the wrapper div: move focus on the first tabbable.
+				 * When pressing Tab and the target element is the wrapper node,
+				 * move focus on the first tabbable.
 				 */
-			} else if (
-				! tabbables.includes( /** @type {Element} */ ( event.target ) )
-			) {
+			} else if ( node === event.target ) {
 				event.preventDefault();
 				/** @type {HTMLElement} */ ( firstTabbable ).focus();
 			}

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -46,11 +46,22 @@ function useConstrainedTabbing() {
 			}
 			const firstTabbable = tabbables[ 0 ];
 			const lastTabbable = tabbables[ tabbables.length - 1 ];
+			const focusables = focus.focusable.find( node );
+			const firstFocusable = focusables[ 0 ];
+			const lastFocusable = focusables[ focusables.length - 1 ];
 
-			if ( event.shiftKey && event.target === firstTabbable ) {
+			if (
+				event.shiftKey &&
+				( event.target === firstTabbable ||
+					event.target === firstFocusable )
+			) {
 				event.preventDefault();
 				/** @type {HTMLElement} */ ( lastTabbable ).focus();
-			} else if ( ! event.shiftKey && event.target === lastTabbable ) {
+			} else if (
+				! event.shiftKey &&
+				( event.target === lastTabbable ||
+					event.target === lastFocusable )
+			) {
 				event.preventDefault();
 				/** @type {HTMLElement} */ ( firstTabbable ).focus();
 				/*


### PR DESCRIPTION
Fixes #34681.

## Description

If an element with `tabindex="-1"` is focused and is rendered inside a component using `useConstrainedTabbing()`, pressing <kbd>Tab</kbd> will not focus the next focusable element, but instead it will go back to the first focusable item. This PR fixes that modifying the check so it no longer relies on the list of tabbable elements (which doesn't include elements with `tabindex="-1"`.

Notice that the solution implemented in commit c0dd4eef73c69f41efeabcc036cfba57e9d895e1 [was already proposed some time ago](https://github.com/WordPress/gutenberg/pull/10174/files), but it wasn't applied because it didn't work well with IE11. However, now that IE11 is no longer supported, it should be good to go.

e1be9f279992bd537438887d203b8d947f2e2d10 fixes the case when the element with `tabindex="-1"` is before or after all tabbable items.

## How has this been tested?

See _Testing instructions_ below. In addition, I tested several components that use `Modal` to verify there are no regressions.

## Testing instructions

One way to verify #34681 is fixed is to modify the `<Modal>` story:

https://github.com/WordPress/gutenberg/blob/9df736c678b2e8ef00c355e6cc9fb8092fe25484/packages/components/src/modal/stories/index.js#L31-L35

Like this:

```diff
<Modal { ...props } onRequestClose={ closeModal }>
+	<Button>Button 1</Button>
+	<div className="placeholder-div" tabIndex={ -1 } />
+	<Button>Button 2</Button>
+	<Button
+		onClick={ () => {
+			const placeholder = document.querySelector(
+				'.placeholder-div'
+			);
+			placeholder.focus();
+		} }
+	>
+		Button 3
+	</Button>
	<Button variant="secondary" onClick={ closeModal }>
		Close Modal
	</Button>
</Modal>
```

1. Run `npm run storybook`.
2. Go to the Modal story, open the modal and, navigating with the keyboard, focus and click `Button 3`.
3. You will notice focus has moved to `.placeholder-div`.
4. Verify pressing <kbd>Tab</kbd> focuses `Button 2` instead of the close button.
5. You can modify the story moving `<div className="placeholder-div" tabIndex={ -1 } />` before or after all buttons and verify focus never escapes the modal. (That's what's fixed in e1be9f279992bd537438887d203b8d947f2e2d10).

## Screenshots

Before:

https://user-images.githubusercontent.com/3616980/132648854-2fb25487-0c38-438e-b40b-a76f8a3ea255.mp4

After:

https://user-images.githubusercontent.com/3616980/132648860-786bbd64-7559-412a-95ff-1fb745a75607.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
