### PR TITLE
Add icons to block settings dropdown

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -9,7 +9,7 @@ import { castArray, flow, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { moreVertical } from '@wordpress/icons';
+import { moreVertical, insertAfter, insertBefore } from '@wordpress/icons';
 
 import { Children, cloneElement, useCallback } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
@@ -138,6 +138,8 @@ export function BlockSettingsDropdown( {
 								{ canInsertDefaultBlock && (
 									<>
 										<MenuItem
+											icon={ insertBefore }
+											iconPosition="left"
 											onClick={ flow(
 												onClose,
 												onInsertBefore
@@ -147,6 +149,8 @@ export function BlockSettingsDropdown( {
 											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
+											icon={ insertAfter }
+											iconPosition="left"
 											onClick={ flow(
 												onClose,
 												onInsertAfter

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,3 +1,15 @@
-.block-editor-block-settings-menu__popover .components-dropdown-menu__menu {
-	padding: 0;
+.block-editor-block-settings-menu__popover {
+	.components-dropdown-menu__menu {
+		padding: 0;
+		.components-menu-item__button {
+			padding-left: $grid-unit-50;
+			/**
+			 * This is only applied to 'left' icons because 'right' icons
+			 * are rendered inside the `button`.
+			 */
+			&.has-icon {
+				padding-left: $grid-unit;
+			}
+		}
+	}
 }

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -10,6 +10,9 @@
 			&.has-icon {
 				padding-left: $grid-unit;
 			}
+			.components-menu-item__item {
+				min-width: 120px;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -5,6 +5,7 @@ import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { switchToBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
+import { group, ungroup } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -48,6 +49,8 @@ function ConvertToGroupButton( {
 		<>
 			{ isGroupable && (
 				<MenuItem
+					icon={ group }
+					iconPosition="left"
 					onClick={ () => {
 						onConvertToGroup();
 						onClose();
@@ -58,6 +61,8 @@ function ConvertToGroupButton( {
 			) }
 			{ isUngroupable && (
 				<MenuItem
+					icon={ ungroup }
+					iconPosition="left"
 					onClick={ () => {
 						onConvertFromGroup();
 						onClose();

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -50,6 +50,14 @@ Refer to documentation for [`label`](#label).
 
 Refer to documentation for [Button's `icon` prop](/packages/components/src/icon-button/README.md#icon).
 
+### `iconPosition`
+
+-   Type: `string`
+-   Required: No
+-   Default: `'right'`
+
+Determines where to display the provided `icon`.
+
 ### `isSelected`
 
 -   Type: `boolean`

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -19,15 +19,16 @@ import Icon from '../icon';
 /**
  * Renders a generic menu item for use inside the more menu.
  *
- * @param {Object}        props                   Component props.
- * @param {WPElement}     props.children          Element to render as child of button.
- * @param {string}        props.info              Text to use as description for button text.
- * @param {string}        props.className         Class to set on the container.
- * @param {WPIcon}        props.icon              Button's `icon` prop.
- * @param {string|Object} props.shortcut          Shortcut's `shortcut` prop.
- * @param {boolean}       props.isSelected        Whether or not the menu item is currently selected.
- * @param {string}        [props.role="menuitem"] ARIA role of the menu item.
- * @param {Object}        ref                     React Element ref.
+ * @param {Object}        props                        Component props.
+ * @param {WPElement}     props.children               Element to render as child of button.
+ * @param {string}        props.info                   Text to use as description for button text.
+ * @param {string}        props.className              Class to set on the container.
+ * @param {WPIcon}        props.icon                   Button's `icon` prop.
+ * @param {string}        [props.iconPosition="right"] Button's `icon` position (left|right).
+ * @param {string|Object} props.shortcut               Shortcut's `shortcut` prop.
+ * @param {boolean}       props.isSelected             Whether or not the menu item is currently selected.
+ * @param {string}        [props.role="menuitem"]      ARIA role of the menu item.
+ * @param {Object}        ref                          React Element ref.
  *
  * @return {WPComponent} The component to be rendered.
  */
@@ -37,6 +38,7 @@ export function MenuItem(
 		info,
 		className,
 		icon,
+		iconPosition = 'right',
 		shortcut,
 		isSelected,
 		role = 'menuitem',
@@ -57,7 +59,9 @@ export function MenuItem(
 
 	if ( icon && ! isString( icon ) ) {
 		icon = cloneElement( icon, {
-			className: 'components-menu-items__item-icon',
+			className: classnames( 'components-menu-items__item-icon', {
+				'has-icon-right': iconPosition === 'right',
+			} ),
 		} );
 	}
 
@@ -71,6 +75,7 @@ export function MenuItem(
 					: undefined
 			}
 			role={ role }
+			icon={ iconPosition === 'left' ? icon : undefined }
 			className={ className }
 			{ ...props }
 		>
@@ -79,7 +84,7 @@ export function MenuItem(
 				className="components-menu-item__shortcut"
 				shortcut={ shortcut }
 			/>
-			{ icon && <Icon icon={ icon } /> }
+			{ icon && iconPosition === 'right' && <Icon icon={ icon } /> }
 		</Button>
 	);
 }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -12,13 +12,15 @@
 	}
 
 	.components-menu-items__item-icon {
-		margin-right: -2px; // This optically balances the icon.
-		margin-left: $grid-unit-30;
 		display: inline-block;
 		flex: 0 0 auto;
+		&.has-icon-right {
+			margin-right: -2px; // This optically balances the icon.
+			margin-left: $grid-unit-30;
+		}
 	}
 
-	.components-menu-item__shortcut + .components-menu-items__item-icon {
+	.components-menu-item__shortcut + .components-menu-items__item-icon.has-icon-right {
 		margin-left: $grid-unit-10;
 	}
 

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
   <Icon
     icon={
       <SVG
-        className="components-menu-items__item-icon"
+        className="components-menu-items__item-icon has-icon-right"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -79,7 +79,7 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
   <Icon
     icon={
       <SVG
-        className="components-menu-items__item-icon"
+        className="components-menu-items__item-icon has-icon-right"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -86,6 +86,7 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
 const PluginBlockSettingsMenuItem = ( {
 	allowedBlocks,
 	icon,
+	iconPosition,
 	label,
 	onClick,
 	small,
@@ -100,6 +101,7 @@ const PluginBlockSettingsMenuItem = ( {
 				<MenuItem
 					onClick={ compose( onClick, onClose ) }
 					icon={ icon }
+					iconPosition={ iconPosition }
 					label={ small ? label : undefined }
 					role={ role }
 				>

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -114,6 +114,7 @@ export default function ReusableBlockConvertButton( {
 				<>
 					<MenuItem
 						icon={ reusableBlock }
+						iconPosition="left"
 						onClick={ () => {
 							setIsModalOpen( true );
 						} }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/25274

This PR adds some icons to some block settings at the toolbar dropdown to give more prominence to them. The changed options are  per @mtias https://github.com/WordPress/gutenberg/issues/25274#issuecomment-879741454.

This PR has some changes at `MenuItem` from [this PR](https://github.com/WordPress/gutenberg/pull/34710), which is not merged (at the time of this PR's creation). 

I have also updated `PluginBlockSettingsMenuItem` which is used for `BlockSettingsMenuControls` slot. You can use the [example here](https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-block-settings-menu-item/) to check that everything seems to work fine with added items.
<!-- Please describe what you have changed or added -->

## Testing instructions
1. Open the `more` settings of a block's toolbar
2. Observe the changes (icons at the left, etc...)


## Screenshots <!-- if applicable -->

### Before
<img width="641" alt="Screenshot 2021-09-13 at 4 52 42 PM" src="https://user-images.githubusercontent.com/16275880/133101035-63e4bfc4-21b8-4981-a8fe-86631de59e53.png">


### After
<img width="688" alt="Screenshot 2021-09-13 at 4 51 05 PM" src="https://user-images.githubusercontent.com/16275880/133101046-88c18196-87af-48fd-93b4-71d5f8621e3e.png">


## Tasks
- [ ] Check `native/mobile` --cc @dcalhoun @guarani 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
