### PR TITLE
`ControlLabel`: refactor away from the `createComponent` function

### DIFF
--- a/packages/components/src/ui/control-label/component.js
+++ b/packages/components/src/ui/control-label/component.js
@@ -1,8 +1,19 @@
 /**
  * Internal dependencies
  */
-import { createComponent } from '../utils';
+import { contextConnect } from '../context';
+import { View } from '../../view';
 import { useControlLabel } from './hook';
+
+/**
+ * @param {import('../context').WordPressComponentProps<import('./types').Props, 'label'>} props
+ * @param {import('react').Ref<any>}                                                       forwardedRef
+ */
+function ControlLabel( props, forwardedRef ) {
+	const controlLabelProps = useControlLabel( props );
+
+	return <View as="label" { ...controlLabelProps } ref={ forwardedRef } />;
+}
 
 /**
  * `ControlLabel` is a form component that works with `FormGroup` to provide a
@@ -21,10 +32,6 @@ import { useControlLabel } from './hook';
  * }
  * ```
  */
-const ControlLabel = createComponent( {
-	as: 'label',
-	useHook: useControlLabel,
-	name: 'ControlLabel',
-} );
+const ConnectedControlLabel = contextConnect( ControlLabel, 'ControlLabel' );
 
-export default ControlLabel;
+export default ConnectedControlLabel;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes partially #34290.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Technically there should be no behavioral changes.

The project should build, the tests should pass, the component should behave as before in Storybook and in the block editor.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->