### PR TITLE
Add a "translators:" comment in the core class used to implement a Block widget

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -197,6 +197,7 @@ class WP_Widget_Block extends WP_Widget {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
 		?>
 		<p>
+		/* translators: HTML code of the block, not an option that blocks HTML */
 		<label for="<?php echo $this->get_field_id( 'content' ); ?>"><?php echo __( 'Block HTML:', 'gutenberg' ); ?></label>
 		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat code"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
 		</p>

--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -197,8 +197,12 @@ class WP_Widget_Block extends WP_Widget {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
 		?>
 		<p>
-		/* translators: HTML code of the block, not an option that blocks HTML */
-		<label for="<?php echo $this->get_field_id( 'content' ); ?>"><?php echo __( 'Block HTML:', 'gutenberg' ); ?></label>
+		<label for="<?php echo $this->get_field_id( 'content' ); ?>">
+			<?php
+			/* translators: HTML code of the block, not an option that blocks HTML. */
+			_e( 'Block HTML:', 'gutenberg' );
+			?>
+		</label>
 		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat code"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
 		</p>
 		<?php


### PR DESCRIPTION
This comment is intended to facilitate the translation of the plugin, which is incorporated in the WordPress core, so that its translation is not ambiguous.

See https://core.trac.wordpress.org/ticket/54110

This PR has been sent to WordPress develop. See [this PR](https://github.com/WordPress/wordpress-develop/pull/1676).

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
