### PR TITLE
Nav block: Don't show the Link UI when you just added a link

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -300,6 +300,7 @@ export default function NavigationLinkEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add link…' );
 	const ref = useRef();
+	const isMounting = useRef( true );
 
 	const {
 		innerBlocks,
@@ -384,11 +385,17 @@ export default function NavigationLinkEdit( {
 		replaceBlock( clientId, newSubmenu );
 	}
 
-	// Show the LinkControl on mount if the URL is empty
+	// Show the LinkControl on mount if the URL is empty and this is
+	// not the first time we've added the item.
 	// ( When adding a new menu item)
 	// This can't be done in the useState call because it conflicts
 	// with the autofocus behavior of the BlockListBlock component.
 	useEffect( () => {
+		if ( isMounting.current ) {
+			isMounting.current = false;
+			return;
+		}
+
 		if ( ! url ) {
 			setIsLinkOpen( true );
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Experimenting off the back of https://github.com/WordPress/gutenberg/pull/34899#pullrequestreview-759569915 to see if stopping the Link UI from _automatically_ appearing when you add a link to a Navigation block improves the "flow" when adding items.

This PR changes things so that the Link UI will only appear when you actively click on the inserted link. That means you can go ahead and add a series of items to a Nav block and then come back and configure them as and when you are ready.

This confirms to the "add then configure" pattern I suggested in https://github.com/WordPress/gutenberg/pull/34899#pullrequestreview-759569915.

Obviously it's pretty unrefined but at this stage it's worth exploring a variety of options.

Also note that if and when https://github.com/WordPress/gutenberg/pull/33849 is merged you will be able to configure text and link at the same time from within the Link UI so that will reduce the number of interactions yet further.

## How has this been tested?

* Add Nav block.
* Use inline inserter to add items. Notice how the link UI doesn't appear automatically.
* Click on each item to configure it with a link.


## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/134157441-dd45dbbb-32f5-45da-93ba-0d6874633c7e.mp4



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
