### PR TITLE
Prevent welcome guide overflow x scroll

### DIFF
--- a/packages/edit-post/src/components/welcome-guide/image.js
+++ b/packages/edit-post/src/components/welcome-guide/image.js
@@ -5,7 +5,7 @@ export default function WelcomeGuideImage( { nonAnimatedSrc, animatedSrc } ) {
 				srcSet={ nonAnimatedSrc }
 				media="(prefers-reduced-motion: reduce)"
 			/>
-			<img src={ animatedSrc } width="100%" height="240" alt="" />
+			<img src={ animatedSrc } width="312" height="240" alt="" />
 		</picture>
 	);
 }

--- a/packages/edit-post/src/components/welcome-guide/image.js
+++ b/packages/edit-post/src/components/welcome-guide/image.js
@@ -5,7 +5,7 @@ export default function WelcomeGuideImage( { nonAnimatedSrc, animatedSrc } ) {
 				srcSet={ nonAnimatedSrc }
 				media="(prefers-reduced-motion: reduce)"
 			/>
-			<img src={ animatedSrc } width="312" height="240" alt="" />
+			<img src={ animatedSrc } width="100%" height="240" alt="" />
 		</picture>
 	);
 }

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -4,6 +4,12 @@
 	&__image {
 		background: #00a0d2;
 		margin: 0 0 $grid-unit-20;
+		
+		> img {
+			display: block;
+			max-width: 100%;
+			object-fit: cover;
+		}
 	}
 
 	&__heading {

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -4,7 +4,6 @@
 	&__image {
 		background: #00a0d2;
 		margin: 0 0 $grid-unit-20;
-		
 		> img {
 			display: block;
 			max-width: 100%;

--- a/packages/edit-widgets/src/components/welcome-guide/style.scss
+++ b/packages/edit-widgets/src/components/welcome-guide/style.scss
@@ -4,6 +4,12 @@
 	&__image {
 		background: #00a0d2;
 		margin: 0 0 $grid-unit-20;
+		
+		> img {
+			display: block;
+			max-width: 100%;
+			object-fit: cover;
+		}
 	}
 
 	&__heading {

--- a/packages/edit-widgets/src/components/welcome-guide/style.scss
+++ b/packages/edit-widgets/src/components/welcome-guide/style.scss
@@ -4,7 +4,6 @@
 	&__image {
 		background: #00a0d2;
 		margin: 0 0 $grid-unit-20;
-		
 		> img {
 			display: block;
 			max-width: 100%;


### PR DESCRIPTION
This happens when the welcome guide has a vertical scroll, the guide image has a fixed width, and it causes the overflow x scroll.

Before | After
--------- | ---------
![1](https://user-images.githubusercontent.com/64708228/132750468-ddaf0c15-62b1-4346-93a3-37a2ce2837c5.png) | ![2](https://user-images.githubusercontent.com/64708228/132750479-60a97bae-6b2f-4c46-ba5c-04625cbbae7f.png)
