### PR TITLE
Fix save-state indicator appearance.

### DIFF
--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -7,6 +7,13 @@
 	overflow: hidden;
 	white-space: nowrap;
 
+	// The disabled version of the save state should be legible as an indicator.
+	&.is-saved[aria-disabled="true"],
+	&.is-saved[aria-disabled="true"]:hover {
+		background: transparent;
+		color: $gray-700;
+	}
+
 	svg {
 		display: inline-block;
 		flex: 0 0 auto;
@@ -20,7 +27,7 @@
 		text-indent: inherit;
 
 		svg {
-			margin-right: $grid-unit-05;
+			margin-right: 0;
 		}
 	}
 }


### PR DESCRIPTION
## Description

A recent refactor of the save state made it a disabled button rather than just text, causing it to have a gray background:

<img width="476" alt="Screenshot 2021-09-20 at 08 40 56" src="https://user-images.githubusercontent.com/1204802/133965161-2579cb6a-1067-4d27-94fe-cbf0fc16bd2f.png">

This PR fixes that:
<img width="372" alt="Screenshot 2021-09-20 at 08 47 15" src="https://user-images.githubusercontent.com/1204802/133965172-97703c17-e680-41f2-b7f0-cd3a95a43b98.png">




## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
