### PR TITLE
Add the global styles preview to the sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -35,6 +35,7 @@ import {
 	default as DimensionsPanel,
 	useHasDimensionsPanel,
 } from './dimensions-panel';
+import { StylePreview } from './global-styles/preview';
 
 function getPanelTitle( blockName ) {
 	const blockType = getBlockType( blockName );
@@ -188,6 +189,11 @@ export default function GlobalStylesSidebar() {
 		>
 			<Navigation>
 				<NavigationMenu>
+					<NavigationGroup>
+						<NavigationItem>
+							<StylePreview />
+						</NavigationItem>
+					</NavigationGroup>
 					<GlobalStylesLevel
 						context={ root }
 						getStyle={ getStyle }

--- a/packages/edit-site/src/components/sidebar/global-styles/preview.js
+++ b/packages/edit-site/src/components/sidebar/global-styles/preview.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	ColorIndicator,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */ import { useGlobalStylesContext } from '../../editor/global-styles-provider';
+
+export const StylePreview = () => {
+	const { getStyle } = useGlobalStylesContext();
+	const fontFamily = getStyle( 'root', 'fontFamily' ) ?? 'serif';
+	const fontSize = getStyle( 'root', 'fontSize' ) ?? 'initial';
+	const textColor = getStyle( 'root', 'color' ) ?? 'black';
+	const linkColor = getStyle( 'root', 'linkColor' ) ?? 'blue';
+	const backgroundColor = getStyle( 'root', 'backgroundColor' ) ?? 'white';
+
+	return (
+		<Card
+			className="edit-site-global-styles-preview"
+			style={ { background: backgroundColor } }
+		>
+			<HStack spacing={ 5 }>
+				<div>
+					<span style={ { fontFamily, fontSize } }>A</span>
+					<span style={ { fontFamily, fontSize } }>a</span>
+				</div>
+				<VStack spacing={ 2 }>
+					<ColorIndicator colorValue={ textColor } />
+					<ColorIndicator colorValue={ linkColor } />
+				</VStack>
+			</HStack>
+		</Card>
+	);
+};

--- a/packages/edit-site/src/components/sidebar/global-styles/preview.js
+++ b/packages/edit-site/src/components/sidebar/global-styles/preview.js
@@ -15,7 +15,6 @@ import {
 export const StylePreview = () => {
 	const { getStyle } = useGlobalStylesContext();
 	const fontFamily = getStyle( 'root', 'fontFamily' ) ?? 'serif';
-	const fontSize = getStyle( 'root', 'fontSize' ) ?? 'initial';
 	const textColor = getStyle( 'root', 'color' ) ?? 'black';
 	const linkColor = getStyle( 'root', 'linkColor' ) ?? 'blue';
 	const backgroundColor = getStyle( 'root', 'backgroundColor' ) ?? 'white';
@@ -27,8 +26,8 @@ export const StylePreview = () => {
 		>
 			<HStack spacing={ 5 }>
 				<div>
-					<span style={ { fontFamily, fontSize } }>A</span>
-					<span style={ { fontFamily, fontSize } }>a</span>
+					<span style={ { fontFamily, fontSize: '80px' } }>A</span>
+					<span style={ { fontFamily, fontSize: '80px' } }>a</span>
 				</div>
 				<VStack spacing={ 2 }>
 					<ColorIndicator colorValue={ textColor } />

--- a/packages/edit-site/src/components/sidebar/global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar/global-styles/style.scss
@@ -1,0 +1,16 @@
+.edit-site-global-styles-preview {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 200px;
+
+	.component-color-indicator {
+		border-radius: 50%;
+		border: 0;
+		height: 25px;
+		width: 25px;
+		margin-left: 0;
+		padding: 0;
+	}
+}
+

--- a/packages/edit-site/src/components/sidebar/global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar/global-styles/style.scss
@@ -2,13 +2,13 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-height: 200px;
+	min-height: 152px;
 
 	.component-color-indicator {
 		border-radius: 50%;
 		border: 0;
-		height: 25px;
-		width: 25px;
+		height: 36px;
+		width: 36px;
 		margin-left: 0;
 		padding: 0;
 	}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -7,6 +7,7 @@
 @import "./components/navigation-sidebar/navigation-toggle/style.scss";
 @import "./components/navigation-sidebar/navigation-panel/style.scss";
 @import "./components/sidebar/style.scss";
+@import "./components/sidebar/global-styles/style.scss";
 @import "./components/sidebar/settings-header/style.scss";
 @import "./components/sidebar/template-card/style.scss";
 @import "./components/editor/style.scss";


### PR DESCRIPTION
Related to #34574 

This implements a first iteration of the Global Styles Preview in the Global Styles sidebar.

<img width="283" alt="Screen Shot 2021-09-21 at 10 50 39 AM" src="https://user-images.githubusercontent.com/272444/134150223-7acea0d8-83f0-4a65-bda6-0ddba66b3f50.png">
