### PR TITLE
Fix for link color in containers

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -38,7 +38,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	}
 	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
 
-	$style = "<style>.$class_name a{" . $link_color_declaration . " !important;}</style>\n";
+	$style = "<style>.$class_name a{" . $link_color_declaration . ";}</style>\n";
 
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
 	// Retrieve the opening tag of the first HTML element.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -59,7 +59,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		$first_element_offset = $html_element_matches[0][1];
 		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
-	return $content . $style;
+	return $style . $content;
 
 }
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -109,9 +109,7 @@ function compileElementsStyles( selector, elements = {} ) {
 				...map(
 					elementStyles,
 					( value, property ) =>
-						`\t${ kebabCase( property ) }: ${ value }${
-							element === 'link' ? '!important' : ''
-						};`
+						`\t${ kebabCase( property ) }: ${ value };`
 				),
 				'}',
 			].join( '\n' );

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -42,6 +42,10 @@ p.has-background {
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }
 
-p.has-text-color a {
+// Use :where to contain the specificity of this rule
+// so it's easily overrideable by any theme that targets
+// links using the a element.
+// For example, this is what global styles does.
+:where(p.has-text-color:not(.has-link-color)) a {
 	color: inherit;
 }

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -41,7 +41,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<p class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p><style>.wp-elements-1 a{color: var(--wp--preset--color--subtle-background) !important;}</style>' . "\n"
+			'<style>.wp-elements-1 a{color: var(--wp--preset--color--subtle-background);}</style>' . "\n" . '<p class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 
@@ -71,7 +71,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<p class="wp-elements-1 has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p><style>.wp-elements-1 a{color: red !important;}</style>' . "\n"
+			'<style>.wp-elements-1 a{color: red;}</style>' . "\n" . '<p class="wp-elements-1 has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 
@@ -100,7 +100,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p><style>.wp-elements-1 a{color: #fff000 !important;}</style>' . "\n"
+			'<style>.wp-elements-1 a{color: #fff000;}</style>' . "\n" . '<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33437

When we [landed support for elements](https://github.com/WordPress/gutenberg/pull/31524#discussion_r634252402) (the link color) we made it so the generated class was this:

`.wp-element-id a { color: color-value !important; }`

Notice the `!important`. This was to make sure user-provided styles weren't overridden by theme-provided styles. However, the selector is too far-reaching and it's affecting blocks that use the `a` but, arguably, should not be considered "links" (such as button and social links).

This PR removes the `!important` so the styles for the link color are:

`.wp-element-id a { color: color-value; }`

**If we go ahead with this change, themes that add additional CSS for link colors need to make sure that user-provided styles are respected in every situation.**

## Testing

<details>
<summary>Blocks at the top-level</summary>

I tested this with the TT1-blocks:

- A paragraph with a link without any user color provided.
- A paragraph with a link and user-provided text color. Make sure links are unaffected by the user-provided text color.
- A paragraph with a link and user-provided text & link colors. Make sure links are affected by the user-provided link color.

![tt1-blocks-top-level](https://user-images.githubusercontent.com/583546/132674665-4c540605-d2a1-4c57-8fa3-7f4ae1d623eb.png)

Note that the **TwentyTwentyOne theme needs to be updated** to not override user styles (see the last paragraph, which should show the links in red):

![twentytwentyone-top-level](https://user-images.githubusercontent.com/583546/132674748-9b26ce59-0afd-4860-9110-b104261a1f7e.png)
</details>

<details>
<summary>Blocks within containers</summary>

I tested this with the TwentyTwentyOne theme:

- Add a group that contains a paragraph with a link, the button block, and the social links. Do not assign any color to the group.
- Add a group that contains a paragraph with a link, the button block, and the social links. Set the text color for the group. Make sure links are unaffected by the text color.
- Add a group that contains a paragraph with a link, the button block, and the social links. Set the text and link color for the group. Make sure links are affected by the link color.

![twentytwentyone-group](https://user-images.githubusercontent.com/583546/132675137-8055363c-649d-42a2-a579-d3b6ab0cfa55.png)

Note that the **TT1-blocks theme needs to be updated** to make sure link color is not used in the button block:

![tt1-blocks-group](https://user-images.githubusercontent.com/583546/132675241-a5852e55-0881-4651-a221-eb6a4d21d4b8.png)
</details>

<details>
<summary>Nested blocks</summary>

See https://github.com/WordPress/gutenberg/pull/34689#issuecomment-916167610 for testing instructions.

</details>