### PR TITLE
Replaces usages of workspaceRoot with workspaceFolder.

### DIFF
--- a/.vscode/launch-example.json
+++ b/.vscode/launch-example.json
@@ -14,10 +14,10 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Debug current e2e test",
-			"program": "${workspaceRoot}/node_modules/@wordpress/scripts/bin/wp-scripts.js",
+			"program": "${workspaceFolder}/node_modules/@wordpress/scripts/bin/wp-scripts.js",
 			"args": [
 				"test-e2e",
-				"--config=${workspaceRoot}/packages/e2e-tests/jest.config.js",
+				"--config=${workspaceFolder}/packages/e2e-tests/jest.config.js",
 				"--verbose=true",
 				"--runInBand",
 				"--watch",

--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -54,10 +54,10 @@ Debugging in a Chrome browser can be replaced with `vscode`'s debugger by adding
 			"type": "node",
 			"request": "launch",
 			"name": "Debug current e2e test",
-			"program": "${workspaceRoot}/node_modules/@wordpress/scripts/bin/wp-scripts.js",
+			"program": "${workspaceFolder}/node_modules/@wordpress/scripts/bin/wp-scripts.js",
 			"args": [
 				"test-e2e",
-				"--config=${workspaceRoot}/packages/e2e-tests/jest.config.js",
+				"--config=${workspaceFolder}/packages/e2e-tests/jest.config.js",
 				"--verbose=true",
 				"--runInBand",
 				"--watch",

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -220,7 +220,7 @@ You should only have to translate `port` and `pathMappings` to the format used b
 	"request": "launch",
 	"port": 9003,
 	"pathMappings": {
-		"/var/www/html/wp-content/plugins/gutenberg": "${workspaceRoot}/"
+		"/var/www/html/wp-content/plugins/gutenberg": "${workspaceFolder}/"
 	}
 }
 ```


### PR DESCRIPTION
Follow up on https://github.com/WordPress/gutenberg/pull/34269.

Replace remaining usages of workspaceRoot with workspaceFolder because workspaceRoot was deprecated as a vscode variable https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented.
