### PR TITLE
Navigation: add new patterns

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -14,6 +14,10 @@ function register_gutenberg_patterns() {
 		register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
 	}
 
+	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'navigation' ) ) {
+		register_block_pattern_category( 'navigation', array( 'label' => __( 'Navigation', 'gutenberg' ) ) );
+	}
+
 	$patterns = array(
 		'query-standard-posts'                 => array(
 			'title'      => _x( 'Standard', 'Block pattern title', 'gutenberg' ),
@@ -156,6 +160,41 @@ function register_gutenberg_patterns() {
 								<!-- wp:social-link {"url":"#","service":"chain"} /-->
 								<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>
 								<!-- /wp:social-links -->',
+		),
+		'navigation-page-links'                => array(
+			'title'      => _x( 'All pages menu', 'Block pattern title', 'gutenberg' ),
+			'categories' => array( 'navigation' ),
+			'blockTypes' => array( 'core/navigation' ),
+			'content'    => '<!-- wp:navigation --><!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /--><!-- /wp:navigation -->',
+		),
+		'navigation-page-links-responsive'     => array(
+			'title'         => _x( 'All pages menu (responsive)', 'Block pattern title', 'gutenberg' ),
+			'viewportWidth' => 500,
+			'categories'    => array( 'navigation' ),
+			'blockTypes'    => array( 'core/navigation' ),
+			'content'       => '<!-- wp:navigation {"isResponsive":true} --><!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /--><!-- /wp:navigation -->',
+		),
+		'navigation-vertical'                  => array(
+			'title'      => _x( 'Vertical navigation menu', 'Block pattern title', 'gutenberg' ),
+			'categories' => array( 'navigation' ),
+			'blockTypes' => array( 'core/navigation' ),
+			'content'    => '<!-- wp:navigation {"orientation":"vertical","style":{"typography":{"fontFamily":"var:preset|font-family|system-fonts"}},"fontSize":"extra-large"} -->
+							<!-- wp:home-link {"label":"Home"} /-->
+							<!-- wp:navigation-link {"label":"About","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- wp:navigation-link {"label":"Contact","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- wp:navigation-link {"label":"Portfolio","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- /wp:navigation -->',
+		),
+		'navigation-horizontal'                => array(
+			'title'      => _x( 'Horizontal navigation menu', 'Block pattern title', 'gutenberg' ),
+			'categories' => array( 'navigation' ),
+			'blockTypes' => array( 'core/navigation' ),
+			'content'    => '<!-- wp:navigation {"style":{"typography":{"fontFamily":"var:preset|font-family|system-fonts"}},"fontSize":"extra-large"} -->
+							<!-- wp:home-link {"label":"Home"} /-->
+							<!-- wp:navigation-link {"label":"About","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- wp:navigation-link {"label":"Contact","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- wp:navigation-link {"label":"Portfolio","type":"page","kind":"post-type","isTopLevelLink":true} /-->
+							<!-- /wp:navigation -->',
 		),
 	);
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -588,6 +588,9 @@ export default function NavigationLinkEdit( {
 			/* translators: label for missing values in navigation link block */
 			missingText = __( 'Add link' );
 	}
+	if ( label ) {
+		missingText = label;
+	}
 
 	return (
 		<Fragment>


### PR DESCRIPTION
A small part of https://github.com/WordPress/gutenberg/issues/34041 and https://github.com/WordPress/gutenberg/issues/33091

> It's time to start allowing initial states for navigation to be pattern-driven. A pattern should be able to express whatever layout they need while making it easy to be replaced by user content. This ranges from using "page list" for cases that are more straightforward, to using individual page items for composition that require careful placement of items. A user should be able to choose what page is assigned to a page item placeholder.

Changes here allow us to use a label as placeholder text instead of "Select Page". This makes patterns more visually interesting and lets users more quickly pick out useful patterns.

Since folks may find multiple ways of things, I also added a few simple patterns to demonstrate features of the navigation block that might not be apparent to folks at first glance.

Let me know if there's a better spot for these.

https://user-images.githubusercontent.com/1270189/134425230-022a7157-7b7b-4e21-8e76-4acc93fb0eba.mp4

### Feedback/Questions

- Without a prompt is it clear that folks know what happens when an item has a wavy line?
- Are navigation patterns (outside of site header) patterns useful? Is there a better spot for these.
- I think it's a good exercise to try building some more experimental menu examples like the following image. However it may more sense in a theme context. Any good candidates that I could explore in a follow up? 
<img width="1236" alt="123940293-4f625480-d999-11eb-8e77-d1882cec8cd7-1" src="https://user-images.githubusercontent.com/1270189/134425605-2b574097-bd6a-4d22-8596-32e40f27e624.png">

