### PR TITLE
Check whether there are any non-empty block template terms before querying for wp_template post type

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -627,7 +627,7 @@ function _gutengerg_has_wp_template_block_templates() {
 	$term_query_args = array(
 		'taxonomy' => 'wp_theme',
 		'field'    => 'name',
-		'terms'    => wp_get_theme()->get_stylesheet(),
+		'name'     => wp_get_theme()->get_stylesheet(),
 	);
 
 	$has_block_templates = false;
@@ -650,7 +650,7 @@ function _gutenberg_has_wp_template_part_block_templates( $area ) {
 	$term_query_args = array(
 		'taxonomy' => 'wp_template_part_area',
 		'field'    => 'name',
-		'terms'    => $area,
+		'name'     => $area,
 	);
 
 	$has_block_templates = false;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -649,7 +649,7 @@ function _gutengerg_has_wp_template_block_templates() {
 function _gutenberg_has_wp_template_part_block_templates( $area ) {
 	$term_query_args = array(
 		'taxonomy' => 'wp_template_part_area',
-		'fields'   => 'name',
+		'field'    => 'name',
 		'terms'    => $area,
 	);
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -628,13 +628,13 @@ function _gutengerg_has_wp_template_block_templates() {
 		'taxonomy' => 'wp_theme',
 		'field'    => 'name',
 		'terms'    => wp_get_theme()->get_stylesheet(),
-        );
+	);
 
 	$has_block_templates = false;
 
-        $term_query = new WP_Term_Query( $term_query_args );
-        if ( ! empty( $term_query->terms ) ) {
-               $has_block_templates = true;
+	$term_query = new WP_Term_Query( $term_query_args );
+	if ( ! empty( $term_query->terms ) ) {
+		$has_block_templates = true;
 	}
 
 	return $has_block_templates;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

When determining whether there are any block templates related to a frontend request, multiple WP_Queries are run, possibly not finding anything in case there are no templates yet.

This is also true the WordPress core which contains a copy of the Gutenberg's `gutenberg_get_block_templates` function, possibly affecting performance of non FSE ready themes. For such themes, the SQL queries produced by the WP_Query class do contain the impossible WHERE ( `AND ( 1 = 0 )` ), but there is still some provision in between the PHP, db server, and evaluation of the query on db server.

This changeset introduces new `gutenberg_has_block_templates` function, which uses the same `WP_Term_Query` requests used internally by `WP_Query` for determining whether there are any non-empty terms of given taxonomies. As the `WP_Term_Query` is being cached by `WP_Cache`, those queries are safe to be run repeatedly (vs. original `WP_Query` composed in `gutenberg_get_block_templates` functon, which does not have any caching).

Fixes #34814

## How has this been tested?
I have installed the query monitor plugin and checked that there are some extra (and even duplicate) SQL queries on frontend returning no results originating the the Gutenberg plugin.
After applying the changeset introduced here, those were gone.
Further I have checked whether it's still possible to add block templates in wp-admin

## Screenshots <!-- if applicable -->

## Types of changes
The changeset adds a couple of new functions (some for internal use only), and performs an extra check before looking for block templates stored in the custom post type objects.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
