### PR TITLE
Fix 'menu_exists' response status code

### DIFF
--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -348,18 +348,11 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 		$term = wp_update_nav_menu_object( 0, wp_slash( (array) $prepared_term ) );
 
 		if ( is_wp_error( $term ) ) {
-			/*
-			 * If we're going to inform the client that the term already exists,
-			 * give them the identifier for future use.
-			 */
-			$term_id = $term->get_error_data( 'term_exists' );
-			if ( $term_id ) {
-				$existing_term = get_term( $term_id, $this->taxonomy );
-				$term->add_data( $existing_term->term_id, 'term_exists' );
+			// Inform client that the menu already exists and set correct status.
+			if ( isset( $term->errors['menu_exists'] ) ) {
 				$term->add_data(
 					array(
-						'status'  => 400,
-						'term_id' => $term_id,
+						'status' => 400,
 					)
 				);
 			}


### PR DESCRIPTION
## Description
Menu REST API was returning response code 500 for menu already exists error. PR adjusts the check to set the status code correctly.

## How has this been tested?
1. Go to the experimental Navigation screen.
2. Try to create a new menu with the name that already exists.
```js
wp.data.dispatch('core').saveMenu( { name: 'Menu' } );
```
3. Check the error in DevTools' Network tab.
4. Status code should be 400.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-16 at 14 02 24](https://user-images.githubusercontent.com/240569/133593157-e0cc09b8-49c4-4c4e-8da3-efd087273fa7.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
