### PR TITLE
Navigation Screen: Display error notice inside modal

### DIFF
--- a/packages/edit-navigation/src/components/add-menu/index.js
+++ b/packages/edit-navigation/src/components/add-menu/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { TextControl, Button } from '@wordpress/components';
+import { Button, TextControl, withNotices } from '@wordpress/components';
 import { useFocusOnMount } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -18,22 +18,23 @@ import { store as coreStore } from '@wordpress/core-data';
 const menuNameMatches = ( menuName ) => ( menu ) =>
 	menu.name.toLowerCase() === menuName.toLowerCase();
 
-export default function AddMenu( {
+function AddMenu( {
 	className,
 	menus,
 	onCreate,
 	titleText,
 	helpText,
 	focusInputOnMount = false,
+	noticeUI,
+	noticeOperations,
 } ) {
+	const inputRef = useFocusOnMount( focusInputOnMount );
 	const [ menuName, setMenuName ] = useState( '' );
-	const { createErrorNotice, createInfoNotice, removeNotice } = useDispatch(
-		noticesStore
-	);
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
+	const { createInfoNotice } = useDispatch( noticesStore );
 	const { saveMenu } = useDispatch( coreStore );
 
-	const inputRef = useFocusOnMount( focusInputOnMount );
+	const { createErrorNotice, removeAllNotices } = noticeOperations;
 
 	const createMenu = async ( event ) => {
 		event.preventDefault();
@@ -42,8 +43,8 @@ export default function AddMenu( {
 			return;
 		}
 
-		// Remove any existing notices so duplicates aren't created.
-		removeNotice( 'edit-navigation-error' );
+		// Remove any existing notices.
+		removeAllNotices();
 
 		if ( some( menus, menuNameMatches( menuName ) ) ) {
 			const message = sprintf(
@@ -53,7 +54,7 @@ export default function AddMenu( {
 				),
 				menuName
 			);
-			createErrorNotice( message, { id: 'edit-navigation-error' } );
+			createErrorNotice( message );
 			return;
 		}
 
@@ -79,6 +80,7 @@ export default function AddMenu( {
 			className={ classnames( 'edit-navigation-add-menu', className ) }
 			onSubmit={ createMenu }
 		>
+			{ noticeUI }
 			{ titleText && (
 				<h3 className="edit-navigation-add-menu__title">
 					{ titleText }
@@ -104,3 +106,5 @@ export default function AddMenu( {
 		</form>
 	);
 }
+
+export default withNotices( AddMenu );

--- a/packages/edit-navigation/src/components/add-menu/style.scss
+++ b/packages/edit-navigation/src/components/add-menu/style.scss
@@ -1,6 +1,25 @@
 .edit-navigation-add-menu {
 	display: flex;
 	flex-direction: column;
+
+	// Notices.
+	.components-with-notices-ui {
+		margin-bottom: $grid-unit-20;
+
+		// Notice is too big with default styles.
+		.components-notice {
+			margin: 0;
+			padding: $grid-unit-10 $grid-unit-15;
+		}
+
+		.components-notice__content {
+			margin: 0;
+		}
+
+		.components-notice__dismiss {
+			align-self: center;
+		}
+	}
 }
 
 .edit-navigation-add-menu__title {

--- a/packages/edit-navigation/src/components/header/new-button.js
+++ b/packages/edit-navigation/src/components/header/new-button.js
@@ -23,6 +23,7 @@ export default function NewButton( { menus } ) {
 			{ isModalOpen && (
 				<Modal
 					title={ __( 'Create a new menu' ) }
+					className="edit-navigation-menu-switcher__modal"
 					onRequestClose={ () => setIsModalOpen( false ) }
 				>
 					<AddMenu

--- a/packages/edit-navigation/src/components/menu-switcher/index.js
+++ b/packages/edit-navigation/src/components/menu-switcher/index.js
@@ -57,10 +57,10 @@ export default function MenuSwitcher( {
 				{ isModalVisible && (
 					<Modal
 						title={ __( 'Create a new menu' ) }
+						className="edit-navigation-menu-switcher__modal"
 						onRequestClose={ closeModal }
 					>
 						<AddMenu
-							className="edit-navigation-menu-switcher__add-menu"
 							menus={ menus }
 							onCreate={ ( menuId ) => {
 								closeModal();

--- a/packages/edit-navigation/src/components/menu-switcher/style.scss
+++ b/packages/edit-navigation/src/components/menu-switcher/style.scss
@@ -1,3 +1,3 @@
-.edit-navigation-header__add-menu {
-	min-width: 220px;
+.edit-navigation-menu-switcher__modal {
+	max-width: 400px;
 }


### PR DESCRIPTION
## Description
The default notices appear under the modal screen overlay. PR updates the `AddMenu` component to use local notices and display them inside the form.

The success still displays the Snackbar message.

Fixes #31100.

## How has this been tested?
1. Go to the experimental Navigation screen.
2. Try to create a new menu with the name that already exists.
3. The form should display an error notice inside the modal.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-16 at 18 20 49](https://user-images.githubusercontent.com/240569/133631982-d516d643-10da-43d5-8ae6-bf3e33c9cb9c.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
