### PR TITLE
Update the global styles sidebar to use a navigation component

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -89,6 +89,7 @@ export const PanelColorGradientSettingsInner = ( {
 	children,
 	settings,
 	title,
+	showTitle,
 	...props
 } ) => {
 	if (
@@ -126,7 +127,7 @@ export const PanelColorGradientSettingsInner = ( {
 				'block-editor-panel-color-gradient-settings',
 				className
 			) }
-			title={ titleElement }
+			title={ showTitle && titleElement }
 			{ ...props }
 		>
 			{ settings.map( ( setting, index ) => (

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -89,7 +89,7 @@ export const PanelColorGradientSettingsInner = ( {
 	children,
 	settings,
 	title,
-	showTitle,
+	showTitle = true,
 	...props
 } ) => {
 	if (
@@ -121,13 +121,14 @@ export const PanelColorGradientSettingsInner = ( {
 			/>
 		</span>
 	);
+
 	return (
 		<PanelBody
 			className={ classnames(
 				'block-editor-panel-color-gradient-settings',
 				className
 			) }
-			title={ showTitle && titleElement }
+			title={ showTitle ? titleElement : undefined }
 			{ ...props }
 		>
 			{ settings.map( ( setting, index ) => (

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 
 /**
@@ -55,9 +54,9 @@ export default function ColorPanel( {
 	return (
 		<InspectorControls>
 			<PanelColorGradientSettings
-				title={ __( 'Color' ) }
 				initialOpen={ false }
 				settings={ settings }
+				showTitle={ false }
 			>
 				{ enableContrastChecking && (
 					<ContrastChecker

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ export default function ColorPanel( {
 	settings,
 	clientId,
 	enableContrastChecking = true,
+	showTitle = true,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -54,9 +56,10 @@ export default function ColorPanel( {
 	return (
 		<InspectorControls>
 			<PanelColorGradientSettings
+				title={ __( 'Color' ) }
 				initialOpen={ false }
 				settings={ settings }
-				showTitle={ false }
+				showTitle={ showTitle }
 			>
 				{ enableContrastChecking && (
 					<ContrastChecker

--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -74,13 +74,15 @@ export default function NavigationMenu( props ) {
 					/>
 				) }
 
-				<NavigationMenuTitle
-					hasSearch={ hasSearch }
-					onSearch={ onSearch }
-					search={ search }
-					title={ title }
-					titleAction={ titleAction }
-				/>
+				{ title && (
+					<NavigationMenuTitle
+						hasSearch={ hasSearch }
+						onSearch={ onSearch }
+						search={ search }
+						title={ title }
+						titleAction={ titleAction }
+					/>
+				) }
 
 				<NavigableMenu>
 					<ul aria-labelledby={ menuTitleId }>

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -161,9 +161,9 @@ export const ItemBaseUI = styled.li`
 	opacity: 0.85;
 	margin-bottom: 0;
 
-	button,
-	a.components-button,
-	a {
+	> button,
+	> a.components-button,
+	> a {
 		width: 100%;
 		color: inherit;
 		opacity: 0.85;
@@ -182,13 +182,13 @@ export const ItemBaseUI = styled.li`
 		background-color: ${ UI.theme };
 		color: ${ UI.textDark };
 
-		button,
-		a {
+		> button,
+		> a {
 			color: ${ UI.textDark };
 		}
 	}
 
-	svg path {
+	> svg path {
 		color: ${ G2.lightGray.ui };
 	}
 `;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -19,9 +19,7 @@ import { space } from '../../ui/utils/space';
 
 export const NavigationUI = styled.div`
 	width: 100%;
-	background-color: ${ G2.darkGray.primary };
 	box-sizing: border-box;
-	color: #f0f0f0;
 	padding: 0 ${ space( 4 ) };
 	overflow: hidden;
 `;
@@ -47,16 +45,19 @@ export const MenuUI = styled.div`
 
 export const MenuBackButtonUI = styled( Button )`
 	&.is-tertiary {
-		color: ${ G2.lightGray.ui };
+		color: inherit;
+		opacity: 0.85;
 
 		&:hover:not( :disabled ) {
-			color: #ddd;
+			opacity: 1;
 			box-shadow: none;
+			color: inherit;
 		}
 
 		&:active:not( :disabled ) {
 			background: transparent;
-			color: #ddd;
+			opacity: 1;
+			color: inherit;
 		}
 	}
 `;
@@ -68,7 +69,7 @@ export const MenuTitleUI = styled.div`
 
 export const MenuTitleHeadingUI = styled( Text )`
 	align-items: center;
-	color: ${ G2.gray[ 100 ] };
+	color: inherit;
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: ${ space( 2 ) };
@@ -84,17 +85,20 @@ export const MenuTitleActionsUI = styled.span`
 	height: ${ space( 6 ) }; // 24px, same height as the buttons inside
 
 	.components-button.is-small {
-		color: ${ G2.lightGray.ui };
+		color: inherit;
+		opacity: 0.85;
 		margin-right: ${ space( 1 ) }; // Avoid hiding the focus outline
 		padding: 0;
 
 		&:active:not( :disabled ) {
 			background: none;
-			color: ${ G2.gray[ 200 ] };
+			opacity: 1;
+			color: inherit;
 		}
 		&:hover:not( :disabled ) {
 			box-shadow: none;
-			color: ${ G2.gray[ 200 ] };
+			opacity: 1;
+			color: inherit;
 		}
 	}
 `;
@@ -142,32 +146,35 @@ export const MenuTitleSearchUI = styled.div`
 `;
 
 export const GroupTitleUI = styled( Text )`
+	color: inherit;
 	margin-top: ${ space( 2 ) };
 	padding: ${ () =>
 		isRTL()
 			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } 0`
 			: `${ space( 1 ) } 0 ${ space( 1 ) } ${ space( 4 ) }` };
 	text-transform: uppercase;
-	color: ${ G2.gray[ 100 ] };
 `;
 
 export const ItemBaseUI = styled.li`
 	border-radius: 2px;
-	color: ${ G2.lightGray.ui };
+	color: inherit;
+	opacity: 0.85;
 	margin-bottom: 0;
 
 	button,
 	a.components-button,
 	a {
 		width: 100%;
-		color: ${ G2.lightGray.ui };
+		color: inherit;
+		opacity: 0.85;
 		padding: ${ space( 2 ) } ${ space( 4 ) }; /* 8px 16px */
 		${ rtl( { textAlign: 'left' }, { textAlign: 'right' } ) }
 
 		&:hover,
 		&:focus:not( [aria-disabled='true'] ):active,
 		&:active:not( [aria-disabled='true'] ):active {
-			color: #ddd;
+			color: inherit;
+			opacity: 1;
 		}
 	}
 
@@ -196,7 +203,8 @@ export const ItemUI = styled.div`
 	font-weight: 400;
 	line-height: 20px;
 	width: 100%;
-	color: ${ G2.lightGray.ui };
+	color: inherit;
+	opacity: 0.9;
 `;
 
 export const ItemBadgeUI = styled.span`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -11,7 +11,7 @@ import { isRTL } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { G2, UI } from '../../utils/colors-values';
+import { BASE, G2, UI } from '../../utils/colors-values';
 import Button from '../../button';
 import { Text } from '../../text';
 import { reduceMotion, rtl } from '../../utils';
@@ -46,7 +46,7 @@ export const MenuUI = styled.div`
 export const MenuBackButtonUI = styled( Button )`
 	&.is-tertiary {
 		color: inherit;
-		opacity: 0.85;
+		opacity: 0.7;
 
 		&:hover:not( :disabled ) {
 			opacity: 1;
@@ -86,7 +86,7 @@ export const MenuTitleActionsUI = styled.span`
 
 	.components-button.is-small {
 		color: inherit;
-		opacity: 0.85;
+		opacity: 0.7;
 		margin-right: ${ space( 1 ) }; // Avoid hiding the focus outline
 		padding: 0;
 
@@ -158,7 +158,6 @@ export const GroupTitleUI = styled( Text )`
 export const ItemBaseUI = styled.li`
 	border-radius: 2px;
 	color: inherit;
-	opacity: 0.85;
 	margin-bottom: 0;
 
 	> button,
@@ -166,7 +165,7 @@ export const ItemBaseUI = styled.li`
 	> a {
 		width: 100%;
 		color: inherit;
-		opacity: 0.85;
+		opacity: 0.7;
 		padding: ${ space( 2 ) } ${ space( 4 ) }; /* 8px 16px */
 		${ rtl( { textAlign: 'left' }, { textAlign: 'right' } ) }
 
@@ -180,11 +179,12 @@ export const ItemBaseUI = styled.li`
 
 	&.is-active {
 		background-color: ${ UI.theme };
-		color: ${ UI.textDark };
+		color: ${ BASE.white };
 
 		> button,
 		> a {
-			color: ${ UI.textDark };
+			color: ${ BASE.white };
+			opacity: 1;
 		}
 	}
 
@@ -204,7 +204,7 @@ export const ItemUI = styled.div`
 	line-height: 20px;
 	width: 100%;
 	color: inherit;
-	opacity: 0.9;
+	opacity: 0.7;
 `;
 
 export const ItemBadgeUI = styled.span`

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -26,10 +26,10 @@ $vertical-tabs-width: 160px;
 	}
 
 	.components-navigation {
-		background-color: $white;
 		padding: 0;
 		max-height: 100%;
 		overflow-y: auto;
+		color: $black;
 
 		> * {
 			// Matches spacing cleared from the modal content element.
@@ -38,42 +38,26 @@ $vertical-tabs-width: 160px;
 
 		.components-navigation__menu {
 			margin: 0;
-			color: $gray-900;
 
 			.components-navigation__item {
-				color: $gray-900; // The inheritance of some items is quite strong, so we have to duplicate this one.
-
 				& > button {
-					color: inherit;
 					padding: 3px $grid-unit-20;
 					height: $grid-unit-60;
 					// Aligns button text instead of button box.
 					margin: 0 #{-$grid-unit-20};
 					width: calc(#{$grid-unit-40} + 100%);
 					&:focus {
-						background: $gray-100;
 						font-weight: 500;
 					}
-					&:hover {
-						color: var(--wp-admin-theme-color);
-					}
-				}
-				.components-toggle-control__label {
-					color: inherit;
 				}
 			}
 			.components-navigation__menu-title-heading {
-				color: inherit;
 				border-bottom: 1px solid $gray-300;
 				padding-left: 0;
 				padding-right: 0;
 			}
 			.components-navigation__back-button {
-				color: inherit;
 				padding-left: 0;
-				&:hover {
-					color: var(--wp-admin-theme-color);
-				}
 			}
 			.edit-post-preferences-modal__custom-fields-confirmation-button {
 				width: auto;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -4,6 +4,7 @@
 	width: 0;
 	overflow: hidden;
 	background: $gray-900;
+	color: $white;
 	transition: width 100ms linear;
 	@include reduce-motion("transition");
 

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -123,6 +123,7 @@ export default function ColorPanel( {
 			gradients={ gradients }
 			disableCustomColors={ ! areCustomSolidsEnabled }
 			disableCustomGradients={ ! areCustomGradientsEnabled }
+			showTitle={ false }
 		>
 			<ColorPalettePanel
 				key={ 'color-palette-panel-' + name }

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -1,15 +1,20 @@
 /**
  * External dependencies
  */
-import { map, sortBy } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Button, PanelBody, TabPanel } from '@wordpress/components';
+import {
+	Button,
+	__experimentalNavigation as Navigation,
+	__experimentalNavigationItem as NavigationItem,
+	__experimentalNavigationMenu as NavigationMenu,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
-import { useMemo } from '@wordpress/element';
+import { styles } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,67 +35,6 @@ import {
 	useHasDimensionsPanel,
 } from './dimensions-panel';
 
-function GlobalStylesPanel( {
-	wrapperPanelTitle,
-	context,
-	getStyle,
-	setStyle,
-	getSetting,
-	setSetting,
-} ) {
-	const hasBorderPanel = useHasBorderPanel( context );
-	const hasColorPanel = useHasColorPanel( context );
-	const hasTypographyPanel = useHasTypographyPanel( context );
-	const hasDimensionsPanel = useHasDimensionsPanel( context );
-
-	if ( ! hasColorPanel && ! hasTypographyPanel && ! hasDimensionsPanel ) {
-		return null;
-	}
-
-	const content = (
-		<>
-			{ hasTypographyPanel && (
-				<TypographyPanel
-					context={ context }
-					getStyle={ getStyle }
-					setStyle={ setStyle }
-				/>
-			) }
-			{ hasColorPanel && (
-				<ColorPanel
-					context={ context }
-					getStyle={ getStyle }
-					setStyle={ setStyle }
-					getSetting={ getSetting }
-					setSetting={ setSetting }
-				/>
-			) }
-			{ hasDimensionsPanel && (
-				<DimensionsPanel
-					context={ context }
-					getStyle={ getStyle }
-					setStyle={ setStyle }
-				/>
-			) }
-			{ hasBorderPanel && (
-				<BorderPanel
-					context={ context }
-					getStyle={ getStyle }
-					setStyle={ setStyle }
-				/>
-			) }
-		</>
-	);
-	if ( ! wrapperPanelTitle ) {
-		return content;
-	}
-	return (
-		<PanelBody title={ wrapperPanelTitle } initialOpen={ false }>
-			{ content }
-		</PanelBody>
-	);
-}
-
 function getPanelTitle( blockName ) {
 	const blockType = getBlockType( blockName );
 
@@ -103,49 +47,104 @@ function getPanelTitle( blockName ) {
 	return blockType.title;
 }
 
-function GlobalStylesBlockPanels( {
-	blocks,
+function GlobalStylesLevel( {
+	context,
 	getStyle,
 	setStyle,
 	getSetting,
 	setSetting,
+	parentMenu = 'root',
 } ) {
-	const panels = useMemo(
-		() =>
-			sortBy(
-				map( blocks, ( block, name ) => {
-					return {
-						block,
-						name,
-						wrapperPanelTitle: getPanelTitle( name ),
-					};
-				} ),
-				( { wrapperPanelTitle } ) => wrapperPanelTitle
-			),
-		[ blocks ]
-	);
+	const hasTypographyPanel = useHasTypographyPanel( context );
+	const hasColorPanel = useHasColorPanel( context );
+	const hasBorderPanel = useHasBorderPanel( context );
+	const hasDimensionsPanel = useHasDimensionsPanel( context );
+	const hasLayoutPanel = hasBorderPanel || hasDimensionsPanel;
 
-	return map( panels, ( { block, name, wrapperPanelTitle } ) => {
-		return (
-			<GlobalStylesPanel
-				key={ 'panel-' + name }
-				wrapperPanelTitle={ wrapperPanelTitle }
-				context={ block }
-				getStyle={ getStyle }
-				setStyle={ setStyle }
-				getSetting={ getSetting }
-				setSetting={ setSetting }
-			/>
-		);
-	} );
+	return (
+		<>
+			{ hasTypographyPanel && (
+				<NavigationItem
+					item="item-typography"
+					navigateToMenu={ parentMenu + '.typography' }
+					title={ __( 'Typography' ) }
+				/>
+			) }
+			{ hasColorPanel && (
+				<NavigationItem
+					item="item-color"
+					navigateToMenu={ parentMenu + '.color' }
+					title={ __( 'Colors' ) }
+				/>
+			) }
+			{ hasLayoutPanel && (
+				<NavigationItem
+					item="item-layout"
+					navigateToMenu={ parentMenu + '.layout' }
+					title={ __( 'Layout' ) }
+				/>
+			) }
+
+			{ hasTypographyPanel && (
+				<NavigationMenu
+					menu={ parentMenu + '.typography' }
+					parentMenu={ parentMenu }
+				>
+					<NavigationItem>
+						<TypographyPanel
+							context={ context }
+							getStyle={ getStyle }
+							setStyle={ setStyle }
+						/>
+					</NavigationItem>
+				</NavigationMenu>
+			) }
+
+			{ hasColorPanel && (
+				<NavigationMenu
+					menu={ parentMenu + '.color' }
+					parentMenu={ parentMenu }
+				>
+					<NavigationItem>
+						<ColorPanel
+							context={ context }
+							getStyle={ getStyle }
+							setStyle={ setStyle }
+							getSetting={ getSetting }
+							setSetting={ setSetting }
+						/>
+					</NavigationItem>
+				</NavigationMenu>
+			) }
+
+			{ hasLayoutPanel && (
+				<NavigationMenu
+					menu={ parentMenu + '.layout' }
+					parentMenu={ parentMenu }
+				>
+					<NavigationItem>
+						{ hasDimensionsPanel && (
+							<DimensionsPanel
+								context={ context }
+								getStyle={ getStyle }
+								setStyle={ setStyle }
+							/>
+						) }
+						{ hasBorderPanel && (
+							<BorderPanel
+								context={ context }
+								getStyle={ getStyle }
+								setStyle={ setStyle }
+							/>
+						) }
+					</NavigationItem>
+				</NavigationMenu>
+			) }
+		</>
+	);
 }
 
-export default function GlobalStylesSidebar( {
-	identifier,
-	title,
-	icon,
-	closeLabel,
-} ) {
+export default function GlobalStylesSidebar() {
 	const {
 		root,
 		blocks,
@@ -154,23 +153,19 @@ export default function GlobalStylesSidebar( {
 		getSetting,
 		setSetting,
 	} = useGlobalStylesContext();
-	const [ canRestart, onReset ] = useGlobalStylesReset();
 
-	if ( typeof blocks !== 'object' || ! root ) {
-		// No sidebar is shown.
-		return null;
-	}
+	const [ canRestart, onReset ] = useGlobalStylesReset();
 
 	return (
 		<DefaultSidebar
 			className="edit-site-global-styles-sidebar"
-			identifier={ identifier }
-			title={ title }
-			icon={ icon }
-			closeLabel={ closeLabel }
+			identifier="edit-site/global-styles"
+			title={ __( 'Styles' ) }
+			icon={ styles }
+			closeLabel={ __( 'Close global styles sidebar' ) }
 			header={
 				<>
-					<strong>{ title }</strong>
+					<strong>{ __( 'Styles' ) }</strong>
 					<Button
 						className="edit-site-global-styles-sidebar__reset-button"
 						isSmall
@@ -183,37 +178,48 @@ export default function GlobalStylesSidebar( {
 				</>
 			}
 		>
-			<TabPanel
-				tabs={ [
-					{ name: 'root', title: __( 'Root' ) },
-					{ name: 'block', title: __( 'By Block Type' ) },
-				] }
-			>
-				{ ( tab ) => {
-					/* Per Block Context */
-					if ( 'block' === tab.name ) {
-						return (
-							<GlobalStylesBlockPanels
-								blocks={ blocks }
-								getStyle={ getStyle }
-								setStyle={ setStyle }
-								getSetting={ getSetting }
-								setSetting={ setSetting }
-							/>
-						);
-					}
-					return (
-						<GlobalStylesPanel
-							hasWrapper={ false }
-							context={ root }
+			<Navigation>
+				<NavigationMenu>
+					<GlobalStylesLevel
+						context={ root }
+						getStyle={ getStyle }
+						setStyle={ setStyle }
+						getSetting={ getSetting }
+						setSetting={ setSetting }
+					/>
+					<NavigationItem
+						item="item-blocks"
+						navigateToMenu="blocks"
+						title={ __( 'Blocks' ) }
+					/>
+				</NavigationMenu>
+				<NavigationMenu menu="blocks" parentMenu="root">
+					{ map( blocks, ( _, name ) => (
+						<NavigationItem
+							key={ 'menu-itemblock-' + name }
+							item={ 'block-' + name }
+							navigateToMenu={ 'block-' + name }
+							title={ getPanelTitle( name ) }
+						/>
+					) ) }
+				</NavigationMenu>
+				{ map( blocks, ( block, name ) => (
+					<NavigationMenu
+						key={ 'menu-block-' + name }
+						menu={ 'block-' + name }
+						parentMenu="blocks"
+					>
+						<GlobalStylesLevel
+							parentMenu={ 'block-' + name }
+							context={ block }
 							getStyle={ getStyle }
 							setStyle={ setStyle }
 							getSetting={ getSetting }
 							setSetting={ setSetting }
 						/>
-					);
-				} }
-			</TabPanel>
+					</NavigationMenu>
+				) ) }
+			</Navigation>
 		</DefaultSidebar>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -11,10 +11,11 @@ import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
+	__experimentalNavigationGroup as NavigationGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
-import { styles } from '@wordpress/icons';
+import { layout, brush, styles, typography } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -63,27 +64,32 @@ function GlobalStylesLevel( {
 
 	return (
 		<>
-			{ hasTypographyPanel && (
-				<NavigationItem
-					item="item-typography"
-					navigateToMenu={ parentMenu + '.typography' }
-					title={ __( 'Typography' ) }
-				/>
-			) }
-			{ hasColorPanel && (
-				<NavigationItem
-					item="item-color"
-					navigateToMenu={ parentMenu + '.color' }
-					title={ __( 'Colors' ) }
-				/>
-			) }
-			{ hasLayoutPanel && (
-				<NavigationItem
-					item="item-layout"
-					navigateToMenu={ parentMenu + '.layout' }
-					title={ __( 'Layout' ) }
-				/>
-			) }
+			<NavigationGroup>
+				{ hasTypographyPanel && (
+					<NavigationItem
+						item="item-typography"
+						navigateToMenu={ parentMenu + '.typography' }
+						icon={ typography }
+						title={ __( 'Typography' ) }
+					/>
+				) }
+				{ hasColorPanel && (
+					<NavigationItem
+						item="item-color"
+						navigateToMenu={ parentMenu + '.color' }
+						title={ __( 'Colors' ) }
+						icon={ brush }
+					/>
+				) }
+				{ hasLayoutPanel && (
+					<NavigationItem
+						item="item-layout"
+						navigateToMenu={ parentMenu + '.layout' }
+						title={ __( 'Layout' ) }
+						icon={ layout }
+					/>
+				) }
+			</NavigationGroup>
 
 			{ hasTypographyPanel && (
 				<NavigationMenu
@@ -189,11 +195,21 @@ export default function GlobalStylesSidebar() {
 						getSetting={ getSetting }
 						setSetting={ setSetting }
 					/>
-					<NavigationItem
-						item="item-blocks"
-						navigateToMenu="blocks"
-						title={ __( 'Blocks' ) }
-					/>
+					<NavigationGroup className="edit-site-global-styles-sidebar__blocks-group">
+						<NavigationItem
+							className="edit-site-global-styles-sidebar__blocks-group-help"
+							isText
+						>
+							{ __(
+								'Customize the appearance of specific blocks for the whole site'
+							) }
+						</NavigationItem>
+						<NavigationItem
+							item="item-blocks"
+							navigateToMenu="blocks"
+							title={ __( 'Blocks' ) }
+						/>
+					</NavigationGroup>
 				</NavigationMenu>
 				<NavigationMenu
 					menu="blocks"

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -89,6 +89,7 @@ function GlobalStylesLevel( {
 				<NavigationMenu
 					menu={ parentMenu + '.typography' }
 					parentMenu={ parentMenu }
+					title={ __( 'Typography' ) }
 				>
 					<NavigationItem>
 						<TypographyPanel
@@ -104,6 +105,7 @@ function GlobalStylesLevel( {
 				<NavigationMenu
 					menu={ parentMenu + '.color' }
 					parentMenu={ parentMenu }
+					title={ __( 'Colors' ) }
 				>
 					<NavigationItem>
 						<ColorPanel
@@ -193,7 +195,11 @@ export default function GlobalStylesSidebar() {
 						title={ __( 'Blocks' ) }
 					/>
 				</NavigationMenu>
-				<NavigationMenu menu="blocks" parentMenu="root">
+				<NavigationMenu
+					menu="blocks"
+					parentMenu="root"
+					title={ __( 'Blocks' ) }
+				>
 					{ map( blocks, ( _, name ) => (
 						<NavigationItem
 							key={ 'menu-itemblock-' + name }
@@ -208,6 +214,7 @@ export default function GlobalStylesSidebar() {
 						key={ 'menu-block-' + name }
 						menu={ 'block-' + name }
 						parentMenu="blocks"
+						title={ getPanelTitle( name ) }
 					>
 						<GlobalStylesLevel
 							parentMenu={ 'block-' + name }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -3,7 +3,7 @@
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { cog, styles } from '@wordpress/icons';
+import { cog } from '@wordpress/icons';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -76,12 +76,7 @@ export function SidebarComplementaryAreaFills() {
 					<InspectorSlot bubblesVirtually />
 				) }
 			</DefaultSidebar>
-			<GlobalStylesSidebar
-				identifier="edit-site/global-styles"
-				title={ __( 'Global Styles' ) }
-				closeLabel={ __( 'Close global styles sidebar' ) }
-				icon={ styles }
-			/>
+			<GlobalStylesSidebar />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -38,3 +38,12 @@
 		margin-bottom: 0;
 	}
 }
+
+.edit-site-global-styles-sidebar .components-navigation__menu-title-heading {
+	font-size: $default-font-size * 1.2;
+}
+
+.edit-site-typography-panel,
+.edit-site-global-styles-sidebar .block-editor-panel-color-gradient-settings {
+	border: 0;
+}

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -41,9 +41,23 @@
 
 .edit-site-global-styles-sidebar .components-navigation__menu-title-heading {
 	font-size: $default-font-size * 1.2;
+	font-weight: 500;
+}
+
+.edit-site-global-styles-sidebar .components-navigation__item > button span {
+	font-weight: 500;
 }
 
 .edit-site-typography-panel,
 .edit-site-global-styles-sidebar .block-editor-panel-color-gradient-settings {
 	border: 0;
+}
+
+.edit-site-global-styles-sidebar__blocks-group {
+	padding-top: $grid-unit-30;
+	border-top: $border-width solid $gray-200;
+}
+
+.edit-site-global-styles-sidebar__blocks-group-help {
+	padding: 0 $grid-unit-20;
 }

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -8,7 +8,6 @@ import {
 	__experimentalLetterSpacingControl as LetterSpacingControl,
 } from '@wordpress/block-editor';
 import { PanelBody, FontSizePicker } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -76,7 +75,7 @@ export default function TypographyPanel( {
 	} );
 
 	return (
-		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
+		<PanelBody className="edit-site-typography-panel" initialOpen={ true }>
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
 					fontFamilies={ fontFamilies }


### PR DESCRIPTION
This is still a bit ugly but it moves us forward a bit in #34574 

Here's the idea:

 - We need to integrate a Navigation component into the global styles sidebar to reduce complexity
 - The current Navigation component is not great and the new one (G2) is not ready yet.
 - Can we update the current global styles a bit to integrate the navigation drill down without big refactorings to existing components to get the ball rolling (which would allow us to see the pieces in action and iterate on them).

Based on this:

 - I updated the existing navigation component to make its colors less specific to the left sidebar (dark background), meaning there are some light changes in the color there but I think it's decent for a temporary component.
 - Integrate the navigation menus into the current sidebar 

This still needs a bit of work to get something shippable as an iteration but I wanted to share to get some eyes on this.
I think it needs:

 - Remove the Collapsible Panels from the sidebar
 - Add some contextual information indicating where we are in the menu (especially for blocks)

WDYT