### PR TITLE
Components: Mark `ControlLabel`, `FormGroupLabel` and `FormGroupContent` as non-polymorphic

### DIFF
--- a/packages/components/src/ui/control-label/component.js
+++ b/packages/components/src/ui/control-label/component.js
@@ -6,8 +6,8 @@ import { View } from '../../view';
 import { useControlLabel } from './hook';
 
 /**
- * @param {import('../context').WordPressComponentProps<import('./types').Props, 'label'>} props
- * @param {import('react').Ref<any>}                                                       forwardedRef
+ * @param {import('../context').WordPressComponentProps<import('./types').Props, 'label', false>} props
+ * @param {import('react').Ref<any>}                                                              forwardedRef
  */
 function ControlLabel( props, forwardedRef ) {
 	const controlLabelProps = useControlLabel( props );

--- a/packages/components/src/ui/control-label/hook.js
+++ b/packages/components/src/ui/control-label/hook.js
@@ -8,7 +8,7 @@ import * as styles from './styles';
 import { useCx } from '../../utils/hooks/use-cx';
 
 /**
- * @param {import('../context').WordPressComponentProps<import('./types').Props, 'label'>} props
+ * @param {import('../context').WordPressComponentProps<import('./types').Props, 'label', false>} props
  */
 export function useControlLabel( props ) {
 	const {

--- a/packages/components/src/ui/form-group/form-group-content.js
+++ b/packages/components/src/ui/form-group/form-group-content.js
@@ -12,7 +12,7 @@ import FormGroupHelp from './form-group-help';
 import FormGroupLabel from './form-group-label';
 
 /**
- * @param {import('../context').WordPressComponentProps<import('./types').FormGroupContentProps, 'label'>} props
+ * @param {import('../context').WordPressComponentProps<import('./types').FormGroupContentProps, 'label', false>} props
  */
 function FormGroupContent( {
 	alignLabel,

--- a/packages/components/src/ui/form-group/form-group-label.js
+++ b/packages/components/src/ui/form-group/form-group-label.js
@@ -10,7 +10,7 @@ import { ControlLabel } from '../control-label';
 import { VisuallyHidden } from '../../visually-hidden';
 
 /**
- * @param {import('../context').WordPressComponentProps<import('./types').FormGroupLabelProps, 'label'>} props
+ * @param {import('../context').WordPressComponentProps<import('./types').FormGroupLabelProps, 'label', false>} props
  * @return {JSX.Element | null} The form group's label.
  */
 function FormGroupLabel( { children, id, labelHidden = false, ...props } ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following up https://github.com/WordPress/gutenberg/pull/34927#pullrequestreview-758789693, this PR marks `ControlLabel` as non-polymorphic.

As a consequence, `FormGroupLabel` and `FormGroupContent` were also marked as non-polymorphic, as they internally rely on `ControlLabel`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Project builds, tests pass, Storybook examples work as expected.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

a11y improvement, I guess?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
