### PR TITLE
Justify Content: Add visual clue for hidden active items

### DIFF
--- a/packages/block-editor/src/components/justify-content-control/ui.js
+++ b/packages/block-editor/src/components/justify-content-control/ui.js
@@ -70,12 +70,16 @@ function JustifyContentUI( {
 
 	const UIComponent = isToolbar ? ToolbarGroup : ToolbarDropdownMenu;
 	const extraProps = isToolbar ? { isCollapsed } : {};
+	const hasActive = allControls.some( ( { name } ) => name === value );
 
 	return (
 		<UIComponent
 			icon={ icon }
 			popoverProps={ popoverProps }
 			label={ __( 'Change items justification' ) }
+			toggleProps={ {
+				className: hasActive ? 'is-pressed' : undefined,
+			} }
 			controls={ allControls.filter( ( elem ) =>
 				allowedControls.includes( elem.name )
 			) }


### PR DESCRIPTION
## Description
Based on #21892.

Adds a visual clue for hidden active items to the Justify Content controls.

P.S. I noticed that currently, it's not possible to unset justification. It always fallback to "items left." Not sure if it's a bug or a feature 😅 

## How has this been tested?
* Add "Social Icons" block.
* Change item justification.
* Check that the toolbar button remains active.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-23 at 12 46 02](https://user-images.githubusercontent.com/240569/134478785-e6da2079-ad94-440a-b05f-a8c03faa3fde.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this P.R. (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
