### PR TITLE
[Mobile] Disable gallery conversion option on mobile

### DIFF
--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -466,7 +466,8 @@ function GalleryEdit( props ) {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			{ __unstableGalleryWithImageBlocks && (
+			{ /* TODO: Remove platform condition when native conversion is ready */ }
+			{ Platform.isWeb && __unstableGalleryWithImageBlocks && (
 				<BlockControls group="other">
 					<ToolbarButton
 						onClick={ openUpdateModal }
@@ -477,7 +478,7 @@ function GalleryEdit( props ) {
 					</ToolbarButton>
 				</BlockControls>
 			) }
-			{ isUpdateOpen && (
+			{ Platform.isWeb && isUpdateOpen && (
 				<UpdateGalleryModal
 					onClose={ closeUpdateModal }
 					clientId={ clientId }


### PR DESCRIPTION
This PR disables the gallery conversion option for mobile. This must be disabled for mobile until the native UI is ready.

#### Related PR:

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3946


## Description
Platform condition to disable an option to convert to the new gallery format on mobile (only available on web for now).

## How has this been tested?

* Create a post with a gallery from the old format (with the gallery flag set to false)
* Set the flag to true
* Open that post with the flag set to true
* Expect that on web, the option exists to convert to the new format (as introduced in [this PR](https://github.com/WordPress/gutenberg/pull/34606))
* Expect that on mobile, the old gallery renders as usual (with no invariant violation) and has no option to convert to the new format


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
