### PR TITLE
Polish responsive navigation modal, inherit justifications, fix submenu direction

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -128,6 +128,10 @@
 				display: flex;
 				flex-grow: 1;
 
+				// Without this, the changing to zero on hover-out can cause wrapping and
+				// result in an invinite hover/hover-out loop.
+				white-space: nowrap;
+
 				// Right-align the chevron in submenus.
 				.wp-block-navigation__submenu-icon {
 					margin-right: 0;
@@ -171,9 +175,6 @@
 			}
 		}
 	}
-
-	// Separating out hover and focus-within so hover works again on IE: https://davidwalsh.name/css-focus-within#comment-513401
-	// We will need to replace focus-within with a JS solution for IE keyboard support.
 
 	// Custom menu items.
 	// Show submenus on hover unless they open on click.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -417,20 +417,56 @@
 		// Give it a z-index just higher than the adminbar.
 		z-index: 100000;
 
-		padding: 24px;
+		// Add extra top padding so items don't conflict with close button.
+		padding: 72px 24px 24px 24px;
 		background-color: inherit;
 
-		.wp-block-navigation__container {
+		.wp-block-navigation__responsive-container-content {
 			display: flex;
 			flex-direction: column;
-			margin-left: auto;
-			margin-right: auto;
-			align-items: flex-start;
-			line-height: 48px;
 			padding: 0;
 
+			.wp-block-navigation__submenu-icon {
+				display: none;
+			}
+
+			// Always expand submenus inside the modal.
+			.has-child .submenu-container,
+			.has-child .wp-block-navigation__submenu-container {
+				position: relative;
+				opacity: 1;
+				visibility: visible;
+				height: auto;
+				width: auto;
+				border: none;
+				padding: 0 0 0 32px;
+
+				.items-justified-right & {
+					padding: 0 32px 0 0;
+				}
+			}
+
+			// A default padding is added to submenu items. It's not appropriate inside the modal.
+			& :where(.wp-block-navigation__submenu-container) a {
+				padding: 0;
+			}
+
+			// Default justification.
+			.wp-block-navigation__container,
+			.wp-block-navigation-item,
 			.wp-block-page-list {
 				flex-direction: column;
+				justify-content: flex-start;
+				align-items: flex-start;
+
+				// Inherit parent justifications inside the menu.
+				.items-justified-right & {
+					align-items: flex-end;
+				}
+
+				.items-justified-center & {
+					align-items: center;
+				}
 			}
 		}
 
@@ -542,31 +578,6 @@
 .is-menu-open .wp-block-navigation__responsive-container-content {
 	width: 100%;
 	height: 100%;
-}
-
-// Always show submenus fully expanded inside the modal menu.
-.wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open {
-	.wp-block-navigation__submenu-icon {
-		display: none;
-	}
-
-	.has-child .submenu-container,
-	.has-child .wp-block-navigation__submenu-container {
-		position: relative;
-		opacity: 1;
-		visibility: visible;
-		height: auto;
-		width: auto;
-
-		padding: 0 0 0 32px;
-		border: none;
-	}
-
-	.wp-block-navigation-item,
-	.wp-block-page-list {
-		flex-direction: column;
-		align-items: flex-start;
-	}
 }
 
 html.has-modal-open {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -272,21 +272,22 @@
 // When justified space-between, open submenus leftward for last menu item.
 // When justified right, open all submenus leftwards.
 // This needs high specificity.
-.wp-block-navigation.items-justified-space-between
-.wp-block-page-list > .has-child:last-child,
-.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
-.wp-block-navigation.items-justified-right > .wp-block-navigation__container
-.has-child {
-	// First submenu.
-	.wp-block-navigation__submenu-container {
-		left: auto;
-		right: 0;
-
-		// Nested submenus.
+// On smaller breakpoints, menus open downwards.
+@include break-medium {
+	.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
+	.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
+	.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
+	.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
+		// First submenu.
 		.wp-block-navigation__submenu-container {
 			left: auto;
-			right: 100%;
+			right: 0;
+
+			// Nested submenus.
+			.wp-block-navigation__submenu-container {
+				left: auto;
+				right: 100%;
+			}
 		}
 	}
 }
@@ -439,6 +440,12 @@
 		.wp-block-navigation-item {
 			color: inherit !important;
 			background: transparent !important;
+		}
+
+		// Override justification dropdown menu positioning rules.
+		.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
+			right: auto;
+			left: auto;
 		}
 	}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -434,20 +434,34 @@
 				display: none;
 			}
 
-			// Always expand submenus inside the modal.
+			// Always expand/unfold submenus inside the modal.
 			.has-child .submenu-container,
 			.has-child .wp-block-navigation__submenu-container {
-				position: relative;
+				// Unset CSS that hides dropdown menus.
 				opacity: 1;
 				visibility: visible;
 				height: auto;
 				width: auto;
+				overflow: initial;
+				min-width: 200px;
+
+				// Position and style.
+				position: static;
 				border: none;
-				padding: 0 0 0 32px;
+				padding-left: 32px;
 
 				.items-justified-right & {
-					padding: 0 32px 0 0;
+					padding-left: 0;
+					padding-right: 32px;
 				}
+			}
+
+			// Space unfolded items using gap and padding for submenus.
+			.wp-block-navigation__submenu-container,
+			.wp-block-navigation__container {
+				gap: 2rem;
+				padding-top: 2rem;
+				padding-bottom: 2rem;
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -335,31 +335,55 @@
 
 // Justification.
 // These target the named container class to work even with the additional mobile menu containers.
-.items-justified-center .wp-block-navigation__container {
-	justify-content: center;
+.items-justified-center {
+	.wp-block-page-list,
+	.wp-block-navigation__container {
+		justify-content: center;
+	}
 }
 
-.items-justified-right .wp-block-navigation__container {
-	justify-content: flex-end;
+.items-justified-right {
+	.wp-block-page-list,
+	.wp-block-navigation__container {
+		justify-content: flex-end;
+	}
 }
 
-.items-justified-space-between .wp-block-navigation__container {
-	justify-content: space-between;
-	flex: 1;
+.items-justified-space-between {
+	.wp-block-navigation__container {
+		justify-content: space-between;
+		flex: 1;
+	}
 }
 
 // Vertical justification.
-.is-vertical.items-justified-center > ul {
+// The vertical variant does not support space-between.
+.is-vertical.items-justified-center {
 	align-items: center;
+
+	.wp-block-navigation-item {
+		justify-content: center;
+	}
+
+	.wp-block-page-list,
+	.wp-block-navigation__container {
+		align-items: center;
+	}
 }
 
-.is-vertical.items-justified-right > ul {
+.is-vertical.items-justified-right {
 	align-items: flex-end;
 
 	.wp-block-navigation-item {
 		justify-content: flex-end;
 	}
+
+	.wp-block-page-list,
+	.wp-block-navigation__container {
+		align-items: flex-end;
+	}
 }
+
 
 /**
  * Mobile menu.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -352,7 +352,9 @@
 }
 
 .items-justified-space-between {
+	.wp-block-navigation__responsive-container-content,
 	.wp-block-navigation__container {
+		display: flex;
 		justify-content: space-between;
 		flex: 1;
 	}
@@ -490,6 +492,7 @@
 		&:not(.is-menu-open) {
 			display: flex;
 			flex-direction: row;
+			width: 100%;
 			position: relative;
 			z-index: 2;
 			background-color: inherit;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -121,6 +121,7 @@
 		// Don't take up space when the menu is collapsed.
 		width: 0;
 		height: 0;
+		overflow: hidden;
 
 		// Submenu items.
 		> .wp-block-navigation-item {
@@ -183,6 +184,7 @@
 		opacity: 1;
 		width: auto;
 		height: auto;
+		overflow: initial;
 		min-width: 200px;
 	}
 


### PR DESCRIPTION
## Description

Fixes #35040. Fixes and issue where justifications were not inherited in the responsive modal, an issue with hover-opening flickering, and an issue with submenus not opening in the right direction.

This is a big of a big one so could use a great deal of testing in a variety of themes, with a variety of content. Things to look for:

- Submenus at small and wide breakpoints
- Submenu directions they open in based on justification
- Modal as it inherits properties, including justifications

All of that, worth testing with and without responsive navigation toggled on, and with and without a Page List block inside.

## How has this been tested?

You can use this testing content:

```
<!-- wp:paragraph -->
<p>Horizontal, justified right, page list:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical, justified right, page list:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","itemsJustification":"right","isResponsive":true} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Horizontal, justified right, manual items:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://local-wordpress.local/sample-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-submenu {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelItem":true} -->
<!-- wp:navigation-submenu {"label":"Subpage","type":"page","id":29873,"url":"http://local-wordpress.local/contact/subpage/","kind":"post-type","isTopLevelItem":false} -->
<!-- wp:navigation-link {"label":"Sub subpage","type":"page","id":29875,"url":"http://local-wordpress.local/contact/subpage/sub-subpage/","kind":"post-type","isTopLevelLink":false} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical, justified right, manual items:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","itemsJustification":"right","isResponsive":true} -->
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://local-wordpress.local/sample-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-submenu {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelItem":true} -->
<!-- wp:navigation-submenu {"label":"Subpage","type":"page","id":29873,"url":"http://local-wordpress.local/contact/subpage/","kind":"post-type","isTopLevelItem":false} -->
<!-- wp:navigation-link {"label":"Sub subpage","type":"page","id":29875,"url":"http://local-wordpress.local/contact/subpage/sub-subpage/","kind":"post-type","isTopLevelLink":false} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p><strong>Not responsive</strong></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Horizontal, justified right, page list:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"itemsJustification":"right"} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical, justified right, page list:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","itemsJustification":"right"} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Horizontal, justified right, manual items:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"itemsJustification":"right"} -->
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://local-wordpress.local/sample-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical, justified right, manual items:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","itemsJustification":"right"} -->
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://local-wordpress.local/sample-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```

## Screenshots <!-- if applicable -->

Before, editor:
<img width="956" alt="before editor" src="https://user-images.githubusercontent.com/1204802/134483639-7e401fd7-1b2d-4ba1-9656-d280678b632d.png">

Before, frontend:

<img width="937" alt="before frontend" src="https://user-images.githubusercontent.com/1204802/134483658-1cd9149f-28a8-4e0e-8f8d-b5540743aea1.png">

Before, inside the modal, even though justification was set to right:

<img width="449" alt="before modal" src="https://user-images.githubusercontent.com/1204802/134483695-90f91ce1-f6a3-48e6-9a40-8744c0b24c91.png">

After, frontend:

<img width="890" alt="after frontend" src="https://user-images.githubusercontent.com/1204802/134483757-7a51ad43-9d78-4631-b30b-17018557eb71.png">

After, submenus when justified right:

<img width="752" alt="after submenus" src="https://user-images.githubusercontent.com/1204802/134483785-77a140f0-e903-4b26-97ae-a40b2b047565.png">

After, modal:

<img width="577" alt="after modal" src="https://user-images.githubusercontent.com/1204802/134483806-a69e85ac-e0c6-4123-9c92-4d750cbbb418.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
