### PR TITLE
Block API: Add role for 'internal' attributes not copied on duplication

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -12,7 +12,11 @@ import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize, store as blocksStore } from '@wordpress/blocks';
+import {
+	serialize,
+	store as blocksStore,
+	__experimentalRemoveAttributesByRole,
+} from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -33,7 +37,12 @@ const POPOVER_PROPS = {
 };
 
 function CopyMenuItem( { blocks, onCopy } ) {
-	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
+	const ref = useCopyToClipboard( () => {
+		blocks = blocks.map( ( block ) =>
+			__experimentalRemoveAttributesByRole( block, 'internal' )
+		);
+		return serialize( blocks );
+	}, onCopy );
 	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -15,7 +15,7 @@ import { Children, cloneElement, useCallback } from '@wordpress/element';
 import {
 	serialize,
 	store as blocksStore,
-	__experimentalRemoveAttributesByRole,
+	__experimentalCloneSanitizedBlock,
 } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
@@ -39,7 +39,7 @@ const POPOVER_PROPS = {
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => {
 		blocks = blocks.map( ( block ) =>
-			__experimentalRemoveAttributesByRole( block, 'internal' )
+			__experimentalCloneSanitizedBlock( block )
 		);
 		return serialize( blocks );
 	}, onCopy );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,7 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
-	__experimentalRemoveAttributesByRole,
+	__experimentalCloneSanitizedBlock,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -125,10 +125,7 @@ export function useClipboardHandler() {
 				let blocks = getBlocksByClientId( selectedBlockClientIds );
 				if ( event.type === 'copy' ) {
 					blocks = blocks.map( ( block ) =>
-						__experimentalRemoveAttributesByRole(
-							block,
-							'internal'
-						)
+						__experimentalCloneSanitizedBlock( block )
 					);
 				}
 				const serialized = serialize( blocks );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,6 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
+	__experimentalRemoveAttributesByRole,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -121,7 +122,15 @@ export function useClipboardHandler() {
 					flashBlock( selectedBlockClientIds[ 0 ] );
 				}
 				notifyCopy( event.type, selectedBlockClientIds );
-				const blocks = getBlocksByClientId( selectedBlockClientIds );
+				let blocks = getBlocksByClientId( selectedBlockClientIds );
+				if ( event.type === 'copy' ) {
+					blocks = blocks.map( ( block ) =>
+						__experimentalRemoveAttributesByRole(
+							block,
+							'internal'
+						)
+					);
+				}
 				const serialized = serialize( blocks );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -32,8 +32,8 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
-	__experimentalStripInternalBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
+	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 /**
@@ -111,21 +111,21 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Merge in new attributes and strip out attributes with the `internal` role,
-	// which should not be copied during block duplication.
-	const retainedAttributes = __experimentalStripInternalBlockAttributes(
-		block.name,
-		{
-			...block.attributes,
-			...mergeAttributes,
-		}
-	);
+	// Merge in new attributes
+	block.attributes = {
+		...block.attributes,
+		...mergeAttributes,
+	};
+
+	// Strip out attributes with the `internal` role, which should not be copied during
+	// block duplication.
+	block = __experimentalRemoveAttributesByRole( block, 'internal' );
 
 	// Remove any attributes not defined in the block type, and fill in default values for
 	// misisng attributes.
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		block.name,
-		retainedAttributes
+		block.attributes
 	);
 
 	return {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -32,6 +32,7 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
+	__experimentalStripInternalBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
 } from './utils';
 
@@ -110,12 +111,21 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+	// Merge in new attributes and strip out attributes with the `internal` role,
+	// which should not be copied during block duplication.
+	const retainedAttributes = __experimentalStripInternalBlockAttributes(
 		block.name,
 		{
 			...block.attributes,
 			...mergeAttributes,
 		}
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		block.name,
+		retainedAttributes
 	);
 
 	return {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -95,8 +95,9 @@ export function createBlocksFromInnerBlocksTemplate(
 }
 
 /**
- * Given a block object, returns a copy of the block object while sanitizing its attributes,
+ * Given a block object, returns a copy of the block object,
  * optionally merging new attributes and/or replacing its inner blocks.
+ * Attributes with the `internal` role are not copied into the new object.
  *
  * @param {Object} block           Block instance.
  * @param {Object} mergeAttributes Block attributes.
@@ -122,17 +123,10 @@ export function __experimentalCloneSanitizedBlock(
 		'internal'
 	);
 
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		block.name,
-		retainedAttributes
-	);
-
 	return {
 		...block,
 		clientId,
-		attributes: sanitizedAttributes,
+		attributes: retainedAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -111,36 +111,34 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Clone the block and merge in new attributes.
-	let clonedBlock = {
-		...block,
-		clientId,
-		attributes: {
+	// Merge in new attributes and strip out attributes with the `internal` role,
+	// which should not be copied during block duplication.
+	const retainedAttributes = __experimentalRemoveAttributesByRole(
+		block.name,
+		{
 			...block.attributes,
 			...mergeAttributes,
 		},
+		'internal'
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		block.name,
+		retainedAttributes
+	);
+
+	return {
+		...block,
+		clientId,
+		attributes: sanitizedAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>
 				__experimentalCloneSanitizedBlock( innerBlock )
 			),
 	};
-
-	// Strip out attributes with the `internal` role, which should not be copied during
-	// block duplication.
-	clonedBlock = __experimentalRemoveAttributesByRole(
-		clonedBlock,
-		'internal'
-	);
-
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	clonedBlock.attributes = __experimentalSanitizeBlockAttributes(
-		clonedBlock.name,
-		clonedBlock.attributes
-	);
-
-	return clonedBlock;
 }
 
 /**

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -16,6 +16,7 @@ import {
 	isEmpty,
 	map,
 	reduce,
+	omit,
 } from 'lodash';
 
 /**
@@ -33,7 +34,7 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
-	__experimentalRemoveAttributesByRole,
+	__experimentalGetBlockAttributesNamesByRole,
 } from './utils';
 
 /**
@@ -142,19 +143,18 @@ export function __experimentalCloneSanitizedBlock(
 
 	// Merge in new attributes and strip out attributes with the `internal` role,
 	// which should not be copied during block duplication.
-	const retainedAttributes = __experimentalRemoveAttributesByRole(
-		block.name,
+	const filteredAttributes = omit(
 		{
 			...block.attributes,
 			...mergeAttributes,
 		},
-		'internal'
+		__experimentalGetBlockAttributesNamesByRole( block.name, 'internal' )
 	);
 
 	return {
 		...block,
 		clientId,
-		attributes: retainedAttributes,
+		attributes: filteredAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -111,33 +111,36 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Merge in new attributes
-	block.attributes = {
-		...block.attributes,
-		...mergeAttributes,
-	};
-
-	// Strip out attributes with the `internal` role, which should not be copied during
-	// block duplication.
-	block = __experimentalRemoveAttributesByRole( block, 'internal' );
-
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		block.name,
-		block.attributes
-	);
-
-	return {
+	// Clone the block and merge in new attributes.
+	let clonedBlock = {
 		...block,
 		clientId,
-		attributes: sanitizedAttributes,
+		attributes: {
+			...block.attributes,
+			...mergeAttributes,
+		},
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>
 				__experimentalCloneSanitizedBlock( innerBlock )
 			),
 	};
+
+	// Strip out attributes with the `internal` role, which should not be copied during
+	// block duplication.
+	clonedBlock = __experimentalRemoveAttributesByRole(
+		clonedBlock,
+		'internal'
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	clonedBlock.attributes = __experimentalSanitizeBlockAttributes(
+		clonedBlock.name,
+		clonedBlock.attributes
+	);
+
+	return clonedBlock;
 }
 
 /**

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -141,7 +141,6 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
-	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
 	__experimentalRemoveAttributesByRole,
 } from './utils';

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -143,6 +143,7 @@ export {
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -142,7 +142,6 @@ export {
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -448,6 +448,33 @@ describe( 'block factory', () => {
 
 			expect( clonedBlock.attributes ).toEqual( {} );
 		} );
+		it( 'should not duplicate internal attributes, but fallback to available defaults', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					internalAttribute: {
+						type: 'string',
+						__experimentalRole: 'internal',
+					},
+					internalAttributeWithDefault: {
+						type: 'string',
+						__experimentalRole: 'internal',
+						default: 'default-value',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				internalAttribute: 'unique-value',
+				internalAttributeWithDefault: 'unique-non-default-value',
+			} );
+
+			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
+
+			expect( clonedBlock.attributes ).toEqual( {
+				internalAttributeWithDefault: 'default-value',
+			} );
+		} );
 	} );
 
 	describe( 'getPossibleBlockTransformations()', () => {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -90,9 +90,12 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
-					content: {
+					childrenContent: {
 						type: 'array',
 						source: 'children',
+					},
+					nodeContent: {
+						source: 'node',
 					},
 				},
 			} );
@@ -100,7 +103,8 @@ describe( 'block factory', () => {
 			const block = createBlock( 'core/test-block' );
 
 			expect( block.attributes ).toEqual( {
-				content: [],
+				childrenContent: [],
+				nodeContent: [],
 			} );
 		} );
 
@@ -176,6 +180,14 @@ describe( 'block factory', () => {
 			} );
 
 			expect( block.attributes ).toEqual( {} );
+		} );
+
+		it( 'throws error if the block is not registered', () => {
+			expect( () => {
+				createBlock( 'core/not-registered-test-block', {} );
+			} ).toThrowErrorMatchingInlineSnapshot(
+				`"Block type 'core/not-registered-test-block' is not registered."`
+			);
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -18,7 +18,6 @@ import {
 	getAccessibleBlockLabel,
 	getBlockLabel,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalRemoveAttributesByRole,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -300,86 +299,5 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 				'content'
 			)
 		).toEqual( [] );
-	} );
-} );
-
-describe( '__experimentalRemoveAttributesByRole', () => {
-	beforeAll( () => {
-		registerBlockType( 'core/test-block-with-internal-attrs', {
-			attributes: {
-				align: {
-					type: 'string',
-				},
-				internalData: {
-					type: 'boolean',
-					__experimentalRole: 'internal',
-				},
-				productId: {
-					type: 'number',
-					__experimentalRole: 'internal',
-				},
-				color: {
-					type: 'string',
-					__experimentalRole: 'other',
-				},
-			},
-			save: noop,
-			category: 'text',
-			title: 'test block with internal attrs',
-		} );
-		registerBlockType( 'core/test-block-with-no-internal-attrs', {
-			attributes: {
-				align: { type: 'string' },
-				color: { type: 'string' },
-			},
-			save: noop,
-			category: 'text',
-			title: 'test block with no internal attrs',
-		} );
-		registerBlockType( 'core/test-block-with-no-attrs', {
-			save: noop,
-			category: 'text',
-			title: 'test block with no attrs',
-		} );
-	} );
-	afterAll( () => {
-		[
-			'core/test-block-with-internal-attrs',
-			'core/test-block-with-no-internal-attrs',
-			'core/test-block-with-no-attrs',
-		].forEach( unregisterBlockType );
-	} );
-
-	it( 'should return empty object if no attributes are passed', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-internal-attrs',
-				{},
-				'internal'
-			)
-		).toEqual( {} );
-	} );
-	it( 'should return all attributes when block has no attributes with given role', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-no-internal-attrs',
-				{ align: 'left', color: 'blue' },
-				'internal'
-			)
-		).toEqual( { align: 'left', color: 'blue' } );
-	} );
-	it( 'should remove attributes with given role and return all others', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-internal-attrs',
-				{
-					align: 'left',
-					internalData: true,
-					productId: 12345,
-					color: 'blue',
-				},
-				'internal'
-			)
-		).toEqual( { align: 'left', color: 'blue' } );
 	} );
 } );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -19,6 +19,7 @@ import {
 	getBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalStripInternalBlockAttributes,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -397,5 +398,83 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 				'content'
 			)
 		).toEqual( [] );
+	} );
+} );
+
+describe( '__experimentalStripInternalBlockAttributes', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/test-block-with-internal-attrs', {
+			attributes: {
+				align: {
+					type: 'string',
+				},
+				internalData: {
+					type: 'boolean',
+					__experimentalRole: 'internal',
+				},
+				productId: {
+					type: 'number',
+					__experimentalRole: 'internal',
+				},
+				color: {
+					type: 'string',
+					__experimentalRole: 'other',
+				},
+			},
+			save: noop,
+			category: 'text',
+			title: 'test block with internal attrs',
+		} );
+		registerBlockType( 'core/test-block-with-no-internal-attrs', {
+			attributes: {
+				align: { type: 'string' },
+				color: { type: 'string' },
+			},
+			save: noop,
+			category: 'text',
+			title: 'test block with no internal attrs',
+		} );
+		registerBlockType( 'core/test-block-with-no-attrs', {
+			save: noop,
+			category: 'text',
+			title: 'test block with no attrs',
+		} );
+	} );
+	afterAll( () => {
+		[
+			'core/test-block-with-internal-attrs',
+			'core/test-block-with-no-internal-attrs',
+			'core/test-block-with-no-attrs',
+		].forEach( unregisterBlockType );
+	} );
+
+	it( 'should return empty object if no attributes are passed', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-internal-attrs',
+				{}
+			)
+		).toEqual( {} );
+	} );
+	it( 'should return all attributes when block has no attributes with internal role', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-no-internal-attrs',
+				{ align: 'left', color: 'blue' }
+			)
+		).toEqual( { align: 'left', color: 'blue' } );
+	} );
+	it( 'should remove attributes with internal role and return all others', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-internal-attrs',
+				{
+					align: 'left',
+					internalData: true,
+					productId: 12345,
+					color: 'blue',
+				}
+			)
+		).toEqual( { align: 'left', color: 'blue' } );
 	} );
 } );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,7 +17,6 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
-	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
 	__experimentalRemoveAttributesByRole,
 } from '../utils';
@@ -213,103 +212,6 @@ describe( 'getAccessibleBlockLabel', () => {
 		expect( getAccessibleBlockLabel( blockType, attributes, 3 ) ).toBe(
 			'Recipe Block. Row 3'
 		);
-	} );
-} );
-
-describe( 'sanitizeBlockAttributes', () => {
-	afterEach( () => {
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
-	} );
-
-	it( 'sanitize block attributes not defined in the block type', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				defined: {
-					type: 'string',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				defined: 'defined-attribute',
-				notDefined: 'not-defined-attribute',
-			}
-		);
-
-		expect( attributes ).toEqual( {
-			defined: 'defined-attribute',
-		} );
-	} );
-
-	it( 'throws error if the block is not registered', () => {
-		expect( () => {
-			__experimentalSanitizeBlockAttributes(
-				'core/not-registered-test-block',
-				{}
-			);
-		} ).toThrowErrorMatchingInlineSnapshot(
-			`"Block type 'core/not-registered-test-block' is not registered."`
-		);
-	} );
-
-	it( 'handles undefined values and default values', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				hasDefaultValue: {
-					type: 'string',
-					default: 'default-value',
-				},
-				noDefaultValue: {
-					type: 'string',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{}
-		);
-
-		expect( attributes ).toEqual( {
-			hasDefaultValue: 'default-value',
-		} );
-	} );
-
-	it( 'handles node and children sources as arrays', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				nodeContent: {
-					source: 'node',
-				},
-				childrenContent: {
-					source: 'children',
-				},
-				withDefault: {
-					source: 'children',
-					default: 'test',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				nodeContent: [ 'test-1', 'test-2' ],
-			}
-		);
-
-		expect( attributes ).toEqual( {
-			nodeContent: [ 'test-1', 'test-2' ],
-			childrenContent: [],
-			withDefault: [ 'test' ],
-		} );
 	} );
 } );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -19,7 +19,7 @@ import {
 	getBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalStripInternalBlockAttributes,
+	__experimentalRemoveAttributesByRole,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -401,7 +401,7 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 	} );
 } );
 
-describe( '__experimentalStripInternalBlockAttributes', () => {
+describe( '__experimentalRemoveAttributesByRole', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block-with-internal-attrs', {
 			attributes: {
@@ -450,30 +450,33 @@ describe( '__experimentalStripInternalBlockAttributes', () => {
 
 	it( 'should return empty object if no attributes are passed', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-internal-attrs',
-				{}
+				{},
+				'internal'
 			)
 		).toEqual( {} );
 	} );
-	it( 'should return all attributes when block has no attributes with internal role', () => {
+	it( 'should return all attributes when block has no attributes with given role', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-no-internal-attrs',
-				{ align: 'left', color: 'blue' }
+				{ align: 'left', color: 'blue' },
+				'internal'
 			)
 		).toEqual( { align: 'left', color: 'blue' } );
 	} );
-	it( 'should remove attributes with internal role and return all others', () => {
+	it( 'should remove attributes with given role and return all others', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-internal-attrs',
 				{
 					align: 'left',
 					internalData: true,
 					productId: 12345,
 					color: 'blue',
-				}
+				},
+				'internal'
 			)
 		).toEqual( { align: 'left', color: 'blue' } );
 	} );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, reduce, maxBy } from 'lodash';
+import { every, has, isFunction, isString, maxBy } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -236,49 +236,6 @@ export function getAccessibleBlockLabel(
 		/* translators: accessibility text. %s: The block title. */
 		__( '%s Block' ),
 		title
-	);
-}
-
-/**
- * Ensure attributes contains only values defined by block type, and merge
- * default values for missing attributes.
- *
- * @param {string} name       The block's name.
- * @param {Object} attributes The block's attributes.
- * @return {Object} The sanitized attributes.
- */
-export function __experimentalSanitizeBlockAttributes( name, attributes ) {
-	// Get the type definition associated with a registered block.
-	const blockType = getBlockType( name );
-
-	if ( undefined === blockType ) {
-		throw new Error( `Block type '${ name }' is not registered.` );
-	}
-
-	return reduce(
-		blockType.attributes,
-		( accumulator, schema, key ) => {
-			const value = attributes[ key ];
-
-			if ( undefined !== value ) {
-				accumulator[ key ] = value;
-			} else if ( schema.hasOwnProperty( 'default' ) ) {
-				accumulator[ key ] = schema.default;
-			}
-
-			if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
-				// Ensure value passed is always an array, which we're expecting in
-				// the RichText component to handle the deprecated value.
-				if ( typeof accumulator[ key ] === 'string' ) {
-					accumulator[ key ] = [ accumulator[ key ] ];
-				} else if ( ! Array.isArray( accumulator[ key ] ) ) {
-					accumulator[ key ] = [];
-				}
-			}
-
-			return accumulator;
-		},
-		{}
 	);
 }
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -302,31 +302,27 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 }
 
 /**
- * Given a block, remove any attributes with the given `role`.
+ * Given attributes, remove any attributes with the given `role`.
  *
- * @param {Object} block           Block instance.
- * @param {string} role            The role of a block attribute.
+ * @param {string} name       The block's name.
+ * @param {Object} attributes The block's attributes.
+ * @param {string} role       The role of a block attribute.
  *
- * @return {Object} The block, with attributes matching the `role` removed.
+ * @return {Object} The attributes, with those matching the `role` removed.
  */
-export function __experimentalRemoveAttributesByRole( block, role ) {
+export function __experimentalRemoveAttributesByRole( name, attributes, role ) {
 	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
-		block.name,
+		name,
 		role
 	);
 	if ( ! attributesByRole?.length ) {
-		return block;
+		return attributes;
 	}
 
-	block.attributes = Object.keys( block.attributes ).reduce(
-		( _accumulator, attribute ) => {
-			if ( ! attributesByRole.includes( attribute ) ) {
-				_accumulator[ attribute ] = block.attributes[ attribute ];
-			}
-			return _accumulator;
-		},
-		{}
-	);
-
-	return block;
+	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
+		if ( ! attributesByRole.includes( attribute ) ) {
+			_accumulator[ attribute ] = attributes[ attribute ];
+		}
+		return _accumulator;
+	}, {} );
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -302,25 +302,31 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 }
 
 /**
- * Given block attributes, return only those which do not have the `internal`
- * role.
+ * Given a block, remove any attributes with the given `role`.
  *
- * @param {string} name       The block's name
- * @param {Object} attributes The block's attributes
- * @return {Object} The attributes, stripped of any internal attributes.
+ * @param {Object} block           Block instance.
+ * @param {string} role            The role of a block attribute.
+ *
+ * @return {Object} The block, with attributes matching the `role` removed.
  */
-export function __experimentalStripInternalBlockAttributes( name, attributes ) {
-	const internalAttributes = __experimentalGetBlockAttributesNamesByRole(
-		name,
-		'internal'
+export function __experimentalRemoveAttributesByRole( block, role ) {
+	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
+		block.name,
+		role
+	);
+	if ( ! attributesByRole?.length ) {
+		return block;
+	}
+
+	block.attributes = Object.keys( block.attributes ).reduce(
+		( _accumulator, attribute ) => {
+			if ( ! attributesByRole.includes( attribute ) ) {
+				_accumulator[ attribute ] = block.attributes[ attribute ];
+			}
+			return _accumulator;
+		},
+		{}
 	);
 
-	if ( ! internalAttributes?.length ) return attributes;
-
-	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
-		if ( ! internalAttributes.includes( attribute ) ) {
-			_accumulator[ attribute ] = attributes[ attribute ];
-		}
-		return _accumulator;
-	}, {} );
+	return block;
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -257,29 +257,3 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 			attributes[ attributeName ]?.__experimentalRole === role
 	);
 }
-
-/**
- * Given attributes, remove any attributes with the given `role`.
- *
- * @param {string} name       The block's name.
- * @param {Object} attributes The block's attributes.
- * @param {string} role       The role of a block attribute.
- *
- * @return {Object} The attributes, with those matching the `role` removed.
- */
-export function __experimentalRemoveAttributesByRole( name, attributes, role ) {
-	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
-		name,
-		role
-	);
-	if ( ! attributesByRole?.length ) {
-		return attributes;
-	}
-
-	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
-		if ( ! attributesByRole.includes( attribute ) ) {
-			_accumulator[ attribute ] = attributes[ attribute ];
-		}
-		return _accumulator;
-	}, {} );
-}

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -300,3 +300,27 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 			attributes[ attributeName ]?.__experimentalRole === role
 	);
 }
+
+/**
+ * Given block attributes, return only those which do not have the `internal`
+ * role.
+ *
+ * @param {string} name       The block's name
+ * @param {Object} attributes The block's attributes
+ * @return {Object} The attributes, stripped of any internal attributes.
+ */
+export function __experimentalStripInternalBlockAttributes( name, attributes ) {
+	const internalAttributes = __experimentalGetBlockAttributesNamesByRole(
+		name,
+		'internal'
+	);
+
+	if ( ! internalAttributes?.length ) return attributes;
+
+	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
+		if ( ! internalAttributes.includes( attribute ) ) {
+			_accumulator[ attribute ] = attributes[ attribute ];
+		}
+		return _accumulator;
+	}, {} );
+}

--- a/packages/customize-widgets/src/filters/move-to-sidebar.js
+++ b/packages/customize-widgets/src/filters/move-to-sidebar.js
@@ -55,10 +55,10 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 			const newSidebarControl = sidebarControls.find(
 				( sidebarControl ) => sidebarControl.id === sidebarControlId
 			);
-
-			if ( widgetId ) {
+			const activeSidebarAdapter = activeSidebarControl.sidebarAdapter;
+			if ( widgetId && activeSidebarAdapter.getWidget( widgetId ) ) {
 				/**
-				 * If there's a widgetId, move it to the other sidebar.
+				 * If there's an existing widget, move it to the other sidebar.
 				 */
 				const oldSetting = activeSidebarControl.setting;
 				const newSetting = newSidebarControl.setting;
@@ -67,15 +67,15 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 				newSetting( [ ...newSetting(), widgetId ] );
 			} else {
 				/**
-				 * If there isn't a widgetId, it's most likely a inner block.
-				 * First, remove the block in the original sidebar,
+				 * If there isn't an existing widget with this id, it's most likely an
+				 * inner block. First, remove the block in the original sidebar,
 				 * then, create a new widget in the new sidebar and get back its widgetId.
 				 */
-				const sidebarAdapter = newSidebarControl.sidebarAdapter;
+				const newSidebarAdapter = newSidebarControl.sidebarAdapter;
 
 				removeBlock( clientId );
-				const addedWidgetIds = sidebarAdapter.setWidgets( [
-					...sidebarAdapter.getWidgets(),
+				const addedWidgetIds = newSidebarAdapter.setWidgets( [
+					...newSidebarAdapter.getWidgets(),
 					blockToWidget( block ),
 				] );
 				// The last non-null id is the added widget's id.

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -8,6 +8,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import {
+	registerInternalWidgetIds,
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
 	registerWidgetGroupBlock,
@@ -59,6 +60,8 @@ export function initialize( editorName, blockEditorSettings ) {
 			block.name.startsWith( 'core/navigation' )
 		);
 	} );
+
+	registerInternalWidgetIds();
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/block-library';
 import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import {
+	registerInternalWidgetIds,
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
 	registerWidgetGroupBlock,
@@ -85,7 +86,10 @@ export function initialize( id, settings ) {
 		themeStyles: true,
 	} );
 
+	registerInternalWidgetIds();
+
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
+
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -28,7 +28,6 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -12,7 +12,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Placeholder, Spinner } from '@wordpress/components';
-import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
@@ -88,20 +87,12 @@ export default function ServerSideRender( props ) {
 
 		setIsLoading( true );
 
-		const sanitizedAttributes =
-			attributes &&
-			__experimentalSanitizeBlockAttributes( block, attributes );
-
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.
 		// This allows sending a larger attributes object than in a GET request, where the attributes are in the URL.
 		const isPostRequest = 'POST' === httpMethod;
-		const urlAttributes = isPostRequest
-			? null
-			: sanitizedAttributes ?? null;
+		const urlAttributes = isPostRequest ? null : attributes ?? null;
 		const path = rendererPath( block, urlAttributes, urlQueryArgs );
-		const data = isPostRequest
-			? { attributes: sanitizedAttributes ?? null }
-			: null;
+		const data = isPostRequest ? { attributes: attributes ?? null } : null;
 
 		// Store the latest fetch request so that when we process it, we can
 		// check if it is the current request, to avoid race conditions on slow networks.

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:.../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
-		"@wordpress/hooks": "file:.../hooks",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -38,7 +38,7 @@ export function addWidgetIdToBlock( block, widgetId ) {
 
 /**
  * Filters registered block settings, extending attributes to include
- * `borderColor` if needed.
+ * `__internalWidgetId` if needed.
  *
  * @param {Object} settings Original block settings.
  *

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Get the internal widget id from block.
@@ -23,11 +27,33 @@ export function getWidgetIdFromBlock( block ) {
  * @return {Block} The updated block.
  */
 export function addWidgetIdToBlock( block, widgetId ) {
+	block.attributes.__internalWidgetId = widgetId;
+	return block;
+}
+
+/**
+ * Filters registered block settings, extending attributes to include
+ * `borderColor` if needed.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Updated block settings.
+ */
+function addAttributes( settings ) {
 	return {
-		...block,
+		...settings,
 		attributes: {
-			...( block.attributes || {} ),
-			__internalWidgetId: widgetId,
+			...settings.attributes,
+			__internalWidgetId: {
+				type: 'string',
+				__experimentalRole: 'internal',
+			},
 		},
 	};
 }
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/widget/addAttributes',
+	addAttributes
+);

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -27,8 +27,13 @@ export function getWidgetIdFromBlock( block ) {
  * @return {Block} The updated block.
  */
 export function addWidgetIdToBlock( block, widgetId ) {
-	block.attributes.__internalWidgetId = widgetId;
-	return block;
+	return {
+		...block,
+		attributes: {
+			...( block.attributes || {} ),
+			__internalWidgetId: widgetId,
+		},
+	};
 }
 
 /**
@@ -39,7 +44,7 @@ export function addWidgetIdToBlock( block, widgetId ) {
  *
  * @return {Object} Updated block settings.
  */
-function addAttributes( settings ) {
+function addInternalWidgetIdAttribute( settings ) {
 	return {
 		...settings,
 		attributes: {
@@ -52,8 +57,10 @@ function addAttributes( settings ) {
 	};
 }
 
-addFilter(
-	'blocks.registerBlockType',
-	'core/widget/addAttributes',
-	addAttributes
-);
+export function registerInternalWidgetIds() {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/widget/addAttributes',
+		addInternalWidgetIdAttribute
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Closes #29693
Alternative to #32604 

## Description
<!-- Please describe what you have changed or added -->

This PR:
* Adds handling for a new `internal` attribute experimentalRole. Attributes registered with this role will not be copied on block duplication.
* Refactors `__internalWidgetID` to use the new experimental role
 
Example fragment of block.json:

```
            "attributes": {
		"myInternalAttribute": {
			"type": "string",
			"default": "my-default-value",
			"__experimentalRole": "internal"
		}
	},
```

For just one example of how this might be used: the Jetpack `Pay with Paypal` block uses a `productId` attribute to identify the actual product record referenced by the block. This data is meant to be internal to the block and should not be exposed to the user. When the user duplicates the block, we want to copy the other attributes used to store price info and other details, but create a brand new product record/productId.

This is similar conceptually to #32604 with a few changes:
* The use of `internal` terminology rather than `duplicable` or `unique`, which implies additional constraints
* The use of the `__experimentalRole` and associated utilities (thanks @ntsekouras for the suggestion)

## Notes

* In other regards, an attribute with this role acts like a normal attribute
    * ~~It respects any configured default values~~ Default values are not filled in on block duplication either; support for this could be easily added if a viable use case becomes apparent, though
    * It can be managed as normal via `setAttributes`
    * It can apply to any type of attribute (ie it is not necessarily an id field)
* While you can give this role to an attribute with a "source"/"selector" configuration, it is not meaningful to do so. For example, adding it to the `content` attribute of the [Code block](https://github.com/WordPress/gutenberg/blob/a84c037a0e62a344005054102544c34d7b970a6b/packages/block-library/src/code/block.json#L9) would not make sense, because although the attribute would not be copied on duplication, it will populate with the same value from the html.
* Because this is experimental and also relies on experimental features, I have not added documentation; happy to do so if that is appropriate!
* A note about Reusable blocks:
Internal attributes are not removed when you convert a block into a Reusable block. I don’t know a ton about Reusable blocks, so calling this out so that someone more familiar can correct me; my understanding is that multiple instances of a Reusable block are not independent of each other (ie editing one copy affects them all), so internal attributes should also be shared.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Play around with adding `__experimentalRole: 'internal'` to any block attribute. 
* Insert the block into a new post, change its attributes, and duplicate it
* Verify that the internal attributes were not copied, but all other attributes were
* ~~Test with attributes that have a `default` value and ensure that the default is respected in the duplicated block~~
* Test Copy+Paste using both the `Copy` menu item, and by keyboard commands
* Test duplicating a block with internal attributes in the widget editor
* Test adding and editing widgets in both the Widget editor and the Customizer
  * Test moving widgets between widget areas/side panels
  * Test a server-side rendered block in the widget editor and make sure the preview is displayed correctly (Basically verify that #29197 is still fixed with the new implementation)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
