### PR TITLE
Resize handles: Grow on hover/active.

### DIFF
--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -29,16 +29,23 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	position: absolute;
 	top: calc(50% - #{ceil($resize-handler-size * 0.5)});
 	right: calc(50% - #{ceil($resize-handler-size * 0.5)});
+	transition: all 0.1s ease;
+	@include reduce-motion("transition");
 
 	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	// Only visible in Windows High Contrast mode.
 	outline: 2px solid transparent;
 }
 
+.components-resizable-box__handle:active::after,
+.components-resizable-box__handle:hover::after {
+	box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) var(--wp-admin-theme-color);
+}
+
 // This is the "visible" resize handle for side handles - the line
 .components-resizable-box__side-handle::before {
 	display: block;
-	border-radius: 2px;
+	border-radius: $radius-block-ui;
 	content: "";
 	width: 3px;
 	height: 3px;


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/34949#issuecomment-922754115. This PR makes the stroke width of the resize handle match the width of the vertical resize indicator:

![resize](https://user-images.githubusercontent.com/1204802/133981255-92ebee0f-d81f-404d-80fc-9666e9c7a09f.gif)

## How has this been tested?

Insert an image, then resize it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
