### PR TITLE
Fix native Latest Posts e2e device tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -292,6 +292,11 @@ class EditorPage {
 		}
 	}
 
+	static getInserterPageHeight( screenHeight ) {
+		// Rough estimate of a swipe distance required to scroll one page of blocks
+		return screenHeight * 0.82;
+	}
+
 	// Attempts to find the given block button in the block inserter control.
 	async findBlockButton( blockName ) {
 		const blockAccessibilityLabel = `${ blockName } block`;
@@ -308,7 +313,7 @@ class EditorPage {
 				swipeFromTo(
 					this.driver,
 					{ x, y: size.height - 100 },
-					{ x, y: size.height - 450 }
+					{ x, y: EditorPage.getInserterPageHeight( size.height ) }
 				);
 			}
 
@@ -330,7 +335,7 @@ class EditorPage {
 				fromX: 50,
 				fromY: height,
 				toX: 50,
-				toY: height - 450,
+				toY: EditorPage.getInserterPageHeight( height ),
 				duration: 0.5,
 			} );
 		}


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3945

## Description
Increase the accuracy of the swipe distance required to scroll one page of blocks within the block inserter. We now have more than two pages of blocks. The previous implementation would scroll too far (to the bottom), which caused failures when the test scrolled _past_ the subject block.

## How has this been tested?
Verified CI checks pass. 

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Automated test improvement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
