### PR TITLE
Navigation Screen: Adjust header toolbar icon styles

### DIFF
--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -18,6 +18,7 @@
 }
 
 .edit-navigation-header__toolbar {
+	align-items: center;
 	border: none;
 
 	// The Toolbar component adds different styles to buttons, so we reset them
@@ -41,6 +42,15 @@
 		&::before {
 			display: none;
 		}
+	}
+
+	> .edit-navigation-header-inserter-toggle.has-icon.has-icon.has-icon {
+		margin-right: $grid-unit-10;
+		// Special dimensions for this button.
+		min-width: 32px;
+		width: 32px;
+		height: 32px;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
## Description
Few minor styling adjustments to match the Inserter toggle icon to other editors.

* Makes toggle icon smaller.
* Correctly align icons.

## How has this been tested?
Check that the toolbar icons look good.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-15 at 09 38 48](https://user-images.githubusercontent.com/240569/133377798-b81edeaf-8bad-4239-9b79-4ffa9ae99e95.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
