### PR TITLE
Save button: prevent focus loss

### DIFF
--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -188,13 +188,15 @@ describe( 'Post generator actions', () => {
 				'yields an action for dispatching a success notice',
 				() => true,
 				() => {
-					if ( ! isAutosave && currentPostStatus === 'publish' ) {
+					if ( ! isAutosave ) {
 						const { value } = fulfillment.next( postType );
 						expect( value ).toEqual(
 							controls.dispatch(
 								noticesStore,
 								'createSuccessNotice',
-								'Updated Post',
+								currentPostStatus === 'publish'
+									? 'Updated Post'
+									: 'Saved',
 								{
 									actions: [],
 									id: 'SAVE_POST_NOTICE_ID',

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -35,9 +35,11 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	let noticeMessage;
 	let shouldShowLink = get( postType, [ 'viewable' ], false );
 
+	// Always should a notice, which will be spoken for accessibility.
 	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
-		noticeMessage = null;
+		noticeMessage = __( 'Saved' );
+		shouldShowLink = false;
 	} else if ( isPublished && ! willPublish ) {
 		// If undoing publish status, show specific notice
 		noticeMessage = postType.labels.item_reverted_to_draft;
@@ -55,25 +57,21 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 		noticeMessage = postType.labels.item_updated;
 	}
 
-	if ( noticeMessage ) {
-		const actions = [];
-		if ( shouldShowLink ) {
-			actions.push( {
-				label: postType.labels.view_item,
-				url: post.link,
-			} );
-		}
-		return [
-			noticeMessage,
-			{
-				id: SAVE_POST_NOTICE_ID,
-				type: 'snackbar',
-				actions,
-			},
-		];
+	const actions = [];
+	if ( shouldShowLink ) {
+		actions.push( {
+			label: postType.labels.view_item,
+			url: post.link,
+		} );
 	}
-
-	return [];
+	return [
+		noticeMessage,
+		{
+			id: SAVE_POST_NOTICE_ID,
+			type: 'snackbar',
+			actions,
+		},
+	];
 }
 
 /**

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -34,7 +34,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		[
 			'when previous post is not published and post will not be published',
 			[ 'draft', 'draft', false ],
-			[],
+			[ 'Saved', defaultExpectedAction ],
 		],
 		[
 			'when previous post is published and post will be unpublished',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #15529.

As recommended in #15529, #34539 already made the changes to keep the same save button through all its states to prevent focus loss, but we still need a spoken message. This can be done by adding a snackbar notice, which also speaks the message.

## How has this been tested?

Save a post. Check the snackbar message.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
