### PR TITLE
[Rnmobile] update font size picker to use css unit normalization 

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -426,6 +426,19 @@ _Returns_
 
 -   `string`: Gradient value.
 
+### getPxFromCssUnit
+
+Returns the px value of a cssUnit.
+
+_Parameters_
+
+-   _cssUnit_ `string`:
+-   _options_ `string`:
+
+_Returns_
+
+-   `string`: returns the cssUnit value in a simple px format.
+
 ### InnerBlocks
 
 _Related_

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -100,26 +100,31 @@ export const SETTINGS_DEFAULTS = {
 		{
 			name: _x( 'Small', 'font size name' ),
 			size: 13,
+			sizePx: '13px',
 			slug: 'small',
 		},
 		{
 			name: _x( 'Normal', 'font size name' ),
 			size: 16,
+			sizePx: '16px',
 			slug: 'normal',
 		},
 		{
 			name: _x( 'Medium', 'font size name' ),
 			size: 20,
+			sizePx: '20px',
 			slug: 'medium',
 		},
 		{
 			name: _x( 'Large', 'font size name' ),
 			size: 36,
+			sizePx: '36px',
 			slug: 'large',
 		},
 		{
 			name: _x( 'Huge', 'font size name' ),
 			size: 42,
+			sizePx: '42px',
 			slug: 'huge',
 		},
 	],

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -100,31 +100,26 @@ export const SETTINGS_DEFAULTS = {
 		{
 			name: _x( 'Small', 'font size name' ),
 			size: 13,
-			sizePx: '13px',
 			slug: 'small',
 		},
 		{
 			name: _x( 'Normal', 'font size name' ),
 			size: 16,
-			sizePx: '16px',
 			slug: 'normal',
 		},
 		{
 			name: _x( 'Medium', 'font size name' ),
 			size: 20,
-			sizePx: '20px',
 			slug: 'medium',
 		},
 		{
 			name: _x( 'Large', 'font size name' ),
 			size: 36,
-			sizePx: '36px',
 			slug: 'large',
 		},
 		{
 			name: _x( 'Huge', 'font size name' ),
 			size: 42,
-			sizePx: '42px',
 			slug: 'huge',
 		},
 	],

--- a/packages/block-editor/src/store/defaults.native.js
+++ b/packages/block-editor/src/store/defaults.native.js
@@ -6,8 +6,14 @@ import {
 	SETTINGS_DEFAULTS as SETTINGS,
 } from './defaults.js';
 
+const fontSizes = SETTINGS.fontSizes.map( ( fontSize ) => {
+	fontSize.sizePx = fontSize.size + 'px';
+	return fontSize;
+} );
+
 const SETTINGS_DEFAULTS = {
 	...SETTINGS,
+	fontSizes,
 	// FOR TESTING ONLY - Later, this will come from a REST API
 	// eslint-disable-next-line no-undef
 	__unstableGalleryWithImageBlocks: __DEV__,

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as transformStyles } from './transform-styles';
 export * from './theme';
 export * from './block-variation-transforms';
+export { default as getPxFromCssUnit } from './parse-css-unit-to-px';

--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -209,7 +209,7 @@ function convertParsedUnitToPx( parsedUnit, options ) {
  * @param {string} options
  * @return {string} returns the cssUnit value in a simple px format.
  */
-export function getPxFromCssUnit( cssUnit, options = {} ) {
+function getPxFromCssUnit( cssUnit, options = {} ) {
 	if ( Number.isFinite( cssUnit ) ) {
 		return cssUnit.toFixed( 0 ) + 'px';
 	}
@@ -228,3 +228,5 @@ export function getPxFromCssUnit( cssUnit, options = {} ) {
 
 	return convertParsedUnitToPx( parsedUnit, options );
 }
+
+export default getPxFromCssUnit;

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getPxFromCssUnit } from '../parse-css-unit-to-px';
+import { default as getPxFromCssUnit } from '../parse-css-unit-to-px';
 
 describe( 'getPxFromCssUnit', () => {
 	// Absolute units

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View } from 'react-native';
+import { View, useWindowDimensions } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -11,12 +11,15 @@ import { useState } from '@wordpress/element';
 import { Icon, chevronRight, check } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { BottomSheet } from '@wordpress/components';
+import { getPxFromCssUnit } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { default as UnitControl, useCustomUnits } from '../unit-control';
 import styles from './style.scss';
+
+const DEFAULT_FONT_SIZE = 16;
 
 function FontSizePicker( {
 	fontSizes = [],
@@ -27,6 +30,13 @@ function FontSizePicker( {
 	const [ showSubSheet, setShowSubSheet ] = useState( false );
 	const navigation = useNavigation();
 
+	const { height, width } = useWindowDimensions();
+	// use fontScale to create a better
+	const cssUnitOptions = { height, width, fontSize: DEFAULT_FONT_SIZE };
+	// We need to always convert to px units because the selected value
+	// could be coming from the web where it could be stored as a different unit.
+	const selectedPxValue = getPxFromCssUnit( selectedValue, cssUnitOptions );
+
 	const onChangeValue = ( value ) => {
 		return () => {
 			goBack();
@@ -35,7 +45,7 @@ function FontSizePicker( {
 	};
 
 	const selectedOption = fontSizes.find(
-		( option ) => option.size === selectedValue
+		( option ) => option.sizePx === selectedPxValue
 	) ?? { name: 'Custom' };
 
 	const goBack = () => {
@@ -65,7 +75,7 @@ function FontSizePicker( {
 									// translators: %1$s: Select control font size name e.g. Small, %2$s: Select control font size e.g. 12px
 									__( '%1$s (%2$s)' ),
 									selectedOption.name,
-									selectedValue
+									selectedPxValue
 							  )
 							: __( 'Default' )
 					}
@@ -112,7 +122,7 @@ function FontSizePicker( {
 					</BottomSheet.Cell>
 					{ fontSizes.map( ( item, index ) => {
 						// Only display a choice that we can currenly select.
-						if ( ! parseFloat( item.size ) ) {
+						if ( ! parseFloat( item.sizePx ) ) {
 							return null;
 						}
 						return (
@@ -120,13 +130,13 @@ function FontSizePicker( {
 								customActionButton
 								separatorType="none"
 								label={ item.name }
-								subLabel={ item.size }
-								onPress={ onChangeValue( item.size ) }
+								subLabel={ item.sizePx }
+								onPress={ onChangeValue( item.sizePx ) }
 								leftAlign={ true }
 								key={ index }
 								accessibilityRole={ 'button' }
 								accessibilityLabel={
-									item.size === selectedValue
+									item.sizePx === selectedValue
 										? sprintf(
 												// translators: %s: Select font size option value e.g: "Selected: Large".
 												__( 'Selected: %s' ),
@@ -139,7 +149,7 @@ function FontSizePicker( {
 								) }
 							>
 								<View>
-									{ item.size === selectedValue && (
+									{ item.sizePx === selectedPxValue && (
 										<Icon icon={ check }></Icon>
 									) }
 								</View>

--- a/packages/components/src/font-size-picker/index.native.js
+++ b/packages/components/src/font-size-picker/index.native.js
@@ -31,7 +31,6 @@ function FontSizePicker( {
 	const navigation = useNavigation();
 
 	const { height, width } = useWindowDimensions();
-	// use fontScale to create a better
 	const cssUnitOptions = { height, width, fontSize: DEFAULT_FONT_SIZE };
 	// We need to always convert to px units because the selected value
 	// could be coming from the web where it could be stored as a different unit.

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -30,7 +30,7 @@ export {
 	Fill,
 	Provider as SlotFillProvider,
 } from './slot-fill';
-export { default as FontSizePicker } from './font-size-picker'; // Intentionally called after slot-fill.
+
 export { default as __experimentalStyleProvider } from './style-provider';
 export { default as BaseControl } from './base-control';
 export { default as TextareaControl } from './textarea-control';
@@ -66,6 +66,7 @@ export { default as Disabled } from './disabled';
 export { default as withConstrainedTabbing } from './higher-order/with-constrained-tabbing';
 export { default as withFallbackStyles } from './higher-order/with-fallback-styles';
 export { default as withFilters } from './higher-order/with-filters';
+export { default as FontSizePicker } from './font-size-picker'; // Intentionally called after slot-fill and withFilters.
 export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withNotices } from './higher-order/with-notices';

--- a/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
+++ b/packages/components/src/mobile/global-styles-context/test/fixtures/theme.native.js
@@ -209,16 +209,19 @@ export const RAW_FEATURES = {
 					name: 'Small',
 					slug: 'small',
 					size: '13px',
+					sizePx: '13px',
 				},
 				{
 					name: 'Normal',
 					slug: 'normal',
 					size: '16px',
+					sizePx: '16px',
 				},
 				{
 					name: 'Huge',
 					slug: 'huge',
 					size: '42px',
+					sizePx: '42px',
 				},
 			],
 			theme: [
@@ -226,15 +229,18 @@ export const RAW_FEATURES = {
 					name: 'Normal',
 					slug: 'normal',
 					size: '18px',
+					sizePx: '18px',
 				},
 				{
 					slug: 'extra-large',
 					size: '40px',
+					sizePx: '40px',
 					name: 'Extra large',
 				},
 				{
 					slug: 'gigantic',
 					size: '144px',
+					sizePx: '144px',
 					name: 'Gigantic',
 				},
 			],

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -251,6 +251,41 @@ export function getMappedValues( features, palette ) {
 	return mappedValues;
 }
 
+/**
+ * Returns the normalized fontSizes to include the sizePx value for each of the different sizes.
+ *
+ * @param {Object} fontSizes found in global styles.
+ * @return {Object} normalized sizes.
+ */
+function normalizeFontSizes( fontSizes ) {
+	// Adds normalized PX values for each of the different keys
+	if ( ! fontSizes ) {
+		return fontSizes;
+	}
+	const normalizedFontSizes = {};
+	const dimensions = Dimensions.get( 'window' );
+
+	[ 'core', 'theme', 'user' ].forEach( ( key ) => {
+		if ( fontSizes[ key ] ) {
+			normalizedFontSizes[ key ] = fontSizes[ key ]?.map(
+				( fontSizeObject ) => {
+					fontSizeObject.sizePx = getPxFromCssUnit(
+						fontSizeObject.size,
+						{
+							width: dimensions.width,
+							height: dimensions.height,
+							fontSize: 16,
+						}
+					);
+					return fontSizeObject;
+				}
+			);
+		}
+	} );
+
+	return normalizedFontSizes;
+}
+
 export function getGlobalStyles( rawStyles, rawFeatures ) {
 	const features = rawFeatures ? JSON.parse( rawFeatures ) : {};
 	const mappedValues = getMappedValues( features, features?.color?.palette );
@@ -272,26 +307,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 		customValues
 	);
 
-	// Adds normalized PX values for each of the different keys
-	const dimensions = Dimensions.get( 'window' );
-	const fontSizes = {};
-	[ 'core', 'theme', 'user' ].forEach( ( key ) => {
-		if ( features?.typography?.fontSizes[ key ] ) {
-			fontSizes[ key ] = features?.typography?.fontSizes[ key ]?.map(
-				( fontSizeObject ) => {
-					fontSizeObject.sizePx = getPxFromCssUnit(
-						fontSizeObject.size,
-						{
-							width: dimensions.width,
-							height: dimensions.height,
-							fontSize: 16,
-						}
-					);
-					return fontSizeObject;
-				}
-			);
-		}
-	} );
+	const fontSizes = normalizeFontSizes( features?.typography?.fontSizes );
 
 	return {
 		colors,

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import { find, startsWith, get, camelCase, has } from 'lodash';
+import { Dimensions } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { getPxFromCssUnit } from '@wordpress/block-editor';
 
 export const BLOCK_STYLE_ATTRIBUTES = [
 	'textColor',
@@ -266,6 +272,26 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 		customValues
 	);
 
+	// Adds normalized PX values for each of the different keys
+	const dimensions = Dimensions.get( 'window' );
+	const fontSizes = {};
+	[ 'core', 'theme', 'user' ].forEach( ( key ) => {
+		if ( features?.typography?.fontSizes[ key ] ) {
+			fontSizes[ key ] = features?.typography?.fontSizes[ key ]?.map(
+				( fontSizeObject ) => {
+					fontSizeObject.sizePx = getPxFromCssUnit(
+						fontSizeObject.size,
+						{
+							width: dimensions.width,
+							height: dimensions.height,
+						}
+					);
+					return fontSizeObject;
+				}
+			);
+		}
+	} );
+
 	return {
 		colors,
 		gradients,
@@ -277,7 +303,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 				background: features?.color?.background ?? true,
 			},
 			typography: {
-				fontSizes: features?.typography?.fontSizes,
+				fontSizes,
 				customLineHeight: features?.custom?.[ 'line-height' ],
 			},
 		},

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -284,6 +284,7 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 						{
 							width: dimensions.width,
 							height: dimensions.height,
+							fontSize: 16,
 						}
 					);
 					return fontSizeObject;


### PR DESCRIPTION
## Description
This PR used the getPxFromCssUnit function to normalize the font size units to px values that then we can use and render on mobile in a consistent way. 

It also makes it possible now to select a larger range of font site values that are defined in theme.json file. 

In this PR we are doing 2 things. 
1. Converting any values of fontSizes to px units. 
2. Making the font picker work as expected.

## How has this been tested?
Load this PR in your setup in a dev environment. 
- Notice that the site running quadrat now displays a few more font size options. 
- Notice that a site that has a default theme (one that doesn't support theme.json yet) still is able to set font size. 
and now the units show as px and not just a number.

## Screenshots <!-- if applicable -->
Before:

<img width="300" alt="Screen Shot 2021-09-09 at 4 01 52 PM" src="https://user-images.githubusercontent.com/115071/132773620-edc7a754-f9c7-407c-99bc-4ecc91cd06f2.png">

After:
<img width="300" alt="Screen Shot 2021-09-09 at 4 01 21 PM" src="https://user-images.githubusercontent.com/115071/132773627-eb15ff7b-8a51-4550-91db-17c5dd30a4c9.png">

Notice that now the quadrat theme shows more font size options. 
https://wordpress.com/theme/quadrat 

## Types of changes
New feature. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
