### PR TITLE
Add API to access global settings, styles, and stylesheet

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -116,10 +116,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$tree                  = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( array(), 'theme' );
-	$theme_settings        = $tree->get_settings();
-	$default_layout        = _wp_array_get( $theme_settings, array( 'layout' ) );
-	$has_block_gap_support = isset( $theme_settings['spacing']['blockGap'] ) ? null !== $theme_settings['spacing']['blockGap'] : false;
+	$block_gap             = gutenberg_get_global_settings( array( 'spacing', 'blockGap' ) );
+	$default_layout        = gutenberg_get_global_settings( array( 'layout' ) );
+	$has_block_gap_support = isset( $block_gap ) ? null !== $block_gap : false;
 	$default_block_layout  = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
 	$used_layout           = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;
 	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] ) {

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * API to interact with global settings & styles.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Function to get the settings resulting of merging core, theme, and user data.
+ *
+ * @param array  $path              Path to the specific setting to retrieve. Optional.
+ *                                  If empty, will return all settings.
+ * @param string $block_name        Which block to retrieve the settings from. Optional
+ *                                  If empty, it'll return the settings for the global context.
+ * @param string $origin            Which origin to take data from. Optional.
+ *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
+ *                                  If empty or unknown, 'all' is used.
+ * @param array  $existing_settings Existing settings to retrofit. Optional.
+ *                                  If empty, the function will retrieve the settings by itself.
+ *
+ * @return array The settings to retrieve.
+ */
+function gutenberg_get_global_settings( $path = array(), $block_name = '', $origin = 'all', $existing_settings = array() ) {
+	if ( '' !== $block_name ) {
+		$path = array_merge( array( 'blocks', $block_name ), $path );
+	}
+
+	if ( empty( $existing_settings ) ) {
+		$existing_settings = gutenberg_get_default_block_editor_settings();
+	}
+
+	if ( 'base' === $origin ) {
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings, 'theme' )->get_settings();
+	} else {
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings )->get_settings();
+	}
+
+	return _wp_array_get( $settings, $path, $settings );
+}
+
+/**
+ * Function to get the styles resulting of merging core, theme, and user data.
+ *
+ * @param array  $path              Path to the specific style to retrieve. Optional.
+ *                                  If empty, will return all styles.
+ * @param string $block_name        Which block to retrieve the styles from. Optional.
+ *                                  If empty, it'll return the styles for the global context.
+ * @param string $origin            Which origin to take data from. Optional.
+ *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
+ *                                  If empty or unknown, 'all' is used.
+ * @param array  $existing_settings Existing settings to retrofit. Optional.
+ *                                  If empty, the function will retrieve the settings by itself.
+ *
+ * @return array The styles to retrieve.
+ */
+function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin = 'all', $existing_settings = array() ) {
+	if ( '' !== $block_name ) {
+		$path = array_merge( array( 'blocks', $block_name ), $path );
+	}
+
+	if ( empty( $existing_settings ) ) {
+		$existing_settings = gutenberg_get_default_block_editor_settings();
+	}
+
+	if ( 'base' === $origin ) {
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings, 'theme' )['styles'];
+	} else {
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings )['styles'];
+	}
+
+	return _wp_array_get( $styles, $path, $styles );
+}
+
+/**
+ * Returns the stylesheet resulting of merging core, theme, and user data.
+ *
+ * @param string $type     Type of the stylesheet. Optional.
+ *                         It accepts 'all', 'block_styles', 'css_variables', 'presets'.
+ *                         If empty, it'll resolve to all (theme with theme.json support)
+ *                         or 'presets' (theme without theme.json support).
+ * @param array  $settings Existing settings to retrofit. Optional.
+ *                         If empty, the function will retrieve the settings itself.
+ *
+ * @return string Stylesheet.
+ */
+function gutenberg_get_global_stylesheet( $type = '', $settings = array() ) {
+	// Return cached value if it can be used and exists.
+	$can_use_cached = (
+		( 'all' === $type ) &&
+		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+		! is_admin()
+	);
+	// It's cached by theme to make sure that theme switching is inmediately reflected.
+	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
+	if ( $can_use_cached ) {
+		$cached = get_transient( $transient_name );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	if ( empty( $settings ) ) {
+		$settings = gutenberg_get_default_block_editor_settings();
+	}
+
+	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+	$supports_link_color = get_theme_support( 'experimental-link-color' );
+	if ( empty( $type ) && ! $supports_theme_json ) {
+		$type = 'presets';
+	} elseif ( empty( $type ) ) {
+		$type = 'all';
+	}
+
+	$origins = array( 'core', 'theme', 'user' );
+	if ( ! $supports_theme_json && ! $supports_link_color ) {
+		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
+		$origins = array( 'core' );
+	} elseif ( ! $supports_theme_json && $supports_link_color ) {
+		// For the legacy link color feauter to work, the CSS Custom Properties
+		// should be in scope (either the core or the theme ones).
+		$origins = array( 'core', 'theme' );
+	}
+
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+	$stylesheet = $tree->get_stylesheet( $type, $origins );
+
+	if ( $can_use_cached ) {
+		// Cache for a minute.
+		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
+		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
+	}
+
+	return $stylesheet;
+}

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -23,13 +23,14 @@ function gutenberg_get_global_settings( $path = array(), $block_name = '', $orig
 		$path = array_merge( array( 'blocks', $block_name ), $path );
 	}
 
-	$theme_supports = gutenberg_get_default_block_editor_settings();
-
 	if ( 'base' === $origin ) {
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, 'theme' )->get_settings();
+		$origin = 'theme';
 	} else {
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports )->get_settings();
+		$origin = 'user';
 	}
+
+	$theme_supports = gutenberg_get_default_block_editor_settings();
+	$settings       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )->get_settings();
 
 	return _wp_array_get( $settings, $path, $settings );
 }

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -60,7 +60,7 @@ function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin
 	}
 
 	$theme_supports = gutenberg_get_default_block_editor_settings();
-	$styles         = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )['styles'];
+	$styles         = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )->get_raw_data()['styles'];
 
 	return _wp_array_get( $styles, $path, $styles );
 }

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -15,24 +15,20 @@
  * @param string $origin            Which origin to take data from. Optional.
  *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
  *                                  If empty or unknown, 'all' is used.
- * @param array  $existing_settings Existing settings to retrofit. Optional.
- *                                  If empty, the function will retrieve the settings by itself.
  *
  * @return array The settings to retrieve.
  */
-function gutenberg_get_global_settings( $path = array(), $block_name = '', $origin = 'all', $existing_settings = array() ) {
+function gutenberg_get_global_settings( $path = array(), $block_name = '', $origin = 'all' ) {
 	if ( '' !== $block_name ) {
 		$path = array_merge( array( 'blocks', $block_name ), $path );
 	}
 
-	if ( empty( $existing_settings ) ) {
-		$existing_settings = gutenberg_get_default_block_editor_settings();
-	}
+	$theme_supports = gutenberg_get_default_block_editor_settings();
 
 	if ( 'base' === $origin ) {
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings, 'theme' )->get_settings();
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, 'theme' )->get_settings();
 	} else {
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings )->get_settings();
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports )->get_settings();
 	}
 
 	return _wp_array_get( $settings, $path, $settings );

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -44,25 +44,22 @@ function gutenberg_get_global_settings( $path = array(), $block_name = '', $orig
  * @param string $origin            Which origin to take data from. Optional.
  *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
  *                                  If empty or unknown, 'all' is used.
- * @param array  $existing_settings Existing settings to retrofit. Optional.
- *                                  If empty, the function will retrieve the settings by itself.
  *
  * @return array The styles to retrieve.
  */
-function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin = 'all', $existing_settings = array() ) {
+function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin = 'all' ) {
 	if ( '' !== $block_name ) {
 		$path = array_merge( array( 'blocks', $block_name ), $path );
 	}
 
-	if ( empty( $existing_settings ) ) {
-		$existing_settings = gutenberg_get_default_block_editor_settings();
+	if ( 'base' === $origin ) {
+		$origin = 'theme';
+	} else {
+		$origin = 'user';
 	}
 
-	if ( 'base' === $origin ) {
-		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings, 'theme' )['styles'];
-	} else {
-		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $existing_settings )['styles'];
-	}
+	$theme_supports = gutenberg_get_default_block_editor_settings();
+	$styles         = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )['styles'];
 
 	return _wp_array_get( $styles, $path, $styles );
 }

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -71,13 +71,12 @@ function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin
  *                         It accepts 'all', 'block_styles', 'css_variables', 'presets'.
  *                         If empty, it'll resolve to all (theme with theme.json support)
  *                         or 'presets' (theme without theme.json support).
- * @param array  $settings Existing settings to retrofit. Optional.
- *                         If empty, the function will retrieve the settings itself.
  *
  * @return string Stylesheet.
  */
-function gutenberg_get_global_stylesheet( $type = '', $settings = array() ) {
+function gutenberg_get_global_stylesheet( $type = '' ) {
 	// Return cached value if it can be used and exists.
+	// It's cached by theme to make sure that theme switching clears the cache.
 	$can_use_cached = (
 		( 'all' === $type ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
@@ -85,17 +84,12 @@ function gutenberg_get_global_stylesheet( $type = '', $settings = array() ) {
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
 		! is_admin()
 	);
-	// It's cached by theme to make sure that theme switching is inmediately reflected.
 	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 	if ( $can_use_cached ) {
 		$cached = get_transient( $transient_name );
 		if ( $cached ) {
 			return $cached;
 		}
-	}
-
-	if ( empty( $settings ) ) {
-		$settings = gutenberg_get_default_block_editor_settings();
 	}
 
 	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
@@ -116,8 +110,9 @@ function gutenberg_get_global_stylesheet( $type = '', $settings = array() ) {
 		$origins = array( 'core', 'theme' );
 	}
 
-	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-	$stylesheet = $tree->get_stylesheet( $type, $origins );
+	$theme_supports = gutenberg_get_default_block_editor_settings();
+	$tree           = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports );
+	$stylesheet     = $tree->get_stylesheet( $type, $origins );
 
 	if ( $can_use_cached ) {
 		// Cache for a minute.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -6,75 +6,11 @@
  */
 
 /**
- * Takes a tree adhering to the theme.json schema and generates
- * the corresponding stylesheet.
- *
- * @param WP_Theme_JSON_Gutenberg $tree Input tree.
- * @param string                  $type Type of stylesheet. It accepts 'all', 'block_styles', 'css_variables', 'presets'.
- *
- * @return string Stylesheet.
- */
-function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = null ) {
-	// Check if we can use cached.
-	$can_use_cached = (
-		( 'all' === $type ) &&
-		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
-		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
-		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
-		! is_admin()
-	);
-
-	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
-	if ( $can_use_cached ) {
-		// Check if we have the styles already cached.
-		// It's cached by theme to make sure that theme switching
-		// is inmediately reflected.
-		$cached = get_transient( $transient_name );
-		if ( $cached ) {
-			return $cached;
-		}
-	}
-
-	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	$supports_link_color = get_theme_support( 'experimental-link-color' );
-
-	// Only modify the $type if the consumer hasn't provided any.
-	if ( null === $type && ! $supports_theme_json ) {
-		$type = 'presets';
-	} elseif ( null === $type ) {
-		$type = 'all';
-	}
-
-	$origins = array( 'core', 'theme', 'user' );
-	if ( ! $supports_theme_json && ! $supports_link_color ) {
-		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-		$origins = array( 'core' );
-	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feauter to work, the CSS Custom Properties
-		// should be in scope (either the core or the theme ones).
-		$origins = array( 'core', 'theme' );
-	}
-
-	$stylesheet = $tree->get_stylesheet( $type, $origins );
-
-	if ( $can_use_cached ) {
-		// Cache for a minute.
-		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
-	}
-
-	return $stylesheet;
-}
-
-/**
  * Fetches the preferences for each origin (core, theme, user)
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	$settings = gutenberg_get_default_block_editor_settings();
-	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-
-	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
+	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -115,25 +51,22 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'mobile';
 	}
 
-	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
+		$settings['__experimentalStyles'] = gutenberg_get_global_styles( array(), '', 'all', $settings );
 	}
 
 	if ( 'site-editor' === $context && gutenberg_experimental_is_site_editor_available() ) {
-		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 
 		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
-		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $theme->get_raw_data()['styles'];
-		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_settings();
+		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = gutenberg_get_global_styles( array(), '', 'base', $settings );
+		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = gutenberg_get_global_settings( array(), '', 'base', $settings );
 	}
 
 	if ( 'other' === $context ) {
-		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'block_styles' ) );
+		$block_styles  = array( 'css' => gutenberg_get_global_stylesheet( 'block_styles', $settings ) );
 		$css_variables = array(
-			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'css_variables' ),
+			'css'                     => gutenberg_get_global_stylesheet( 'css_variables', $settings ),
 			'__experimentalNoWrapper' => true,
 		);
 
@@ -158,7 +91,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = $consolidated->get_settings();
+	$settings['__experimentalFeatures'] = gutenberg_get_global_settings( array(), '', 'all', $settings );
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -5,6 +5,67 @@
  * @package gutenberg
  */
 
+ /**
+ * Takes a tree adhering to the theme.json schema and generates
+ * the corresponding stylesheet.
+ *
+ * @param string                  $type Type of stylesheet. It accepts 'all', 'block_styles', 'css_variables', 'presets'.
+ * @param WP_Theme_JSON_Gutenberg $tree Input tree.
+ *
+ * @return string Stylesheet.
+ */
+function gutenberg_experimental_global_styles_get_stylesheet( $type, $tree ) {
+	// Check if we can use cached.
+	$can_use_cached = (
+		( 'all' === $type ) &&
+		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+		! is_admin()
+	);
+
+	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
+	if ( $can_use_cached ) {
+		// Check if we have the styles already cached.
+		// It's cached by theme to make sure that theme switching
+		// is inmediately reflected.
+		$cached = get_transient( $transient_name );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+	$supports_link_color = get_theme_support( 'experimental-link-color' );
+
+	// Only modify the $type if the consumer hasn't provided any.
+	if ( null === $type && ! $supports_theme_json ) {
+		$type = 'presets';
+	} elseif ( null === $type ) {
+		$type = 'all';
+	}
+
+	$origins = array( 'core', 'theme', 'user' );
+	if ( ! $supports_theme_json && ! $supports_link_color ) {
+		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
+		$origins = array( 'core' );
+	} elseif ( ! $supports_theme_json && $supports_link_color ) {
+		// For the legacy link color feauter to work, the CSS Custom Properties
+		// should be in scope (either the core or the theme ones).
+		$origins = array( 'core', 'theme' );
+	}
+
+	$stylesheet = $tree->get_stylesheet( $type, $origins );
+
+	if ( $can_use_cached ) {
+		// Cache for a minute.
+		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
+		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
+	}
+
+	return $stylesheet;
+}
+
 /**
  * Fetches the preferences for each origin (core, theme, user)
  * and enqueues the resulting stylesheet.
@@ -66,9 +127,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'other' === $context ) {
-		$block_styles  = array( 'css' => gutenberg_get_global_stylesheet( 'block_styles', $settings ) );
+		$tree          = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( 'block_styles', $tree ) );
 		$css_variables = array(
-			'css'                     => gutenberg_get_global_stylesheet( 'css_variables', $settings ),
+			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( 'css_variables', $tree ),
 			'__experimentalNoWrapper' => true,
 		);
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
- /**
+/**
  * Takes a tree adhering to the theme.json schema and generates
  * the corresponding stylesheet.
  *

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -119,12 +119,12 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'site-editor' === $context && gutenberg_experimental_is_site_editor_available() ) {
+		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
-		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 
 		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
-		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $tree->get_raw_data()['styles'];
-		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $tree->get_settings();
+		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $theme->get_raw_data()['styles'];
+		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_settings();
 	}
 
 	if ( 'other' === $context ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -57,10 +57,11 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( 'site-editor' === $context && gutenberg_experimental_is_site_editor_available() ) {
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 
 		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = gutenberg_get_global_styles( array(), '', 'base', $settings );
-		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = gutenberg_get_global_settings( array(), '', 'base', $settings );
+		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $tree->get_settings();
 	}
 
 	if ( 'other' === $context ) {
@@ -91,7 +92,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = gutenberg_get_global_settings( array(), '', 'all', $settings );
+	$tree                               = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+	$settings['__experimentalFeatures'] = $tree->get_settings();
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -52,7 +52,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$settings['__experimentalStyles'] = gutenberg_get_global_styles( array(), '', 'all', $settings );
+		$tree                             = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+		$settings['__experimentalStyles'] = $tree->get_raw_data()['styles'];
 	}
 
 	if ( 'site-editor' === $context && gutenberg_experimental_is_site_editor_available() ) {
@@ -60,7 +61,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 
 		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
-		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = gutenberg_get_global_styles( array(), '', 'base', $settings );
+		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $tree->get_raw_data()['styles'];
 		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $tree->get_settings();
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -9,12 +9,12 @@
  * Takes a tree adhering to the theme.json schema and generates
  * the corresponding stylesheet.
  *
- * @param string                  $type Type of stylesheet. It accepts 'all', 'block_styles', 'css_variables', 'presets'.
  * @param WP_Theme_JSON_Gutenberg $tree Input tree.
+ * @param string                  $type Type of stylesheet. It accepts 'all', 'block_styles', 'css_variables', 'presets'.
  *
  * @return string Stylesheet.
  */
-function gutenberg_experimental_global_styles_get_stylesheet( $type, $tree ) {
+function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = null ) {
 	// Check if we can use cached.
 	$can_use_cached = (
 		( 'all' === $type ) &&
@@ -128,9 +128,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'other' === $context ) {
-		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( 'block_styles', $consolidated ) );
+		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'block_styles' ) );
 		$css_variables = array(
-			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( 'css_variables', $consolidated ),
+			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'css_variables' ),
 			'__experimentalNoWrapper' => true,
 		);
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -112,9 +112,10 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'mobile';
 	}
 
+	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$tree                             = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-		$settings['__experimentalStyles'] = $tree->get_raw_data()['styles'];
+		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
 	}
 
 	if ( 'site-editor' === $context && gutenberg_experimental_is_site_editor_available() ) {
@@ -127,10 +128,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'other' === $context ) {
-		$tree          = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( 'block_styles', $tree ) );
+		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( 'block_styles', $consolidated ) );
 		$css_variables = array(
-			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( 'css_variables', $tree ),
+			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( 'css_variables', $consolidated ),
 			'__experimentalNoWrapper' => true,
 		);
 
@@ -155,8 +155,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$tree                               = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
-	$settings['__experimentalFeatures'] = $tree->get_settings();
+	$settings['__experimentalFeatures'] = $consolidated->get_settings();
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];

--- a/lib/load.php
+++ b/lib/load.php
@@ -84,6 +84,7 @@ require __DIR__ . '/compat.php';
 require __DIR__ . '/compat/wordpress-5.8/index.php';
 require __DIR__ . '/compat/wordpress-5.8.1/index.php';
 require __DIR__ . '/compat/wordpress-5.9/default-editor-styles.php';
+require __DIR__ . '/compat/wordpress-5.9/get-global-styles-and-settings.php';
 require __DIR__ . '/utils.php';
 require __DIR__ . '/editor-settings.php';
 


### PR DESCRIPTION
This is a proposal to add a public API for plugins/themes to extract data from the settings & styles instead of using the `WP_Theme_JSON_Resolver` which is marked as private. It's also arguably easier to reason about for consumers.

### The signatures

`gutenberg_get_global_settings( $path = array() , $block_name = '', $origin = 'all' )`
`gutenberg_get_global_styles( $path = array() , $block_name = '', $origin = 'all' )`
`gutenberg_get_global_stylesheet( $type = '' )`

### Common use cases

Get all settings: `gutenberg_get_global_settings()`.
Get layout settings for the root context: `gutenberg_get_global_settings( array( 'layout' ) )`.
Get color settings for the paragraph block: `gutenberg_get_global_settings( array( 'color' ), 'core/paragraph' )`.

Get all styles: `gutenberg_get_global_styles()`.

Get the stylesheet: `gutenberg_get_global_stylesheet()`.
Get the stylesheet corresponding to block styles: `gutenberg_get_global_stylesheet( 'block_styles' ) )`.
Get the stylesheet corresponding to CSS vars: `gutenberg_get_global_stylesheet( 'css_variables' ) )`.

### Notes

1. This doesn't cover all the use cases we have in our code base. People also use the resolver to retrieve the template parts ([see](https://github.com/WordPress/gutenberg/blob/8d8e07699df7c31fd89c07406356fb779de90b33/lib/full-site-editing/block-templates.php#L128)), which I intentionally left out can be added later if we want.

2. These functions can't be used in a callback to the `block_editor_settings` filter, like the one used in the Gutenberg plugin. The reason is that these new functions don't take the filtered theme supports.
