### PR TITLE
HTML block: Prevent external styling of editing UI

### DIFF
--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,6 +1,4 @@
 .block-library-html__edit {
-	margin-bottom: $default-block-margin;
-
 	.block-library-html__preview-overlay {
 		position: absolute;
 		width: 100%;
@@ -9,22 +7,30 @@
 		left: 0;
 	}
 
+	// The editing view for the HTML block is equivalent to block UI.
+	// Therefore we increase specificity to avoid theme styles bleeding in.
 	.block-editor-plain-text {
-		font-family: $editor-html-font;
-		color: $gray-900;
-		padding: 0.8em 1em;
-		border: 1px solid $gray-300;
-		border-radius: 4px;
+		font-family: $editor-html-font !important;
+		color: $gray-900 !important;
+		background: $white !important;
+		padding: $grid-unit-15 !important;
+		border: $border-width solid $gray-900 !important;
+		box-shadow: none !important;
+		border-radius: $radius-block-ui !important;
 		max-height: 250px;
 
 		/* Fonts smaller than 16px causes mobile safari to zoom. */
-		font-size: $mobile-text-min-font-size;
+		font-size: $mobile-text-min-font-size !important;
 		@include break-small {
-			font-size: $default-font-size;
+			font-size: $default-font-size !important;
 		}
 
 		&:focus {
-			box-shadow: none;
+			border-color: var(--wp-admin-theme-color) !important;
+			box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color) !important;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent !important;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #34645.

The editing interface for the HTML block is block UI and is not meant to be styled by themes. Because of low specificity, this view is lacking contrast in some themes. By increasing specificity, we fix that. 

## How has this been tested?

Test in the Quadrat theme, for example, which styles the textarea. Insert the HTML block and add some markup. Verify that the editing field looks like block UI — dark border, white background.

## Screenshots <!-- if applicable -->

Before:

![before](https://user-images.githubusercontent.com/1204802/132813137-28527784-0e48-4254-ab92-0da9f09231e7.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/132813151-f4b73ee0-0cea-46b5-b837-ecb37786784b.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
