### PR TITLE
Remove polyfills from view.js block scripts

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -9,7 +9,7 @@ const fastGlob = require( 'fast-glob' );
 /**
  * Internal dependencies
  */
-const { baseConfig, plugins, stylesTransform } = require( './shared' );
+const { baseConfig, pluginsNoPolyfills, stylesTransform } = require( './shared' );
 
 /*
  * Matches a block's name in paths in the form
@@ -53,7 +53,7 @@ module.exports = {
 		path: join( __dirname, '..', '..' ),
 	},
 	plugins: [
-		...plugins,
+		...pluginsNoPolyfills,
 		new CopyWebpackPlugin( {
 			patterns: [].concat(
 				[

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -9,7 +9,11 @@ const fastGlob = require( 'fast-glob' );
 /**
  * Internal dependencies
  */
-const { baseConfig, pluginsNoPolyfills, stylesTransform } = require( './shared' );
+const {
+	baseConfig,
+	pluginsNoPolyfills,
+	stylesTransform,
+} = require( './shared' );
 
 /*
  * Matches a block's name in paths in the form

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -7,13 +7,14 @@ const { join, sep } = require( 'path' );
 const fastGlob = require( 'fast-glob' );
 
 /**
+ * WordPress dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+/**
  * Internal dependencies
  */
-const {
-	baseConfig,
-	pluginsNoPolyfills,
-	stylesTransform,
-} = require( './shared' );
+const { baseConfig, plugins, stylesTransform } = require( './shared' );
 
 /*
  * Matches a block's name in paths in the form
@@ -57,7 +58,8 @@ module.exports = {
 		path: join( __dirname, '..', '..' ),
 	},
 	plugins: [
-		...pluginsNoPolyfills,
+		...plugins,
+		new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
 		new CopyWebpackPlugin( {
 			patterns: [].concat(
 				[

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -10,6 +10,7 @@ const { join } = require( 'path' );
 const {
 	camelCaseDash,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/lib/util' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
 /**
  * Internal dependencies
@@ -65,6 +66,7 @@ module.exports = {
 	},
 	plugins: [
 		...plugins,
+		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 		new CopyWebpackPlugin( {
 			patterns: gutenbergPackages.map( ( packageName ) => ( {
 				from: '*.css',

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -76,6 +76,20 @@ const plugins = [
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 ];
 
+const pluginsNoPolyfills = [
+	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+	// content as a convenient interactive zoomable treemap.
+	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
+	new DefinePlugin( {
+		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
+		'process.env.GUTENBERG_PHASE': JSON.stringify(
+			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
+		),
+	} ),
+	new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
+	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
+];
+
 const stylesTransform = ( content ) => {
 	if ( mode === 'production' ) {
 		return postcss( [
@@ -102,5 +116,6 @@ const stylesTransform = ( content ) => {
 module.exports = {
 	baseConfig,
 	plugins,
+	pluginsNoPolyfills,
 	stylesTransform,
 };

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -10,7 +10,6 @@ const postcss = require( 'postcss' );
 /**
  * WordPress dependencies
  */
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const ReadableJsAssetsWebpackPlugin = require( '@wordpress/readable-js-assets-webpack-plugin' );
 
 const {
@@ -72,21 +71,6 @@ const plugins = [
 			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
 		),
 	} ),
-	new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
-];
-
-const pluginsNoPolyfills = [
-	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
-	// content as a convenient interactive zoomable treemap.
-	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
-	new DefinePlugin( {
-		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
-		'process.env.GUTENBERG_PHASE': JSON.stringify(
-			parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1
-		),
-	} ),
-	new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 ];
 
@@ -116,6 +100,5 @@ const stylesTransform = ( content ) => {
 module.exports = {
 	baseConfig,
 	plugins,
-	pluginsNoPolyfills,
 	stylesTransform,
 };


### PR DESCRIPTION
## Description
When adding a block with a `view.js` script, the frontend loads an additional ~20kb of scripts that were previously not there. These are coming from polyfills that are defined as a dependency for `view.js` scripts.
Since WordPress dropped support for IE, these polyfills are no longer needed and can be removed.
This will improve performance and sustainability.

## How has this been tested?
Tested with the navigation block in Safari & Firefox, confirmed that everything works both on the frontend and the editor.
Confirmed that the extra assets are no longer loaded on the frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
