### PR TITLE
[RNMobile]: Column: fix width float attribute cut off

### DIFF
--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -86,8 +86,6 @@ function ColumnEdit( {
 	}, [] );
 
 	const onChangeWidth = ( nextWidth ) => {
-		// Rounds the number to 1 decimal place max.
-		nextWidth = Math.round( nextWidth * 10 ) / 10;
 		const widthWithUnit = getWidthWithUnit( nextWidth, widthUnit );
 
 		setAttributes( {

--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -86,6 +86,8 @@ function ColumnEdit( {
 	}, [] );
 
 	const onChangeWidth = ( nextWidth ) => {
+		// Rounds the number to 1 decimal place max.
+		nextWidth = Math.round( nextWidth * 10 ) / 10;
 		const widthWithUnit = getWidthWithUnit( nextWidth, widthUnit );
 
 		setAttributes( {

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -18,8 +18,18 @@ export default function save( { attributes } ) {
 	let style;
 
 	if ( width ) {
+		let flexBasis = Number.isFinite( width ) ? width + '%' : width;
+		// In some cases we need to round the width to a shorter float.
+		if ( ! Number.isFinite( width ) && width?.endsWith( '%' ) ) {
+			const multiplier = 1000000000000;
+			// Shrink the number back to a reasonable float.
+			flexBasis =
+				Math.round( Number.parseFloat( width ) * multiplier ) /
+					multiplier +
+				'%';
+		}
 		// Numbers are handled for backward compatibility as they can be still provided with templates.
-		style = { flexBasis: Number.isFinite( width ) ? width + '%' : width };
+		style = { flexBasis };
 	}
 
 	return (

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -18,6 +18,7 @@ export default function save( { attributes } ) {
 	let style;
 
 	if ( width ) {
+		// Numbers are handled for backward compatibility as they can be still provided with templates.
 		let flexBasis = Number.isFinite( width ) ? width + '%' : width;
 		// In some cases we need to round the width to a shorter float.
 		if ( ! Number.isFinite( width ) && width?.endsWith( '%' ) ) {
@@ -28,7 +29,6 @@ export default function save( { attributes } ) {
 					multiplier +
 				'%';
 		}
-		// Numbers are handled for backward compatibility as they can be still provided with templates.
 		style = { flexBasis };
 	}
 

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -25,6 +25,7 @@ class BottomSheetRangeCell extends Component {
 	constructor( props ) {
 		super( props );
 		this.onSliderChange = this.onSliderChange.bind( this );
+		this.onCompleteSliderChange = this.onCompleteSliderChange.bind( this );
 		this.onTextInputChange = this.onTextInputChange.bind( this );
 		this.a11yIncrementValue = this.a11yIncrementValue.bind( this );
 		this.a11yDecrementValue = this.a11yDecrementValue.bind( this );
@@ -56,6 +57,14 @@ class BottomSheetRangeCell extends Component {
 			sliderValue: nextValue,
 		} );
 		onChange( nextValue );
+		if ( onComplete ) {
+			onComplete( nextValue );
+		}
+	}
+
+	onCompleteSliderChange( nextValue ) {
+		const { decimalNum, onComplete } = this.props;
+		nextValue = toFixed( nextValue, decimalNum );
 		if ( onComplete ) {
 			onComplete( nextValue );
 		}
@@ -138,7 +147,6 @@ class BottomSheetRangeCell extends Component {
 			thumbTintColor = ! isIOS && '#00669b',
 			preview,
 			cellContainerStyle,
-			onComplete,
 			shouldDisplayTextInput = true,
 			unitLabel = '',
 			settingLabel = 'Value',
@@ -225,7 +233,9 @@ class BottomSheetRangeCell extends Component {
 								maximumTrackTintColor={ maximumTrackTintColor }
 								thumbTintColor={ thumbTintColor }
 								onValueChange={ this.onSliderChange }
-								onSlidingComplete={ onComplete }
+								onSlidingComplete={
+									this.onCompleteSliderChange
+								}
 								ref={ ( slider ) => {
 									this.sliderRef = slider;
 								} }


### PR DESCRIPTION
Gutenberg Mobile : https://github.com/wordpress-mobile/gutenberg-mobile/pull/4012

## Description
Currently when you save the update the width of a columns block on mobile and you save it. 
You can end up in a state where the content of the block results in a Problem displaying the block error. 

This happens because the width value gets stored as a really long float + '%' value. 
Then when that width gets compared we end up in a state where the value doesn't match between the generated value and the saved value. 

This PR intends to fix this issue in 2 ways. 
1. Stop generating a really long float value. 
2. If we get content that has a really long float value strip it so that it gets display anyways and do not display the "Problem displaying the block" error.

This issue was discovered during 1.62 release process of gutenberg mobile. 

## How has this been tested?
This was tested on the mobile simulator. 
1. Create a columns block. Add content to the block. 
2. Change the width via the slider. 
3. Save the post. 
4. Notice that it works as expected. 

## Screenshots

Before:
<img src="https://user-images.githubusercontent.com/115071/134407850-39aa9bb4-ed53-4d8d-ae68-49666aa1b869.png" width="400" />

After:
<img src="https://user-images.githubusercontent.com/115071/134407865-a29af452-8bd6-4156-b968-89bd3df684ed.png" width="400" />

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
