### PR TITLE
Navigation Screen: Stop submitting Create Menu form in busy state

### DIFF
--- a/packages/edit-navigation/src/components/add-menu/index.js
+++ b/packages/edit-navigation/src/components/add-menu/index.js
@@ -102,7 +102,8 @@ function AddMenu( {
 				variant="primary"
 				disabled={ ! menuName.length }
 				isBusy={ isCreatingMenu }
-				aria-disabled={ isCreatingMenu }
+				/* Button is disabled but still focusable */
+				aria-disabled={ ! menuName.length || isCreatingMenu }
 			>
 				{ __( 'Create menu' ) }
 			</Button>

--- a/packages/edit-navigation/src/components/add-menu/index.js
+++ b/packages/edit-navigation/src/components/add-menu/index.js
@@ -53,13 +53,14 @@ function AddMenu( {
 	const createMenu = async ( event ) => {
 		event.preventDefault();
 
-		if ( ! menuName.length ) {
+		if ( ! menuName.length || isCreatingMenu ) {
 			return;
 		}
 
+		setIsCreatingMenu( true );
+
 		// Remove any existing notices.
 		removeAllNotices();
-		setIsCreatingMenu( true );
 
 		const menu = await saveMenu( { name: menuName } );
 
@@ -101,6 +102,7 @@ function AddMenu( {
 				variant="primary"
 				disabled={ ! menuName.length }
 				isBusy={ isCreatingMenu }
+				aria-disabled={ isCreatingMenu }
 			>
 				{ __( 'Create menu' ) }
 			</Button>


### PR DESCRIPTION
## Description
PR updates logic inside the AddMenu component to prevent dispatching the `saveMenu` action multiple times and adds `aria-disabled` to the button.

## How has this been tested?
1. Go to Gutenberg > Navigation (beta)
2. Emulate slow 3G network in DevTools.
3. Create a new menu.
4. Try clicking the "Create menu" button again while in a busy state.
5. There shouldn't be a second request to create a menu.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
