### PR TITLE
Navigation: Allow a label to used for placeholder text

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -437,13 +437,10 @@ export default function NavigationLinkEdit( {
 	 * Removes the current link if set.
 	 */
 	function removeLink() {
-		// Reset all attributes that comprise the link.
+		// Reset the specific url and id
 		setAttributes( {
 			url: '',
-			label: '',
 			id: '',
-			kind: '',
-			type: '',
 		} );
 
 		// Close the link editing UI.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -542,6 +542,9 @@ export default function NavigationLinkEdit( {
 			/* translators: label for missing values in navigation link block */
 			missingText = __( 'Add link' );
 	}
+	if ( label ) {
+		missingText = label;
+	}
 
 	return (
 		<Fragment>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -270,6 +270,9 @@ export default function NavigationLinkEdit( {
 	onReplace,
 	context,
 	clientId,
+	// These props are used by the navigation editor to override specific
+	// navigation block settings.
+	allowPlaceholderLabels = true,
 } ) {
 	const {
 		label,
@@ -437,11 +440,22 @@ export default function NavigationLinkEdit( {
 	 * Removes the current link if set.
 	 */
 	function removeLink() {
-		// Reset the specific url and id
-		setAttributes( {
-			url: '',
-			id: '',
-		} );
+		if ( allowPlaceholderLabels ) {
+			// Reset the specific url and id
+			setAttributes( {
+				url: '',
+				id: '',
+			} );
+		} else {
+			// Reset all attributes that comprise the link.
+			setAttributes( {
+				url: '',
+				label: '',
+				id: '',
+				kind: '',
+				type: '',
+			} );
+		}
 
 		// Close the link editing UI.
 		setIsLinkOpen( false );
@@ -539,7 +553,7 @@ export default function NavigationLinkEdit( {
 			/* translators: label for missing values in navigation link block */
 			missingText = __( 'Add link' );
 	}
-	if ( label ) {
+	if ( allowPlaceholderLabels && label ) {
 		missingText = label;
 	}
 

--- a/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
+++ b/packages/edit-navigation/src/filters/remove-edit-unsupported-features.js
@@ -6,18 +6,20 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 
 const removeNavigationBlockEditUnsupportedFeatures = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		if ( props.name !== 'core/navigation' ) {
-			return <BlockEdit { ...props } />;
+		if ( props.name === 'core/navigation' ) {
+			return (
+				<BlockEdit
+					{ ...props }
+					hasSubmenuIndicatorSetting={ false }
+					hasItemJustificationControls={ false }
+					hasColorSettings={ false }
+				/>
+			);
+		} else if ( props.name === 'core/navigation-link' ) {
+			return <BlockEdit { ...props } allowPlaceholderLabels={ false } />;
 		}
 
-		return (
-			<BlockEdit
-				{ ...props }
-				hasSubmenuIndicatorSetting={ false }
-				hasItemJustificationControls={ false }
-				hasColorSettings={ false }
-			/>
-		);
+		return <BlockEdit { ...props } />;
 	},
 	'removeNavigationBlockEditUnsupportedFeatures'
 );


### PR DESCRIPTION
Changes here allow us to use a label as placeholder text instead of "Select Page". This makes creating navigation patterns more visually interesting and lets users more quickly pick out useful patterns. See related https://github.com/WordPress/gutenberg/pull/35063

https://user-images.githubusercontent.com/1270189/134546277-0b689eef-a62f-476d-956b-42ab5b01ceb3.mp4

### Testing Instructions

- Create a new post or page
- In the code editor add the following:
```
<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"About","type":"page","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```
- Switch back to the Visual Editor
- Verify that newly added links still have the correct placeholder text like "Select page"
- Navigate to the Navigation Editor
- Add a Page Link
- Unlink
- Verify that all attributes have been removed (the same behavior as trunk).