### PR TITLE
Force remount LinkControl when moving between links within same richtext block

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -222,6 +222,7 @@ function InlineLinkUI( {
 			position="bottom center"
 		>
 			<LinkControl
+				key={ linkValue?.url }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -214,6 +214,8 @@ function InlineLinkUI( {
 		);
 	}
 
+	const linkControlRemountKey = anchorRef?.outerHTML;
+
 	return (
 		<Popover
 			anchorRef={ anchorRef }
@@ -222,7 +224,7 @@ function InlineLinkUI( {
 			position="bottom center"
 		>
 			<LinkControl
-				key={ anchorRef }
+				key={ linkControlRemountKey }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -222,7 +222,7 @@ function InlineLinkUI( {
 			position="bottom center"
 		>
 			<LinkControl
-				key={ linkValue?.url }
+				key={ anchorRef }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -26,6 +26,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
+import useLinkInstanceKey from './use-link-instance-key';
 
 function InlineLinkUI( {
 	isActive,
@@ -184,6 +185,12 @@ function InlineLinkUI( {
 
 	const anchorRef = useAnchorRef( { ref: contentRef, value, settings } );
 
+	// Generate a string based key that is unique to this anchor reference.
+	// This is used to force re-mount the LinkControl component to avoid
+	// potential stale state bugs caused by the component not being remounted
+	// See https://github.com/WordPress/gutenberg/pull/34742.
+	const forceRemountKey = useLinkInstanceKey( anchorRef );
+
 	// The focusOnMount prop shouldn't evolve during render of a Popover
 	// otherwise it causes a render of the content.
 	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
@@ -214,8 +221,6 @@ function InlineLinkUI( {
 		);
 	}
 
-	const linkControlRemountKey = anchorRef?.outerHTML;
-
 	return (
 		<Popover
 			anchorRef={ anchorRef }
@@ -224,7 +229,7 @@ function InlineLinkUI( {
 			position="bottom center"
 		>
 			<LinkControl
-				key={ linkControlRemountKey }
+				key={ forceRemountKey }
 				value={ linkValue }
 				onChange={ onChangeLink }
 				onRemove={ removeLink }

--- a/packages/format-library/src/link/use-link-instance-key.js
+++ b/packages/format-library/src/link/use-link-instance-key.js
@@ -1,0 +1,31 @@
+// Weakly referenced map allows unused ids to be garbage collected.
+const weakMap = new WeakMap();
+
+// Incrementing zero-based ID value
+let id = -1;
+
+const prefix = 'link-control-instance';
+
+function getKey( _id ) {
+	return `${ prefix }-${ _id }`;
+}
+
+/**
+ * Builds a unique link control key for the given object reference.
+ *
+ * @param {Object} instance an unique object reference specific to this link control instance.
+ * @return {string} the unique key to use for this link control.
+ */
+function useLinkInstanceKey( instance ) {
+	if ( weakMap.has( instance ) ) {
+		return getKey( weakMap.get( instance ) );
+	}
+
+	id += 1;
+
+	weakMap.set( instance, id );
+
+	return getKey( id );
+}
+
+export default useLinkInstanceKey;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description



In https://github.com/WordPress/gutenberg/pull/32320 we learnt that the Link UI could be made to display values that were out of the sync with its underlying data.

We should still pursue https://github.com/WordPress/gutenberg/pull/32320 as a means of solving this issues at an underlying level. 

However, a contributing problem is that `<LinkControl>` **isn't being remounted** when it's used within the rich text package. This is because it's within a `<Popover />`, and because `<Popover>` isn't unmounted, as you click between links the `<LinkControl>` is also **_not_ unmounted**. This allows values to stay in state (and get shared) between what should be considered two entirely separate instances of `<LinkCongrol>`. This allows these bugs to manifest more easily.

I think it's reasonable to expect `<LinkControl />` to _remount_ as you click between links. Indeed if you are in edit mode on link 1 and then you click away on to link 2, then you should expect that you will no longer be in edit mode on link 2.

This PR forces that to happen via the addition of a `key` prop which is set to ~the stringified HTML of the anchor ref to which the link UI is "attached". This is not _guaranteed_ to be unique but 99.9% of the time it will be because you rarely make the same link within the same paragraph block with the exact same attributes~ a unique ID based key in the form `link-control-instance-${id}`. A unique ID is "assigned" to each LinkControl based on a map of anchorRef -> uniqueIDs. This map is stored as a `WeakMap` to avoid memory leaks. Hat tip to @kevin940726 for the inspiration.

Please note that `useInstanceId` could not be used because the component does not remount and thus the instance id generated by that hook remains identical between links. 

## How has this been tested?

1. Create new post.
2. Create single paragraph block and add some text.
3. Create x3 links:
   - `wordpress.org`
   - `wordpress.org` (yes that's correct I want you to add the same link!)
   - `wordpress.org/gutenberg`
4. Click on one of the links and click `Edit` to go into "edit mode".
5. Now click on any of the other links and check that you are forced to leave edit mode.

Bottom line - if you leave the link you are currently on you should have to click edit again.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/140541582-4a661279-4e38-463e-be17-dafba262b7eb.mov




## Types of changes
 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
