### PR TITLE
Try to fix flaky iframe test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
@@ -44,10 +44,12 @@ describe( 'changing image size', () => {
 		await clickButton( 'Create' );
 		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
 
-		const iframedText = await canvas().evaluate( () => {
-			return document.querySelector( '.wp-block-test-iframed-block' )
-				.innerText;
-		} );
+		const iframeElement = await canvas().waitForSelector(
+			'.wp-block-test-iframed-block'
+		);
+		const iframedText = await iframeElement.evaluate(
+			( el ) => el.textContent
+		);
 
 		// Expect the script to load in the iframe, which replaces the block
 		// text.

--- a/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-block.test.js
@@ -27,11 +27,10 @@ describe( 'changing image size', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
-		await page.waitForSelector( '.wp-block-test-iframed-block' );
-		const text = await page.evaluate( () => {
-			return document.querySelector( '.wp-block-test-iframed-block' )
-				.innerText;
-		} );
+		const element = await page.waitForSelector(
+			'.wp-block-test-iframed-block'
+		);
+		const text = await element.evaluate( ( el ) => el.textContent );
 
 		expect( text ).toBe( 'Iframed Block (set with jQuery)' );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
