### PR TITLE
Plugin: Ensure that all `*.asset.php` files are included in `plugin.zip`

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -113,8 +113,7 @@ build_files=$(
 	ls build/*/*.{js,css,asset.php} \
 	build/block-library/blocks/*.php \
 	build/block-library/blocks/*/block.json \
-	build/block-library/blocks/*/*.css \
-	build/block-library/blocks/*/*.js \
+	build/block-library/blocks/*/*.{js,css,asset.php} \
 	build/edit-widgets/blocks/*/block.json \
 	build/widgets/blocks/*.php \
 	build/widgets/blocks/*/block.json \


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes a bug reported by @aaroncampbell in https://github.com/WordPress/gutenberg/pull/33082#issuecomment-920348835:

> I'm still seeing this on WP 5.9-alpha-51272-src with Gutenberg 11.4.1. It looks like it's looking for a `gutenberg/build/block-library/blocks/file/view.min.asset.php` but [no `*.asset.php` file exists there](https://plugins.trac.wordpress.org/browser/gutenberg/trunk/build/block-library/blocks/file)? Same with with [navigation block](https://plugins.trac.wordpress.org/browser/gutenberg/trunk/build/block-library/blocks/navigation) and probably others although those are the two triggering notices on the plugins page when I click activate.
> 
> [Core appends the `asset.php`](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/blocks.php?rev=51674#L88), and the [core blocks seem to have files named accordingly](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/blocks/file).


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I executed the command that generates the `gutenberg.zip` file:

```bash
./bin/build-plugin-zip.sh
```

I checked if the asset files get included:

<img width="723" alt="Screen Shot 2021-09-16 at 14 22 45" src="https://user-images.githubusercontent.com/699132/133612254-755aa40f-71ab-499f-9d45-02ebf6cd0113.png">

The same File block looks like this in the `build` folder: 
<img width="297" alt="Screen Shot 2021-09-16 at 13 57 36" src="https://user-images.githubusercontent.com/699132/133612252-67ef821e-9549-4faf-8eeb-689d42d1d4ba.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
