### PR TITLE
Add styling for disabled options in ToggleGroupControl and try polish

### DIFF
--- a/packages/components/src/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/styles.ts
@@ -68,7 +68,7 @@ export const buttonView = css`
 	background: transparent;
 	border: none;
 	border-radius: ${ CONFIG.controlBorderRadius };
-	color: ${ COLORS.gray[ 700 ] };
+	color: ${ COLORS.ui.label };
 	cursor: pointer;
 	display: flex;
 	height: 100%;
@@ -98,13 +98,13 @@ export const buttonActive = css`
 	color: ${ COLORS.white };
 `;
 
+export const buttonDisabled = css`
+	color: ${ COLORS.ui.textDisabled };
+`;
+
 export const ButtonContentView = styled.div`
 	font-size: ${ CONFIG.fontSize };
 	line-height: 1;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
 `;
 
 export const SeparatorView = styled.div`
@@ -120,14 +120,6 @@ export const SeparatorView = styled.div`
 
 export const separatorActive = css`
 	background: transparent;
-`;
-
-export const LabelPlaceholderView = styled.div`
-	font-size: ${ CONFIG.fontSize };
-	font-weight: bold;
-	height: 0;
-	overflow: hidden;
-	visibility: hidden;
 `;
 
 export const medium = css`

--- a/packages/components/src/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -27,17 +27,12 @@ function ToggleGroupControlBackdrop( {
 		 * Workaround for Reakit
 		 */
 		const targetNode = containerNode.querySelector(
-			`[data-value="${ state }"]`
-		);
+			'[data-active="true"]'
+		) as HTMLElement;
 		if ( ! targetNode ) return;
 
-		const { x: parentX } = containerNode.getBoundingClientRect();
-		const { width: offsetWidth, x } = targetNode.getBoundingClientRect();
-		const borderWidth = 1;
-		const offsetLeft = x - parentX - borderWidth;
-
-		setLeft( offsetLeft );
-		setWidth( offsetWidth );
+		setLeft( targetNode.offsetLeft );
+		setWidth( targetNode.offsetWidth );
 
 		let requestId: number;
 		if ( ! canAnimate ) {

--- a/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
@@ -16,12 +16,7 @@ import * as styles from './styles';
 import type { ToggleGroupControlButtonProps } from './types';
 import { useCx } from '../utils/hooks';
 
-const {
-	ButtonContentView,
-	LabelPlaceholderView,
-	LabelView,
-	SeparatorView,
-} = styles;
+const { ButtonContentView, LabelView, SeparatorView } = styles;
 
 function ToggleGroupControlButton( {
 	className,
@@ -38,7 +33,7 @@ function ToggleGroupControlButton( {
 	const classes = cx(
 		styles.buttonView,
 		className,
-		isActive && styles.buttonActive
+		props.disabled ? styles.buttonDisabled : isActive && styles.buttonActive
 	);
 	return (
 		<LabelView className={ labelViewClasses } data-active={ isActive }>
@@ -52,9 +47,6 @@ function ToggleGroupControlButton( {
 				value={ value }
 			>
 				<ButtonContentView>{ label }</ButtonContentView>
-				<LabelPlaceholderView aria-hidden>
-					{ label }
-				</LabelPlaceholderView>
 			</Radio>
 			<ToggleGroupControlSeparator isActive={ ! showSeparator } />
 		</LabelView>

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -83,6 +83,7 @@ export type ToggleGroupControlButtonProps = {
 	showSeparator?: boolean;
 	value?: ReactText;
 	state?: any;
+	disabled?: boolean;
 };
 
 export type ToggleGroupControlBackdropProps = {


### PR DESCRIPTION
While working on #34893, I found that `ToggleGroupControl` has no styling for disabled options. It gets an inline `pointer-events: none` thanks to Reakit but that's it. So mainly this PR is about adding some basic styles to help differentiate disabled states. I think the difference may be too subtle but I'd like to get some feedback.

Besides that there are two more small changes that I think are improvements.

- The selected indicator can be a bit smudgy (probably difficult to discernible on 2x+ screens). In order to sharpen it up it needs to be sized and placed on whole pixels so the code is revised for integers and it ends up a bit simplified too.
- While looking around the component I found myself confused about the purpose of `LabelPlaceholderView`because it is both visually and aria-hidden. I removed it and still can't figure out what it does. I will not be surprised if I'm missing something and have to restore this though.

## How has this been tested?
Manually

## Screenshots

### Disabled Styles
Options 1 & 2 are disabled

Before | After
---|---
![image](https://user-images.githubusercontent.com/9000376/133953736-7ae74839-c4fe-4b4a-82b5-5f3543a79c51.png) | ![image](https://user-images.githubusercontent.com/9000376/133947869-d51f513d-c433-4a49-aae2-52cece41529a.png)

### Post Featured Image block inspector
Before: smudgy | After: crispy
---|---
![image](https://user-images.githubusercontent.com/9000376/133953033-b5e85c8e-b4f5-44be-9981-c8539e01df5b.png) | ![image](https://user-images.githubusercontent.com/9000376/133949922-9ccb454c-e754-4a8a-9af6-04222d3beb58.png)
![image](https://user-images.githubusercontent.com/9000376/133952933-b87705d7-fe57-482b-86fe-17fb99902872.png)| ![image](https://user-images.githubusercontent.com/9000376/133949971-b4f312b9-ea30-4f00-a45c-882ac9bf7ed4.png)

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
