### PR TITLE
Try: Polish wavy underline

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -646,7 +646,7 @@ export default function NavigationLinkEdit( {
 					{ /* eslint-enable */ }
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
-							{ missingText }
+							<span>{ missingText }</span>
 						</div>
 					) : (
 						<RichText

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -88,9 +88,14 @@
 		$stop1: 30%;
 		$stop2: 64%;
 
+		--wp-underline-color: var(--wp-admin-theme-color);
+		.is-dark-theme & {
+			--wp-underline-color: #{ $dark-theme-focus };
+		}
+
 		background-image:
-			linear-gradient(45deg, transparent ($stop1 - $blur), currentColor $stop1, currentColor ($stop1 + $width), transparent ($stop1 + $width + $blur)),
-			linear-gradient(135deg, transparent ($stop2 - $blur), currentColor $stop2, currentColor ($stop2 + $width), transparent ($stop2 + $width + $blur));
+			linear-gradient(45deg, transparent ($stop1 - $blur), var(--wp-underline-color) $stop1, var(--wp-underline-color) ($stop1 + $width), transparent ($stop1 + $width + $blur)),
+			linear-gradient(135deg, transparent ($stop2 - $blur), var(--wp-underline-color) $stop2, var(--wp-underline-color) ($stop2 + $width), transparent ($stop2 + $width + $blur));
 		background-position: 0 100%;
 		background-size: 6px 3px;
 		background-repeat: repeat-x;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -82,7 +82,7 @@
 	position: relative;
 
 	// Draw a wavy underline.
-	.wp-block-navigation-link__placeholder-text {
+	.wp-block-navigation-link__placeholder-text span {
 		$blur: 10%;
 		$width: 6%;
 		$stop1: 30%;
@@ -94,6 +94,10 @@
 		background-position: 0 100%;
 		background-size: 6px 3px;
 		background-repeat: repeat-x;
+
+		// Since applied to a span, it doesn't change the footprint of the item,
+		// but it does vertically shift the underline to better align.
+		padding-bottom: 0.1em;
 	}
 
 	// This needs extra specificity.


### PR DESCRIPTION
## Description

Fixes #34780. When you insert a menu item in a navigation menu, but do not point it to a destination, this unlinked item will not be published or shown on the frontend. To indicate this missing piece, a wavy underline is shown so as to — just like grammar tools — indicate that this item needs attention.

However the wavy underline as implemented currently is affected by line-height, so it can sit far from the text:

<img width="686" alt="Screenshot 2021-09-20 at 11 40 00" src="https://user-images.githubusercontent.com/1204802/133984140-0d627a08-18ed-4b36-afcc-48d23e6a1650.png">

This PR fixes that by wrapping the text in an inline element, ensuring the underline will always sit the same distance below the text:

<img width="671" alt="Screenshot 2021-09-20 at 11 44 44" src="https://user-images.githubusercontent.com/1204802/133984198-62350892-ada2-400d-8c9f-e74d84c29c39.png">

It also adds the admin theme spot color to the underline, to share some block editor UI DNA:

<img width="587" alt="Screenshot 2021-09-20 at 11 48 23" src="https://user-images.githubusercontent.com/1204802/133984312-fe0b79a3-630e-403f-b2a7-9ce66521c9bb.png">

_If the theme has a dark background, white will be used instead of the spot color._

The spot color is perhaps more visible when shown in context of the rest of the UI:

<img width="1270" alt="Screenshot 2021-09-20 at 11 50 36" src="https://user-images.githubusercontent.com/1204802/133984409-167ff5e4-0692-4251-9998-2c169e528bc0.png">

This PR would likely pair well with #34486.

## How has this been tested?

Insert a navigation block, then add a new page item. But instead of choosing a page to link to, press Escape. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
