### PR TITLE
Transform Nav Links with children into Submenus

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -21,8 +21,6 @@ import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
-	InnerBlocks,
-	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
@@ -45,10 +43,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { ItemSubmenuIcon } from './icons';
 import { name } from './block.json';
-
-const ALLOWED_BLOCKS = [ 'core/navigation-link' ];
 
 const MAX_NESTING = 5;
 
@@ -289,7 +284,6 @@ export default function NavigationLinkEdit( {
 		url,
 		opensInNewTab,
 	};
-	const { showSubmenuIcon } = context;
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const {
 		replaceBlock,
@@ -306,9 +300,7 @@ export default function NavigationLinkEdit( {
 		isAtMaxNesting,
 		isTopLevelLink,
 		isParentOfSelectedBlock,
-		isImmediateParentOfSelectedBlock,
 		hasDescendants,
-		selectedBlockHasDescendants,
 		userCanCreatePages,
 		userCanCreatePosts,
 	} = useSelect(
@@ -384,13 +376,17 @@ export default function NavigationLinkEdit( {
 		replaceBlock( clientId, newSubmenu );
 	}
 
-	// Show the LinkControl on mount if the URL is empty
-	// ( When adding a new menu item)
-	// This can't be done in the useState call because it conflicts
-	// with the autofocus behavior of the BlockListBlock component.
 	useEffect( () => {
+		// Show the LinkControl on mount if the URL is empty
+		// ( When adding a new menu item)
+		// This can't be done in the useState call because it conflicts
+		// with the autofocus behavior of the BlockListBlock component.
 		if ( ! url ) {
 			setIsLinkOpen( true );
+		}
+		// If block has inner blocks, transform to Submenu.
+		if ( hasDescendants ) {
+			transformToSubmenu();
 		}
 	}, [] );
 
@@ -518,45 +514,6 @@ export default function NavigationLinkEdit( {
 	if ( ! url ) {
 		blockProps.onClick = () => setIsLinkOpen( true );
 	}
-
-	// Always use overlay colors for submenus
-	const innerBlocksColors = getColors( context, true );
-	const innerBlocksProps = useInnerBlocksProps(
-		{
-			className: classnames(
-				'wp-block-navigation-link__container',
-				'wp-block-navigation__submenu-container',
-				{
-					'is-parent-of-selected-block': isParentOfSelectedBlock,
-					'has-text-color': !! (
-						innerBlocksColors.textColor ||
-						innerBlocksColors.customTextColor
-					),
-					[ `has-${ innerBlocksColors.textColor }-color` ]: !! innerBlocksColors.textColor,
-					'has-background': !! (
-						innerBlocksColors.backgroundColor ||
-						innerBlocksColors.customBackgroundColor
-					),
-					[ `has-${ innerBlocksColors.backgroundColor }-background-color` ]: !! innerBlocksColors.backgroundColor,
-				}
-			),
-			style: {
-				color: innerBlocksColors.customTextColor,
-				backgroundColor: innerBlocksColors.customBackgroundColor,
-			},
-		},
-		{
-			allowedBlocks: ALLOWED_BLOCKS,
-			renderAppender:
-				( isSelected && hasDescendants ) ||
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasDescendants ) ||
-				// Show the appender while dragging to allow inserting element between item and the appender.
-				hasDescendants
-					? InnerBlocks.DefaultAppender
-					: false,
-		}
-	);
 
 	const classes = classnames(
 		'wp-block-navigation-link__content',
@@ -727,13 +684,7 @@ export default function NavigationLinkEdit( {
 							/>
 						</Popover>
 					) }
-					{ hasDescendants && showSubmenuIcon && (
-						<span className="wp-block-navigation-link__submenu-icon wp-block-navigation__submenu-icon">
-							<ItemSubmenuIcon />
-						</span>
-					) }
 				</a>
-				<div { ...innerBlocksProps } />
 			</div>
 		</Fragment>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

With #33775, navigation submenus are now rendered as Submenu blocks, instead of being nested inside Navigation Link blocks. 

Although Navigation is not yet in core, it's in Gutenberg, so there are likely instances of it in use out there. This means we need to consider how to deprecate submenus in Navigation Links and migrate them safely to Submenu blocks.

Because we're switching from one type of block to another, a standard block deprecation/migration won't work here.

This PR tries transforming Navigation Link blocks with children into Submenu blocks as soon as they load in the editor. 

Advantages:

* Removes a bunch of submenu-related logic from Navigation Link.
*  Navigation block "open on click" setting will work seamlessly with existing submenus, whereas it wouldn't work at all if the submenus were still rendered in Navigation Link blocks.

~~Downsides:~~

~~Opening a post with legacy Navigation Links in it will show unsaved changes straightaway.~~ (Edit: this is expected with deprecations)

Other thoughts:

* We could also try changing the server side render so that Navigation Links with children are output instead as Submenus, but this would mean users wouldn't be able to preserve the old markup for existing Navigation blocks on the front end. Block deprecations don't do that, and I'm thinking it would be good to keep the behaviour similar to a regular deprecation.

All thoughts and feedback welcome!

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Checkout a branch prior to #33775 being merged, and create a Navigation block with submenus.
2. Checkout this PR, and open the post with the previously created Navigation block.
3. Verify that all Navigation Links with submenus have been converted to Submenu blocks.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

(Marking this as bug fix mostly because it patches the issue of using the new open on click functionality with Navigation blocks created prior to #33775, though it's not really a bug as much as a known breaking change 🤔)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
