### PR TITLE
Insert Links by default in Navigation block

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -42,7 +42,8 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
-		directInsert,
+		__experimentalDefaultBlock,
+		__experimentalDirectInsert,
 		template,
 		templateLock,
 		wrapperRef,
@@ -58,7 +59,8 @@ function UncontrolledInnerBlocks( props ) {
 	useNestedSettingsUpdate(
 		clientId,
 		allowedBlocks,
-		directInsert,
+		__experimentalDefaultBlock,
+		__experimentalDirectInsert,
 		templateLock,
 		captureToolbars,
 		orientation,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -42,6 +42,7 @@ function UncontrolledInnerBlocks( props ) {
 	const {
 		clientId,
 		allowedBlocks,
+		directInsert,
 		template,
 		templateLock,
 		wrapperRef,
@@ -57,6 +58,7 @@ function UncontrolledInnerBlocks( props ) {
 	useNestedSettingsUpdate(
 		clientId,
 		allowedBlocks,
+		directInsert,
 		templateLock,
 		captureToolbars,
 		orientation,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -18,24 +18,26 @@ import { getLayoutType } from '../../layouts';
  * the block-editor store, then the store is updated with the new settings which
  * came from props.
  *
- * @param {string}   clientId        The client ID of the block to update.
- * @param {string[]} allowedBlocks   An array of block names which are permitted
- *                                   in inner blocks.
- * @param {?Array}   directInsert    A block name to be inserted directly by the
- *                                   appender.
- * @param {string}   [templateLock]  The template lock specified for the inner
- *                                   blocks component. (e.g. "all")
- * @param {boolean}  captureToolbars Whether or children toolbars should be shown
- *                                   in the inner blocks component rather than on
- *                                   the child block.
- * @param {string}   orientation     The direction in which the block
- *                                   should face.
- * @param {Object}   layout          The layout object for the block container.
+ * @param {string}   clientId                   The client ID of the block to update.
+ * @param {string[]} allowedBlocks              An array of block names which are permitted
+ *                                              in inner blocks.
+ * @param {?Array}   __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
+ * @param {boolean}  __experimentalDirectInsert If a default block should be inserted directly by the
+ *                                              appender.
+ * @param {string}   [templateLock]             The template lock specified for the inner
+ *                                              blocks component. (e.g. "all")
+ * @param {boolean}  captureToolbars            Whether or children toolbars should be shown
+ *                                              in the inner blocks component rather than on
+ *                                              the child block.
+ * @param {string}   orientation                The direction in which the block
+ *                                              should face.
+ * @param {Object}   layout                     The layout object for the block container.
  */
 export default function useNestedSettingsUpdate(
 	clientId,
 	allowedBlocks,
-	directInsert,
+	__experimentalDefaultBlock,
+	__experimentalDirectInsert,
 	templateLock,
 	captureToolbars,
 	orientation,
@@ -86,8 +88,12 @@ export default function useNestedSettingsUpdate(
 			newSettings.orientation = layoutType.getOrientation( layout );
 		}
 
-		if ( directInsert !== undefined ) {
-			newSettings.directInsert = directInsert;
+		if ( __experimentalDefaultBlock !== undefined ) {
+			newSettings.__experimentalDefaultBlock = __experimentalDefaultBlock;
+		}
+
+		if ( __experimentalDirectInsert !== undefined ) {
+			newSettings.__experimentalDirectInsert = __experimentalDirectInsert;
 		}
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
@@ -97,7 +103,8 @@ export default function useNestedSettingsUpdate(
 		clientId,
 		blockListSettings,
 		_allowedBlocks,
-		directInsert,
+		__experimentalDefaultBlock,
+		__experimentalDirectInsert,
 		templateLock,
 		parentLock,
 		captureToolbars,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -21,7 +21,7 @@ import { getLayoutType } from '../../layouts';
  * @param {string}   clientId        The client ID of the block to update.
  * @param {string[]} allowedBlocks   An array of block names which are permitted
  *                                   in inner blocks.
- * @param {?string}  directInsert    A block name to be inserted directly by the
+ * @param {?Array}   directInsert    A block name to be inserted directly by the
  *                                   appender.
  * @param {string}   [templateLock]  The template lock specified for the inner
  *                                   blocks component. (e.g. "all")

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -21,6 +21,8 @@ import { getLayoutType } from '../../layouts';
  * @param {string}   clientId        The client ID of the block to update.
  * @param {string[]} allowedBlocks   An array of block names which are permitted
  *                                   in inner blocks.
+ * @param {?string}  directInsert    A block name to be inserted directly by the
+ *                                   appender.
  * @param {string}   [templateLock]  The template lock specified for the inner
  *                                   blocks component. (e.g. "all")
  * @param {boolean}  captureToolbars Whether or children toolbars should be shown
@@ -33,6 +35,7 @@ import { getLayoutType } from '../../layouts';
 export default function useNestedSettingsUpdate(
 	clientId,
 	allowedBlocks,
+	directInsert,
 	templateLock,
 	captureToolbars,
 	orientation,
@@ -83,6 +86,10 @@ export default function useNestedSettingsUpdate(
 			newSettings.orientation = layoutType.getOrientation( layout );
 		}
 
+		if ( directInsert !== undefined ) {
+			newSettings.directInsert = directInsert;
+		}
+
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
 			updateBlockListSettings( clientId, newSettings );
 		}
@@ -90,6 +97,7 @@ export default function useNestedSettingsUpdate(
 		clientId,
 		blockListSettings,
 		_allowedBlocks,
+		directInsert,
 		templateLock,
 		parentLock,
 		captureToolbars,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -18,20 +18,20 @@ import { getLayoutType } from '../../layouts';
  * the block-editor store, then the store is updated with the new settings which
  * came from props.
  *
- * @param {string}   clientId                   The client ID of the block to update.
- * @param {string[]} allowedBlocks              An array of block names which are permitted
- *                                              in inner blocks.
- * @param {?Array}   __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
- * @param {boolean}  __experimentalDirectInsert If a default block should be inserted directly by the
- *                                              appender.
- * @param {string}   [templateLock]             The template lock specified for the inner
- *                                              blocks component. (e.g. "all")
- * @param {boolean}  captureToolbars            Whether or children toolbars should be shown
- *                                              in the inner blocks component rather than on
- *                                              the child block.
- * @param {string}   orientation                The direction in which the block
- *                                              should face.
- * @param {Object}   layout                     The layout object for the block container.
+ * @param {string}            clientId                   The client ID of the block to update.
+ * @param {string[]}          allowedBlocks              An array of block names which are permitted
+ *                                                       in inner blocks.
+ * @param {?Array}            __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
+ * @param {?Function|boolean} __experimentalDirectInsert If a default block should be inserted directly by the
+ *                                                       appender.
+ * @param {string}            [templateLock]             The template lock specified for the inner
+ *                                                       blocks component. (e.g. "all")
+ * @param {boolean}           captureToolbars            Whether or children toolbars should be shown
+ *                                                       in the inner blocks component rather than on
+ *                                                       the child block.
+ * @param {string}            orientation                The direction in which the block
+ *                                                       should face.
+ * @param {Object}            layout                     The layout object for the block container.
  */
 export default function useNestedSettingsUpdate(
 	clientId,

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -176,7 +176,7 @@ class Inserter extends Component {
 			onSelectOrClose,
 		} = this.props;
 
-		if ( hasSingleBlockType || directInsert ) {
+		if ( hasSingleBlockType || directInsert?.length ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
 
@@ -249,7 +249,7 @@ export default compose( [
 					onSelectOrClose,
 				} = ownProps;
 
-				if ( ! hasSingleBlockType && ! directInsert ) {
+				if ( ! hasSingleBlockType && ! directInsert?.length ) {
 					return;
 				}
 
@@ -282,8 +282,8 @@ export default compose( [
 
 				const { insertBlock } = dispatch( blockEditorStore );
 
-				const blockToInsert = directInsert
-					? createBlock( directInsert )
+				const blockToInsert = directInsert?.length
+					? createBlock( directInsert[ 0 ], directInsert[ 1 ] )
 					: createBlock( allowedBlockType.name );
 
 				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -102,6 +102,7 @@ class Inserter extends Component {
 			disabled,
 			blockTitle,
 			hasSingleBlockType,
+			directInsert,
 			toggleProps,
 			hasItems,
 			renderToggle = defaultRenderToggle,
@@ -113,6 +114,7 @@ class Inserter extends Component {
 			disabled: disabled || ! hasItems,
 			blockTitle,
 			hasSingleBlockType,
+			directInsert,
 			toggleProps,
 		} );
 	}
@@ -168,12 +170,13 @@ class Inserter extends Component {
 		const {
 			position,
 			hasSingleBlockType,
+			directInsert,
 			insertOnlyAllowedBlock,
 			__experimentalIsQuick: isQuick,
 			onSelectOrClose,
 		} = this.props;
 
-		if ( hasSingleBlockType ) {
+		if ( hasSingleBlockType || directInsert ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
 
@@ -202,6 +205,7 @@ export default compose( [
 			getBlockRootClientId,
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
+			__experimentalGetDirectInsert,
 		} = select( blockEditorStore );
 		const { getBlockVariations } = select( blocksStore );
 
@@ -209,6 +213,8 @@ export default compose( [
 			rootClientId || getBlockRootClientId( clientId ) || undefined;
 
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
+
+		const directInsert = __experimentalGetDirectInsert( rootClientId );
 
 		const hasSingleBlockType =
 			size( allowedBlocks ) === 1 &&
@@ -226,6 +232,7 @@ export default compose( [
 			hasSingleBlockType,
 			blockTitle: allowedBlockType ? allowedBlockType.title : '',
 			allowedBlockType,
+			directInsert,
 			rootClientId,
 		};
 	} ),
@@ -238,10 +245,11 @@ export default compose( [
 					isAppender,
 					hasSingleBlockType,
 					allowedBlockType,
+					directInsert,
 					onSelectOrClose,
 				} = ownProps;
 
-				if ( ! hasSingleBlockType ) {
+				if ( ! hasSingleBlockType && ! directInsert ) {
 					return;
 				}
 
@@ -274,7 +282,9 @@ export default compose( [
 
 				const { insertBlock } = dispatch( blockEditorStore );
 
-				const blockToInsert = createBlock( allowedBlockType.name );
+				const blockToInsert = directInsert
+					? createBlock( directInsert )
+					: createBlock( allowedBlockType.name );
 
 				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -285,10 +285,7 @@ export default compose( [
 				const { insertBlock } = dispatch( blockEditorStore );
 
 				const blockToInsert = directInsertBlock?.length
-					? createBlock(
-							directInsertBlock[ 0 ],
-							directInsertBlock[ 1 ]
-					  )
+					? createBlock( ...directInsertBlock )
 					: createBlock( allowedBlockType.name );
 
 				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -102,7 +102,7 @@ class Inserter extends Component {
 			disabled,
 			blockTitle,
 			hasSingleBlockType,
-			directInsert,
+			directInsertBlock,
 			toggleProps,
 			hasItems,
 			renderToggle = defaultRenderToggle,
@@ -114,7 +114,7 @@ class Inserter extends Component {
 			disabled: disabled || ! hasItems,
 			blockTitle,
 			hasSingleBlockType,
-			directInsert,
+			directInsertBlock,
 			toggleProps,
 		} );
 	}
@@ -170,13 +170,13 @@ class Inserter extends Component {
 		const {
 			position,
 			hasSingleBlockType,
-			directInsert,
+			directInsertBlock,
 			insertOnlyAllowedBlock,
 			__experimentalIsQuick: isQuick,
 			onSelectOrClose,
 		} = this.props;
 
-		if ( hasSingleBlockType || directInsert?.length ) {
+		if ( hasSingleBlockType || directInsertBlock?.length ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
 
@@ -205,7 +205,7 @@ export default compose( [
 			getBlockRootClientId,
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
-			__experimentalGetDirectInsert,
+			__experimentalGetDirectInsertBlock,
 		} = select( blockEditorStore );
 		const { getBlockVariations } = select( blocksStore );
 
@@ -214,7 +214,9 @@ export default compose( [
 
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
 
-		const directInsert = __experimentalGetDirectInsert( rootClientId );
+		const directInsertBlock = __experimentalGetDirectInsertBlock(
+			rootClientId
+		);
 
 		const hasSingleBlockType =
 			size( allowedBlocks ) === 1 &&
@@ -232,7 +234,7 @@ export default compose( [
 			hasSingleBlockType,
 			blockTitle: allowedBlockType ? allowedBlockType.title : '',
 			allowedBlockType,
-			directInsert,
+			directInsertBlock,
 			rootClientId,
 		};
 	} ),
@@ -245,11 +247,11 @@ export default compose( [
 					isAppender,
 					hasSingleBlockType,
 					allowedBlockType,
-					directInsert,
+					directInsertBlock,
 					onSelectOrClose,
 				} = ownProps;
 
-				if ( ! hasSingleBlockType && ! directInsert?.length ) {
+				if ( ! hasSingleBlockType && ! directInsertBlock?.length ) {
 					return;
 				}
 
@@ -282,8 +284,11 @@ export default compose( [
 
 				const { insertBlock } = dispatch( blockEditorStore );
 
-				const blockToInsert = directInsert?.length
-					? createBlock( directInsert[ 0 ], directInsert[ 1 ] )
+				const blockToInsert = directInsertBlock?.length
+					? createBlock(
+							directInsertBlock[ 0 ],
+							directInsertBlock[ 1 ]
+					  )
 					: createBlock( allowedBlockType.name );
 
 				insertBlock( blockToInsert, getInsertionIndex(), rootClientId );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1792,6 +1792,24 @@ export const __experimentalGetAllowedBlocks = createSelector(
 	]
 );
 
+/**
+ * Returns the block to be directly inserted by the block appender.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @return {string?} The block type to be directly inserted.
+ */
+export const __experimentalGetDirectInsert = createSelector(
+	( state, rootClientId = null ) => {
+		if ( ! rootClientId ) {
+			return;
+		}
+		return state.blockListSettings[ rootClientId ].directInsert;
+	},
+	( state, rootClientId ) => state.blockListSettings[ rootClientId ]
+);
+
 const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
 	if ( isBoolean( allowedBlockTypes ) ) {
 		return allowedBlockTypes;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1805,9 +1805,9 @@ export const __experimentalGetDirectInsert = createSelector(
 		if ( ! rootClientId ) {
 			return;
 		}
-		return state.blockListSettings[ rootClientId ].directInsert;
+		return state.blockListSettings[ rootClientId ]?.directInsert;
 	},
-	( state, rootClientId ) => state.blockListSettings[ rootClientId ]
+	( state, rootClientId ) => [ state.blockListSettings[ rootClientId ] ]
 );
 
 const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1809,12 +1809,20 @@ export const __experimentalGetDirectInsertBlock = createSelector(
 			state.blockListSettings[ rootClientId ]?.__experimentalDefaultBlock;
 		const directInsert =
 			state.blockListSettings[ rootClientId ]?.__experimentalDirectInsert;
-		if ( ! defaultBlock?.length || ! directInsert ) {
+		if ( ! defaultBlock || ! directInsert ) {
 			return;
+		}
+		if ( typeof directInsert === 'function' ) {
+			return directInsert( getBlock( state, rootClientId ) )
+				? defaultBlock
+				: null;
 		}
 		return defaultBlock;
 	},
-	( state, rootClientId ) => [ state.blockListSettings[ rootClientId ] ]
+	( state, rootClientId ) => [
+		state.blockListSettings[ rootClientId ],
+		state.blocks.tree[ rootClientId ],
+	]
 );
 
 const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1798,14 +1798,21 @@ export const __experimentalGetAllowedBlocks = createSelector(
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
- * @return {string?} The block type to be directly inserted.
+ * @return {?Array} The block type to be directly inserted.
  */
-export const __experimentalGetDirectInsert = createSelector(
+export const __experimentalGetDirectInsertBlock = createSelector(
 	( state, rootClientId = null ) => {
 		if ( ! rootClientId ) {
 			return;
 		}
-		return state.blockListSettings[ rootClientId ]?.directInsert;
+		const defaultBlock =
+			state.blockListSettings[ rootClientId ]?.__experimentalDefaultBlock;
+		const directInsert =
+			state.blockListSettings[ rootClientId ]?.__experimentalDirectInsert;
+		if ( ! defaultBlock?.length || ! directInsert ) {
+			return;
+		}
+		return defaultBlock;
 	},
 	( state, rootClientId ) => [ state.blockListSettings[ rootClientId ] ]
 );

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -50,10 +50,7 @@ import { name } from './block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
-const DIRECT_INSERT = [
-	'core/navigation-link',
-	{ type: 'page', kind: 'post-type' },
-];
+const DIRECT_INSERT = [ 'core/navigation-link' ];
 
 const MAX_NESTING = 5;
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -50,7 +50,7 @@ import { name } from './block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
-const DIRECT_INSERT = [ 'core/navigation-link' ];
+const DEFAULT_BLOCK = [ 'core/navigation-link' ];
 
 const MAX_NESTING = 5;
 
@@ -506,7 +506,8 @@ export default function NavigationSubmenuEdit( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			directInsert: DIRECT_INSERT,
+			__experimentalDefaultBlock: DEFAULT_BLOCK,
+			__experimentalDirectInsert: true,
 			renderAppender:
 				isSelected ||
 				( isImmediateParentOfSelectedBlock &&

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -50,7 +50,10 @@ import { name } from './block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
-const DIRECT_INSERT = 'core/navigation-link';
+const DIRECT_INSERT = [
+	'core/navigation-link',
+	{ type: 'page', kind: 'post-type' },
+];
 
 const MAX_NESTING = 5;
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -50,6 +50,8 @@ import { name } from './block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
+const DIRECT_INSERT = 'core/navigation-link';
+
 const MAX_NESTING = 5;
 
 /**
@@ -504,6 +506,7 @@ export default function NavigationSubmenuEdit( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
+			directInsert: DIRECT_INSERT,
 			renderAppender:
 				isSelected ||
 				( isImmediateParentOfSelectedBlock &&

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -95,7 +95,7 @@ function Navigation( {
 	hasExistingNavItems,
 	isImmediateParentOfSelectedBlock,
 	isSelected,
-	innerBlocks,
+	onlyLinkInnerBlocks,
 	updateInnerBlocks,
 	className,
 	backgroundColor,
@@ -164,10 +164,9 @@ function Navigation( {
 			? undefined
 			: false;
 
-	const onlyLinkInnerBlocks = innerBlocks.every(
-		( block ) =>
-			block.name === 'core/navigation-link' ||
-			block.name === 'core/navigation-submenu'
+	const directInsertValue = useMemo(
+		() => ( onlyLinkInnerBlocks ? DIRECT_INSERT : [] ),
+		[ onlyLinkInnerBlocks ]
 	);
 
 	const innerBlocksProps = useInnerBlocksProps(
@@ -176,7 +175,7 @@ function Navigation( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			directInsert: onlyLinkInnerBlocks ? DIRECT_INSERT : [],
+			directInsert: directInsertValue,
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
 
@@ -379,6 +378,12 @@ export default compose( [
 			selectedBlockId,
 		] )?.length;
 
+		const onlyLinkInnerBlocks = innerBlocks.every(
+			( block ) =>
+				block.name === 'core/navigation-link' ||
+				block.name === 'core/navigation-submenu'
+		);
+
 		return {
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
@@ -387,7 +392,7 @@ export default compose( [
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,
-			innerBlocks,
+			onlyLinkInnerBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -50,7 +50,10 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
-const DIRECT_INSERT = 'core/navigation-link';
+const DIRECT_INSERT = [
+	'core/navigation-link',
+	{ type: 'page', kind: 'post-type' },
+];
 
 const LAYOUT = {
 	type: 'default',
@@ -167,7 +170,7 @@ function Navigation( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			directInsert: onlyLinkInnerBlocks ? DIRECT_INSERT : '',
+			directInsert: onlyLinkInnerBlocks ? DIRECT_INSERT : [],
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -52,6 +52,14 @@ const ALLOWED_BLOCKS = [
 
 const DEFAULT_BLOCK = [ 'core/navigation-link' ];
 
+const DIRECT_INSERT = ( block ) => {
+	return block.innerBlocks.every(
+		( { name } ) =>
+			name === 'core/navigation-link' ||
+			name === 'core/navigation-submenu'
+	);
+};
+
 const LAYOUT = {
 	type: 'default',
 	alignments: [],
@@ -92,7 +100,6 @@ function Navigation( {
 	hasExistingNavItems,
 	isImmediateParentOfSelectedBlock,
 	isSelected,
-	onlyLinkInnerBlocks,
 	updateInnerBlocks,
 	className,
 	backgroundColor,
@@ -168,7 +175,7 @@ function Navigation( {
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
-			__experimentalDirectInsert: onlyLinkInnerBlocks,
+			__experimentalDirectInsert: DIRECT_INSERT,
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
 
@@ -371,12 +378,6 @@ export default compose( [
 			selectedBlockId,
 		] )?.length;
 
-		const onlyLinkInnerBlocks = innerBlocks.every(
-			( block ) =>
-				block.name === 'core/navigation-link' ||
-				block.name === 'core/navigation-submenu'
-		);
-
 		return {
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
@@ -385,7 +386,6 @@ export default compose( [
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,
-			onlyLinkInnerBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -371,7 +371,9 @@ export default compose( [
 		] )?.length;
 
 		const onlyLinkInnerBlocks = innerBlocks.every(
-			( block ) => block.name === 'core/navigation-link'
+			( block ) =>
+				block.name === 'core/navigation-link' ||
+				block.name === 'core/navigation-submenu'
 		);
 
 		return {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -50,10 +50,7 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
-const DIRECT_INSERT = [
-	'core/navigation-link',
-	{ type: 'page', kind: 'post-type' },
-];
+const DIRECT_INSERT = [ 'core/navigation-link' ];
 
 const LAYOUT = {
 	type: 'default',

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -50,6 +50,8 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
+const DIRECT_INSERT = 'core/navigation-link';
+
 const LAYOUT = {
 	type: 'default',
 	alignments: [],
@@ -90,6 +92,7 @@ function Navigation( {
 	hasExistingNavItems,
 	isImmediateParentOfSelectedBlock,
 	isSelected,
+	onlyLinkInnerBlocks,
 	updateInnerBlocks,
 	className,
 	backgroundColor,
@@ -164,6 +167,7 @@ function Navigation( {
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
+			directInsert: onlyLinkInnerBlocks ? DIRECT_INSERT : '',
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
 
@@ -366,6 +370,10 @@ export default compose( [
 			selectedBlockId,
 		] )?.length;
 
+		const onlyLinkInnerBlocks = innerBlocks.every(
+			( block ) => block.name === 'core/navigation-link'
+		);
+
 		return {
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
@@ -374,6 +382,7 @@ export default compose( [
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,
+			onlyLinkInnerBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -50,7 +50,7 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
-const DIRECT_INSERT = [ 'core/navigation-link' ];
+const DEFAULT_BLOCK = [ 'core/navigation-link' ];
 
 const LAYOUT = {
 	type: 'default',
@@ -161,18 +161,14 @@ function Navigation( {
 			? undefined
 			: false;
 
-	const directInsertValue = useMemo(
-		() => ( onlyLinkInnerBlocks ? DIRECT_INSERT : [] ),
-		[ onlyLinkInnerBlocks ]
-	);
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
 		},
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
-			directInsert: directInsertValue,
+			__experimentalDefaultBlock: DEFAULT_BLOCK,
+			__experimentalDirectInsert: onlyLinkInnerBlocks,
 			orientation: attributes.orientation,
 			renderAppender: CustomAppender || appender,
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -95,7 +95,7 @@ function Navigation( {
 	hasExistingNavItems,
 	isImmediateParentOfSelectedBlock,
 	isSelected,
-	onlyLinkInnerBlocks,
+	innerBlocks,
 	updateInnerBlocks,
 	className,
 	backgroundColor,
@@ -163,6 +163,12 @@ function Navigation( {
 		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants )
 			? undefined
 			: false;
+
+	const onlyLinkInnerBlocks = innerBlocks.every(
+		( block ) =>
+			block.name === 'core/navigation-link' ||
+			block.name === 'core/navigation-submenu'
+	);
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
@@ -373,12 +379,6 @@ export default compose( [
 			selectedBlockId,
 		] )?.length;
 
-		const onlyLinkInnerBlocks = innerBlocks.every(
-			( block ) =>
-				block.name === 'core/navigation-link' ||
-				block.name === 'core/navigation-submenu'
-		);
-
 		return {
 			isImmediateParentOfSelectedBlock,
 			selectedBlockHasDescendants,
@@ -387,7 +387,7 @@ export default compose( [
 			// This prop is already available but computing it here ensures it's
 			// fresh compared to isImmediateParentOfSelectedBlock
 			isSelected: selectedBlockId === clientId,
-			onlyLinkInnerBlocks,
+			innerBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/blocks/__snapshots__/navigation.test.js.snap
@@ -44,6 +44,16 @@ exports[`Navigation Creating from existing Pages allows a navigation block to be
 <!-- /wp:navigation -->"
 `;
 
+exports[`Navigation Shows the quick inserter when the block contains non-navigation specific blocks 1`] = `
+"<!-- wp:navigation -->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+
+<!-- wp:site-title /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"WP News\\",\\"url\\":\\"https://wordpress.org/news/\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+<!-- /wp:navigation -->"
+`;
+
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -246,17 +246,6 @@ async function createEmptyNavBlock() {
 	await startEmptyButton.click();
 }
 
-async function addLinkBlock() {
-	// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
-	// an issue where the block appender requires two clicks.
-	await page.click( '.wp-block-navigation .block-list-appender' );
-
-	const [ linkButton ] = await page.$x(
-		"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Custom Link']"
-	);
-	await linkButton.click();
-}
-
 async function toggleSidebar() {
 	await page.click(
 		'.edit-post-header__settings button[aria-label="Settings"]'
@@ -414,7 +403,7 @@ describe( 'Navigation', () => {
 
 		await createEmptyNavBlock();
 
-		await addLinkBlock();
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// Add a link to the Link block.
 		await updateActiveNavigationLink( {
@@ -425,7 +414,7 @@ describe( 'Navigation', () => {
 
 		await showBlockToolbar();
 
-		await addLinkBlock();
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// After adding a new block, search input should be shown immediately.
 		// Verify that Escape would close the popover.
@@ -477,7 +466,7 @@ describe( 'Navigation', () => {
 
 		await createEmptyNavBlock();
 
-		await addLinkBlock();
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// Add a link to the Link block.
 		await updateActiveNavigationLink( {
@@ -487,7 +476,7 @@ describe( 'Navigation', () => {
 
 		await showBlockToolbar();
 
-		await addLinkBlock();
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// Wait for URL input to be focused
 		await page.waitForSelector(
@@ -548,7 +537,7 @@ describe( 'Navigation', () => {
 		// Create an empty nav block.
 		await createEmptyNavBlock();
 
-		await addLinkBlock();
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// Wait for URL input to be focused
 		await page.waitForSelector(
@@ -640,6 +629,46 @@ describe( 'Navigation', () => {
 
 		// Assert the correct number of button toggles are present.
 		expect( navSubmenusLength ).toEqual( navButtonTogglesLength );
+	} );
+
+	it( 'Shows the quick inserter when the block contains non-navigation specific blocks', async () => {
+		// Add the navigation block.
+		await insertBlock( 'Navigation' );
+
+		// Create an empty nav block.
+		await page.waitForSelector( '.wp-block-navigation-placeholder' );
+
+		await createEmptyNavBlock();
+
+		// Add a Link block first.
+		await page.click( '.wp-block-navigation .block-list-appender' );
+
+		// Add a link to the Link block.
+		await updateActiveNavigationLink( {
+			url: 'https://wordpress.org',
+			label: 'WP',
+			type: 'url',
+		} );
+
+		// Now add a different block type.
+		await insertBlock( 'Site Title' );
+
+		// Now try inserting another Link block via the quick inserter.
+		await page.click( '.wp-block-navigation .block-list-appender' );
+
+		const [ linkButton ] = await page.$x(
+			"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Custom Link']"
+		);
+		await linkButton.click();
+
+		await updateActiveNavigationLink( {
+			url: 'https://wordpress.org/news/',
+			label: 'WP News',
+			type: 'url',
+		} );
+
+		// Expect a Navigation block with two links and a Site Title.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	// The following tests are unstable, roughly around when https://github.com/WordPress/wordpress-develop/pull/1412

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -380,11 +380,6 @@ describe( 'Navigation editor', () => {
 		);
 		await appender.click();
 
-		const linkInserterItem = await page.waitForXPath(
-			'//button[@role="option"]//span[.="Custom Link"]'
-		);
-		await linkInserterItem.click();
-
 		await page.waitForSelector( 'input[aria-label="URL"]' );
 
 		// The link suggestions should be searchable.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

First steps to address #34041:

Changes Navigation block appender to insert Navigation Links by default, unless there are other types of blocks in the Navigation block already. 

This is a rough draft so we can have a play and see how it feels. 

One thing I'm not sure about is how it should behave when we "Add all pages". Due to the Page List being a different block type, should we show the quick inserter? Or should we treat Page List as if it were just a bunch of Navigation Links?

~~The other question is how to address submenu: when a Submenu block is added, the quick inserter will appear because Submenus are a different block type. But because they are often part of simple navs, should we consider them the same as Navigation Links?~~

~~Likewise, it might be good to insert links by default inside submenus too.~~

Updated to insert links by default when submenus are present (and inside submenus).


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Add a Navigation block, choose "Start Empty" and click the plus button. A Navigation Link block should be inserted straightway. 
* From the top inserter, insert a different type of block, e.g. Search. Clicking the plus button should now show the quick inserter.
* In the Navigation screen, check that Navigation Link blocks are inserted straightway.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is more of an enhancement than a new feature, but 🤷 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
