### PR TITLE
[Block: Post Navigation Link] Add an option for displaying the label inside the link

### DIFF
--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -19,6 +19,10 @@
 		"showTitle": {
 			"type": "boolean",
 			"default": false
+		},
+		"linkLabel": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -24,7 +24,8 @@ export default function PostNavigationLinkEdit( {
 	let placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
 
 	if ( showTitle ) {
-		placeholder = isNext ? __( 'Next:' ) : __( 'Previous:' );
+		/* translators: Label before for next and previous post. There is a space after the colon. */
+		placeholder = isNext ? __( 'Next: ' ) : __( 'Previous: ' );
 	}
 
 	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );
@@ -83,7 +84,14 @@ export default function PostNavigationLinkEdit( {
 						setAttributes( { label: newLabel } )
 					}
 				/>
-				{ showTitle && <span> { __( 'An example title' ) } </span> }
+				{ showTitle && (
+					<a
+						href="#post-navigation-pseudo-link"
+						onClick={ ( event ) => event.preventDefault() }
+					>
+						{ __( 'An example title' ) }
+					</a>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -17,11 +17,16 @@ import {
 import { __ } from '@wordpress/i18n';
 
 export default function PostNavigationLinkEdit( {
-	attributes: { type, label, showTitle, textAlign },
+	attributes: { type, label, showTitle, textAlign, linkLabel },
 	setAttributes,
 } ) {
 	const isNext = type === 'next';
-	const placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
+	let placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
+
+	if ( showTitle ) {
+		placeholder = isNext ? __( 'Next:' ) : __( 'Previous:' );
+	}
+
 	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -44,6 +49,19 @@ export default function PostNavigationLinkEdit( {
 							} )
 						}
 					/>
+					{ showTitle && (
+						<ToggleControl
+							label={ __(
+								'Include the label as part of the link'
+							) }
+							checked={ !! linkLabel }
+							onChange={ () =>
+								setAttributes( {
+									linkLabel: ! linkLabel,
+								} )
+							}
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
@@ -65,6 +83,7 @@ export default function PostNavigationLinkEdit( {
 						setAttributes( { label: newLabel } )
 					}
 				/>
+				{ showTitle && <span> { __( 'An example title' ) } </span> }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -43,9 +43,10 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 
 	// If we want to also show the page title, make the page title a link and prepend the label.
 	if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
-		/* If the label link option is not enabled but there is a custom label,
+		/*
+		 * If the label link option is not enabled but there is a custom label,
 		 * display the custom label as text before the linked title.
-		 **/
+		 */
 		if ( ! $attributes['linkLabel'] ) {
 			if ( $label ) {
 				$format = '<span class="post-navigation-link__label">' . $label . '</span> %link';
@@ -56,14 +57,16 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 			if ( $label ) {
 				$link = '<span class="post-navigation-link__label">' . $label . '</span> <span class="post-navigation-link__title">%title</title>';
 			} else {
-				/* If the label link option is enabled and there is no custom label,
+				/*
+				 * If the label link option is enabled and there is no custom label,
 				 * add a colon between the label and the post title.
 				 */
 				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
 				$link  = sprintf(
+					/* translators: 1: label. 2: post title */
 					__( '<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>' ),
 					$label,
-					'%title',
+					'%title'
 				);
 			}
 		}

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -54,13 +54,13 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
 			// If the label link option is enabled and there is a custom label, display it before the title.
 			if ( $label ) {
-				$link = '<span class="post-navigation-link__label">$label</span> <span class="post-navigation-link__title">%title</title>';
+				$link = '<span class="post-navigation-link__label">' . $label . '</span> <span class="post-navigation-link__title">%title</title>';
 			} else {
 				/* If the label link option is enabled and there is no custom label,
 				 * add a colon between the label and the post title.
 				 */
 				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
-				$link = sprintf(
+				$link  = sprintf(
 					__( '<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>' ),
 					$label,
 					'%title',

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -33,6 +33,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$format = '%link';
 	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
 	$label  = '';
+
 	// If a custom label is provided, make this a link.
 	// `$label` is used to prepend the provided label, if we want to show the page title as well.
 	if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
@@ -42,11 +43,32 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 
 	// If we want to also show the page title, make the page title a link and prepend the label.
 	if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
-		if ( $label ) {
-			$format = "$label %link";
+		/* If the label link option is not enabled but there is a custom label,
+		 * display the custom label as text before the linked title.
+		 **/
+		if ( ! $attributes['linkLabel'] ) {
+			if ( $label ) {
+				$format = '<span class="post-navigation-link__label">' . $label . '</span> %link';
+			}
+			$link = '%title';
+		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
+			// If the label link option is enabled and there is a custom label, display it before the title.
+			if ( $label ) {
+				$link = '<span class="post-navigation-link__label">$label</span> <span class="post-navigation-link__title">%title</title>';
+			} else {
+				/* If the label link option is enabled and there is no custom label,
+				 * add a colon between the label and the post title.
+				 */
+				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
+				$link = sprintf(
+					__( '<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>' ),
+					$label,
+					'%title',
+				);
+			}
 		}
-		$link = '%title';
 	}
+
 	// The dynamic portion of the function name, `$navigation_type`,
 	// refers to the type of adjacency, 'next' or 'previous'.
 	$get_link_function = "get_{$navigation_type}_post_link";

--- a/test/integration/fixtures/blocks/core__post-navigation-link.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link.json
@@ -5,7 +5,8 @@
 		"isValid": true,
 		"attributes": {
 			"type": "next",
-			"showTitle": false
+			"showTitle": false,
+			"linkLabel": false
 		},
 		"innerBlocks": [],
 		"originalContent": ""


### PR DESCRIPTION
[Block: Post Navigation Link] Add the ability to have both the text title and the label be a part of the link
Closes #29032

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
An option to include the label as part of the link is displayed when the display the title as a link option is enabled.

With the PR, the following scenarios will be possible:

- Default Next and Previous label, linked
- Post title without label, linked
- Default Next and Previous labels followed by the post title, linked
- Custom label, linked
- Custom label followed by the post title, linked
- Custom label that is not linked, followed by the post title that is linked

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add two post navigation link blocks, one for each variation
2. Test that the default is unchanged.
3. Enable the "Display the title as a link" option and view the front. 
4. Confirm that the label is not visible and the title is showing.
5. With the "Display the title as a link option" enabled, enable the "Include the label as part of the link" option and view the front.
6. Confirm that both the label and the title are showing and are linked.

Add a custom label and retest the options.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
