### PR TITLE
Experiment with allowing Theme JSON to control Navigation block within the Navigation Editor screen

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -80,6 +80,7 @@ class WP_Theme_JSON_Gutenberg {
 	const VALID_SETTINGS = array(
 		'core/navigation' => array(
 			'hasSubmenuIndicatorSetting' => null,
+			'hasItemJustificationControls' => null,
 		),
 		'border'          => array(
 			'customColor'  => null,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -78,13 +78,16 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	const VALID_SETTINGS = array(
-		'border'     => array(
+		'core/navigation' => array(
+			'hasSubmenuIndicatorSetting' => null,
+		),
+		'border'          => array(
 			'customColor'  => null,
 			'customRadius' => null,
 			'customStyle'  => null,
 			'customWidth'  => null,
 		),
-		'color'      => array(
+		'color'           => array(
 			'background'     => null,
 			'custom'         => null,
 			'customDuotone'  => null,
@@ -95,19 +98,19 @@ class WP_Theme_JSON_Gutenberg {
 			'palette'        => null,
 			'text'           => null,
 		),
-		'custom'     => null,
-		'layout'     => array(
+		'custom'          => null,
+		'layout'          => array(
 			'contentSize' => null,
 			'wideSize'    => null,
 		),
-		'spacing'    => array(
+		'spacing'         => array(
 			'blockGap'      => null,
 			'customMargin'  => null,
 			'customPadding' => null,
 			'units'         => null,
 			'blockGap'      => null,
 		),
-		'typography' => array(
+		'typography'      => array(
 			'customFontSize'        => null,
 			'customFontStyle'       => null,
 			'customFontWeight'      => null,
@@ -315,11 +318,14 @@ class WP_Theme_JSON_Gutenberg {
 		}
 		$schema_styles_blocks   = array();
 		$schema_settings_blocks = array();
+
 		foreach ( $valid_block_names as $block ) {
-			$schema_settings_blocks[ $block ]           = self::VALID_SETTINGS;
+			$schema_settings_blocks[ $block ]           = self::VALID_SETTINGS[ $block ] ? array_merge( self::VALID_SETTINGS, self::VALID_SETTINGS[ $block ] ) : self::VALID_SETTINGS;
 			$schema_styles_blocks[ $block ]             = self::VALID_STYLES;
 			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
 		}
+
+
 		$schema['styles']             = self::VALID_STYLES;
 		$schema['styles']['blocks']   = $schema_styles_blocks;
 		$schema['styles']['elements'] = $schema_styles_elements;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -81,6 +81,7 @@ class WP_Theme_JSON_Gutenberg {
 		'core/navigation' => array(
 			'hasSubmenuIndicatorSetting' => null,
 			'hasItemJustificationControls' => null,
+			'hasColorSettings' => null,
 		),
 		'border'          => array(
 			'customColor'  => null,

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -412,7 +412,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		if (
 			! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
-			! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
+			! self::theme_has_support()
 		) {
 			return $result;
 		}
@@ -423,6 +423,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );
 		}
+
+		$result = apply_filters( 'theme_json_resolver_merged_data', $result );
 
 		return $result;
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -420,11 +420,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
+		$filter_data = new WP_Theme_JSON_Gutenberg( apply_filters( 'theme_json_resolver_merged_data', $result->get_raw_data() ) );
+
+		$result->merge( $filter_data );
+
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );
 		}
-
-		$result = apply_filters( 'theme_json_resolver_merged_data', $result );
 
 		return $result;
 	}

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -74,7 +74,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && get_current_screen() && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base ) {
+	if ( is_navigation_editor_screen() ) {
 		return true;
 	}
 
@@ -82,3 +82,35 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 }
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
+
+/**
+ * Filters the Theme JSON to alter the settings of the Navigation block.
+ *
+ * @param Array $data the raw Theme JSON config at the Theme level.
+ * @return Array the amended Theme JSON config.
+ */
+function gutenberg_navigation_editor_filter_navigation_block_settings( $data ) {
+	if ( is_navigation_editor_screen() ) {
+		$data['settings']['blocks']['core/navigation'] = array(
+			'hasSubmenuIndicatorSetting'   => false,
+			'hasItemJustificationControls' => false,
+			'hasColorSettings'             => false,
+		);
+	}
+
+	return $data;
+}
+
+add_filter(
+	'theme_json_resolver_merged_data',
+	'gutenberg_navigation_editor_filter_navigation_block_settings'
+);
+
+/**
+ * Determines whether we are on the navigation editor screen.
+ *
+ * @return boolean whether or not we are on the navigation editor screen.
+ */
+function is_navigation_editor_screen() {
+	return is_callable( 'get_current_screen' ) && get_current_screen() && 'gutenberg_page_gutenberg-navigation' === get_current_screen()->base;
+}

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -384,3 +384,29 @@ CSS;
 	}
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_add_block_menu_item_styles_to_nav_menus' );
+
+
+/**
+ * Filters the Theme JSON settings for the Navigation block
+ * when used in the Nav Editor.
+ */
+
+
+$is_nav_editor_screen = true;
+
+// TODO: only apply filter when on Nav Editor screen.
+if ( $is_nav_editor_screen ) {
+	add_filter(
+		'theme_json_resolver_merged_data',
+		function( $data ) {
+
+			$data['settings']['blocks']['core/navigation'] = array(
+				'hasSubmenuIndicatorSetting'   => false,
+				'hasItemJustificationControls' => false,
+				'hasColorSettings'             => false,
+			);
+
+			return $data;
+		}
+	);
+}

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -386,27 +386,3 @@ CSS;
 add_action( 'admin_enqueue_scripts', 'gutenberg_add_block_menu_item_styles_to_nav_menus' );
 
 
-/**
- * Filters the Theme JSON settings for the Navigation block
- * when used in the Nav Editor.
- */
-
-
-$is_nav_editor_screen = true;
-
-// TODO: only apply filter when on Nav Editor screen.
-if ( $is_nav_editor_screen ) {
-	add_filter(
-		'theme_json_resolver_merged_data',
-		function( $data ) {
-
-			$data['settings']['blocks']['core/navigation'] = array(
-				'hasSubmenuIndicatorSetting'   => false,
-				'hasItemJustificationControls' => false,
-				'hasColorSettings'             => false,
-			);
-
-			return $data;
-		}
-	);
-}

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -104,7 +104,6 @@ function Navigation( {
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
-	hasItemJustificationControls = true,
 	hasColorSettings = true,
 	customPlaceholder: CustomPlaceholder = null,
 	customAppender: CustomAppender = null,
@@ -115,9 +114,11 @@ function Navigation( {
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] = useState(
 		false
 	);
-
 	const hasSubmenuIndicatorSetting =
-		useSetting( 'hasSubmenuIndicatorSetting' ) || true; // retain original prop default of "true"
+		useSetting( 'hasSubmenuIndicatorSetting' ) ?? true; // retain original prop default of "true" if there is no setting defined.
+
+	const hasItemJustificationControls =
+		useSetting( 'hasItemJustificationControls' ) ?? true; // retain original prop default of "true" if there is no setting defined.
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -104,7 +104,6 @@ function Navigation( {
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
-	hasColorSettings = true,
 	customPlaceholder: CustomPlaceholder = null,
 	customAppender: CustomAppender = null,
 } ) {
@@ -119,6 +118,8 @@ function Navigation( {
 
 	const hasItemJustificationControls =
 		useSetting( 'hasItemJustificationControls' ) ?? true; // retain original prop default of "true" if there is no setting defined.
+
+	const hasColorSettings = useSetting( 'hasColorSettings' ) ?? true; // retain original prop default of "true" if there is no setting defined.
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -24,6 +24,7 @@ import {
 	PanelColorSettings,
 	ContrastChecker,
 	getColorClassName,
+	useSetting,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
@@ -103,7 +104,6 @@ function Navigation( {
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
-	hasSubmenuIndicatorSetting = true,
 	hasItemJustificationControls = true,
 	hasColorSettings = true,
 	customPlaceholder: CustomPlaceholder = null,
@@ -115,6 +115,9 @@ function Navigation( {
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] = useState(
 		false
 	);
+
+	const hasSubmenuIndicatorSetting =
+		useSetting( 'hasSubmenuIndicatorSetting' ) || true; // retain original prop default of "true"
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 

--- a/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
+++ b/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
@@ -13,7 +13,6 @@ const removeNavigationBlockEditUnsupportedFeatures = createHigherOrderComponent(
 		return (
 			<BlockEdit
 				{ ...props }
-				hasSubmenuIndicatorSetting={ false }
 				hasItemJustificationControls={ false }
 				hasColorSettings={ false }
 			/>

--- a/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
+++ b/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
@@ -10,13 +10,7 @@ const removeNavigationBlockEditUnsupportedFeatures = createHigherOrderComponent(
 			return <BlockEdit { ...props } />;
 		}
 
-		return (
-			<BlockEdit
-				{ ...props }
-				hasItemJustificationControls={ false }
-				hasColorSettings={ false }
-			/>
-		);
+		return <BlockEdit { ...props } />;
 	},
 	'removeNavigationBlockEditUnsupportedFeatures'
 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
As part of https://github.com/WordPress/gutenberg/issues/30007#issuecomment-893575752 I proposed we could control some of the features of the Navigation block via Theme JSON. This would:

* Make the block more configurable for Themers - this is very important. Many themes will want to allow only very simple Navigations to be created.
* Allow us to filter the settings when the Nav block is utilised in the Nav Editor to create a "paired down" version of the block.

This is **a PoC PR** which _experiments_ with this approach for x3 Nav _block_ settings for which were currently rely on controlling via `props` and modifying (for the Nav Editor) using the `editor.BlockEdit` filter.

To do this I have

* Allowed _blocks_ to define their own settings (in addition to the default top-level settings) for Theme JSON under the `settings.blocks` key. These would likely be custom to the block and allows any block to define its own extension point.
* Added a new filter hook to allow developers to filter the Theme JSON config at a Theme level - this ensures they cannot override user-level settings provided via Theme JSON thus keeping the feature limited in scope).
* Used the new filter hook to modifying the Theme JSON config for the Navigation block to set the x3 new settings to `false`.
* Updated the Navigation block's `edit` implementation to use `useSetting()` to get the block's behaviour configuration data (settings) from Theme JSON rather than from props.

The result should be exactly the same as what we have in `trunk` right now. The difference is we're controlling via Theme JSON and a filter.

Closes https://github.com/WordPress/gutenberg/issues/34775

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Firstly check that the Nav block still shows the UI for x3 settings when used _outside_ the Nav Editor.
* Then check that the Nav block does _not_ show the UI for x3 settings when used _within_ the Nav Editor.
* Edit the `gutenberg_navigation_editor_filter_navigation_block_settings` function inside `lib/navigation-page.php` and try turning the features on and off. They should reflect in the Nav Editor _only_.
* Try removing the filter entirely. The block should default to all the settings being `true` - this mirrors the original default settings for the `prop` versions of the settings.
* Bonus: try using a `theme.json` file to configure the Nav _block_ _outside_ of the Nav editor.

## Screenshots <!-- if applicable -->

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected) 



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
