### PR TITLE
Popover: fix __unstableBoundaryParent

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -326,9 +326,7 @@ const Popover = (
 
 			let boundaryElement;
 			if ( __unstableBoundaryParent ) {
-				boundaryElement = containerRef.current.closest(
-					'.popover-slot'
-				)?.parentNode;
+				boundaryElement = containerRef.current.parentElement;
 			}
 
 			const usedContentSize = ! contentSize.height

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -139,8 +139,10 @@ export function computePopoverXAxisPosition(
 	}
 
 	if ( boundaryElement ) {
-		const boundaryRect = boundaryElement.getBoundingClientRect();
-		popoverLeft = Math.min( popoverLeft, boundaryRect.right - width );
+		popoverLeft = Math.min(
+			popoverLeft,
+			boundaryElement.offsetLeft + boundaryElement.offsetWidth - width
+		);
 
 		// Avoid the popover being position beyond the left boundary if the
 		// direction is left to right.

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -361,4 +361,37 @@ describe( 'Image', () => {
 		// broken temporary URL.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should align right and have visible toolbar', async () => {
+		await insertBlock( 'Image' );
+		const filename1 = await upload( '.wp-block-image input[type="file"]' );
+		await waitForImage( filename1 );
+
+		const regex1 = new RegExp(
+			`<!-- wp:image {"id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-full"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
+		);
+		expect( await getEditedPostContent() ).toMatch( regex1 );
+
+		await clickBlockToolbarButton( 'Align' );
+		await clickButton( 'Align right' );
+
+		const regex2 = new RegExp(
+			`<!-- wp:image {"align":"right","id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<div class="wp-block-image"><figure class="alignright size-full"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure></div>\\s*<!-- \\/wp:image -->`
+		);
+
+		expect( await getEditedPostContent() ).toMatch( regex2 );
+
+		// Ensure that the end of the toolbar is not hidden.
+		// The page should not have to scroll horizontall to access the toolbar.
+		// See: https://github.com/WordPress/gutenberg/pull/35082.
+		await clickBlockToolbarButton( 'Options' );
+
+		const scrollLeft = await page.evaluate( () => {
+			return wp.dom.getScrollContainer(
+				document.querySelector( '.wp-block' )
+			).scrollLeft;
+		} );
+
+		expect( scrollLeft ).toBe( 0 );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -361,37 +361,4 @@ describe( 'Image', () => {
 		// broken temporary URL.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
-
-	it( 'should align right and have visible toolbar', async () => {
-		await insertBlock( 'Image' );
-		const filename1 = await upload( '.wp-block-image input[type="file"]' );
-		await waitForImage( filename1 );
-
-		const regex1 = new RegExp(
-			`<!-- wp:image {"id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-full"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
-		);
-		expect( await getEditedPostContent() ).toMatch( regex1 );
-
-		await clickBlockToolbarButton( 'Align' );
-		await clickButton( 'Align right' );
-
-		const regex2 = new RegExp(
-			`<!-- wp:image {"align":"right","id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<div class="wp-block-image"><figure class="alignright size-full"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure></div>\\s*<!-- \\/wp:image -->`
-		);
-
-		expect( await getEditedPostContent() ).toMatch( regex2 );
-
-		// Ensure that the end of the toolbar is not hidden.
-		// The page should not have to scroll horizontall to access the toolbar.
-		// See: https://github.com/WordPress/gutenberg/pull/35082.
-		await clickBlockToolbarButton( 'Options' );
-
-		const scrollLeft = await page.evaluate( () => {
-			return wp.dom.getScrollContainer(
-				document.querySelector( '.wp-block' )
-			).scrollLeft;
-		} );
-
-		expect( scrollLeft ).toBe( 0 );
-	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #34053.
Fixes #32402.
Regressed in #31134 because the block toolbar is no longer rendered in a slot.

<img width="869" alt="Screenshot 2021-09-23 at 13 53 47" src="https://user-images.githubusercontent.com/4710635/134495208-dfe430f4-4527-450c-98b0-bc1213bef433.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
