### PR TITLE
Mobile Release v1.62.0-alpha

### DIFF
--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.61.0",
+	"version": "1.62.0-alpha",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.61.0",
+	"version": "1.62.0-alpha",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/ios/Gemfile.lock
+++ b/packages/react-native-editor/ios/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - Gutenberg (1.61.0):
+  - Gutenberg (1.62.0-alpha):
     - React-Core (= 0.64.0)
     - React-CoreModules (= 0.64.0)
     - React-RCTImage (= 0.64.0)
@@ -303,7 +303,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.7-wp):
     - React-Core
-  - RNTAztecView (1.61.0):
+  - RNTAztecView (1.62.0-alpha):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -457,9 +457,9 @@ SPEC CHECKSUMS:
   BVLinearGradient: 2c791e973a3df0df46028210c530fde52c06b717
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: ca068ae274cbd52c8638d4b44a8b9c6a35ae975e
+  FBReactNativeSpec: 3c357ea1a6e11209364d830bed4ebc7a365842d8
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  Gutenberg: c0b1c47cf3c63f795570e83a12a5df2cb38d9c5e
+  Gutenberg: 6fbb42a2bb44d734f070dc3c2cf9d909676aedd1
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -496,7 +496,7 @@ SPEC CHECKSUMS:
   RNReanimated: ca6105fdc2739ea1b3a7a5350b6490d8160143bc
   RNScreens: eb4e23256e7f2a5a1af87ea24dfeb49aea0ef310
   RNSVG: 1b6dcbec5884b6dbe256bf8c38eeeab0acf05926
-  RNTAztecView: e632368bd658eb1ead726ce7ac1c010c6bd10a72
+  RNTAztecView: cadf78f7ecb1632dc1ee290867d7af2344dc98a1
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.61.0",
+	"version": "1.62.0-alpha",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.62.0-alpha of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3976

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->