### PR TITLE
Try: Fix missing save label.

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -154,7 +154,7 @@ export default function PostSavedState( {
 			shortcut={ displayShortcut.primary( 's' ) }
 			variant={ isLargeViewport ? 'tertiary' : undefined }
 			icon={ isLargeViewport ? undefined : cloudUpload }
-			label={ isLargeViewport ? undefined : label }
+			label={ label }
 			aria-disabled={ isDisabled }
 		>
 			{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -24,6 +24,7 @@ exports[`PostSavedState should return Save button if edits to be saved 1`] = `
 <ForwardRef(Button)
   aria-disabled={false}
   className="editor-post-save-draft"
+  label="Save draft"
   onClick={[Function]}
   shortcut="Ctrl+S"
   variant="tertiary"


### PR DESCRIPTION
## Description

The save state tooltip is missing a label:

<img width="210" alt="Screenshot 2021-09-20 at 08 53 17" src="https://user-images.githubusercontent.com/1204802/133967281-4cd61171-78f8-46bb-ab20-d35fc934fa96.png">

This PR adds it back:

<img width="182" alt="Screenshot 2021-09-20 at 09 12 20" src="https://user-images.githubusercontent.com/1204802/133967302-6a329f22-9977-47d8-ba58-675d3a7dfb48.png">

The gray background in that resting state is fixes separately in #34947.

Note that the ternery logic I removed here appears unneeded. The label is visually hidden on mobile, even without the logic.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
