### PR TITLE
Cache global stylesheet keyed by theme

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -24,11 +24,12 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		! is_admin()
 	);
 
+	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 	if ( $can_use_cached ) {
 		// Check if we have the styles already cached.
 		// It's cached by theme to make sure that theme switching
 		// is inmediately reflected.
-		$cached = get_transient( 'gutenberg_global_styles_' . get_stylesheet() );
+		$cached = get_transient( $transient_name );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -39,7 +40,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 	if ( $can_use_cached ) {
 		// Cache for a minute.
 		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-		set_transient( 'gutenberg_global_styles', $stylesheet, MINUTE_IN_SECONDS );
+		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
 	}
 
 	return $stylesheet;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -26,7 +26,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 
 	if ( $can_use_cached ) {
 		// Check if we have the styles already cached.
-		$cached = get_transient( 'gutenberg_global_styles' );
+		// It's cached by theme to make sure that theme switching
+		// is inmediately reflected.
+		$cached = get_transient( 'gutenberg_global_styles_' . get_stylesheet() );
 		if ( $cached ) {
 			return $cached;
 		}


### PR DESCRIPTION
We want to make sure that theme switching immediately clears the cache.

[Props](https://profiles.wordpress.org/dd32/) to @dd32 

## How to test

- Use an environment where `WP_DEBUG` and `SCRIPT_DEBUG` is `false`.
- Use a theme with the `theme.json` file. For example, the empty theme.
- Load the front-end. Check the styles of the `global-styles-inline-css` embedded stylesheet.
- Switch to a different theme. For example, tt1-blocks.
- Load the front-end. Check the styles of the `global-styles-inline-css` embedded stylesheet.

The expected result is that switching the theme immediately loads the new styles. The `global-styles-inline-css` should be different for both themes.
