### PR TITLE
Rich Text: also strip object replacement character when removing padding

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -13,6 +13,7 @@ import { mergePair } from './concat';
 import {
 	LINE_SEPARATOR,
 	OBJECT_REPLACEMENT_CHARACTER,
+	ZWNBSP,
 } from './special-characters';
 
 /**
@@ -312,7 +313,10 @@ function collapseWhiteSpace( string ) {
  */
 export function removeReservedCharacters( string ) {
 	//with the global flag, note that we should create a new regex each time OR reset lastIndex state.
-	return string.replace( /[\uFEFF\uFFFC]/gu, '' );
+	return string.replace(
+		new RegExp( `[${ ZWNBSP }${ OBJECT_REPLACEMENT_CHARACTER }]`, 'gu' ),
+		''
+	);
 }
 
 /**

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -306,15 +306,18 @@ function collapseWhiteSpace( string ) {
 	return string.replace( /[\n\r\t]+/g, ' ' );
 }
 
-const ZWNBSPRegExp = new RegExp( ZWNBSP, 'g' );
+const REMOVE_PADDING_REGEX = new RegExp(
+	`[${ ZWNBSP }${ OBJECT_REPLACEMENT_CHARACTER }]`,
+	'g'
+);
 
 /**
- * Removes padding (zero width non breaking spaces) added by `toTree`.
+ * Removes padding (zero width non breaking spaces added by `toTree` and object replacement characters).
  *
  * @param {string} string
  */
 function removePadding( string ) {
-	return string.replace( ZWNBSPRegExp, '' );
+	return string.replace( REMOVE_PADDING_REGEX, '' );
 }
 
 /**

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -306,19 +306,13 @@ function collapseWhiteSpace( string ) {
 }
 
 /**
- * Matches the object replacement character or Zero width non-breaking space
- *
- * @type {RegExp}
- */
-export const REMOVE_PADDING_REGEX = /(\u{feff}?|\u{fffc}?)+/gu;
-
-/**
- * Removes padding (zero width non breaking spaces added by `toTree` and object replacement characters).
+ * Removes reserved characters used by rich-text (zero width non breaking spaces added by `toTree` and object replacement characters).
  *
  * @param {string} string
  */
-function removePadding( string ) {
-	return string.replace( REMOVE_PADDING_REGEX, '' );
+export function removeReservedCharacters( string ) {
+	//with the global flag, note that we should create a new regex each time OR reset lastIndex state.
+	return string.replace( /[\uFEFF\uFFFC]/gu, '' );
 }
 
 /**
@@ -366,11 +360,11 @@ function createFromElement( {
 		const type = node.nodeName.toLowerCase();
 
 		if ( node.nodeType === node.TEXT_NODE ) {
-			let filter = removePadding;
+			let filter = removeReservedCharacters;
 
 			if ( ! preserveWhiteSpace ) {
 				filter = ( string ) =>
-					removePadding( collapseWhiteSpace( string ) );
+					removeReservedCharacters( collapseWhiteSpace( string ) );
 			}
 
 			const text = filter( node.nodeValue );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -13,7 +13,6 @@ import { mergePair } from './concat';
 import {
 	LINE_SEPARATOR,
 	OBJECT_REPLACEMENT_CHARACTER,
-	ZWNBSP,
 } from './special-characters';
 
 /**
@@ -306,10 +305,12 @@ function collapseWhiteSpace( string ) {
 	return string.replace( /[\n\r\t]+/g, ' ' );
 }
 
-const REMOVE_PADDING_REGEX = new RegExp(
-	`[${ ZWNBSP }${ OBJECT_REPLACEMENT_CHARACTER }]`,
-	'g'
-);
+/**
+ * Matches the object replacement character or Zero width non-breaking space
+ *
+ * @type {RegExp}
+ */
+export const REMOVE_PADDING_REGEX = /(\u{feff}?|\u{fffc}?)+/gu;
 
 /**
  * Removes padding (zero width non breaking spaces added by `toTree` and object replacement characters).

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -341,6 +341,23 @@ exports[`recordToDom should ignore formats at line separator 1`] = `
 </body>
 `;
 
+exports[`recordToDom should ignore manually added object replacement character 1`] = `
+<body>
+  test
+</body>
+`;
+
+exports[`recordToDom should ignore manually added object replacement character with formatting 1`] = `
+<body>
+  <em
+    data-rich-text-format-boundary="true"
+  >
+    hi
+  </em>
+  
+</body>
+`;
+
 exports[`recordToDom should not error with overlapping formats (1) 1`] = `
 <body>
   <a

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -7,7 +7,8 @@ import { JSDOM } from 'jsdom';
 /**
  * Internal dependencies
  */
-import { create } from '../create';
+import { create, REMOVE_PADDING_REGEX } from '../create';
+import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from '../special-characters';
 import { createElement } from '../create-element';
 import { registerFormatType } from '../register-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
@@ -121,5 +122,24 @@ describe( 'create', () => {
 
 		// Format arrays per index.
 		expect( value.formats[ 0 ] ).not.toBe( value.formats[ 1 ] );
+	} );
+
+	it( 'remove padding regex should match all expected padding characters', () => {
+		expect(
+			REMOVE_PADDING_REGEX.test( OBJECT_REPLACEMENT_CHARACTER )
+		).toEqual( true );
+		expect( REMOVE_PADDING_REGEX.test( ZWNBSP ) ).toEqual( true );
+		expect(
+			`${ OBJECT_REPLACEMENT_CHARACTER }te${ ZWNBSP }st${ OBJECT_REPLACEMENT_CHARACTER }`.replace(
+				REMOVE_PADDING_REGEX,
+				''
+			)
+		).toEqual( 'test' );
+		expect(
+			`te${ OBJECT_REPLACEMENT_CHARACTER }st${ ZWNBSP }${ ZWNBSP }`.replace(
+				REMOVE_PADDING_REGEX,
+				''
+			)
+		).toEqual( 'test' );
 	} );
 } );

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom';
 /**
  * Internal dependencies
  */
-import { create, REMOVE_PADDING_REGEX } from '../create';
+import { create, removeReservedCharacters } from '../create';
 import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from '../special-characters';
 import { createElement } from '../create-element';
 import { registerFormatType } from '../register-format-type';
@@ -124,21 +124,22 @@ describe( 'create', () => {
 		expect( value.formats[ 0 ] ).not.toBe( value.formats[ 1 ] );
 	} );
 
-	it( 'remove padding regex should match all expected padding characters', () => {
+	it( 'removeReservedCharacters should remove all reserved characters', () => {
 		expect(
-			REMOVE_PADDING_REGEX.test( OBJECT_REPLACEMENT_CHARACTER )
-		).toEqual( true );
-		expect( REMOVE_PADDING_REGEX.test( ZWNBSP ) ).toEqual( true );
+			removeReservedCharacters( `${ OBJECT_REPLACEMENT_CHARACTER }` )
+		).toEqual( '' );
+		expect( removeReservedCharacters( `${ ZWNBSP }` ) ).toEqual( '' );
 		expect(
-			`${ OBJECT_REPLACEMENT_CHARACTER }te${ ZWNBSP }st${ OBJECT_REPLACEMENT_CHARACTER }`.replace(
-				REMOVE_PADDING_REGEX,
-				''
+			removeReservedCharacters(
+				`${ OBJECT_REPLACEMENT_CHARACTER }c${ OBJECT_REPLACEMENT_CHARACTER }at${ OBJECT_REPLACEMENT_CHARACTER }`
 			)
-		).toEqual( 'test' );
+		).toEqual( 'cat' );
 		expect(
-			`te${ OBJECT_REPLACEMENT_CHARACTER }st${ ZWNBSP }${ ZWNBSP }`.replace(
-				REMOVE_PADDING_REGEX,
-				''
+			removeReservedCharacters( `${ ZWNBSP }b${ ZWNBSP }at${ ZWNBSP }` )
+		).toEqual( 'bat' );
+		expect(
+			removeReservedCharacters(
+				`te${ OBJECT_REPLACEMENT_CHARACTER }st${ ZWNBSP }${ ZWNBSP }`
 			)
 		).toEqual( 'test' );
 	} );

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ZWNBSP } from '../../special-characters';
+import { ZWNBSP, OBJECT_REPLACEMENT_CHARACTER } from '../../special-characters';
 
 export function getSparseArrayLength( array ) {
 	return array.reduce( ( accumulator ) => accumulator + 1, 0 );
@@ -32,6 +32,46 @@ export const spec = [
 			formats: [],
 			replacements: [],
 			text: '',
+		},
+	},
+	{
+		description:
+			'should ignore manually added object replacement character',
+		html: `test${ OBJECT_REPLACEMENT_CHARACTER }`,
+		createRange: ( element ) => ( {
+			startOffset: 0,
+			startContainer: element,
+			endOffset: 1,
+			endContainer: element,
+		} ),
+		startPath: [ 0, 0 ],
+		endPath: [ 0, 4 ],
+		record: {
+			start: 0,
+			end: 4,
+			formats: [ , , , , ],
+			replacements: [ , , , , ],
+			text: 'test',
+		},
+	},
+	{
+		description:
+			'should ignore manually added object replacement character with formatting',
+		html: `<em>h${ OBJECT_REPLACEMENT_CHARACTER }i</em>`,
+		createRange: ( element ) => ( {
+			startOffset: 0,
+			startContainer: element,
+			endOffset: 1,
+			endContainer: element,
+		} ),
+		startPath: [ 0, 0, 0 ],
+		endPath: [ 0, 0, 2 ],
+		record: {
+			start: 0,
+			end: 2,
+			formats: [ [ em ], [ em ] ],
+			replacements: [ , , ],
+			text: 'hi',
 		},
 	},
 	{


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34602. Rich text instances should ignore the object replacement character U+FFFC, since this is used internally by the package.

Changes here strip this special character when we remove other whitespace characters like `u+feff`,

### Testing Instructions
- related unit tests pass
- Try manually adding an object replacement character to a rich text instance. One way of doing this is pasting in a post title like `This post title crashes Gutenberg &#xfffc;`
- Save the post
- Re-open the post for editing
Verify that no JS errors are thrown

| Before | After |
|-----|-----|
| ![CleanShot 2021-09-15 at 10 12 21](https://user-images.githubusercontent.com/1270189/133479006-1da64be5-a463-44ac-b1de-6b45a256050e.gif) | ![CleanShot 2021-09-15 at 10 10 54](https://user-images.githubusercontent.com/1270189/133479036-2df87285-54a1-445b-833b-1b3215235afd.gif) |

