### PR TITLE
Navigation: change navigation link variation scope to block to avoid cluttering the inserter

### DIFF
--- a/packages/block-library/src/navigation-link/fallback-variations.js
+++ b/packages/block-library/src/navigation-link/fallback-variations.js
@@ -20,6 +20,7 @@ const fallbackVariations = [
 		title: __( 'Custom Link' ),
 		description: __( 'A link to a custom URL.' ),
 		attributes: {},
+		scope: [ 'block' ],
 	},
 	{
 		name: 'post',
@@ -27,6 +28,7 @@ const fallbackVariations = [
 		title: __( 'Post Link' ),
 		description: __( 'A link to a post.' ),
 		attributes: { type: 'post', kind: 'post-type' },
+		scope: [ 'block' ],
 	},
 	{
 		name: 'page',
@@ -34,6 +36,7 @@ const fallbackVariations = [
 		title: __( 'Page Link' ),
 		description: __( 'A link to a page.' ),
 		attributes: { type: 'page', kind: 'post-type' },
+		scope: [ 'block' ],
 	},
 	{
 		name: 'category',
@@ -41,6 +44,7 @@ const fallbackVariations = [
 		title: __( 'Category Link' ),
 		description: __( 'A link to a category.' ),
 		attributes: { type: 'category', kind: 'taxonomy' },
+		scope: [ 'block' ],
 	},
 	{
 		name: 'tag',
@@ -48,6 +52,7 @@ const fallbackVariations = [
 		title: __( 'Tag Link' ),
 		description: __( 'A link to a tag.' ),
 		attributes: { type: 'tag', kind: 'taxonomy' },
+		scope: [ 'block' ],
 	},
 ];
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -270,6 +270,7 @@ function build_variation_for_navigation_link( $entity, $kind ) {
 			'type' => $entity->name,
 			'kind' => $kind,
 		),
+		'scope'       => array( 'block' ),
 	);
 
 	// Tweak some value for the variations.


### PR DESCRIPTION
This PR changes navigation link variations to block scope. A quick draft, we likely can't land this until we have alternate ways of searching/filtering out other types of links.

<img width="1045" alt="CleanShot 2021-09-22 at 09 53 55@2x" src="https://user-images.githubusercontent.com/1270189/134387802-9dc94c96-c86b-4b4f-a5e2-ee3c9415fe96.png">