### PR TITLE
interface: migrate the toggleFeature action to a thunk

### DIFF
--- a/packages/interface/src/store/actions.js
+++ b/packages/interface/src/store/actions.js
@@ -1,14 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { controls } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { STORE_NAME as interfaceStoreName } from './constants';
-
-/**
  * Returns an action object used in signalling that an active area should be changed.
  *
  * @param {string} itemType Type of item.
@@ -99,21 +89,11 @@ export function unpinItem( scope, itemId ) {
  * @param {string} scope       The feature scope (e.g. core/edit-post).
  * @param {string} featureName The feature name.
  */
-export function* toggleFeature( scope, featureName ) {
-	const currentValue = yield controls.select(
-		interfaceStoreName,
-		'isFeatureActive',
-		scope,
-		featureName
-	);
-
-	yield controls.dispatch(
-		interfaceStoreName,
-		'setFeatureValue',
-		scope,
-		featureName,
-		! currentValue
-	);
+export function toggleFeature( scope, featureName ) {
+	return function ( { select, dispatch } ) {
+		const currentValue = select.isFeatureActive( scope, featureName );
+		dispatch.setFeatureValue( scope, featureName, ! currentValue );
+	};
 }
 
 /**

--- a/packages/interface/src/store/index.js
+++ b/packages/interface/src/store/index.js
@@ -23,6 +23,7 @@ export const store = createReduxStore( STORE_NAME, {
 	actions,
 	selectors,
 	persist: [ 'enableItems', 'preferences' ],
+	__experimentalUseThunks: true,
 } );
 
 // Once we build a more generic persistence plugin that works across types of stores
@@ -32,4 +33,5 @@ registerStore( STORE_NAME, {
 	actions,
 	selectors,
 	persist: [ 'enableItems', 'preferences' ],
+	__experimentalUseThunks: true,
 } );

--- a/packages/interface/src/store/reducer.js
+++ b/packages/interface/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -89,7 +89,7 @@ export function multipleEnableItems(
  *
  * @return {Object} Updated state.
  */
-export const preferenceDefaults = flow( [ combineReducers ] )( {
+export const preferenceDefaults = combineReducers( {
 	features( state = {}, action ) {
 		if ( action.type === 'SET_FEATURE_DEFAULTS' ) {
 			const { scope, defaults } = action;
@@ -114,7 +114,7 @@ export const preferenceDefaults = flow( [ combineReducers ] )( {
  *
  * @return {Object} Updated state.
  */
-export const preferences = flow( [ combineReducers ] )( {
+export const preferences = combineReducers( {
 	features( state = {}, action ) {
 		if ( action.type === 'SET_FEATURE_VALUE' ) {
 			const { scope, featureName, value } = action;


### PR DESCRIPTION
Migrates the `@wordpress/interface` data store to thunks, removing usages of rungen generators.

There is only the `toggleFeature` action that reads the current value of a feature and flips it -- taking defaults from `state.preferenceDefaults` into account, and that's why the action can't be a plain action handled by a single reducer.

As a drive-by fix, I'm converting `flow( [ combineReducers ] )( ... )` calls to a simple `combineReducers( ... )` -- there's no point in combining just a single function with `flow`.

I'm also changing how the store is registered. In #26655 @gziolo added a comment that says:

> Once we build a more generic persistence plugin that works across types of stores we'd be able to replace this with a register call.

But I don't understand what it tries to say. Both the old `registerStore` and the new `register` do exactly the same sequence of `createReduxStore`, `store.instantiate` and `registerGenericStore` calls, the new `register` version being much simpler. Maybe something was different back in November 2020?