### PR TITLE
Revert "Bump plugin version to 11.5.1"

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.7
  * Requires PHP: 5.6
- * Version: 11.5.1
+ * Version: 11.5.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "11.5.1",
+	"version": "11.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "11.5.1",
+	"version": "11.5.0",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 11.5.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v11.5.1">release page</a>.
+To read the changelog for Gutenberg 11.5.0, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v11.5.0">release page</a>.


### PR DESCRIPTION
Revert version bump that were created by a Build Gutenberg Plugin Zip action runs that ended up error'ing partially (the actions are non-transactional, unfortunately).