### PR TITLE
[Block Library - Query Pagination]: Fix `center` alignment

### DIFF
--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -6,6 +6,11 @@ $pagination-margin: 0.5em;
 	flex-direction: row;
 }
 
+// Center flex items. This has an equivalent in style.scss.
+.wp-block[data-align="center"] > .wp-block-query-pagination {
+	justify-content: center;
+}
+
 .editor-styles-wrapper {
 	.wp-block-query-pagination {
 		max-width: 100%;

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -36,4 +36,8 @@ $pagination-margin: 0.5em;
 			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
 		}
 	}
+
+	&.aligncenter {
+		justify-content: center;
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/32678

This PR just adds the missing styles to properly handle the `center` alignment for `QueryPagination` block.