### PR TITLE
inspector-section: Track isOpen to make a better isContextuallyActive() function

### DIFF
--- a/packages/customize-widgets/src/controls/inspector-section.js
+++ b/packages/customize-widgets/src/controls/inspector-section.js
@@ -10,6 +10,7 @@ export default function getInspectorSection() {
 			this.parentSection = options.parentSection;
 
 			this.returnFocusWhenClose = null;
+			this.isOpen = false;
 		}
 		ready() {
 			this.contentContainer[ 0 ].classList.add(
@@ -17,7 +18,7 @@ export default function getInspectorSection() {
 			);
 		}
 		isContextuallyActive() {
-			return this.active();
+			return this.isOpen;
 		}
 		onChangeExpanded( expanded, args ) {
 			super.onChangeExpanded( expanded, args );
@@ -46,6 +47,7 @@ export default function getInspectorSection() {
 			}
 		}
 		open( { returnFocusWhenClose } = {} ) {
+			this.setIsOpen( true );
 			this.returnFocusWhenClose = returnFocusWhenClose;
 
 			this.expand( {
@@ -56,6 +58,17 @@ export default function getInspectorSection() {
 			this.collapse( {
 				allowMultiple: true,
 			} );
+		}
+		collapse( opt ) {
+			this.setIsOpen( false );
+			super.collapse( opt );
+		}
+		setIsOpen( value ) {
+			this.isOpen = value;
+			this.triggerActiveCallbacks();
+		}
+		triggerActiveCallbacks() {
+			this.active.callbacks.fireWith( this.active, [ false, true ] );
 		}
 	};
 }

--- a/packages/customize-widgets/src/controls/inspector-section.js
+++ b/packages/customize-widgets/src/controls/inspector-section.js
@@ -10,7 +10,14 @@ export default function getInspectorSection() {
 			this.parentSection = options.parentSection;
 
 			this.returnFocusWhenClose = null;
-			this.isOpen = false;
+			this._isOpen = false;
+		}
+		get isOpen() {
+			return this._isOpen;
+		}
+		set isOpen( value ) {
+			this._isOpen = value;
+			this.triggerActiveCallbacks();
 		}
 		ready() {
 			this.contentContainer[ 0 ].classList.add(
@@ -47,7 +54,7 @@ export default function getInspectorSection() {
 			}
 		}
 		open( { returnFocusWhenClose } = {} ) {
-			this.setIsOpen( true );
+			this.isOpen = true;
 			this.returnFocusWhenClose = returnFocusWhenClose;
 
 			this.expand( {
@@ -59,15 +66,32 @@ export default function getInspectorSection() {
 				allowMultiple: true,
 			} );
 		}
-		collapse( opt ) {
-			this.setIsOpen( false );
-			super.collapse( opt );
-		}
-		setIsOpen( value ) {
-			this.isOpen = value;
-			this.triggerActiveCallbacks();
+		collapse( options ) {
+			// Overridden collapse() function. Mostly call the parent collapse(), but also
+			// move our .isOpen to false.
+			// Initially, I tried tracking this with onChangeExpanded(), but it doesn't work
+			// because the block settings sidebar is a layer "on top of" the G editor sidebar.
+			//
+			// For example, when closing the block settings sidebar, the G
+			// editor sidebar would display, and onChangeExpanded in
+			// inspector-section would run with expanded=true, but I want
+			// isOpen to be false when the block settings is closed.
+			this.isOpen = false;
+			super.collapse( options );
 		}
 		triggerActiveCallbacks() {
+			// Manually fire the callbacks associated with moving this.active
+			// from false to true.  "active" is always true for this section,
+			// and "isContextuallyActive" reflects if the block settings
+			// sidebar is currently visible, that is, it has replaced the main
+			// Gutenberg view.
+			// The WP customizer only checks ".isContextuallyActive()" when
+			// ".active" changes values. But our ".active" never changes value.
+			// The WP customizer never foresaw a section being used a way we
+			// fit the block settings sidebar into a section. By manually
+			// triggering the "this.active" callbacks, we force the WP
+			// customizer to query our .isContextuallyActive() function and
+			// update its view of our status.
 			this.active.callbacks.fireWith( this.active, [ false, true ] );
 		}
 	};

--- a/packages/customize-widgets/src/controls/sidebar-section.js
+++ b/packages/customize-widgets/src/controls/sidebar-section.js
@@ -36,9 +36,6 @@ export default function getSidebarSection() {
 				'customize-widgets__sidebar-section'
 			);
 		}
-		isContextuallyActive() {
-			return this.active();
-		}
 		hasSubSectionOpened() {
 			return this.inspector.expanded();
 		}

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -17,6 +17,7 @@ import {
  */
 // eslint-disable-next-line no-restricted-imports
 import { find, findAll } from 'puppeteer-testing-library';
+import { first } from 'lodash';
 
 const twentyTwentyError = `Stylesheet twentytwenty-block-editor-styles-css was not properly added.
 For blocks, use the block API's style (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) or editorStyle (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style).
@@ -771,8 +772,86 @@ describe( 'Widgets Customizer', () => {
 		const findAllBlockSettingsHeader = findAll( {
 			role: 'heading',
 			name: /Block Settings/,
+			timeout: 250,
 		} );
 		await expect( findAllBlockSettingsHeader ).toThrowQueryEmptyError();
+	} );
+
+	it( 'should stay in block settings after making a change in that area', async () => {
+		// Open footer block widgets
+		const widgetsPanel = await find( {
+			role: 'heading',
+			name: /Widgets/,
+			level: 3,
+		} );
+		await widgetsPanel.click();
+
+		const footer1Section = await find( {
+			role: 'heading',
+			name: /^Footer #1/,
+			level: 3,
+		} );
+		await footer1Section.click();
+
+		// Add a block to make the publish button active.
+		await addBlock( 'Paragraph' );
+		await page.keyboard.type( 'First Paragraph' );
+
+		await waitForPreviewIframe();
+
+		// Click Publish
+		const publishButton = await find( {
+			role: 'button',
+			name: 'Publish',
+		} );
+		await publishButton.click();
+
+		// Wait for publishing to finish.
+		await page.waitForResponse( createURL( '/wp-admin/admin-ajax.php' ) );
+		await expect( publishButton ).toMatchQuery( {
+			disabled: true,
+		} );
+
+		// Select the paragraph block
+		const paragraphBlock = await find( {
+			role: 'document',
+			name: 'Paragraph block',
+		} );
+		await paragraphBlock.focus();
+
+		// Click the three dots button, then click "Show More Settings".
+		await showBlockToolbar();
+		await clickBlockToolbarButton( 'Options' );
+		const showMoreSettingsButton = await find( {
+			role: 'menuitem',
+			name: 'Show more settings',
+		} );
+		await showMoreSettingsButton.click();
+
+		// Change font size (Any change made in this section is sufficient; not required to be font size)
+		const CUSTOM_FONT_SIZE_LABEL_SELECTOR =
+			"//fieldset[legend[contains(text(),'Font size')]]//label[contains(text(), 'Custom')]";
+		await first( await page.$x( CUSTOM_FONT_SIZE_LABEL_SELECTOR ) ).click();
+		await page.keyboard.type( '23' );
+		await page.keyboard.press( 'Enter' );
+
+		// Now that we've made a change:
+		// (1) Publish button should be active
+		// (2) We should still be in the "Block Settings" area
+		await find( {
+			role: 'button',
+			name: 'Publish',
+		} );
+
+		// This fails on 539cea09 and earlier; we get kicked back to the widgets area.
+		// We expect to stay in block settings.
+		await find( {
+			role: 'heading',
+			name: 'Customizing ▸ Widgets ▸ Footer #1 Block Settings',
+			level: 3,
+		} );
+
+		expect( console ).toHaveErrored( twentyTwentyError );
 	} );
 } );
 

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -16,7 +16,7 @@ import {
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { find } from 'puppeteer-testing-library';
+import { find, findAll } from 'puppeteer-testing-library';
 
 const twentyTwentyError = `Stylesheet twentytwenty-block-editor-styles-css was not properly added.
 For blocks, use the block API's style (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style) or editorStyle (https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style).
@@ -762,6 +762,17 @@ describe( 'Widgets Customizer', () => {
 		await expect( movedParagraphBlock ).toHaveFocus();
 
 		expect( console ).toHaveErrored( twentyTwentyError );
+	} );
+
+	it( 'should not render Block Settings sections', async () => {
+		// We add Block Settings as a section, but it shouldn't display to
+		// the user as a section on the main menu. It's simply how we
+		// integrate the G sidebar inside the customizer.
+		const findAllBlockSettingsHeader = findAll( {
+			role: 'heading',
+			name: /Block Settings/,
+		} );
+		await expect( findAllBlockSettingsHeader ).toThrowQueryEmptyError();
 	} );
 } );
 

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -769,11 +769,14 @@ describe( 'Widgets Customizer', () => {
 		// We add Block Settings as a section, but it shouldn't display to
 		// the user as a section on the main menu. It's simply how we
 		// integrate the G sidebar inside the customizer.
-		const findAllBlockSettingsHeader = findAll( {
-			role: 'heading',
-			name: /Block Settings/,
-			timeout: 250,
-		} );
+		const findAllBlockSettingsHeader = findAll(
+			{
+				role: 'heading',
+				name: /Block Settings/,
+				level: 3,
+			},
+			{ timeout: 0 }
+		);
 		await expect( findAllBlockSettingsHeader ).toThrowQueryEmptyError();
 	} );
 


### PR DESCRIPTION
## Description
Inside the WP customizer, with certain themes, you can edit block widgets using the gutenberg editor. One of the features available is to choose "Show more settings", which replaces the entire editor with the settings sidebar. Typically, gutenberg has its own sidebar display area, but in the customizer, we use this neat trick because we're already rendered inside a sidebar.

https://user-images.githubusercontent.com/937354/134374046-78d018f3-b10b-47a5-ae90-6bfe7d226716.mp4

The way this is done is by adding a customizer "section", the "inspector section". This is unconventional, because sections are typically shown at the root level of the customizer:

![2021-09-22_10-31](https://user-images.githubusercontent.com/937354/134374405-72f45fb3-db5f-43f2-8763-02d0e87ee8c0.png)

The customizer checks two active-related values about each section, deciding if it should be drawn. A month ago, the values for this inspector section were as follows:
* `active()`: Always true.
* `isContextuallyActive()`: Always false.
This allowed the section to be used, but to not be rendered at the root level.

In #34543, it was discovered that `isContextuallyActive()` always returning false lead to some bugs while using the section. Notably, sometimes you would be kicked out of the section while using it. A much more detailed writeup is available in that issue.  That changes the values for the inspector section to be:
* `active()`: Always true.
* `isContextuallyActive()`: Returns `active()`, which is the same as always true.
This allows the section to be used, and stops the bugs discovered in #34543 from kicking the user out of the section while using it, but it introduced a new bug: "Block Settings" menu entries are now rendered at the root level (#35041).

This PR fixes the issue in #35041 while keeping the issue in #34543 fixed as well. That is, it changes the values for the inspector section to be:
* `active()`: Always true.
* `isContextuallyActive()`: Only true when the block settings section is actively open.

I had to get a bit tricky with this. First, I had to add a new `this.isOpen` variable and track it in the custom open function ([link1](https://github.com/mreishus/gutenberg/blob/f6833587e3fa14b0e9ab43c01596d83733cfc671/packages/customize-widgets/src/components/block-inspector-button/index.js#L23-L30), [link2](https://github.com/mreishus/gutenberg/blob/f6833587e3fa14b0e9ab43c01596d83733cfc671/packages/customize-widgets/src/controls/inspector-section.js#L49)), and [create an overridden collapse function](https://github.com/mreishus/gutenberg/blob/f6833587e3fa14b0e9ab43c01596d83733cfc671/packages/customize-widgets/src/controls/inspector-section.js#L62-L65) that sets `isOpen` to be false. My first approach was to use `onChangeExpanded` to track this state, but it doesn't work properly since the block settings sidebar is a layer "on top of" the G editor sidebar. For example, when closing the block settings sidebar, the G editor sidebar would display, and `onChangeExpanded` in inspector-section would run with expanded=true.. but I want `isOpen` to be false when the block settings is closed.

Finally, I had to make the customizer "ask about" the `isContextuallyActive()` value more often. It simply doesn't expect the value to change when it does, and doesn't query the `isContextuallyActive()` value when it needs to. The relevant part of WP is here:

https://github.com/WordPress/wordpress-develop/blob/b83b01e1b01429dc4a6da49ec23e1f7dfc4ae446/src/js/_enqueues/wp/customize/controls.js#L996-L1001

```js
			container.active.bind( function ( active ) {
				var args = container.activeArgumentsQueue.shift();
				args = $.extend( {}, container.defaultActiveArguments, args );
				active = ( active && container.isContextuallyActive() );
				container.onChangeActive( active, args );
			});
```

Here, it's setting up this function with `container.active.bind`, which uses a custom binding system to define callbacks that run when `container.active` changes. This callback takes into consideration `isContextuallyActive()`. The problem is, `container.active` isn't something that changes for block settings; it's always something that we want to be able to render when the user presses the "Show More Settings" menu item. So I manually called a part of the customizer's binding code to fire the function above, which considers `isContextuallyActive.` Link: https://github.com/mreishus/gutenberg/blob/f6833587e3fa14b0e9ab43c01596d83733cfc671/packages/customize-widgets/src/controls/inspector-section.js#L70-L72

`this.active.callbacks.fireWith( this.active, [ false, true ] );` 
^ This says "Fire the callbacks associated with this.active moving from false to true".

I did first try `this.active.set(true)`, but [the callbacks do not fire when moving from true to true](https://github.com/WordPress/wordpress-develop/blob/b83b01e1b01429dc4a6da49ec23e1f7dfc4ae446/src/js/_enqueues/wp/customize/base.js#L231-L234).

Ultimately, these are complex changes driven by the settings sidebar of gutenberg not fitting cleanly with the customizer's notion of a "Section". However, this change works well in my testing and fixes both issues.

Additionally, I removed the overrided added to sidebar-section.js. It seems to not be needed to fix #34543.

## How has this been tested?
* Used wp-env
* Follow steps to reproduce in #34543
* Follow steps to reproduce in #35041
* BOTH issues should be fixed after these changes

## Screenshots <!-- if applicable -->
* See screenshots and videos in  #34543 and  #35041. Here, we're keeping both issues fixed at the same time.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
