### PR TITLE
Navigation Editor: Fix failing e2e test

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { find } from 'puppeteer-testing-library';
+import { find, findAll } from 'puppeteer-testing-library';
 
 /**
  * WordPress dependencies
@@ -773,12 +773,12 @@ describe( 'Navigation editor', () => {
 				focused: true,
 			} ).toBeFound();
 
-			const itemToSelectTitle = searchFixture[ 0 ].title;
+			const [ itemToSelect ] = searchFixture;
 
 			// Add Custom Link item.
-			const firstSearchSuggestion = await find( {
+			const [ firstSearchSuggestion ] = await findAll( {
 				role: 'option',
-				name: `${ itemToSelectTitle } ${ searchFixture[ 0 ].subtype }`,
+				name: `${ itemToSelect.title } ${ itemToSelect.subtype }`,
 			} );
 
 			await firstSearchSuggestion.click();
@@ -801,7 +801,7 @@ describe( 'Navigation editor', () => {
 			} );
 
 			// Check the last item is the one we just inserted
-			expect( lastItemAttributes.label ).toEqual( itemToSelectTitle );
+			expect( lastItemAttributes.label ).toEqual( itemToSelect.title );
 			expect( lastItemAttributes.isTopLevelLink ).toBeTruthy();
 		} );
 	} );


### PR DESCRIPTION
## Description
Search suggestions can contain items with the same name and type since WP doesn't require posts/pages to have a unique name.

## How has this been tested?
E2E Tests are passing locally:

```
npm run test-e2e -- packages/e2e-tests/specs/experiments/navigation-editor.test.js
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
