### PR TITLE
[Block Editor]: Remove visual clue from alignment toolbar

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
@@ -67,7 +67,6 @@ exports[`BlockAlignmentUI should match snapshot 1`] = `
   }
   toggleProps={
     Object {
-      "className": "is-pressed",
       "describedBy": "Change alignment",
     }
   }

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -67,7 +67,6 @@ function BlockAlignmentUI( {
 
 	const UIComponent = isToolbar ? ToolbarGroup : ToolbarDropdownMenu;
 	const extraProps = isToolbar ? { isCollapsed } : {};
-	const hasActive = enabledControls.some( ( control ) => control === value );
 
 	return (
 		<UIComponent
@@ -78,10 +77,7 @@ function BlockAlignmentUI( {
 					: defaultAlignmentControl.icon
 			}
 			label={ __( 'Align' ) }
-			toggleProps={ {
-				describedBy: __( 'Change alignment' ),
-				className: hasActive ? 'is-pressed' : undefined,
-			} }
+			toggleProps={ { describedBy: __( 'Change alignment' ) } }
 			controls={ enabledControls.map( ( control ) => {
 				return {
 					...BLOCK_ALIGNMENTS_CONTROLS[ control ],


### PR DESCRIPTION
The toggle state [was discussed](https://github.com/WordPress/gutenberg/pull/34710#issuecomment-918994087) in the `none` alignment option PR and removed it there, but it seems better to make this change in a separate PR.

## Testing instructions
1. Add a block with alignment options (like a Heading)
2. select an `align`, for example `wide`
3. observe that there is no visual clue(background) in resting state of the block toolbar - that means when the alignments dropdown is not open.