### PR TITLE
Gallery block: replace gallery experimental setting with a check for use_balanceTags

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -98,7 +98,7 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	// The refactored gallery currently can't be run on sites with use_balanceTags option set.
-	// This bypass need to remain in place until this is is resolved and patch released.
+	// This bypass needs to remain in place until this is is resolved and a patch released.
 	// https://core.trac.wordpress.org/ticket/54130.
 	$balance_tags         = get_option( 'use_balanceTags' );
 	$experiments_settings = array(

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -51,17 +51,6 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-navigation',
 		)
 	);
-	add_settings_field(
-		'gutenberg-gallery-refactor',
-		__( 'Gallery block experiment', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test a new gallery block that uses nested image blocks (Warning: The new gallery is not compatible with WordPress mobile apps prior to version 18.2. If you use the mobile app, please update to the latest version to avoid content loss.)', 'gutenberg' ),
-			'id'    => 'gutenberg-gallery-refactor',
-		)
-	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'
@@ -108,9 +97,12 @@ function gutenberg_display_experiment_section() {
  * @return array Filtered editor settings.
  */
 function gutenberg_experiments_editor_settings( $settings ) {
-	$experiments          = get_option( 'gutenberg-experiments' );
+	// The refactored gallery currently can't be run on sites with use_balanceTags option set.
+	// This bypass need to remain in place until this is is resolved and patch released.
+	// https://core.trac.wordpress.org/ticket/54130.
+	$balance_tags         = get_option( 'use_balanceTags' );
 	$experiments_settings = array(
-		'__unstableGalleryWithImageBlocks' => isset( $experiments['gutenberg-gallery-refactor'] ),
+		'__unstableGalleryWithImageBlocks' => '1' !== $balance_tags,
 	);
 	return array_merge( $settings, $experiments_settings );
 }

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -98,11 +98,10 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	// The refactored gallery currently can't be run on sites with use_balanceTags option set.
-	// This bypass needs to remain in place until this is is resolved and a patch released.
+	// This bypass needs to remain in place until this is resolved and a patch released.
 	// https://core.trac.wordpress.org/ticket/54130.
-	$balance_tags         = get_option( 'use_balanceTags' );
 	$experiments_settings = array(
-		'__unstableGalleryWithImageBlocks' => '1' !== $balance_tags,
+		'__unstableGalleryWithImageBlocks' => (int) get_option( 'use_balanceTags' ) !== 1,
 	);
 	return array_merge( $settings, $experiments_settings );
 }

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -47,7 +47,7 @@ describe( 'Gallery', () => {
 		const filename = await upload( '.wp-block-gallery input[type="file"]' );
 
 		const regex = new RegExp(
-			`<!-- wp:gallery {"ids":\\[\\d+\\],"linkTo":"none"} -->\\s*<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="[^"]+\\/${ filename }\\.png" alt="" data-id="\\d+" data-link=".+" class="wp-image-\\d+"\\/><\\/figure><\\/li><\\/ul><\\/figure>\\s*<!-- \\/wp:gallery -->`
+			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"full\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image size-full\\"><img src=\\"[^"]+\/${ filename }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
@@ -71,7 +71,7 @@ describe( 'Gallery', () => {
 		await upload( '.wp-block-gallery input[type="file"]' );
 
 		const figureElement = await page.waitForSelector(
-			'.blocks-gallery-item figure'
+			'.wp-block-gallery .wp-block-image'
 		);
 
 		await figureElement.click();


### PR DESCRIPTION
# Do not merge before release 11.8

## Description

Currently the new gallery block structure can't be used on sites that have the `use_BalanceTags` option  set due to this issue - https://core.trac.wordpress.org/ticket/54130. It is likely that a patch for this won't be available until the 5.9 WP release, so rather than delaying removal of the experimental flag until then another option would be to disable the new gallery format on sites that have this flag set.

This PR replaces the experimental flag with a check for `use_BalanceTags`

## Testing

- Check out this PR and run on a site that doesn't have the `use_BalanceTags` option set
- Add a new gallery block and check it has the new innerBlocks structure
- Set the `use_BalanceTags` option to a string of '1'
- Add another gallery block and check that it has the old non innerBlocks structure
