### PR TITLE
Constrained tabbing: simplify

### DIFF
--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -19,6 +19,9 @@ exports[`Popover should pass additional props to portaled element 1`] = `
         Hello
       </div>
     </div>
+    <div
+      tabindex="-1"
+    />
   </div>
 </span>
 `;
@@ -41,6 +44,9 @@ exports[`Popover should render content 1`] = `
         Hello
       </div>
     </div>
+    <div
+      tabindex="-1"
+    />
   </div>
 </span>
 `;

--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -19,9 +19,6 @@ exports[`Popover should pass additional props to portaled element 1`] = `
         Hello
       </div>
     </div>
-    <div
-      tabindex="-1"
-    />
   </div>
 </span>
 `;
@@ -44,9 +41,6 @@ exports[`Popover should render content 1`] = `
         Hello
       </div>
     </div>
-    <div
-      tabindex="-1"
-    />
   </div>
 </span>
 `;

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -31,6 +31,14 @@ function useConstrainedTabbing() {
 		if ( ! node ) {
 			return;
 		}
+
+		const { ownerDocument } = node;
+		if ( ! ownerDocument ) return;
+
+		const trailingElement = ownerDocument.createElement( 'div' );
+		trailingElement.tabIndex = -1;
+		node.appendChild( trailingElement );
+
 		node.addEventListener( 'keydown', ( /** @type {Event} */ event ) => {
 			if ( ! ( event instanceof window.KeyboardEvent ) ) {
 				return;
@@ -41,15 +49,18 @@ function useConstrainedTabbing() {
 			}
 
 			const action = event.shiftKey ? 'findPrevious' : 'findNext';
+			const nextElement = focus.tabbable[ action ](
+				/** @type {HTMLElement} */ ( event.target )
+			);
 
 			if (
-				! node.contains(
-					/** @type {HTMLElement} */ ( focus.tabbable[ action ](
-						/** @type {HTMLElement} */ ( event.target )
-					) )
-				)
+				! node.contains( /** @type {HTMLElement} */ ( nextElement ) )
 			) {
-				/** @type {HTMLElement} */ ( node ).focus();
+				// By not preventing default behaviour, the browser will move
+				// focus from here in the right direction.
+				/** @type {HTMLElement} */ ( event.shiftKey
+					? trailingElement
+					: node ).focus();
 			}
 		} );
 	}, [] );

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -53,15 +53,15 @@ function useConstrainedTabbing() {
 				/** @type {HTMLElement} */ ( event.target )
 			);
 
-			if (
-				! node.contains( /** @type {HTMLElement} */ ( nextElement ) )
-			) {
-				// By not preventing default behaviour, the browser will move
-				// focus from here in the right direction.
-				/** @type {HTMLElement} */ ( event.shiftKey
-					? trailingElement
-					: node ).focus();
+			if ( node.contains( /** @type {HTMLElement} */ ( nextElement ) ) ) {
+				return;
 			}
+
+			// By not preventing default behaviour, the browser will move
+			// focus from here in the right direction.
+			/** @type {HTMLElement} */ ( event.shiftKey
+				? trailingElement
+				: node ).focus();
 		} );
 	}, [] );
 

--- a/packages/compose/src/hooks/use-constrained-tabbing/index.js
+++ b/packages/compose/src/hooks/use-constrained-tabbing/index.js
@@ -40,28 +40,16 @@ function useConstrainedTabbing() {
 				return;
 			}
 
-			const tabbables = focus.tabbable.find( node );
-			if ( ! tabbables.length ) {
-				return;
-			}
-			const firstTabbable = tabbables[ 0 ];
-			const lastTabbable = tabbables[ tabbables.length - 1 ];
+			const action = event.shiftKey ? 'findPrevious' : 'findNext';
 
-			if ( event.shiftKey && event.target === firstTabbable ) {
-				event.preventDefault();
-				/** @type {HTMLElement} */ ( lastTabbable ).focus();
-			} else if ( ! event.shiftKey && event.target === lastTabbable ) {
-				event.preventDefault();
-				/** @type {HTMLElement} */ ( firstTabbable ).focus();
-				/*
-				 * When pressing Tab and none of the tabbables has focus, the keydown
-				 * event happens on the wrapper div: move focus on the first tabbable.
-				 */
-			} else if (
-				! tabbables.includes( /** @type {Element} */ ( event.target ) )
+			if (
+				! node.contains(
+					/** @type {HTMLElement} */ ( focus.tabbable[ action ](
+						/** @type {HTMLElement} */ ( event.target )
+					) )
+				)
 			) {
-				event.preventDefault();
-				/** @type {HTMLElement} */ ( firstTabbable ).focus();
+				/** @type {HTMLElement} */ ( node ).focus();
 			}
 		} );
 	}, [] );

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -181,10 +181,8 @@ export function findNext( element ) {
 	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 
-	// Remove all focusables before and inside `element`.
-	const remaining = focusables
-		.slice( index + 1 )
-		.filter( ( node ) => ! element.contains( node ) );
+	// Remove all focusables before and including `element`.
+	const remaining = focusables.slice( index + 1 );
 
 	return first( filterTabbable( remaining ) );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #34681.
Alternative to #34684.

Idea: on tab, check if the previous/next tubbable is outside the constrained tabbing area, and if so, move focus to the wrapper. **Since we're not preventing default behaviour, the browser will automatically move focus in the right direction!**

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
