### PR TITLE
Fix navigation editor undo button being active when editor loads

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -172,7 +172,7 @@ export const deleteEntityRecord = (
 	const entity = find( entities, { kind, name } );
 	let error;
 	let deletedRecord = false;
-	if ( ! entity ) {
+	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
 	}
 
@@ -349,7 +349,7 @@ export const saveEntityRecord = (
 ) => async ( { select, resolveSelect, dispatch } ) => {
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
 	}
 	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -54,7 +54,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 } ) => {
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
 	}
 
@@ -140,7 +140,7 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 } ) => {
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
 	}
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -338,6 +338,24 @@ describe( 'Navigation editor', () => {
 		expect( blockListAppender ).toBeTruthy();
 	} );
 
+	it( 'has a disabled undo button when an existing menu is loaded', async () => {
+		// The test requires the presence of existing menus.
+		await setUpResponseMocking( [
+			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
+			...getMenuItemMocks( { GET: menuItemsFixture } ),
+		] );
+		await visitNavigationEditor();
+
+		// Wait for at least one block to be present on the page.
+		await page.waitForSelector( '.wp-block' );
+
+		// Check whether there's a disabled undo button.
+		const disabledUndoButton = await page.waitForSelector(
+			'button[aria-label="Undo"][aria-disabled="true"]'
+		);
+		expect( disabledUndoButton.length ).toBeTruthy();
+	} );
+
 	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {
 		await setUpResponseMocking( [
 			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -353,7 +353,7 @@ describe( 'Navigation editor', () => {
 		const disabledUndoButton = await page.waitForSelector(
 			'button[aria-label="Undo"][aria-disabled="true"]'
 		);
-		expect( disabledUndoButton.length ).toBeTruthy();
+		expect( disabledUndoButton ).toBeTruthy();
 	} );
 
 	it( 'shows a submenu when a link is selected and hides it when clicking the editor to deselect it', async () => {

--- a/packages/edit-navigation/src/constants/index.js
+++ b/packages/edit-navigation/src/constants/index.js
@@ -17,7 +17,7 @@ export const MENU_POST_TYPE = 'menu';
  *
  * @type {string}
  */
-export const NAVIGATION_POST_KIND = 'postType';
+export const NAVIGATION_POST_KIND = 'root';
 
 /**
  * "post type" of the navigation post.

--- a/packages/edit-navigation/src/constants/index.js
+++ b/packages/edit-navigation/src/constants/index.js
@@ -24,7 +24,7 @@ export const NAVIGATION_POST_KIND = 'postType';
  *
  * @type {string}
  */
-export const NAVIGATION_POST_POST_TYPE = 'navigation_post';
+export const NAVIGATION_POST_POST_TYPE = 'navigationPost';
 
 /**
  * The scope name of the editor's complementary area.

--- a/packages/edit-navigation/src/constants/index.js
+++ b/packages/edit-navigation/src/constants/index.js
@@ -17,14 +17,14 @@ export const MENU_POST_TYPE = 'menu';
  *
  * @type {string}
  */
-export const NAVIGATION_POST_KIND = 'root';
+export const NAVIGATION_POST_KIND = 'postType';
 
 /**
  * "post type" of the navigation post.
  *
  * @type {string}
  */
-export const NAVIGATION_POST_POST_TYPE = 'postType';
+export const NAVIGATION_POST_POST_TYPE = 'navigation_post';
 
 /**
  * The scope name of the editor's complementary area.

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -67,6 +67,7 @@ function setUpEditor( settings ) {
 			name: NAVIGATION_POST_POST_TYPE,
 			transientEdits: { blocks: true, selection: true },
 			label: __( 'Navigation Post' ),
+			__experimentalNoFetch: true,
 		},
 	] );
 

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -6,12 +6,17 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { render, useMemo } from '@wordpress/element';
-import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import {
+	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { dispatch, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from './constants';
 import { store as editNavigationStore } from './store';
 import { addFilters } from './filters';
 import Layout from './components/layout';
@@ -54,6 +59,16 @@ function NavEditor( { settings } ) {
 function setUpEditor( settings ) {
 	addFilters( ! settings.blockNavMenus );
 	registerCoreBlocks();
+
+	// Set up the navigation post entity.
+	dispatch( coreStore ).addEntities( [
+		{
+			kind: NAVIGATION_POST_KIND,
+			name: NAVIGATION_POST_POST_TYPE,
+			transientEdits: { blocks: true, selection: true },
+			label: __( 'Navigation Post' ),
+		},
+	] );
 
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks();


### PR DESCRIPTION
## Description
Fixes #34802

The navigation editor is an entity driven editor, like the post or widget editor. But the entity that drives it is never saved, it's only a convenient in-memory entity. It also didn't have any configuration (edit: it actually presently uses the `postTypes` entity, which is a bit of a hack), which caused the undo feature in the nav editor to work differently to other editors (more details in point 2 here - https://github.com/WordPress/gutenberg/issues/34802#issuecomment-919839931).

In this PR I've made it so that the entity config is created at initialisation of the editor. As it's only a convenience entity, I don't think it makes sense to add it to the `entities.js` file. This seems like a decent alternative.

It also changes the kind and type so that the navigation post is more like a `postType` entity.

To avoid this entity making REST API calls I've added an `__experimentalNoFetch` property to it.

## How has this been tested?
1. Create a menu with menu items and save it
2. Reload the editor

Expected: The `undo` button should be disabled.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
