### PR TITLE
Update the Global Styles Icon and use in the site editor's panel

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -3,7 +3,7 @@
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { cog, typography } from '@wordpress/icons';
+import { cog, globalStyles } from '@wordpress/icons';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -80,7 +80,7 @@ export function SidebarComplementaryAreaFills() {
 				identifier="edit-site/global-styles"
 				title={ __( 'Global Styles' ) }
 				closeLabel={ __( 'Close global styles sidebar' ) }
-				icon={ typography }
+				icon={ globalStyles }
 			/>
 		</>
 	);

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -81,6 +81,7 @@ export { default as formatUnderline } from './library/format-underline';
 export { default as formatUppercase } from './library/format-uppercase';
 export { default as fullscreen } from './library/fullscreen';
 export { default as gallery } from './library/gallery';
+export { default as globalStyles } from './library/global-styles';
 export { default as globe } from './library/globe';
 export { default as grid } from './library/grid';
 export { default as group } from './library/group';

--- a/packages/icons/src/library/global-styles.js
+++ b/packages/icons/src/library/global-styles.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+export const globalStyles = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z" />
+	</SVG>
+);
+
+export default globalStyles;


### PR DESCRIPTION
closes #20873 

Here's how it looks like

<img width="307" alt="Screen Shot 2021-09-16 at 11 36 12 AM" src="https://user-images.githubusercontent.com/272444/133597704-0439daaa-fa49-4b45-ba8e-2f27187c32b1.png">
<img width="292" alt="Screen Shot 2021-09-16 at 11 36 23 AM" src="https://user-images.githubusercontent.com/272444/133597709-f86a21a4-24f3-49cb-8464-9607e470304d.png">
