### PR TITLE
`__experimentalShareWithChildBlocks` should apply to all children, any depth in the inner-block hierarchy

### DIFF
--- a/packages/block-editor/src/components/block-controls/hook.js
+++ b/packages/block-editor/src/components/block-controls/hook.js
@@ -28,7 +28,7 @@ export default function useBlockControlsFill( group, shareWithChildBlocks ) {
 					'__experimentalExposeControlsToChildren',
 					false
 				) &&
-				hasSelectedInnerBlock( clientId )
+				hasSelectedInnerBlock( clientId, true )
 			);
 		},
 		[ shareWithChildBlocks, clientId ]


### PR DESCRIPTION
## Description
When using controls using `__experimentalShareWithChildBlocks`, only the direct children show the controls. 

For example, if I have a block containing inner blocks, and have his defined:

```
<BlockControls __experimentalShareWithChildBlocks>
	<ViewSwitcherComponent />
</BlockControls>
```

I see the control when the top-level block is selected, and when its direct children (inner blocks) are selected:

![Screenshot 2021-09-23 at 10 29 27](https://user-images.githubusercontent.com/90977/134484552-7fcb9213-59cd-4d6b-831d-50b6e9c761da.png)
![Screenshot 2021-09-23 at 10 29 40](https://user-images.githubusercontent.com/90977/134484548-5405d98d-47b9-4a45-8eff-762d80c4cd83.png)

Without this patch, any deeper inner blocks do not show the above control.

[This code determines if parent controls are displayed.](https://github.com/WordPress/gutenberg/pull/33955/files#diff-a2c1f38cda10559e8bf7cb5f76c9981b368b7570ee42dbd0320da4c612e3a27cR18-R35) Notice is uses `hasSelectedInnerBlock` to determine if an inner block is selected and so needs the controls to be added. This does not factor in multiple levels of inner blocks hierarchy.

[`hasSelectedInnerBlock` has support for a `deep` parameter](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#hasselectedinnerblock) which searches inner blocks recursively. This is what we need here to solve the issue.

## How has this been tested?
This has been tested in WooCommerce Blocks only, with the above use case. I could find little usage of `__experimentalShareWithChildBlocks` in Gutenberg (ButtonEdit block uses it).

ref: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4812

## Types of changes
This changes the behaviour of an experimental feature only available in this plugin.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

cc @senadir 
