### PR TITLE
[Block: Search] Add a visually hidden label

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -43,37 +43,17 @@ function render_block_core_search( $attributes ) {
 	// Border color classes need to be applied to the elements that have a border color.
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
 
-	if ( $show_label ) {
-		if ( ! empty( $attributes['label'] ) ) {
-			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label">%s</label>',
-				$input_id,
-				$attributes['label']
-			);
-		} else {
-			// If the label text has been removed but not toggled off, add a visually hidden label with default text.
-			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
-				$input_id,
-				__( 'Search' )
-			);
-		}
-	} else {
-		// If there is a custom label and the label is toggled off, add a visually hidden label with custom text.
-		if ( ! empty( $attributes['label'] ) ) {
-			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
-				$input_id,
-				$attributes['label']
-			);
-		} else {
-			// If the label text has been removed and toggled off, add a visually hidden label with default text.
-			$label_markup = sprintf(
-				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
-				$input_id,
-				__( 'Search' )
-			);
-		}
+	$label_markup = sprintf(
+		'<label for="%1$s" class="wp-block-search__label screen-reader-text">%2$s</label>',
+		$input_id,
+		empty( $attributes['label'] ) ? __( 'Search' ) : $attributes['label']
+	);
+	if ( $show_label && ! empty( $attributes['label'] ) ) {
+		$label_markup = sprintf(
+			'<label for="%1$s" class="wp-block-search__label">%2$s</label>',
+			$input_id,
+			$attributes['label']
+		);
 	}
 
 	if ( $show_input ) {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -51,6 +51,23 @@ function render_block_core_search( $attributes ) {
 				$attributes['label']
 			);
 		} else {
+			// If the label text has been removed but not toggled off, add a visually hidden label with default text.
+			$label_markup = sprintf(
+				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
+				$input_id,
+				__( 'Search' )
+			);
+		}
+	} else {
+		// If there is a custom label and the label is toggled off, add a visually hidden label with custom text.
+		if ( ! empty( $attributes['label'] ) ) {
+			$label_markup = sprintf(
+				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
+				$input_id,
+				$attributes['label']
+			);
+		} else {
+			// If the label text has been removed and toggled off, add a visually hidden label with default text.
 			$label_markup = sprintf(
 				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
 				$input_id,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Closes #34989
Adds a visually hidden label to the search block when the label is toggled off or the label text is removed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. You can use this sample code to add search blocks with different settings:
```
<!-- wp:paragraph -->
<p>Default:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Search","buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Default label is toggled off:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Custom label, toggled on:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Custom label","buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Custom label, toggled off:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Custom label","showLabel":false,"buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Text label is removed and toggled on:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"","buttonText":"Search"} /-->

<!-- wp:paragraph -->
<p>Text label is removed and toggled off:</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"","showLabel":false,"buttonText":"Search"} /-->
```

2. View the front and confirm that every search block has a label.
3. Confirm that custom labels are used even when the label is visually hidden.
4. Test that screen readers announce the label.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
