### PR TITLE
Add initial navigation editor user docs

### DIFF
--- a/packages/edit-navigation/docs/README.md
+++ b/packages/edit-navigation/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+This folder contains documentations for the Navigation Editor.
+
+1. [User Documentation](./user-documentation.md)

--- a/packages/edit-navigation/docs/user-documentation.md
+++ b/packages/edit-navigation/docs/user-documentation.md
@@ -1,0 +1,72 @@
+Note: this documentation is a work in progress.
+
+# Block-based menu editor
+
+The Block-based Navigation Editor brings the power of blocks to the Appearance > Navigation section in the WordPress Administration Screens allowing you use blocks to create menus.
+
+## How to use the editor
+
+The interface replicates the Post Editor experience, allowing you to use similar workflows like drag and drop.
+
+The editor provides access to all the menus created using the previous Menu screen in WordPress.
+
+New menus can also easily be created, providing options to easily create a menu from an existing page hierarchy, by copying an existing menu, or creating a blank menu.
+
+Rather than the paragraph being the go-to block, the Navigation Editor provides a link block for creating links to different types of items. Page, post, tag, category and custom links can all be created. Links can be nested to create sub-menus.
+
+### How to create a menu
+
+1. At the top of the editor select 'New menu'.
+2. Type the name of your menu.
+3. Choose a starting option of either 'Start blank', 'Add all pages', or 'Copy existing menu'.
+
+### How to add a block
+
+1. Click one of the `+` buttons.
+2. Select the type of link you want to add.
+3. Use the dialog to search for the item you want to link to. For a custom link, type in a URL and hit 'Enter'.
+
+### How to add a submenu block
+
+There are two ways to create a submenu, the first option is to create a new submenu from scratch:
+
+1. Click one of the `+` buttons.
+2. Select the 'Submenu' block.
+3. (Optional) Add a URL for the submenu.
+4. Use the nested `+` button in the submenu to add blocks in the submenu
+
+Alternatively, an existing link can be converted into a submenu:
+
+1. Select an existing link block.
+2. From the toolbar, select the 'Add submenu' button.
+
+### How to rename a menu
+
+1. If the settings sidebar isn't visible, click the 'Settings' button in the top-right corner of the screen.
+2. Select the 'Menu' tab.
+3. Use the name field at the top of the sidebar to rename a menu.
+4. Save any changes.
+
+### Assigning a menu to a theme location
+
+A theme location designates the part of your site that a menu is displayed. To assign, change or unassign a theme location.
+
+1. If the settings sidebar isn't visible, click the 'Settings' button in the top-right corner of the screen.
+2. Select the 'Menu' tab.
+3. Use the Theme Locations panel to select which locations the menu should be assigned to.
+4. Save any changes.
+
+For an overview of which menus are assigned to which locations, use the 'Manage locations' button in the same part of the screen.
+
+### Deleting a menu
+
+1. Choose a menu to delete using the menu selector in the middle of the editor's header.
+2. If the settings sidebar isn't visible, click the 'Settings' button in the top-right corner of the screen.
+3. Select the 'Menu' tab.
+4. Click the 'Delete menu' button.
+
+### How to opt-in or out of using the block-based navigation editor
+
+1. From WordPress admin, select the Gutenberg > Experiments option.
+2. Uncheck the tickbox to disable the editor or check it to enable it.
+3. Save changes.

--- a/packages/edit-navigation/docs/user-documentation.md
+++ b/packages/edit-navigation/docs/user-documentation.md
@@ -1,6 +1,6 @@
 Note: this documentation is a work in progress.
 
-# Block-based menu editor
+# Block-based navigation editor
 
 The Block-based Navigation Editor brings the power of blocks to the Appearance > Navigation section in the WordPress Administration Screens allowing you use blocks to create menus.
 
@@ -8,9 +8,13 @@ The Block-based Navigation Editor brings the power of blocks to the Appearance >
 
 The interface replicates the Post Editor experience, allowing you to use similar workflows like drag and drop.
 
-The editor provides access to all the menus created using the previous Menu screen in WordPress.
+The editor provides access to any menus created using the previous Menus screen in WordPress.
 
-New menus can also easily be created, providing options to easily create a menu from an existing page hierarchy, by copying an existing menu, or creating a blank menu.
+New menus can easily be created, options are provided to do so in a few different ways:
+* from an existing page hierarchy
+* by copying an existing menu
+* by creating a blank menu
+
 
 Rather than the paragraph being the go-to block, the Navigation Editor provides a link block for creating links to different types of items. Page, post, tag, category and custom links can all be created. Links can be nested to create sub-menus.
 
@@ -20,15 +24,25 @@ Rather than the paragraph being the go-to block, the Navigation Editor provides 
 2. Type the name of your menu.
 3. Choose a starting option of either 'Start blank', 'Add all pages', or 'Copy existing menu'.
 
-### How to add a block
+### How to insert a link
+
+If you'd like to link to a page, post, tag, or category:
 
 1. Click one of the `+` buttons.
 2. Select the type of link you want to add.
-3. Use the dialog to search for the item you want to link to. For a custom link, type in a URL and hit 'Enter'.
+3. Use the dialog to search for the item you want to link to.
 
-### How to add a submenu block
+For a custom link:
 
-There are two ways to create a submenu, the first option is to create a new submenu from scratch:
+1. Click one of the `+` buttons.
+2. Select the 'Custom Link' block.
+3. Using the dialog that appears, type in a URL and press 'Enter'.
+
+### How to insert a submenu
+
+There are two ways to insert a submenu.
+
+The first option is to create a new submenu from scratch:
 
 1. Click one of the `+` buttons.
 2. Select the 'Submenu' block.

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -15,6 +15,7 @@ import SaveButton from './save-button';
 import UndoButton from './undo-button';
 import RedoButton from './redo-button';
 import InserterToggle from './inserter-toggle';
+import MoreMenu from './more-menu';
 
 export default function Header( {
 	isMenuSelected,
@@ -65,6 +66,7 @@ export default function Header( {
 				{ isMediumViewport && <NewButton /> }
 				<SaveButton navigationPost={ navigationPost } />
 				<PinnedItems.Slot scope="core/edit-navigation" />
+				<MoreMenu />
 			</div>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/header/more-menu.js
+++ b/packages/edit-navigation/src/components/header/more-menu.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { external } from '@wordpress/icons';
+import { MoreMenuDropdown } from '@wordpress/interface';
+import { __ } from '@wordpress/i18n';
+
+export default function MoreMenu() {
+	return (
+		<MoreMenuDropdown>
+			{ () => (
+				<MenuItem
+					role="menuitem"
+					icon={ external }
+					href={ __(
+						'https://github.com/WordPress/gutenberg/tree/trunk/packages/edit-navigation/docs/user-documentation.md'
+					) }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __( 'Help' ) }
+					<VisuallyHidden as="span">
+						{
+							/* translators: accessibility text */
+							__( '(opens in a new tab)' )
+						}
+					</VisuallyHidden>
+				</MenuItem>
+			) }
+		</MoreMenuDropdown>
+	);
+}

--- a/packages/edit-navigation/src/components/header/more-menu.js
+++ b/packages/edit-navigation/src/components/header/more-menu.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { MenuGroup, MenuItem, VisuallyHidden } from '@wordpress/components';
 import { external } from '@wordpress/icons';
 import { MoreMenuDropdown } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
@@ -10,23 +10,25 @@ export default function MoreMenu() {
 	return (
 		<MoreMenuDropdown>
 			{ () => (
-				<MenuItem
-					role="menuitem"
-					icon={ external }
-					href={ __(
-						'https://github.com/WordPress/gutenberg/tree/trunk/packages/edit-navigation/docs/user-documentation.md'
-					) }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ __( 'Help' ) }
-					<VisuallyHidden as="span">
-						{
-							/* translators: accessibility text */
-							__( '(opens in a new tab)' )
-						}
-					</VisuallyHidden>
-				</MenuItem>
+				<MenuGroup label={ __( 'Tools' ) }>
+					<MenuItem
+						role="menuitem"
+						icon={ external }
+						href={ __(
+							'https://github.com/WordPress/gutenberg/tree/trunk/packages/edit-navigation/docs/user-documentation.md'
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'Help' ) }
+						<VisuallyHidden as="span">
+							{
+								/* translators: accessibility text */
+								__( '(opens in a new tab)' )
+							}
+						</VisuallyHidden>
+					</MenuItem>
+				</MenuGroup>
 			) }
 		</MoreMenuDropdown>
 	);


### PR DESCRIPTION
## Description
Fixes #34266

Adds some initial navigation editor user documentation.

This is heavily based on the docs for the widget editor (https://wordpress.org/support/article/block-based-widgets-editor/).

As the editor is developed these can be refined before eventually making their way to the wordpress.org website prior to release.

I've also added a link to the documentation from the editor in this PR, but unfortunately that won't work until the PR is merged.