### PR TITLE
Navigation Screen: Add space between menu name and switcher button

### DIFF
--- a/packages/edit-navigation/src/components/header/style.scss
+++ b/packages/edit-navigation/src/components/header/style.scss
@@ -66,6 +66,10 @@
 		align-items: center;
 	}
 
+	.components-dropdown {
+		margin-left: $grid-unit-05;
+	}
+
 	.edit-navigation-menu-actions__switcher-toggle {
 		padding: 0;
 		min-width: 0;


### PR DESCRIPTION
## Description
Add a little more space between the menu name and switcher button to avoid overlapping when the latter is focused.

Fixes #34935.

## How has this been tested?
1. Go to Gutenberg > Navigation (beta)
2. See that there's an extra space between the menu name and the switcher button.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-20 at 16 37 35](https://user-images.githubusercontent.com/240569/134003437-c1c73cd6-c3d1-41b2-b562-740801d1da32.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
