### PR TITLE
Navigation: add transformations from a link to other allowed nav blocks

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -5,7 +5,6 @@ import { _x } from '@wordpress/i18n';
 import { customLink as linkIcon } from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
-import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ import metadata from './block.json';
 import edit from './edit';
 import save from './save';
 import { enhanceNavigationLinkVariations } from './hooks';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -85,20 +85,7 @@ export const settings = {
 			},
 		},
 	],
-	transforms: {
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/navigation-submenu' ],
-				transform: ( attributes, innerBlocks ) =>
-					createBlock(
-						'core/navigation-submenu',
-						attributes,
-						innerBlocks
-					),
-			},
-		],
-	},
+	transforms,
 };
 
 // importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects

--- a/packages/block-library/src/navigation-link/transforms.js
+++ b/packages/block-library/src/navigation-link/transforms.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/site-logo' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/spacer' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/home-link' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/social-links' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/search' ],
+			transform: () => {
+				return createBlock( 'core/navigation-link' );
+			},
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/navigation-submenu' ],
+			transform: ( attributes, innerBlocks ) =>
+				createBlock(
+					'core/navigation-submenu',
+					attributes,
+					innerBlocks
+				),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/spacer' ],
+			transform: () => {
+				return createBlock( 'core/spacer' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/site-logo' ],
+			transform: () => {
+				return createBlock( 'core/site-logo' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/home-link' ],
+			transform: () => {
+				return createBlock( 'core/home-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/social-links' ],
+			transform: () => {
+				return createBlock( 'core/social-links' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/search' ],
+			transform: () => {
+				return createBlock( 'core/search' );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -10,6 +10,7 @@ import { addSubmenu } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -23,4 +24,6 @@ export const settings = {
 	edit,
 
 	save,
+
+	transforms,
 };

--- a/packages/block-library/src/navigation-submenu/transforms.js
+++ b/packages/block-library/src/navigation-submenu/transforms.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/navigation-link' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/navigation-link', attributes ),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/spacer' ],
+			transform: () => {
+				return createBlock( 'core/spacer' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/site-logo' ],
+			transform: () => {
+				return createBlock( 'core/site-logo' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/home-link' ],
+			transform: () => {
+				return createBlock( 'core/home-link' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/social-links' ],
+			transform: () => {
+				return createBlock( 'core/social-links' );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/search' ],
+			transform: () => {
+				return createBlock( 'core/search' );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/navigation-submenu/transforms.js
+++ b/packages/block-library/src/navigation-submenu/transforms.js
@@ -8,12 +8,14 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/navigation-link' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: ( attributes ) =>
 				createBlock( 'core/navigation-link', attributes ),
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/spacer' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: () => {
 				return createBlock( 'core/spacer' );
 			},
@@ -21,6 +23,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/site-logo' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: () => {
 				return createBlock( 'core/site-logo' );
 			},
@@ -28,6 +31,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/home-link' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: () => {
 				return createBlock( 'core/home-link' );
 			},
@@ -35,6 +39,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/social-links' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: () => {
 				return createBlock( 'core/social-links' );
 			},
@@ -42,6 +47,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/search' ],
+			isMatch: ( attributes, block ) => block?.innerBlocks?.length === 0,
 			transform: () => {
 				return createBlock( 'core/search' );
 			},


### PR DESCRIPTION
Small part of https://github.com/WordPress/gutenberg/issues/34041

> Transforming an empty "page item" should expose the most relevant alternative blocks for a navigation block (search, social icon, pages list, home link, etc).

This adds to transforms for other navigation blocks (search, home link, social icons, site-logo and spacer.

https://user-images.githubusercontent.com/1270189/134079923-9a649260-b7d1-4d6a-8de6-c32f787d1f0c.mp4

### TODO

- [x] Navigation Editor has a WSOD in `trunk` when attempting to transform to a submenu. https://github.com/WordPress/gutenberg/pull/34980 fixes this

### Testing Instructions

- Build this branch with `npm run build`
- In the post, site, or widget editor:
- Add a navigation block 
- Start from empty
- Try transforming links to various block types
- Try adding a spacer outside of a navigation block, verify that custom link is not a transform option
- In the navigation editor:
- Verify that only the submenu transform is available

### Question: How useful are the Navigation Link Variations?

Specific navigation link variations like a Post Link, Page Link, Category Link (CPT Link) etc feel like they clutter up the inserter and the transformation mechanism is separate from a normal block transform. Since we're interested in simplifying workflows I wonder if we could remove these from being so prominent. 🤔