### PR TITLE
Update: Custom gradient picker design.

### DIFF
--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -6,33 +6,25 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import BaseControl from '../base-control';
 import { FlexBlock, FlexItem } from '../flex';
-import NumberControl from '../number-control';
+import InputControl from '../input-control';
 import AngleCircle from './angle-circle';
 import { Root } from './styles/angle-picker-control-styles';
+import { space } from '../ui/utils/space';
+import { Text } from '../text';
+import { Spacer } from '../spacer';
 
 export default function AnglePickerControl( {
 	className,
-	hideLabelFromVision,
-	id: idProp,
 	label = __( 'Angle' ),
 	onChange,
 	value,
-	...props
 } ) {
-	const instanceId = useInstanceId(
-		AnglePickerControl,
-		'components-angle-picker-control__input'
-	);
-	const id = idProp || instanceId;
-
 	const handleOnNumberChange = ( unprocessedValue ) => {
 		const inputValue =
 			unprocessedValue !== '' ? parseInt( unprocessedValue, 10 ) : 0;
@@ -42,33 +34,40 @@ export default function AnglePickerControl( {
 	const classes = classnames( 'components-angle-picker-control', className );
 
 	return (
-		<BaseControl
-			className={ classes }
-			hideLabelFromVision={ hideLabelFromVision }
-			id={ id }
-			label={ label }
-			{ ...props }
-		>
-			<Root>
-				<FlexBlock>
-					<NumberControl
-						className="components-angle-picker-control__input-field"
-						id={ id }
-						max={ 360 }
-						min={ 0 }
-						onChange={ handleOnNumberChange }
-						step="1"
-						value={ value }
-					/>
-				</FlexBlock>
-				<FlexItem>
-					<AngleCircle
-						aria-hidden="true"
-						value={ value }
-						onChange={ onChange }
-					/>
-				</FlexItem>
-			</Root>
-		</BaseControl>
+		<Root className={ classes }>
+			<FlexBlock>
+				<InputControl
+					label={ label }
+					className="components-angle-picker-control__input-field"
+					max={ 360 }
+					min={ 0 }
+					onChange={ handleOnNumberChange }
+					step="1"
+					value={ value }
+					suffix={
+						<Spacer
+							as={ Text }
+							marginRight={ space( 3 ) }
+							color="blue"
+						>
+							°
+						</Spacer>
+					}
+				/>
+			</FlexBlock>
+			<FlexItem
+				style={ {
+					marginLeft: space( 4 ),
+					marginBottom: space( 1 ),
+					marginTop: 'auto',
+				} }
+			>
+				<AngleCircle
+					aria-hidden="true"
+					value={ value }
+					onChange={ onChange }
+				/>
+			</FlexItem>
+		</Root>
 	);
 }

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { FlexBlock, FlexItem } from '../flex';
-import InputControl from '../input-control';
+import NumberControl from '../input-control';
 import AngleCircle from './angle-circle';
 import { Root } from './styles/angle-picker-control-styles';
 import { space } from '../ui/utils/space';
@@ -36,7 +36,7 @@ export default function AnglePickerControl( {
 	return (
 		<Root className={ classes }>
 			<FlexBlock>
-				<InputControl
+				<NumberControl
 					label={ label }
 					className="components-angle-picker-control__input-field"
 					max={ 360 }
@@ -44,6 +44,7 @@ export default function AnglePickerControl( {
 					onChange={ handleOnNumberChange }
 					step="1"
 					value={ value }
+					hideHTMLArrows
 					suffix={
 						<Spacer
 							as={ Text }

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -8,16 +8,17 @@ import styled from '@emotion/styled';
  */
 import { Flex } from '../../flex';
 import { COLORS } from '../../utils';
+import { space } from '../../ui/utils/space';
 
-const CIRCLE_SIZE = 30;
+const CIRCLE_SIZE = 32;
 
 export const Root = styled( Flex )`
-	max-width: 200px;
+	margin-bottom: ${ space( 2 ) };
 `;
 
 export const CircleRoot = styled.div`
 	border-radius: 50%;
-	border: 1px solid ${ COLORS.ui.borderLight };
+	border: 1px solid ${ COLORS.ui.border };
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
@@ -33,17 +34,17 @@ export const CircleIndicatorWrapper = styled.div`
 `;
 
 export const CircleIndicator = styled.div`
-	background: ${ COLORS.ui.border };
+	background: #3858e9;
 	border-radius: 50%;
-	border: 3px solid ${ COLORS.ui.border };
+	border: 3px solid #3858e9;
 	bottom: 0;
 	box-sizing: border-box;
 	display: block;
-	height: 1px;
+	height: 0px;
 	left: 0;
 	margin: auto;
 	position: absolute;
 	right: 0;
 	top: -${ CIRCLE_SIZE / 2 }px;
-	width: 1px;
+	width: 0px;
 `;

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -9,8 +9,10 @@ import styled from '@emotion/styled';
 import { Flex } from '../../flex';
 import { COLORS } from '../../utils';
 import { space } from '../../ui/utils/space';
+import CONFIG from '../../utils/config-values';
 
 const CIRCLE_SIZE = 32;
+const INNER_CIRCLE_SIZE = 3;
 
 export const Root = styled( Flex )`
 	margin-bottom: ${ space( 2 ) };
@@ -18,7 +20,7 @@ export const Root = styled( Flex )`
 
 export const CircleRoot = styled.div`
 	border-radius: 50%;
-	border: 1px solid ${ COLORS.ui.border };
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
@@ -36,7 +38,7 @@ export const CircleIndicatorWrapper = styled.div`
 export const CircleIndicator = styled.div`
 	background: #3858e9;
 	border-radius: 50%;
-	border: 3px solid #3858e9;
+	border: ${ INNER_CIRCLE_SIZE }px solid #3858e9;
 	bottom: 0;
 	box-sizing: border-box;
 	display: block;

--- a/packages/components/src/custom-gradient-bar/constants.js
+++ b/packages/components/src/custom-gradient-bar/constants.js
@@ -3,8 +3,8 @@ export const COLOR_POPOVER_PROPS = {
 	position: 'top',
 };
 
-export const GRADIENT_MARKERS_WIDTH = 18;
-export const INSERT_POINT_WIDTH = 23;
+export const GRADIENT_MARKERS_WIDTH = 16;
+export const INSERT_POINT_WIDTH = 16;
 export const MINIMUM_ABSOLUTE_LEFT_POSITION = 5;
 export const MINIMUM_DISTANCE_BETWEEN_INSERTER_AND_POINT = 10;
 export const MINIMUM_DISTANCE_BETWEEN_POINTS = 0;

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -52,8 +52,8 @@ const GradientAnglePicker = ( { gradientAST, hasGradient, onChange } ) => {
 	};
 	return (
 		<AnglePickerControl
-			hideLabelFromVision
 			onChange={ onAngleChange }
+			labelPosition="top"
 			value={ hasGradient ? angle : '' }
 		/>
 	);
@@ -95,7 +95,7 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 		<SelectControl
 			className="components-custom-gradient-picker__type-picker"
 			label={ __( 'Type' ) }
-			labelPosition={ 'side' }
+			labelPosition="top"
 			onChange={ handleOnChange }
 			options={ GRADIENT_OPTIONS }
 			value={ hasGradient && type }

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -17,7 +17,7 @@ import { Flex } from '../flex';
 import SelectControl from '../select-control';
 import {
 	getGradientAstWithDefault,
-	getLinearGradientRepresentationOfARadial,
+	getLinearGradientRepresentation,
 	getGradientAstWithControlPoints,
 	getStopCssColor,
 } from './utils';
@@ -107,10 +107,8 @@ export default function CustomGradientPicker( { value, onChange } ) {
 	const gradientAST = getGradientAstWithDefault( value );
 	// On radial gradients the bar should display a linear gradient.
 	// On radial gradients the bar represents a slice of the gradient from the center until the outside.
-	const background =
-		gradientAST.type === 'radial-gradient'
-			? getLinearGradientRepresentationOfARadial( gradientAST )
-			: gradientAST.value;
+	// On liner gradients the bar represents the color stops from left to right independently of the angle.
+	const background = getLinearGradientRepresentation( gradientAST );
 	const hasGradient = gradientAST.value !== DEFAULT_GRADIENT;
 	// Control points color option may be hex from presets, custom colors will be rgb.
 	// The position should always be a percentage.

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -5,6 +5,7 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 }
 
 .components-custom-gradient-picker__gradient-bar {
+	border-radius: $radius-block-ui;
 	margin-top: $grid-unit-15;
 	width: 100%;
 	height: $grid-unit-60;
@@ -34,18 +35,25 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 	}
 
 	.components-custom-gradient-picker__control-point-button {
-		border: 1.5px solid $white;
-		box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
 		border-radius: 50%;
 		height: $grid-unit-20;
 		width: $grid-unit-20;
 		padding: 0;
 		position: absolute;
 		top: $components-custom-gradient-picker__padding;
+
+		// Shadow and stroke.
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 2px 0 rgba($black, 0.25);
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+
 		&:focus,
 		&.is-active {
-			box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
-			outline: none;
+			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 2px 0 rgba($black, 0.25);
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 4px solid transparent;
 		}
 	}
 }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,4 +1,4 @@
-$components-custom-gradient-picker__padding: 6px; // 36px container, 24px handles inside, that leaves 12px padding, half of which is 6.
+$components-custom-gradient-picker__padding: 16px; // 48px container, 16px handles inside, that leaves 32px padding, half of which is 1å6.
 
 .components-custom-gradient-picker__gradient-bar:not(.has-gradient) {
 	opacity: 0.4;
@@ -7,13 +7,10 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 .components-custom-gradient-picker__gradient-bar {
 	margin-top: $grid-unit-15;
 	width: 100%;
-	height: $button-size;
-	border-radius: $button-size;
-	margin-bottom: $grid-unit-15;
+	height: $grid-unit-60;
+	margin-bottom: $grid-unit-20+$grid-unit-05;
 	/*rtl:ignore*/
-	padding-left: $components-custom-gradient-picker__padding;
-	/*rtl:ignore*/
-	padding-right: $button-size - $components-custom-gradient-picker__padding;
+	padding-right: $components-custom-gradient-picker__padding;
 
 	.components-custom-gradient-picker__markers-container {
 		position: relative;
@@ -24,9 +21,9 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 		background: $white;
 		padding: 2px;
 		top: $components-custom-gradient-picker__padding;
-		min-width: $button-size-small;
-		width: $button-size-small;
-		height: $button-size-small;
+		min-width: $grid-unit-20;
+		width: $grid-unit-20;
+		height: $grid-unit-20;
 		position: relative;
 		color: $gray-900;
 
@@ -37,20 +34,18 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 	}
 
 	.components-custom-gradient-picker__control-point-button {
-		border: 2px solid transparent;
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
+		border: 1.5px solid $white;
+		box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
 		border-radius: 50%;
-		height: $button-size-small;
-		width: $button-size-small;
+		height: $grid-unit-20;
+		width: $grid-unit-20;
 		padding: 0;
 		position: absolute;
 		top: $components-custom-gradient-picker__padding;
-
 		&:focus,
 		&.is-active {
-			box-shadow:
-				0 0 0 1px $white,
-				0 0 0 3px $gray-900;
+			box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
+			outline: none;
 		}
 	}
 }
@@ -100,5 +95,20 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 				border-radius: 2px;
 			}
 		}
+	}
+}
+
+// All these styles should be made generic and changed on the inputs for all components.
+.components-custom-gradient-picker {
+	.components-select-control__input,
+	.components-input-control__input {
+		height: 40px !important;
+	}
+	.components-input-control__label {
+		line-height: 1;
+		padding-bottom: $grid-unit-10 !important;
+	}
+	label {
+		text-transform: uppercase;
 	}
 }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,4 +1,4 @@
-$components-custom-gradient-picker__padding: 16px; // 48px container, 16px handles inside, that leaves 32px padding, half of which is 1å6.
+$components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 16px handles inside, that leaves 32px padding, half of which is 1å6.
 
 .components-custom-gradient-picker__gradient-bar:not(.has-gradient) {
 	opacity: 0.4;
@@ -15,6 +15,9 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 
 	.components-custom-gradient-picker__markers-container {
 		position: relative;
+		width: calc(100% - #{ $grid-unit-40 });
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	.components-custom-gradient-picker__insert-point {
@@ -43,17 +46,17 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 		top: $components-custom-gradient-picker__padding;
 
 		// Shadow and stroke.
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 2px 0 rgba($black, 0.25);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 $border-width-focus 0 rgba($black, 0.25);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 
 		&:focus,
 		&.is-active {
-			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 2px 0 rgba($black, 0.25);
+			box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) $white, 0 0 $border-width-focus 0 rgba($black, 0.25);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 4px solid transparent;
+			outline: $border-width-tab solid transparent;
 		}
 	}
 }
@@ -62,7 +65,7 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 	margin-left: auto;
 	margin-right: auto;
 	display: block;
-	margin-bottom: 8px;
+	margin-bottom: $grid-unit-10;
 }
 
 .components-custom-gradient-picker__inserter {
@@ -118,5 +121,7 @@ $components-custom-gradient-picker__padding: 16px; // 48px container, 16px handl
 	}
 	label {
 		text-transform: uppercase;
+		font-size: 11px;
+		font-weight: 500;
 	}
 }

--- a/packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.js
+++ b/packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.js
@@ -12,5 +12,5 @@ export const SelectWrapper = styled( FlexBlock )`
 `;
 
 export const AccessoryWrapper = styled( FlexBlock )`
-	flex-grow: 4;
+	flex-grow: 5;
 `;

--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -14,7 +14,7 @@ import {
 } from './constants';
 import { serializeGradient } from './serializer';
 
-export function getLinearGradientRepresentationOfARadial( gradientAST ) {
+export function getLinearGradientRepresentation( gradientAST ) {
 	return serializeGradient( {
 		type: 'linear-gradient',
 		orientation: HORIZONTAL_GRADIENT_ORIENTATION,


### PR DESCRIPTION
This PR updates the design of the custom gradient picker to the new version.
Part of: https://github.com/WordPress/gutenberg/issues/34574

| Before | After |
|---|---|
| <img width="226" alt="color-picker-after" src="https://user-images.githubusercontent.com/11271197/132877124-f5c259ad-419e-4012-9725-4e1558542b58.png"> | <img width="226" alt="color-picker-after" src="https://user-images.githubusercontent.com/11271197/132877013-4775c564-b86f-42e0-81ba-86315a157069.png"> |