### PR TITLE
Directly handle shift-stepping in RangeControl

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -216,6 +216,7 @@ function RangeControl(
 						className="components-range-control__slider"
 						describedBy={ describedBy }
 						disabled={ disabled }
+						failsafeValue={ rangeFillValue }
 						id={ id }
 						isShiftStepEnabled={ isShiftStepEnabled }
 						label={ label }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -226,6 +226,7 @@ function RangeControl(
 						onFocus={ handleOnFocus }
 						onMouseMove={ onMouseMove }
 						onMouseLeave={ onMouseLeave }
+						onShiftStep={ handleOnChange }
 						ref={ setRef }
 						shiftStep={ shiftStep }
 						step={ step }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -115,8 +115,7 @@ function RangeControl(
 	const describedBy = !! help ? `${ id }__help` : undefined;
 	const enableTooltip = showTooltipProp !== false && isFinite( value );
 
-	const handleOnRangeChange = ( event ) => {
-		const nextValue = parseFloat( event.target.value );
+	const handleOnRangeChange = ( nextValue ) => {
 		setValue( nextValue );
 		onChange( nextValue );
 	};
@@ -227,7 +226,6 @@ function RangeControl(
 						onFocus={ handleOnFocus }
 						onMouseMove={ onMouseMove }
 						onMouseLeave={ onMouseLeave }
-						onShiftStep={ handleOnChange }
 						ref={ setRef }
 						shiftStep={ shiftStep }
 						step={ step }

--- a/packages/components/src/range-control/input-range.js
+++ b/packages/components/src/range-control/input-range.js
@@ -30,6 +30,7 @@ const operationList = {
 function InputRange(
 	{
 		describedBy,
+		failsafeValue,
 		isShiftStepEnabled = true,
 		label,
 		onHideTooltip = noop,
@@ -54,7 +55,10 @@ function InputRange(
 			event.preventDefault();
 			const { min, max, step } = props;
 			const modifiedStep = shiftStep * step;
-			const nextValue = operationList[ keyCode ]( value, modifiedStep );
+			const nextValue = operationList[ keyCode ](
+				failsafeValue,
+				modifiedStep
+			);
 			onShiftStep( roundClamp( nextValue, min, max, modifiedStep ) );
 		}
 	};

--- a/packages/components/src/range-control/input-range.js
+++ b/packages/components/src/range-control/input-range.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 import { UP, RIGHT, DOWN, LEFT } from '@wordpress/keycodes';
 
 /**
@@ -17,11 +18,13 @@ import { InputRange as BaseInputRange } from './styles/range-control-styles';
 import { useDebouncedHoverInteraction } from './utils';
 import { add, subtract } from '../utils/math';
 
+const _isRTL = isRTL();
+
 const operationList = {
 	[ UP ]: add,
-	[ RIGHT ]: add,
+	[ RIGHT ]: _isRTL ? subtract : add,
 	[ DOWN ]: subtract,
-	[ LEFT ]: subtract,
+	[ LEFT ]: _isRTL ? add : subtract,
 };
 
 function InputRange(

--- a/packages/components/src/range-control/input-range.js
+++ b/packages/components/src/range-control/input-range.js
@@ -16,7 +16,7 @@ import { UP, RIGHT, DOWN, LEFT } from '@wordpress/keycodes';
  */
 import { InputRange as BaseInputRange } from './styles/range-control-styles';
 import { useDebouncedHoverInteraction } from './utils';
-import { add, subtract } from '../utils/math';
+import { add, subtract, roundClamp } from '../utils/math';
 
 const _isRTL = isRTL();
 
@@ -52,9 +52,10 @@ function InputRange(
 
 		if ( isShiftStepEnabled && shiftKey && keyCode in operationList ) {
 			event.preventDefault();
-			const modifiedStep = shiftStep * props.step;
+			const { min, max, step } = props;
+			const modifiedStep = shiftStep * step;
 			const nextValue = operationList[ keyCode ]( value, modifiedStep );
-			onShiftStep( nextValue );
+			onShiftStep( roundClamp( nextValue, min, max, modifiedStep ) );
 		}
 	};
 


### PR DESCRIPTION
To fix: #34363

The linked issue is prevented by using our own logic to shift-step the input instead of the current approach which modifies the DOM `step` attribute and relies on the UA stepping behavior. The `step` attribute is a factor in validation so modifying it while a value is already present is likely to invalidate the value. An invalid value may get rounded to the nearest valid value by the UA. One (and maybe only) such UA is Firefox and that is why our current approach is problematic.

## How has this been tested?
Manually, verifying that the linked issue can no longer be reproduced and that shift-stepping of range controls still works.

## Screenshots
### Shift+tab no longer causing the columns value to jump back to 1.
Also shows shift-step working toward the end of the video

https://user-images.githubusercontent.com/9000376/132774146-9ef2f507-3bbf-42a9-b049-91c995a70585.mp4

### Shift-step in RTL
Aside: we seem to have style issues with RTL and RangeControl
![after-RTL-range-control-shift-tab-reset](https://user-images.githubusercontent.com/9000376/132774427-2e2b6a1d-53b0-4692-b623-21f9a2df79a8.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
