### PR TITLE
Build plugin zip: Verify npm cache before a clean install

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -99,6 +99,7 @@ done
 
 # Run the build.
 status "Installing dependencies... 📦"
+npm cache verify
 npm ci
 status "Generating build... 👷‍♀️"
 npm run build


### PR DESCRIPTION
The `Build Release Artifact` step of the `Build Plugin Zip` GH action sometimes fails because of `npm` cache issues. Namely, it could fail with a `npm ERR cb() never called` error message. This attempt to verify the cache before the `ci` to give `npm` a chance to repair it, if needed.
