### PR TITLE
Update new navigation editor test to use REST API to create a menu instead of response mocking

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -311,10 +311,7 @@ describe( 'Navigation editor', () => {
 
 	it( 'has a disabled undo button when an existing menu is loaded', async () => {
 		// The test requires the presence of existing menus.
-		await setUpResponseMocking( [
-			...getMenuMocks( { GET: assignMockMenuIds( menusFixture ) } ),
-			...getMenuItemMocks( { GET: menuItemsFixture } ),
-		] );
+		await createMenu( { name: 'Test Menu 1' }, menuItemsFixture );
 		await visitNavigationEditor();
 
 		// Wait for at least one block to be present on the page.

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -37,6 +37,10 @@ import Editor from '../editor';
 import InserterSidebar from '../inserter-sidebar';
 import UnsavedChangesWarning from './unsaved-changes-warning';
 import { store as editNavigationStore } from '../../store';
+import {
+	NAVIGATION_POST_KIND,
+	NAVIGATION_POST_POST_TYPE,
+} from '../../constants';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the navigation screen top bar landmark region. */
@@ -69,8 +73,8 @@ export default function Layout( { blockEditorSettings } ) {
 	} = useNavigationEditor();
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'root',
-		'postType',
+		NAVIGATION_POST_KIND,
+		NAVIGATION_POST_POST_TYPE,
 		{
 			id: navigationPost?.id,
 		}

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -20,6 +20,7 @@ import {
 	isBlockSupportedInNav,
 } from './utils';
 import { blockToMenuItem, menuItemToBlockAttributes } from './transform';
+import { NAVIGATION_POST_KIND, NAVIGATION_POST_POST_TYPE } from '../constants';
 
 /**
  * Returns an action object used to select menu.
@@ -73,7 +74,12 @@ export const saveNavigationPost = ( post ) => async ( {
 		// Clear "stub" navigation post edits to avoid a false "dirty" state.
 		registry
 			.dispatch( coreDataStore )
-			.receiveEntityRecords( 'root', 'postType', post, undefined );
+			.receiveEntityRecords(
+				NAVIGATION_POST_KIND,
+				NAVIGATION_POST_POST_TYPE,
+				post,
+				undefined
+			);
 
 		const updatedPost = {
 			...post,
@@ -81,7 +87,12 @@ export const saveNavigationPost = ( post ) => async ( {
 		};
 		registry
 			.dispatch( coreDataStore )
-			.receiveEntityRecords( 'root', 'postType', updatedPost, undefined );
+			.receiveEntityRecords(
+				NAVIGATION_POST_KIND,
+				NAVIGATION_POST_POST_TYPE,
+				updatedPost,
+				undefined
+			);
 
 		registry
 			.dispatch( noticesStore )


### PR DESCRIPTION
Fixes failing e2e tests in `trunk` (🤞), which was my fault because I merged #34869, which removed `getMenuMocks` and then followed that up by merging #34839 which added a new test using `getMenuMocks` 🤦 

There was also a second issue between #34839 and #34541 where #34839 relied on everywhere using the defined constants to determine the entity for the navigation post type, but #34839 introduced a few places where the constants weren't used.

So in hindsight #34839 should have been rebased before merging!