### PR TITLE
Unit Control: Always display current unit value if valid

### DIFF
--- a/packages/components/src/unit-control/README.md
+++ b/packages/components/src/unit-control/README.md
@@ -102,7 +102,7 @@ Example:
 
 Collection of available units.
 
--   Type: `Array<Object>`
+-   Type: `Array<WPUnitControlUnit>`
 -   Required: No
 
 Example:

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useRef } from '@wordpress/element';
+import { forwardRef, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -18,7 +18,12 @@ import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { composeStateReducers } from '../input-control/reducer/reducer';
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
-import { CSS_UNITS, getParsedValue, getValidParsedUnit } from './utils';
+import {
+	CSS_UNITS,
+	getParsedValue,
+	getUnitsWithCurrentUnit,
+	getValidParsedUnit,
+} from './utils';
 import { useControlledState } from '../utils/hooks';
 
 function UnitControl(
@@ -37,12 +42,16 @@ function UnitControl(
 		size = 'default',
 		style,
 		unit: unitProp,
-		units = CSS_UNITS,
+		units: unitsProp = CSS_UNITS,
 		value: valueProp,
 		...props
 	},
 	ref
 ) {
+	const units = useMemo(
+		() => getUnitsWithCurrentUnit( valueProp, unitProp, unitsProp ),
+		[ valueProp, unitProp, unitsProp ]
+	);
 	const [ value, initialUnit ] = getParsedValue( valueProp, unitProp, units );
 	const [ unit, setUnit ] = useControlledState( unitProp, {
 		initial: initialUnit,

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -350,5 +350,23 @@ describe( 'UnitControl', () => {
 
 			expect( getSelect().value ).toBe( 'px' );
 		} );
+
+		it( 'should display valid CSS unit when not explicitly included in units list', () => {
+			render(
+				<UnitControl
+					value={ '10%' }
+					units={ [
+						{ value: 'px', label: 'px' },
+						{ value: 'em', label: 'em' },
+					] }
+				/>
+			);
+
+			const select = getSelect();
+			const options = select.querySelectorAll( 'option' );
+
+			expect( select.value ).toBe( '%' );
+			expect( options.length ).toBe( 3 );
+		} );
 	} );
 } );

--- a/packages/components/src/unit-control/test/utils.js
+++ b/packages/components/src/unit-control/test/utils.js
@@ -5,6 +5,7 @@ import {
 	filterUnitsWithSettings,
 	useCustomUnits,
 	getValidParsedUnit,
+	getUnitsWithCurrentUnit,
 } from '../utils';
 
 describe( 'UnitControl utils', () => {
@@ -113,6 +114,63 @@ describe( 'UnitControl utils', () => {
 				101,
 				'px',
 			] );
+		} );
+	} );
+
+	describe( 'getUnitsWithCurrentUnit', () => {
+		const limitedUnits = [
+			{
+				value: 'px',
+				label: 'px',
+			},
+			{
+				value: 'em',
+				label: 'em',
+			},
+		];
+
+		it( 'should return units list with valid current unit prepended', () => {
+			const result = getUnitsWithCurrentUnit( '20%', null, limitedUnits );
+
+			expect( result ).toHaveLength( 3 );
+
+			const currentUnit = result.shift();
+			expect( currentUnit.value ).toBe( '%' );
+			expect( currentUnit.label ).toBe( '%' );
+			expect( result ).toEqual( limitedUnits );
+		} );
+
+		it( 'should return units list with valid current unit prepended using legacy values', () => {
+			const result = getUnitsWithCurrentUnit( 20, '%', limitedUnits );
+
+			expect( result ).toHaveLength( 3 );
+
+			const currentUnit = result.shift();
+			expect( currentUnit.value ).toBe( '%' );
+			expect( currentUnit.label ).toBe( '%' );
+			expect( result ).toEqual( limitedUnits );
+		} );
+
+		it( 'should return units list without invalid current unit prepended', () => {
+			const result = getUnitsWithCurrentUnit(
+				'20null',
+				null,
+				limitedUnits
+			);
+
+			expect( result ).toHaveLength( 2 );
+			expect( result ).toEqual( limitedUnits );
+		} );
+
+		it( 'should return units list without an existing current unit prepended', () => {
+			const result = getUnitsWithCurrentUnit(
+				'20em',
+				null,
+				limitedUnits
+			);
+
+			expect( result ).toHaveLength( 2 );
+			expect( result ).toEqual( limitedUnits );
 		} );
 	} );
 } );

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -11,7 +11,7 @@ import { Platform } from '@wordpress/element';
 
 const isWeb = Platform.OS === 'web';
 
-export const allUnits = {
+const allUnits = {
 	px: {
 		value: 'px',
 		label: isWeb ? 'px' : __( 'Pixels (px)' ),
@@ -151,8 +151,7 @@ export const DEFAULT_UNIT = allUnits.px;
  * @return {Array<number, string>} The extracted number and unit.
  */
 export function getParsedValue( value, unit, units ) {
-	const initialValue =
-		unit && Number.isFinite( value ) ? `${ value }${ unit }` : value;
+	const initialValue = unit ? `${ value }${ unit }` : value;
 
 	return parseUnit( initialValue, units );
 }

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -301,11 +301,11 @@ export const useCustomUnits = ( { units, availableUnits, defaultValues } ) => {
  * accurately displayed in the UI, even if the intention is to hide
  * the availability of that unit.
  *
- * @param {number|string} currentValue Selected value to parse.
- * @param {string}        legacyUnit   Legacy unit value, if currentValue needs it appended.
- * @param {Array<Object>} units        List of available units.
+ * @param {number|string}            currentValue Selected value to parse.
+ * @param {string}                   legacyUnit   Legacy unit value, if currentValue needs it appended.
+ * @param {Array<WPUnitControlUnit>} units        List of available units.
  *
- * @return {Array<Object>} A collection of units containing the unit for the current value.
+ * @return {Array<WPUnitControlUnit>} A collection of units containing the unit for the current value.
  */
 export function getUnitsWithCurrentUnit(
 	currentValue,

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -180,8 +180,8 @@ export function hasUnits( units ) {
 /**
  * Parses a number and unit from a value.
  *
- * @param {string}        initialValue Value to parse
- * @param {Array<Object>} units        Units to derive from.
+ * @param {string}                   initialValue Value to parse
+ * @param {Array<WPUnitControlUnit>} units        Units to derive from.
  * @return {Array<number, string>} The extracted number and unit.
  */
 export function parseUnit( initialValue, units = ALL_CSS_UNITS ) {
@@ -209,10 +209,10 @@ export function parseUnit( initialValue, units = ALL_CSS_UNITS ) {
  * Parses a number and unit from a value. Validates parsed value, using fallback
  * value if invalid.
  *
- * @param {number|string} next          The next value.
- * @param {Array<Object>} units         Units to derive from.
- * @param {number|string} fallbackValue The fallback value.
- * @param {string}        fallbackUnit  The fallback value.
+ * @param {number|string}            next          The next value.
+ * @param {Array<WPUnitControlUnit>} units         Units to derive from.
+ * @param {number|string}            fallbackValue The fallback value.
+ * @param {string}                   fallbackUnit  The fallback value.
  * @return {Array<number, string>} The extracted number and unit.
  */
 export function getValidParsedUnit( next, units, fallbackValue, fallbackUnit ) {
@@ -268,10 +268,10 @@ export function filterUnitsWithSettings( settings = [], units = [] ) {
  * TODO: ideally this hook shouldn't be needed
  * https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823
  *
- * @param {Object}                  args                An object containing units, settingPath & defaultUnits.
- * @param {Array<Object>|undefined} args.units          Collection of available units.
- * @param {Array<string>|undefined} args.availableUnits The setting path. Defaults to 'spacing.units'.
- * @param {Object|undefined}        args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
+ * @param {Object}                             args                An object containing units, settingPath & defaultUnits.
+ * @param {Array<WPUnitControlUnit>|undefined} args.units          Collection of available units.
+ * @param {Array<string>|undefined}            args.availableUnits The setting path. Defaults to 'spacing.units'.
+ * @param {Object|undefined}                   args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
  *
  * @return {Array|boolean} Filtered units based on settings.
  */

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -22,6 +22,7 @@ import { Platform } from '@wordpress/element';
 
 const isWeb = Platform.OS === 'web';
 
+/** @type {Record<string, WPUnitControlUnit>} */
 const allUnits = {
 	px: {
 		value: 'px',

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -19,7 +19,7 @@ export const allUnits = {
 		a11yLabel: __( 'Pixels (px)' ),
 		step: 1,
 	},
-	percent: {
+	'%': {
 		value: '%',
 		label: isWeb ? '%' : __( 'Percentage (%)' ),
 		default: '',
@@ -129,7 +129,7 @@ export const ALL_CSS_UNITS = Object.values( allUnits );
  */
 export const CSS_UNITS = [
 	allUnits.px,
-	allUnits.percent,
+	allUnits[ '%' ],
 	allUnits.em,
 	allUnits.rem,
 	allUnits.vw,
@@ -302,6 +302,10 @@ export function getUnitsWithCurrentUnit(
 	legacyUnit,
 	units = ALL_CSS_UNITS
 ) {
+	if ( ! Array.isArray( units ) ) {
+		return units;
+	}
+
 	const unitsWithCurrentUnit = [ ...units ];
 	const [ , currentUnit ] = getParsedValue(
 		currentValue,
@@ -313,10 +317,8 @@ export function getUnitsWithCurrentUnit(
 		currentUnit &&
 		! unitsWithCurrentUnit.some( ( unit ) => unit.value === currentUnit )
 	) {
-		const currentUnitKey = currentUnit === '%' ? 'percent' : currentUnit;
-
-		if ( allUnits[ currentUnitKey ] ) {
-			unitsWithCurrentUnit.unshift( allUnits[ currentUnitKey ] );
+		if ( allUnits[ currentUnit ] ) {
+			unitsWithCurrentUnit.unshift( allUnits[ currentUnit ] );
 		}
 	}
 

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -9,6 +9,17 @@ import { isEmpty } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
 
+/**
+ * An object containing the details of a unit.
+ *
+ * @typedef {Object} WPUnitControlUnit
+ * @property {string}        value       The value for the unit, used in a CSS value (e.g `px`).
+ * @property {string}        label       The label used in a dropdown selector for the unit.
+ * @property {string|number} [default]   Default value for the unit, used when switching units.
+ * @property {string}        [a11yLabel] An accessible label used by screen readers.
+ * @property {number}        [step]      A step value used when incrementing/decrementing the value.
+ */
+
 const isWeb = Platform.OS === 'web';
 
 const allUnits = {
@@ -145,9 +156,9 @@ export const DEFAULT_UNIT = allUnits.px;
  * Moving forward, ideally the value should be a string that contains both
  * the value and unit, example: '10px'
  *
- * @param {number|string} value Value
- * @param {string}        unit  Unit value
- * @param {Array<Object>} units Units to derive from.
+ * @param {number|string}            value Value
+ * @param {string}                   unit  Unit value
+ * @param {Array<WPUnitControlUnit>} units Units to derive from.
  * @return {Array<number, string>} The extracted number and unit.
  */
 export function getParsedValue( value, unit, units ) {

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -11,7 +11,7 @@ import { Platform } from '@wordpress/element';
 
 const isWeb = Platform.OS === 'web';
 
-const allUnits = {
+export const allUnits = {
 	px: {
 		value: 'px',
 		label: isWeb ? 'px' : __( 'Pixels (px)' ),
@@ -151,7 +151,8 @@ export const DEFAULT_UNIT = allUnits.px;
  * @return {Array<number, string>} The extracted number and unit.
  */
 export function getParsedValue( value, unit, units ) {
-	const initialValue = unit ? `${ value }${ unit }` : value;
+	const initialValue =
+		unit && Number.isFinite( value ) ? `${ value }${ unit }` : value;
 
 	return parseUnit( initialValue, units );
 }
@@ -281,3 +282,43 @@ export const useCustomUnits = ( { units, availableUnits, defaultValues } ) => {
 
 	return usedUnits.length === 0 ? false : usedUnits;
 };
+
+/**
+ * Get available units with the unit for the currently selected value
+ * prepended if it is not available in the list of units.
+ *
+ * This is useful to ensure that the current value's unit is always
+ * accurately displayed in the UI, even if the intention is to hide
+ * the availability of that unit.
+ *
+ * @param {number|string} currentValue Selected value to parse.
+ * @param {string}        legacyUnit   Legacy unit value, if currentValue needs it appended.
+ * @param {Array<Object>} units        List of available units.
+ *
+ * @return {Array<Object>} A collection of units containing the unit for the current value.
+ */
+export function getUnitsWithCurrentUnit(
+	currentValue,
+	legacyUnit,
+	units = ALL_CSS_UNITS
+) {
+	const unitsWithCurrentUnit = [ ...units ];
+	const [ , currentUnit ] = getParsedValue(
+		currentValue,
+		legacyUnit,
+		ALL_CSS_UNITS
+	);
+
+	if (
+		currentUnit &&
+		! unitsWithCurrentUnit.some( ( unit ) => unit.value === currentUnit )
+	) {
+		const currentUnitKey = currentUnit === '%' ? 'percent' : currentUnit;
+
+		if ( allUnits[ currentUnitKey ] ) {
+			unitsWithCurrentUnit.unshift( allUnits[ currentUnitKey ] );
+		}
+	}
+
+	return unitsWithCurrentUnit;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #34096 

In #34096 it was reported that in themes that don't include the `%` unit in the theme.json `settings.spacing.units` list, that percentage width column blocks display the current value as `px` instead of as `%`. This PR explores ensuring that if there is a current value, that its unit is displayed correctly in the UnitControl's drop-down.

The idea here is that whether or not we wish to hide or disable a particular unit, if the current value has somehow managed to be a valid CSS unit, we should still do our best to display it correctly and allow it to be editable. Once the user switches to another unit, then the provided list of allowed units will take precedence.

For ease of testing, the TT1-Blocks theme is a good candidate, as it does not list the `%` unit, and the Columns block is a good block to test, as its placeholder variations use percentage units.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Test that % units are displayed correctly in TT1-Blocks

* With TT1-Blocks theme active, go to add a Columns block and select one of the 70/30 variations, which sets a percentage width for each column
* Select the column, and you should see that the UnitControl value for width includes the currently selected unit `%`
* Adjusting the width in `%` should work
* Switch to a different unit (e.g. `px`)
* In the drop-down for the unit, you should no longer be able to select `%`

#### Test that the % unit doesn't show up where it isn't expected

* In the Column block's padding control, check that the unit drop-down list does not contain `%`
* In the padding unit control, attempt to type in `10%` and hit ENTER. It should not let you commit the value as a percentage.

#### Run tests

```
npm run test-unit -- --testPathPattern packages/components/src/unit-control/test/
```

## Screenshots <!-- if applicable -->

### Before

Note that with TT1-Blocks active, after selecting the Columns block's 70 / 30 variation, the current value is displayed as if it's in `px` units. (If you switch to the code view, you can see that the attribute's value is currently in `%`).

![unit-control-percentage-before-sml](https://user-images.githubusercontent.com/14988353/133202406-4a82c5dd-82e5-4829-8b08-2da64c35c4ca.gif)

### After

After selecting the Columns block's 70 / 30 variation, the current value is correctly rendered with the `%` unit. Switching away from that unit will hide the availability of the unit, as the theme is still attempting to keep it hidden. Here, this PR attempts to respect the settings, while still displaying an accurate value.

![unit-control-percentage-after-sml](https://user-images.githubusercontent.com/14988353/133202423-21dbeba4-1fbb-4492-bf46-e5137a7e0985.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md --> (This change only applies to the web-based component)
