### PR TITLE
Fix stroke width of resize handles.

### DIFF
--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -23,13 +23,16 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	content: "";
 	width: $resize-handler-size;
 	height: $resize-handler-size;
-	border: 2px solid var(--wp-admin-theme-color);
 	border-radius: 50%;
 	background: $white;
 	cursor: inherit;
 	position: absolute;
 	top: calc(50% - #{ceil($resize-handler-size * 0.5)});
 	right: calc(50% - #{ceil($resize-handler-size * 0.5)});
+
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	// Only visible in Windows High Contrast mode.
+	outline: 2px solid transparent;
 }
 
 // This is the "visible" resize handle for side handles - the line


### PR DESCRIPTION
## Description

The resize handles border-material is the same material as that used for focus styles. That is, 1.5px blue borders. But the resize handles are 2px bordered:

<img width="805" alt="Screenshot 2021-09-20 at 09 14 26" src="https://user-images.githubusercontent.com/1204802/133968063-fb94dce8-a76c-4afb-ac6f-b6baf376f9ee.png">

This PR fixes that to match:

<img width="828" alt="Screenshot 2021-09-20 at 09 19 32" src="https://user-images.githubusercontent.com/1204802/133968075-b890a470-4416-4df0-8a99-d0f317b0bbfa.png">


## How has this been tested?

Insert and image and observe a 1.5px blue border around the resize handle.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
