### PR TITLE
Add new ESLint rule to enforce comment case/punctuation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
 	rules: {
 		'jest/expect-expect': 'off',
 		'@wordpress/dependency-group': 'error',
+		'@wordpress/comment-case': 'error',
 		'@wordpress/gutenberg-phase': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',
 		'@wordpress/i18n-text-domain': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
 	rules: {
 		'jest/expect-expect': 'off',
 		'@wordpress/dependency-group': 'error',
-		'@wordpress/comment-case': 'error',
+		'@wordpress/comment-case': 'warn',
 		'@wordpress/gutenberg-phase': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',
 		'@wordpress/i18n-text-domain': [

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -2,7 +2,7 @@ module.exports = {
 	plugins: [ '@wordpress' ],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': 'error',
-		'@wordpress/comment-case': 'error',
+		'@wordpress/comment-case': 'warn',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
 		'@wordpress/no-global-active-element': 'error',

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -2,6 +2,7 @@ module.exports = {
 	plugins: [ '@wordpress' ],
 	rules: {
 		'@wordpress/no-unused-vars-before-return': 'error',
+		'@wordpress/comment-case': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
 		'@wordpress/no-global-active-element': 'error',

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -50,6 +50,9 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// prettier-ignore some rule`,
 		},
 		{
+			code: `// noinspection DuplicatedCode`,
+		},
+		{
 			code: `// @ts-expect-error The \`direction\` prop from Flex (FlexDirection) conflicts with legacy SVGAttributes \`direction\` (string) that come from React intrinsic prop definitions`,
 		},
 		{

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -17,6 +17,9 @@ const ruleTester = new RuleTester( {
 ruleTester.run( 'comment-case', rule, {
 	valid: [
 		{
+			code: `/* Same line block comment. */`,
+		},
+		{
 			code: `// My period ending comment.`,
 		},
 		{
@@ -30,6 +33,12 @@ ruleTester.run( 'comment-case', rule, {
 		},
 		{
 			code: `// @todo type comments don't need to be punctuated`,
+		},
+		{
+			code: `/* translators: some translation hint */`,
+		},
+		{
+			code: `// translators: some translation hint`,
 		},
 		{
 			code: `const someVar = 1; // Describe the var.`,
@@ -73,6 +82,21 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// My comment without a period`,
 			output: `// My comment without a period.`,
 			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+		{
+			code: `/* Block comment without a period */`,
+			output: `/* Block comment without a period. */`,
+			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+		{
+			code: `/*Block comment without a space. */`,
+			output: `/* Block comment without a space. */`,
+			errors: [ { messageId: 'missingSpace' } ],
+		},
+		{
+			code: `/* block comment without a capital. */`,
+			output: `/* Block comment without a capital. */`,
+			errors: [ { messageId: 'capitalLetter' } ],
 		},
 		{
 			code: `//My comment without a space.`,

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -50,6 +50,9 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// prettier-ignore some rule`,
 		},
 		{
+			code: `// @ts-expect-error The \`direction\` prop from Flex (FlexDirection) conflicts with legacy SVGAttributes \`direction\` (string) that come from React intrinsic prop definitions`,
+		},
+		{
 			code: `// https://github.com/WordPress/gutenberg starts with URL.`,
 		},
 		{

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -60,19 +60,15 @@ ruleTester.run( 'comment-case', rule, {
 	invalid: [
 		{
 			code: `const someVar = 1; // Describe the var`,
-			output: `const someVar = 1; // Describe the var.`,
 			errors: [ { messageId: 'missingPunctuation' } ],
 		},
 		{
 			code: `const someVar = 1; // no capital letter.`,
-			output: `const someVar = 1; // No capital letter.`,
 			errors: [ { messageId: 'capitalLetter' } ],
 		},
 		{
 			code: `const someVar = 1; // Describe the var
 			const someOtherVar = 2; // Describe this one too`,
-			output: `const someVar = 1; // Describe the var.
-			const someOtherVar = 2; // Describe this one too.`,
 			errors: [
 				{ messageId: 'missingPunctuation' },
 				{ messageId: 'missingPunctuation' },
@@ -80,36 +76,28 @@ ruleTester.run( 'comment-case', rule, {
 		},
 		{
 			code: `// My comment without a period`,
-			output: `// My comment without a period.`,
 			errors: [ { messageId: 'missingPunctuation' } ],
 		},
 		{
 			code: `/* Block comment without a period */`,
-			output: `/* Block comment without a period. */`,
 			errors: [ { messageId: 'missingPunctuation' } ],
 		},
 		{
 			code: `/*Block comment without a space. */`,
-			output: `/* Block comment without a space. */`,
 			errors: [ { messageId: 'missingSpace' } ],
 		},
 		{
 			code: `/* block comment without a capital. */`,
-			output: `/* Block comment without a capital. */`,
 			errors: [ { messageId: 'capitalLetter' } ],
 		},
 		{
 			code: `//My comment without a space.`,
-			output: `// My comment without a space.`,
 			errors: [ { messageId: 'missingSpace' } ],
 		},
 		{
 			code: `//My multi line
 			//comments without
 			//spaces`,
-			output: `// My multi line
-			// comments without
-			// spaces`, // No period here because this test case is for a single pass.
 			errors: [
 				{ messageId: 'missingSpace' },
 				{ messageId: 'missingSpace' },

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -47,6 +47,9 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// https://github.com/WordPress/gutenberg`,
 		},
 		{
+			code: `// prettier-ignore some rule`,
+		},
+		{
 			code: `// https://github.com/WordPress/gutenberg starts with URL.`,
 		},
 		{

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -41,11 +41,25 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// translators: some translation hint`,
 		},
 		{
+			code: `// Ends with URL https://github.com/WordPress/gutenberg`,
+		},
+		{
+			code: `// https://github.com/WordPress/gutenberg`,
+		},
+		{
+			code: `// https://github.com/WordPress/gutenberg starts with URL.`,
+		},
+		{
 			code: `const someVar = 1; // Describe the var.`,
 		},
 		{
 			code: `// My period ending comment
 			// that runs on to the next line.`,
+		},
+		{
+			code: `const codeOnLine = true; // Disable reason: valid-sprintf applies to \`@wordpress/i18n\` where
+// strings are expected to need to be extracted, and thus variables are
+// not allowed. This string will not need to be extracted.`,
 		},
 		{
 			code: `// A few.

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -50,6 +50,9 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// prettier-ignore some rule`,
 		},
 		{
+			code: `/* istanbul ignore next */`,
+		},
+		{
 			code: `// noinspection DuplicatedCode`,
 		},
 		{

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -53,6 +53,12 @@ ruleTester.run( 'comment-case', rule, {
 			code: `/* istanbul ignore next */`,
 		},
 		{
+			code: `/* $FlowFixMe some other text */`,
+		},
+		{
+			code: `/* $FlowIssue some other text */`,
+		},
+		{
 			code: `// noinspection DuplicatedCode`,
 		},
 		{

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -32,6 +32,9 @@ ruleTester.run( 'comment-case', rule, {
 			code: `// @todo type comments don't need to be punctuated`,
 		},
 		{
+			code: `const someVar = 1; // Describe the var.`,
+		},
+		{
 			code: `// My period ending comment
 			// that runs on to the next line.`,
 		},
@@ -47,9 +50,48 @@ ruleTester.run( 'comment-case', rule, {
 	],
 	invalid: [
 		{
+			code: `const someVar = 1; // Describe the var`,
+			output: `const someVar = 1; // Describe the var.`,
+			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+		{
+			code: `const someVar = 1; // no capital letter.`,
+			output: `const someVar = 1; // No capital letter.`,
+			errors: [ { messageId: 'capitalLetter' } ],
+		},
+		{
+			code: `const someVar = 1; // Describe the var
+			const someOtherVar = 2; // Describe this one too`,
+			output: `const someVar = 1; // Describe the var.
+			const someOtherVar = 2; // Describe this one too.`,
+			errors: [
+				{ messageId: 'missingPunctuation' },
+				{ messageId: 'missingPunctuation' },
+			],
+		},
+		{
 			code: `// My comment without a period`,
 			output: `// My comment without a period.`,
 			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+		{
+			code: `//My comment without a space.`,
+			output: `// My comment without a space.`,
+			errors: [ { messageId: 'missingSpace' } ],
+		},
+		{
+			code: `//My multi line
+			//comments without
+			//spaces`,
+			output: `// My multi line
+			// comments without
+			// spaces`, // No period here because this test case is for a single pass.
+			errors: [
+				{ messageId: 'missingSpace' },
+				{ messageId: 'missingSpace' },
+				{ messageId: 'missingSpace' },
+				{ messageId: 'missingPunctuation' },
+			],
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../comment-case';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'comment-case', rule, {
+	valid: [
+		{
+			code: `// My period ending comment.`,
+		},
+		{
+			code: `// My exclamation ending comment!`,
+		},
+		{
+			code: `// My question mark ending comment?`,
+		},
+		{
+			code: `// @see type comments don't need to be punctuated`,
+		},
+		{
+			code: `// @todo type comments don't need to be punctuated`,
+		},
+		{
+			code: `// My period ending comment
+			// that runs on to the next line.`,
+		},
+		{
+			code: `// A few.
+			// comments that all end.
+			// with periods.`,
+		},
+		{
+			code: `// My exclamation ending comment
+			// that runs on to the next line!`,
+		},
+	],
+	invalid: [
+		{
+			code: `// My comment without a period`,
+			output: `// My comment without a period.`,
+			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/comment-case.js
+++ b/packages/eslint-plugin/rules/__tests__/comment-case.js
@@ -80,6 +80,10 @@ ruleTester.run( 'comment-case', rule, {
 // not allowed. This string will not need to be extracted.`,
 		},
 		{
+			code: `// codeOnLine small c.
+			const codeOnLine = true;`,
+		},
+		{
 			code: `// A few.
 			// comments that all end.
 			// with periods.`,
@@ -93,6 +97,11 @@ ruleTester.run( 'comment-case', rule, {
 		{
 			code: `const someVar = 1; // Describe the var`,
 			errors: [ { messageId: 'missingPunctuation' } ],
+		},
+		{
+			code: `// comment small c.
+			const c = true;`,
+			errors: [ { messageId: 'capitalLetter' } ],
 		},
 		{
 			code: `const someVar = 1; // no capital letter.`,

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -154,7 +154,7 @@ module.exports = {
 					// one is.
 					if (
 						! endsWithURL &&
-						! value.match( /\W$/ ) &&
+						! trimmedValue.match( /\W$/ ) &&
 						! isFollowedDirectlyByLineComment
 					) {
 						context.report( {

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -22,6 +22,8 @@ module.exports = {
 		messages: {
 			missingPunctuation:
 				'Comments must end with a period (.), exclamation mark (!), or question mark (?).',
+			missingSpace: 'Comments must have a space after the comment token.',
+			capitalLetter: 'Comments must start with a capital letter.',
 		},
 		fixable: 'code',
 	},

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -4,7 +4,7 @@ const createFixerFunction = ( node ) => ( arg ) => {
 
 module.exports = {
 	meta: {
-		type: 'layout',
+		type: 'problem',
 		schema: [],
 		messages: {
 			missingPunctuation:

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -48,7 +48,26 @@ module.exports = {
 						trimmedValue.length - 1
 					);
 
-					// Check to see if the comment contains an \@see or @todo type directive.
+					const previousComment =
+						index !== 0 ? comments[ index - 1 ] : null;
+					const nextComment =
+						index !== comments.length - 1
+							? comments[ index + 1 ]
+							: null;
+
+					const isFollowedDirectlyByLineComment =
+						nextComment &&
+						! codeBeforeComment( sourceCode, comment ) &&
+						nextComment.type === 'Line' &&
+						nextComment.loc.start.line ===
+							comment.loc.start.line + 1;
+					const isPrecededDirectlyByLineComment =
+						previousComment &&
+						! codeBeforeComment( sourceCode, comment ) &&
+						previousComment.type === 'Line' &&
+						previousComment.loc.end.line ===
+							comment.loc.start.line - 1;
+
 					const todoTypeCommentRegex = /@\w*\s/;
 					if (
 						! trimmedValue.match( todoTypeCommentRegex ) &&

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -82,7 +82,7 @@ module.exports = {
 					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Ignore pragmas/compiler hints/shebangs.
-					const pragmaRegex = /prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check)|eslint-(disable|enable)(-next-line)?|global\s\S/;
+					const pragmaRegex = /browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
 
 					// Ignore known common words that don't need to be capitalized.
 					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -82,7 +82,7 @@ module.exports = {
 					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Ignore pragmas/compiler hints/shebangs.
-					const pragmaRegex = /__mocks__\/.*\.js|@ts-(ignore|(no)?check)|eslint-(disable|enable)(-next-line)?|global\s\S/;
+					const pragmaRegex = /prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check)|eslint-(disable|enable)(-next-line)?|global\s\S/;
 
 					// Ignore known common words that don't need to be capitalized.
 					const commonWordRegex = /iOS|npm-?\w*|lint-?\w*|id/;

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -1,5 +1,18 @@
-const createFixerFunction = ( node ) => ( arg ) => {
-	return arg.insertTextAfter( node, '.' );
+const createFixerFunction = ( errorType, node ) => ( arg ) => {
+	switch ( errorType ) {
+		case 'missingSpace':
+			return arg.replaceText( node, `// ${ node.value }` );
+		case 'missingPunctuation':
+			return arg.insertTextAfter( node, '.' );
+		case 'capitalLetter':
+			const trimmedComment = node.value.trim();
+			return arg.replaceText(
+				node,
+				`// ${ trimmedComment
+					.charAt( 0 )
+					.toUpperCase() }${ trimmedComment.substring( 1 ) }`
+			);
+	}
 };
 
 module.exports = {

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -79,6 +79,21 @@ module.exports = {
 						} );
 					}
 
+					// Check to see if first word starts with a capital letter.
+					if (
+						! isPrecededDirectlyByLineComment &&
+						trimmedValue.charAt( 0 ) !==
+							trimmedValue.charAt( 0 ).toUpperCase()
+					) {
+						const errorType = 'capitalLetter';
+						context.report( {
+							node,
+							loc: comment.loc,
+							messageId: errorType,
+							fix: createFixerFunction( errorType, comment ),
+						} );
+					}
+
 					const todoTypeCommentRegex = /@\w*\s/;
 					if (
 						! trimmedValue.match( todoTypeCommentRegex ) &&

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -85,7 +85,8 @@ module.exports = {
 					const pragmaRegex = /prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check)|eslint-(disable|enable)(-next-line)?|global\s\S/;
 
 					// Ignore known common words that don't need to be capitalized.
-					const commonWordRegex = /i(Pad|Phone|Mac|OS)|npm-?\w*|lint-?\w*|id/;
+					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.
+					const commonWordRegex = /i(Pad|Phone|Mac|OS)|npm-?\w*|lint-?\w*|id|v\d+/;
 
 					// Ignore if comment contains a URL.
 					const regexTests = [

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -68,6 +68,17 @@ module.exports = {
 						previousComment.loc.end.line ===
 							comment.loc.start.line - 1;
 
+					// Check to see if the comment starts with a space.
+					if ( value.charAt( 0 ) !== ' ' ) {
+						const errorType = 'missingSpace';
+						context.report( {
+							node,
+							loc: comment.loc,
+							messageId: errorType,
+							fix: createFixerFunction( errorType, comment ),
+						} );
+					}
+
 					const todoTypeCommentRegex = /@\w*\s/;
 					if (
 						! trimmedValue.match( todoTypeCommentRegex ) &&

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -85,7 +85,7 @@ module.exports = {
 					const pragmaRegex = /prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check)|eslint-(disable|enable)(-next-line)?|global\s\S/;
 
 					// Ignore known common words that don't need to be capitalized.
-					const commonWordRegex = /iOS|npm-?\w*|lint-?\w*|id/;
+					const commonWordRegex = /i(Pad|Phone|Mac|OS)|npm-?\w*|lint-?\w*|id/;
 
 					// Ignore if comment contains a URL.
 					const regexTests = [

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -82,7 +82,7 @@ module.exports = {
 					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Ignore pragmas/compiler hints/shebangs.
-					const pragmaRegex = /noinspection\s\S+|istanbul|browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
+					const pragmaRegex = /\$Flow|noinspection\s\S+|istanbul|browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
 
 					// Ignore known common words that don't need to be capitalized.
 					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -24,8 +24,7 @@ module.exports = {
 				const { comments } = node;
 				comments.forEach( ( comment, index ) => {
 					// Regex to check if the comment contains an \@see or @todo type directive - any @ sign followed by a word.
-					const todoTypeCommentRegex = /@\w*\s/;
-					const translatorCommentRegex = /translators:/;
+					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Skip block comments that cross multiple lines.
 					if (
@@ -37,10 +36,7 @@ module.exports = {
 					const { value } = comment;
 
 					// Skip translator or @see/@todo etc. comments
-					if (
-						value.match( todoTypeCommentRegex ) ||
-						value.match( translatorCommentRegex )
-					) {
+					if ( value.match( translatorOrTodoTypeCommentRegex ) ) {
 						return;
 					}
 

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -52,10 +52,27 @@ module.exports = {
 			Program( node ) {
 				const { comments } = node;
 				comments.forEach( ( comment, index ) => {
-					if ( comment.type !== 'Line' ) {
+					// Regex to check if the comment contains an \@see or @todo type directive - any @ sign followed by a word.
+					const todoTypeCommentRegex = /@\w*\s/;
+					const translatorCommentRegex = /translators:/;
+
+					// Skip block comments that cross multiple lines.
+					if (
+						comment.type === 'Block' &&
+						comment.loc.start.line !== comment.loc.end.line
+					) {
 						return;
 					}
 					const { value } = comment;
+
+					// Skip translator or @see/@todo etc. comments
+					if (
+						value.match( todoTypeCommentRegex ) ||
+						value.match( translatorCommentRegex )
+					) {
+						return;
+					}
+
 					const trimmedValue = value.trim();
 					const lastChar = trimmedValue.charAt(
 						trimmedValue.length - 1
@@ -108,10 +125,7 @@ module.exports = {
 					}
 
 					// Check for correct punctuation.
-					// Regex to check if the comment contains an \@see or @todo type directive.
-					const todoTypeCommentRegex = /@\w*\s/;
 					if (
-						! trimmedValue.match( todoTypeCommentRegex ) &&
 						lastChar !== '.' &&
 						lastChar !== '!' &&
 						lastChar !== '?'

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -1,16 +1,28 @@
 const createFixerFunction = ( errorType, node ) => ( arg ) => {
+	const commentType = node.type;
+	const commentOpenToken = commentType === 'Line' ? '//' : '/*';
+	const commentCloseToken = commentType === 'Line' ? '' : ' */';
+	const trimmedComment = node.value.trim();
+
 	switch ( errorType ) {
 		case 'missingSpace':
-			return arg.replaceText( node, `// ${ node.value }` );
-		case 'missingPunctuation':
-			return arg.insertTextAfter( node, '.' );
-		case 'capitalLetter':
-			const trimmedComment = node.value.trim();
 			return arg.replaceText(
 				node,
-				`// ${ trimmedComment
+				`${ commentOpenToken } ${ trimmedComment }${ commentCloseToken }`
+			);
+		case 'missingPunctuation':
+			return arg.replaceText(
+				node,
+				`${ commentOpenToken } ${ trimmedComment }.${ commentCloseToken }`
+			);
+		case 'capitalLetter':
+			return arg.replaceText(
+				node,
+				`${ commentOpenToken } ${ trimmedComment
 					.charAt( 0 )
-					.toUpperCase() }${ trimmedComment.substring( 1 ) }`
+					.toUpperCase() }${ trimmedComment.substring(
+					1
+				) }${ commentCloseToken }`
 			);
 	}
 };

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -35,6 +35,7 @@ module.exports = {
 		fixable: 'code',
 	},
 	create( context ) {
+		const sourceCode = context.getSourceCode();
 		return {
 			Program( node ) {
 				const { comments } = node;
@@ -94,6 +95,8 @@ module.exports = {
 						} );
 					}
 
+					// Check for correct punctuation.
+					// Regex to check if the comment contains an \@see or @todo type directive.
 					const todoTypeCommentRegex = /@\w*\s/;
 					if (
 						! trimmedValue.match( todoTypeCommentRegex ) &&
@@ -101,21 +104,17 @@ module.exports = {
 						lastChar !== '!' &&
 						lastChar !== '?'
 					) {
-						if (
-							index + 1 !== comments.length &&
-							comments[ index + 1 ].type === 'Line' &&
-							comments[ index + 1 ].loc.start.line ===
-								comment.loc.start.line + 1
-						) {
-							// Check if next comment is on the following line, if it is then this rule doesn't count
-							// because comments could be formatted like this.
+						// Check if next comment is on the following line, if it is then this rule doesn't count
+						// because comments could be formatted over multiple lines like this one is.
+						if ( isFollowedDirectlyByLineComment ) {
 							return;
 						}
+						const errorType = 'missingPunctuation';
 						context.report( {
 							node,
 							loc: comment.loc,
-							messageId: 'missingPunctuation',
-							fix: createFixerFunction( comment ),
+							messageId: errorType,
+							fix: createFixerFunction( errorType, comment ),
 						} );
 					}
 				} );

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -82,7 +82,7 @@ module.exports = {
 					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Ignore pragmas/compiler hints/shebangs.
-					const pragmaRegex = /browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
+					const pragmaRegex = /noinspection\s\S+|browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
 
 					// Ignore known common words that don't need to be capitalized.
 					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -15,6 +15,13 @@ const createFixerFunction = ( errorType, node ) => ( arg ) => {
 	}
 };
 
+const codeBeforeComment = ( sourceCode, node ) => {
+	const prevToken = sourceCode.getTokenBefore( node );
+	if ( prevToken && prevToken.loc.end.line === node.loc.start.line ) {
+		return true;
+	}
+};
+
 module.exports = {
 	meta: {
 		type: 'problem',

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -1,32 +1,3 @@
-const createFixerFunction = ( errorType, node ) => ( arg ) => {
-	const commentType = node.type;
-	const commentOpenToken = commentType === 'Line' ? '//' : '/*';
-	const commentCloseToken = commentType === 'Line' ? '' : ' */';
-	const trimmedComment = node.value.trim();
-
-	switch ( errorType ) {
-		case 'missingSpace':
-			return arg.replaceText(
-				node,
-				`${ commentOpenToken } ${ trimmedComment }${ commentCloseToken }`
-			);
-		case 'missingPunctuation':
-			return arg.replaceText(
-				node,
-				`${ commentOpenToken } ${ trimmedComment }.${ commentCloseToken }`
-			);
-		case 'capitalLetter':
-			return arg.replaceText(
-				node,
-				`${ commentOpenToken } ${ trimmedComment
-					.charAt( 0 )
-					.toUpperCase() }${ trimmedComment.substring(
-					1
-				) }${ commentCloseToken }`
-			);
-	}
-};
-
 const codeBeforeComment = ( sourceCode, node ) => {
 	const prevToken = sourceCode.getTokenBefore( node );
 	if ( prevToken && prevToken.loc.end.line === node.loc.start.line ) {
@@ -100,12 +71,10 @@ module.exports = {
 
 					// Check to see if the comment starts with a space.
 					if ( value.charAt( 0 ) !== ' ' ) {
-						const errorType = 'missingSpace';
 						context.report( {
 							node,
 							loc: comment.loc,
-							messageId: errorType,
-							fix: createFixerFunction( errorType, comment ),
+							messageId: 'missingSpace',
 						} );
 					}
 
@@ -115,12 +84,10 @@ module.exports = {
 						trimmedValue.charAt( 0 ) !==
 							trimmedValue.charAt( 0 ).toUpperCase()
 					) {
-						const errorType = 'capitalLetter';
 						context.report( {
 							node,
 							loc: comment.loc,
-							messageId: errorType,
-							fix: createFixerFunction( errorType, comment ),
+							messageId: 'capitalLetter',
 						} );
 					}
 
@@ -135,12 +102,11 @@ module.exports = {
 						if ( isFollowedDirectlyByLineComment ) {
 							return;
 						}
-						const errorType = 'missingPunctuation';
+
 						context.report( {
 							node,
 							loc: comment.loc,
-							messageId: errorType,
-							fix: createFixerFunction( errorType, comment ),
+							messageId: 'missingPunctuation',
 						} );
 					}
 				} );

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -1,0 +1,58 @@
+const createFixerFunction = ( node ) => ( arg ) => {
+	return arg.insertTextAfter( node, '.' );
+};
+
+module.exports = {
+	meta: {
+		type: 'layout',
+		schema: [],
+		messages: {
+			missingPunctuation:
+				'Comments must end with a period (.), exclamation mark (!), or question mark (?).',
+		},
+		fixable: 'code',
+	},
+	create( context ) {
+		return {
+			Program( node ) {
+				const { comments } = node;
+				comments.forEach( ( comment, index ) => {
+					if ( comment.type !== 'Line' ) {
+						return;
+					}
+					const { value } = comment;
+					const trimmedValue = value.trim();
+					const lastChar = trimmedValue.charAt(
+						trimmedValue.length - 1
+					);
+
+					// Check to see if the comment contains an \@see or @todo type directive.
+					const todoTypeCommentRegex = /@\w*\s/;
+					if (
+						! trimmedValue.match( todoTypeCommentRegex ) &&
+						lastChar !== '.' &&
+						lastChar !== '!' &&
+						lastChar !== '?'
+					) {
+						if (
+							index + 1 !== comments.length &&
+							comments[ index + 1 ].type === 'Line' &&
+							comments[ index + 1 ].loc.start.line ===
+								comment.loc.start.line + 1
+						) {
+							// Check if next comment is on the following line, if it is then this rule doesn't count
+							// because comments could be formatted like this.
+							return;
+						}
+						context.report( {
+							node,
+							loc: comment.loc,
+							messageId: 'missingPunctuation',
+							fix: createFixerFunction( comment ),
+						} );
+					}
+				} );
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -82,7 +82,7 @@ module.exports = {
 					const translatorOrTodoTypeCommentRegex = /translators:|@\w*\s/;
 
 					// Ignore pragmas/compiler hints/shebangs.
-					const pragmaRegex = /noinspection\s\S+|browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
+					const pragmaRegex = /noinspection\s\S+|istanbul|browserslist|prettier-?\w*|__mocks__\/.*\.js|@ts-(ignore|(no)?check|expect-error)|eslint-(disable|enable)(-next-line)?|globals?\s\S+/;
 
 					// Ignore known common words that don't need to be capitalized.
 					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -55,7 +55,8 @@ module.exports = {
 						nextComment &&
 						nextComment.type === 'Line' &&
 						nextComment.loc.start.line ===
-							comment.loc.start.line + 1;
+							comment.loc.start.line + 1 &&
+						! codeBeforeComment( sourceCode, nextComment );
 					const isPrecededDirectlyByLineComment =
 						previousComment &&
 						! codeBeforeComment( sourceCode, comment ) &&

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -86,7 +86,7 @@ module.exports = {
 
 					// Ignore known common words that don't need to be capitalized.
 					// Includes npm, lint, id, v1, v2 etc. (when referring to versions), and the Apple products.
-					const commonWordRegex = /i(Pad|Phone|Mac|OS)|npm-?\w*|lint-?\w*|id|v\d+/;
+					const commonWordRegex = /^i(Pad|Phone|Mac|OS)|^npm-?\w*|^lint-?\w*|^id|^v\d+/;
 
 					// Ignore if comment contains a URL.
 					const regexTests = [

--- a/packages/eslint-plugin/rules/comment-case.js
+++ b/packages/eslint-plugin/rules/comment-case.js
@@ -136,7 +136,9 @@ module.exports = {
 						if (
 							! identifiersOnNextOrPreviousLines.some(
 								( identifier ) =>
-									trimmedComment.indexOf( identifier ) === 0
+									trimmedComment.indexOf(
+										`${ identifier } `
+									) === 0
 							)
 						) {
 							context.report( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

**Note: I have never written an ESLint rule from scratch before, so any suggestions for improvement will be really appreciated**

As part of the [new proposal to amend the Coding Standards](https://make.wordpress.org/core/2021/09/21/wordpress-javascript-standards-change-proposal/) this PR adds a new custom ESLint rule that will find comments that don't terminate with a sentence-ending punctuation mark (`!`, `?`, or `.`), comments that do not contain a space between the comment token and the first word, and comments where the first word is not capitalised.

I do not know if there's a way to detect if a comment is commented out code, or if it's just a regular inline comment.

This rule only targets comments of type `Line` and `Block` functions that start and terminate on the same line. It won't consider multi-line block comments.

The rule also considers whether a `Line` comment is followed or preceded directly by another comment. The reason for this is so comments of the below type are considered as one comment. The first and middle lines don't need to end with punctuation, and the middle and last line don't need to have capital letters. All lines do need to have spaces between the token and the words though.
```
// Some comments
// are split over
// multiple lines.
```

I also excludes comments that contain `translators:`, and `@see` or `@todo` type comments. There is a RegEx I used to check if comments were of this type: `/translators:|@\w*\s/`. In plain English this rule translates to "Any string containing `translators` or an @ sign followed immediately by a word and a whitespace character". 

I have elected not to include an automatic fixer function to this. This is on the basis that it degrades the Developer Experience when it adds periods/spaces/capitals to commented out code. A situation where this could be annoying is when developing with `Fix eslint errors on save` enabled in your IDE, commenting/uncommenting lines of code becomes tedious when punctuation gets added.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
There are ESLint tests that run against this rule.

 To test this, you may also add a comment to a JavaScript file such as `// My comment without punctuation` and ensure that ESLint reports this as an error.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature/build tools modification

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
