### PR TITLE
Navigation Screen: Consolidate menu name and switcher

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -147,7 +147,7 @@ $z-layers: (
 	".components-popover.edit-widgets-more-menu__content": 99998,
 	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
 	".components-popover.block-editor-warning__dropdown": 99998,
-	".components-popover.edit-navigation-header__menu-switcher-dropdown": 99998,
+	".components-popover.edit-navigation-menu-actions__switcher-dropdown": 99998,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -254,18 +254,12 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.
-		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]', {
+		await page.waitForXPath( '//h2[contains(., "Test Menu 1")]', {
 			visible: true,
 		} );
 
-		// Open up the menu creation dialog and create a new menu.
-		const switchMenuButton = await page.waitForXPath(
-			'//button[.="Switch menu"]'
-		);
-		await switchMenuButton.click();
-
 		const createMenuButton = await page.waitForXPath(
-			'//button[.="Create a new menu"]'
+			'//button[.="New menu"]'
 		);
 		await createMenuButton.click();
 
@@ -305,7 +299,7 @@ describe( 'Navigation editor', () => {
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.
-		await page.waitForXPath( '//h2[contains(., "Editing: Test Menu 1")]', {
+		await page.waitForXPath( '//h2[contains(., "Test Menu 1")]', {
 			visible: true,
 		} );
 
@@ -495,13 +489,13 @@ describe( 'Navigation editor', () => {
 			await saveButton.click();
 			await page.waitForSelector( '.components-snackbar' );
 			const headerSubtitle = await page.waitForSelector(
-				'.edit-navigation-header__subtitle'
+				'.edit-navigation-menu-actions__subtitle'
 			);
 			expect( headerSubtitle ).toBeTruthy();
 			const headerSubtitleText = await headerSubtitle.evaluate(
 				( element ) => element.innerText
 			);
-			expect( headerSubtitleText ).toBe( `Editing: ${ newName }` );
+			expect( headerSubtitleText ).toBe( newName );
 		} );
 
 		it( 'does not save a menu name upon clicking save button when name is empty', async () => {
@@ -532,15 +526,13 @@ describe( 'Navigation editor', () => {
 			await saveButton.click();
 			await page.waitForSelector( '.components-snackbar' );
 			const headerSubtitle = await page.waitForSelector(
-				'.edit-navigation-header__subtitle'
+				'.edit-navigation-menu-actions__subtitle'
 			);
 			expect( headerSubtitle ).toBeTruthy();
 			const headerSubtitleText = await headerSubtitle.evaluate(
 				( element ) => element.innerText
 			);
-			expect( headerSubtitleText ).toBe(
-				`Editing: ${ initialMenuName }`
-			);
+			expect( headerSubtitleText ).toBe( initialMenuName );
 		} );
 	} );
 

--- a/packages/edit-navigation/src/components/header/actions.js
+++ b/packages/edit-navigation/src/components/header/actions.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { sprintf, __ } from '@wordpress/i18n';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItemsChoice,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
+import { useRef } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { useMenuEntityProp, useSelectedMenuId } from '../../hooks';
+
+export default function HeaderActions( { menus, isLoading } ) {
+	const [ selectedMenuId, setSelectedMenuId ] = useSelectedMenuId();
+	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
+
+	// The title ref is passed to the popover as the anchorRef so that the
+	// dropdown is centered over the whole title area rather than just one
+	// part of it.
+	const titleRef = useRef();
+
+	if ( isLoading ) {
+		return (
+			<div className="edit-navigation-menu-actions">
+				{ __( 'Loading…' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="edit-navigation-menu-actions">
+			<div
+				ref={ titleRef }
+				className="edit-navigation-menu-actions__subtitle-wrapper"
+			>
+				<Text
+					size="body"
+					className="edit-navigation-menu-actions__subtitle"
+					as="h2"
+				>
+					{ decodeEntities( menuName ) }
+				</Text>
+
+				<DropdownMenu
+					icon={ chevronDown }
+					toggleProps={ {
+						label: __( 'Switch menu' ),
+						className:
+							'edit-navigation-menu-actions__switcher-toggle',
+						showTooltip: false,
+						__experimentalIsFocusable: true,
+					} }
+					popoverProps={ {
+						className:
+							'edit-navigation-menu-actions__switcher-dropdown',
+						position: 'bottom center',
+						anchorRef: titleRef.current,
+					} }
+				>
+					{ ( { onClose } ) => (
+						<MenuGroup>
+							<MenuItemsChoice
+								value={ selectedMenuId }
+								choices={ menus.map( ( { id, name } ) => ( {
+									value: id,
+									label: decodeEntities( name ),
+									'aria-label': sprintf(
+										/* translators: %s: The name of a menu. */
+										__( "Switch to '%s'" ),
+										name
+									),
+								} ) ) }
+								onSelect={ ( value ) => {
+									setSelectedMenuId( value );
+									onClose();
+								} }
+							/>
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-navigation/src/components/header/actions.js
+++ b/packages/edit-navigation/src/components/header/actions.js
@@ -1,11 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
-	MenuGroup,
-	MenuItemsChoice,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
@@ -15,6 +13,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import MenuSwitcher from '../menu-switcher';
 import { useMenuEntityProp, useSelectedMenuId } from '../../hooks';
 
 export default function HeaderActions( { menus, isLoading } ) {
@@ -65,24 +64,14 @@ export default function HeaderActions( { menus, isLoading } ) {
 					} }
 				>
 					{ ( { onClose } ) => (
-						<MenuGroup>
-							<MenuItemsChoice
-								value={ selectedMenuId }
-								choices={ menus.map( ( { id, name } ) => ( {
-									value: id,
-									label: decodeEntities( name ),
-									'aria-label': sprintf(
-										/* translators: %s: The name of a menu. */
-										__( "Switch to '%s'" ),
-										name
-									),
-								} ) ) }
-								onSelect={ ( value ) => {
-									setSelectedMenuId( value );
-									onClose();
-								} }
-							/>
-						</MenuGroup>
+						<MenuSwitcher
+							menus={ menus }
+							selectedMenuId={ selectedMenuId }
+							onSelectMenu={ ( menuId ) => {
+								setSelectedMenuId( menuId );
+								onClose();
+							} }
+						/>
 					) }
 				</DropdownMenu>
 			</div>

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -52,7 +52,7 @@ export default function Header( {
 			) }
 			{ isMenuSelected && (
 				<div className="edit-navigation-header__actions">
-					<NewButton menus={ menus } />
+					{ isMediumViewport && <NewButton menus={ menus } /> }
 					<SaveButton navigationPost={ navigationPost } />
 					<PinnedItems.Slot scope="core/edit-navigation" />
 				</div>

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -1,49 +1,28 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { NavigableToolbar } from '@wordpress/block-editor';
-import { DropdownMenu } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PinnedItems } from '@wordpress/interface';
-import { __, sprintf } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
+import MenuActions from './actions';
+import NewButton from './new-button';
 import SaveButton from './save-button';
 import UndoButton from './undo-button';
 import RedoButton from './redo-button';
 import InserterToggle from './inserter-toggle';
-import MenuSwitcher from '../menu-switcher';
-import { useMenuEntityProp } from '../../hooks';
 
 export default function Header( {
 	isMenuSelected,
 	menus,
-	selectedMenuId,
-	onSelectMenu,
 	isPending,
 	navigationPost,
 } ) {
 	const isMediumViewport = useViewportMatch( 'medium' );
-
-	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
-
-	let actionHeaderText;
-
-	if ( menuName ) {
-		actionHeaderText = sprintf(
-			// translators: Name of the menu being edited, e.g. 'Main Menu'.
-			__( 'Editing: %s' ),
-			menuName
-		);
-	} else if ( isPending ) {
-		// Loading text won't be displayed if menus are preloaded.
-		actionHeaderText = __( 'Loading …' );
-	} else {
-		actionHeaderText = __( 'No menus available' );
-	}
 
 	return (
 		<div className="edit-navigation-header">
@@ -68,42 +47,12 @@ export default function Header( {
 				</NavigableToolbar>
 			</div>
 
-			<h2 className="edit-navigation-header__subtitle">
-				{ isMenuSelected && decodeEntities( actionHeaderText ) }
-			</h2>
-
+			{ isMenuSelected && (
+				<MenuActions menus={ menus } isLoading={ isPending } />
+			) }
 			{ isMenuSelected && (
 				<div className="edit-navigation-header__actions">
-					<DropdownMenu
-						icon={ null }
-						toggleProps={ {
-							children: __( 'Switch menu' ),
-							'aria-label': __(
-								'Switch menu, or create a new menu'
-							),
-							showTooltip: false,
-							variant: 'tertiary',
-							disabled: ! menus?.length,
-							__experimentalIsFocusable: true,
-						} }
-						popoverProps={ {
-							className:
-								'edit-navigation-header__menu-switcher-dropdown',
-							position: 'bottom center',
-						} }
-					>
-						{ ( { onClose } ) => (
-							<MenuSwitcher
-								menus={ menus }
-								selectedMenuId={ selectedMenuId }
-								onSelectMenu={ ( menuId ) => {
-									onSelectMenu( menuId );
-									onClose();
-								} }
-							/>
-						) }
-					</DropdownMenu>
-
+					<NewButton menus={ menus } />
 					<SaveButton navigationPost={ navigationPost } />
 					<PinnedItems.Slot scope="core/edit-navigation" />
 				</div>

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -24,6 +24,18 @@ export default function Header( {
 } ) {
 	const isMediumViewport = useViewportMatch( 'medium' );
 
+	if ( ! isMenuSelected ) {
+		return (
+			<div className="edit-navigation-header">
+				<div className="edit-navigation-header__toolbar-wrapper">
+					<h1 className="edit-navigation-header__title">
+						{ __( 'Navigation' ) }
+					</h1>
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div className="edit-navigation-header">
 			<div className="edit-navigation-header__toolbar-wrapper">
@@ -47,16 +59,13 @@ export default function Header( {
 				</NavigableToolbar>
 			</div>
 
-			{ isMenuSelected && (
-				<MenuActions menus={ menus } isLoading={ isPending } />
-			) }
-			{ isMenuSelected && (
-				<div className="edit-navigation-header__actions">
-					{ isMediumViewport && <NewButton menus={ menus } /> }
-					<SaveButton navigationPost={ navigationPost } />
-					<PinnedItems.Slot scope="core/edit-navigation" />
-				</div>
-			) }
+			<MenuActions menus={ menus } isLoading={ isPending } />
+
+			<div className="edit-navigation-header__actions">
+				{ isMediumViewport && <NewButton menus={ menus } /> }
+				<SaveButton navigationPost={ navigationPost } />
+				<PinnedItems.Slot scope="core/edit-navigation" />
+			</div>
 		</div>
 	);
 }

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -9,7 +9,7 @@ import { PinnedItems } from '@wordpress/interface';
 /**
  * Internal dependencies
  */
-import MenuActions from './actions';
+import MenuActions from './menu-actions';
 import NewButton from './new-button';
 import SaveButton from './save-button';
 import UndoButton from './undo-button';

--- a/packages/edit-navigation/src/components/header/menu-actions.js
+++ b/packages/edit-navigation/src/components/header/menu-actions.js
@@ -16,7 +16,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import MenuSwitcher from '../menu-switcher';
 import { useMenuEntityProp, useSelectedMenuId } from '../../hooks';
 
-export default function HeaderActions( { menus, isLoading } ) {
+export default function MenuActions( { menus, isLoading } ) {
 	const [ selectedMenuId, setSelectedMenuId ] = useSelectedMenuId();
 	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
 

--- a/packages/edit-navigation/src/components/header/new-button.js
+++ b/packages/edit-navigation/src/components/header/new-button.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AddMenu from '../add-menu';
+import { useSelectedMenuId } from '../../hooks';
+
+export default function NewButton( { menus } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ , setSelectedMenuId ] = useSelectedMenuId();
+
+	return (
+		<>
+			<Button variant="tertiary" onClick={ () => setIsModalOpen( true ) }>
+				{ __( 'New menu' ) }
+			</Button>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Create a new menu' ) }
+					onRequestClose={ () => setIsModalOpen( false ) }
+				>
+					<AddMenu
+						menus={ menus }
+						helpText={ __(
+							'A short descriptive name for your menu.'
+						) }
+						onCreate={ ( menuId ) => {
+							setIsModalOpen( false );
+							setSelectedMenuId( menuId );
+						} }
+					/>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -62,6 +62,11 @@
 	}
 }
 
+.edit-navigation-menu-actions__switcher-dropdown {
+	// Appear below the modal overlay.
+	z-index: z-index(".components-popover.edit-navigation-menu-actions__switcher-dropdown");
+}
+
 .edit-navigation-header__actions {
 	display: flex;
 
@@ -72,11 +77,6 @@
 			margin-right: $grid-unit-15;
 		}
 	}
-}
-
-.edit-navigation-header__menu-switcher-dropdown {
-	// Appear below the modal overlay.
-	z-index: z-index(".components-popover.edit-navigation-header__menu-switcher-dropdown");
 }
 
 // Hide notices.

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -44,11 +44,22 @@
 	}
 }
 
-.edit-navigation-header__subtitle {
-	display: block;
-	margin: 0;
-	font-size: 15px;
-	font-weight: normal;
+.edit-navigation-menu-actions {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	.edit-navigation-menu-actions__subtitle-wrapper {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.edit-navigation-menu-actions__switcher-toggle {
+		padding: 0;
+		min-width: 0;
+	}
 }
 
 .edit-navigation-header__actions {

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -65,6 +65,36 @@
 .edit-navigation-menu-actions__switcher-dropdown {
 	// Appear below the modal overlay.
 	z-index: z-index(".components-popover.edit-navigation-menu-actions__switcher-dropdown");
+
+	.components-menu-group.has-hidden-separator {
+		padding: 0;
+	}
+
+	.edit-navigation-menu-switcher__new-button.components-button {
+		justify-content: center;
+		background: $gray-900;
+		color: $white;
+		height: ($button-size + $grid-unit-10);
+		border-radius: 0;
+
+		&:hover {
+			color: $white;
+		}
+
+		&:active {
+			color: $gray-400;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+		}
+
+		// This is needed to center the button text.
+		.components-menu-item__item {
+			min-width: 0;
+			margin: 0;
+		}
+	}
 }
 
 .edit-navigation-header__actions {

--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -66,6 +66,7 @@
 	// Appear below the modal overlay.
 	z-index: z-index(".components-popover.edit-navigation-menu-actions__switcher-dropdown");
 
+	// Resetting MenuItemGroup padding so button can take full space.
 	.components-menu-group.has-hidden-separator {
 		padding: 0;
 	}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -137,8 +137,6 @@ export default function Layout( { blockEditorSettings } ) {
 										isMenuSelected={ isMenuSelected }
 										isPending={ ! hasLoadedMenus }
 										menus={ menus }
-										selectedMenuId={ selectedMenuId }
-										onSelectMenu={ selectMenu }
 										navigationPost={ navigationPost }
 									/>
 								}

--- a/packages/edit-navigation/src/components/menu-switcher/index.js
+++ b/packages/edit-navigation/src/components/menu-switcher/index.js
@@ -48,7 +48,10 @@ export default function MenuSwitcher( {
 				/>
 			</MenuGroup>
 			<MenuGroup hideSeparator>
-				<MenuItem variant="primary" onClick={ openModal }>
+				<MenuItem
+					className="edit-navigation-menu-switcher__new-button"
+					onClick={ openModal }
+				>
 					{ __( 'Create a new menu' ) }
 				</MenuItem>
 				{ isModalVisible && (


### PR DESCRIPTION
## Description
Part of #31241.

PR combines the menu name and switcher into a single component. It also introduces a new top-level "New menu" button.

P.S. Header menu actions will center on small screens once #34619 is merged.

## How has this been tested?
The e2e tests are passing.

1. Click on the "chevron" icon near the menu name.
2. Switch to a different menu.
3. Try creating a new menu from the Dropdown or with the "New menu" button.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/133242539-24089412-7e8e-447a-af4f-ccf74de51f88.mp4

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
