### PR TITLE
Columns block: Prevent reducing column count from deleting content

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -91,9 +91,11 @@ function ColumnInspectorControls( {
 			<>
 				<ToggleGroupControl
 					help={ help }
+					isBlock
 					label={ __( 'Columns' ) }
 					onChange={ updateColumns }
 					value={ count }
+					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				>
 					{ optionList }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -81,9 +81,16 @@ function ColumnInspectorControls( {
 			const itemProps = { value: count, label: count, key: count };
 			optionList.push( <ToggleGroupControlOption { ...itemProps } /> );
 		}
+		let help;
+		if ( countMin > 6 ) {
+			help = `Options disabled due to six or more columns being nonempty or locked.`;
+		} else if ( countMin > 1 ) {
+			help = `Options for fewer than ${ countMin } disabled due to some columns being nonempty or locked.`;
+		}
 		quantityControl = (
 			<>
 				<ToggleGroupControl
+					help={ help }
 					label={ __( 'Columns' ) }
 					onChange={ updateColumns }
 					value={ count }

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
  * Returns a column width attribute value rounded to standard precision.
  * Returns `undefined` if the value is not a valid finite number.
  *
@@ -173,4 +178,85 @@ export function getWidthWithUnit( width, unit ) {
  */
 export function isPercentageUnit( unit ) {
 	return unit === '%';
+}
+
+/**
+ * Returns indexes of inner blocks that aren’t locked from removal and have no
+ * inner blocks of their own.
+ *
+ * @param {Array} blockList A block list as returned by `getBlocks`.
+ */
+export function getDispensableIndexes( blockList ) {
+	return blockList.reduce(
+		( vacants, { attributes, innerBlocks: { length } }, index ) =>
+			attributes.lock?.remove || length ? vacants : [ ...vacants, index ],
+		[]
+	);
+}
+
+/**
+ * Creates new child Column blocks by adding or removing columns and revises
+ * existant column widths to grant required or redistribute available space.
+ * When removing columns it does not remove any that are locked or have their
+ * own children.
+ *
+ * @param {Array}  currentBlocks Current inner blocks.
+ * @param {number} newCount      New column count.
+ */
+export function getRevisedColumns( currentBlocks, newCount ) {
+	const currentCount = currentBlocks.length;
+	const hasExplicitWidths = hasExplicitPercentColumnWidths( currentBlocks );
+
+	// Redistribute available width for existing inner blocks.
+	const isAddingColumn = newCount > currentCount;
+
+	let innerBlocks;
+	if ( isAddingColumn && hasExplicitWidths ) {
+		// If adding a new column, assign width to the new column equal to
+		// as if it were `1 / columns` of the total available space.
+		const newColumnWidth = toWidthPrecision( 100 / newCount );
+
+		// Redistribute in consideration of pending block insertion as
+		// constraining the available working width.
+		const widths = getRedistributedColumnWidths(
+			currentBlocks,
+			100 - newColumnWidth
+		);
+
+		innerBlocks = [
+			...getMappedColumnWidths( currentBlocks, widths ),
+			...Array.from( {
+				length: newCount - currentCount,
+			} ).map( () => {
+				return createBlock( 'core/column', {
+					width: `${ newColumnWidth }%`,
+				} );
+			} ),
+		];
+	} else if ( isAddingColumn ) {
+		innerBlocks = [
+			...currentBlocks,
+			...Array.from( {
+				length: newCount - currentCount,
+			} ).map( () => {
+				return createBlock( 'core/column' );
+			} ),
+		];
+	} else {
+		// Removes dispensable columns.
+		const dispensableIndexes = getDispensableIndexes( currentBlocks );
+		const difference = currentCount - newCount;
+		const indexesToRemove = dispensableIndexes.slice( -difference );
+		innerBlocks = currentBlocks.filter(
+			( item, index ) => ! indexesToRemove.includes( index )
+		);
+
+		if ( hasExplicitWidths ) {
+			// Redistribute as if block is already removed.
+			const widths = getRedistributedColumnWidths( innerBlocks, 100 );
+
+			innerBlocks = getMappedColumnWidths( innerBlocks, widths );
+		}
+	}
+	return innerBlocks;
 }

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Navigating the block hierarchy', () => {
 			.click();
 
 		// Tweak the columns count.
-		await page.getByRole( 'spinbutton', { name: 'Columns' } ).fill( '3' );
+		await page.getByRole( 'radio', { name: '3' } ).check();
 
 		// Wait for the new column block to appear in the list view
 		const column = listView.getByRole( 'gridcell', {
@@ -129,7 +129,7 @@ test.describe( 'Navigating the block hierarchy', () => {
 		// Navigate to the block settings sidebar and tweak the column count.
 		await pageUtils.pressKeys( 'Tab', { times: 5 } );
 		await expect(
-			page.getByRole( 'slider', { name: 'Columns' } )
+			page.getByRole( 'radiogroup', { name: 'Columns' } )
 		).toBeFocused();
 		await page.keyboard.press( 'ArrowRight' );
 


### PR DESCRIPTION
This is aimed to resolve a rather old issue #9009. It should probably be vetted UX-wise before worrying about a code-review so it's drafted for now.

The control for the column quantity is now a `ToggleGroupControl` which has its options disabled in accord with the number of occupied columns and thereby prevents deleting content. Even without that, the new control seems like an improvement because it communicates the recommended range of columns whereas the slider is vague.

## Testing Instructions
…

## Screenshots 

https://github.com/user-attachments/assets/a436bc1d-cb5f-49e3-be66-85066682e9f5

## Types of changes
Enhancement to close: #9009

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
