### PR TITLE
Navigation Editor: Re-enable unsaved changes e2e tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -476,11 +476,6 @@ describe( 'Navigation editor', () => {
 	} );
 
 	describe( 'Change detections', () => {
-		beforeEach( async () => {
-			await createMenu( { name: 'Main' } );
-			await visitNavigationEditor();
-		} );
-
 		async function assertIsDirty( isDirty ) {
 			let hadDialog = false;
 
@@ -494,20 +489,23 @@ describe( 'Navigation editor', () => {
 
 				// Ensure whether it was expected that dialog was encountered.
 				expect( hadDialog ).toBe( isDirty );
-			} catch ( error ) {
-				throw error;
 			} finally {
 				page.removeListener( 'dialog', handleOnDialog );
 			}
 		}
 
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
+		it( 'should not prompt to confirm unsaved changes for the newly selected menu', async () => {
+			await createMenu( { name: 'Main' } );
+			await visitNavigationEditor();
 			await assertIsDirty( false );
 		} );
 
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
+		it( 'should prompt to confirm unsaved changes when menu name is edited', async () => {
+			await createMenu( { name: 'Main' } );
+			await visitNavigationEditor();
+
+			// Wait for at least one block to be present on the page.
+			await page.waitForSelector( '.wp-block' );
 			await page.type(
 				'.edit-navigation-name-editor__text-control input',
 				' Menu'


### PR DESCRIPTION
## Description
My local tests aren't reliable at the moment. Going to try to run those here for few times.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
