### PR TITLE
Try: Fix Global Styles double border.

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -36,7 +36,6 @@
 	align-items: center;
 	padding: 0 $grid-unit-20;
 	height: $grid-unit-60;
-	border-top: $border-width solid $gray-300;
 	border-bottom: $border-width solid $gray-300;
 
 	h2 {
@@ -50,7 +49,7 @@
 .components-panel__body + .components-panel__header,
 .components-panel__header + .components-panel__body,
 .components-panel__header + .components-panel__header {
-	margin-top: -1px;
+	margin-top: -$border-width;
 }
 
 .components-panel__body > .components-panel__body-title {


### PR DESCRIPTION
## Description

The Global Styles sidebar has a top double border:

<img width="347" alt="Screenshot 2021-09-17 at 14 21 31" src="https://user-images.githubusercontent.com/1204802/133781769-6f4133ce-3a20-41ca-b1ed-4aa132552cf6.png">

This PR removes it:

<img width="420" alt="Screenshot 2021-09-17 at 14 15 56" src="https://user-images.githubusercontent.com/1204802/133781776-9c9a67b0-34f3-4b15-a9c6-974ecd6da4a6.png">

Note that removing the top border entirely doesn't appear to have any side effects such as missing borders, that I could find. I did also try this type of rule:

```
.components-panel__header {
	...
	border-bottom: $border-width solid $gray-300;

	& + .components-panel__header {
		border-top: $border-width solid $gray-300;	
	}
}
```

That would theoretically have kept the top border for the case where the panel header wasn't the first in the sidebar, and where it followed an element that didn't have a bottom border. 

However that rule doesn't work as it appears at any given time we have two panel headers, one for small screens, one for large screens:

```
			<div className="components-panel__header interface-complementary-area-header__small">
				{ smallScreenTitle && (
					<span className="interface-complementary-area-header__small-title">
						{ smallScreenTitle }
					</span>
				) }
				{ toggleButton }
			</div>
			<div
				className={ classnames(
					'components-panel__header',
					'interface-complementary-area-header',
					className
				) }
				tabIndex={ -1 }
			>
				{ children }
				{ toggleButton }
			</div>
```

Is that still necessary? It seems like we might be able to get away with a single one.

## How has this been tested?

Test the global styles sidebar and verify there's a single top border.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
