### PR TITLE
Navigation Editor: avoid crash when transforming navigation link

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -168,8 +168,8 @@ function Iframe( { contentRef, children, head, tabIndex = 0, ...props }, ref ) {
 	const [ , forceRender ] = useReducer( () => ( {} ) );
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
-	const styles = useParsedAssets( window.__editorAssets.styles );
-	const scripts = useParsedAssets( window.__editorAssets.scripts );
+	const styles = useParsedAssets( window.__editorAssets?.styles );
+	const scripts = useParsedAssets( window.__editorAssets?.scripts );
 	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const setRef = useRefEffect( ( node ) => {


### PR DESCRIPTION
In the Navigation Editor, attempting to transform a link throws a JS error when we hover over the transform option. Changes in this PR avoid this error when editorAssets is undefined.

Before

https://user-images.githubusercontent.com/1270189/134085773-458868b4-7618-43c9-847b-1416f613622b.mp4

After:

https://user-images.githubusercontent.com/1270189/134085818-432e87a8-e5dd-46d0-987f-7abc52a6c8ed.mp4

### Testing Instructions
- In the Experiments page, enable the Navigation link editor `/wp-admin/admin.php?page=gutenberg-experiments`
- Visit `/wp-admin/admin.php?page=gutenberg-navigation`
- Start from empty
- Add a link
- Try to transform it to a submenu
- Verify that no error is thrown and that the editor does not crash

