### PR TITLE
[Inserter]: Pass filter value when clicking `Browse All`

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -21,6 +21,7 @@ function InserterLibrary( {
 	showInserterHelpPanel,
 	showMostUsedBlocks = false,
 	__experimentalInsertionIndex,
+	__experimentalFilterValue,
 	onSelect = noop,
 	shouldFocusBlock = false,
 } ) {
@@ -44,6 +45,7 @@ function InserterLibrary( {
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
+			__experimentalFilterValue={ __experimentalFilterValue }
 			shouldFocusBlock={ shouldFocusBlock }
 		/>
 	);

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -27,9 +27,12 @@ function InserterMenu( {
 	onSelect,
 	showInserterHelpPanel,
 	showMostUsedBlocks,
+	__experimentalFilterValue = '',
 	shouldFocusBlock = true,
 } ) {
-	const [ filterValue, setFilterValue ] = useState( '' );
+	const [ filterValue, setFilterValue ] = useState(
+		__experimentalFilterValue
+	);
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
 		null

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -75,7 +75,7 @@ export default function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected
 	const onBrowseAll = () => {
-		setInserterIsOpened( { rootClientId, insertionIndex } );
+		setInserterIsOpened( { rootClientId, insertionIndex, filterValue } );
 	};
 
 	return (

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -11,6 +11,7 @@ import {
 	searchForBlock,
 	setBrowserViewport,
 	showBlockToolbar,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
@@ -352,6 +353,28 @@ describe( 'Inserting blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Paragraph inside group' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'passes the search value in the main inserter when clicking `Browse all`', async () => {
+		const INSERTER_SEARCH_SELECTOR =
+			'.block-editor-inserter__search input,.block-editor-inserter__search-input,input.block-editor-inserter__search';
+		await insertBlock( 'Group' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Text' );
+		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
+		await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
+		await page.focus( INSERTER_SEARCH_SELECTOR );
+		await pressKeyWithModifier( 'primary', 'a' );
+		const searchTerm = 'Heading';
+		await page.keyboard.type( searchTerm );
+		const browseAll = await page.waitForXPath(
+			'//button[text()="Browse all"]'
+		);
+		await browseAll.click();
+		const availableBlocks = await page.$$(
+			'.block-editor-block-types-list__list-item'
+		);
+		expect( availableBlocks ).toHaveLength( 1 );
 	} );
 
 	// Check for regression of https://github.com/WordPress/gutenberg/issues/27586

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -53,6 +53,7 @@ export default function InserterSidebar() {
 					__experimentalInsertionIndex={
 						insertionPoint.insertionIndex
 					}
+					__experimentalFilterValue={ insertionPoint.filterValue }
 				/>
 			</div>
 		</div>

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -338,11 +338,15 @@ export function isInserterOpened( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {Object} The root client ID and index to insert at.
+ * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex } = state.blockInserterPanel;
-	return { rootClientId, insertionIndex };
+	const {
+		rootClientId,
+		insertionIndex,
+		filterValue,
+	} = state.blockInserterPanel;
+	return { rootClientId, insertionIndex, filterValue };
 }
 
 /**

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -47,6 +47,7 @@ export default function InserterSidebar() {
 					__experimentalInsertionIndex={
 						insertionPoint.insertionIndex
 					}
+					__experimentalFilterValue={ insertionPoint.filterValue }
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -239,11 +239,15 @@ export function isInserterOpened( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {Object} The root client ID and index to insert at.
+ * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex } = state.blockInserterPanel;
-	return { rootClientId, insertionIndex };
+	const {
+		rootClientId,
+		insertionIndex,
+		filterValue,
+	} = state.blockInserterPanel;
+	return { rootClientId, insertionIndex, filterValue };
 }
 
 /**


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/34607

From the ticket:

>When searching blocks from the Quick Inserter, if I can't find what I'm looking for, I am presented with a "No results found" notice with the persistent "Browse all" button below it.

>When selecting "Browse all" the Quick Inserter closes and the Block Library sidebar opens up in its default state. At this point, the experience of not finding a block or pattern is completely ignored. I am starting my search over within the Block Library, which brings in results from the Block Directory to hopefully suggest relative blocks.

This PR implements the second proposed solution:
>Selecting "Browse all" carries the search term(s) to the Block Library sidebar

## Testing instructions
1. Open the `Quick inserter`, enter a search term and click `Browse All`
2. Observe that the searched term is carried over to the main inserter

## Screenshot

https://user-images.githubusercontent.com/16275880/133805170-420379d8-13cd-46db-b8ab-c98c7a80887b.mov



## Notes
1. The `__experimentalGetInsertionPoint` that is used to pass the filter value might not a very good fit semantically. Should we rename `__experimentalGetInsertionPoint`? Should I create new actions/selectors, etc...? WDYT?
2. I have updated only the post and site editors for now to gather feedback. The additions to other screens is easy if we proceed..