### PR TITLE
Chore: Update caniuse package to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29870,9 +29870,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001237",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-			"integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw=="
+			"version": "1.0.30001255",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+			"integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to #33344.

Executed `npx browserslist@latest --update-db` with the following result:

```diff
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 91
+ and_chr 92
- android 91
+ android 92
- chrome 90
- chrome 89
+ chrome 93
+ chrome 92
- edge 91
- edge 90
+ edge 93
+ edge 92
- firefox 89
- firefox 88
+ firefox 91
+ firefox 90
- ios_saf 14.5-14.6
+ ios_saf 14.5-14.7
- opera 76
- opera 75
+ opera 78
+ opera 77
```
