### PR TITLE
Font Appearance Control: Fix selectedItem downshift uncontrolled prop warning

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -143,7 +143,8 @@ export default function FontAppearanceControl( props ) {
 		return hasFontStyles ? styleOptions() : weightOptions();
 	}, [ props.options ] );
 
-	// Find current selection by comparing font style & weight against options.
+	// Find current selection by comparing font style & weight against options,
+	// and fall back to the Default option if there is no matching option.
 	const currentSelection =
 		selectOptions.find(
 			( option ) =>

--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -144,11 +144,12 @@ export default function FontAppearanceControl( props ) {
 	}, [ props.options ] );
 
 	// Find current selection by comparing font style & weight against options.
-	const currentSelection = selectOptions.find(
-		( option ) =>
-			option.style.fontStyle === fontStyle &&
-			option.style.fontWeight === fontWeight
-	);
+	const currentSelection =
+		selectOptions.find(
+			( option ) =>
+				option.style.fontStyle === fontStyle &&
+				option.style.fontWeight === fontWeight
+		) || selectOptions[ 0 ];
 
 	// Adjusts field label in case either styles or weights are disabled.
 	const getLabel = () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Fixes #34524

## Description
<!-- Please describe what you have changed or added -->

Following on from #34520, in the Font Appearance Control component, if we don't pass in a selected item to `CustomSelectControl` then that control sets the `selectedItem` as `undefined`, which then results in a warning in the console from `downshift`, when we switch between the Default and any other appearance option (or back and forth between them).

This is replicable in the TT1-Blocks theme, when selecting the Appearance for the Site Title block in Global Styles, because that theme sets a default value for `fontWeight` but not `fontStyle`, which means that its default value doesn't match one of the Font Appearance Control's available values.

In this PR, we default to the Default value in the UI if the current value doesn't match one of the available options. This _should_ visually match the existing behaviour on trunk, because the CustomSelectControl component defaults to setting the first item of options as selected. But with this PR applied, we should no longer see the warning in the console.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Without this PR applied:

* Using TT1-Blocks theme, open up the site editor, and global styles.
* With your dev console open, switch the Appearance for the Site Title block between the Default option and any of the other options, back and forth a couple of times, and see that a console warning in the screenshot below is generated

With this PR applied:

* Repeat the above steps — it should behave the same, but no longer report a warning in the console

## Screenshots <!-- if applicable -->

The warning in the console looks like this:

![image](https://user-images.githubusercontent.com/14988353/132788188-e569ced0-6401-473a-995f-6cd3663f2056.png)

With this PR applied, you should be able to switch between appearances without the warning being thrown:

![font-appearance-control-sml](https://user-images.githubusercontent.com/14988353/132788310-955b98b9-0d3f-4c1c-bf53-f44402af767a.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (Manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
