### PR TITLE
Global Styles: Fix dimensions panel default controls display

### DIFF
--- a/packages/edit-site/src/components/sidebar/dimensions-panel.js
+++ b/packages/edit-site/src/components/sidebar/dimensions-panel.js
@@ -109,7 +109,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	};
 	const resetPaddingValue = () => setPaddingValues( {} );
 	const hasPaddingValue = () =>
-		paddingValues && Object.keys( paddingValues ).length;
+		!! paddingValues && Object.keys( paddingValues ).length;
 
 	const marginValues = splitStyleValue( getStyle( name, 'margin' ) );
 	const marginSides = useCustomSides( name, 'margin' );
@@ -123,7 +123,7 @@ export default function DimensionsPanel( { context, getStyle, setStyle } ) {
 	};
 	const resetMarginValue = () => setMarginValues( {} );
 	const hasMarginValue = () =>
-		marginValues && Object.keys( marginValues ).length;
+		!! marginValues && Object.keys( marginValues ).length;
 
 	const gapValue = getStyle( name, '--wp--style--block-gap' );
 


### PR DESCRIPTION
## Description

This PR fixes an issue where default controls within the dimensions panel in the site editor do not display initially.
- Forces the `dimensions-panel.js` callbacks checking for padding and margin values to return a defined value.

## How has this been tested?

1. Load site editor, select "By block type" tab in sidebar then expand Group block panel
2. Confirm Dimensions panel is empty but the padding item exists in the panel menu
3. Checkout this PR, build, then reload the site editor
4. Confirm that the padding control now displays correctly within the dimensions panel

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![GlobalStylesDimensionPanelBefore](https://user-images.githubusercontent.com/60436221/133360121-e171db6f-f404-4f2e-90fd-f1d0d6dfed07.gif) | ![GlobalStylesDimensionPanelAfter](https://user-images.githubusercontent.com/60436221/133360133-a3de8f0f-8425-490f-9163-380653096a76.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
