### PR TITLE
Cover block: Allow setting the height from the placeholder state.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -37,6 +37,7 @@ $z-layers: (
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block
+	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__image-background": 0, // Image background inside cover block.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -78,6 +78,7 @@ export function MediaPlaceholder( {
 	children,
 	mediaLibraryButton,
 	placeholder,
+	style,
 } ) {
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -248,6 +249,7 @@ export function MediaPlaceholder( {
 				notices={ notices }
 				onDoubleClick={ onDoubleClick }
 				preview={ mediaPreview }
+				style={ style }
 			>
 				{ content }
 				{ children }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -274,29 +274,32 @@ function CoverPlaceholder( {
 	noticeUI,
 	noticeOperations,
 	onSelectMedia,
+	style,
 } ) {
 	const { removeAllNotices, createErrorNotice } = noticeOperations;
 	return (
-		<MediaPlaceholder
-			icon={ <BlockIcon icon={ icon } /> }
-			labels={ {
-				title: __( 'Cover' ),
-				instructions: __(
-					'Drag and drop onto this block, upload, or select existing media from your library.'
-				),
-			} }
-			onSelect={ onSelectMedia }
-			accept="image/*,video/*"
-			allowedTypes={ ALLOWED_MEDIA_TYPES }
-			notices={ noticeUI }
-			disableMediaButtons={ disableMediaButtons }
-			onError={ ( message ) => {
-				removeAllNotices();
-				createErrorNotice( message );
-			} }
-		>
-			{ children }
-		</MediaPlaceholder>
+		<div className="cover-block__cover-placeholder-container" style={ style }>
+			<MediaPlaceholder
+				icon={ <BlockIcon icon={ icon } /> }
+				labels={ {
+					title: __( 'Cover' ),
+					instructions: __(
+						'Drag and drop onto this block, upload, or select existing media from your library.'
+					),
+				} }
+				onSelect={ onSelectMedia }
+				accept="image/*,video/*"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				notices={ noticeUI }
+				disableMediaButtons={ disableMediaButtons }
+				onError={ ( message ) => {
+					removeAllNotices();
+					createErrorNotice( message );
+				} }
+			>
+				{ children }
+			</MediaPlaceholder>
+		</div>
 	);
 }
 
@@ -637,10 +640,25 @@ function CoverEdit( {
 						blockProps.className
 					) }
 				>
+					<ResizableCover
+						className="block-library-cover__resize-container"
+						onResizeStart={ () => {
+							setAttributes( { minHeightUnit: 'px' } );
+							toggleSelection( false );
+						} }
+						onResize={ setTemporaryMinHeight }
+						onResizeStop={ ( newMinHeight ) => {
+							toggleSelection( true );
+							setAttributes( { minHeight: newMinHeight } );
+							setTemporaryMinHeight( null );
+						} }
+						showHandle={ isSelected }
+					/>
 					<CoverPlaceholder
 						noticeUI={ noticeUI }
 						onSelectMedia={ onSelectMedia }
 						noticeOperations={ noticeOperations }
+						style={ { minHeight: temporaryMinHeight || minHeight } }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -278,7 +278,10 @@ function CoverPlaceholder( {
 } ) {
 	const { removeAllNotices, createErrorNotice } = noticeOperations;
 	return (
-		<div className="cover-block__cover-placeholder-container" style={ style }>
+		<div
+			className="cover-block__cover-placeholder-container"
+			style={ style }
+		>
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
 				labels={ {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -277,29 +277,27 @@ function CoverPlaceholder( {
 } ) {
 	const { removeAllNotices, createErrorNotice } = noticeOperations;
 	return (
-		<div className="cover-block__cover-placeholder-container">
-			<MediaPlaceholder
-				icon={ <BlockIcon icon={ icon } /> }
-				labels={ {
-					title: __( 'Cover' ),
-					instructions: __(
-						'Drag and drop onto this block, upload, or select existing media from your library.'
-					),
-				} }
-				onSelect={ onSelectMedia }
-				accept="image/*,video/*"
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				notices={ noticeUI }
-				disableMediaButtons={ disableMediaButtons }
-				onError={ ( message ) => {
-					removeAllNotices();
-					createErrorNotice( message );
-				} }
-				style={ style }
-			>
-				{ children }
-			</MediaPlaceholder>
-		</div>
+		<MediaPlaceholder
+			icon={ <BlockIcon icon={ icon } /> }
+			labels={ {
+				title: __( 'Cover' ),
+				instructions: __(
+					'Drag and drop onto this block, upload, or select existing media from your library.'
+				),
+			} }
+			onSelect={ onSelectMedia }
+			accept="image/*,video/*"
+			allowedTypes={ ALLOWED_MEDIA_TYPES }
+			notices={ noticeUI }
+			disableMediaButtons={ disableMediaButtons }
+			onError={ ( message ) => {
+				removeAllNotices();
+				createErrorNotice( message );
+			} }
+			style={ style }
+		>
+			{ children }
+		</MediaPlaceholder>
 	);
 }
 
@@ -646,20 +644,6 @@ function CoverEdit( {
 						noticeOperations={ noticeOperations }
 						style={ { minHeight: temporaryMinHeight || minHeight } }
 					>
-						<ResizableCover
-							className="block-library-cover__resize-container"
-							onResizeStart={ () => {
-								setAttributes( { minHeightUnit: 'px' } );
-								toggleSelection( false );
-							} }
-							onResize={ setTemporaryMinHeight }
-							onResizeStop={ ( newMinHeight ) => {
-								toggleSelection( true );
-								setAttributes( { minHeight: newMinHeight } );
-								setTemporaryMinHeight( null );
-							} }
-							showHandle={ isSelected }
-						/>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
 								disableCustomColors={ true }
@@ -669,6 +653,20 @@ function CoverEdit( {
 							/>
 						</div>
 					</CoverPlaceholder>
+					<ResizableCover
+						className="block-library-cover__resize-container"
+						onResizeStart={ () => {
+							setAttributes( { minHeightUnit: 'px' } );
+							toggleSelection( false );
+						} }
+						onResize={ setTemporaryMinHeight }
+						onResizeStop={ ( newMinHeight ) => {
+							toggleSelection( true );
+							setAttributes( { minHeight: newMinHeight } );
+							setTemporaryMinHeight( null );
+						} }
+						showHandle={ isSelected }
+					/>
 				</div>
 			</>
 		);

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -198,7 +198,6 @@ function ResizableCover( {
 				onResizeStop( elt.clientHeight );
 				setIsResizing( false );
 			} }
-			minHeight={ COVER_MIN_HEIGHT }
 			{ ...props }
 		/>
 	);
@@ -278,10 +277,7 @@ function CoverPlaceholder( {
 } ) {
 	const { removeAllNotices, createErrorNotice } = noticeOperations;
 	return (
-		<div
-			className="cover-block__cover-placeholder-container"
-			style={ style }
-		>
+		<div className="cover-block__cover-placeholder-container">
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
 				labels={ {
@@ -299,6 +295,7 @@ function CoverPlaceholder( {
 					removeAllNotices();
 					createErrorNotice( message );
 				} }
+				style={ style }
 			>
 				{ children }
 			</MediaPlaceholder>
@@ -643,26 +640,26 @@ function CoverEdit( {
 						blockProps.className
 					) }
 				>
-					<ResizableCover
-						className="block-library-cover__resize-container"
-						onResizeStart={ () => {
-							setAttributes( { minHeightUnit: 'px' } );
-							toggleSelection( false );
-						} }
-						onResize={ setTemporaryMinHeight }
-						onResizeStop={ ( newMinHeight ) => {
-							toggleSelection( true );
-							setAttributes( { minHeight: newMinHeight } );
-							setTemporaryMinHeight( null );
-						} }
-						showHandle={ isSelected }
-					/>
 					<CoverPlaceholder
 						noticeUI={ noticeUI }
 						onSelectMedia={ onSelectMedia }
 						noticeOperations={ noticeOperations }
 						style={ { minHeight: temporaryMinHeight || minHeight } }
 					>
+						<ResizableCover
+							className="block-library-cover__resize-container"
+							onResizeStart={ () => {
+								setAttributes( { minHeightUnit: 'px' } );
+								toggleSelection( false );
+							} }
+							onResize={ setTemporaryMinHeight }
+							onResizeStop={ ( newMinHeight ) => {
+								toggleSelection( true );
+								setAttributes( { minHeight: newMinHeight } );
+								setTemporaryMinHeight( null );
+							} }
+							showHandle={ isSelected }
+						/>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
 								disableCustomColors={ true }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -9,6 +9,22 @@
 	&.is-placeholder {
 		min-height: auto !important;
 		padding: 0 !important;
+
+		// Resizeable placeholder
+		.components-resizable-box__container {
+			display: none;
+		}
+		.components-placeholder {
+			&.is-large {
+				min-height: 250px;
+				justify-content: flex-start;
+				z-index: z-index(".wp-block-cover.is-placeholder .components-placeholder.is-large");
+				+ .components-resizable-box__container {
+					min-height: 250px;
+					display: block;
+				}
+			}
+		}
 	}
 
 	&.components-placeholder h2 {
@@ -115,23 +131,4 @@
 // doesn't work with the transforms that are applied to resize the block in that context.
 .block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
 	background-attachment: scroll;
-}
-
-// Resizeable placeholder
-.wp-block-cover.is-placeholder .cover-block__cover-placeholder-container {
-	width: 100%;
-	.components-resizable-box__container {
-		display: none;
-	}
-	.components-placeholder {
-		justify-content: flex-start;
-		&.is-large {
-			min-height: 250px;
-
-			.components-resizable-box__container {
-				min-height: 250px;
-				display: block;
-			}
-		}
-	}
 }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -9,6 +9,7 @@
 	&.is-placeholder {
 		min-height: auto !important;
 		padding: 0 !important;
+		border: $border-width solid  $gray-900;
 	}
 
 	&.components-placeholder h2 {
@@ -117,8 +118,10 @@
 	background-attachment: scroll;
 }
 
-.cover-block__cover-placeholder-container {
-	background: white;
+// Ensure the placeholder container styles are consistent when resizing.
+.wp-block-cover.is-placeholder .cover-block__cover-placeholder-container {
+	background: $white;
+	width: 100%;
 	.block-editor-media-placeholder {
 		box-shadow: none;
 	}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -119,25 +119,17 @@
 
 // Resizeable placeholder
 .wp-block-cover.is-placeholder .cover-block__cover-placeholder-container {
+	.components-resizable-box__container {
+		display: none;
+	}
 	.components-placeholder {
-		&.is-tall {
+		justify-content: flex-start;
+		&.is-large {
 			min-height: 250px;
+
 			.components-resizable-box__container {
 				min-height: 250px;
-			}
-		}
-
-		&.is-middle {
-			min-height: 150px;
-			.components-resizable-box__container {
-				min-height: 150px;
-			}
-		}
-
-		&.is-short {
-			min-height: 100px;
-			.components-resizable-box__container {
-				min-height: 100px;
+				display: block;
 			}
 		}
 	}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -10,8 +10,8 @@
 		min-height: auto !important;
 		padding: 0 !important;
 
-		// Resizeable placeholder
-		.components-resizable-box__container {
+		// Resizeable placeholder for placeholder.
+		.block-library-cover__resize-container {
 			display: none;
 		}
 		.components-placeholder {
@@ -19,7 +19,7 @@
 				min-height: 240px;
 				justify-content: flex-start;
 				z-index: z-index(".wp-block-cover.is-placeholder .components-placeholder.is-large");
-				+ .components-resizable-box__container {
+				+ .block-library-cover__resize-container {
 					min-height: 240px;
 					display: block;
 				}
@@ -80,6 +80,7 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
+	min-height: 50px;
 }
 
 .block-library-cover__resize-container:not(.is-resizing) {

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -119,6 +119,7 @@
 
 // Resizeable placeholder
 .wp-block-cover.is-placeholder .cover-block__cover-placeholder-container {
+	width: 100%;
 	.components-resizable-box__container {
 		display: none;
 	}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -9,7 +9,6 @@
 	&.is-placeholder {
 		min-height: auto !important;
 		padding: 0 !important;
-		border: $border-width solid  $gray-900;
 	}
 
 	&.components-placeholder h2 {
@@ -118,11 +117,28 @@
 	background-attachment: scroll;
 }
 
-// Ensure the placeholder container styles are consistent when resizing.
+// Resizeable placeholder
 .wp-block-cover.is-placeholder .cover-block__cover-placeholder-container {
-	background: $white;
-	width: 100%;
-	.block-editor-media-placeholder {
-		box-shadow: none;
+	.components-placeholder {
+		&.is-tall {
+			min-height: 250px;
+			.components-resizable-box__container {
+				min-height: 250px;
+			}
+		}
+
+		&.is-middle {
+			min-height: 150px;
+			.components-resizable-box__container {
+				min-height: 150px;
+			}
+		}
+
+		&.is-short {
+			min-height: 100px;
+			.components-resizable-box__container {
+				min-height: 100px;
+			}
+		}
 	}
 }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -116,3 +116,10 @@
 .block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
 	background-attachment: scroll;
 }
+
+.cover-block__cover-placeholder-container {
+	background: white;
+	.block-editor-media-placeholder {
+		box-shadow: none;
+	}
+}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -16,11 +16,11 @@
 		}
 		.components-placeholder {
 			&.is-large {
-				min-height: 250px;
+				min-height: 240px;
 				justify-content: flex-start;
 				z-index: z-index(".wp-block-cover.is-placeholder .components-placeholder.is-large");
 				+ .components-resizable-box__container {
-					min-height: 250px;
+					min-height: 240px;
 					display: block;
 				}
 			}

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -39,7 +39,7 @@ function Placeholder( {
 	isColumnLayout,
 	...additionalProps
 } ) {
-	const [ resizeListener, { width, height } ] = useResizeObserver();
+	const [ resizeListener, { width } ] = useResizeObserver();
 
 	// Since `useResizeObserver` will report a width of `null` until after the
 	// first render, avoid applying any modifier classes until width is known.
@@ -49,9 +49,6 @@ function Placeholder( {
 			'is-large': width >= 480,
 			'is-medium': width >= 160 && width < 480,
 			'is-small': width < 160,
-			'is-tall': height >= 250,
-			'is-middle': height >= 100 && height < 250,
-			'is-short': height < 100,
 		};
 	}
 

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -39,7 +39,7 @@ function Placeholder( {
 	isColumnLayout,
 	...additionalProps
 } ) {
-	const [ resizeListener, { width } ] = useResizeObserver();
+	const [ resizeListener, { width, height } ] = useResizeObserver();
 
 	// Since `useResizeObserver` will report a width of `null` until after the
 	// first render, avoid applying any modifier classes until width is known.
@@ -49,6 +49,9 @@ function Placeholder( {
 			'is-large': width >= 480,
 			'is-medium': width >= 160 && width < 480,
 			'is-small': width < 160,
+			'is-tall': height >= 250,
+			'is-middle': height >= 100 && height < 250,
+			'is-short': height < 100,
 		};
 	}
 


### PR DESCRIPTION
## Description

This PR allows us to set the min-height value for the Cover Block by resizing the placeholder. 🪄 

It's part of a [wider issue to improve the Cover Block UX](https://github.com/WordPress/gutenberg/issues/28385).

This PR also updates the copy in the placeholder to describe this functionality. Note, there's a [PR](https://github.com/WordPress/gutenberg/pull/34970) to update the Cover Block placeholder copy, so we don't have to do it here.

https://user-images.githubusercontent.com/6458278/135028287-6131ce47-c74d-42b9-8821-5b3793c0bc0b.mp4

Kudos to @jasmussen for the original [UX idea](https://github.com/WordPress/gutenberg/issues/34706#issuecomment-921534880). 🎉 

Resolves https://github.com/WordPress/gutenberg/issues/34706

## Testing

1. Add a Cover Block 
2. Adjust placeholder's height using the resize handle
3. The min-height value in the block inspector controls (in the Dimensions panel) should reflect the resized placeholder's min-height
4. Ensure that the placeholder's background color and border is otherwise unaffected by window resizing.
5. Check that you can interact with all controls and text inside the placeholder, and also drag an image on top of it.
5. Also make sure that the resizer itself only appears for large placeholders. You can test this by resizing the window or inserting a cover block into a narrow column. You shouldn't be able to resize placeholders with a width of `< 480px`
5. Select a color or a media file
6. Ensure that the min-height value is retained and displays correctly in the editor and the frontend.
7. Check that the resizer works as expected, with a min-height of 50px after we've inserted the Cover Block.
8. Things should work as above on a mobile device as well.


## Types of changes
UX enhancement on a block placeholder.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
