### PR TITLE
Remove shift-stepping from range in RangeControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fix
 
--   Fixed rounding of value in `RangeControl` component when it looses focus while the `SHIFT` key is held. ([#34363](https://github.com/WordPress/gutenberg/issues/34363)).
+-   Fixed rounding of value in `RangeControl` component when it loses focus while the `SHIFT` key is held. ([#35020](https://github.com/WordPress/gutenberg/pull/35020)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 ## Unreleased
 
-### Breaking changes
+### Breaking Changes
 
 -   Removed the deprecated `position` and `menuLabel` from the `DropdownMenu` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
 -   Removed the deprecated `onClickOutside` prop from the `Popover` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
+-   Changed `RangeControl` component to not apply `shiftStep` to inputs from its `<input type="range"/>` ([35020](https://github.com/WordPress/gutenberg/pull/35020)).
+
+### Bug Fix
+
+-   Fixed rounding of value in `RangeControl` component when it looses focus while the `SHIFT` key is held. ([#34363](https://github.com/WordPress/gutenberg/issues/34363)).
+
+### Internal
+
+-   Deleted the `createComponent` utility function ([#34929](https://github.com/WordPress/gutenberg/pull/34929)).
 
 ## 17.0.0 (2021-09-09)
 
@@ -22,7 +31,6 @@
 ### Internal
 
 -   Renamed `PolymorphicComponent*` types to `WordPressComponent*` ([#34330](https://github.com/WordPress/gutenberg/pull/34330)).
--   Deleted the `createComponent` utility function ([#34929](https://github.com/WordPress/gutenberg/pull/34929)).
 
 ## 16.0.0 (2021-08-23)
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -172,11 +172,10 @@ If no value exists this prop contains the slider starting position.
 
 ### isShiftStepEnabled
 
-If true, pressing `UP` or `DOWN` along with the `SHIFT` key will increment the value by the `shiftStep` value.
+Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` is true. If true, while the number input has focus, pressing `UP` or `DOWN` along with the `SHIFT` key will change the value by the `shiftStep` value.
 
 -   Type: `Boolean`
 -   Required: No
--   Default: `true`
 
 #### marks
 
@@ -286,6 +285,13 @@ The stepping interval between `min` and `max` values. Step is used both for user
 -   Type: `Number`
 -   Required: No
 -   Platform: Web
+
+### shiftStep
+
+Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` and `isShiftStepEnabled` are both true and while the number input has focus. Acts as a multiplier of `step`.
+
+-   Type: `Number`
+-   Required: No
 
 #### trackColor
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -170,7 +170,7 @@ If no value exists this prop contains the slider starting position.
 -   Required: No
 -   Platform: Web | Mobile
 
-### isShiftStepEnabled
+#### isShiftStepEnabled
 
 Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` is true. If true, while the number input has focus, pressing `UP` or `DOWN` along with the `SHIFT` key will change the value by the `shiftStep` value.
 
@@ -286,7 +286,7 @@ The stepping interval between `min` and `max` values. Step is used both for user
 -   Required: No
 -   Platform: Web
 
-### shiftStep
+#### shiftStep
 
 Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` and `isShiftStepEnabled` are both true and while the number input has focus. Acts as a multiplier of `step`.
 

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -217,7 +217,6 @@ function RangeControl(
 						describedBy={ describedBy }
 						disabled={ disabled }
 						id={ id }
-						isShiftStepEnabled={ isShiftStepEnabled }
 						label={ label }
 						max={ max }
 						min={ min }
@@ -227,7 +226,6 @@ function RangeControl(
 						onMouseMove={ onMouseMove }
 						onMouseLeave={ onMouseLeave }
 						ref={ setRef }
-						shiftStep={ shiftStep }
 						step={ step }
 						value={ inputSliderValue }
 					/>

--- a/packages/components/src/range-control/input-range.js
+++ b/packages/components/src/range-control/input-range.js
@@ -14,33 +14,20 @@ import { forwardRef } from '@wordpress/element';
  */
 import { InputRange as BaseInputRange } from './styles/range-control-styles';
 import { useDebouncedHoverInteraction } from './utils';
-import { useJumpStep } from '../utils/hooks';
 
 function InputRange(
 	{
 		describedBy,
-		isShiftStepEnabled = true,
 		label,
 		onHideTooltip = noop,
 		onMouseLeave = noop,
-		step = 1,
-		onBlur = noop,
-		onChange = noop,
-		onFocus = noop,
 		onMouseMove = noop,
 		onShowTooltip = noop,
-		shiftStep = 10,
 		value,
 		...props
 	},
 	ref
 ) {
-	const jumpStep = useJumpStep( {
-		step,
-		shiftStep,
-		isShiftStepEnabled,
-	} );
-
 	const hoverInteractions = useDebouncedHoverInteraction( {
 		onHide: onHideTooltip,
 		onMouseLeave,
@@ -55,11 +42,7 @@ function InputRange(
 			aria-describedby={ describedBy }
 			aria-label={ label }
 			aria-hidden={ false }
-			onBlur={ onBlur }
-			onChange={ onChange }
-			onFocus={ onFocus }
 			ref={ ref }
-			step={ jumpStep }
 			tabIndex={ 0 }
 			type="range"
 			value={ value }


### PR DESCRIPTION
An alternative to #34719 to fix #34363. Removes the application of `shiftStep` to the changes from the `input [type=range]` in `RangeControl`.

I threw in a smidgen of cleanup of some props in the range sub-component. I was tempted to remove the whole thing as it doesn't do much besides add boilerplate at this point.

## How has this been tested?
Verifying that the bug from #34363 can no longer be reproduced as well as less specific instances of it.
Verifying that the NumberControl still shift-steps as expected.

## Types of changes
Bug fix
(Technically a breaking change. Though after discussion in #34719, no one raised concerns that it would break code.)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
