### PR TITLE
[RNMobile] Check if inserter should be fullscreen on first render

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -37,7 +37,6 @@ function InserterMenu( {
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ showTabs, setShowTabs ] = useState( true );
-	// eslint-disable-next-line no-undef
 	const [ showSearchForm, setShowSearchForm ] = useState( true );
 	const [ tabIndex, setTabIndex ] = useState( 0 );
 
@@ -178,6 +177,13 @@ function InserterMenu( {
 		setShowTabs,
 	] );
 
+	function isFullScreen() {
+		// The bottomsheet will not re-render after setting showSeachForm to false
+		// after mounting the component. In this case the searchForm is fliped from true to false
+		// after checking the min items for search but we can make that check on the first render.
+		return ! isIOS && showSearchForm && items.length > MIN_ITEMS_FOR_SEARCH;
+	}
+
 	return (
 		<BottomSheet
 			isVisible={ true }
@@ -203,7 +209,7 @@ function InserterMenu( {
 			hasNavigation
 			setMinHeightToMaxHeight={ true }
 			contentStyle={ styles[ 'inserter-menu__list' ] }
-			isFullScreen={ ! isIOS && showSearchForm }
+			isFullScreen={ isFullScreen() }
 			allowDragIndicator={ true }
 		>
 			<BottomSheetConsumer>
@@ -218,7 +224,7 @@ function InserterMenu( {
 								filterValue={ filterValue }
 								onSelect={ onSelectItem }
 								listProps={ listProps }
-								isFullScreen={ ! isIOS && showSearchForm }
+								isFullScreen={ isFullScreen() }
 							/>
 						) : (
 							<InserterTabs

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -37,7 +37,6 @@ function InserterMenu( {
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ showTabs, setShowTabs ] = useState( true );
-	const [ showSearchForm, setShowSearchForm ] = useState( true );
 	const [ tabIndex, setTabIndex ] = useState( 0 );
 
 	const isIOS = Platform.OS === 'ios';
@@ -103,11 +102,6 @@ function InserterMenu( {
 			}
 		}
 		showInsertionPoint( destinationRootClientId, insertionIndex );
-
-		// Show search form if there are enough items to filter.
-		if ( items.length < MIN_ITEMS_FOR_SEARCH ) {
-			setShowSearchForm( false );
-		}
 
 		return hideInsertionPoint;
 	}, [] );
@@ -177,12 +171,8 @@ function InserterMenu( {
 		setShowTabs,
 	] );
 
-	function isFullScreen() {
-		// The bottomsheet will not re-render after setting showSeachForm to false
-		// after mounting the component. In this case the searchForm is fliped from true to false
-		// after checking the min items for search but we can make that check on the first render.
-		return ! isIOS && showSearchForm && items.length > MIN_ITEMS_FOR_SEARCH;
-	}
+	const showSearchForm = items.length > MIN_ITEMS_FOR_SEARCH;
+	const isFullScreen = ! isIOS && showSearchForm;
 
 	return (
 		<BottomSheet
@@ -209,7 +199,7 @@ function InserterMenu( {
 			hasNavigation
 			setMinHeightToMaxHeight={ true }
 			contentStyle={ styles[ 'inserter-menu__list' ] }
-			isFullScreen={ isFullScreen() }
+			isFullScreen={ isFullScreen }
 			allowDragIndicator={ true }
 		>
 			<BottomSheetConsumer>
@@ -224,7 +214,7 @@ function InserterMenu( {
 								filterValue={ filterValue }
 								onSelect={ onSelectItem }
 								listProps={ listProps }
-								isFullScreen={ isFullScreen() }
+								isFullScreen={ isFullScreen }
 							/>
 						) : (
 							<InserterTabs


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
fixes https://github.com/WordPress/gutenberg/issues/34740
Only render the inserter menu fullscreen when expected.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Start the mobile demo app
- Add a Buttons block.
- While in the Buttons block scope, open the inserter menu.
- The inserter menu should not open fullscreen.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This adds a check to make sure the bottom sheet `isFullScreen` prop is set to the correct value before the first render.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
