### PR TITLE
Remove `.has-link-color` class upon clearing the link color

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -335,10 +335,13 @@ export function ColorEdit( props ) {
 		const newLinkColorValue = colorObject?.slug
 			? `var:preset|color|${ colorObject.slug }`
 			: value;
-		const newStyle = immutableSet(
-			style,
-			[ 'elements', 'link', 'color', 'text' ],
-			newLinkColorValue
+
+		const newStyle = cleanEmptyObject(
+			immutableSet(
+				style,
+				[ 'elements', 'link', 'color', 'text' ],
+				newLinkColorValue
+			)
 		);
 		props.setAttributes( { style: newStyle } );
 	};


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/31524

While looking into https://github.com/WordPress/gutenberg/pull/34689 I've realized that the `.has-link-color` class was not removed upon clearing the link color.

The reason for that was that the `style.elements.link.color` attribute was never cleared. This PR clears the link color when it's empty, and the class will be removed too.

## Test

Make sure the class is added:

- Add a paragraph with a link.
- Set a link color. Save/publish.
- Verify the paragraph has the `.has-link-color` class.

Make sure the class is removed:

- Clear the link color. Save/publish.
- Verify the paragraph doesn't have the `.has-link-color` class anymore.

Random tests can include setting & clearing other colors, etc.
