### PR TITLE
Rich text: fix arrow navigation with consecutive formats

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -54,6 +54,18 @@ exports[`RichText should navigate arround emoji 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should navigate consecutive format boundaries 1`] = `
+"<!-- wp:paragraph -->
+<p><strong>1</strong><em>2</em></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should navigate consecutive format boundaries 2`] = `
+"<!-- wp:paragraph -->
+<p><strong>1</strong>-<em>2</em></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should not format text after code backtick 1`] = `
 "<!-- wp:paragraph -->
 <p>A <code>backtick</code> and more.</p>

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -470,4 +470,28 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should navigate consecutive format boundaries', async () => {
+		await clickBlockAppender();
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await pressKeyWithModifier( 'primary', 'i' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'i' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Should move into the second format.
+		await page.keyboard.press( 'ArrowLeft' );
+		// Should move to the start of the second format.
+		await page.keyboard.press( 'ArrowLeft' );
+		// Should move between the first and second format.
+		await page.keyboard.press( 'ArrowLeft' );
+
+		await page.keyboard.type( '-' );
+
+		// Expect: <strong>1</strong>-<em>2</em>
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/component/use-format-boundaries.js
+++ b/packages/rich-text/src/component/use-format-boundaries.js
@@ -70,55 +70,28 @@ export function useFormatBoundaries( props ) {
 
 			const formatsBefore = formats[ start - 1 ] || EMPTY_ACTIVE_FORMATS;
 			const formatsAfter = formats[ start ] || EMPTY_ACTIVE_FORMATS;
+			const destination = isReverse ? formatsBefore : formatsAfter;
+			const isIncreasing = currentActiveFormats.every(
+				( format, index ) => format === destination[ index ]
+			);
 
 			let newActiveFormatsLength = currentActiveFormats.length;
-			let source = formatsAfter;
 
-			if ( formatsBefore.length > formatsAfter.length ) {
-				source = formatsBefore;
-			}
-
-			// If the amount of formats before the caret and after the caret is
-			// different, the caret is at a format boundary.
-			if ( formatsBefore.length < formatsAfter.length ) {
-				if (
-					! isReverse &&
-					currentActiveFormats.length < formatsAfter.length
-				) {
-					newActiveFormatsLength++;
-				}
-
-				if (
-					isReverse &&
-					currentActiveFormats.length > formatsBefore.length
-				) {
-					newActiveFormatsLength--;
-				}
-			} else if ( formatsBefore.length > formatsAfter.length ) {
-				if (
-					! isReverse &&
-					currentActiveFormats.length > formatsAfter.length
-				) {
-					newActiveFormatsLength--;
-				}
-
-				if (
-					isReverse &&
-					currentActiveFormats.length < formatsBefore.length
-				) {
-					newActiveFormatsLength++;
-				}
+			if ( ! isIncreasing ) {
+				newActiveFormatsLength--;
+			} else if ( newActiveFormatsLength < destination.length ) {
+				newActiveFormatsLength++;
 			}
 
 			if ( newActiveFormatsLength === currentActiveFormats.length ) {
-				record.current._newActiveFormats = isReverse
-					? formatsBefore
-					: formatsAfter;
+				record.current._newActiveFormats = destination;
 				return;
 			}
 
 			event.preventDefault();
 
+			const origin = isReverse ? formatsAfter : formatsBefore;
+			const source = isIncreasing ? destination : origin;
 			const newActiveFormats = source.slice( 0, newActiveFormatsLength );
 			const newValue = {
 				...record.current,

--- a/packages/rich-text/src/update-formats.js
+++ b/packages/rich-text/src/update-formats.js
@@ -19,8 +19,11 @@ import { isFormatEqual } from './is-format-equal';
  * @return {RichTextValue} Mutated value.
  */
 export function updateFormats( { value, start, end, formats } ) {
-	const formatsBefore = value.formats[ start - 1 ] || [];
-	const formatsAfter = value.formats[ end ] || [];
+	// Start and end may be switched in case of delete.
+	const min = Math.min( start, end );
+	const max = Math.max( start, end );
+	const formatsBefore = value.formats[ min - 1 ] || [];
+	const formatsAfter = value.formats[ max ] || [];
 
 	// First, fix the references. If any format right before or after are
 	// equal, the replacement format should use the same reference.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

If there are two consecutive formats, arrow navigation from one format to the other is broken. See e2e test.
|Before|After|
|-|-|
|![arrow-nav-before](https://user-images.githubusercontent.com/4710635/134205387-9fa51d82-367a-407b-9f9c-e7f2fbdebb41.gif)|![arrow-nav-after](https://user-images.githubusercontent.com/4710635/134205760-3ef98494-c46b-41ee-b1f7-99a041c1401b.gif)|

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
