### PR TITLE
Fix theme supports for themes without theme.json

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -595,7 +595,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array  $preset_per_origin Array of presets keyed by origin.
 	 * @param string $value_key         The property of the preset that contains its value.
-	 * @param array $origins            List of origins to process.
+	 * @param array  $origins           List of origins to process.
 	 *
 	 * @return array Array of presets where each key is a slug and each value is the preset value.
 	 */
@@ -622,6 +622,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array  $settings Settings to process.
 	 * @param string $selector Selector wrapping the classes.
+	 * @param array  $origins  List of origins to process.
 	 *
 	 * @return string The result of processing the presets.
 	 */
@@ -1081,7 +1082,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *                         'block_styles': only block & preset classes.
 	 *                         'css_variables': only css variables.
 	 *                         'presets': only css variables and preset classes.
-	 * @param array $origins A list of origins to include. By default it includes 'core', 'theme', and 'user'.
+	 * @param array  $origins A list of origins to include. By default it includes 'core', 'theme', and 'user'.
 	 *
 	 * @return string Stylesheet.
 	 */

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -595,12 +595,13 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array  $preset_per_origin Array of presets keyed by origin.
 	 * @param string $value_key         The property of the preset that contains its value.
+	 * @param array $origins            List of origins to process.
 	 *
 	 * @return array Array of presets where each key is a slug and each value is the preset value.
 	 */
-	private static function get_merged_preset_by_slug( $preset_per_origin, $value_key ) {
+	private static function get_merged_preset_by_slug( $preset_per_origin, $value_key, $origins ) {
 		$result = array();
-		foreach ( self::VALID_ORIGINS as $origin ) {
+		foreach ( $origins as $origin ) {
 			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
 				continue;
 			}
@@ -624,7 +625,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @return string The result of processing the presets.
 	 */
-	private static function compute_preset_classes( $settings, $selector ) {
+	private static function compute_preset_classes( $settings, $selector, $origins ) {
 		if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
 			// Classes at the global level do not need any CSS prefixed,
 			// and we don't want to increase its specificity.
@@ -634,7 +635,7 @@ class WP_Theme_JSON_Gutenberg {
 		$stylesheet = '';
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
-			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
+			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'], $origins );
 			foreach ( $preset['classes'] as $class ) {
 				foreach ( $preset_by_slug as $slug => $value ) {
 					$stylesheet .= self::to_ruleset(
@@ -666,14 +667,15 @@ class WP_Theme_JSON_Gutenberg {
 	 * ```
 	 *
 	 * @param array $settings Settings to process.
+	 * @param array $origins  List of origins to process.
 	 *
 	 * @return array Returns the modified $declarations.
 	 */
-	private static function compute_preset_vars( $settings ) {
+	private static function compute_preset_vars( $settings, $origins ) {
 		$declarations = array();
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
-			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
+			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'], $origins );
 			foreach ( $preset_by_slug as $slug => $value ) {
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . gutenberg_experimental_to_kebab_case( $slug ),
@@ -769,10 +771,11 @@ class WP_Theme_JSON_Gutenberg {
 	 *   }
 	 *
 	 * @param array $nodes Nodes with settings.
+	 * @param array $origins List of origins to process.
 	 *
 	 * @return string The new stylesheet.
 	 */
-	private function get_css_variables( $nodes ) {
+	private function get_css_variables( $nodes, $origins ) {
 		$stylesheet = '';
 		foreach ( $nodes as $metadata ) {
 			if ( null === $metadata['selector'] ) {
@@ -782,7 +785,7 @@ class WP_Theme_JSON_Gutenberg {
 			$selector = $metadata['selector'];
 
 			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
-			$declarations = array_merge( self::compute_preset_vars( $node ), self::compute_theme_vars( $node ) );
+			$declarations = array_merge( self::compute_preset_vars( $node, $origins ), self::compute_theme_vars( $node ) );
 
 			$stylesheet .= self::to_ruleset( $selector, $declarations );
 		}
@@ -858,10 +861,11 @@ class WP_Theme_JSON_Gutenberg {
 	 *   }
 
 	 * @param array $setting_nodes Nodes with settings.
+	 * @param array $origins       List of origins to process presets from.
 	 *
 	 * @return string The new stylesheet.
 	 */
-	private function get_preset_classes( $setting_nodes ) {
+	private function get_preset_classes( $setting_nodes, $origins ) {
 		$preset_rules = '';
 
 		foreach ( $setting_nodes as $metadata ) {
@@ -871,7 +875,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			$selector      = $metadata['selector'];
 			$node          = _wp_array_get( $this->theme_json, $metadata['path'], array() );
-			$preset_rules .= self::compute_preset_classes( $node, $selector );
+			$preset_rules .= self::compute_preset_classes( $node, $selector, $origins );
 		}
 
 		return $preset_rules;
@@ -1072,27 +1076,29 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the stylesheet that results of processing
 	 * the theme.json structure this object represents.
 	 *
-	 * @param string $type Type of stylesheet. It accepts:
-	 *                     'all': css variables, block classes, preset classes. The default.
-	 *                     'block_styles': only block & preset classes.
-	 *                     'css_variables': only css variables.
-	 *                     'presets': only css variables and preset classes.
+	 * @param string $type   Type of stylesheet. It accepts:
+	 *                         'all': css variables, block classes, preset classes. The default.
+	 *                         'block_styles': only block & preset classes.
+	 *                         'css_variables': only css variables.
+	 *                         'presets': only css variables and preset classes.
+	 * @param array $origins A list of origins to include. By default it includes 'core', 'theme', and 'user'.
+	 *
 	 * @return string Stylesheet.
 	 */
-	public function get_stylesheet( $type = 'all' ) {
+	public function get_stylesheet( $type = 'all', $origins = self::VALID_ORIGINS ) {
 		$blocks_metadata = self::get_blocks_metadata();
 		$style_nodes     = self::get_style_nodes( $this->theme_json, $blocks_metadata );
 		$setting_nodes   = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
 
 		switch ( $type ) {
 			case 'block_styles':
-				return $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes );
+				return $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes, $origins );
 			case 'css_variables':
-				return $this->get_css_variables( $setting_nodes );
+				return $this->get_css_variables( $setting_nodes, $origins );
 			case 'presets':
-				return $this->get_css_variables( $setting_nodes ) . $this->get_preset_classes( $setting_nodes );
+				return $this->get_css_variables( $setting_nodes, $origins ) . $this->get_preset_classes( $setting_nodes, $origins );
 			default:
-				return $this->get_css_variables( $setting_nodes ) . $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes );
+				return $this->get_css_variables( $setting_nodes, $origins ) . $this->get_block_classes( $style_nodes ) . $this->get_preset_classes( $setting_nodes, $origins );
 		}
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -411,17 +411,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$result->merge( self::get_core_data() );
 
 		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
-		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
-		$result->merge( $with_theme_supports );
-
-		if (
-			! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
-			! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
-			) {
-			return $result;
-		}
-
-		$result->merge( self::get_theme_data() );
+		$result->merge( self::get_theme_data( $theme_support_data ) );
 
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -410,7 +410,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
 
-		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
+		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
 		$result->merge( self::get_theme_data( $theme_support_data ) );
 
 		if ( 'user' === $origin ) {

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -410,15 +410,18 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
 
+		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
+		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
+		$result->merge( $with_theme_supports );
+
 		if (
 			! get_theme_support( 'experimental-link-color' ) && // link color support needs the presets CSS variables regardless of the presence of theme.json file.
 			! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
-		) {
+			) {
 			return $result;
 		}
 
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
-		$result->merge( self::get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_theme_data() );
 
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,11 +10,11 @@
  * the corresponding stylesheet.
  *
  * @param WP_Theme_JSON_Gutenberg $tree Input tree.
- * @param string                  $type Type of stylesheet we want accepts 'all', 'block_styles', 'css_variables', and 'presets'.
+ * @param string                  $type Type of stylesheet. It accepts 'all', 'block_styles', 'css_variables', 'presets'.
  *
  * @return string Stylesheet.
  */
-function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'all' ) {
+function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = null ) {
 	// Check if we can use cached.
 	$can_use_cached = (
 		( 'all' === $type ) &&
@@ -35,7 +35,27 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = 'al
 		}
 	}
 
-	$stylesheet = $tree->get_stylesheet( $type );
+	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+	$supports_link_color = get_theme_support( 'experimental-link-color' );
+
+	// Only modify the $type if the consumer hasn't provided any.
+	if ( $type === null && ! $supports_theme_json ) {
+		$type = 'presets';
+	} else if ( $type === null ) {
+		$type = 'all';
+	}
+
+	$origins = array( 'core', 'theme', 'user' );
+	if ( ! $supports_theme_json && ! $supports_link_color ) {
+		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
+		$origins = array( 'core' );
+	} else if ( ! $supports_theme_json && $supports_link_color ) {
+		// For the legacy link color feauter to work, the CSS Custom Properties
+		// should be in scope (either the core or the theme ones).
+		$origins = array( 'core', 'theme' );
+	}
+
+	$stylesheet = $tree->get_stylesheet( $type, $origins );
 
 	if ( $can_use_cached ) {
 		// Cache for a minute.
@@ -54,11 +74,7 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 	$settings = gutenberg_get_default_block_editor_settings();
 	$all      = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
 
-	$type = 'all';
-	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$type = 'presets';
-	}
-	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all, $type );
+	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
 	if ( empty( $stylesheet ) ) {
 		return;
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -39,9 +39,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = nul
 	$supports_link_color = get_theme_support( 'experimental-link-color' );
 
 	// Only modify the $type if the consumer hasn't provided any.
-	if ( $type === null && ! $supports_theme_json ) {
+	if ( null === $type && ! $supports_theme_json ) {
 		$type = 'presets';
-	} else if ( $type === null ) {
+	} elseif ( null === $type ) {
 		$type = 'all';
 	}
 
@@ -49,7 +49,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $type = nul
 	if ( ! $supports_theme_json && ! $supports_link_color ) {
 		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
 		$origins = array( 'core' );
-	} else if ( ! $supports_theme_json && $supports_link_color ) {
+	} elseif ( ! $supports_theme_json && $supports_link_color ) {
 		// For the legacy link color feauter to work, the CSS Custom Properties
 		// should be in scope (either the core or the theme ones).
 		$origins = array( 'core', 'theme' );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34931
Fixes https://wordpress.org/support/topic/gutenberg-plugin-over-rides-custom-editor-color-palette/

https://github.com/WordPress/gutenberg/pull/34334 introduced a bug by which settings provided via theme supports were not passed to the editor for themes without `theme.json` supports. This resulted in bugs like the palette of the theme not showing in the editor (it was shown the core palette instead) or that a plugin could not enable the `custom-line-height` support.

## Tests

Activate **TT1-blocks**: a theme with `theme.json` support.

- Visit the front end. Check the content of `global-styles-inline-css` is: both core & theme presets (classes and variables), the block gap styles ([see](https://github.com/WordPress/gutenberg/pull/34334#issuecomment-906498931)), the theme styles.
- Visit the editor and verify that the editor palette is the theme palette.

Activate the **TwentyTwentyOne** theme: a theme without theme.json but with `experimental-link-color` support.

- Visit the front end. Check the content of `global-styles-inline-css` is both core & theme presets (classes and variables).
- Visit the editor and verify that the editor palette is the theme palette.

Activate the **TwentyTwenty** theme: a theme without theme.json and no `experimental-link-color` support.

- Visit the front end. Check the content of `global-styles-inline-css` is the core presets (classes & variables).
- Visit the editor and verify that the editor palette is the theme palette.
- Enable the `custom-line-height` and verify the control is shown in the editor. See [full instructions](https://github.com/WordPress/gutenberg/issues/34931) or paste the following code in the `global-styles.php` file:

```php

function test_modify_theme_support() {
	add_theme_support( 'custom-line-height' );
}
add_action( 'after_setup_theme', 'test_modify_theme_support', 11 );
```
