### PR TITLE
Show "none" as an alignment option and use contextual text to clarify settings

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/style.scss
+++ b/packages/block-editor/src/components/block-alignment-control/style.scss
@@ -1,0 +1,5 @@
+.block-editor-block-alignment-control__menu-group {
+	.components-menu-item__info {
+		margin-top: 0;
+	}
+}

--- a/packages/block-editor/src/components/block-alignment-control/style.scss
+++ b/packages/block-editor/src/components/block-alignment-control/style.scss
@@ -3,3 +3,6 @@
 		margin-top: 0;
 	}
 }
+.block-editor-block-alignment-control__help {
+	padding: $grid-unit-10;
+}

--- a/packages/block-editor/src/components/block-alignment-control/style.scss
+++ b/packages/block-editor/src/components/block-alignment-control/style.scss
@@ -3,6 +3,3 @@
 		margin-top: 0;
 	}
 }
-.block-editor-block-alignment-control__help {
-	padding: $grid-unit-10;
-}

--- a/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
@@ -10,6 +10,20 @@ exports[`BlockAlignmentUI should match snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <Path
+            d="M5 15h14V9H5v6zm0 4.8h14v-1.5H5v1.5zM5 4.2v1.5h14V4.2H5z"
+          />
+        </SVG>,
+        "isActive": false,
+        "onClick": [Function],
+        "role": "menuitemradio",
+        "title": "None",
+      },
+      Object {
+        "icon": <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
             d="M4 9v6h14V9H4zm8-4.8H4v1.5h8V4.2zM4 19.8h8v-1.5H4v1.5z"
           />
         </SVG>,
@@ -24,7 +38,7 @@ exports[`BlockAlignmentUI should match snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <Path
-            d="M5 15h14V9H5v6zm0 4.8h14v-1.5H5v1.5zM5 4.2v1.5h14V4.2H5z"
+            d="M7 9v6h10V9H7zM5 19.8h14v-1.5H5v1.5zM5 4.3v1.5h14V4.3H5z"
           />
         </SVG>,
         "isActive": false,

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -108,9 +108,8 @@ function BlockAlignmentUI( {
 	// Always add the `none` option.
 	enabledControls.unshift( 'none' );
 
-	function applyOrUnset( align ) {
-		return () =>
-			onChange( [ value, 'none' ].includes( align ) ? undefined : align );
+	function onChangeAlignment( align ) {
+		onChange( [ value, 'none' ].includes( align ) ? undefined : align );
 	}
 
 	const activeAlignmentControl = BLOCK_ALIGNMENTS_CONTROLS[ value ];
@@ -134,12 +133,12 @@ function BlockAlignmentUI( {
 						...BLOCK_ALIGNMENTS_CONTROLS[ control ],
 						isActive: value === control,
 						role: isCollapsed ? 'menuitemradio' : undefined,
-						onClick: applyOrUnset( control ),
+						onClick: () => onChangeAlignment( control ),
 					};
 				} ),
 		  }
 		: {
-				children: () => {
+				children: ( { onClose } ) => {
 					return (
 						<>
 							<MenuGroup className="block-editor-block-alignment-control__menu-group">
@@ -165,7 +164,10 @@ function BlockAlignmentUI( {
 												}
 											) }
 											isSelected={ isSelected }
-											onClick={ applyOrUnset( control ) }
+											onClick={ () => {
+												onChangeAlignment( control );
+												onClose();
+											} }
 											role="menuitemradio"
 											info={ alignmentsInfo[ control ] }
 										>

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -54,7 +54,7 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 };
 
 const DEFAULT_CONTROL = 'none';
-const help = __( 'Your theme does not support wide alignments' );
+const help = __( 'The theme does not support wider alignments.' );
 
 const POPOVER_PROPS = {
 	isAlternate: true,

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -79,11 +79,23 @@ function BlockAlignmentUI( {
 			return;
 		}
 		const info = {};
-		if ( !! contentSize ) {
+		/**
+		 * Besides checking if `contentSize` and `wideSize` have a
+		 * value, we now show this information only if their values
+		 * are not a `css var`. This needs to change when parsing
+		 * css variables land.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/pull/34710#issuecomment-918000752
+		 */
+		if ( !! contentSize && ! contentSize?.startsWith( 'var' ) ) {
 			// translators: %s: container size (i.e. 600px etc)
 			info.none = sprintf( __( 'Max %s wide' ), contentSize );
 		}
-		if ( wideAlignmentsSupport && !! wideSize ) {
+		if (
+			wideAlignmentsSupport &&
+			!! wideSize &&
+			! wideSize?.startsWith( 'var' )
+		) {
 			// translators: %s: container size (i.e. 600px etc)
 			info.wide = sprintf( __( 'Max %s wide' ), wideSize );
 		}

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -1,8 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { ToolbarDropdownMenu, ToolbarGroup } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	ToolbarDropdownMenu,
+	ToolbarGroup,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 import {
 	positionCenter,
 	positionLeft,
@@ -10,13 +15,22 @@ import {
 	stretchFullWidth,
 	stretchWide,
 } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import useAvailableAlignments from './use-available-alignments';
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
+	none: {
+		icon: positionCenter,
+		title: __( 'None' ),
+	},
 	left: {
 		icon: positionLeft,
 		title: __( 'Align left' ),
@@ -39,7 +53,8 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 	},
 };
 
-const DEFAULT_CONTROL = 'center';
+const DEFAULT_CONTROL = 'none';
+const help = __( 'Your theme does not support wide alignments' );
 
 const POPOVER_PROPS = {
 	isAlternate: true,
@@ -52,13 +67,37 @@ function BlockAlignmentUI( {
 	isToolbar,
 	isCollapsed = true,
 } ) {
-	const enabledControls = useAvailableAlignments( controls );
-	if ( enabledControls.length === 0 ) {
+	const {
+		enabledControls,
+		layout: { contentSize, wideSize } = {},
+		wideAlignmentsSupport,
+	} = useAvailableAlignments( controls );
+	const hasEnabledControls = !! enabledControls.length;
+	const alignmentsInfo = useMemo( () => {
+		if ( ! hasEnabledControls ) {
+			return;
+		}
+		const info = {};
+		if ( !! contentSize ) {
+			// translators: %s: container size (i.e. 600px etc)
+			info.none = sprintf( __( 'Max %s wide' ), contentSize );
+		}
+		if ( wideAlignmentsSupport && !! wideSize ) {
+			// translators: %s: container size (i.e. 600px etc)
+			info.wide = sprintf( __( 'Max %s wide' ), wideSize );
+		}
+		return info;
+	}, [ hasEnabledControls, contentSize, wideSize, wideAlignmentsSupport ] );
+
+	if ( ! hasEnabledControls ) {
 		return null;
 	}
+	// Always add the `none` option.
+	enabledControls.unshift( 'none' );
 
 	function applyOrUnset( align ) {
-		return () => onChange( value === align ? undefined : align );
+		return () =>
+			onChange( [ value, 'none' ].includes( align ) ? undefined : align );
 	}
 
 	const activeAlignmentControl = BLOCK_ALIGNMENTS_CONTROLS[ value ];
@@ -66,29 +105,69 @@ function BlockAlignmentUI( {
 		BLOCK_ALIGNMENTS_CONTROLS[ DEFAULT_CONTROL ];
 
 	const UIComponent = isToolbar ? ToolbarGroup : ToolbarDropdownMenu;
-	const extraProps = isToolbar ? { isCollapsed } : {};
+	const commonProps = {
+		popoverProps: POPOVER_PROPS,
+		icon: activeAlignmentControl
+			? activeAlignmentControl.icon
+			: defaultAlignmentControl.icon,
+		label: __( 'Align' ),
+		toggleProps: { describedBy: __( 'Change alignment' ) },
+	};
+	const extraProps = isToolbar
+		? {
+				isCollapsed,
+				controls: enabledControls.map( ( control ) => {
+					return {
+						...BLOCK_ALIGNMENTS_CONTROLS[ control ],
+						isActive: value === control,
+						role: isCollapsed ? 'menuitemradio' : undefined,
+						onClick: applyOrUnset( control ),
+					};
+				} ),
+		  }
+		: {
+				children: () => {
+					return (
+						<>
+							<MenuGroup className="block-editor-block-alignment-control__menu-group">
+								{ enabledControls.map( ( control ) => {
+									const {
+										icon,
+										title,
+									} = BLOCK_ALIGNMENTS_CONTROLS[ control ];
+									// check when `undefined` to select `none`..
+									const isSelected =
+										control === value ||
+										( ! value && control === 'none' );
 
-	return (
-		<UIComponent
-			popoverProps={ POPOVER_PROPS }
-			icon={
-				activeAlignmentControl
-					? activeAlignmentControl.icon
-					: defaultAlignmentControl.icon
-			}
-			label={ __( 'Align' ) }
-			toggleProps={ { describedBy: __( 'Change alignment' ) } }
-			controls={ enabledControls.map( ( control ) => {
-				return {
-					...BLOCK_ALIGNMENTS_CONTROLS[ control ],
-					isActive: value === control,
-					role: isCollapsed ? 'menuitemradio' : undefined,
-					onClick: applyOrUnset( control ),
-				};
-			} ) }
-			{ ...extraProps }
-		/>
-	);
+									return (
+										<MenuItem
+											key={ control }
+											icon={ icon }
+											iconPosition="left"
+											className={ classNames(
+												'components-dropdown-menu__menu-item',
+												{
+													'is-active': isSelected,
+												}
+											) }
+											isSelected={ isSelected }
+											onClick={ applyOrUnset( control ) }
+											role="menuitemradio"
+											info={ alignmentsInfo[ control ] }
+										>
+											{ title }
+										</MenuItem>
+									);
+								} ) }
+							</MenuGroup>
+							{ ! wideAlignmentsSupport && <div>{ help }</div> }
+						</>
+					);
+				},
+		  };
+
+	return <UIComponent { ...commonProps } { ...extraProps } />;
 }
 
 export default BlockAlignmentUI;

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -9,6 +9,7 @@ import {
 	MenuItem,
 } from '@wordpress/components';
 import {
+	alignNone,
 	positionCenter,
 	positionLeft,
 	positionRight,
@@ -28,7 +29,7 @@ import classNames from 'classnames';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	none: {
-		icon: positionCenter,
+		icon: alignNone,
 		title: __( 'None' ),
 	},
 	left: {
@@ -135,7 +136,7 @@ function BlockAlignmentUI( {
 										icon,
 										title,
 									} = BLOCK_ALIGNMENTS_CONTROLS[ control ];
-									// check when `undefined` to select `none`..
+									// If no value is provided, mark as selected the `none` option.
 									const isSelected =
 										control === value ||
 										( ! value && control === 'none' );

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -27,7 +27,6 @@ import {
  */
 import useAvailableAlignments from './use-available-alignments';
 
-const WIDE_CONTROLS = [ 'wide', 'full' ];
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	none: {
 		icon: alignNone,
@@ -56,7 +55,6 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 };
 
 const DEFAULT_CONTROL = 'none';
-const help = __( 'Wider alignments are not available.' );
 
 const POPOVER_PROPS = {
 	isAlternate: true,
@@ -74,13 +72,6 @@ function BlockAlignmentUI( {
 
 	if ( ! hasEnabledControls ) {
 		return null;
-	}
-	const wideAlignmentsSupport = enabledControls.some( ( { name } ) =>
-		WIDE_CONTROLS.includes( name )
-	);
-	// Always add the `none` option if not exists.
-	if ( ! enabledControls.some( ( { name } ) => name === 'none' ) ) {
-		enabledControls.unshift( { name: 'none' } );
 	}
 
 	function onChangeAlignment( align ) {
@@ -159,11 +150,6 @@ function BlockAlignmentUI( {
 									}
 								) }
 							</MenuGroup>
-							{ ! wideAlignmentsSupport && (
-								<div className="block-editor-block-alignment-control__help">
-									{ help }
-								</div>
-							) }
 						</>
 					);
 				},

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -55,7 +55,7 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 };
 
 const DEFAULT_CONTROL = 'none';
-const help = __( 'The theme does not support wider alignments.' );
+const help = __( 'Wider alignments are not available.' );
 
 const POPOVER_PROPS = {
 	isAlternate: true,
@@ -176,7 +176,11 @@ function BlockAlignmentUI( {
 									);
 								} ) }
 							</MenuGroup>
-							{ ! wideAlignmentsSupport && <div>{ help }</div> }
+							{ ! wideAlignmentsSupport && (
+								<div className="block-editor-block-alignment-control__help">
+									{ help }
+								</div>
+							) }
 						</>
 					);
 				},

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -151,7 +151,6 @@ function BlockAlignmentUI( {
 									const isSelected =
 										control === value ||
 										( ! value && control === 'none' );
-
 									return (
 										<MenuItem
 											key={ control }
@@ -169,7 +168,7 @@ function BlockAlignmentUI( {
 												onClose();
 											} }
 											role="menuitemradio"
-											info={ alignmentsInfo[ control ] }
+											info={ alignmentsInfo?.[ control ] }
 										>
 											{ title }
 										</MenuItem>

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -30,14 +30,18 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	const layoutAlignments = layoutType.getAlignments( layout );
 
 	if ( themeSupportsLayout ) {
-		return layoutAlignments.filter( ( control ) =>
-			controls.includes( control )
-		);
+		return {
+			enabledControls: layoutAlignments.filter( ( control ) =>
+				controls.includes( control )
+			),
+			layout,
+			wideAlignmentsSupport: true,
+		};
 	}
 
 	// Starting here, it's the fallback for themes not supporting the layout config.
 	if ( layoutType.name !== 'default' ) {
-		return [];
+		return { enabledControls: [] };
 	}
 	const { alignments: availableAlignments = DEFAULT_CONTROLS } = layout;
 	const enabledControls = controls.filter(
@@ -48,5 +52,10 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 			availableAlignments.includes( control )
 	);
 
-	return enabledControls;
+	return {
+		enabledControls,
+		layout,
+		// TODO check if this is the check we need to show the `doesn't support wide alignments` text.
+		wideAlignmentsSupport: layout.alignments || wideControlsEnabled,
+	};
 }

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -30,31 +30,26 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	const layoutAlignments = layoutType.getAlignments( layout );
 
 	if ( themeSupportsLayout ) {
-		return {
-			enabledControls: layoutAlignments.filter( ( control ) =>
-				controls.includes( control )
-			),
-			layout,
-			wideAlignmentsSupport: true,
-		};
+		return layoutAlignments.filter(
+			( { name: alignmentName } ) =>
+				alignmentName === 'none' || controls.includes( alignmentName )
+		);
 	}
 
 	// Starting here, it's the fallback for themes not supporting the layout config.
 	if ( layoutType.name !== 'default' ) {
-		return { enabledControls: [] };
+		return [];
 	}
 	const { alignments: availableAlignments = DEFAULT_CONTROLS } = layout;
-	const enabledControls = controls.filter(
-		( control ) =>
-			( layout.alignments || // Ignore the global wideAlignment check if the layout explicitely defines alignments.
-				wideControlsEnabled ||
-				! WIDE_CONTROLS.includes( control ) ) &&
-			availableAlignments.includes( control )
-	);
+	const enabledControls = controls
+		.filter(
+			( control ) =>
+				( layout.alignments || // Ignore the global wideAlignment check if the layout explicitely defines alignments.
+					wideControlsEnabled ||
+					! WIDE_CONTROLS.includes( control ) ) &&
+				availableAlignments.includes( control )
+		)
+		.map( ( enabledControl ) => ( { name: enabledControl } ) );
 
-	return {
-		enabledControls,
-		layout,
-		wideAlignmentsSupport: layout.alignments || wideControlsEnabled,
-	};
+	return enabledControls;
 }

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -55,7 +55,6 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	return {
 		enabledControls,
 		layout,
-		// TODO check if this is the check we need to show the `doesn't support wide alignments` text.
 		wideAlignmentsSupport: layout.alignments || wideControlsEnabled,
 	};
 }

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -10,10 +10,14 @@ import { useLayout } from '../block-list/layout';
 import { store as blockEditorStore } from '../../store';
 import { getLayoutType } from '../../layouts';
 
-const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full' ];
+const DEFAULT_CONTROLS = [ 'none', 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
 export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
+	// Always add the `none` option if not exists.
+	if ( ! controls.includes( 'none' ) ) {
+		controls.unshift( 'none' );
+	}
 	const { wideControlsEnabled = false, themeSupportsLayout } = useSelect(
 		( select ) => {
 			const { getSettings } = select( blockEditorStore );
@@ -30,9 +34,8 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	const layoutAlignments = layoutType.getAlignments( layout );
 
 	if ( themeSupportsLayout ) {
-		return layoutAlignments.filter(
-			( { name: alignmentName } ) =>
-				alignmentName === 'none' || controls.includes( alignmentName )
+		return layoutAlignments.filter( ( { name: alignmentName } ) =>
+			controls.includes( alignmentName )
 		);
 	}
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -173,7 +173,7 @@ export const withDataAlign = createHigherOrderComponent(
 			getBlockSupport( name, 'align' ),
 			hasBlockSupport( name, 'alignWide', true )
 		);
-		const validAlignments = useAvailableAlignments(
+		const { enabledControls: validAlignments } = useAvailableAlignments(
 			blockAllowedAlignments
 		);
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -173,7 +173,7 @@ export const withDataAlign = createHigherOrderComponent(
 			getBlockSupport( name, 'align' ),
 			hasBlockSupport( name, 'alignWide', true )
 		);
-		const { enabledControls: validAlignments } = useAvailableAlignments(
+		const validAlignments = useAvailableAlignments(
 			blockAllowedAlignments
 		);
 
@@ -184,7 +184,9 @@ export const withDataAlign = createHigherOrderComponent(
 		}
 
 		let wrapperProps = props.wrapperProps;
-		if ( validAlignments.includes( align ) ) {
+		if (
+			validAlignments.some( ( alignment ) => alignment.name === align )
+		) {
 			wrapperProps = { ...wrapperProps, 'data-align': align };
 		}
 

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -206,11 +206,12 @@ export default {
 function getAlignmentsInfo( layout ) {
 	const { contentSize, wideSize } = layout;
 	const alignmentInfo = {};
-	if ( contentSize && ! contentSize?.startsWith( 'var' ) ) {
+	const sizeRegex = /^(?!0)\d+(px|em|rem|vw|vh|%)?$/i;
+	if ( sizeRegex.test( contentSize ) ) {
 		// translators: %s: container size (i.e. 600px etc)
 		alignmentInfo.none = sprintf( __( 'Max %s wide' ), contentSize );
 	}
-	if ( wideSize && ! wideSize?.startsWith( 'var' ) ) {
+	if ( sizeRegex.test( wideSize ) ) {
 		// translators: %s: container size (i.e. 600px etc)
 		alignmentInfo.wide = sprintf( __( 'Max %s wide' ), wideSize );
 	}

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -157,9 +157,14 @@ export default {
 		return 'vertical';
 	},
 	getAlignments( layout ) {
+		const alignmentInfo = getAlignmentsInfo( layout );
 		if ( layout.alignments !== undefined ) {
+			if ( ! layout.alignments.includes( 'none' ) ) {
+				layout.alignments.unshift( 'none' );
+			}
 			return layout.alignments.map( ( alignment ) => ( {
 				name: alignment,
+				info: alignmentInfo[ alignment ],
 			} ) );
 		}
 		const { contentSize, wideSize } = layout;
@@ -174,32 +179,40 @@ export default {
 			alignments.unshift( { name: 'full' } );
 		}
 
-		/**
-		 * Besides checking if `contentSize` and `wideSize` have a
-		 * value, we now show this information only if their values
-		 * are not a `css var`. This needs to change when parsing
-		 * css variables land.
-		 *
-		 * @see https://github.com/WordPress/gutenberg/pull/34710#issuecomment-918000752
-		 */
 		if ( wideSize ) {
-			const wideAlignment = { name: 'wide' };
-			if ( ! wideSize?.startsWith( 'var' ) ) {
-				// translators: %s: container size (i.e. 600px etc)
-				wideAlignment.info = sprintf( __( 'Max %s wide' ), wideSize );
-			}
-			alignments.unshift( wideAlignment );
+			alignments.unshift( { name: 'wide', info: alignmentInfo.wide } );
 		}
 
-		// Add `none` alignment with info text.
-		if ( contentSize && ! contentSize?.startsWith( 'var' ) ) {
-			alignments.unshift( {
-				name: 'none',
-				// translators: %s: container size (i.e. 600px etc)
-				info: sprintf( __( 'Max %s wide' ), contentSize ),
-			} );
-		}
+		alignments.unshift( { name: 'none', info: alignmentInfo.none } );
 
 		return alignments;
 	},
 };
+
+/**
+ * Helper method to assign contextual info to clarify
+ * alignment settings.
+ *
+ * Besides checking if `contentSize` and `wideSize` have a
+ * value, we now show this information only if their values
+ * are not a `css var`. This needs to change when parsing
+ * css variables land.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/34710#issuecomment-918000752
+ *
+ * @param {Object} layout The layout object.
+ * @return {Object} An object with contextual info per alignment.
+ */
+function getAlignmentsInfo( layout ) {
+	const { contentSize, wideSize } = layout;
+	const alignmentInfo = {};
+	if ( contentSize && ! contentSize?.startsWith( 'var' ) ) {
+		// translators: %s: container size (i.e. 600px etc)
+		alignmentInfo.none = sprintf( __( 'Max %s wide' ), contentSize );
+	}
+	if ( wideSize && ! wideSize?.startsWith( 'var' ) ) {
+		// translators: %s: container size (i.e. 600px etc)
+		alignmentInfo.wide = sprintf( __( 'Max %s wide' ), wideSize );
+	}
+	return alignmentInfo;
+}

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -6,7 +6,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 
 /**
@@ -158,17 +158,46 @@ export default {
 	},
 	getAlignments( layout ) {
 		if ( layout.alignments !== undefined ) {
-			return layout.alignments;
+			return layout.alignments.map( ( alignment ) => ( {
+				name: alignment,
+			} ) );
+		}
+		const { contentSize, wideSize } = layout;
+
+		const alignments = [
+			{ name: 'left' },
+			{ name: 'center' },
+			{ name: 'right' },
+		];
+
+		if ( contentSize ) {
+			alignments.unshift( { name: 'full' } );
 		}
 
-		const alignments = [ 'left', 'center', 'right' ];
-
-		if ( layout.contentSize ) {
-			alignments.unshift( 'full' );
+		/**
+		 * Besides checking if `contentSize` and `wideSize` have a
+		 * value, we now show this information only if their values
+		 * are not a `css var`. This needs to change when parsing
+		 * css variables land.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/pull/34710#issuecomment-918000752
+		 */
+		if ( wideSize ) {
+			const wideAlignment = { name: 'wide' };
+			if ( ! wideSize?.startsWith( 'var' ) ) {
+				// translators: %s: container size (i.e. 600px etc)
+				wideAlignment.info = sprintf( __( 'Max %s wide' ), wideSize );
+			}
+			alignments.unshift( wideAlignment );
 		}
 
-		if ( layout.wideSize ) {
-			alignments.unshift( 'wide' );
+		// Add `none` alignment with info text.
+		if ( contentSize && ! contentSize?.startsWith( 'var' ) ) {
+			alignments.unshift( {
+				name: 'none',
+				// translators: %s: container size (i.e. 600px etc)
+				info: sprintf( __( 'Max %s wide' ), contentSize ),
+			} );
 		}
 
 		return alignments;

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -1,4 +1,5 @@
 @import "./autocompleters/style.scss";
+@import "./components/block-alignment-control/style.scss";
 @import "./components/block-alignment-matrix-control/style.scss";
 @import "./components/block-icon/style.scss";
 @import "./components/block-inspector/style.scss";

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -50,6 +50,14 @@ Refer to documentation for [`label`](#label).
 
 Refer to documentation for [Button's `icon` prop](/packages/components/src/icon-button/README.md#icon).
 
+### `iconPosition`
+
+-   Type: `string`
+-   Required: No
+-   Default: `'right'`
+
+Determines where to display the provided `icon`.
+
 ### `isSelected`
 
 -   Type: `boolean`

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -59,7 +59,7 @@ export function MenuItem( props, ref ) {
 					: undefined
 			}
 			role={ role }
-			icon={ iconPosition === 'left' && icon }
+			icon={ iconPosition === 'left' ? icon : undefined }
 			className={ className }
 			{ ...buttonProps }
 		>

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -23,6 +23,7 @@ export function MenuItem( props, ref ) {
 		info,
 		className,
 		icon,
+		iconPosition = 'right',
 		shortcut,
 		isSelected,
 		role = 'menuitem',
@@ -42,7 +43,9 @@ export function MenuItem( props, ref ) {
 
 	if ( icon && ! isString( icon ) ) {
 		icon = cloneElement( icon, {
-			className: 'components-menu-items__item-icon',
+			className: classnames( 'components-menu-items__item-icon', {
+				'has-icon-right': iconPosition === 'right',
+			} ),
 		} );
 	}
 
@@ -56,6 +59,7 @@ export function MenuItem( props, ref ) {
 					: undefined
 			}
 			role={ role }
+			icon={ iconPosition === 'left' && icon }
 			className={ className }
 			{ ...buttonProps }
 		>
@@ -64,7 +68,7 @@ export function MenuItem( props, ref ) {
 				className="components-menu-item__shortcut"
 				shortcut={ shortcut }
 			/>
-			{ icon && <Icon icon={ icon } /> }
+			{ icon && iconPosition === 'right' && <Icon icon={ icon } /> }
 		</Button>
 	);
 }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -12,13 +12,15 @@
 	}
 
 	.components-menu-items__item-icon {
-		margin-right: -2px; // This optically balances the icon.
-		margin-left: $grid-unit-30;
 		display: inline-block;
 		flex: 0 0 auto;
+		&.has-icon-right {
+			margin-right: -2px; // This optically balances the icon.
+			margin-left: $grid-unit-30;
+		}
 	}
 
-	.components-menu-item__shortcut + .components-menu-items__item-icon {
+	.components-menu-item__shortcut + .components-menu-items__item-icon.has-icon-right {
 		margin-left: $grid-unit-10;
 	}
 

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
   <Icon
     icon={
       <SVG
-        className="components-menu-items__item-icon"
+        className="components-menu-items__item-icon has-icon-right"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -79,7 +79,7 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
   <Icon
     icon={
       <SVG
-        className="components-menu-items__item-icon"
+        className="components-menu-items__item-icon has-icon-right"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -14,11 +14,123 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 const alignLabels = {
+	none: 'None',
 	left: 'Align left',
 	center: 'Align center',
 	right: 'Align right',
 	wide: 'Wide width',
 	full: 'Full width',
+};
+
+/**
+ * Helper function to get the `labels` of align control. It actually evaluates the
+ * basic label of the button without the `info` text node if exists.
+ *
+ * @param {Object}  options                               Options for the util function
+ * @param {boolean} [options.getActiveButtonLabels=false] Flag for returning the active buttons labels only.
+ * @return {string[]} The matched labels.
+ */
+const getAlignmentToolbarLabels = async ( {
+	getActiveButtonLabels = false,
+} = {} ) => {
+	const selector = `.components-dropdown-menu__menu button${
+		getActiveButtonLabels ? '.is-active' : ''
+	} .components-menu-item__item`;
+	return page.evaluate( ( _selector ) => {
+		return (
+			Array.from( document.querySelectorAll( _selector ) )
+				/**
+				 * We neede this for now because conditionally there could be two nodes
+				 * with the same class(). This should be removed when the following
+				 * issue is resolved.
+				 *
+				 * @see https://github.com/WordPress/gutenberg/issues/34838
+				 */
+				.filter( ( contentNode ) => ! contentNode.childElementCount )
+				.map( ( contentNode ) => {
+					return contentNode.innerText;
+				} )
+		);
+	}, selector );
+};
+
+const expectActiveButtonLabelToBe = async ( expected ) => {
+	await clickBlockToolbarButton( 'Align' );
+	const activeButtonLabels = await getAlignmentToolbarLabels( {
+		getActiveButtonLabels: true,
+	} );
+	expect( activeButtonLabels ).toHaveLength( 1 );
+	expect( activeButtonLabels[ 0 ] ).toEqual( expected );
+};
+
+const createShowsTheExpectedButtonsTest = ( blockName, buttonLabels ) => {
+	it( 'Shows the expected buttons on the alignment toolbar', async () => {
+		await insertBlock( blockName );
+		await clickBlockToolbarButton( 'Align' );
+		expect( await getAlignmentToolbarLabels() ).toEqual(
+			expect.arrayContaining( buttonLabels )
+		);
+	} );
+};
+
+const createAppliesNoneAlignmentByDefaultTest = ( blockName ) => {
+	it( 'applies none alignment by default', async () => {
+		await insertBlock( blockName );
+		await expectActiveButtonLabelToBe( alignLabels.none );
+	} );
+};
+
+const verifyMarkupIsValid = async ( htmlMarkup ) => {
+	await setPostContent( htmlMarkup );
+	const blocks = await getAllBlocks();
+	expect( blocks ).toHaveLength( 1 );
+	expect( blocks[ 0 ].isValid ).toBeTruthy();
+};
+
+const createCorrectlyAppliesAndRemovesAlignmentTest = (
+	blockName,
+	alignment
+) => {
+	it( 'Correctly applies the selected alignment and correctly removes the alignment', async () => {
+		const BUTTON_XPATH = `//button[contains(@class,'components-dropdown-menu__menu-item')]//span[contains(text(), '${ alignLabels[ alignment ] }')]`;
+
+		// set the specified alignment.
+		await insertBlock( blockName );
+		await clickBlockToolbarButton( 'Align' );
+		await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
+
+		// verify the button of the specified alignment is pressed.
+		await expectActiveButtonLabelToBe( alignLabels[ alignment ] );
+
+		let htmlMarkup = await getEditedPostContent();
+
+		// verify the markup of the selected alignment was generated.
+		expect( htmlMarkup ).toMatchSnapshot();
+
+		// verify the markup can be correctly parsed
+		await verifyMarkupIsValid( htmlMarkup );
+
+		await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+
+		// remove the alignment.
+		await clickBlockToolbarButton( 'Align' );
+		await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
+
+		// verify 'none' alignment button is in pressed state.
+		await expectActiveButtonLabelToBe( alignLabels.none );
+
+		// verify alignment markup was removed from the block.
+		htmlMarkup = await getEditedPostContent();
+		expect( htmlMarkup ).toMatchSnapshot();
+
+		// verify the markup when no alignment is set is valid
+		await verifyMarkupIsValid( htmlMarkup );
+
+		await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+
+		// verify alignment `none` button is in pressed state after parsing the block.
+		await expectActiveButtonLabelToBe( alignLabels.none );
+	} );
 };
 
 describe( 'Align Hook Works As Expected', () => {
@@ -33,102 +145,6 @@ describe( 'Align Hook Works As Expected', () => {
 	afterAll( async () => {
 		await deactivatePlugin( 'gutenberg-test-align-hook' );
 	} );
-
-	const getAlignmentToolbarLabels = async () => {
-		await clickBlockToolbarButton( 'Align' );
-		const buttonLabels = await page.evaluate( () => {
-			return Array.from(
-				document.querySelectorAll(
-					'.components-dropdown-menu__menu button'
-				)
-			).map( ( button ) => {
-				return button.innerText;
-			} );
-		} );
-		return buttonLabels;
-	};
-
-	const createShowsTheExpectedButtonsTest = ( blockName, buttonLabels ) => {
-		it( 'Shows the expected buttons on the alignment toolbar', async () => {
-			await insertBlock( blockName );
-			expect( await getAlignmentToolbarLabels() ).toEqual( buttonLabels );
-		} );
-	};
-
-	const createDoesNotApplyAlignmentByDefaultTest = ( blockName ) => {
-		it( 'Does not apply any alignment by default', async () => {
-			await insertBlock( blockName );
-			await clickBlockToolbarButton( 'Align' );
-			const pressedButtons = await page.$$(
-				'.components-dropdown-menu__menu button.is-active'
-			);
-			expect( pressedButtons ).toHaveLength( 0 );
-		} );
-	};
-
-	const verifyMarkupIsValid = async ( htmlMarkup ) => {
-		await setPostContent( htmlMarkup );
-		const blocks = await getAllBlocks();
-		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ].isValid ).toBeTruthy();
-	};
-
-	const createCorrectlyAppliesAndRemovesAlignmentTest = (
-		blockName,
-		alignment
-	) => {
-		it( 'Correctly applies the selected alignment and correctly removes the alignment', async () => {
-			const BUTTON_XPATH = `//button[contains(@class,'components-dropdown-menu__menu-item') and contains(text(), '${ alignLabels[ alignment ] }')]`;
-			const BUTTON_PRESSED_SELECTOR =
-				'.components-dropdown-menu__menu button.is-active';
-			// set the specified alignment.
-			await insertBlock( blockName );
-			await clickBlockToolbarButton( 'Align' );
-			await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
-
-			// verify the button of the specified alignment is pressed.
-			await clickBlockToolbarButton( 'Align' );
-			let pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 1 );
-
-			let htmlMarkup = await getEditedPostContent();
-
-			// verify the markup of the selected alignment was generated.
-			expect( htmlMarkup ).toMatchSnapshot();
-
-			// verify the markup can be correctly parsed
-			await verifyMarkupIsValid( htmlMarkup );
-
-			await selectBlockByClientId(
-				( await getAllBlocks() )[ 0 ].clientId
-			);
-
-			// remove the alignment.
-			await clickBlockToolbarButton( 'Align' );
-			await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
-
-			// verify no alignment button is in pressed state.
-			await clickBlockToolbarButton( 'Align' );
-			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 0 );
-
-			// verify alignment markup was removed from the block.
-			htmlMarkup = await getEditedPostContent();
-			expect( htmlMarkup ).toMatchSnapshot();
-
-			// verify the markup when no alignment is set is valid
-			await verifyMarkupIsValid( htmlMarkup );
-
-			await selectBlockByClientId(
-				( await getAllBlocks() )[ 0 ].clientId
-			);
-
-			// verify no alignment button is in pressed state after parsing the block.
-			await clickBlockToolbarButton( 'Align' );
-			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
-			expect( pressedButtons ).toHaveLength( 0 );
-		} );
-	};
 
 	describe( 'Block with no alignment set', () => {
 		const BLOCK_NAME = 'Test No Alignment Set';
@@ -151,15 +167,12 @@ describe( 'Align Hook Works As Expected', () => {
 	describe( 'Block with align true', () => {
 		const BLOCK_NAME = 'Test Align True';
 
-		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
-			alignLabels.left,
-			alignLabels.center,
-			alignLabels.right,
-			alignLabels.wide,
-			alignLabels.full,
-		] );
+		createShowsTheExpectedButtonsTest(
+			BLOCK_NAME,
+			Object.values( alignLabels )
+		);
 
-		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );
+		createAppliesNoneAlignmentByDefaultTest( BLOCK_NAME );
 
 		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'right' );
 	} );
@@ -168,11 +181,12 @@ describe( 'Align Hook Works As Expected', () => {
 		const BLOCK_NAME = 'Test Align Array';
 
 		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
+			alignLabels.none,
 			alignLabels.left,
 			alignLabels.center,
 		] );
 
-		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );
+		createAppliesNoneAlignmentByDefaultTest( BLOCK_NAME );
 
 		createCorrectlyAppliesAndRemovesAlignmentTest( BLOCK_NAME, 'center' );
 	} );
@@ -180,14 +194,11 @@ describe( 'Align Hook Works As Expected', () => {
 	describe( 'Block with default align', () => {
 		const BLOCK_NAME = 'Test Default Align';
 		const SELECTED_ALIGNMENT_CONTROL_SELECTOR =
-			'//div[contains(@class, "components-dropdown-menu__menu")]//button[contains(@class, "is-active")][text()="Align right"]';
-		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
-			alignLabels.left,
-			alignLabels.center,
-			alignLabels.right,
-			alignLabels.wide,
-			alignLabels.full,
-		] );
+			'//div[contains(@class, "components-dropdown-menu__menu")]//button[contains(@class, "is-active")]/span[text()="Align right"]';
+		createShowsTheExpectedButtonsTest(
+			BLOCK_NAME,
+			Object.values( alignLabels )
+		);
 
 		it( 'Applies the selected alignment by default', async () => {
 			await insertBlock( BLOCK_NAME );

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -163,7 +163,7 @@ describe( 'Block Grouping', () => {
 			await insertBlock( 'Image' );
 			await clickBlockToolbarButton( 'Align' );
 			const fullButton = await page.waitForXPath(
-				`//button[contains(@class,'components-dropdown-menu__menu-item') and contains(text(), 'Full width')]`
+				`//button[contains(@class,'components-dropdown-menu__menu-item')]//span[contains(text(), 'Full width')]`
 			);
 			await fullButton.evaluate( ( element ) =>
 				element.scrollIntoView()
@@ -174,7 +174,7 @@ describe( 'Block Grouping', () => {
 			await insertBlock( 'Image' );
 			await clickBlockToolbarButton( 'Align' );
 			const wideButton = await page.waitForXPath(
-				`//button[contains(@class,'components-dropdown-menu__menu-item') and contains(text(), 'Wide width')]`
+				`//button[contains(@class,'components-dropdown-menu__menu-item')]//span[contains(text(), 'Wide width')]`
 			);
 			await wideButton.evaluate( ( element ) =>
 				element.scrollIntoView()

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -9,7 +9,6 @@ import {
 	pressKeyWithModifier,
 	insertBlock,
 	clickBlockToolbarButton,
-	clickButton,
 } from '@wordpress/e2e-test-utils';
 
 const getActiveBlockName = async () =>
@@ -556,7 +555,10 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.type( '/image' );
 		await page.keyboard.press( 'Enter' );
 		await clickBlockToolbarButton( 'Align' );
-		await clickButton( 'Wide width' );
+		const wideButton = await page.waitForXPath(
+			`//button[contains(@class,'components-dropdown-menu__menu-item')]//span[contains(text(), 'Wide width')]`
+		);
+		await wideButton.click();
 
 		// Select the previous block.
 		await page.keyboard.press( 'ArrowUp' );

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -6,6 +6,7 @@ export { default as alignCenter } from './library/align-center';
 export { default as alignJustify } from './library/align-justify';
 export { default as alignJustifyAlt } from './library/align-justify-alt';
 export { default as alignLeft } from './library/align-left';
+export { default as alignNone } from './library/align-none';
 export { default as alignRight } from './library/align-right';
 export { default as archive } from './library/archive';
 export { default as archiveTitle } from './library/archive-title';

--- a/packages/icons/src/library/align-none.js
+++ b/packages/icons/src/library/align-none.js
@@ -3,10 +3,10 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const positionCenter = (
+const alignNone = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M7 9v6h10V9H7zM5 19.8h14v-1.5H5v1.5zM5 4.3v1.5h14V4.3H5z" />
+		<Path d="M5 15h14V9H5v6zm0 4.8h14v-1.5H5v1.5zM5 4.2v1.5h14V4.2H5z" />
 	</SVG>
 );
 
-export default positionCenter;
+export default alignNone;


### PR DESCRIPTION
## Description
Resolves: https://github.com/WordPress/gutenberg/issues/34597
Fixes: https://github.com/WordPress/gutenberg/issues/30782
<!-- Please describe what you have changed or added -->

This PR is for now a rough POC to update the design of the alignment dropdown to include "none" as an option (it's the same as unsetting). The center icon has been updated, and the previous icon for centering has been repurposed for indicating "None". There's help text for "None" and "Wide", to show the values for the content and wide area layout values.

<div align="center"><img width="444" alt="Group 259" src="https://user-images.githubusercontent.com/1204802/132249337-49089891-a9d2-44c8-bd1c-db923a8fb031.png"></div>

For themes that do not support wide or fullwide alignments we render some contextual text to clarify the missing buttons:

<div align="center"><img width="444" alt="Group 260" src="https://user-images.githubusercontent.com/1204802/132249552-d45aafa8-dc32-4b80-8e6f-985cbb98c7bf.png"></div>

-- the above description is from the issue

## Testing instructions
1. In a theme that supports `layout` (like `tt1-blocks`) insert a `Heading` in a post
2. Insert a `Group` and change the `layout`'s widths (`content` and `wide`)
3. Insert another `Heading` inside this `Group`
4. Check the `alignment control options` in both `Heading` blocks.

In general I will need help with testing to find out missing functionality/info, especially from folks experienced in themes.

## Tasks / Notes
- [ ] Decide on the text to show when `wide alignments` are not supported.
- [ ] Check how to calculate properly if `wide alignments` are supported
- [ ] Can we get `wide and content` widths from somewhere else besides `layout`?
- [x] Check if the align control when is a toolbar (`ToolbarGroup`) is affected somehow or needs changes
- [x] Update the `center` icon with the new one
- [ ] Check mobile
- [ ] Check whether to leave `useAvailableAlignments` intact and incorporate a new helper hook

## Notes
1. I updated the `align` tests also made sure that work as expected in `tt1 and tt1-blocks` as the button context changes. I didn't add to run on both themes though.. Should we run these for both themes? 🤔 
