### PR TITLE
Remove npm cache for CI workflows

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -165,7 +165,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Build Gutenberg plugin ZIP file
               run: ./bin/build-plugin-zip.sh

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -48,7 +48,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - uses: preactjs/compressed-size-action@df6e03e187079aef959a2878311639c77b95ee2e # v2.2.0
               with:

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -29,7 +29,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - name: npm install, build, format and lint
               run: |

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -33,7 +33,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - name: Npm install and build
               run: |

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -18,7 +18,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Npm install
               run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,7 +27,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Npm install
               run: |

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -24,13 +24,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
-            - name: Cache NPM packages
-              uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pr-automation-cache-${{ hashFiles('**/package-lock.json') }}
-
             # Changing into the action's directory and running `npm install` is much
             # faster than a full project-wide `npm ci`.
             - name: Install NPM dependencies

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -29,7 +29,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - run: npm ci
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -29,7 +29,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - run: npm ci
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -28,7 +28,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Npm install
               # A "full" install is executed, since `npm ci` does not always exit

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -23,7 +23,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - name: Install Dependencies
               run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,7 +35,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: ${{ matrix.node }}
-                  cache: npm
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret
@@ -63,7 +62,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Npm install and build
               run: |
@@ -97,7 +95,6 @@ jobs:
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
               with:
                   node-version: 14
-                  cache: npm
 
             - name: Npm install and build
               # It's not necessary to run the full build, since Jest can interpret


### PR DESCRIPTION
We do see a lot of npm install errors Example https://github.com/WordPress/gutenberg/runs/3609715479
Some google searches suggests that it's cache related, I'm not sure if we're doing anything wrong there but I'm checking what impact disabling npm cache has. Is it really a lot slower? is it better in terms of stability.