### PR TITLE
Lower specificity of padding declaration in group block.

### DIFF
--- a/packages/block-library/src/group/theme.scss
+++ b/packages/block-library/src/group/theme.scss
@@ -1,5 +1,5 @@
 .wp-block-group {
-	&.has-background {
+	&:where(.has-background) {
 		// Matches paragraph Block padding
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/33456

This PR lowers the specificity of the padding declaration for the group block when it has a background attached, so other styles (including global styles) can override them.