### PR TITLE
Navigation Editor: Update the Hooks section in docs

### DIFF
--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -125,39 +125,46 @@ For historical reasons, the following properties display some inconsistency in t
 
 ## Hooks
 
-`useMenuItems` and `useNavigationBlock` hooks are the central part of this package. They bridge the gap between the API and the block editor interface:
+The `useNavigationEditor` and `useEntityBlockEditor` hooks are the central part of this package. They bridge the gap between the API and the block editor interface:
 
-```js
-const menuId = 1;
-const query = useMemo( () => ( { menus: menuId, per_page: -1 } ), [ menuId ] );
-// Data manipulation:
+```jsx
+// Data from API:
 const {
-	menuItems,
-	eventuallySaveMenuItems,
-	createMissingMenuItems,
-} = useMenuItems( query );
+	menus,
+	hasLoadedMenus,
+	selectedMenuId,
+	navigationPost,
+} = useNavigationEditor();
 
 // Working state:
-const { blocks, setBlocks, menuItemsRef } = useNavigationBlocks( menuItems );
+const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+	NAVIGATION_POST_KIND,
+	NAVIGATION_POST_POST_TYPE,
+	{
+		id: navigationPost?.id,
+	}
+);
+
+const isBlockEditorReady = !! (
+	menus?.length &&
+	navigationPost &&
+	selectedMenuId
+);
 
 return (
 	<BlockEditorProvider
 		value={ blocks }
-		onInput={ ( updatedBlocks ) => setBlocks( updatedBlocks ) }
-		onChange={ ( updatedBlocks ) => {
-			createMissingMenuItems( updatedBlocks, menuItemsRef );
-			setBlocks( updatedBlocks );
-		} }
+		onInput={ onInput }
+		onChange={ onChange }
 		settings={ blockEditorSettings }
 	>
-		<NavigationStructureArea blocks={ blocks } initialOpen />
-		<BlockEditorArea
-			menuId={ menuId }
-			saveBlocks={ () => eventuallySaveMenuItems( blocks, menuItemsRef ) }
-			onDeleteMenu={ () => {
-				/* ... */
-			} }
-		/>
+		{ isBlockEditorReady && (
+			<div className="edit-navigation-layout__content-area">
+				<BlockTools>
+					<Editor isPending={ ! hasLoadedMenus } />
+				</BlockTools>
+			</div>
+		) }
 	</BlockEditorProvider>
 );
 ```

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -172,7 +172,6 @@ export default function Layout( { blockEditorSettings } ) {
 														isPending={
 															! hasLoadedMenus
 														}
-														blocks={ blocks }
 													/>
 												</BlockTools>
 											</div>


### PR DESCRIPTION
## Description
Follow-up for #34682.

PR updates the "Hooks" section in README to match the current component state.

([View rendered](https://github.com/WordPress/gutenberg/blob/e33dfcf0b12463e40920dba3014d4631ec2aa2d8/packages/edit-navigation/README.md))

## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
