### PR TITLE
Navigation Screen: Correctly display notices

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -109,7 +109,6 @@ export default function Layout( { blockEditorSettings } ) {
 					<BlockEditorKeyboardShortcuts.Register />
 					<NavigationEditorShortcuts.Register />
 					<NavigationEditorShortcuts saveBlocks={ savePost } />
-					<Notices />
 					<BlockEditorProvider
 						value={ blocks }
 						onInput={ onInput }
@@ -142,6 +141,7 @@ export default function Layout( { blockEditorSettings } ) {
 								}
 								content={
 									<>
+										<Notices />
 										{ ! hasFinishedInitialLoad && (
 											<Spinner />
 										) }

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -5,18 +5,13 @@
 }
 
 .edit-navigation-notices__notice-list {
-	// The page has a 10px left margin at narrower widths, reverse that so that the notice sits flush.
-	margin-left: -10px;
-
-	@include break-medium {
-		// The page has a 20px left margin at wider widths, reverse that so that the notice sits flush.
-		margin-left: -20px;
-	}
-
 	// Notices have some unusual margin and padding by default, reset that.
 	.components-notice {
+		box-sizing: border-box;
 		margin: 0;
-		padding-right: 12px;
+		border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+		padding: 0 12px;
+		min-height: 60px;
 
 		// Make sure the close button is centered.
 		.components-button {


### PR DESCRIPTION
## Description
The new top bar was overlapping the notices on the Navigation screen. PR moves notices inside the interface skeleton content and updated styling to match other editors.

## How has this been tested?
Run the following actions using the DevTools console to display notices:

```js
wp.data.dispatch( 'core/notices' ).createInfoNotice( 'Hello world!' );
wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Hello world!' );
```

Check that notices don't overlap with block inserter and other elements on the screen.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-15 at 21 04 54](https://user-images.githubusercontent.com/240569/133478100-97790c71-71d8-47b9-962f-e16bc34299ee.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
