### PR TITLE
Snackbar: fix focus loss on dismiss

### DIFF
--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -53,6 +53,7 @@ function Snackbar(
 		// It is distinct from onRemove, which _looks_ like a callback but is
 		// actually the function to call to remove the snackbar from the UI.
 		onDismiss = noop,
+		listRef,
 	},
 	ref
 ) {
@@ -62,6 +63,9 @@ function Snackbar(
 		if ( event && event.preventDefault ) {
 			event.preventDefault();
 		}
+
+		// Prevent focus loss by moving it to the list element.
+		listRef.current.focus();
 
 		onDismiss();
 		onRemove();

--- a/packages/components/src/snackbar/list.js
+++ b/packages/components/src/snackbar/list.js
@@ -8,6 +8,7 @@ import { omit, noop } from 'lodash';
  * WordPress dependencies
  */
 import { useReducedMotion } from '@wordpress/compose';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,11 +57,12 @@ const SNACKBAR_REDUCE_MOTION_VARIANTS = {
  * @return {Object} The rendered notices list.
  */
 function SnackbarList( { notices, className, children, onRemove = noop } ) {
+	const listRef = useRef();
 	const isReducedMotion = useReducedMotion();
 	className = classnames( 'components-snackbar-list', className );
 	const removeNotice = ( notice ) => () => onRemove( notice.id );
 	return (
-		<div className={ className }>
+		<div className={ className } tabIndex={ -1 } ref={ listRef }>
 			{ children }
 			<AnimatePresence>
 				{ notices.map( ( notice ) => {
@@ -81,6 +83,7 @@ function SnackbarList( { notices, className, children, onRemove = noop } ) {
 								<Snackbar
 									{ ...omit( notice, [ 'content' ] ) }
 									onRemove={ removeNotice( notice ) }
+									listRef={ listRef }
 								>
 									{ notice.content }
 								</Snackbar>

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -889,6 +889,10 @@ async function saveWidgets() {
 	// Close the snackbar.
 	const savedSnackbar = await find( savedSnackbarQuery );
 	await savedSnackbar.click();
+	// Expect focus not to be lost.
+	await expect(
+		await page.evaluate( () => document.activeElement.className )
+	).toBe( 'components-snackbar-list edit-widgets-notices__snackbar' );
 	await expect( savedSnackbarQuery ).not.toBeFound();
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently, when you click on a notice to dismiss it, focus is lost because the element disappears. Solution is the move focus to the notice list element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
