### PR TITLE
[RNMobile] Show always the symbol icon in the block picker for reusable blocks

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1586,7 +1586,10 @@ export const getInserterItems = createSelector(
 				name: 'core/block',
 				initialAttributes: { ref: reusableBlock.id },
 				title: reusableBlock.title.raw,
-				icon: referencedBlockType ? referencedBlockType.icon : symbol,
+				icon:
+					referencedBlockType && Platform.OS === 'web'
+						? referencedBlockType.icon
+						: symbol,
 				category: 'reusable',
 				keywords: [],
 				isDisabled: false,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### Context
When getting the inserter items for the block picker, new inserter items are built for each reusable block, this includes generating the different properties like the name or the icon. Specifically for the icon, in case the reusable block only contains a single block, instead of using the `symbol` icon the icon of that block is used.

https://github.com/WordPress/gutenberg/blob/e6700102c2ae497a0c537a1f7ae6d2023794421a/packages/block-editor/src/store/selectors.js#L1567-L1599

### Solution

When a reusable block is created from a non-supported block, the icon used for generating the inserter item could be in a format that is not supported in the native version, leading to an exception. For this reason, this logic will be limited to the web version.

Additionally, it was recently mentioned in [this issue](https://github.com/WordPress/gutenberg/issues/34794) that using a different icon in reusable blocks could be confusing to users so this PR will also address it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the web version of the editor.
1. Open a post/page.
1. Add a block that is not supported by the native version of the editor like the Tiled Gallery block.
1. Select the block and click on the options button located in the toolbar (the three dots icon).
1. Click on "Add to Reusable blocks" and set a name for the block.
1. Open the app (native version of the editor).
1. Open a post/page.
1. Tap on the ➕ button.
1. Observe that no error is shown and that the recently created reusable block shows the `symbol` icon.

## Screenshots <!-- if applicable -->

<img src=https://user-images.githubusercontent.com/14905380/133600225-8ee1e1a4-940d-4fa2-9e24-bce3bd5a7544.png width=350>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
