### PR TITLE
Chore: Move `react-native-url-polyfill` to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19050,8 +19050,7 @@
 			"version": "file:packages/url",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.21",
-				"react-native-url-polyfill": "^1.1.2"
+				"lodash": "^4.17.21"
 			}
 		},
 		"@wordpress/viewport": {

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
 		"react": "17.0.1",
 		"react-dom": "17.0.1",
 		"react-native": "0.64.0",
+		"react-native-url-polyfill": "1.1.2",
 		"react-test-renderer": "17.0.1",
 		"rimraf": "3.0.2",
 		"rtlcss": "2.6.2",

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Removed unused `react-native-url-polyfill` dependency ([#34687](https://github.com/WordPress/gutenberg/pull/34687)).
+
 ## 3.2.0 (2021-07-21)
 
 ## 3.1.0 (2021-05-20)

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -28,7 +28,9 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",
-		"lodash": "^4.17.21",
+		"lodash": "^4.17.21"
+	},
+	"devDependencies": {
 		"react-native-url-polyfill": "^1.1.2"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -30,9 +30,6 @@
 		"@babel/runtime": "^7.13.10",
 		"lodash": "^4.17.21"
 	},
-	"devDependencies": {
-		"react-native-url-polyfill": "^1.1.2"
-	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Replaces #32207.

> No longer necessary as a runtime dependency after `is-url.native.js` file was removed