### PR TITLE
[Experiment] Try running performance tests w/ Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.playwright.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
-		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",
+		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.playwright.performance.config.js",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"test-php:watch": "wp-env run composer run-script test:watch",
 		"test-unit": "wp-scripts test-unit-js --config test/unit/jest.config.js",

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -62,17 +62,17 @@ export async function toggleGlobalBlockInserter() {
  * Moves focus to the selected block.
  */
 async function focusSelectedBlock() {
-	const blockId = await page.evaluate( () =>
-		wp.data.select( 'core/block-editor' ).getSelectedBlockClientId()
-	);
-	const blockElement = await page.waitForSelector(
-		`[data-block="${ blockId }"]`
-	);
-	// Ideally there should be a UI way to do this. (Focus the selected block)
-	await page.evaluate( ( id ) => {
-		wp.data.dispatch( 'core/block-editor' ).selectBlock( id, 0 );
-	}, blockId );
-	await blockElement.waitForElementState( 'stable' );
+	// Ideally there shouuld be a UI way to do this. (Focus the selected block)
+	await page.evaluate( () => {
+		wp.data
+			.dispatch( 'core/block-editor' )
+			.selectBlock(
+				wp.data
+					.select( 'core/block-editor' )
+					.getSelectedBlockClientId(),
+				0
+			);
+	} );
 }
 
 /**

--- a/packages/e2e-tests/jest.playwright.performance.config.js
+++ b/packages/e2e-tests/jest.playwright.performance.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+	preset: 'jest-playwright-preset',
+	reporters: [ 'default', '<rootDir>/config/performance-reporter.js' ],
+	setupFiles: [ '<rootDir>/config/gutenberg-phase.js' ],
+	setupFilesAfterEnv: [
+		'<rootDir>/config/setup-playwright.js',
+		'@wordpress/jest-console',
+	],
+	testMatch: [ '**/performance/*.test.js' ],
+	testPathIgnorePatterns: [ '/node_modules/', '/wordpress/' ],
+	testRunner: 'jest-circus/runner',
+	testEnvironmentOptions: {
+		'jest-playwright': {
+			launchOptions: {
+				devtools: process.env.PLAYWRIGHT_DEVTOOLS === 'true',
+				headless: process.env.PLAYWRIGHT_HEADLESS !== 'false',
+				slowMo: parseInt( process.env.PLAYWRIGHT_SLOWMO, 10 ) || 0,
+				args: [ '--enable-blink-features=ComputedAccessibilityInfo' ],
+			},
+		},
+	},
+};

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -101,7 +101,7 @@ describe( 'Post Editor Performance', () => {
 		// Measuring typing performance
 		await insertBlock( 'Paragraph' );
 		let i = 20;
-		await page.context().tracing.start( {
+		await context.browser().startTracing( page, {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
@@ -114,7 +114,7 @@ describe( 'Post Editor Performance', () => {
 			await page.waitForTimeout( 2000 );
 			await page.keyboard.type( 'x' );
 		}
-		await page.context().tracing.stop();
+		await context.browser().stopTracing();
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [
 			keyDownEvents,
@@ -147,7 +147,7 @@ describe( 'Post Editor Performance', () => {
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
 		const paragraphs = await page.$$( '.wp-block' );
-		await page.context().tracing.start( {
+		await context.browser().startTracing( page, {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
@@ -159,7 +159,7 @@ describe( 'Post Editor Performance', () => {
 			await page.waitForTimeout( 1000 );
 			await paragraphs[ j ].click();
 		}
-		await page.context().tracing.stop();
+		await context.browser().stopTracing();
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [ focusEvents ] = getSelectionEventDurations( traceResults );
 		results.focus = focusEvents;
@@ -169,13 +169,13 @@ describe( 'Post Editor Performance', () => {
 		// Measure time to open inserter
 		await page.waitForSelector( '.edit-post-layout' );
 		for ( let j = 0; j < 10; j++ ) {
-			await page.context().tracing.start( {
+			await context.browser().startTracing( page, {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await openGlobalBlockInserter();
-			await page.context().tracing.stop();
+			await context.browser().stopTracing();
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [ mouseClickEvents ] = getClickEventDurations( traceResults );
 			for ( let k = 0; k < mouseClickEvents.length; k++ ) {
@@ -192,13 +192,13 @@ describe( 'Post Editor Performance', () => {
 			// Wait for the browser to be idle before starting the monitoring.
 			// eslint-disable-next-line no-restricted-syntax
 			await page.waitForTimeout( 500 );
-			await page.context().tracing.start( {
+			await context.browser().startTracing( page, {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await page.keyboard.type( 'p' );
-			await page.context().tracing.stop();
+			await context.browser().stopTracing();
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [
 				keyDownEvents,
@@ -234,14 +234,14 @@ describe( 'Post Editor Performance', () => {
 			// Wait for the browser to be idle before starting the monitoring.
 			// eslint-disable-next-line no-restricted-syntax
 			await page.waitForTimeout( 200 );
-			await page.context().tracing.start( {
+			await context.browser().startTracing( page, {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await page.hover( paragraphBlockItem );
 			await page.hover( headingBlockItem );
-			await page.context().tracing.stop();
+			await context.browser().stopTracing();
 
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [ mouseOverEvents, mouseOutEvents ] = getHoverEventDurations(

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -101,7 +101,7 @@ describe( 'Post Editor Performance', () => {
 		// Measuring typing performance
 		await insertBlock( 'Paragraph' );
 		let i = 20;
-		await page.tracing.start( {
+		await page.context().tracing.start( {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
@@ -114,7 +114,7 @@ describe( 'Post Editor Performance', () => {
 			await page.waitForTimeout( 2000 );
 			await page.keyboard.type( 'x' );
 		}
-		await page.tracing.stop();
+		await page.context().tracing.stop();
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [
 			keyDownEvents,
@@ -147,7 +147,7 @@ describe( 'Post Editor Performance', () => {
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
 		const paragraphs = await page.$$( '.wp-block' );
-		await page.tracing.start( {
+		await page.context().tracing.start( {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
@@ -159,7 +159,7 @@ describe( 'Post Editor Performance', () => {
 			await page.waitForTimeout( 1000 );
 			await paragraphs[ j ].click();
 		}
-		await page.tracing.stop();
+		await page.context().tracing.stop();
 		traceResults = JSON.parse( readFile( traceFile ) );
 		const [ focusEvents ] = getSelectionEventDurations( traceResults );
 		results.focus = focusEvents;
@@ -169,13 +169,13 @@ describe( 'Post Editor Performance', () => {
 		// Measure time to open inserter
 		await page.waitForSelector( '.edit-post-layout' );
 		for ( let j = 0; j < 10; j++ ) {
-			await page.tracing.start( {
+			await page.context().tracing.start( {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await openGlobalBlockInserter();
-			await page.tracing.stop();
+			await page.context().tracing.stop();
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [ mouseClickEvents ] = getClickEventDurations( traceResults );
 			for ( let k = 0; k < mouseClickEvents.length; k++ ) {
@@ -192,13 +192,13 @@ describe( 'Post Editor Performance', () => {
 			// Wait for the browser to be idle before starting the monitoring.
 			// eslint-disable-next-line no-restricted-syntax
 			await page.waitForTimeout( 500 );
-			await page.tracing.start( {
+			await page.context().tracing.start( {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await page.keyboard.type( 'p' );
-			await page.tracing.stop();
+			await page.context().tracing.stop();
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [
 				keyDownEvents,
@@ -234,14 +234,14 @@ describe( 'Post Editor Performance', () => {
 			// Wait for the browser to be idle before starting the monitoring.
 			// eslint-disable-next-line no-restricted-syntax
 			await page.waitForTimeout( 200 );
-			await page.tracing.start( {
+			await page.context().tracing.start( {
 				path: traceFile,
 				screenshots: false,
 				categories: [ 'devtools.timeline' ],
 			} );
 			await page.hover( paragraphBlockItem );
 			await page.hover( headingBlockItem );
-			await page.tracing.stop();
+			await page.context().tracing.stop();
 
 			traceResults = JSON.parse( readFile( traceFile ) );
 			const [ mouseOverEvents, mouseOutEvents ] = getHoverEventDurations(

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -98,7 +98,7 @@ describe( 'Site Editor Performance', () => {
 		await insertBlock( 'Paragraph' );
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
-		await page.tracing.start( {
+		await context.browser().startTracing( page, {
 			path: traceFile,
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
@@ -106,7 +106,7 @@ describe( 'Site Editor Performance', () => {
 		while ( i-- ) {
 			await page.keyboard.type( 'x' );
 		}
-		await page.tracing.stop();
+		await context.browser().stopTracing();
 		const traceResults = JSON.parse( readFile( traceFile ) );
 		const [
 			keyDownEvents,

--- a/packages/eslint-plugin/configs/test-e2e.js
+++ b/packages/eslint-plugin/configs/test-e2e.js
@@ -6,6 +6,7 @@ module.exports = {
 	globals: {
 		browser: 'readonly',
 		page: 'readonly',
+		context: 'readonly',
 		wp: 'readonly',
 	},
 };


### PR DESCRIPTION
Base PR: https://github.com/WordPress/gutenberg/pull/34089

Following up on [concerns about performance metrics](https://wordpress.slack.com/archives/C02QB2JS7/p1630494285149300), I've migrated (all) the performance tests to Playwright and compared them to ones ran with Puppeteer. It looks like Playwright is showing just a tad better numbers in terms of speed and stability, but the important part is that those metrics do not differ significantly, I guess? Pinging @youknowriad and @tellthemachines for some feedback on these numbers 🙏  

| Puppeteer (finished in 35m 12s, [source](https://github.com/WordPress/gutenberg/pull/34697/checks?check_run_id=3556853305)) | Playwright (finished in 33m 2s, [source](https://github.com/WordPress/gutenberg/runs/3557280865?check_suite_focus=true)) |
| ------------- | ------------- |
| <img width="590" alt="Screenshot 2021-09-09 at 17 00 09" src="https://user-images.githubusercontent.com/1451471/132711006-70d3fb98-d96c-49d1-b83c-766700ddb411.png"> | <img width="584" alt="Screenshot 2021-09-09 at 16 59 40" src="https://user-images.githubusercontent.com/1451471/132711000-b08d754c-6a19-4c71-a650-e37057e8f61c.png"> |

You can run migrated performance tests locally by checking out this branch and running `npm run test-performance`.