### PR TITLE
MediaPlaceholder: Fix media library button opening the file upload modal

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -178,7 +178,7 @@ export function MediaPlaceholder( {
 		onFilesUpload( event.target.files );
 	};
 
-	const renderPlaceholder = ( content, onClick ) => {
+	const renderPlaceholder = ( content ) => {
 		let { instructions, title } = labels;
 
 		if ( ! mediaUpload && ! onSelectURL ) {
@@ -244,7 +244,6 @@ export function MediaPlaceholder( {
 				instructions={ instructions }
 				className={ placeholderClassName }
 				notices={ notices }
-				onClick={ onClick }
 				onDoubleClick={ onDoubleClick }
 				preview={ mediaPreview }
 			>
@@ -349,6 +348,7 @@ export function MediaPlaceholder( {
 											'block-editor-media-placeholder__button',
 											'block-editor-media-placeholder__upload-button'
 										) }
+										onClick={ openFileDialog }
 									>
 										{ __( 'Upload' ) }
 									</Button>
@@ -357,7 +357,7 @@ export function MediaPlaceholder( {
 									{ renderCancelLink() }
 								</>
 							);
-							return renderPlaceholder( content, openFileDialog );
+							return renderPlaceholder( content );
 						} }
 					/>
 				</>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #34099

This PR fixes an issue with the appender state of the MediaPlaceholder component where clicking the "Media library" button causes the file dialog modal to open. A common place to test this is with adding an image to a gallery that already has images.

### Background on the issue

The regression appears to have been introduced in https://github.com/WordPress/gutenberg/pull/33632 which removed the `event.stopPropagation()` call on the `mediaLibraryButton` so the click event bubbles up to the Placeholder component, which in the `isAppender` state opens up the file dialog.

### Proposed fix

While we could re-instate the `event.stopPropagation()` call, I propose we remove the `onClick` handler on the overall Placeholder and move it down to the Upload button, to avoid unexpected behaviour. This is just my personal preference of course, so happy for design feedback on this! CC: @jorgefilipecosta as it looks like the original behaviour was introduced back in https://github.com/WordPress/gutenberg/pull/12367

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually in the editor. In looks like there were no other uses of the `onClick` param in the `renderPlaceholder` function, but do let me know if you can think of any uses I've missed!

### Prior to applying this PR

* Insert a gallery block with at least one image
* From the placeholder state, click the Media library button — observe that the file dialog modal opens

### After applying this PR

* Insert a gallery block with at least one image
* From the placeholder state, click the Media library button — observe that the media library opens, but the file dialog does not
* Click elsewhere in the Placeholder — neither the media library nor the file dialog should open
* Click on the Upload button — the file dialog should open

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![media-library-file-modal-before-sml](https://user-images.githubusercontent.com/14988353/133713987-250547ac-4a05-43ad-9059-efd554b1e202.gif) | ![media-library-file-modal-after-sml](https://user-images.githubusercontent.com/14988353/133714045-4762bd50-c3e7-4c81-8015-bb84655e312a.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (Manually)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
