### PR TITLE
MediaUpload: Ensure current images in a gallery are selected after opening media library

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -387,7 +387,14 @@ class MediaUpload extends Component {
 			return;
 		}
 
+		const isGallery = this.props.gallery;
 		const selection = this.frame.state().get( 'selection' );
+
+		if ( ! isGallery ) {
+			castArray( this.props.value ).forEach( ( id ) => {
+				selection.add( wp.media.attachment( id ) );
+			} );
+		}
 
 		// Load the images so they are available in the media modal.
 		const attachments = getAttachmentsCollection(
@@ -396,7 +403,7 @@ class MediaUpload extends Component {
 
 		// Once attachments are loaded, set the current selection.
 		attachments.more().done( function () {
-			if ( attachments?.models?.length ) {
+			if ( isGallery && attachments?.models?.length ) {
 				selection.add( attachments.models );
 			}
 		} );

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -387,15 +387,19 @@ class MediaUpload extends Component {
 			return;
 		}
 
-		if ( ! this.props.gallery ) {
-			const selection = this.frame.state().get( 'selection' );
-			castArray( this.props.value ).forEach( ( id ) => {
-				selection.add( wp.media.attachment( id ) );
-			} );
-		}
+		const selection = this.frame.state().get( 'selection' );
 
-		// load the images so they are available in the media modal.
-		getAttachmentsCollection( castArray( this.props.value ) ).more();
+		// Load the images so they are available in the media modal.
+		const attachments = getAttachmentsCollection(
+			castArray( this.props.value )
+		);
+
+		// Once attachments are loaded, set the current selection.
+		attachments.more().done( function () {
+			if ( attachments?.models?.length ) {
+				selection.add( attachments.models );
+			}
+		} );
 	}
 
 	onClose() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #33769

Before this change, when we open the media library for a gallery with existing images, in the media library's Add to Gallery view, the current images are not selected, and the state for the edit controller isn't loaded yet, which means that the gallery is treated as empty. Adding any images at this point effectively replaces all images in the gallery.

In this fix, to workaround that the `GalleryAdd` controller [watches the gallery-edit state](https://github.com/wordpress/wordpress-develop/blob/a03bb5454673d62dae26f50cd13619e92b23c884/src/js/media/controllers/gallery-add.js#L80-L80) to determine which attachments are already in the gallery, we explicitly set the current images in the gallery to be selected, once they're loaded.

This means that when the user opens the media library, they will see the current images selected in addition to other images in their library. If they click to the Edit view and then back to Add to Gallery, the existing behaviour where the current images are hidden will persist, after all this is just a workaround! But on balance, it should mean that people don't unexpectedly wind up removing images from their image galleries.

This fix preserves the optimisation introduced back in https://github.com/WordPress/gutenberg/pull/2488, so shouldn't result in any additional API calls.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually:

* Add a gallery block and a couple of images to it.
* Select the gallery again and click the Media library button.
* It should open up to the Add to Gallery view, with the current images in the gallery already selected.

Also test other media library behaviour in the gallery, image, and video blocks to ensure there are no regressions.

## Screenshots <!-- if applicable -->

In the before screengrab, no images are selected and clicking on one effectively replaces the entire gallery. In the after screengrab, the current images are pre-selected so clicking on an additional image adds it to the gallery.

| Before | After |
| --- | --- |
| ![Kapture 2021-09-23 at 17 17 59](https://user-images.githubusercontent.com/14988353/134468273-406f28b0-eb5e-4b38-928d-c6385e2a9505.gif) | ![Kapture 2021-09-23 at 17 15 26](https://user-images.githubusercontent.com/14988353/134468015-39f23a77-5cba-47b0-8de4-2dfdbbf41e61.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (Manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
