### PR TITLE
[Block Library - QueryPagination]: Fix layout support

### DIFF
--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -9,6 +9,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { getBlockSupport } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 
 /**
@@ -22,11 +23,21 @@ const TEMPLATE = [
 	[ 'core/query-pagination-next' ],
 ];
 
+const getDefaultBlockLayout = ( blockTypeOrName ) => {
+	const layoutBlockSupportConfig = getBlockSupport(
+		blockTypeOrName,
+		'__experimentalLayout'
+	);
+	return layoutBlockSupportConfig?.default;
+};
+
 export default function QueryPaginationEdit( {
-	attributes: { paginationArrow },
+	attributes: { paginationArrow, layout },
 	setAttributes,
 	clientId,
+	name,
 } ) {
+	const usedLayout = layout || getDefaultBlockLayout( name );
 	const hasNextPreviousBlocks = useSelect( ( select ) => {
 		const { getBlocks } = select( blockEditorStore );
 		const innerBlocks = getBlocks( clientId );
@@ -49,7 +60,7 @@ export default function QueryPaginationEdit( {
 			'core/query-pagination-numbers',
 			'core/query-pagination-next',
 		],
-		orientation: 'horizontal',
+		__experimentalLayout: usedLayout,
 	} );
 	return (
 		<>

--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -22,8 +22,6 @@ $pagination-margin: 0.5em;
 	> .wp-block-query-pagination-next,
 	> .wp-block-query-pagination-previous,
 	> .wp-block-query-pagination-numbers {
-		display: inline-block;
-
 		// Override editor auto block margins.
 		margin-left: 0;
 		margin-top: $pagination-margin;

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -4,7 +4,6 @@ $pagination-margin: 0.5em;
 	> .wp-block-query-pagination-next,
 	> .wp-block-query-pagination-previous,
 	> .wp-block-query-pagination-numbers {
-		display: inline-block;
 		/*rtl:ignore*/
 		margin-right: $pagination-margin;
 		margin-bottom: $pagination-margin;


### PR DESCRIPTION
I got a bit sloppy 😞 yesterday with `QueryPagination` [flex layout](https://github.com/WordPress/gutenberg/pull/34876), so this is a follow up for it.

While this seemed to work fine with the flex default layout, I didn't make the proper changes to fully support the used `layout`. This PR does that.

## Testing instructions
1. Just for testing purposes change `allowSwitching` to `true` in [block.json](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query-pagination/block.json#L28)
2. Select the block and change  the layout to `flow` in the `Layout` panel
3. Observe that currently it will be shown in a horizontal orientation and in this PR it will be shown in a vertical orientation