### PR TITLE
Disallow creation of empty links using Link UI directly

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -137,7 +137,7 @@ function LinkControl( {
 	);
 	const isEndingEditWithFocus = useRef( false );
 
-	const currentInputNotEmpty = currentInputValue?.trim()?.length;
+	const currentInputIsEmpty = ! currentInputValue?.trim()?.length;
 
 	useEffect( () => {
 		if (
@@ -238,7 +238,7 @@ function LinkControl( {
 										const { keyCode } = event;
 										if (
 											keyCode === ENTER &&
-											currentInputNotEmpty // disallow submitting empty values.
+											! currentInputIsEmpty // disallow submitting empty values.
 										) {
 											event.preventDefault();
 											handleSubmitButton();
@@ -247,7 +247,7 @@ function LinkControl( {
 									label={ __( 'Submit' ) }
 									icon={ keyboardReturn }
 									className="block-editor-link-control__search-submit"
-									disabled={ ! currentInputNotEmpty } // disallow submitting empty values.
+									disabled={ currentInputIsEmpty } // disallow submitting empty values.
 								/>
 							</div>
 						</LinkControlSearchInput>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -137,6 +137,8 @@ function LinkControl( {
 	);
 	const isEndingEditWithFocus = useRef( false );
 
+	const currentInputNotEmpty = currentInputValue?.trim()?.length;
+
 	useEffect( () => {
 		if (
 			forceIsEditingLink !== undefined &&
@@ -234,7 +236,10 @@ function LinkControl( {
 									onClick={ () => handleSubmitButton() }
 									onKeyDown={ ( event ) => {
 										const { keyCode } = event;
-										if ( keyCode === ENTER ) {
+										if (
+											keyCode === ENTER &&
+											currentInputNotEmpty // disallow submitting empty values.
+										) {
 											event.preventDefault();
 											handleSubmitButton();
 										}
@@ -242,6 +247,7 @@ function LinkControl( {
 									label={ __( 'Submit' ) }
 									icon={ keyboardReturn }
 									className="block-editor-link-control__search-submit"
+									disabled={ ! currentInputNotEmpty } // disallow submitting empty values.
 								/>
 							</div>
 						</LinkControlSearchInput>

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -132,10 +132,18 @@ const LinkControlSearchInput = forwardRef(
 					__experimentalShowInitialSuggestions={
 						showInitialSuggestions
 					}
-					onSubmit={ ( suggestion ) => {
-						onSuggestionSelected(
-							suggestion || focusedSuggestion || { url: value }
-						);
+					onSubmit={ ( suggestion, event ) => {
+						const hasSuggestion = suggestion || focusedSuggestion;
+
+						// If there is no suggestion and the value (ie: any manually entered URL) is empty
+						// then don't allow submission otherwise we get empty links.
+						if ( ! hasSuggestion && ! value?.trim()?.length ) {
+							event.preventDefault();
+						} else {
+							onSuggestionSelected(
+								hasSuggestion || { url: value }
+							);
+						}
 					} }
 					ref={ ref }
 				/>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -165,6 +165,51 @@ describe( 'Basic rendering', () => {
 		} );
 	} );
 
+	it( 'should not allow creation of links containing only whitespace', async () => {
+		act( () => {
+			render( <LinkControl />, container );
+		} );
+
+		// Search Input UI
+		const searchInput = getURLInput();
+
+		let submitButton = queryByRole( container, 'button', {
+			name: 'Submit',
+		} );
+
+		expect( submitButton.disabled ).toBeTruthy();
+		expect( submitButton ).not.toBeNull();
+		expect( submitButton ).toBeInTheDocument();
+
+		// Simulate searching for a term
+		act( () => {
+			Simulate.change( searchInput, {
+				target: { value: '      ' },
+			} );
+		} );
+
+		// fetchFauxEntitySuggestions resolves on next "tick" of event loop
+		await eventLoopTick();
+
+		// expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
+
+		// Commit the selected item as the current link
+		act( () => {
+			Simulate.keyDown( searchInput, { keyCode: ENTER } );
+		} );
+
+		submitButton = queryByRole( container, 'button', {
+			name: 'Submit',
+		} );
+
+		expect( searchInput ).toBeInTheDocument();
+		expect( submitButton.disabled ).toBeTruthy();
+		expect( submitButton ).not.toBeNull();
+		expect( submitButton ).toBeInTheDocument();
+
+		// console.log( container.innerHTML );
+	} );
+
 	describe( 'forceIsEditingLink', () => {
 		const isEditing = () => !! getURLInput();
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -165,51 +165,6 @@ describe( 'Basic rendering', () => {
 		} );
 	} );
 
-	it( 'should not allow creation of links containing only whitespace', async () => {
-		act( () => {
-			render( <LinkControl />, container );
-		} );
-
-		// Search Input UI
-		const searchInput = getURLInput();
-
-		let submitButton = queryByRole( container, 'button', {
-			name: 'Submit',
-		} );
-
-		expect( submitButton.disabled ).toBeTruthy();
-		expect( submitButton ).not.toBeNull();
-		expect( submitButton ).toBeInTheDocument();
-
-		// Simulate searching for a term
-		act( () => {
-			Simulate.change( searchInput, {
-				target: { value: '      ' },
-			} );
-		} );
-
-		// fetchFauxEntitySuggestions resolves on next "tick" of event loop
-		await eventLoopTick();
-
-		// expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
-
-		// Commit the selected item as the current link
-		act( () => {
-			Simulate.keyDown( searchInput, { keyCode: ENTER } );
-		} );
-
-		submitButton = queryByRole( container, 'button', {
-			name: 'Submit',
-		} );
-
-		expect( searchInput ).toBeInTheDocument();
-		expect( submitButton.disabled ).toBeTruthy();
-		expect( submitButton ).not.toBeNull();
-		expect( submitButton ).toBeInTheDocument();
-
-		// console.log( container.innerHTML );
-	} );
-
 	describe( 'forceIsEditingLink', () => {
 		const isEditing = () => !! getURLInput();
 
@@ -607,6 +562,104 @@ describe( 'Manual link entry', () => {
 			);
 		}
 	);
+
+	describe( 'Handling of empty values', () => {
+		const testTable = [
+			[ 'containing only spaces', '        ' ],
+			[ 'containing only tabs', '		' ],
+			[ 'from strings with no length', '' ],
+		];
+
+		it.each( testTable )(
+			'should not allow creation of links %s when using the keyboard',
+			async ( _desc, searchString ) => {
+				act( () => {
+					render( <LinkControl />, container );
+				} );
+
+				// Search Input UI
+				const searchInput = getURLInput();
+
+				let submitButton = queryByRole( container, 'button', {
+					name: 'Submit',
+				} );
+
+				expect( submitButton.disabled ).toBeTruthy();
+				expect( submitButton ).not.toBeNull();
+				expect( submitButton ).toBeInTheDocument();
+
+				// Simulate searching for a term
+				act( () => {
+					Simulate.change( searchInput, {
+						target: { value: searchString },
+					} );
+				} );
+
+				// fetchFauxEntitySuggestions resolves on next "tick" of event loop
+				await eventLoopTick();
+
+				// Attempt to submit the empty search value in the input.
+				act( () => {
+					Simulate.keyDown( searchInput, { keyCode: ENTER } );
+				} );
+
+				submitButton = queryByRole( container, 'button', {
+					name: 'Submit',
+				} );
+
+				// Verify the UI hasn't allowed submission.
+				expect( searchInput ).toBeInTheDocument();
+				expect( submitButton.disabled ).toBeTruthy();
+				expect( submitButton ).not.toBeNull();
+				expect( submitButton ).toBeInTheDocument();
+			}
+		);
+
+		it.each( testTable )(
+			'should not allow creation of links %s via the UI "submit" button',
+			async ( _desc, searchString ) => {
+				act( () => {
+					render( <LinkControl />, container );
+				} );
+
+				// Search Input UI
+				const searchInput = getURLInput();
+
+				let submitButton = queryByRole( container, 'button', {
+					name: 'Submit',
+				} );
+
+				expect( submitButton.disabled ).toBeTruthy();
+				expect( submitButton ).not.toBeNull();
+				expect( submitButton ).toBeInTheDocument();
+
+				// Simulate searching for a term
+				act( () => {
+					Simulate.change( searchInput, {
+						target: { value: searchString },
+					} );
+				} );
+
+				// fetchFauxEntitySuggestions resolves on next "tick" of event loop
+				await eventLoopTick();
+
+				// Attempt to submit the empty search value in the input.
+				act( () => {
+					Simulate.click( submitButton );
+				} );
+
+				submitButton = queryByRole( container, 'button', {
+					name: 'Submit',
+				} );
+
+				// Verify the UI hasn't allowed submission.
+				expect( searchInput ).toBeInTheDocument();
+				expect( submitButton.disabled ).toBeTruthy();
+				expect( submitButton ).not.toBeNull();
+				expect( submitButton ).toBeInTheDocument();
+			}
+		);
+	} );
 
 	describe( 'Alternative link protocols and formats', () => {
 		it.each( [

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -134,13 +134,13 @@ class URLInput extends Component {
 			return;
 		}
 
-		// Test search string for:
-		// 1. only whitespace characters (via inversion of test for any non-whitespace character).
-		// 2. must have a length - otherwise test from #1 will be truthy for string with no characters.
+		// Test for whitespace only:
+		// 1. must have a length - otherwise test from #1 will be truthy for string with no characters.
+		// 2. if all whitespace is stripped must be empty.
 		const containsOnlyWhitespace = value?.length && value.trim() === '';
 
 		// Initial suggestions are those shown when no search has been made.
-		// The criteria for no search are:
+		// The criteria for "no search" are:
 		// 1. No value.
 		// 2. Value must not be entirely whitespace.
 		const isInitialSuggestions =

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -138,7 +138,8 @@ class URLInput extends Component {
 		// (note: this includes whitespace).
 		const isInitialSuggestions = ! value?.length;
 
-		// Trim only now we've determined it's not composed of purely whitespace.
+		// Trim only now we've determined whether or not it originally had a "length"
+		// (even if that value was all whitespace).
 		value = value.trim();
 
 		// Allow a suggestions request if:

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -288,7 +288,7 @@ class URLInput extends Component {
 				// Submitting while loading should trigger onSubmit
 				case ENTER: {
 					if ( this.props.onSubmit ) {
-						this.props.onSubmit();
+						this.props.onSubmit( null, event );
 					}
 
 					break;
@@ -338,10 +338,10 @@ class URLInput extends Component {
 					this.selectLink( suggestion );
 
 					if ( this.props.onSubmit ) {
-						this.props.onSubmit( suggestion );
+						this.props.onSubmit( suggestion, event );
 					}
 				} else if ( this.props.onSubmit ) {
-					this.props.onSubmit();
+					this.props.onSubmit( null, event );
 				}
 
 				break;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -134,17 +134,9 @@ class URLInput extends Component {
 			return;
 		}
 
-		// Test for whitespace only:
-		// 1. must have a length - otherwise test from #1 will be truthy for string with no characters.
-		// 2. if all whitespace is stripped must be empty.
-		const containsOnlyWhitespace = value?.length && value.trim() === '';
-
-		// Initial suggestions are those shown when no search has been made.
-		// The criteria for "no search" are:
-		// 1. No value.
-		// 2. Value must not be entirely whitespace.
-		const isInitialSuggestions =
-			! value?.length && ! containsOnlyWhitespace;
+		// Initial suggestions may only show if there is no value
+		// (note: this includes whitespace).
+		const isInitialSuggestions = ! value?.length;
 
 		// Trim only now we've determined it's not composed of purely whitespace.
 		value = value.trim();

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -137,9 +137,7 @@ class URLInput extends Component {
 		// Test search string for:
 		// 1. only whitespace characters (via inversion of test for any non-whitespace character).
 		// 2. must have a length - otherwise test from #1 will be truthy for string with no characters.
-		const containsOnlyWhitespace = !! (
-			! /\S/.test( value ) && value?.length
-		);
+		const containsOnlyWhitespace = value?.length && value.trim() === '';
 
 		// Initial suggestions are those shown when no search has been made.
 		// The criteria for no search are:

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -134,7 +134,17 @@ class URLInput extends Component {
 			return;
 		}
 
-		const isInitialSuggestions = ! ( value && value.length );
+		const containsOnlyWhitespace = ! /\S/.test( value );
+
+		// Initial suggestions are those shown when no search has been made.
+		// The criteria for no search are:
+		// 1. No value.
+		// 2. Value must not be entirely whitespace.
+		const isInitialSuggestions =
+			! ( value && value.length ) && ! containsOnlyWhitespace;
+
+		// Trim only now we've determined it's not composed of purely whitespace.
+		value = value.trim();
 
 		// Allow a suggestions request if:
 		// - there are at least 2 characters in the search input (except manual searches where
@@ -219,7 +229,7 @@ class URLInput extends Component {
 
 		this.props.onChange( inputValue );
 		if ( ! this.props.disableSuggestions ) {
-			this.updateSuggestions( inputValue.trim() );
+			this.updateSuggestions( inputValue );
 		}
 	}
 
@@ -236,7 +246,7 @@ class URLInput extends Component {
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value
-			this.updateSuggestions( value.trim() );
+			this.updateSuggestions( value );
 		}
 	}
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -134,14 +134,19 @@ class URLInput extends Component {
 			return;
 		}
 
-		const containsOnlyWhitespace = ! /\S/.test( value );
+		// Test search string for:
+		// 1. only whitespace characters (via inversion of test for any non-whitespace character).
+		// 2. must have a length - otherwise test from #1 will be truthy for string with no characters.
+		const containsOnlyWhitespace = !! (
+			! /\S/.test( value ) && value?.length
+		);
 
 		// Initial suggestions are those shown when no search has been made.
 		// The criteria for no search are:
 		// 1. No value.
 		// 2. Value must not be entirely whitespace.
 		const isInitialSuggestions =
-			! ( value && value.length ) && ! containsOnlyWhitespace;
+			! value?.length && ! containsOnlyWhitespace;
 
 		// Trim only now we've determined it's not composed of purely whitespace.
 		value = value.trim();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description



In https://github.com/WordPress/gutenberg/issues/17972#issuecomment-920182578 we learnt that you can create empty links using the Link UI. This **doesn't** seem like something we should allow (I'm open to counter opinions!).

To add an empty link all you need do is add a link to a paragraph of text and then either with/without typing in a few spaces:

* hit ENTER
* click the "submit" arrow icon (far right of search input).

This will result in an empty link. There's nothing to stop you submitting it...which seems odd.

This PR works on the premise that "empty" means no value or a value composed purely of whitespace. It employs a basic fix to:

* Disable the submit button when the input is empty.
* Disable the ability to hit `ENTER` to submit when focused in the input and the input is empty.
* Disable the "initial suggestions" appearing if the search input is empty.

Note this PR **does _not_** attempt to fix the situation whereby you can still create an empty link by using the "Code view" of the editor. That is [handled in a companion PR](https://github.com/WordPress/gutenberg/pull/35043).

## How has this been tested?

Try out the issue first on `trunk` in order to experience the error. 

Then retry on this PR's branch.

1. Create a paragraph of text.
2. Add a link by clicking the toolbar icon or CMD+K.
3. Hit `Enter` or the "Submit" button. See that the link will now not be created.
4. Try typing in a few spaces (as many as you like!). Try hitting `ENTER` or "Submit" again. See the link won't be created.



## Screenshots <!-- if applicable -->



### Before
https://user-images.githubusercontent.com/444434/134404898-919e49f7-b774-4ca7-8f68-6e2e8b2743b5.mov

### After
https://user-images.githubusercontent.com/444434/134404514-4f04fef7-b80c-4741-b0c9-b3d783aba507.mov


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
