### PR TITLE
Enable ability to create Pages from the inline Link UI

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -380,6 +380,14 @@ $preview-image-height: 140px;
 	}
 }
 
+.block-editor-link-control__search-create {
+	align-items: center; // align text with icon.
+
+	.block-editor-link-control__search-item-icon {
+		top: 0; // cancel compensatory spacing added to default suggestions.
+	}
+}
+
 // Specificity overide
 .block-editor-link-control__search-results div[role="menu"] > .block-editor-link-control__search-item.block-editor-link-control__search-item {
 	padding: 10px;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -383,6 +383,10 @@ $preview-image-height: 140px;
 .block-editor-link-control__search-create {
 	align-items: center; // align text with icon.
 
+	.block-editor-link-control__search-item-title {
+		margin-bottom: 0;
+	}
+
 	.block-editor-link-control__search-item-icon {
 		top: 0; // cancel compensatory spacing added to default suggestions.
 	}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -34,7 +34,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
 		userCanCreatePages,
-		userCanCreatePosts,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
@@ -63,14 +62,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			),
 			hasResolvedLocalSiteData: hasFinishedResolvingSiteData,
 			baseUrl: siteData?.url || '',
-			userCanCreatePages: select( coreStore ).canUser(
-				'create',
-				'pages'
-			),
-			userCanCreatePosts: select( coreStore ).canUser(
-				'create',
-				'posts'
-			),
+			userCanCreatePages: canUser( 'create', 'pages' ),
 		};
 	}, [] );
 
@@ -157,8 +149,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,
 			__experimentalCreateEntity: createEntity,
-			__experimentalUserCanCreateEntities:
-				userCanCreatePosts && userCanCreatePages,
+			__experimentalUserCanCreatePages: userCanCreatePages,
 		} ),
 		[
 			settings,
@@ -167,7 +158,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			canUseUnfilteredHTML,
 			undo,
 			hasTemplate,
-			userCanCreatePosts,
+
 			userCanCreatePages,
 			createEntity,
 		]

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -87,22 +87,19 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	 * @return {Object} the post type object that was created.
 	 */
 	const createEntity = ( postType, options ) => {
-		const postTypeWhitelist = [ 'post', 'page' ];
+		// The function is intentionally left open for extension in the future.
+		// However for now we lock this down to only allow Pages.
+		const postTypeWhitelist = [ 'page' ];
 
 		if ( ! postTypeWhitelist.includes( postType ) ) {
 			return Promise.reject( {
-				message: `Only Posts and Pages may be created.`,
+				message: 'Only Pages may be created.',
 			} );
 		}
 
-		const permsOnEntity =
-			postType === 'page' ? userCanCreatePages : userCanCreatePosts;
-
-		const pluralType = postType === 'page' ? 'Pages' : 'Posts';
-
-		if ( ! permsOnEntity ) {
+		if ( ! userCanCreatePages ) {
 			return Promise.reject( {
-				message: `You do not have permission to create ${ pluralType }.`,
+				message: 'You do not have permission to create Pages.',
 			} );
 		}
 		return saveEntityRecord( 'postType', postType, options );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -13,6 +13,7 @@ import {
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -74,27 +75,16 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	 * Creates a Post entity.
 	 * This is utilised by the Link UI to allow for on-the-fly creation of Posts/Pages.
 	 *
-	 * @param {string} postType the post type of the "post" to be created.
-	 * @param {Object} options  parameters for the post being created. These mirror those used on 3rd param of saveEntityRecord.
+	 * @param {Object} options parameters for the post being created. These mirror those used on 3rd param of saveEntityRecord.
 	 * @return {Object} the post type object that was created.
 	 */
-	const createEntity = ( postType, options ) => {
-		// The function is intentionally left open for extension in the future.
-		// However for now we lock this down to only allow Pages.
-		const postTypeWhitelist = [ 'page' ];
-
-		if ( ! postTypeWhitelist.includes( postType ) ) {
-			return Promise.reject( {
-				message: 'Only Pages may be created.',
-			} );
-		}
-
+	const createPageEntity = ( options ) => {
 		if ( ! userCanCreatePages ) {
 			return Promise.reject( {
-				message: 'You do not have permission to create Pages.',
+				message: __( 'You do not have permission to create Pages.' ),
 			} );
 		}
-		return saveEntityRecord( 'postType', postType, options );
+		return saveEntityRecord( 'postType', 'page', options );
 	};
 
 	return useMemo(
@@ -148,7 +138,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCanUserUseUnfilteredHTML: canUseUnfilteredHTML,
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,
-			__experimentalCreateEntity: createEntity,
+			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
 		} ),
 		[
@@ -160,7 +150,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			hasTemplate,
 
 			userCanCreatePages,
-			createEntity,
+			createPageEntity,
 		]
 	);
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -157,7 +157,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalUndo: undo,
 			outlineMode: hasTemplate,
 			__experimentalCreateEntity: createEntity,
-			__experimentalUserCanCreate:
+			__experimentalUserCanCreateEntities:
 				userCanCreatePosts && userCanCreatePages,
 		} ),
 		[

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useState, useRef, createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { withSpokenMessages, Popover } from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
 import {
@@ -152,8 +152,7 @@ function InlineLinkUI( {
 	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
 
 	async function handleCreate( pageTitle ) {
-		const type = 'page';
-		const postType = type || 'page';
+		const postType = 'page';
 
 		const page = await createEntity( postType, {
 			title: pageTitle,
@@ -167,6 +166,17 @@ function InlineLinkUI( {
 			url: page.link,
 			kind: 'post-type',
 		};
+	}
+
+	function createButtonText( searchTerm ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: %s: search term. */
+				__( 'Create Page: <mark>%s</mark>' ),
+				searchTerm
+			),
+			{ mark: <mark /> }
+		);
 	}
 
 	return (
@@ -184,6 +194,7 @@ function InlineLinkUI( {
 				hasRichPreviews
 				createSuggestion={ createEntity && handleCreate }
 				withCreateSuggestion={ userCanCreate }
+				createSuggestionButtonText={ createButtonText }
 			/>
 		</Popover>
 	);

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -51,7 +51,7 @@ function InlineLinkUI( {
 
 		return {
 			createEntity: _settings.__experimentalCreateEntity,
-			userCanCreate: _settings.__experimentalUserCanCreate,
+			userCanCreate: _settings.__experimentalUserCanCreateEntities,
 		};
 	}, [] );
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -45,13 +45,13 @@ function InlineLinkUI( {
 	 */
 	const [ nextLinkValue, setNextLinkValue ] = useState();
 
-	const { createEntity, userCanCreate } = useSelect( ( select ) => {
+	const { createEntity, userCanCreatePages } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const _settings = getSettings();
 
 		return {
 			createEntity: _settings.__experimentalCreateEntity,
-			userCanCreate: _settings.__experimentalUserCanCreateEntities,
+			userCanCreatePages: _settings.__experimentalUserCanCreatePages,
 		};
 	}, [] );
 
@@ -193,7 +193,7 @@ function InlineLinkUI( {
 				forceIsEditingLink={ addingLink }
 				hasRichPreviews
 				createSuggestion={ createEntity && handleCreate }
-				withCreateSuggestion={ userCanCreate }
+				withCreateSuggestion={ userCanCreatePages }
 				createSuggestionButtonText={ createButtonText }
 			/>
 		</Popover>

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -45,12 +45,12 @@ function InlineLinkUI( {
 	 */
 	const [ nextLinkValue, setNextLinkValue ] = useState();
 
-	const { createEntity, userCanCreatePages } = useSelect( ( select ) => {
+	const { createPageEntity, userCanCreatePages } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const _settings = getSettings();
 
 		return {
-			createEntity: _settings.__experimentalCreateEntity,
+			createPageEntity: _settings.__experimentalCreatePageEntity,
 			userCanCreatePages: _settings.__experimentalUserCanCreatePages,
 		};
 	}, [] );
@@ -152,16 +152,14 @@ function InlineLinkUI( {
 	const focusOnMount = useRef( addingLink ? 'firstElement' : false );
 
 	async function handleCreate( pageTitle ) {
-		const postType = 'page';
-
-		const page = await createEntity( postType, {
+		const page = await createPageEntity( {
 			title: pageTitle,
 			status: 'draft',
 		} );
 
 		return {
 			id: page.id,
-			type: postType,
+			type: page.type,
 			title: page.title.rendered,
 			url: page.link,
 			kind: 'post-type',
@@ -192,7 +190,7 @@ function InlineLinkUI( {
 				onRemove={ removeLink }
 				forceIsEditingLink={ addingLink }
 				hasRichPreviews
-				createSuggestion={ createEntity && handleCreate }
+				createSuggestion={ createPageEntity && handleCreate }
 				withCreateSuggestion={ userCanCreatePages }
 				createSuggestionButtonText={ createButtonText }
 			/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/pull/19775 we added the ability to create entities (Posts/Pages) from within the Link UI interface. 

As we learnt in https://github.com/WordPress/gutenberg/issues/26317 the feature is not enabled within the "inline" link UI which is the link interface used when you add a link to a paragraph of text.

This PR enables page creation from within the link ui within the Post Editor only.

**Please note**: this PR does not attempt to address any visual updates to the "Create button", although I'm happy to tackle that in a follow up.


<img width="834" alt="Screen Shot 2021-09-23 at 12 54 47" src="https://user-images.githubusercontent.com/444434/134502483-c62c57e2-f655-426e-91df-6f7c562872f8.png">

Closes https://github.com/WordPress/gutenberg/issues/26317

## How has this been tested?


#### Test with Admin user

* Check you are an Admin level user.
* Create Post - add text.
* Select some text and click the icon to add a link.
* Type in some random words for a page you'd like to create (eg: `This is a nice little page`).
* See option appear in search suggestions for `Create page`.
* Click.
* See page created as a draft.
* Click the link you just added and see the page has been created.




#### Test with low perms user

* Create a new User and make them a lower permission user (Contributor) which doesn't have permissions to create posts or pages.
* Switch to/Login as that user.
* Create Post - add text.
* Select some text and click the icon to add a link.
* Type in some random words for a page you'd like to create (eg: `This is a nice little page`).
* See no option to Create - this is not available unless you have the appropriate permissions.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/134501615-f178f637-d26c-4fca-842e-a6b80963aa58.mov


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
