### PR TITLE
Navigation Editor e2e tests: migrate from response mocking to rest api util

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -205,10 +205,6 @@ _Parameters_
 
 Undocumented declaration.
 
-### deleteAllObjects
-
-Undocumented declaration.
-
 ### deleteAllWidgets
 
 Delete all the widgets in the widgets screen.

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -205,6 +205,10 @@ _Parameters_
 
 Undocumented declaration.
 
+### deleteAllObjects
+
+Undocumented declaration.
+
 ### deleteAllWidgets
 
 Delete all the widgets in the widgets screen.

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -135,6 +135,10 @@ _Returns_
 
 -   `Promise`: Promise that responds to a request with the mock JSON response.
 
+### createMenu
+
+Undocumented declaration.
+
 ### createNewPost
 
 Creates new post.
@@ -196,6 +200,10 @@ Deactivates an active plugin.
 _Parameters_
 
 -   _slug_ `string`: Plugin slug.
+
+### deleteAllMenus
+
+Undocumented declaration.
 
 ### deleteAllWidgets
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -137,7 +137,12 @@ _Returns_
 
 ### createMenu
 
-Undocumented declaration.
+Create menus and all linked resources for the menu using the REST API.
+
+_Parameters_
+
+-   _menu_ `Object`: Rest payload for the menu
+-   _menuItems_ `?Array`: Data for any menu items to be created.
 
 ### createNewPost
 
@@ -203,7 +208,7 @@ _Parameters_
 
 ### deleteAllMenus
 
-Undocumented declaration.
+Delete all menus using the REST API
 
 ### deleteAllWidgets
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -52,6 +52,7 @@ export { installTheme } from './install-theme';
 export { isCurrentURL } from './is-current-url';
 export { isInDefaultBlock } from './is-in-default-block';
 export { loginUser } from './login-user';
+export { createMenu, deleteAllMenus } from './menus';
 export {
 	enableFocusLossObservation,
 	disableFocusLossObservation,

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -52,7 +52,7 @@ export { installTheme } from './install-theme';
 export { isCurrentURL } from './is-current-url';
 export { isInDefaultBlock } from './is-in-default-block';
 export { loginUser } from './login-user';
-export { createMenu, deleteAllMenus } from './menus';
+export { createMenu, deleteAllMenus, deleteAllObjects } from './menus';
 export {
 	enableFocusLossObservation,
 	disableFocusLossObservation,

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -52,7 +52,7 @@ export { installTheme } from './install-theme';
 export { isCurrentURL } from './is-current-url';
 export { isInDefaultBlock } from './is-in-default-block';
 export { loginUser } from './login-user';
-export { createMenu, deleteAllMenus, deleteAllObjects } from './menus';
+export { createMenu, deleteAllMenus } from './menus';
 export {
 	enableFocusLossObservation,
 	disableFocusLossObservation,

--- a/packages/e2e-test-utils/src/menus.js
+++ b/packages/e2e-test-utils/src/menus.js
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import { rest, batch } from './rest-api';
+
+const menusEndpoint = '/__experimental/menus';
+const menuItemsEndpoint = '/__experimental/menu-items';
+
+export async function deleteAllMenus() {
+	const menus = await rest( { path: menusEndpoint } );
+
+	await batch(
+		menus.map( ( menu ) => ( {
+			method: 'DELETE',
+			path: `${ menusEndpoint }/${ menu.id }?force=true`,
+		} ) )
+	);
+}
+
+export async function createMenu( menu, menuItems ) {
+	const newMenu = await rest( {
+		method: 'POST',
+		path: menusEndpoint,
+		data: menu,
+	} );
+
+	const menuItemRequests = menuItems?.map( ( menuItem ) => {
+		return {
+			method: 'POST',
+			path: menuItemsEndpoint,
+			body: {
+				menus: newMenu.id,
+				...menuItem,
+				// We need ids for the menu items first before we're able
+				// to set the correct parent id. Set `0` as the parent in
+				// this first request to get the ids.
+				parent: undefined,
+			},
+		};
+	} );
+
+	if ( menuItemRequests?.length ) {
+		const response = await batch( menuItemRequests );
+
+		// Make a second batch request to assign parents.
+		const menuItemsWithParentRequests = menuItems
+			.map( ( menuItem, index ) => {
+				// In the fixture data, the parent corresponds to the
+				// index in the array, dereference that to find the actual
+				// menu item id.
+				const fixtureParentIndex = menuItem?.parent !== undefined;
+
+				// Skip any menu items that are top level.
+				if ( ! fixtureParentIndex ) {
+					return undefined;
+				}
+
+				const parent = response.responses[ menuItem.parent ].body.id;
+				const menuItemId = response.responses[ index ].body.id;
+
+				return {
+					method: 'PUT',
+					path: `${ menuItemsEndpoint }/${ menuItemId }`,
+					body: { parent },
+				};
+			} )
+			.filter( ( menuItem ) => !! menuItem );
+
+		await batch( menuItemsWithParentRequests );
+	}
+}

--- a/packages/e2e-test-utils/src/menus.js
+++ b/packages/e2e-test-utils/src/menus.js
@@ -30,6 +30,9 @@ const menuItemObjectMatchers = {
 	page: ( menuItem, page ) => menuItem.title === page.title.raw,
 };
 
+/**
+ * Delete all menus using the REST API
+ */
 export async function deleteAllMenus() {
 	const menus = await rest( { path: menusEndpoint } );
 
@@ -41,6 +44,12 @@ export async function deleteAllMenus() {
 	);
 }
 
+/**
+ * Create menus and all linked resources for the menu using the REST API.
+ *
+ * @param {Object} menu      Rest payload for the menu
+ * @param {?Array} menuItems Data for any menu items to be created.
+ */
 export async function createMenu( menu, menuItems ) {
 	// Step 1. Create the menu.
 	const menuResponse = await rest( {

--- a/packages/e2e-test-utils/src/menus.js
+++ b/packages/e2e-test-utils/src/menus.js
@@ -126,12 +126,13 @@ export async function createMenu( menu, menuItems ) {
 
 				const parent =
 					menuItemsResponse.responses[ menuItem.parent ].body.id;
-				const menuItemId = menuItemsResponse.responses[ index ].body.id;
+				const menuItemResponse = menuItemsResponse.responses[ index ];
+				const menuItemId = menuItemResponse.body.id;
 
 				return {
 					method: 'PUT',
 					path: `${ menuItemsEndpoint }/${ menuItemId }`,
-					body: { parent },
+					body: { ...menuItemResponse.body, parent },
 				};
 			} )
 			.filter( ( request ) => !! request )

--- a/packages/e2e-test-utils/src/menus.js
+++ b/packages/e2e-test-utils/src/menus.js
@@ -41,19 +41,6 @@ export async function deleteAllMenus() {
 	);
 }
 
-export async function deleteAllObjects() {
-	[ '/wp/v2/posts', '/wp/v2/pages' ].forEach( async ( path ) => {
-		const items = await rest( { path } );
-
-		for ( const item of items ) {
-			await rest( {
-				method: 'DELETE',
-				path: `${ path }/${ item.id }?force=true`,
-			} );
-		}
-	} );
-}
-
 export async function createMenu( menu, menuItems ) {
 	// Step 1. Create the menu.
 	const menuResponse = await rest( {

--- a/packages/e2e-test-utils/src/menus.js
+++ b/packages/e2e-test-utils/src/menus.js
@@ -6,6 +6,30 @@ import { rest, batch } from './rest-api';
 const menusEndpoint = '/__experimental/menus';
 const menuItemsEndpoint = '/__experimental/menu-items';
 
+const menuItemObjectRequests = {
+	post: ( menuItem ) => ( {
+		path: '/wp/v2/posts',
+		method: 'POST',
+		data: {
+			title: menuItem.title,
+			status: 'publish',
+		},
+	} ),
+	page: ( menuItem ) => ( {
+		path: '/wp/v2/pages',
+		method: 'POST',
+		data: {
+			title: menuItem.title,
+			status: 'publish',
+		},
+	} ),
+};
+
+const menuItemObjectMatchers = {
+	post: ( menuItem, post ) => menuItem.title === post.title.raw,
+	page: ( menuItem, page ) => menuItem.title === page.title.raw,
+};
+
 export async function deleteAllMenus() {
 	const menus = await rest( { path: menusEndpoint } );
 
@@ -17,33 +41,78 @@ export async function deleteAllMenus() {
 	);
 }
 
+export async function deleteAllObjects() {
+	[ '/wp/v2/posts', '/wp/v2/pages' ].forEach( async ( path ) => {
+		const items = await rest( { path } );
+
+		for ( const item of items ) {
+			await rest( {
+				method: 'DELETE',
+				path: `${ path }/${ item.id }?force=true`,
+			} );
+		}
+	} );
+}
+
 export async function createMenu( menu, menuItems ) {
-	const newMenu = await rest( {
+	// Step 1. Create the menu.
+	const menuResponse = await rest( {
 		method: 'POST',
 		path: menusEndpoint,
 		data: menu,
 	} );
 
-	const menuItemRequests = menuItems?.map( ( menuItem ) => {
-		return {
-			method: 'POST',
-			path: menuItemsEndpoint,
-			body: {
-				menus: newMenu.id,
-				...menuItem,
-				// We need ids for the menu items first before we're able
-				// to set the correct parent id. Set `0` as the parent in
-				// this first request to get the ids.
-				parent: undefined,
-			},
-		};
-	} );
+	if ( ! menuItems?.length ) {
+		return;
+	}
 
-	if ( menuItemRequests?.length ) {
-		const response = await batch( menuItemRequests );
+	// Step 2. Create all the pages/posts/categories etc. that menu items
+	// are linked to. These items don't support rest batching so create them
+	// using individual requests.
+	const objectRequests = menuItems
+		.map( ( menuItem ) => {
+			const getRequest = menuItemObjectRequests[ menuItem.object ];
+			return getRequest ? getRequest( menuItem ) : undefined;
+		} )
+		.filter( ( request ) => !! request );
+	const objectResponses = [];
+	for ( const objectRequest of objectRequests ) {
+		const objectResponse = await rest( objectRequest );
+		objectResponses.push( objectResponse );
+	}
 
-		// Make a second batch request to assign parents.
-		const menuItemsWithParentRequests = menuItems
+	// Step 3. Create the initial menu items without assigned parents. We need
+	// the ids of all the menu items first before being able to assign the
+	// correct id of the parent.
+	const menuItemsResponse = await batch(
+		menuItems.map( ( menuItem ) => {
+			// If the menu item is linked to an 'object', get the id for that
+			// object.
+			const objectMatcher = menuItemObjectMatchers[ menuItem.object ];
+			let object;
+			if ( objectMatcher ) {
+				object = objectResponses.find( ( objectResponse ) =>
+					objectMatcher( menuItem, objectResponse )
+				);
+			}
+
+			return {
+				method: 'POST',
+				path: menuItemsEndpoint,
+				body: {
+					menus: menuResponse.id,
+					object_id: object?.id,
+					url: object?.link,
+					...menuItem,
+					parent: undefined,
+				},
+			};
+		} )
+	);
+
+	// Step 4. Make another menu item request to assign parents.
+	await batch(
+		menuItems
 			.map( ( menuItem, index ) => {
 				// In the fixture data, the parent corresponds to the
 				// index in the array, dereference that to find the actual
@@ -55,8 +124,9 @@ export async function createMenu( menu, menuItems ) {
 					return undefined;
 				}
 
-				const parent = response.responses[ menuItem.parent ].body.id;
-				const menuItemId = response.responses[ index ].body.id;
+				const parent =
+					menuItemsResponse.responses[ menuItem.parent ].body.id;
+				const menuItemId = menuItemsResponse.responses[ index ].body.id;
 
 				return {
 					method: 'PUT',
@@ -64,8 +134,6 @@ export async function createMenu( menu, menuItems ) {
 					body: { parent },
 				};
 			} )
-			.filter( ( menuItem ) => !! menuItem );
-
-		await batch( menuItemsWithParentRequests );
-	}
+			.filter( ( request ) => !! request )
+	);
 }

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -8,38 +8,38 @@ exports[`Navigation editor allows creation of a menu when there are no current m
 <!-- /wp:navigation -->"
 `;
 
-exports[`Navigation editor displays the first menu from the REST response when at least one menu exists 1`] = `
+exports[`Navigation editor displays the first created menu when at least one menu exists 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"http://localhost:8889/?page_id=41\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"page\\",\\"id\\":51,\\"url\\":\\"http://localhost:8889/?page_id=51\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-submenu {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"page\\",\\"id\\":51,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"page\\",\\"id\\":53,\\"url\\":\\"http://localhost:8889/?page_id=53\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"page\\",\\"id\\":56,\\"url\\":\\"http://localhost:8889/?page_id=56\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"page\\",\\"id\\":15,\\"url\\":\\"http://localhost:8889/?page_id=15\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"page\\",\\"id\\":45,\\"url\\":\\"http://localhost:8889/?page_id=45\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"page\\",\\"id\\":27,\\"url\\":\\"http://localhost:8889/?page_id=27\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-submenu {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"page\\",\\"id\\":53,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"page\\",\\"id\\":56,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"page\\",\\"id\\":15,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"page\\",\\"id\\":45,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"page\\",\\"id\\":27,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"page\\",\\"id\\":43,\\"url\\":\\"http://localhost:8889/?page_id=43\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"page\\",\\"id\\":43,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"category\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"id\\":7,\\"url\\":\\"http://localhost:8889/?cat=7\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"category\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"id\\":19,\\"url\\":\\"http://localhost:8889/?cat=19\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"category\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"id\\":6,\\"url\\":\\"http://localhost:8889/?cat=6\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"category\\",\\"description\\":\\"Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora\\",\\"id\\":16,\\"url\\":\\"http://localhost:8889/?cat=16\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-submenu {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"category\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"id\\":7,\\"url\\":\\"\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"category\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"id\\":19,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"category\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"id\\":6,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"category\\",\\"description\\":\\"Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora\\",\\"id\\":16,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://google.com\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -10,7 +10,7 @@ exports[`Navigation editor allows creation of a menu when there are no current m
 
 exports[`Navigation editor displays the first created menu when at least one menu exists 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
 <!-- wp:navigation-link {\\"label\\":\\"Our team\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
@@ -32,8 +32,8 @@ exports[`Navigation editor displays the first created menu when at least one men
 
 <!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation-editor.test.js.snap
@@ -4,42 +4,36 @@ exports[`Navigation editor allows creation of a menu when there are existing men
 
 exports[`Navigation editor allows creation of a menu when there are no current menu items 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"My page\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://example.com/1\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"My page\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"isTopLevelLink\\":true} /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation editor displays the first created menu when at least one menu exists 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"vertical\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"page\\",\\"id\\":41,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"page\\",\\"id\\":51,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-submenu -->
-
-<!-- wp:navigation-submenu {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"page\\",\\"id\\":53,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"page\\",\\"id\\":56,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"page\\",\\"id\\":15,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"page\\",\\"id\\":45,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"page\\",\\"id\\":27,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-submenu -->
-<!-- /wp:navigation-submenu -->
-<!-- /wp:navigation-submenu -->
+<!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-link {\\"label\\":\\"Our team\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"page\\",\\"id\\":43,\\"url\\":\\"\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-submenu {\\"label\\":\\"Shop\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-submenu {\\"label\\":\\"Winter apparel\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelItem\\":false} -->
+<!-- wp:navigation-link {\\"label\\":\\"Chunky socks\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Hideous hats\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"category\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"id\\":7,\\"url\\":\\"\\",\\"kind\\":\\"taxonomy\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"category\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"id\\":19,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-submenu {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"category\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"id\\":6,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":false} -->
-<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"category\\",\\"description\\":\\"Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora\\",\\"id\\":16,\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
-<!-- /wp:navigation-submenu -->
+<!-- wp:navigation-link {\\"label\\":\\"Glorious gloves\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Jazzy Jumpers\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation-submenu -->
 
-<!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
-<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Shipping\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":\\"number\\",\\"url\\":\\"string\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->
+
+<!-- wp:navigation-submenu {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelItem\\":true} -->
+<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"id\\":\\"undefined\\",\\"url\\":\\"string\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":false} /-->
 <!-- /wp:navigation-submenu -->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
+++ b/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
@@ -1,0 +1,171 @@
+[
+	{
+		"title": "Home",
+		"url": "http://localhost:8889/",
+		"attr_title": "",
+		"description": "",
+		"type": "custom",
+		"object": "custom",
+		"object_id": 94,
+		"menu_order": 1
+	},
+	{
+		"title": "Accusamus quo repellat illum magnam quas",
+		"url": "http://localhost:8889/?page_id=41",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 41,
+		"menu_order": 2
+	},
+	{
+		"title": "Debitis cum consequatur sit doloremque",
+		"url": "http://localhost:8889/?page_id=51",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 51,
+		"menu_order": 3,
+		"parent": 1
+	},
+	{
+		"title": "Est ea vero non nihil officiis in",
+		"url": "http://localhost:8889/?page_id=53",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 53,
+		"menu_order": 4
+	},
+	{
+		"title": "Fuga odio quis tempora",
+		"url": "http://localhost:8889/?page_id=56",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 56,
+		"menu_order": 5,
+		"parent": 3
+	},
+	{
+		"title": "In consectetur repellendus eveniet maiores aperiam",
+		"url": "http://localhost:8889/?page_id=15",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 15,
+		"menu_order": 6,
+		"parent": 4
+	},
+	{
+		"title": "Mollitia maiores consequatur ea dolorem blanditiis",
+		"url": "http://localhost:8889/?page_id=45",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 45,
+		"menu_order": 7,
+		"parent": 5
+	},
+	{
+		"title": "Necessitatibus nisi qui qui necessitatibus quaerat possimus",
+		"url": "http://localhost:8889/?page_id=27",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 27,
+		"menu_order": 8,
+		"parent": 6
+	},
+	{
+		"title": "Nulla omnis autem dolores eligendi",
+		"url": "http://localhost:8889/?page_id=43",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 43,
+		"menu_order": 9
+	},
+	{
+		"title": "Sample Page",
+		"url": "http://localhost:8889/?page_id=2",
+		"attr_title": "",
+		"description": "",
+		"type": "post_type",
+		"object": "page",
+		"object_id": 2,
+		"menu_order": 10
+	},
+	{
+		"title": "Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est",
+		"url": "http://localhost:8889/?cat=7",
+		"attr_title": "",
+		"description": "Ratione nemo ut aut ullam sed assumenda quis est exercitationem",
+		"type": "taxonomy",
+		"object": "category",
+		"object_id": 7,
+		"menu_order": 11
+	},
+	{
+		"title": "Et minus itaque velit tempore hic quisquam saepe quas asperiores",
+		"url": "http://localhost:8889/?cat=19",
+		"attr_title": "",
+		"description": "Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum",
+		"type": "taxonomy",
+		"object": "category",
+		"object_id": 19,
+		"menu_order": 12,
+		"parent": 10
+	},
+	{
+		"title": "Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut",
+		"url": "http://localhost:8889/?cat=6",
+		"attr_title": "",
+		"description": "Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam",
+		"type": "taxonomy",
+		"object": "category",
+		"object_id": 6,
+		"menu_order": 13,
+		"parent": 11
+	},
+	{
+		"title": "Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error",
+		"url": "http://localhost:8889/?cat=16",
+		"attr_title": "",
+		"description": "Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora",
+		"type": "taxonomy",
+		"object": "category",
+		"object_id": 16,
+		"menu_order": 14,
+		"parent": 12
+	},
+	{
+		"title": "WordPress.org",
+		"url": "https://wordpress.org",
+		"attr_title": "",
+		"description": "",
+		"type": "custom",
+		"object": "custom",
+		"object_id": 108,
+		"menu_order": 15
+	},
+	{
+		"title": "Google",
+		"url": "https://google.com",
+		"attr_title": "",
+		"description": "",
+		"type": "custom",
+		"object": "custom",
+		"object_id": 109,
+		"menu_order": 16,
+		"parent": 14
+	}
+]

--- a/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
+++ b/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
@@ -5,73 +5,80 @@
 		"menu_order": 1
 	},
 	{
-		"title": "Accusamus quo repellat illum magnam quas",
+		"title": "About",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 2
 	},
 	{
-		"title": "Debitis cum consequatur sit doloremque",
+		"title": "Our team",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 3,
 		"parent": 1
 	},
 	{
-		"title": "Est ea vero non nihil officiis in",
+		"title": "Shop",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 4
 	},
 	{
-		"title": "Fuga odio quis tempora",
+		"title": "Winter apparel",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 5,
 		"parent": 3
 	},
 	{
-		"title": "In consectetur repellendus eveniet maiores aperiam",
+		"title": "Chunky socks",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 6,
 		"parent": 4
 	},
 	{
-		"title": "Mollitia maiores consequatur ea dolorem blanditiis",
+		"title": "Hideous hats",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 7,
-		"parent": 5
+		"parent": 4
 	},
 	{
-		"title": "Necessitatibus nisi qui qui necessitatibus quaerat possimus",
+		"title": "Glorious gloves",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 8,
-		"parent": 6
+		"parent": 4
 	},
 	{
-		"title": "Nulla omnis autem dolores eligendi",
+		"title": "Jazzy Jumpers",
 		"type": "post_type",
 		"object": "page",
-		"menu_order": 9
+		"menu_order": 9,
+		"parent": 4
 	},
 	{
-		"title": "Sample Page",
+		"title": "Shipping",
 		"type": "post_type",
 		"object": "page",
 		"menu_order": 10
 	},
 	{
+		"title": "Contact Us",
+		"type": "post_type",
+		"object": "page",
+		"menu_order": 11
+	},
+	{
 		"title": "WordPress.org",
 		"url": "https://wordpress.org",
-		"menu_order": 11
+		"menu_order": 12
 	},
 	{
 		"title": "Google",
 		"url": "https://google.com",
-		"menu_order": 12,
-		"parent": 10
+		"menu_order": 13,
+		"parent": 11
 	}
 ]

--- a/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
+++ b/packages/e2e-tests/specs/experiments/fixtures/menu-items-request-fixture.json
@@ -2,170 +2,76 @@
 	{
 		"title": "Home",
 		"url": "http://localhost:8889/",
-		"attr_title": "",
-		"description": "",
-		"type": "custom",
-		"object": "custom",
-		"object_id": 94,
 		"menu_order": 1
 	},
 	{
 		"title": "Accusamus quo repellat illum magnam quas",
-		"url": "http://localhost:8889/?page_id=41",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 41,
 		"menu_order": 2
 	},
 	{
 		"title": "Debitis cum consequatur sit doloremque",
-		"url": "http://localhost:8889/?page_id=51",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 51,
 		"menu_order": 3,
 		"parent": 1
 	},
 	{
 		"title": "Est ea vero non nihil officiis in",
-		"url": "http://localhost:8889/?page_id=53",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 53,
 		"menu_order": 4
 	},
 	{
 		"title": "Fuga odio quis tempora",
-		"url": "http://localhost:8889/?page_id=56",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 56,
 		"menu_order": 5,
 		"parent": 3
 	},
 	{
 		"title": "In consectetur repellendus eveniet maiores aperiam",
-		"url": "http://localhost:8889/?page_id=15",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 15,
 		"menu_order": 6,
 		"parent": 4
 	},
 	{
 		"title": "Mollitia maiores consequatur ea dolorem blanditiis",
-		"url": "http://localhost:8889/?page_id=45",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 45,
 		"menu_order": 7,
 		"parent": 5
 	},
 	{
 		"title": "Necessitatibus nisi qui qui necessitatibus quaerat possimus",
-		"url": "http://localhost:8889/?page_id=27",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 27,
 		"menu_order": 8,
 		"parent": 6
 	},
 	{
 		"title": "Nulla omnis autem dolores eligendi",
-		"url": "http://localhost:8889/?page_id=43",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 43,
 		"menu_order": 9
 	},
 	{
 		"title": "Sample Page",
-		"url": "http://localhost:8889/?page_id=2",
-		"attr_title": "",
-		"description": "",
 		"type": "post_type",
 		"object": "page",
-		"object_id": 2,
 		"menu_order": 10
-	},
-	{
-		"title": "Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est",
-		"url": "http://localhost:8889/?cat=7",
-		"attr_title": "",
-		"description": "Ratione nemo ut aut ullam sed assumenda quis est exercitationem",
-		"type": "taxonomy",
-		"object": "category",
-		"object_id": 7,
-		"menu_order": 11
-	},
-	{
-		"title": "Et minus itaque velit tempore hic quisquam saepe quas asperiores",
-		"url": "http://localhost:8889/?cat=19",
-		"attr_title": "",
-		"description": "Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum",
-		"type": "taxonomy",
-		"object": "category",
-		"object_id": 19,
-		"menu_order": 12,
-		"parent": 10
-	},
-	{
-		"title": "Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut",
-		"url": "http://localhost:8889/?cat=6",
-		"attr_title": "",
-		"description": "Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam",
-		"type": "taxonomy",
-		"object": "category",
-		"object_id": 6,
-		"menu_order": 13,
-		"parent": 11
-	},
-	{
-		"title": "Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error",
-		"url": "http://localhost:8889/?cat=16",
-		"attr_title": "",
-		"description": "Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora",
-		"type": "taxonomy",
-		"object": "category",
-		"object_id": 16,
-		"menu_order": 14,
-		"parent": 12
 	},
 	{
 		"title": "WordPress.org",
 		"url": "https://wordpress.org",
-		"attr_title": "",
-		"description": "",
-		"type": "custom",
-		"object": "custom",
-		"object_id": 108,
-		"menu_order": 15
+		"menu_order": 11
 	},
 	{
 		"title": "Google",
 		"url": "https://google.com",
-		"attr_title": "",
-		"description": "",
-		"type": "custom",
-		"object": "custom",
-		"object_id": 109,
-		"menu_order": 16,
-		"parent": 14
+		"menu_order": 12,
+		"parent": 10
 	}
 ]

--- a/packages/e2e-tests/specs/experiments/fixtures/menu-items-response-fixture.json
+++ b/packages/e2e-tests/specs/experiments/fixtures/menu-items-response-fixture.json
@@ -16,16 +16,10 @@
 		"parent": 0,
 		"menu_order": 1,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -95,16 +89,10 @@
 		"parent": 0,
 		"menu_order": 2,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -181,16 +169,10 @@
 		"parent": 95,
 		"menu_order": 3,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -267,16 +249,10 @@
 		"parent": 0,
 		"menu_order": 4,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -353,16 +329,10 @@
 		"parent": 97,
 		"menu_order": 5,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -439,16 +409,10 @@
 		"parent": 98,
 		"menu_order": 6,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -525,16 +489,10 @@
 		"parent": 99,
 		"menu_order": 7,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -611,16 +569,10 @@
 		"parent": 100,
 		"menu_order": 8,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -697,16 +649,10 @@
 		"parent": 0,
 		"menu_order": 9,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -783,16 +729,10 @@
 		"parent": 0,
 		"menu_order": 10,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -869,16 +809,10 @@
 		"parent": 0,
 		"menu_order": 11,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -955,16 +889,10 @@
 		"parent": 104,
 		"menu_order": 12,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -1041,16 +969,10 @@
 		"parent": 105,
 		"menu_order": 13,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -1127,16 +1049,10 @@
 		"parent": 106,
 		"menu_order": 14,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -1213,16 +1129,10 @@
 		"parent": 0,
 		"menu_order": 15,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{
@@ -1292,16 +1202,10 @@
 		"parent": 108,
 		"menu_order": 16,
 		"target": "",
-		"classes": [
-			""
-		],
-		"xfn": [
-			""
-		],
+		"classes": [ "" ],
+		"xfn": [ "" ],
 		"meta": [],
-		"menus": [
-			23
-		],
+		"menus": [ 23 ],
 		"_links": {
 			"self": [
 				{

--- a/packages/e2e-tests/specs/experiments/fixtures/menu-items-response-fixture.json
+++ b/packages/e2e-tests/specs/experiments/fixtures/menu-items-response-fixture.json
@@ -16,10 +16,16 @@
 		"parent": 0,
 		"menu_order": 1,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -89,10 +95,16 @@
 		"parent": 0,
 		"menu_order": 2,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -169,10 +181,16 @@
 		"parent": 95,
 		"menu_order": 3,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -249,10 +267,16 @@
 		"parent": 0,
 		"menu_order": 4,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -329,10 +353,16 @@
 		"parent": 97,
 		"menu_order": 5,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -409,10 +439,16 @@
 		"parent": 98,
 		"menu_order": 6,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -489,10 +525,16 @@
 		"parent": 99,
 		"menu_order": 7,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -569,10 +611,16 @@
 		"parent": 100,
 		"menu_order": 8,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -649,10 +697,16 @@
 		"parent": 0,
 		"menu_order": 9,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -729,10 +783,16 @@
 		"parent": 0,
 		"menu_order": 10,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -809,10 +869,16 @@
 		"parent": 0,
 		"menu_order": 11,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -889,10 +955,16 @@
 		"parent": 104,
 		"menu_order": 12,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -969,10 +1041,16 @@
 		"parent": 105,
 		"menu_order": 13,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -1049,10 +1127,16 @@
 		"parent": 106,
 		"menu_order": 14,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -1129,10 +1213,16 @@
 		"parent": 0,
 		"menu_order": 15,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{
@@ -1202,10 +1292,16 @@
 		"parent": 108,
 		"menu_order": 16,
 		"target": "",
-		"classes": [ "" ],
-		"xfn": [ "" ],
+		"classes": [
+			""
+		],
+		"xfn": [
+			""
+		],
 		"meta": [],
-		"menus": [ 23 ],
+		"menus": [
+			23
+		],
 		"_links": {
 			"self": [
 				{

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -129,7 +129,6 @@ async function getSerializedBlocks() {
 		wp.data.select( 'core/block-editor' ).getBlocks()
 	);
 	const safeBlocks = replaceUnstableBlockAttributes( blocks );
-	// return serialize( safeBlocks );
 	return page.evaluate(
 		( blocksToSerialize ) => wp.blocks.serialize( blocksToSerialize ),
 		safeBlocks

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -424,7 +424,8 @@ describe( 'Navigation editor', () => {
 			expect( headerSubtitleText ).toBe( newName );
 		} );
 
-		it( 'does not save a menu name upon clicking save button when name is empty', async () => {
+		// Flaky test, see https://github.com/WordPress/gutenberg/pull/34869#issuecomment-922711557.
+		it.skip( 'does not save a menu name upon clicking save button when name is empty', async () => {
 			await createMenu( { name: initialMenuName } );
 			await visitNavigationEditor();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -148,12 +148,17 @@ async function getSerializedBlocks() {
  */
 function replaceUnstableBlockAttributes( blocks ) {
 	return blocks?.map( ( block ) => {
+		const id = block.attributes.id ? typeof block.attributes.id : undefined;
+		const url = block.attributes.url
+			? typeof block.attributes.url
+			: undefined;
+
 		return {
 			...block,
 			attributes: {
 				...block.attributes,
-				id: typeof block.attributes.id,
-				url: typeof block.attributes.url,
+				id,
+				url,
 			},
 			innerBlocks: replaceUnstableBlockAttributes( block.innerBlocks ),
 		};

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -434,7 +434,8 @@ describe( 'Navigation editor', () => {
 			await pressKeyTimes( 'Backspace', initialMenuName.length );
 			await page.click( '.edit-navigation-toolbar__save-button' );
 			const snackbar = await page.waitForSelector(
-				'.components-snackbar'
+				'.components-snackbar',
+				{ visible: true }
 			);
 			const snackbarText = await snackbar.evaluate(
 				( element ) => element.innerText

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -11,6 +11,7 @@ import {
 	createJSONResponse,
 	createMenu,
 	deleteAllMenus,
+	deleteAllObjects,
 	pressKeyTimes,
 	pressKeyWithModifier,
 	setUpResponseMocking,
@@ -129,10 +130,12 @@ describe( 'Navigation editor', () => {
 
 	beforeAll( async () => {
 		await deleteAllMenus();
+		await deleteAllObjects();
 	} );
 
 	afterEach( async () => {
 		await deleteAllMenus();
+		await deleteAllObjects();
 		await setUpResponseMocking( [] );
 	} );
 
@@ -188,7 +191,6 @@ describe( 'Navigation editor', () => {
 	it( 'allows creation of a menu when there are existing menu items', async () => {
 		await createMenu( { name: 'Test Menu 1' }, menuItemsFixture );
 		await createMenu( { name: 'Test Menu 2' }, menuItemsFixture );
-		await createMenu( { name: 'Test Menu 3' }, menuItemsFixture );
 		await visitNavigationEditor();
 
 		// Wait for the header to show the menu name.
@@ -221,7 +223,6 @@ describe( 'Navigation editor', () => {
 	it( 'displays the first created menu when at least one menu exists', async () => {
 		await createMenu( { name: 'Test Menu 1' }, menuItemsFixture );
 		await createMenu( { name: 'Test Menu 2' }, menuItemsFixture );
-		await createMenu( { name: 'Test Menu 3' }, menuItemsFixture );
 
 		await visitNavigationEditor();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -11,11 +11,11 @@ import {
 	createJSONResponse,
 	createMenu,
 	deleteAllMenus,
-	deleteAllObjects,
 	pressKeyTimes,
 	pressKeyWithModifier,
 	setUpResponseMocking,
 	visitAdminPage,
+	__experimentalRest as rest,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -160,17 +160,30 @@ function replaceUnstableBlockAttributes( blocks ) {
 	} );
 }
 
+async function deleteAllLinkedResources() {
+	[ '/wp/v2/posts', '/wp/v2/pages' ].forEach( async ( path ) => {
+		const items = await rest( { path } );
+
+		for ( const item of items ) {
+			await rest( {
+				method: 'DELETE',
+				path: `${ path }/${ item.id }?force=true`,
+			} );
+		}
+	} );
+}
+
 describe( 'Navigation editor', () => {
 	useExperimentalFeatures( [ '#gutenberg-navigation' ] );
 
 	beforeAll( async () => {
 		await deleteAllMenus();
-		await deleteAllObjects();
+		await deleteAllLinkedResources();
 	} );
 
 	afterEach( async () => {
 		await deleteAllMenus();
-		await deleteAllObjects();
+		await deleteAllLinkedResources();
 		await setUpResponseMocking( [] );
 	} );
 


### PR DESCRIPTION
## Description
Fixes #34765 (near enough)

This was a lot more difficult than I anticipated. The tough thing with menu items is that they usually link to other resources (pages, posts, categories), and those need to be created before the menu items so that we have valid ids and urls for the menu items. Otherwise the menu items are considered invalid.

Menu items also require two batch requests, once to create the items initially, and then once we have the ids a second request to set the correct `parent`s using those ids.

The last thing is that now we're using the REST API, the ids and urls of items are unstable, they change between test runs, so can no longer be used in snapshots. I wrote a function to go through block attributes and ensure the value of those attributes is not stored in the snapshot (the type of the value is used instead).

What I haven't done (in the interested of not making this PR huge):
- Categories are unique, so cannot be created or deleted very easily on the fly. The REST API calls will be more complicated. I need to work on a follow-up to handle taxonomies generally. I've dropped the category menu items from the fixture data for now.
- Search and pages mocks are still used in a few places. Pages should be fairly easy to sort out in a follow-up, but search again requires the creation of taxonomy data.