### PR TITLE
[RNMobile] Fix back button style name to match the light mode one

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/nav-bar/back-button.native.js
+++ b/packages/components/src/mobile/bottom-sheet/nav-bar/back-button.native.js
@@ -50,7 +50,7 @@ function BackButton( { onPress } ) {
 	);
 	const arrowLeftStyle = usePreferredColorSchemeStyle(
 		styles[ 'arrow-left-icon' ],
-		styles[ 'arrow-right-icon-dark' ]
+		styles[ 'arrow-left-icon-dark' ]
 	);
 
 	let backIcon;
@@ -73,7 +73,7 @@ function BackButton( { onPress } ) {
 function DismissButton( { onPress, iosText } ) {
 	const arrowLeftStyle = usePreferredColorSchemeStyle(
 		styles[ 'arrow-left-icon' ],
-		styles[ 'arrow-right-icon-dark' ]
+		styles[ 'arrow-left-icon-dark' ]
 	);
 
 	let backIcon;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR fixes a (probably) typo error when referencing which style to use for the left arrow bottomsheet navigation icon when in Dark Mode.

### Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3957

## How has this been tested?
Using the demo app and navigating in a bottomsheet with nested pages (e.g. the "Font Size" settings on a paragraph block).

## Types of changes
Use `arrow-left-icon-dark` instead of the `arrow-right-icon-dark` typo (which is actually not defined anywhere anyway).

### Screenshots

Before | After
-|-
![screenshot-1631616510444](https://user-images.githubusercontent.com/1032913/133255639-e56c9a11-4fa3-4418-9b7f-c2175f4c2687.png) |  ![screenshot-1631621716125](https://user-images.githubusercontent.com/1032913/133255760-61eb3e55-3237-4f9f-9a5d-5d11a099adaf.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
