### PR TITLE
Cover block: check fontSizes settings before setting fontSize in innerBlocks

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -65,22 +65,20 @@ import {
 	getPositionClassName,
 } from './shared';
 
-/**
- * Module Constants
- */
-
-const INNER_BLOCKS_TEMPLATE = [
-	[
-		'core/paragraph',
-		{
-			align: 'center',
-			fontSize: 'large',
-			placeholder: __( 'Write title…' ),
-		},
-	],
-];
-
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
+
+function getInnerBlocksTemplate( attributes ) {
+	return [
+		[
+			'core/paragraph',
+			{
+				align: 'center',
+				placeholder: __( 'Write title…' ),
+				...attributes,
+			},
+		],
+	];
+}
 
 function retrieveFastAverageColor() {
 	if ( ! retrieveFastAverageColor.fastAverageColor ) {
@@ -603,12 +601,19 @@ function CoverEdit( {
 
 	const ref = useRef();
 	const blockProps = useBlockProps( { ref } );
+
+	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
+	const hasFontSizes = !! useSetting( 'typography.fontSizes' )?.length;
+	const innerBlocksTemplate = getInnerBlocksTemplate( {
+		fontSize: hasFontSizes ? 'large' : undefined,
+	} );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
 		},
 		{
-			template: INNER_BLOCKS_TEMPLATE,
+			template: innerBlocksTemplate,
 			templateInsertUpdatesSelection: true,
 		}
 	);


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/34120

And so the days of the Cover block dictating font size attributes to its innerBlocks irrespective of the contents of theme.json and the wishes of theme developers ... _takes breath_ ... are over.

In this proposed code change, we check the editor settings for `fontSizes` block support before setting a `fontSize` attribute on the Cover block's innards (a paragraph).

Why? Because, as described in https://github.com/WordPress/gutenberg/issues/34120, the existence of the `fontSize` attribute, even where the theme has deactivated fontSize support, tells the [fontSize hook](https://github.com/WordPress/gutenberg/blob/a7e2895829c16ecd77a5ba22d84f1dee1cfb0977/packages/block-editor/src/hooks/font-size.js#L73) to add the `has-large-font-size` class to the block container.

Props to @andrewserong and @philbuchanan

## How has this been tested?

Manually, using a browser with 👀 We don't set innerBlock attributes for native mobile.

Best tested with smooth blues or jazz.

For testing, I'm using TT1 Blocks theme and editing the `theme.json` directly in WordPress, e.g., `/wp-admin/theme-editor.php?file=theme.json&theme=tt1-blocks`

### Existing behavior

Before applying this patch, check existing behavior.

Edit `settings.typography` in your `theme.json`:

```json
"fontSizes": []
```

In the editor, insert a cover block. Check that font size controls are disabled in the block inspector sidebar, and that the paragraph inner block has the class of `has-large-font-size`.

<img width="250" alt="Screen Shot 2021-09-21 at 7 48 56 pm" src="https://user-images.githubusercontent.com/6458278/134149964-08bda7fd-cb2f-48b5-801b-06f4c83013c3.png">

### With the changes in this PR applied

With this patch applied, refresh the editor and insert a new cover block. 

Check that font size controls are disabled in the block inspector sidebar, and that the paragraph inner block **does not** have the class of `has-large-font-size`.

Publish that post and check the frontend! The class should be absent on the paragraph block as well.

## Known knowns

Here are some things I discovered along the way. None have any negative impact on this PR I think.

We can override via specific block settings in `theme.json` as well. For example, deactivating `fontSizes` in `settings.typography`, but activating them in `settings.blocks['core/cover'].typography`.

```json
		"blocks": {
			"core/cover": {
				"typography": {
					"fontSizes": [
						{
							"slug": "extra-small",
							"size": "16px",
							"name": "Extra small"
						},
						{
							"slug": "small",
							"size": "18px",
							"name": "Small"
						}
					]
				}
			}
		}
```

The values themselves won't have any effect since the Cover Block doesn't yet support fontSizes.

Edge case: a mismatch might also occur when we turn off fontSizes for the paragraph block in `settings.blocks['core/paragraph'].typography`, but it's still activated in `settings.typography`.

```json
		"blocks": {
			"core/paragraph": {
				"typography": {
					"fontSizes": []
				}
			}
		
```

The controls do not appear, but the Cover block will read the global settings.

<img width="400" alt="Screen Shot 2021-09-22 at 11 13 25 am" src="https://user-images.githubusercontent.com/6458278/134268052-f5ff2c0c-628d-4651-a295-e44a64ef3876.png">

Oh yes, and [WordPress core fontSizes](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/theme.json#L188) will ultimately kick in if none are enabled elsewhere. 😄 

## Screenshots 

With `fontSizes` enabled:

<img width="300" alt="Screen Shot 2021-09-21 at 7 09 13 pm" src="https://user-images.githubusercontent.com/6458278/134145968-d64625c6-9a6b-4ff7-875a-c0d2fc253372.png">

**Without** `fontSizes` enabled:
<img width="300" alt="Screen Shot 2021-09-21 at 7 23 09 pm" src="https://user-images.githubusercontent.com/6458278/134146283-737e97a1-a88a-4637-bcb1-27dc799b5293.png">

## Types of changes
This is a compatibility change, ensure the inner blocks of the Cover block respect the theme.json settings.




## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
