### PR TITLE
Fix gap in vertical page list.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -330,7 +330,7 @@
 // Vertical layout
 .is-vertical .wp-block-page-list, // Page list.
 .is-vertical .wp-block-navigation__container {
-	display: block;
+	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 }

--- a/packages/block-library/src/page-list/style.scss
+++ b/packages/block-library/src/page-list/style.scss
@@ -16,7 +16,7 @@
 .is-vertical .wp-block-navigation__container,
 .is-open .wp-block-navigation__container {
 	.wp-block-page-list {
-		display: block;
+		display: flex;
 	}
 }
 


### PR DESCRIPTION
## Description

Props @scruffian for the suggestion. This PR fixes an issue where the vertical page list was not affected by the recently introduced `gap` spacing.

Before:

<img width="552" alt="Screenshot 2021-09-22 at 08 04 23" src="https://user-images.githubusercontent.com/1204802/134291272-b61f2dc1-98b6-4495-8eda-de538065ad24.png">

After:

<img width="536" alt="Screenshot 2021-09-22 at 08 01 18" src="https://user-images.githubusercontent.com/1204802/134291232-680df078-0fc3-4728-9cdd-15266b6b8361.png">

<img width="362" alt="Screenshot 2021-09-22 at 08 01 23" src="https://user-images.githubusercontent.com/1204802/134291235-34ab989e-0b1d-4443-a719-e2af8f7e1229.png">


## How has this been tested?

Insert horizontal and vertical navigation blocks, verify the gap is the same between items in both.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
