### PR TITLE
block-directory: migrate store actions to thunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18041,7 +18041,6 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
-				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/edit-post": "file:packages/edit-post",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -34,7 +34,6 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
-		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/edit-post": "file:../edit-post",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -50,11 +50,11 @@ export function receiveDownloadableBlocks( downloadableBlocks, filterValue ) {
  * @return {boolean} Whether the block was successfully installed & loaded.
  */
 export function* installBlockType( block ) {
-	const { id, assets } = block;
+	const { id } = block;
 	let success = false;
 	yield clearErrorNotice( id );
 	try {
-		yield setIsInstalling( block.id, true );
+		yield setIsInstalling( id, true );
 
 		// If we have a wp:plugin link, the plugin is installed but inactive.
 		const url = getPluginUrl( block );
@@ -71,7 +71,7 @@ export function* installBlockType( block ) {
 			const response = yield apiFetch( {
 				path: 'wp/v2/plugins',
 				data: {
-					slug: block.id,
+					slug: id,
 					status: 'active',
 				},
 				method: 'POST',
@@ -85,7 +85,7 @@ export function* installBlockType( block ) {
 			links: { ...block.links, ...links },
 		} );
 
-		yield loadAssets( assets );
+		yield loadAssets();
 		const registeredBlocks = yield controls.select(
 			blocksStore,
 			'getBlockTypes'
@@ -137,7 +137,7 @@ export function* installBlockType( block ) {
 			isDismissible: true,
 		} );
 	}
-	yield setIsInstalling( block.id, false );
+	yield setIsInstalling( id, false );
 	return success;
 }
 

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -3,14 +3,13 @@
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
-import { controls } from '@wordpress/data';
-import { apiFetch } from '@wordpress/data-controls';
+import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import { loadAssets } from './controls';
+import { loadAssets } from './load-assets';
 import getPluginUrl from './utils/get-plugin-url';
 
 /**
@@ -49,56 +48,49 @@ export function receiveDownloadableBlocks( downloadableBlocks, filterValue ) {
  *
  * @return {boolean} Whether the block was successfully installed & loaded.
  */
-export function* installBlockType( block ) {
+export const installBlockType = ( block ) => async ( {
+	registry,
+	dispatch,
+} ) => {
 	const { id } = block;
 	let success = false;
-	yield clearErrorNotice( id );
+	dispatch.clearErrorNotice( id );
 	try {
-		yield setIsInstalling( id, true );
+		dispatch.setIsInstalling( id, true );
 
 		// If we have a wp:plugin link, the plugin is installed but inactive.
 		const url = getPluginUrl( block );
 		let links = {};
 		if ( url ) {
-			yield apiFetch( {
-				url,
-				data: {
-					status: 'active',
-				},
+			await apiFetch( {
 				method: 'PUT',
+				url,
+				data: { status: 'active' },
 			} );
 		} else {
-			const response = yield apiFetch( {
-				path: 'wp/v2/plugins',
-				data: {
-					slug: id,
-					status: 'active',
-				},
+			const response = await apiFetch( {
 				method: 'POST',
+				path: 'wp/v2/plugins',
+				data: { slug: id, status: 'active' },
 			} );
 			// Add the `self` link for newly-installed blocks.
 			links = response._links;
 		}
 
-		yield addInstalledBlockType( {
+		dispatch.addInstalledBlockType( {
 			...block,
 			links: { ...block.links, ...links },
 		} );
 
-		yield loadAssets();
-		const registeredBlocks = yield controls.select(
-			blocksStore,
-			'getBlockTypes'
-		);
+		await loadAssets();
+		const registeredBlocks = registry.select( blocksStore ).getBlockTypes();
 		if ( ! registeredBlocks.some( ( i ) => i.name === block.name ) ) {
 			throw new Error(
 				__( 'Error registering block. Try reloading the page.' )
 			);
 		}
 
-		yield controls.dispatch(
-			noticesStore,
-			'createInfoNotice',
+		registry.dispatch( noticesStore ).createInfoNotice(
 			sprintf(
 				// translators: %s is the block title.
 				__( 'Block %s installed and added.' ),
@@ -131,43 +123,43 @@ export function* installBlockType( block ) {
 			message = fatalAPIErrors[ error.code ];
 		}
 
-		yield setErrorNotice( id, message, isFatal );
-		yield controls.dispatch( noticesStore, 'createErrorNotice', message, {
+		dispatch.setErrorNotice( id, message, isFatal );
+		registry.dispatch( noticesStore ).createErrorNotice( message, {
 			speak: true,
 			isDismissible: true,
 		} );
 	}
-	yield setIsInstalling( id, false );
+	dispatch.setIsInstalling( id, false );
 	return success;
-}
+};
 
 /**
  * Action triggered to uninstall a block plugin.
  *
  * @param {Object} block The blockType object.
  */
-export function* uninstallBlockType( block ) {
+export const uninstallBlockType = ( block ) => async ( {
+	registry,
+	dispatch,
+} ) => {
 	try {
-		yield apiFetch( {
-			url: getPluginUrl( block ),
-			data: {
-				status: 'inactive',
-			},
+		const url = getPluginUrl( block );
+		await apiFetch( {
 			method: 'PUT',
+			url,
+			data: { status: 'inactive' },
 		} );
-		yield apiFetch( {
-			url: getPluginUrl( block ),
+		await apiFetch( {
 			method: 'DELETE',
+			url,
 		} );
-		yield removeInstalledBlockType( block );
+		dispatch.removeInstalledBlockType( block );
 	} catch ( error ) {
-		yield controls.dispatch(
-			noticesStore,
-			'createErrorNotice',
-			error.message || __( 'An error occurred.' )
-		);
+		registry
+			.dispatch( noticesStore )
+			.createErrorNotice( error.message || __( 'An error occurred.' ) );
 	}
-}
+};
 
 /**
  * Returns an action object used to add a block type to the "newly installed"

--- a/packages/block-directory/src/store/controls.js
+++ b/packages/block-directory/src/store/controls.js
@@ -50,14 +50,11 @@ export const loadAsset = ( el ) => {
 /**
  * Load the asset files for a block
  *
- * @param {Array} assets A collection of URLs for the assets.
- *
  * @return {Object} Control descriptor.
  */
-export function loadAssets( assets ) {
+export function loadAssets() {
 	return {
 		type: 'LOAD_ASSETS',
-		assets,
 	};
 }
 

--- a/packages/block-directory/src/store/index.js
+++ b/packages/block-directory/src/store/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
-import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -10,8 +9,7 @@ import { controls as dataControls } from '@wordpress/data-controls';
 import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';
-import resolvers from './resolvers';
-import controls from './controls';
+import * as resolvers from './resolvers';
 
 /**
  * Module Constants
@@ -29,8 +27,8 @@ export const storeConfig = {
 	reducer,
 	selectors,
 	actions,
-	controls: { ...dataControls, ...controls },
 	resolvers,
+	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/block-directory/src/store/load-assets.js
+++ b/packages/block-directory/src/store/load-assets.js
@@ -49,47 +49,33 @@ export const loadAsset = ( el ) => {
 
 /**
  * Load the asset files for a block
- *
- * @return {Object} Control descriptor.
  */
-export function loadAssets() {
-	return {
-		type: 'LOAD_ASSETS',
-	};
+export async function loadAssets() {
+	/*
+	 * Fetch the current URL (post-new.php, or post.php?post=1&action=edit) and compare the
+	 * JavaScript and CSS assets loaded between the pages. This imports the required assets
+	 * for the block into the current page while not requiring that we know them up-front.
+	 * In the future this can be improved by reliance upon block.json and/or a script-loader
+	 * dependency API.
+	 */
+	const response = await apiFetch( {
+		url: document.location.href,
+		parse: false,
+	} );
+
+	const data = await response.text();
+
+	const doc = new window.DOMParser().parseFromString( data, 'text/html' );
+
+	const newAssets = Array.from(
+		doc.querySelectorAll( 'link[rel="stylesheet"],script' )
+	).filter( ( asset ) => asset.id && ! document.getElementById( asset.id ) );
+
+	/*
+	 * Load each asset in order, as they may depend upon an earlier loaded script.
+	 * Stylesheets and Inline Scripts will resolve immediately upon insertion.
+	 */
+	for ( const newAsset of newAssets ) {
+		await loadAsset( newAsset );
+	}
 }
-
-const controls = {
-	async LOAD_ASSETS() {
-		/*
-		 * Fetch the current URL (post-new.php, or post.php?post=1&action=edit) and compare the
-		 * JavaScript and CSS assets loaded between the pages. This imports the required assets
-		 * for the block into the current page while not requiring that we know them up-front.
-		 * In the future this can be improved by reliance upon block.json and/or a script-loader
-		 * dependency API.
-		 */
-		const response = await apiFetch( {
-			url: document.location.href,
-			parse: false,
-		} );
-
-		const data = await response.text();
-
-		const doc = new window.DOMParser().parseFromString( data, 'text/html' );
-
-		const newAssets = Array.from(
-			doc.querySelectorAll( 'link[rel="stylesheet"],script' )
-		).filter(
-			( asset ) => asset.id && ! document.getElementById( asset.id )
-		);
-
-		/*
-		 * Load each asset in order, as they may depend upon an earlier loaded script.
-		 * Stylesheets and Inline Scripts will resolve immediately upon insertion.
-		 */
-		for ( const newAsset of newAssets ) {
-			await loadAsset( newAsset );
-		}
-	},
-};
-
-export default controls;

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -6,31 +6,29 @@ import { camelCase, mapKeys } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { fetchDownloadableBlocks, receiveDownloadableBlocks } from './actions';
 
-export default {
-	*getDownloadableBlocks( filterValue ) {
-		if ( ! filterValue ) {
-			return;
-		}
+export const getDownloadableBlocks = ( filterValue ) => async ( {
+	dispatch,
+} ) => {
+	if ( ! filterValue ) {
+		return;
+	}
 
-		try {
-			yield fetchDownloadableBlocks( filterValue );
-			const results = yield apiFetch( {
-				path: `wp/v2/block-directory/search?term=${ filterValue }`,
-			} );
-			const blocks = results.map( ( result ) =>
-				mapKeys( result, ( value, key ) => {
-					return camelCase( key );
-				} )
-			);
+	try {
+		dispatch( fetchDownloadableBlocks( filterValue ) );
+		const results = await apiFetch( {
+			path: `wp/v2/block-directory/search?term=${ filterValue }`,
+		} );
+		const blocks = results.map( ( result ) =>
+			mapKeys( result, ( value, key ) => camelCase( key ) )
+		);
 
-			yield receiveDownloadableBlocks( blocks, filterValue );
-		} catch ( error ) {}
-	},
+		dispatch( receiveDownloadableBlocks( blocks, filterValue ) );
+	} catch {}
 };

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -18,13 +18,7 @@ import hasBlockType from './utils/has-block-type';
  * @return {boolean} Whether a request is in progress for the blocks list.
  */
 export function isRequestingDownloadableBlocks( state, filterValue ) {
-	if (
-		! state.downloadableBlocks[ filterValue ] ||
-		! state.downloadableBlocks[ filterValue ].isRequesting
-	) {
-		return false;
-	}
-	return state.downloadableBlocks[ filterValue ].isRequesting;
+	return state.downloadableBlocks[ filterValue ]?.isRequesting ?? false;
 }
 
 /**
@@ -36,13 +30,7 @@ export function isRequestingDownloadableBlocks( state, filterValue ) {
  * @return {Array} Downloadable blocks.
  */
 export function getDownloadableBlocks( state, filterValue ) {
-	if (
-		! state.downloadableBlocks[ filterValue ] ||
-		! state.downloadableBlocks[ filterValue ].results
-	) {
-		return [];
-	}
-	return state.downloadableBlocks[ filterValue ].results;
+	return state.downloadableBlocks[ filterValue ]?.results ?? [];
 }
 
 /**

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -11,10 +11,11 @@ import { installBlockType, uninstallBlockType } from '../actions';
 
 describe( 'actions', () => {
 	const pluginEndpoint =
-		'https://example.com/wp-json/wp/v2/plugins/block/block';
+		'https://example.com/wp-json/wp/v2/plugins/block-block';
 	const item = {
-		id: 'block/block',
-		name: 'Test Block',
+		id: 'block-block',
+		name: 'block/block',
+		title: 'Test Block',
 		links: {
 			'wp:install-plugin': [
 				{

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -15,7 +15,6 @@ describe( 'actions', () => {
 	const item = {
 		id: 'block/block',
 		name: 'Test Block',
-		assets: [ 'script.js' ],
 		links: {
 			'wp:install-plugin': [
 				{
@@ -80,7 +79,6 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'LOAD_ASSETS',
-				assets: block.assets,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -148,7 +146,6 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'LOAD_ASSETS',
-				assets: inactiveBlock.assets,
 			} );
 
 			expect( generator.next().value ).toEqual( {

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -1,18 +1,57 @@
 /**
  * WordPress dependencies
  */
+import { createRegistry } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { installBlockType, uninstallBlockType } from '../actions';
+import { loadAssets } from '../load-assets';
+import { store as blockDirectoryStore } from '..';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../load-assets', () => ( {
+	loadAssets: jest.fn(),
+} ) );
+
+function createRegistryWithStores() {
+	// create a registry and register stores
+	const registry = createRegistry();
+
+	registry.register( blockDirectoryStore );
+	registry.register( noticesStore );
+	registry.register( blocksStore );
+
+	return registry;
+}
+
+// mock the `loadAssets` function. The real function would load the installed
+// block's script assets, which in turn register the block. That registration
+// call is the only thing we need to mock.
+function loadAssetsMock( registry ) {
+	return async function () {
+		registry
+			.dispatch( blocksStore )
+			.addBlockTypes( [ { name: 'block/block' } ] );
+	};
+}
+
+function blockWithLinks( block, links ) {
+	return { ...block, links: { ...block.links, ...links } };
+}
 
 describe( 'actions', () => {
 	const pluginEndpoint =
 		'https://example.com/wp-json/wp/v2/plugins/block-block';
-	const item = {
+
+	const block = {
 		id: 'block-block',
 		name: 'block/block',
 		title: 'Test Block',
@@ -25,286 +64,218 @@ describe( 'actions', () => {
 			],
 		},
 	};
-	const plugin = {
+
+	const pluginResponse = {
 		plugin: 'block/block.php',
 		status: 'active',
 		name: 'Test Block',
 		version: '1.0.0',
 		_links: {
-			self: [
-				{
-					href: pluginEndpoint,
-				},
-			],
+			self: [ { href: pluginEndpoint } ],
 		},
 	};
 
 	describe( 'installBlockType', () => {
-		const block = item;
-		it( 'should install a block successfully', () => {
-			const generator = installBlockType( block );
+		it( 'should install a block successfully', async () => {
+			const registry = createRegistryWithStores();
 
-			expect( generator.next().value ).toEqual( {
-				type: 'CLEAR_ERROR_NOTICE',
-				blockId: block.id,
+			// mock the api-fetch and load-assets modules
+			apiFetch.mockImplementation( async ( { path } ) => {
+				switch ( path ) {
+					case 'wp/v2/plugins':
+						return pluginResponse;
+					default:
+						throw new Error( `unexpected API endpoint: ${ path }` );
+				}
 			} );
 
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: block.id,
-				isInstalling: true,
-			} );
+			loadAssets.mockImplementation( loadAssetsMock( registry ) );
 
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					path: 'wp/v2/plugins',
-					method: 'POST',
-				},
-			} );
+			// install the block
+			await registry
+				.dispatch( blockDirectoryStore )
+				.installBlockType( block );
 
-			expect( generator.next( plugin ).value ).toEqual( {
-				type: 'ADD_INSTALLED_BLOCK_TYPE',
-				item: {
-					...block,
-					links: {
-						...block.links,
-						self: [
-							{
-								href: pluginEndpoint,
-							},
-						],
-					},
-				},
-			} );
+			// check that blocks store contains the new block
+			const registeredBlock = registry
+				.select( blocksStore )
+				.getBlockType( 'block/block' );
+			expect( registeredBlock ).toBeTruthy();
 
-			expect( generator.next().value ).toEqual( {
-				type: 'LOAD_ASSETS',
-			} );
+			// check that the block-directory store contains the new block, too
+			const installedBlockTypes = registry
+				.select( blockDirectoryStore )
+				.getInstalledBlockTypes();
+			expect( installedBlockTypes ).toMatchObject( [
+				{ name: 'block/block' },
+			] );
 
-			expect( generator.next().value ).toEqual( {
-				args: [],
-				selectorName: 'getBlockTypes',
-				storeKey: blocksStore.name,
-				type: '@@data/SELECT',
-			} );
-
-			expect( generator.next( [ block ] ).value ).toMatchObject( {
-				type: '@@data/DISPATCH',
-				actionName: 'createInfoNotice',
-				storeKey: noticesStore.name,
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: block.id,
-				isInstalling: false,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: true,
-				done: true,
-			} );
+			// check that notice was displayed
+			const notices = registry.select( noticesStore ).getNotices();
+			expect( notices ).toMatchObject( [
+				{ content: 'Block Test Block installed and added.' },
+			] );
 		} );
 
-		it( 'should activate an inactive block plugin successfully', () => {
-			const inactiveBlock = {
-				...block,
-				links: {
-					...block.links,
-					'wp:plugin': [
-						{
-							href: pluginEndpoint,
-						},
-					],
-				},
-			};
-			const generator = installBlockType( inactiveBlock );
+		it( 'should activate an inactive block plugin successfully', async () => {
+			const registry = createRegistryWithStores();
 
-			expect( generator.next().value ).toEqual( {
-				type: 'CLEAR_ERROR_NOTICE',
-				blockId: inactiveBlock.id,
+			// mock the api-fetch and load-assets modules
+			apiFetch.mockImplementation( async ( p ) => {
+				const { url } = p;
+				switch ( url ) {
+					case pluginEndpoint:
+						return pluginResponse;
+					default:
+						throw new Error( `unexpected API endpoint: ${ url }` );
+				}
 			} );
 
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: inactiveBlock.id,
-				isInstalling: true,
-			} );
+			loadAssets.mockImplementation( loadAssetsMock( registry ) );
 
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					url: pluginEndpoint,
-					method: 'PUT',
-				},
-			} );
+			// install the block
+			await registry.dispatch( blockDirectoryStore ).installBlockType(
+				blockWithLinks( block, {
+					'wp:plugin': [ { href: pluginEndpoint } ],
+				} )
+			);
 
-			expect( generator.next( plugin ).value ).toEqual( {
-				type: 'ADD_INSTALLED_BLOCK_TYPE',
-				item: inactiveBlock,
-			} );
+			// check that blocks store contains the new block
+			const registeredBlock = registry
+				.select( blocksStore )
+				.getBlockType( 'block/block' );
+			expect( registeredBlock ).toBeTruthy();
 
-			expect( generator.next().value ).toEqual( {
-				type: 'LOAD_ASSETS',
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				args: [],
-				selectorName: 'getBlockTypes',
-				storeKey: blocksStore.name,
-				type: '@@data/SELECT',
-			} );
-
-			expect( generator.next( [ inactiveBlock ] ).value ).toMatchObject( {
-				type: '@@data/DISPATCH',
-				actionName: 'createInfoNotice',
-				storeKey: noticesStore.name,
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: inactiveBlock.id,
-				isInstalling: false,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: true,
-				done: true,
-			} );
+			// check that notice was displayed
+			const notices = registry.select( noticesStore ).getNotices();
+			expect( notices ).toMatchObject( [
+				{ content: 'Block Test Block installed and added.' },
+			] );
 		} );
 
-		it( "should set an error if the plugin can't install", () => {
-			const generator = installBlockType( block );
+		it( "should set an error if the plugin can't install", async () => {
+			const registry = createRegistryWithStores();
 
-			expect( generator.next().value ).toEqual( {
-				type: 'CLEAR_ERROR_NOTICE',
-				blockId: block.id,
+			// mock the api-fetch and load-assets modules
+			apiFetch.mockImplementation( async ( { path } ) => {
+				switch ( path ) {
+					case 'wp/v2/plugins':
+						throw {
+							code: 'plugins_api_failed',
+							message: 'Plugin not found.',
+							data: null,
+						};
+					default:
+						throw new Error( `unexpected API endpoint: ${ path }` );
+				}
 			} );
 
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: block.id,
-				isInstalling: true,
-			} );
+			loadAssets.mockImplementation( loadAssetsMock( registry ) );
 
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					path: 'wp/v2/plugins',
-					method: 'POST',
-				},
-			} );
+			// install the block
+			await registry
+				.dispatch( blockDirectoryStore )
+				.installBlockType( block );
 
-			const apiError = {
-				code: 'plugins_api_failed',
-				message: 'Plugin not found.',
-				data: null,
-			};
-			expect( generator.throw( apiError ).value ).toMatchObject( {
-				type: 'SET_ERROR_NOTICE',
-				blockId: block.id,
-			} );
+			// check that blocks store doesn't contain the new block
+			const registeredBlock = registry
+				.select( blocksStore )
+				.getBlockType( 'block/block' );
+			expect( registeredBlock ).toBeUndefined();
 
-			expect( generator.next().value ).toMatchObject( {
-				type: '@@data/DISPATCH',
-				actionName: 'createErrorNotice',
-				storeKey: noticesStore.name,
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: block.id,
-				isInstalling: false,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: false,
-				done: true,
-			} );
+			// check that error notice was displayed
+			const notices = registry.select( noticesStore ).getNotices();
+			expect( notices ).toMatchObject( [
+				{ content: 'Plugin not found.' },
+			] );
 		} );
 	} );
 
 	describe( 'uninstallBlockType', () => {
-		const block = {
-			...item,
-			links: {
-				...item.links,
-				self: [
-					{
-						href: pluginEndpoint,
-					},
-				],
-			},
-		};
-
-		it( 'should uninstall a block successfully', () => {
-			const generator = uninstallBlockType( block );
-
-			// First the deactivation step
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					url: pluginEndpoint,
-					method: 'PUT',
-				},
-			} );
-
-			// Then the deletion step
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					url: pluginEndpoint,
-					method: 'DELETE',
-				},
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
-				item: block,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: undefined,
-				done: true,
-			} );
+		const installedBlock = blockWithLinks( block, {
+			self: [ { href: pluginEndpoint } ],
 		} );
 
-		it( "should set a global notice if the plugin can't be deleted", () => {
-			const generator = uninstallBlockType( block );
+		it( 'should uninstall a block successfully', async () => {
+			const registry = createRegistryWithStores();
 
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					url: pluginEndpoint,
-					method: 'PUT',
+			apiFetch.mockImplementation( async ( { url, method } ) => {
+				switch ( url ) {
+					case pluginEndpoint:
+						switch ( method ) {
+							case 'PUT':
+							case 'DELETE':
+								return;
+							default:
+								throw new Error(
+									`unexpected API endpoint method: ${ method }`
+								);
+						}
+					default:
+						throw new Error( `unexpected API endpoint: ${ url }` );
+				}
+			} );
+
+			// add installed block type that we're going to uninstall
+			registry
+				.dispatch( blockDirectoryStore )
+				.addInstalledBlockType( installedBlock );
+
+			// uninstall the block
+			await registry
+				.dispatch( blockDirectoryStore )
+				.uninstallBlockType( installedBlock );
+
+			// check that no error notice was displayed
+			const notices = registry.select( noticesStore ).getNotices();
+			expect( notices ).toEqual( [] );
+
+			// verify that the block was uninstalled
+			const installedBlockTypes = registry
+				.select( blockDirectoryStore )
+				.getInstalledBlockTypes();
+			expect( installedBlockTypes ).toEqual( [] );
+		} );
+
+		it( "should set a global notice if the plugin can't be deleted", async () => {
+			const registry = createRegistryWithStores();
+
+			apiFetch.mockImplementation( async ( { url, method } ) => {
+				switch ( url ) {
+					case pluginEndpoint:
+						switch ( method ) {
+							case 'PUT':
+								return;
+							case 'DELETE':
+								throw {
+									code: 'rest_cannot_delete_active_plugin',
+									message:
+										'Cannot delete an active plugin. Please deactivate it first.',
+									data: null,
+								};
+							default:
+								throw new Error(
+									`unexpected API endpoint method: ${ method }`
+								);
+						}
+					default:
+						throw new Error( `unexpected API endpoint: ${ url }` );
+				}
+			} );
+
+			// uninstall the block
+			await registry
+				.dispatch( blockDirectoryStore )
+				.uninstallBlockType( installedBlock );
+
+			// check that error notice was displayed
+			const notices = registry.select( noticesStore ).getNotices();
+			expect( notices ).toMatchObject( [
+				{
+					content:
+						'Cannot delete an active plugin. Please deactivate it first.',
 				},
-			} );
-
-			expect( generator.next().value ).toMatchObject( {
-				type: 'API_FETCH',
-				request: {
-					url: pluginEndpoint,
-					method: 'DELETE',
-				},
-			} );
-
-			const apiError = {
-				code: 'rest_cannot_delete_active_plugin',
-				message:
-					'Cannot delete an active plugin. Please deactivate it first.',
-				data: null,
-			};
-			expect( generator.throw( apiError ).value ).toMatchObject( {
-				type: '@@data/DISPATCH',
-				actionName: 'createErrorNotice',
-				storeKey: noticesStore.name,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: undefined,
-				done: true,
-			} );
+			] );
 		} );
 	} );
 } );

--- a/packages/block-directory/src/store/test/load-assets.js
+++ b/packages/block-directory/src/store/test/load-assets.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { loadAsset } from '../controls';
+import { loadAsset } from '../load-assets';
 
 describe( 'controls', () => {
 	describe( 'loadAsset', () => {


### PR DESCRIPTION
This PR migrates the `block-directory` data store to thunks, namely the `installBlockType` and `uninstallBlockType` actions. And removes dependency on `@wordpress/data-controls` and on any other controls for that matter.

The first three commits do some preparatory fixing and cleanups:
- use `optional?.chaining?.[ 'and' ] ?? 'coalescing'` in selectors to make them nicer
- there is no longer any `assets: [ ... ]` field on the block search results and the `loadAssets( assets )` doesn't really have/use the `assets` param so I'm removing that. `loadAssets` fetches the HTML document after a plugin was installed, looks for `script` tags that are new, and loads them into the current document.
- make the `block` object more close to what a real REST endpoint for block directory search would return, namely there are `id` (plugin id), `name` (block id) and `title` (block name for humans) fields.

And then there's the real migration in the commit number four.

I completely reworked the unit test for actions. Instead of checking the objects produced by the generator, they set up a real registry with real stores, mock the external modules like `apiFetch` or `loadAssets`, and then dispatch real actions to the registry and check how that affects the state. That's still a self-contained unit test, but way closer to how the code is used in the real editor.

**How to test:**
In the block inserter, search for a block you don't have installed (I use a `mathml` search term and install the MathML block for testing) and verify you can install it from block directory. Or when the plugin is installed and merely deactivated, that you can activate it from the block directory UI.

Then, if you don't use that new block in your document, and do a save, that the block gets automatically uninstalled.