### PR TITLE
Revert "Resize handles: Grow on hover/active."

### DIFF
--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -29,23 +29,16 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	position: absolute;
 	top: calc(50% - #{ceil($resize-handler-size * 0.5)});
 	right: calc(50% - #{ceil($resize-handler-size * 0.5)});
-	transition: all 0.1s ease;
-	@include reduce-motion("transition");
 
 	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	// Only visible in Windows High Contrast mode.
 	outline: 2px solid transparent;
 }
 
-.components-resizable-box__handle:active::after,
-.components-resizable-box__handle:hover::after {
-	box-shadow: inset 0 0 0 calc(var(--wp-admin-border-width-focus) * 2) var(--wp-admin-theme-color);
-}
-
 // This is the "visible" resize handle for side handles - the line
 .components-resizable-box__side-handle::before {
 	display: block;
-	border-radius: $radius-block-ui;
+	border-radius: 2px;
 	content: "";
 	width: 3px;
 	height: 3px;


### PR DESCRIPTION
Reverts WordPress/gutenberg#34953