### PR TITLE
Fix navigation editor spacing.

### DIFF
--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -47,8 +47,7 @@
 
 .edit-navigation-empty-state {
 	max-width: $navigation-editor-width;
-	margin-left: auto;
-	margin-right: auto;
+	margin: $grid-unit-40 auto 0 auto;
 	@include break-medium() {
 		// Match the padding top of the editor canvas.
 		margin-top: $navigation-editor-spacing-top;


### PR DESCRIPTION
## Description
Fixes #34032

1. Adds padding to the top of the editor layout when the empty state view and first menu form are displayed. fig. 1)
2. Makes it so `BlockContextualToolbar` is not rendered if no block has been selected, removing the empty container (fig. 2).
3. Padding on top of the Navigation Editor content area is required in order to avoid having the content moving up and down when the bar is not present (fig. 3)

@javierarce I'd like to hear your thoughts on 3, since it seems necessary to maintain the menu at a consistent place, but at the same time the extra padding (seen on fig. 2) might look a bit odd.

## Screenshots

|fig. 1| fig. 2| fig 3|
|--|--|--|
|<img width="417" alt="image" src="https://user-images.githubusercontent.com/1157901/134577884-77a296ac-6301-41a8-b6f4-871262b536e5.png">|![Kapture 2021-09-23 at 17 15 21](https://user-images.githubusercontent.com/1157901/134577569-eae6dec3-0641-4a4b-bdb2-e3efd096e1ec.gif)|![Kapture 2021-09-23 at 17 17 19](https://user-images.githubusercontent.com/1157901/134577724-e3f7329b-3c5e-4f98-b1bd-635bb1c0a9be.gif)|

