### PR TITLE
Test that `add_theme_supports` are loaded for themes without `theme.json`

### DIFF
--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -214,7 +214,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
 		switch_theme( 'default' );
-		add_theme_support('custom-line-height');
+		add_theme_support( 'custom-line-height' );
 		$color_palette = array(
 			array(
 				'name'  => 'Primary',

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -212,4 +212,33 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $fse );
 	}
 
+	function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
+		switch_theme( 'default' );
+		add_theme_support('custom-line-height');
+		$color_palette = array(
+			array(
+				'name'  => 'Primary',
+				'slug'  => 'primary',
+				'color' => '#F00',
+			),
+			array(
+				'name'  => 'Secondary',
+				'slug'  => 'secondary',
+				'color' => '#0F0',
+			),
+			array(
+				'name'  => 'Tertiary',
+				'slug'  => 'tertiary',
+				'color' => '#00F',
+			),
+		);
+		add_theme_support( 'editor-color-palette', $color_palette );
+		$supports = gutenberg_get_default_block_editor_settings();
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $supports )->get_settings();
+
+		$this->assertSame( false, WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() );
+		$this->assertSame( true, $settings['typography']['customLineHeight'] );
+		$this->assertSame( $color_palette, $settings['color']['palette']['theme'] );
+	}
+
 }


### PR DESCRIPTION
Adds tests for https://github.com/WordPress/gutenberg/pull/34955

## How to test

Make sure the test passes in the current `trunk`:

- `npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-resolver-test.php`

Make sure the test would have failed before https://github.com/WordPress/gutenberg/pull/34955: 

- `git checkout -b test/before 4474d01bc88d7ee4edadbf3227852e43e141fb56` => checks out commit prior 
- `npm run test-unit-php -- /var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-theme-json-resolver-test.php` => the expected result is that the test fails.
