### PR TITLE
[Site Logo]: Add option to remove/clear logo from the block

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -398,11 +398,9 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			/>
-			<ToolbarButton
-				title={ __( 'Remove logo' ) }
-				onClick={ onRemoveLogo }
-				icon={ trash }
-			/>
+			<ToolbarButton onClick={ onRemoveLogo }>
+				{ __( 'Remove' ) }
+			</ToolbarButton>
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -398,7 +398,11 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			/>
-			<ToolbarButton onClick={ onRemoveLogo } icon={ trash } />
+			<ToolbarButton
+				title={ __( 'Remove logo' ) }
+				onClick={ onRemoveLogo }
+				icon={ trash }
+			/>
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -398,9 +398,7 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			/>
-			<ToolbarButton onClick={ onRemoveLogo }>
-				{ __( 'Remove' ) }
-			</ToolbarButton>
+			<ToolbarButton onClick={ onRemoveLogo } icon={ trash } />
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -18,6 +18,7 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarButton,
+	ToolbarGroup,
 	Placeholder,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -398,9 +399,11 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			/>
-			<ToolbarButton onClick={ onRemoveLogo }>
-				{ __( 'Remove' ) }
-			</ToolbarButton>
+			<ToolbarGroup>
+				<ToolbarButton onClick={ onRemoveLogo }>
+					{ __( 'Remove' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -326,7 +326,7 @@ export default function LogoEdit( {
 		const _siteLogo = siteSettings?.site_logo;
 		const _readOnlyLogo = siteData?.site_logo;
 		const _canUserEdit = canUser( 'update', 'settings' );
-		const _siteLogoId = _siteLogo || _readOnlyLogo;
+		const _siteLogoId = _canUserEdit ? _siteLogo : _readOnlyLogo;
 		const mediaItem =
 			_siteLogoId &&
 			select( coreStore ).getMedia( _siteLogoId, {
@@ -380,6 +380,11 @@ export default function LogoEdit( {
 		setLogo( media.id );
 	};
 
+	const onRemoveLogo = () => {
+		setLogo( null );
+		setLogoUrl( undefined );
+	};
+
 	const onUploadError = ( message ) => {
 		setError( message[ 2 ] ? message[ 2 ] : null );
 	};
@@ -393,6 +398,9 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			/>
+			<ToolbarButton onClick={ onRemoveLogo }>
+				{ __( 'Remove' ) }
+			</ToolbarButton>
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -401,7 +401,7 @@ export default function LogoEdit( {
 			/>
 			<ToolbarGroup>
 				<ToolbarButton onClick={ onRemoveLogo }>
-					{ __( 'Remove' ) }
+					{ __( 'Reset' ) }
 				</ToolbarButton>
 			</ToolbarGroup>
 		</BlockControls>

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -160,3 +160,25 @@ function _delete_site_logo_on_remove_custom_logo_on_setup_theme() {
 	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 }
 add_action( 'setup_theme', '_delete_site_logo_on_remove_custom_logo_on_setup_theme', 11 );
+
+/**
+ * Removes the custom_logo theme-mod when the site_logo option gets deleted.
+ *
+ * @param mixed $old_value The old option value.
+ * @param mixed $value     The new option value.
+ *
+ * @return void
+ */
+function _delete_custom_logo_on_remove_site_logo() {
+	// Unhook update and delete actions for custom_logo to prevent a loop of hooks.
+	remove_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10 );
+	remove_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
+
+	// Remove the custom logo
+	remove_theme_mod( 'custom_logo' );
+
+	// Restore update and delete actions.
+	add_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10, 2 );
+	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
+}
+add_action( 'delete_option_site_logo', '_delete_custom_logo_on_remove_site_logo' );

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -163,18 +163,15 @@ add_action( 'setup_theme', '_delete_site_logo_on_remove_custom_logo_on_setup_the
 
 /**
  * Removes the custom_logo theme-mod when the site_logo option gets deleted.
- *
- * @param mixed $old_value The old option value.
- * @param mixed $value     The new option value.
- *
- * @return void
  */
 function _delete_custom_logo_on_remove_site_logo() {
+	$theme = get_option( 'stylesheet' );
+
 	// Unhook update and delete actions for custom_logo to prevent a loop of hooks.
 	remove_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10 );
 	remove_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 
-	// Remove the custom logo
+	// Remove the custom logo.
 	remove_theme_mod( 'custom_logo' );
 
 	// Restore update and delete actions.

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -132,7 +132,7 @@ add_filter( 'pre_set_theme_mod_custom_logo', '_sync_custom_logo_to_site_logo' );
  * @param array $old_value Previous theme mod settings.
  * @param array $value     Updated theme mod settings.
  */
-function _delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
+function _gutenberg_delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
 	// If the custom_logo is being unset, it's being removed from theme mods.
 	if ( isset( $old_value['custom_logo'] ) && ! isset( $value['custom_logo'] ) ) {
 		delete_option( 'site_logo' );
@@ -142,7 +142,7 @@ function _delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
 /**
  * Deletes the site logo when all theme mods are being removed.
  */
-function _delete_site_logo_on_remove_theme_mods() {
+function _gutenberg_delete_site_logo_on_remove_theme_mods() {
 	if ( false !== get_theme_support( 'custom-logo' ) ) {
 		delete_option( 'site_logo' );
 	}
@@ -168,6 +168,11 @@ function _delete_custom_logo_on_remove_site_logo() {
 	$theme = get_option( 'stylesheet' );
 
 	// Unhook update and delete actions for custom_logo to prevent a loop of hooks.
+	// Gutenberg hooks
+	remove_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10 );
+	remove_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
+
+	// Core hooks
 	remove_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10 );
 	remove_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 
@@ -175,6 +180,11 @@ function _delete_custom_logo_on_remove_site_logo() {
 	remove_theme_mod( 'custom_logo' );
 
 	// Restore update and delete actions.
+	// Gutenberg hooks
+	add_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10, 2 );
+	add_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
+
+	// Core hooks
 	add_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10, 2 );
 	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 }

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -168,11 +168,11 @@ function _delete_custom_logo_on_remove_site_logo() {
 	$theme = get_option( 'stylesheet' );
 
 	// Unhook update and delete actions for custom_logo to prevent a loop of hooks.
-	// Gutenberg hooks
+	// Remove Gutenberg hooks.
 	remove_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10 );
 	remove_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
 
-	// Core hooks
+	// Remove Core hooks.
 	remove_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10 );
 	remove_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 
@@ -180,11 +180,11 @@ function _delete_custom_logo_on_remove_site_logo() {
 	remove_theme_mod( 'custom_logo' );
 
 	// Restore update and delete actions.
-	// Gutenberg hooks
+	// Restore Gutenberg hooks.
 	add_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10, 2 );
 	add_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
 
-	// Core hooks
+	// Restore Core hooks.
 	add_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10, 2 );
 	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Closes #34796, tracked in #30406

## Description
<!-- Please describe what you have changed or added -->
This PR adds a way to clear/remove the media from the Site Logo from within the block. I've added this as ~~a `Remove` button in the block toolbar, similar to `Replace`, an icon in the block toolbar, but would love design feedback.~~ a `Reset` button in the block toolbar, similar to `Replace`, and in keeping with the terminology used by the ToolsPanel.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've attempted to test all the edge cases described in #33179 and #32919 for regressions with these new changes.

**IMPORTANT TESTING INSTRUCTIONS: ** Due to an issue raised in #33177, it's tricky to test updates to the actions (basically, the Core php file and the plugin php file for site-logo _both_ get loaded), so you will need to either manually disable the similar code that's running in Core (`wp-includes/blocks/site-logo.php`) or copy over the changes in this PR to that file as well.

Simple flow:
* On a site with no logo, insert a Site Logo block into a post. You should see the placeholder; neither the `Replace` nor `Reset` options are present in the toolbar.
* Upload a logo through the media library. It should replace the placeholder; you should now see the `Replace` and `Reset` options.
* Test that the `Replace` option still works
* Click `Reset`; the placeholder should render again
* Publish the post and refresh. You should still see the placeholder; on the frontend you should see no site logo.

When the logo is persisted:
* Upload a logo through the Site Logo block and save the post; make sure to also save the Site Logo
* Check that you see the Site Logo on the frontend of the post
* In the editor, click `Reset`. You should see the placeholder rendered again.
* Save the post. You should see the option to save the Site Logo as well; make sure this is selected. Refresh the page and the site logo should still display only the placeholder; it should not render on the frontend.

Custom Logo through customizer:
* Set a custom logo in Customizer -> Site Identity and publish. In the block editor, insert a Site Logo block and make sure that it populates with the custom logo you just set.
* Click `Reset` and save the post & Site logo
* Open the Customizer -> Site Identity and verify the logo was removed here as well
* Add a logo through the Site Logo block. Verify it appears in Customizer -> Site Identity.
* Remove the logo from the Customizer, and verify that it is deleted in the block in the block editor as well.

Read-only logos for non-admins:
* Make sure that your test site has a site logo set, either through the block or customizer.
* Create a user with a non-admin role like Author (they should not have the ability to edit the site logo)
* As this user, create a new post and insert a Site Logo block. They should see the site logo, but the `Replace` and `Reset` buttons should not be available. They should still be able to edit block attributes like the rounded style, width, etc.

## Screenshots <!-- if applicable -->
Updated design using 'Reset': 
<img width="370" alt="Screen Shot 2021-09-22 at 11 29 57 AM" src="https://user-images.githubusercontent.com/63313398/134401190-e0847825-70af-4fa5-8067-9a488d7b4f88.png">


Read-only logo with no option to remove/replace, but access to block attrs (design has changed slightly to `Reset`):
<img width="628" alt="Screen Shot 2021-09-14 at 11 12 59 AM" src="https://user-images.githubusercontent.com/63313398/133317492-50c8de61-7fde-45d5-bd86-19c31814732b.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
