### PR TITLE
Fix Link UI when hyperlink has an empty `href` value

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -60,7 +60,7 @@ export default function LinkPreview( {
 				'is-rich': hasRichData,
 				'is-fetching': !! isFetching,
 				'is-preview': true,
-				'is-empty': isEmptyURL,
+				'is-error': isEmptyURL,
 			} ) }
 		>
 			<div className="block-editor-link-control__search-item-top">

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -13,7 +13,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
-import { Icon, globe, warning } from '@wordpress/icons';
+import { Icon, globe, info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ export default function LinkPreview( {
 	if ( richData?.icon ) {
 		icon = <img src={ richData?.icon } alt="" />;
 	} else if ( isEmptyURL ) {
-		icon = <Icon icon={ warning } size={ 32 } />;
+		icon = <Icon icon={ info } size={ 32 } />;
 	} else {
 		icon = <Icon icon={ globe } />;
 	}

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -13,7 +13,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
-import { Icon, globe } from '@wordpress/icons';
+import { Icon, globe, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -38,6 +38,19 @@ export default function LinkPreview( {
 	const displayURL =
 		( value && filterURLForDisplay( safeDecodeURI( value.url ), 16 ) ) ||
 		'';
+
+	const isEmptyURL = ! value.url.length;
+
+	let icon;
+
+	if ( richData?.icon ) {
+		icon = <img src={ richData?.icon } alt="" />;
+	} else if ( isEmptyURL ) {
+		icon = <Icon icon={ warning } size={ 32 } />;
+	} else {
+		icon = <Icon icon={ globe } />;
+	}
+
 	return (
 		<div
 			aria-label={ __( 'Currently selected' ) }
@@ -47,6 +60,7 @@ export default function LinkPreview( {
 				'is-rich': hasRichData,
 				'is-fetching': !! isFetching,
 				'is-preview': true,
+				'is-empty': isEmptyURL,
 			} ) }
 		>
 			<div className="block-editor-link-control__search-item-top">
@@ -59,22 +73,29 @@ export default function LinkPreview( {
 							}
 						) }
 					>
-						{ richData?.icon ? (
-							<img src={ richData?.icon } alt="" />
-						) : (
-							<Icon icon={ globe } />
-						) }
+						{ icon }
 					</span>
 					<span className="block-editor-link-control__search-item-details">
-						<ExternalLink
-							className="block-editor-link-control__search-item-title"
-							href={ value.url }
-						>
-							{ richData?.title || value?.title || displayURL }
-						</ExternalLink>
-						{ value?.url && (
-							<span className="block-editor-link-control__search-item-info">
-								{ displayURL }
+						{ ! isEmptyURL ? (
+							<>
+								<ExternalLink
+									className="block-editor-link-control__search-item-title"
+									href={ value.url }
+								>
+									{ richData?.title ||
+										value?.title ||
+										displayURL }
+								</ExternalLink>
+
+								{ value?.url && (
+									<span className="block-editor-link-control__search-item-info">
+										{ displayURL }
+									</span>
+								) }
+							</>
+						) : (
+							<span className="block-editor-link-control__search-item-error-notice">
+								Link is empty
 							</span>
 						) }
 					</span>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -181,7 +181,7 @@ $preview-image-height: 140px;
 		flex: 1; // fill available space.
 	}
 
-	&.is-empty .block-editor-link-control__search-item-header {
+	&.is-error .block-editor-link-control__search-item-header {
 		align-items: center;
 	}
 
@@ -204,7 +204,7 @@ $preview-image-height: 140px;
 		}
 	}
 
-	&.is-empty .block-editor-link-control__search-item-icon {
+	&.is-error .block-editor-link-control__search-item-icon {
 		top: 0;
 		width: 32px;
 		max-height: 32px;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -181,6 +181,10 @@ $preview-image-height: 140px;
 		flex: 1; // fill available space.
 	}
 
+	&.is-empty .block-editor-link-control__search-item-header {
+		align-items: center;
+	}
+
 	.block-editor-link-control__search-item-details {
 		overflow: hidden; // clip to force text ellipsis.
 	}
@@ -198,6 +202,12 @@ $preview-image-height: 140px;
 		img {
 			width: 16px; // favicons often have a source of 32px
 		}
+	}
+
+	&.is-empty .block-editor-link-control__search-item-icon {
+		top: 0;
+		width: 32px;
+		max-height: 32px;
 	}
 
 
@@ -239,6 +249,11 @@ $preview-image-height: 140px;
 		color: $gray-700;
 		font-size: 0.9em;
 		line-height: 1.3;
+	}
+
+	.block-editor-link-control__search-item-error-notice {
+		font-style: italic;
+		font-size: 1.1em;
 	}
 
 	.block-editor-link-control__search-item-type {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -226,6 +226,35 @@ describe( 'Basic rendering', () => {
 
 			expect( isEditing() ).toBe( false );
 		} );
+
+		it( 'should display human friendly error message if value URL prop is empty when component is forced into no-editing (preview) mode', async () => {
+			// occasionally forceIsEditingLink is set explictly to `false` which causes the link UI to render
+			// it's preview even if the `value` has no URL.
+			const valueWithEmptyURL = {
+				url: '',
+				id: 123,
+				type: 'post',
+			};
+
+			act( () => {
+				render(
+					<LinkControl
+						value={ valueWithEmptyURL }
+						forceIsEditingLink={ false }
+					/>,
+					container
+				);
+			} );
+
+			const linkPreview = queryByRole( container, 'generic', {
+				name: 'Currently selected',
+			} );
+
+			const isPreviewError = linkPreview.classList.contains( 'is-error' );
+			expect( isPreviewError ).toBe( true );
+
+			expect( queryByText( linkPreview, 'Link is empty' ) ).toBeTruthy();
+		} );
 	} );
 
 	describe( 'Unlinking', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -228,8 +228,13 @@ describe( 'Basic rendering', () => {
 		} );
 
 		it( 'should display human friendly error message if value URL prop is empty when component is forced into no-editing (preview) mode', async () => {
-			// occasionally forceIsEditingLink is set explictly to `false` which causes the link UI to render
+			// Why do we need this test?
+			// Occasionally `forceIsEditingLink` is set explictly to `false` which causes the Link UI to render
 			// it's preview even if the `value` has no URL.
+			// for an example of this see the usage in the following file whereby forceIsEditingLink is used to start/stop editing mode:
+			// https://github.com/WordPress/gutenberg/blob/fa5728771df7cdc86369f7157d6aa763649937a7/packages/format-library/src/link/inline.js#L151.
+			// see also: https://github.com/WordPress/gutenberg/issues/17972.
+
 			const valueWithEmptyURL = {
 				url: '',
 				id: 123,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/issues/17972#issuecomment-919710999 we learnt that if any inline link (within paragraph text) has an empty `href` then the Link UI can end up in an unexpected "preview" state. This UI state provides no feedback to the user as to the cause of the error.

This PR resolves that by switching to rendering an "error" state in the link preview if the `value`'s `url` prop is empty.

This does not attempt to resolve the situation where you create an empty link using the Link UI. That's [handled in a companion PR](https://github.com/WordPress/gutenberg/pull/35060).


Fixes https://github.com/WordPress/gutenberg/issues/17972#issuecomment-919710999

## Why does this happen?

Back when it was created a `forceIsEditingLink` prop was addd to the `<LinkControl>` in order to force it in and out of "editing" mode.

This was then [utilised in the "inline link" part of the format library](https://github.com/WordPress/gutenberg/blob/fa5728771df7cdc86369f7157d6aa763649937a7/packages/format-library/src/link/inline.js#L151) to allow various user UI actions ([example](https://github.com/WordPress/gutenberg/blob/fa5728771df7cdc86369f7157d6aa763649937a7/packages/format-library/src/link/index.js#L75)) to [trigger the Link UI](https://github.com/WordPress/gutenberg/blob/fa5728771df7cdc86369f7157d6aa763649937a7/packages/format-library/src/link/index.js#L41-L61).

However, this allows for an edge case - if `forceIsEditingLink` is set to `false` _and_ the `value.url` is falsey then:

* the Link UI's "Preview" will be force-shown.
* the "Preview" will be empty due to the absence of a URL in the `value.url` property.

## Other options considered

I did consider updating the `<LinkControl>` to reverse the effect of `forceIsEditingLink` if:

1. The value of `forceIsEditingLink` is `false`, _**AND...**_
2. The value of `value.url` is empty.

If I had done that then even if `forceIsEditingLink` was `false` then the Link UI would not render the preview or the editing mode because of the absence of a valid `value.url`. 

I decided not to pursue this as the prop is very explicitly forcing a state on the LinkControl and therefore I wanted to avoid "magic" within the component subverting that "instruction".


## How has this been tested?

We have a new unit test coverage for this scenario.

You can also manually test: 

1. Add a paragraph.
2. Create a link (to anything).
3. Switch to "Code" view.
4. Alter the link by setting the `href` to an empty string.
5. Switch back to Visual mode.
6. Click on the link to trigger the link UI.
7. See the new "Error" state.
8. Click edit to check it's possible to "fix" (re-instate) the link.
9. Check other editors.

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/134349552-418b2be0-3de7-4482-875b-3d4f8772ea73.mp4



## Types of changes
Bug fix (non-breaking change which fixes an issue) 
## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
