### PR TITLE
Color Picker: Match figma metrics.

### DIFF
--- a/packages/components/src/ui/color-picker/styles.ts
+++ b/packages/components/src/ui/color-picker/styles.ts
@@ -91,8 +91,15 @@ export const ColorfulWrapper = styled.div`
 	.react-colorful__pointer {
 		height: 16px;
 		width: 16px;
-		border: ${ CONFIG.borderWidthFocus } solid rgba( 255, 255, 255, 0 );
-		box-shadow: inset 0px 0px 0px ${ CONFIG.borderWidthFocus } #ffffff;
+		border: none;
+		box-shadow: 0 0 2px 0 rgba( 0, 0, 0, 0.25 );
+
+		// Shown instead of box-shadow to Windows high contrast mode.
+		outline: 2px solid transparent;
+	}
+
+	.react-colorful__pointer-fill {
+		box-shadow: inset 0 0 0 ${ CONFIG.borderWidthFocus } #fff;
 	}
 
 	${ interactiveHueStyles }


### PR DESCRIPTION
## Description

Followup to #34598. This one changes the handle to use a box-shadow with a fallback transparent outline for Windows High Contrast mode. This lets us match the Figma specs:

<img width="277" alt="Screenshot 2021-09-22 at 13 48 42" src="https://user-images.githubusercontent.com/1204802/134338830-a4678d25-e30e-4bc8-8717-c779bb5659ff.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
