### PR TITLE
Fix the parent menu item field in REST API responses

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -671,7 +671,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		if ( rest_is_field_included( 'parent', $fields ) ) {
 			// Same as post_parent, expose as integer.
-			$data['parent'] = (int) $menu_item->post_parent;
+			$data['parent'] = (int) $menu_item->menu_item_parent;
 		}
 
 		if ( rest_is_field_included( 'menu_order', $fields ) ) {


### PR DESCRIPTION
## Description
It looks like there was a small regression in https://github.com/WordPress/gutenberg/pull/34673 which caused menu items to return a `parent` of `0`. The `parent` field was switched to using the `post_parent` instead of the `menu_item_parent` field. Switching it back seems to fix things.

I'm not sure exactly what the difference between the two is. It looks like there's a little difference in how `wp_setup_nav_menu_item` handles this value - https://github.com/WordPress/wordpress-develop/blob/c3ef52ded7bb480899adfd2f69d9e3fddd210615/src/wp-includes/nav-menu.php#L819

I'll add some tests for this once https://github.com/WordPress/gutenberg/issues/34765 has been tackled.

## How has this been tested?
1. Create a nested menu
2. Save it
3. Reload

Expected: the menu should have the same structure as when it was saved.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
