### PR TITLE
Storybook: Remove G2 prefix from the Components section

### DIFF
--- a/packages/components/src/flex/stories/index.js
+++ b/packages/components/src/flex/stories/index.js
@@ -6,7 +6,7 @@ import { View } from '../../view';
 
 export default {
 	component: Flex,
-	title: 'G2 Components (Experimental)/Flex',
+	title: 'Components (Experimental)/Flex',
 };
 
 export const _default = () => {

--- a/packages/components/src/h-stack/stories/index.js
+++ b/packages/components/src/h-stack/stories/index.js
@@ -6,7 +6,7 @@ import { HStack } from '..';
 
 export default {
 	component: HStack,
-	title: 'G2 Components (Experimental)/HStack',
+	title: 'Components (Experimental)/HStack',
 };
 
 export const _default = () => {

--- a/packages/components/src/heading/stories/index.js
+++ b/packages/components/src/heading/stories/index.js
@@ -5,7 +5,7 @@ import { Heading } from '../';
 
 export default {
 	component: Heading,
-	title: 'G2 Components (Experimental)/Heading',
+	title: 'Components (Experimental)/Heading',
 };
 
 export const _default = () => {

--- a/packages/components/src/truncate/stories/index.js
+++ b/packages/components/src/truncate/stories/index.js
@@ -10,7 +10,7 @@ import { Truncate } from '..';
 
 export default {
 	component: Truncate,
-	title: 'G2 Components (Experimental)/Truncate',
+	title: 'Components (Experimental)/Truncate',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/context/stories/ComponentsProvider.stories.js
+++ b/packages/components/src/ui/context/stories/ComponentsProvider.stories.js
@@ -16,7 +16,7 @@ const useSomeContext = () => useContext( SomeContext );
 
 export default {
 	component: ContextSystemProvider,
-	title: 'G2 Components (Experimental)/ContextSystemProvider',
+	title: 'Components (Experimental)/ContextSystemProvider',
 };
 
 const outerContext = {

--- a/packages/components/src/ui/control-label/stories/index.js
+++ b/packages/components/src/ui/control-label/stories/index.js
@@ -5,7 +5,7 @@ import { ControlLabel } from '../index';
 
 export default {
 	component: ControlLabel,
-	title: 'G2 Components (Experimental)/ControlLabel',
+	title: 'Components (Experimental)/ControlLabel',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/form-group/stories/index.js
+++ b/packages/components/src/ui/form-group/stories/index.js
@@ -16,7 +16,7 @@ const TextInput = ( { id: idProp, ...props } ) => {
 
 export default {
 	component: FormGroup,
-	title: 'G2 Components (Experimental)/FormGroup',
+	title: 'Components (Experimental)/FormGroup',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/spinner/stories/index.js
+++ b/packages/components/src/ui/spinner/stories/index.js
@@ -5,7 +5,7 @@ import { Spinner } from '../index';
 
 export default {
 	component: Spinner,
-	title: 'G2 Components (Experimental)/Spinner',
+	title: 'Components (Experimental)/Spinner',
 };
 
 export const _default = () => {

--- a/packages/components/src/ui/tooltip/stories/index.js
+++ b/packages/components/src/ui/tooltip/stories/index.js
@@ -6,7 +6,7 @@ import { Tooltip } from '../index';
 
 export default {
 	component: Tooltip,
-	title: 'G2 Components (Experimental)/Tooltip',
+	title: 'Components (Experimental)/Tooltip',
 };
 
 export const _default = () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Discovered when testing #34708.

Let's group all experimental components under one section.

### Before

<img width="247" alt="Screen Shot 2021-09-10 at 11 01 08" src="https://user-images.githubusercontent.com/699132/132830363-09525aff-29f0-42e0-86f1-9bae29f48b2b.png">

### After

<img width="213" alt="Screen Shot 2021-09-10 at 11 06 23" src="https://user-images.githubusercontent.com/699132/132830370-57618598-a9ee-4294-a0ae-4ed8760f7a7b.png">


