### PR TITLE
fix: backtick added around `<textarea>` input tag in readme file

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -58,8 +58,8 @@ _Returns_
 ### documentHasUncollapsedSelection
 
 Check whether the current document has any sort of selection. This includes
-ranges of text across elements and any selection inside <input> and
-<textarea> elements.
+ranges of text across elements and any selection inside `<input>` and
+`<textarea>` elements.
 
 _Parameters_
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -42,7 +42,7 @@ _Returns_
 ### documentHasTextSelection
 
 Check whether the current document has selected text. This applies to ranges
-of text in the document, and not selection inside <input> and <textarea>
+of text in the document, and not selection inside `<input>` and `<textarea>`
 elements.
 
 See: <https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects>.

--- a/packages/dom/src/dom/document-has-text-selection.js
+++ b/packages/dom/src/dom/document-has-text-selection.js
@@ -5,7 +5,7 @@ import { assertIsDefined } from '../utils/assert-is-defined';
 
 /**
  * Check whether the current document has selected text. This applies to ranges
- * of text in the document, and not selection inside <input> and <textarea>
+ * of text in the document, and not selection inside `<input>` and `<textarea>`
  * elements.
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects.

--- a/packages/dom/src/dom/document-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/document-has-uncollapsed-selection.js
@@ -6,8 +6,8 @@ import inputFieldHasUncollapsedSelection from './input-field-has-uncollapsed-sel
 
 /**
  * Check whether the current document has any sort of selection. This includes
- * ranges of text across elements and any selection inside <input> and
- * <textarea> elements.
+ * ranges of text across elements and any selection inside `<input>` and
+ * `<textarea>` elements.
  *
  * @param {Document} doc The document to check.
  *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

In the [Documentation page](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dom/) for `@wordpress/dom` on **developer.wordpress.org** is broken because of misrendering `<input>` and `<textarea>` tag.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="1210" alt="Screenshot 2021-09-14 at 8 31 42 PM" src="https://user-images.githubusercontent.com/5476784/133278048-9ecf882c-09b2-45e3-ad3e-42e4eef460f4.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Readme text change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
