### PR TITLE
Filters are incorrectly applied in the __experimental/menu-items controller

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -916,7 +916,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'The DB ID of the nav_menu_item that is this item\'s menu parent, if any, otherwise 0.', 'gutenberg' ),
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'integer',
-			'minimum'     => 0,
+			'minimum'     => 1,
 			'default'     => 1,
 		);
 

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -543,17 +543,6 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			$prepared_nav_item[ $key ] = implode( ' ', array_map( 'sanitize_html_class', $value ) );
 		}
 
-		// Apply the same filters as when calling wp_insert_post().
-
-		/** This filter is documented in wp-includes/post.php */
-		$prepared_nav_item['menu-item-title'] = wp_unslash( apply_filters( 'title_save_pre', wp_slash( $prepared_nav_item['menu-item-title'] ) ) );
-
-		/** This filter is documented in wp-includes/post.php */
-		$prepared_nav_item['menu-item-attr-title'] = wp_unslash( apply_filters( 'excerpt_save_pre', wp_slash( $prepared_nav_item['menu-item-attr-title'] ) ) );
-
-		/** This filter is documented in wp-includes/post.php */
-		$prepared_nav_item['menu-item-description'] = wp_unslash( apply_filters( 'content_save_pre', wp_slash( $prepared_nav_item['menu-item-description'] ) ) );
-
 		// Valid url.
 		if ( '' !== $prepared_nav_item['menu-item-url'] ) {
 			$prepared_nav_item['menu-item-url'] = esc_url_raw( $prepared_nav_item['menu-item-url'] );
@@ -927,7 +916,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'description' => __( 'The DB ID of the nav_menu_item that is this item\'s menu parent, if any, otherwise 0.', 'gutenberg' ),
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'type'        => 'integer',
-			'minimum'     => 1,
+			'minimum'     => 0,
 			'default'     => 1,
 		);
 

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -745,9 +745,9 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_filters_only_get_applied_once_when_creating_a_menu_item() {
 		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
-		add_filter( 'excerpt_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
-		add_filter( 'content_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
+		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter') );
 
 		$request = new WP_REST_Request( 'POST', '/__experimental/menu-items' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
@@ -764,9 +764,9 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_filters_only_get_applied_once_when_updating_a_menu_item() {
 		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
-		add_filter( 'excerpt_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
-		add_filter( 'content_save_pre', array( $this, 'count_times_filters_have_been_applied' ) );
+		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter') );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/__experimental/menu-items/%d', $this->menu_item_id ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
@@ -792,7 +792,7 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 		$this->assertSame( 3, self::$times_filters_applied, 'Callback function must be called 3 times (meaning each filter has been applied only once)' );
 	}
 
-	public function count_times_filters_have_been_applied( $value ) {
+	public function increment_filters_applied_counter( $value ) {
 		++self::$times_filters_applied;
 		return $value;
 	}

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -36,11 +36,6 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	protected static $subscriber_id;
 
 	/**
-	 * @var int
-	 */
-	protected static $times_filters_applied;
-
-	/**
 	 *
 	 */
 	const POST_TYPE = 'nav_menu_item';
@@ -91,8 +86,6 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 				'menu-item-status'    => 'publish',
 			)
 		);
-
-		self::$times_filters_applied = 0;
 	}
 
 	/**
@@ -738,63 +731,6 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 		$request  = new WP_REST_Request( 'GET', '/__experimental/menu-items/' . $this->menu_item_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_view', $response, 403 );
-	}
-
-	/**
-	 *
-	 */
-	public function test_filters_only_get_applied_once_when_creating_a_menu_item() {
-		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-
-		$request = new WP_REST_Request( 'POST', '/__experimental/menu-items' );
-		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
-		$params = $this->set_menu_item_data();
-		$request->set_body_params( $params );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->check_create_menu_item_response( $response );
-		$this->assertSame( 3, self::$times_filters_applied, 'Callback function must be called 3 times (meaning each filter has been applied only once)' );
-	}
-
-	/**
-	 *
-	 */
-	public function test_filters_only_get_applied_once_when_updating_a_menu_item() {
-		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter' ) );
-
-		$request = new WP_REST_Request( 'PUT', sprintf( '/__experimental/menu-items/%d', $this->menu_item_id ) );
-		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
-		$params = $this->set_menu_item_data(
-			array(
-				'xfn' => array( 'test1', 'test2', 'test3' ),
-			)
-		);
-		$request->set_body_params( $params );
-		$response = rest_get_server()->dispatch( $request );
-		$this->check_update_menu_item_response( $response );
-		$new_data = $response->get_data();
-		$this->assertEquals( $this->menu_item_id, $new_data['id'] );
-		$this->assertEquals( $params['title'], $new_data['title']['raw'] );
-		$this->assertEquals( $params['description'], $new_data['description'] );
-		$this->assertEquals( $params['type_label'], $new_data['type_label'] );
-		$this->assertEquals( $params['xfn'], $new_data['xfn'] );
-		$post      = get_post( $this->menu_item_id );
-		$menu_item = wp_setup_nav_menu_item( $post );
-		$this->assertEquals( $params['title'], $menu_item->title );
-		$this->assertEquals( $params['description'], $menu_item->description );
-		$this->assertEquals( $params['xfn'], explode( ' ', $menu_item->xfn ) );
-		$this->assertSame( 3, self::$times_filters_applied, 'Callback function must be called 3 times (meaning each filter has been applied only once)' );
-	}
-
-	public function increment_filters_applied_counter( $value ) {
-		++self::$times_filters_applied;
-		return $value;
 	}
 
 	/**

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -745,9 +745,9 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_filters_only_get_applied_once_when_creating_a_menu_item() {
 		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter') );
-		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter') );
-		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter' ) );
+		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter' ) );
+		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter' ) );
 
 		$request = new WP_REST_Request( 'POST', '/__experimental/menu-items' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
@@ -764,9 +764,9 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_filters_only_get_applied_once_when_updating_a_menu_item() {
 		wp_set_current_user( self::$admin_id );
-		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter') );
-		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter') );
-		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter') );
+		add_filter( 'title_save_pre', array( $this, 'increment_filters_applied_counter' ) );
+		add_filter( 'excerpt_save_pre', array( $this, 'increment_filters_applied_counter' ) );
+		add_filter( 'content_save_pre', array( $this, 'increment_filters_applied_counter' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/__experimental/menu-items/%d', $this->menu_item_id ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR fixes an issue with the filters in the `WP_REST_Menu_Items_Controller::prepare_item_for_database` method.
We explicitly apply `title_save_pre`, `exceprt_save_pre`, `content_save_pre` filters in there.
But later, we apply the same filters in the `wp_insert_post` function, so we don't need to apply them in the `WP_REST_Menu_Items_Controller::prepare_item_for_database` method.
Fixes https://github.com/WordPress/gutenberg/issues/25095

## How has this been tested?
Two regression unit tests have been written to cover this case. So I would say no testing is needed.
However, If you still want/need to test this, you can do it as described below.
**Prerequisite**: you will need XDebug to test it.
1. Go to the Gutenberg -> Experiments page and enable `Navigation screen` feature.
2. Save the changes.
3. Open `/wp-includes/plugin.php` file in your IDE and place a conditional breakpoint at the beginning of the `apply_filters` function (somewhere around line 166).
4. Use the following condition for your breakpoint:
```php
$hook_name === 'content_save_pre'
```

5. Go back to your browser, and open the Gutenberg  -> Navigation page.
6.  Run the following JavaScript code in your browser's console:
```javascript
wp.apiFetch( {
    path: '/__experimental/menu-items',
    method: 'POST',
    data: { title: 'Some Link', url: 'https://my.test.url' },
} ).then( ( res ) => {
    console.log( res );
} );
```

7. Make sure that `apply_filters` function gets called only once (with $hook_name === 'content_save_pre').

## Screenshots <!-- if applicable -->
No screenshots are needed for this issue.

## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
