### PR TITLE
Cache the template_part_post lookup in render_block_core_template_part function

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -24,24 +24,33 @@ function render_block_core_template_part( $attributes ) {
 		isset( $attributes['theme'] ) &&
 		wp_get_theme()->get_stylesheet() === $attributes['theme']
 	) {
-		$template_part_id    = $attributes['theme'] . '//' . $attributes['slug'];
-		$template_part_query = new WP_Query(
-			array(
-				'post_type'      => 'wp_template_part',
-				'post_status'    => 'publish',
-				'post_name__in'  => array( $attributes['slug'] ),
-				'tax_query'      => array(
-					array(
-						'taxonomy' => 'wp_theme',
-						'field'    => 'slug',
-						'terms'    => $attributes['theme'],
+		$template_part_id   = $attributes['theme'] . '//' . $attributes['slug'];
+		$last_changed       = wp_cache_get_last_changed( 'posts' );
+		$cache_key          = "$template_part_id:$last_changed";
+		$cache_group        = 'render_block_core_template_part';
+		$template_part_post = wp_cache_get( $cache_key, $cache_group );
+
+		if ( false === $template_part_post ) {
+			$template_part_query = new WP_Query(
+				array(
+					'post_type'      => 'wp_template_part',
+					'post_status'    => 'publish',
+					'post_name__in'  => array( $attributes['slug'] ),
+					'tax_query'      => array(
+						array(
+							'taxonomy' => 'wp_theme',
+							'field'    => 'slug',
+							'terms'    => $attributes['theme'],
+						),
 					),
-				),
-				'posts_per_page' => 1,
-				'no_found_rows'  => true,
-			)
-		);
-		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+					'posts_per_page' => 1,
+					'no_found_rows'  => true,
+				)
+			);
+			$template_part_post = $template_part_query->have_posts() ? $template_part_query->next_post() : 0;
+			wp_cache_set( $cache_key, $template_part_post, $cache_group );
+		}
+
 		if ( $template_part_post ) {
 			// A published post might already exist if this template part was customized elsewhere
 			// or if it's part of a customized template.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -26,9 +26,8 @@ function render_block_core_template_part( $attributes ) {
 	) {
 		$template_part_id   = $attributes['theme'] . '//' . $attributes['slug'];
 		$last_changed       = wp_cache_get_last_changed( 'posts' );
-		$cache_key          = "$template_part_id:$last_changed";
-		$cache_group        = 'render_block_core_template_part';
-		$template_part_post = wp_cache_get( $cache_key, $cache_group );
+		$transient          = "render_block_core_template_part:$template_part_id:$last_changed";
+		$template_part_post = get_transient( $transient );
 
 		if ( false === $template_part_post ) {
 			$template_part_query = new WP_Query(
@@ -48,7 +47,7 @@ function render_block_core_template_part( $attributes ) {
 				)
 			);
 			$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : 0;
-			wp_cache_set( $cache_key, $template_part_post, $cache_group );
+			set_transient( $transient, $template_part_post, DAY_IN_SECONDS );
 		}
 
 		if ( $template_part_post ) {

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -47,7 +47,7 @@ function render_block_core_template_part( $attributes ) {
 					'no_found_rows'  => true,
 				)
 			);
-			$template_part_post = $template_part_query->have_posts() ? $template_part_query->next_post() : 0;
+			$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : 0;
 			wp_cache_set( $cache_key, $template_part_post, $cache_group );
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

In case a template part's post does not exist, a repeated WP_Query is triggered on every page load, not finding any posts to display.

This may lead to performance issues, which can be mitigated by adding some caching to the function.

This changeset adds related caching, which is being automatically invalidated via `wp_cache_get_last_changed( 'posts' )` function. Plus, in order to allow the transients to fade out more naturally, an expiration is set to a day.

By using the transient system of the WordPress, even sites without persistent caching in place could benefit from the performance improvements in this changeset.

fixes #35088

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I have set up a template using a template part for which there is no existing post holding the structure, so it falls back to the theme's default.
I have refreshed the screen multiple times seeing the same query attempting to find the post being run.
After applying the patch, the query is gone, until the post is created.

## Screenshots <!-- if applicable -->

## Types of changes
Adds caching to the `render_block_core_template_part`, and changes the default value of `$template_part_post` from `null` to `0` for caching purposes.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
