### PR TITLE
Widget Group: Make title directly editable

### DIFF
--- a/packages/widgets/src/blocks/widget-group/edit.js
+++ b/packages/widgets/src/blocks/widget-group/edit.js
@@ -13,7 +13,6 @@ import { Placeholder } from '@wordpress/components';
 import { group as groupIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { getBlockType } from '@wordpress/blocks';
 
 export default function Edit( props ) {
 	const { clientId } = props;
@@ -26,7 +25,7 @@ export default function Edit( props ) {
 			{ innerBlocks.length === 0 ? (
 				<PlaceholderContent { ...props } />
 			) : (
-				<PreviewContent { ...props } innerBlocks={ innerBlocks } />
+				<PreviewContent { ...props } />
 			) }
 		</div>
 	);
@@ -47,26 +46,18 @@ function PlaceholderContent( { clientId } ) {
 	);
 }
 
-function PreviewContent( { attributes, setAttributes, innerBlocks } ) {
+function PreviewContent( { attributes, setAttributes } ) {
 	return (
 		<>
 			<RichText
 				tagName="h2"
 				className="widget-title"
 				allowedFormats={ [] }
-				value={
-					attributes.title ?? getDefaultTitle( innerBlocks ) ?? ''
-				}
+				placeholder={ __( 'Title' ) }
+				value={ attributes.title ?? '' }
 				onChange={ ( title ) => setAttributes( { title } ) }
 			/>
 			<InnerBlocks />
 		</>
 	);
-}
-
-function getDefaultTitle( innerBlocks ) {
-	if ( innerBlocks.length === 0 ) {
-		return null;
-	}
-	return getBlockType( innerBlocks[ 0 ].name ).title;
 }

--- a/packages/widgets/src/blocks/widget-group/edit.js
+++ b/packages/widgets/src/blocks/widget-group/edit.js
@@ -7,30 +7,28 @@ import {
 	ButtonBlockAppender,
 	InnerBlocks,
 	store as blockEditorStore,
+	RichText,
 } from '@wordpress/block-editor';
-import { Placeholder, TextControl } from '@wordpress/components';
+import { Placeholder } from '@wordpress/components';
 import { group as groupIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
 
 export default function Edit( props ) {
-	const { clientId, isSelected } = props;
+	const { clientId } = props;
 	const { innerBlocks } = useSelect( ( select ) =>
 		select( blockEditorStore ).getBlock( clientId )
 	);
 
-	let content;
-	if ( innerBlocks.length === 0 ) {
-		content = <PlaceholderContent { ...props } />;
-	} else if ( isSelected ) {
-		content = <EditFormContent { ...props } innerBlocks={ innerBlocks } />;
-	} else {
-		content = <PreviewContent { ...props } innerBlocks={ innerBlocks } />;
-	}
-
 	return (
-		<div { ...useBlockProps( { className: 'widget' } ) }>{ content }</div>
+		<div { ...useBlockProps( { className: 'widget' } ) }>
+			{ innerBlocks.length === 0 ? (
+				<PlaceholderContent { ...props } />
+			) : (
+				<PreviewContent { ...props } innerBlocks={ innerBlocks } />
+			) }
+		</div>
 	);
 }
 
@@ -49,28 +47,18 @@ function PlaceholderContent( { clientId } ) {
 	);
 }
 
-function EditFormContent( { attributes, setAttributes, innerBlocks } ) {
-	return (
-		<div className="wp-block-widget-group__edit-form">
-			<h2 className="wp-block-widget-group__edit-form-title">
-				{ __( 'Widget Group' ) }
-			</h2>
-			<TextControl
-				label={ __( 'Title' ) }
-				placeholder={ getDefaultTitle( innerBlocks ) }
-				value={ attributes.title ?? '' }
-				onChange={ ( title ) => setAttributes( { title } ) }
-			/>
-		</div>
-	);
-}
-
-function PreviewContent( { attributes, innerBlocks } ) {
+function PreviewContent( { attributes, setAttributes, innerBlocks } ) {
 	return (
 		<>
-			<h2 className="widget-title">
-				{ attributes.title || getDefaultTitle( innerBlocks ) }
-			</h2>
+			<RichText
+				tagName="h2"
+				className="widget-title"
+				allowedFormats={ [] }
+				value={
+					attributes.title ?? getDefaultTitle( innerBlocks ) ?? ''
+				}
+				onChange={ ( title ) => setAttributes( { title } ) }
+			/>
 			<InnerBlocks />
 		</>
 	);

--- a/packages/widgets/src/blocks/widget-group/editor.scss
+++ b/packages/widgets/src/blocks/widget-group/editor.scss
@@ -29,18 +29,3 @@
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	color: $gray-900;
 }
-
-.wp-block-widget-group__edit-form {
-	background: $white;
-	border-radius: $radius-block-ui;
-	border: 1px solid $gray-900;
-	padding: $grid-unit-15 - 1px; // Subtract the border width.
-
-	.wp-block-widget-group__edit-form-title {
-		color: $black;
-		font-family: $default-font;
-		font-size: 14px;
-		font-weight: 600;
-		margin: 0 0 $grid-unit-15 0;
-	}
-}

--- a/packages/widgets/src/blocks/widget-group/index.php
+++ b/packages/widgets/src/blocks/widget-group/index.php
@@ -28,13 +28,7 @@ function render_block_core_widget_group( $attributes, $content, $block ) {
 	$html = '';
 
 	if ( ! empty( $attributes['title'] ) ) {
-		$title = $attributes['title'];
-	} elseif ( ! empty( $block->inner_blocks ) ) {
-		$title = $block->inner_blocks[0]->block_type->title;
-	}
-
-	if ( isset( $title ) ) {
-		$html .= $before_title . $title . $after_title;
+		$html .= $before_title . $attributes['title'] . $after_title;
 	}
 
 	$html .= '<div class="wp-widget-group__inner-blocks">';


### PR DESCRIPTION
## Description

Implements the design feedback in https://github.com/WordPress/gutenberg/pull/34484#issuecomment-915509590.

This changes the Widget Group block so that the title is directly editable using a `RichText`. It's a little disingenuous to do this because the title isn't truly WYSIWYG, but it has the benefit of meaning that elements don't jump around the screen when you select the Widget Group.

## How has this been tested?

1. Go to Appearance → Widgets or Appearance → Customize.
2. Add a Widget Group block.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/612155/133194390-b29794d7-85b0-4bc9-9001-05edf17a5554.mp4

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->