### PR TITLE
Rich text: only merge neighbouring equal formats when applying a format

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -7,7 +7,6 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { store as richTextStore } from './store';
-import { isFormatEqual } from './is-format-equal';
 import { createElement } from './create-element';
 import { mergePair } from './concat';
 import {
@@ -424,16 +423,10 @@ function createFromElement( {
 			continue;
 		}
 
-		const lastFormats =
-			accumulator.formats[ accumulator.formats.length - 1 ];
-		const lastFormat = lastFormats && lastFormats[ lastFormats.length - 1 ];
-		const newFormat = toFormat( {
+		const format = toFormat( {
 			type,
 			attributes: getAttributes( { element: node } ),
 		} );
-		const format = isFormatEqual( newFormat, lastFormat )
-			? lastFormat
-			: newFormat;
 
 		if (
 			multilineWrapperTags &&

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -250,4 +250,23 @@ describe( 'applyFormat', () => {
 		expect( result ).not.toBe( record );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
 	} );
+
+	it( 'should merge equal neighbouring formats', () => {
+		const record = {
+			// Use a different reference but equal content.
+			formats: [ , , [ { ...em } ], [ { ...em } ] ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			activeFormats: [ em ],
+			// All references should be the same.
+			formats: [ [ em ], [ em ], [ em ], [ em ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), em, 0, 2 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
 } );

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -104,11 +104,11 @@ describe( 'create', () => {
 		expect( value.formats[ 2 ] ).toBe( value.formats[ 3 ] );
 	} );
 
-	it( 'should use same reference for equal format', () => {
+	it( 'should use different reference for equal format', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#">a</a>' } );
 
 		// Format objects.
-		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 1 ][ 0 ] );
+		expect( value.formats[ 0 ][ 0 ] ).not.toBe( value.formats[ 1 ][ 0 ] );
 
 		// Format arrays per index.
 		expect( value.formats[ 0 ] ).not.toBe( value.formats[ 1 ] );

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -134,10 +134,9 @@ describe( 'toHTMLString', () => {
 	it( 'should serialize neighbouring same formats', () => {
 		const HTML = '<a href="a">a</a><a href="a">a</a>';
 		const element = createNode( `<p>${ HTML }</p>` );
-		const expectedHTML = '<a href="a">aa</a>';
 
 		expect( toHTMLString( { value: create( { element } ) } ) ).toEqual(
-			expectedHTML
+			HTML
 		);
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently, when creating a rich text value, we merge formats when they neighbour and are equal in type and attributes. This causes the original value and the serialised value to be different. In other words `toHTMLString(create(value)) !== value`. Ideally, the original HTML tags should be preserved if there was no user action.

Additionally, there are cases where merging formats changes the meaning, e.g. in [mi element](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mi) and in a [ruby element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element) element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
