### PR TITLE
Patterns explorer experiment

### DIFF
--- a/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
+++ b/packages/block-editor/src/components/block-switcher/use-transformed-patterns.js
@@ -92,7 +92,6 @@ export const getPatternTransformedBlocks = (
  * @param {WPBlock[]}        selectedBlocks The currently selected blocks.
  * @return {TransformedBlockPattern[]} Returns the eligible matched patterns with all the selected blocks.
  */
-// TODO tests
 const useTransformedPatterns = ( patterns, selectedBlocks ) => {
 	return useMemo(
 		() =>

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -140,6 +140,7 @@ export { useCanvasClickRedirect as __unstableUseCanvasClickRedirect } from './us
 export { default as useBlockDisplayInformation } from './use-block-display-information';
 export { default as __unstableIframe } from './iframe';
 export { default as __experimentalUseNoRecursiveRenders } from './use-no-recursive-renders';
+export { default as __experimentalPatternExplorer } from './pattern-explorer';
 
 /*
  * State Related Components

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -20,12 +20,16 @@ import BlockPatternList from '../block-patterns-list';
 function BlockPatternsCategory( {
 	rootClientId,
 	onInsert,
+	onSelectPattern,
 	selectedCategory,
 	onClickCategory,
+	isDraggable = true, // TODO: check docs (onSelectPattern too)
 } ) {
+	// TODO: check other usages of `usePatternState`
 	const [ allPatterns, allCategories, onClick ] = usePatternsState(
 		onInsert,
-		rootClientId
+		rootClientId,
+		onSelectPattern
 	);
 
 	// Remove any empty categories
@@ -115,7 +119,7 @@ function BlockPatternsCategory( {
 						onClickPattern={ onClick }
 						label={ patternCategory.label }
 						orientation="vertical"
-						isDraggable
+						isDraggable={ isDraggable }
 					/>
 				</PatternInserterPanel>
 			) }
@@ -127,14 +131,18 @@ function BlockPatternsTabs( {
 	rootClientId,
 	onInsert,
 	onClickCategory,
+	onSelectPattern,
 	selectedCategory,
+	isDraggable = true,
 } ) {
 	return (
 		<BlockPatternsCategory
 			rootClientId={ rootClientId }
 			selectedCategory={ selectedCategory }
 			onInsert={ onInsert }
+			onSelectPattern={ onSelectPattern }
 			onClickCategory={ onClickCategory }
+			isDraggable={ isDraggable }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -167,7 +167,12 @@ function useInsertionPoint( {
 		]
 	);
 
-	return [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ];
+	return [
+		destinationRootClientId,
+		onInsertBlocks,
+		onToggleInsertionPoint,
+		destinationIndex,
+	];
 }
 
 export default useInsertionPoint;

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -20,12 +20,13 @@ import { store as blockEditorStore } from '../../../store';
 /**
  * Retrieves the block patterns inserter state.
  *
- * @param {Function} onInsert     function called when inserter a list of blocks.
- * @param {string=}  rootClientId Insertion's root client ID.
+ * @param {Function} onInsert        function called when inserter a list of blocks.
+ * @param {string=}  rootClientId    Insertion's root client ID.
+ * @param {Function} onSelectPattern Callback function on pattern select.
  *
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
-const usePatternsState = ( onInsert, rootClientId ) => {
+const usePatternsState = ( onInsert, rootClientId, onSelectPattern ) => {
 	const { patternCategories, patterns } = useSelect(
 		( select ) => {
 			const { __experimentalGetAllowedPatterns, getSettings } = select(
@@ -41,20 +42,25 @@ const usePatternsState = ( onInsert, rootClientId ) => {
 	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onClickPattern = useCallback( ( pattern, blocks ) => {
-		onInsert(
-			map( blocks, ( block ) => cloneBlock( block ) ),
-			pattern.name
-		);
-		createSuccessNotice(
-			sprintf(
-				/* translators: %s: block pattern title. */
-				__( 'Block pattern "%s" inserted.' ),
-				pattern.title
-			),
-			{
-				type: 'snackbar',
-			}
-		);
+		if ( onSelectPattern ) {
+			onSelectPattern( pattern );
+		}
+		if ( onInsert ) {
+			onInsert(
+				map( blocks, ( block ) => cloneBlock( block ) ),
+				pattern.name
+			);
+			createSuccessNotice(
+				sprintf(
+					/* translators: %s: block pattern title. */
+					__( 'Block pattern "%s" inserted.' ),
+					pattern.title
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+		}
 	}, [] );
 
 	return [ patterns, patternCategories, onClickPattern ];

--- a/packages/block-editor/src/components/pattern-explorer/index.js
+++ b/packages/block-editor/src/components/pattern-explorer/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PatternExplorerSidebar from './sidebar';
+import PatternExplorerPreview from './preview';
+import useInsertionPoint from '../inserter/hooks/use-insertion-point';
+
+function PatternExplorer( { rootClientId, __experimentalInsertionIndex } ) {
+	const [ selectedPattern, setSelectedPattern ] = useState();
+	const [
+		destinationRootClientId,
+		onInsertBlocks,
+		,
+		destinationIndex,
+	] = useInsertionPoint( {
+		rootClientId,
+		insertionIndex: __experimentalInsertionIndex,
+	} );
+	return (
+		<div className="block-editor-pattern-explorer">
+			<PatternExplorerSidebar
+				rootClientId={ destinationRootClientId }
+				setSelectedPattern={ setSelectedPattern }
+			/>
+			{ selectedPattern && (
+				<PatternExplorerPreview
+					rootClientId={ destinationRootClientId }
+					destinationIndex={ destinationIndex }
+					selectedPattern={ selectedPattern }
+					onInsertBlocks={ onInsertBlocks }
+				/>
+			) }
+		</div>
+	);
+}
+
+export default PatternExplorer;

--- a/packages/block-editor/src/components/pattern-explorer/preview/index.js
+++ b/packages/block-editor/src/components/pattern-explorer/preview/index.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import PreviewHeader from './preview-header';
+import PreviewPattern from './preview-pattern';
+
+function PatternExplorerPreview( {
+	rootClientId,
+	destinationIndex,
+	selectedPattern = {},
+	onInsertBlocks,
+} ) {
+	const baseCssClass = 'block-editor-pattern-explorer__preview';
+	return (
+		<div className={ baseCssClass }>
+			<PreviewHeader
+				pattern={ selectedPattern }
+				onInsertBlocks={ onInsertBlocks }
+			/>
+			<PreviewPattern
+				pattern={ selectedPattern }
+				destinationRootClientId={ rootClientId }
+				destinationIndex={ destinationIndex }
+			/>
+		</div>
+	);
+}
+
+export default PatternExplorerPreview;

--- a/packages/block-editor/src/components/pattern-explorer/preview/preview-header.js
+++ b/packages/block-editor/src/components/pattern-explorer/preview/preview-header.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { cloneBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+function PreviewHeader( { pattern, onInsertBlocks } ) {
+	const { title, categories = [], blocks } = pattern;
+	const baseCssClass = 'block-editor-pattern-explorer__preview__header';
+
+	return (
+		<div className={ baseCssClass }>
+			<div className={ `${ baseCssClass }__title` }>{ title }</div>
+			{ !! categories?.length && (
+				// Todo print categories properly
+				<div className={ `${ baseCssClass }__category` }>
+					{ categories.map( ( category ) => (
+						<span key={ category }>{ category }</span>
+					) ) }
+				</div>
+			) }
+			<div className={ `${ baseCssClass }__choose` }>
+				<Button
+					onClick={ () =>
+						onInsertBlocks(
+							blocks.map( ( block ) => cloneBlock( block ) )
+						)
+					}
+					isPrimary
+				>
+					{ __( 'Choose' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export default PreviewHeader;

--- a/packages/block-editor/src/components/pattern-explorer/preview/preview-pattern.js
+++ b/packages/block-editor/src/components/pattern-explorer/preview/preview-pattern.js
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { ResizableBox } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useState, useMemo } from '@wordpress/element';
+import { cloneBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import PreviewSettings from './preview-settings';
+import BlockPreview from '../../block-preview';
+import { store as blockEditorStore } from '../../../store';
+
+const INITIAL_WIDTH = 660;
+const MIN_PREVIEW_WIDTH = 280;
+const enableHandlers = {
+	left: true,
+	right: true,
+	top: false,
+	bottom: false,
+};
+
+// TODO: refactor, doc, tests (mutation)
+const getPreviewBlocksInRootBlock = (
+	block,
+	patternBlocks,
+	destinationRootClientId,
+	destinationIndex
+) => {
+	const { clientId } = block;
+	if ( clientId === destinationRootClientId ) {
+		block.innerBlocks = [
+			...block.innerBlocks.slice( 0, destinationIndex ),
+			...patternBlocks,
+			...block.innerBlocks.slice( destinationIndex ),
+		];
+		return block;
+	}
+	return {
+		...block,
+		innerBlocks: block.innerBlocks.map( ( innerBlock ) =>
+			getPreviewBlocksInRootBlock(
+				innerBlock,
+				patternBlocks,
+				destinationRootClientId,
+				destinationIndex
+			)
+		),
+	};
+};
+
+function PreviewPattern( {
+	pattern,
+	destinationRootClientId,
+	destinationIndex,
+} ) {
+	// const [ width, setWidth ] = useState(
+	// 	window.innerWidth < INITIAL_WIDTH ? window.innerWidth : INITIAL_WIDTH
+	// );
+	const [ width, setWidth ] = useState( INITIAL_WIDTH );
+	const [ showPreviewWithContent, setShowPreviewWithContent ] = useState(
+		false
+	);
+	const { blocks } = pattern;
+	const baseCssClass = 'block-editor-pattern-explorer__preview__pattern';
+	const rootBlock = useSelect(
+		( select ) => {
+			const { getBlock, getBlockHierarchyRootClientId } = select(
+				blockEditorStore
+			);
+			return (
+				destinationRootClientId &&
+				getBlock(
+					getBlockHierarchyRootClientId( destinationRootClientId )
+				)
+			);
+		},
+		[ destinationRootClientId ]
+	);
+
+	const previewBlocks = useMemo( () => {
+		if ( ! showPreviewWithContent || ! rootBlock ) {
+			return blocks;
+		}
+
+		const _rootBlock = cloneDeep( rootBlock );
+		return [
+			cloneBlock(
+				getPreviewBlocksInRootBlock(
+					_rootBlock,
+					blocks,
+					destinationRootClientId,
+					destinationIndex
+				)
+			),
+		];
+	}, [
+		blocks,
+		rootBlock,
+		destinationRootClientId,
+		destinationIndex,
+		showPreviewWithContent,
+	] );
+
+	return (
+		<div className={ baseCssClass }>
+			<PreviewSettings
+				width={ width }
+				setWidth={ setWidth }
+				showPreviewWithContentControl={ !! destinationRootClientId }
+				showPreviewWithContent={ showPreviewWithContent }
+				setShowPreviewWithContent={ setShowPreviewWithContent }
+			/>
+			<ResizableBox
+				size={ {
+					width: width ?? 'auto',
+					height: 'auto',
+				} }
+				minWidth={ MIN_PREVIEW_WIDTH }
+				// maxWidth={ maxWidthBuffer }
+				// minHeight={ minHeight }
+				// maxHeight="50vh"
+				enable={ enableHandlers }
+				onResize={ ( _event, _direction, elt ) => {
+					setWidth( parseInt( elt.offsetWidth, 10 ) );
+				} }
+				// onResizeStop={ ( _event, _direction, elt ) => {
+				// 	setWidth( parseInt( elt.offsetWidth, 10 ) );
+				// } }
+			>
+				<BlockPreview
+					blocks={ previewBlocks }
+					viewportWidth={ width }
+				/>
+			</ResizableBox>
+		</div>
+	);
+}
+
+export default PreviewPattern;

--- a/packages/block-editor/src/components/pattern-explorer/preview/preview-settings.js
+++ b/packages/block-editor/src/components/pattern-explorer/preview/preview-settings.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	SelectControl,
+	ToggleControl,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
+
+// TODO: check name of const..
+const mediumViewWidths = [
+	{ label: __( 'Medium (480px)' ), value: 480 },
+	{ label: __( 'Narrow (320px)' ), value: 320 },
+];
+
+const largeViewWidths = [
+	{
+		label: __( 'Default (960px)' ),
+		value: 960,
+	},
+	...mediumViewWidths,
+];
+const wideViewWidths = [
+	{ label: __( 'Full (1200px)' ), value: 1200 },
+	...largeViewWidths,
+];
+
+const MIN_PREVIEW_WIDTH = 280;
+
+function PreviewWidths( { width, setWidth } ) {
+	const showViewportControl = useViewportMatch( 'mobile', '>=' );
+	const showViewportControlLarge = useViewportMatch( 'large', '>=' );
+	const showViewportControlWide = useViewportMatch( 'wide', '>=' );
+
+	const availableWidths = useMemo( () => {
+		// Less than 480 wide.
+		if ( ! showViewportControl ) {
+			return [];
+		}
+		if ( showViewportControlWide ) {
+			// More than 1280 wide.
+			return wideViewWidths;
+		} else if ( showViewportControlLarge ) {
+			// Less than 1280, more than 960.
+			return largeViewWidths;
+		}
+		// Less than 960, but larger than 480.
+		return mediumViewWidths;
+	}, [
+		showViewportControl,
+		showViewportControlWide,
+		showViewportControlLarge,
+	] );
+
+	let currentOpt = false;
+	if ( ! availableWidths.some( ( opt ) => opt.value === width ) ) {
+		const displayWidth = Math.max( Math.floor( width ), MIN_PREVIEW_WIDTH );
+		currentOpt = {
+			/* translators: %s is the width in pixels, ex 600. */
+			label: sprintf( __( 'Current (%spx)' ), displayWidth ),
+			value: displayWidth,
+		};
+	}
+	return (
+		<div className="pattern-preview__size-control">
+			{ showViewportControl && (
+				<SelectControl
+					hideLabelFromVision
+					label={ __( 'Preview Width' ) }
+					value={ width }
+					options={
+						currentOpt
+							? [ currentOpt, ...availableWidths ]
+							: availableWidths
+					}
+					onChange={ ( value ) => setWidth( Number( value ) ) }
+				/>
+			) }
+		</div>
+	);
+}
+
+function PreviewSettings( {
+	width,
+	setWidth,
+	showPreviewWithContentControl,
+	showPreviewWithContent,
+	setShowPreviewWithContent,
+} ) {
+	return (
+		<Flex
+			justify="space-between"
+			className="block-editor-pattern-explorer__preview__settings"
+		>
+			<FlexItem>
+				<PreviewWidths width={ width } setWidth={ setWidth } />
+			</FlexItem>
+			{ showPreviewWithContentControl && (
+				<FlexItem>
+					<ToggleControl
+						label="Show preview with parent block's content"
+						checked={ !! showPreviewWithContent }
+						onChange={ () =>
+							setShowPreviewWithContent(
+								! showPreviewWithContent
+							)
+						}
+					/>
+				</FlexItem>
+			) }
+		</Flex>
+	);
+}
+
+export default PreviewSettings;

--- a/packages/block-editor/src/components/pattern-explorer/sidebar/index.js
+++ b/packages/block-editor/src/components/pattern-explorer/sidebar/index.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { SearchControl } from '@wordpress/components';
+import {
+	// useViewportMatch,
+	__experimentalUseDialog as useDialog,
+} from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useState, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockPatternsTabs from '../../inserter/block-patterns-tab';
+import SearchResults from './search-results';
+
+function PatternExplorerSidebar( { rootClientId, setSelectedPattern } ) {
+	const [ filterValue, setFilterValue ] = useState( '' );
+	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
+		null
+	);
+
+	// const isMobile = useViewportMatch( 'medium', '<' );
+	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
+		// onClose: () => setIsInserterOpened( false ),
+	} );
+	const onClickPatternCategory = useCallback(
+		( patternCategory ) => {
+			setSelectedPatternCategory( patternCategory );
+		},
+		[ setSelectedPatternCategory ]
+	);
+
+	const onSelectPattern = useCallback( ( pattern ) => {
+		setSelectedPattern( pattern );
+	}, [] );
+	const baseCssClass = 'block-editor-pattern-explorer__sidebar';
+	return (
+		<div
+			ref={ inserterDialogRef }
+			{ ...inserterDialogProps }
+			className={ baseCssClass }
+		>
+			<div className={ `${ baseCssClass }__main-area` }>
+				{ /* the following div is necessary to fix the sticky position of the search form */ }
+				<div className={ `${ baseCssClass }__content` }>
+					<SearchControl
+						className={ `${ baseCssClass }__search` }
+						// className="block-editor-inserter__search"
+						onChange={ ( value ) => {
+							setFilterValue( value );
+						} }
+						value={ filterValue }
+						label={ __( 'Search for patterns' ) }
+						placeholder={ __( 'Search for patterns' ) }
+					/>
+					{ !! filterValue && (
+						<SearchResults
+							filterValue={ filterValue }
+							onSelect={ onSelectPattern }
+							rootClientId={ rootClientId }
+							// __experimentalInsertionIndex={
+							// 	__experimentalInsertionIndex
+							// }
+						/>
+					) }
+					{ ! filterValue && (
+						<BlockPatternsTabs
+							rootClientId={ rootClientId }
+							onSelectPattern={ onSelectPattern }
+							onClickCategory={ onClickPatternCategory }
+							selectedCategory={ selectedPatternCategory }
+							isDraggable={ false }
+						/>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default PatternExplorerSidebar;

--- a/packages/block-editor/src/components/pattern-explorer/sidebar/search-results.js
+++ b/packages/block-editor/src/components/pattern-explorer/sidebar/search-results.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
+import { useDebounce, useAsyncList } from '@wordpress/compose';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import BlockPatternsList from '../../block-patterns-list';
+import InserterPanel from '../../inserter/panel';
+import InserterNoResults from '../../inserter/no-results';
+import useInsertionPoint from '../../inserter/hooks/use-insertion-point';
+import usePatternsState from '../../inserter/hooks/use-patterns-state';
+import { searchItems } from '../../inserter/search-items';
+import InserterListbox from '../../inserter-listbox';
+
+function InserterSearchResults( {
+	filterValue,
+	onSelect,
+	rootClientId,
+	__experimentalInsertionIndex,
+	maxBlockPatterns,
+} ) {
+	const debouncedSpeak = useDebounce( speak, 500 );
+	const [ destinationRootClientId ] = useInsertionPoint( {
+		rootClientId,
+		insertionIndex: __experimentalInsertionIndex,
+	} );
+	const [ patterns, , onSelectBlockPattern ] = usePatternsState(
+		undefined,
+		destinationRootClientId,
+		onSelect
+	);
+
+	const filteredBlockPatterns = useMemo( () => {
+		const results = searchItems( patterns, filterValue );
+		return maxBlockPatterns !== undefined
+			? results.slice( 0, maxBlockPatterns )
+			: results;
+	}, [ filterValue, patterns, maxBlockPatterns ] );
+
+	// Announce search results on change
+	useEffect( () => {
+		if ( ! filterValue ) {
+			return;
+		}
+		const count = filteredBlockPatterns.length;
+		const resultsFoundMessage = sprintf(
+			/* translators: %d: number of results. */
+			_n( '%d result found.', '%d results found.', count ),
+			count
+		);
+		debouncedSpeak( resultsFoundMessage );
+	}, [ filterValue, debouncedSpeak ] );
+	const currentShownPatterns = useAsyncList( filteredBlockPatterns );
+	const hasItems = !! filteredBlockPatterns?.length;
+	return (
+		<InserterListbox>
+			{ ! hasItems && <InserterNoResults /> }
+			{ !! filteredBlockPatterns.length && (
+				<InserterPanel
+					title={
+						<VisuallyHidden>
+							{ __( 'Block Patterns' ) }
+						</VisuallyHidden>
+					}
+				>
+					<div className="block-editor-inserter__quick-inserter-patterns">
+						<BlockPatternsList
+							shownPatterns={ currentShownPatterns }
+							blockPatterns={ filteredBlockPatterns }
+							onClickPattern={ onSelectBlockPattern }
+							isDraggable={ false }
+						/>
+					</div>
+				</InserterPanel>
+			) }
+		</InserterListbox>
+	);
+}
+
+export default InserterSearchResults;

--- a/packages/block-editor/src/components/pattern-explorer/style.scss
+++ b/packages/block-editor/src/components/pattern-explorer/style.scss
@@ -1,0 +1,28 @@
+.block-editor-pattern-explorer {
+	display: flex;
+	&__sidebar {
+		padding-right: $grid-unit-40;
+		border-right: $border-width solid $gray-300;
+	}
+	&__preview {
+		padding-left: $grid-unit-40;
+		flex: 1;
+		&__header {
+			border-bottom: $border-width solid $gray-300;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: $grid-unit-15;
+			padding-bottom: $grid-unit-15;
+		}
+		&__pattern {
+			.components-resizable-box__container {
+				margin: 0 auto;
+			}
+		}
+		&__settings {
+			border-bottom: $border-width solid $gray-300;
+			margin-bottom: $grid-unit-15;
+		}
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -41,6 +41,7 @@
 @import "./components/media-replace-flow/style.scss";
 @import "./components/media-placeholder/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
+@import "./components/pattern-explorer/style.scss";
 @import "./components/plain-text/style.scss";
 @import "./components/responsive-block-control/style.scss";
 @import "./components/rich-text/style.scss";

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -52,6 +52,7 @@ export default function Modal( {
 	className,
 	contentLabel,
 	onKeyDown,
+	isFullScreen,
 } ) {
 	const ref = useRef();
 	const instanceId = useInstanceId( Modal );
@@ -112,7 +113,9 @@ export default function Modal( {
 			onKeyDown={ handleEscapeKeyDown }
 		>
 			<div
-				className={ classnames( 'components-modal__frame', className ) }
+				className={ classnames( 'components-modal__frame', className, {
+					'is-full-screen': isFullScreen,
+				} ) }
 				style={ style }
 				ref={ useMergeRefs( [
 					constrainedTabbingRef,

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -37,6 +37,11 @@
 		animation: components-modal__appear-animation 0.1s ease-out;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
+
+		&.is-full-screen {
+			min-width: 90vw;
+			min-height: 80vw;
+		}
 	}
 
 	@include break-large() {

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -23,6 +23,7 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
+import PatternExplorerButton from '../../pattern-explorer-button';
 import { store as editPostStore } from '../../../store';
 
 const preventDefault = ( event ) => {
@@ -163,6 +164,7 @@ function HeaderToolbar() {
 						{ overflowItems }
 					</>
 				) }
+				<ToolbarItem as={ PatternExplorerButton } />
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/edit-post/src/components/pattern-explorer-button/index.js
+++ b/packages/edit-post/src/components/pattern-explorer-button/index.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { layout } from '@wordpress/icons';
+import { forwardRef, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { __experimentalPatternExplorer as PatternExplorer } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+function PatternExplorerButton( props, ref ) {
+	const [ isModalOpen, setIsModalOpen ] = useState();
+	const insertionPoint = useSelect( ( select ) => {
+		const { __experimentalGetInsertionPoint } = select( editPostStore );
+		return __experimentalGetInsertionPoint();
+	}, [] );
+	return (
+		<>
+			<Button
+				{ ...props }
+				ref={ ref }
+				icon={ layout }
+				label={ __( 'Pattern explorer' ) }
+				onClick={ () => {
+					setIsModalOpen( true );
+				} }
+			/>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Pattern explorer' ) }
+					closeLabel={ __( 'Close' ) }
+					onRequestClose={ () => {
+						setIsModalOpen( false );
+					} }
+					overlayClassName="edit-post-pattern-explorer-button__modal"
+					isFullScreen
+				>
+					<PatternExplorer
+						rootClientId={ insertionPoint.rootClientId }
+						__experimentalInsertionIndex={
+							insertionPoint.insertionIndex
+						}
+					/>
+				</Modal>
+			) }
+		</>
+	);
+}
+
+export default forwardRef( PatternExplorerButton );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/26905, 

This is way far from being good and functioning properly but it's an experiment for a `pattern explorer`. The poor design is just for demo purposes and just wanted to gather feedback if any of these parts makes sense to integrate.

We could just keep part of this functionality with changes or nothing at all 😄 

The flex layout I've used is not good and I'm attaching a video with okayish dimensions to show the functionality.
I've added a `button` for now in the `header of post-editor`, next to the `list view` icon (it was easier for me to one-click).

The main new functionality would be:
1. Preview patterns with a resizable component (something like [pattern directory](https://wordpress.org/patterns/pattern/large-background-image-with-title-and-description/))
2. If you have selected a block which is nested (for example in `Columns`), you can toggle `preview with parent block` and can see how it looks where it's going to be inserted.



https://user-images.githubusercontent.com/16275880/134176097-df41957d-1ed3-4c00-9faf-9cab10991f30.mov



