### PR TITLE
[Server Side Render] Delayed loading state of SSR component

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -39,21 +39,25 @@ function DefaultErrorResponsePlaceholder( { response, className } ) {
 	return <Placeholder className={ className }>{ errorMessage }</Placeholder>;
 }
 
-function DefaultLoadingResponsePlaceholder( { children } ) {
+function DefaultLoadingResponsePlaceholder( { children, showLoader } ) {
 	return (
 		<div style={ { position: 'relative' } }>
-			<div
-				style={ {
-					position: 'absolute',
-					top: '50%',
-					left: '50%',
-					marginTop: '-9px',
-					marginLeft: '-9px',
-				} }
-			>
-				<Spinner />
+			{ showLoader && (
+				<div
+					style={ {
+						position: 'absolute',
+						top: '50%',
+						left: '50%',
+						marginTop: '-9px',
+						marginLeft: '-9px',
+					} }
+				>
+					<Spinner />
+				</div>
+			) }
+			<div style={ { opacity: showLoader ? '0.3' : 1 } }>
+				{ children }
 			</div>
-			<div style={ { opacity: '0.3' } }>{ children }</div>
 		</div>
 	);
 }
@@ -71,6 +75,7 @@ export default function ServerSideRender( props ) {
 	} = props;
 
 	const isMountedRef = useRef( true );
+	const [ showLoader, setShowLoader ] = useState( false );
 	const fetchRequestRef = useRef();
 	const [ response, setResponse ] = useState( null );
 	const prevResponse = usePrevious( response );
@@ -151,11 +156,29 @@ export default function ServerSideRender( props ) {
 		}
 	} );
 
+	/**
+	 * Effect to handle showing the loading placeholder.
+	 * Show it only if there is no previous response or
+	 * the request takes more than one second.
+	 */
+	useEffect( () => {
+		if ( response !== null ) {
+			return;
+		}
+		const timeout = setTimeout( () => {
+			setShowLoader( true );
+		}, 1000 );
+		return () => clearTimeout( timeout );
+	}, [ response ] );
+
 	if ( response === '' ) {
 		return <EmptyResponsePlaceholder { ...props } />;
 	} else if ( ! response ) {
 		return (
-			<LoadingResponsePlaceholder { ...props }>
+			<LoadingResponsePlaceholder
+				{ ...props }
+				showLoader={ ! prevResponse || showLoader }
+			>
 				{ !! prevResponse && (
 					<RawHTML className={ className }>{ prevResponse }</RawHTML>
 				) }


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/35027

This PR shows the loading placeholder of SSR component with a delay of `1 second`.

It still shows it if there is no previous response(such as when loading the post) and it also shows only the previous response (without the `spinner`) if the one second has not passed and there was a previous response obviously 😄 . This way we avoid the `flickering` that used to exist before..

## Testing instructions
1. Insert an RSS block and save
2. Reload to see that the loader is shown on first request
3. Make changes to the block's settings and observe that in quick requests the spinner is not shown and the previous response is shown
4. To test that this is the outcome of the `timeout`, you can change the timeout to something small (like 10) [here](https://github.com/WordPress/gutenberg/pull/35033/files#diff-1fcc38b89edc0d5f7b6239481f42d74b8e2010d792fb26b1e0f8623b222a06fbR170)

