### PR TITLE
Create Block: Remove wp-cli callout since not recommended and outdated

### DIFF
--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -191,8 +191,4 @@ The following configurable variables are used with the template files. Template 
 -   `editorStyle` (default: `'file:./build/index.css'`)
 -   `style` (default: `'file:./build/style-index.css'`)
 
-## WP-CLI
-
-Another way of making a developer’s life easier is to use [WP-CLI](https://wp-cli.org), which provides a command-line interface for many actions you might perform on the WordPress instance. One of the commands `wp scaffold block` was used as the baseline for this tool and ES5 template in particular.
-
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION

## Description

Remove the wp-cli callout in the create block script. It is not recommended to use the old scaffold command, which is now quite outdated, so it is not necessary to included in documentation for create-block, it only causes additional confusion.

## Types of changes

Documentation.

