### PR TITLE
Fix 'menu_exists' response status code 

### DIFF
--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -352,16 +352,18 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 			 * If we're going to inform the client that the term already exists,
 			 * give them the identifier for future use.
 			 */
-			$term_id = $term->get_error_data( 'term_exists' );
-			if ( $term_id ) {
-				$existing_term = get_term( $term_id, $this->taxonomy );
-				$term->add_data( $existing_term->term_id, 'term_exists' );
+
+			if ( in_array( 'menu_exists', $term->get_error_codes(), true ) ) {
+				$existing_term = get_term_by( 'name', $prepared_term['menu-name'], $this->taxonomy );
+				$term->add_data( $existing_term->term_id, 'menu_exists' );
 				$term->add_data(
 					array(
 						'status'  => 400,
-						'term_id' => $term_id,
+						'term_id' => $existing_term->term_id,
 					)
 				);
+			} else {
+				$term->add_data( array( 'status' => 400 ) );
 			}
 
 			return $term;

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -224,6 +224,28 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 *
 	 */
+	public function test_create_item_same_name() {
+		wp_set_current_user( self::$admin_id );
+
+		wp_update_nav_menu_object(
+			0,
+			array(
+				'description' => 'This menu is so Original',
+				'menu-name'   => 'Original',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );
+		$request->set_param( 'name', 'Original' );
+		$request->set_param( 'description', 'This menu is so Original' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'menu_exists', $response, 400 );
+	}
+
+	/**
+	 *
+	 */
 	public function test_update_item() {
 		wp_set_current_user( self::$admin_id );
 


### PR DESCRIPTION
## Description
Alterative version of https://github.com/WordPress/gutenberg/pull/34868

Menu REST API was returning response code 500 for menu already exists error. PR adjusts the check to set the status code correctly.

## How has this been tested?
1. Go to the experimental Navigation screen.
2. Try to create a new menu with the name that already exists.
```js
wp.data.dispatch('core').saveMenu( { name: 'Menu' } );
```
3. Check the error in DevTools' Network tab.
4. Status code should be 400.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-16 at 14 02 24](https://user-images.githubusercontent.com/240569/133593157-e0cc09b8-49c4-4c4e-8da3-efd087273fa7.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
