### PR TITLE
[Block Library - QueryPagination]:  Use `flex` layout

### DIFF
--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -23,6 +23,13 @@
 		"color": {
 			"gradients": true,
 			"link": true
+		},
+		"__experimentalLayout": {
+			"allowSwitching": false,
+			"allowInheriting": false,
+			"default": {
+				"type": "flex"
+			}
 		}
 	},
 	"editorStyle": "wp-block-query-pagination-editor",

--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -1,11 +1,5 @@
 $pagination-margin: 0.5em;
 
-.wp-block > .wp-block-query-pagination {
-	display: flex;
-	flex-wrap: wrap;
-	flex-direction: row;
-}
-
 // Center flex items. This has an equivalent in style.scss.
 .wp-block[data-align="center"] > .wp-block-query-pagination {
 	justify-content: center;

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -1,9 +1,5 @@
 $pagination-margin: 0.5em;
 .wp-block-query-pagination {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-
 	// Increased specificity to override blocks default margin.
 	> .wp-block-query-pagination-next,
 	> .wp-block-query-pagination-previous,


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/32680

This PR add `flex` layout support to `QueryPagination` block.

## Testing instructions
1. Previous `Query Pagination` blocks (with or without alignments set) should work as before
2. Insert a new `Query Pagination` and test the `justification` controls
3. Test the justification controls to existent `Query Pagination` blocks.

### Notes
`Query Pagination` block can only be inserted inside of a `Query Loop` block.