### PR TITLE
[Mobile] - Image block - Fix height and border regression

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -514,7 +514,9 @@ export class ImageEdit extends Component {
 			wasBlockJustInserted,
 		} = this.props;
 		const { align, url, alt, id, sizeSlug, className } = attributes;
-		const hasImageContext = Object.keys( context ).length > 0;
+		const hasImageContext = context
+			? Object.keys( context ).length > 0
+			: false;
 
 		const imageSizes = Array.isArray( this.props.imageSizes )
 			? this.props.imageSizes

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -509,11 +509,12 @@ export class ImageEdit extends Component {
 			image,
 			clientId,
 			imageDefaultSize,
-			context: { imageCrop = false } = {},
+			context,
 			featuredImageId,
 			wasBlockJustInserted,
 		} = this.props;
 		const { align, url, alt, id, sizeSlug, className } = attributes;
+		const hasImageContext = Object.keys( context ).length > 0;
 
 		const imageSizes = Array.isArray( this.props.imageSizes )
 			? this.props.imageSizes
@@ -627,8 +628,10 @@ export class ImageEdit extends Component {
 
 		const additionalImageProps = {
 			height: '100%',
-			resizeMode: imageCrop ? 'cover' : 'contain',
+			resizeMode: context?.imageCrop ? 'cover' : 'contain',
 		};
+
+		const imageContainerStyles = [ hasImageContext && styles.fixedHeight ];
 
 		const getImageComponent = ( openMediaOptions, getMediaOptions ) => (
 			<Badge label={ __( 'Featured' ) } show={ isFeaturedImage }>
@@ -662,7 +665,7 @@ export class ImageEdit extends Component {
 								retryMessage,
 							} ) => {
 								return (
-									<View style={ styles.isGallery }>
+									<View style={ imageContainerStyles }>
 										<Image
 											align={
 												align && alignToFlex[ align ]
@@ -686,7 +689,9 @@ export class ImageEdit extends Component {
 											url={ url }
 											shapeStyle={ styles[ className ] }
 											width={ this.getWidth() }
-											{ ...additionalImageProps }
+											{ ...( hasImageContext
+												? additionalImageProps
+												: {} ) }
 										/>
 									</View>
 								);

--- a/packages/block-library/src/image/styles.native.scss
+++ b/packages/block-library/src/image/styles.native.scss
@@ -31,7 +31,7 @@
 	padding-bottom: $grid-unit;
 }
 
-.isGallery {
+.fixedHeight {
 	height: 150;
 	overflow: visible;
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3987

- [x] https://github.com/wordpress-mobile/gutenberg-mobile/pull/3992

## Description
This PR fixes a regression in the Image block introduced by [these changes](https://github.com/WordPress/gutenberg/pull/25940/files#diff-7126ae03000a022bcefa0d2a5fb03b6aca56ed4047e3a49d2131babf229cf6c1). Causing the images to have a fixed height and not adjusting correctly, as well as making the border settings to not work as expected.

## How has this been tested?

### Test case 1 - Image block

- Open the app
- Add an Image block
- Select an image
- Change the image size to full size
- **Expect** to see the image to have full width
- Open the settings of the Image block again
- Select the rounded border setting
- **Expect** the image borders to change accordingly

### Test case 2 - Gallery block 

Precondition: Make sure to have enabled the `__unstableGalleryWithImageBlocks` flag.

- Open the app
- Add a Gallery block
- Select some images
- Open the settings of the block
- Toggle the crop images option
- **Expect** the size of the images to change accordingly

## Screenshots 

Image block Before |Image block After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/133996948-81fe97de-d2c0-4288-8fbf-9d16d7c54fd5.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/133997335-2401cf97-87ea-482e-964e-bcba3be9cc33.gif" width="200" /></kbd>

Gallery block Before |Gallery block After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/133997405-cfce2548-457f-4c6d-ae51-f69531b93ff5.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/133997459-dd522db5-e92a-432c-b472-4d1ff26219e6.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
