### PR TITLE
Button: Add prefix to the description ID

### DIFF
--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -3,13 +3,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isArray, uniqueId } from 'lodash';
+import { isArray } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
 import { forwardRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -86,6 +87,7 @@ export function Button( props, ref ) {
 		describedBy,
 		...additionalProps
 	} = useDeprecatedProps( props );
+	const instanceId = useInstanceId( Button );
 
 	const classes = classnames( 'components-button', className, {
 		'is-secondary': variant === 'secondary',
@@ -139,7 +141,9 @@ export function Button( props, ref ) {
 				// the tooltip is not explicitly disabled.
 				false !== showTooltip ) );
 
-	const descriptionId = describedBy ? uniqueId() : null;
+	const descriptionId = describedBy
+		? `components-button__description-${ instanceId }`
+		: null;
 
 	const describedById =
 		additionalProps[ 'aria-describedby' ] || descriptionId;

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -87,7 +87,10 @@ export function Button( props, ref ) {
 		describedBy,
 		...additionalProps
 	} = useDeprecatedProps( props );
-	const instanceId = useInstanceId( Button );
+	const instanceId = useInstanceId(
+		Button,
+		'components-button__description'
+	);
 
 	const classes = classnames( 'components-button', className, {
 		'is-secondary': variant === 'secondary',
@@ -141,9 +144,7 @@ export function Button( props, ref ) {
 				// the tooltip is not explicitly disabled.
 				false !== showTooltip ) );
 
-	const descriptionId = describedBy
-		? `components-button__description-${ instanceId }`
-		: null;
+	const descriptionId = describedBy ? instanceId : null;
 
 	const describedById =
 		additionalProps[ 'aria-describedby' ] || descriptionId;


### PR DESCRIPTION
## Description
Adds a prefix to the `descriptionId` since HTML IDs must start with this string.

Replaces `uniqueId()` with `useInstanceId()` so values are memoized.

Fixes #34879.

## How has this been tested?
1. Inspect the Block Switcher element.
2. The `aria-describedby` value should follow this pattern:

```js
`components-button__description-${ instanceId }`
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-17 at 11 53 37](https://user-images.githubusercontent.com/240569/133746066-1a8e80c6-e0c3-40a7-8e6c-15cd81ac14b8.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
