### PR TITLE
Polish submenu indicator button.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -85,18 +85,16 @@
 		line-height: 0;
 		margin-left: 6px;
 
+		// Affect the button as well.
+		padding: 0;
+		background-color: inherit;
+		color: currentColor;
+		border: none;
+
 		svg {
 			display: inline-block;
 			stroke: currentColor;
 		}
-	}
-
-	// Styles for button toggles.
-	button.wp-block-navigation__submenu-icon.wp-block-navigation__submenu-icon.wp-block-navigation__submenu-icon.wp-block-navigation__submenu-icon {
-		padding: $grid-unit $grid-unit-20;
-		background-color: inherit;
-		color: currentColor;
-		border: none;
 	}
 }
 


### PR DESCRIPTION
## Description

There's a small discrepancy between frontend and editor for the dropdown indicator, where on the frontend, the separate button has a lot of padding. Here's the editor, showing no padding around the indicator:

<img width="826" alt="editor-before" src="https://user-images.githubusercontent.com/1204802/134306987-eb9341a6-ba3e-4390-a2c3-1b5d818df031.png">

Here's the frontend, showing extra padding around the chevron:

<img width="706" alt="editor-after" src="https://user-images.githubusercontent.com/1204802/134307021-4c392947-cd72-4d20-8ad4-8651d85a281d.png">

This PR makes the padding the same, zero, and reduces the specificity so themes can more easily style this. Editor:

<img width="700" alt="Screenshot 2021-09-22 at 10 11 03" src="https://user-images.githubusercontent.com/1204802/134307108-cc00c1bf-53c4-403a-92a7-6e77c5649483.png">

Frontend:

<img width="713" alt="Screenshot 2021-09-22 at 10 11 00" src="https://user-images.githubusercontent.com/1204802/134307125-99740bf9-470c-4b77-8583-be71c701a747.png">

Note that in the editor, the submenu indicator is shown inside the `a`, whereas on the frontend it's outside, so items with underlines like shown above are cropped. That's something to consider separately.

## How has this been tested?

Insert a navigation block with submenus, ensure the "Show submenu indicator icons" property is toggled, and compare editor with frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
