### PR TITLE
Report dependencies externalized with Dependency Extraction Plugin

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add the optional `externalizedReportFile` option ([#35106](https://github.com/WordPress/gutenberg/pull/35106)).
+
 ## 3.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -135,12 +135,13 @@ Pass `useDefaults: false` to disable the default request handling.
 
 Force `wp-polyfill` to be included in each entry point's dependency list. This would be the same as adding `import '@wordpress/polyfill';` to each entry point.
 
-##### `externalizedReportFile`
+##### `externalizedReport`
 
--   Type: string
--   Default: `undefined`
+-   Type: boolean | string
+-   Default: `false`
 
-Pass a filename to report all externalized dependencies as an array in JSON format. It could be used for further manual or automated inspection.
+Report all externalized dependencies as an array in JSON format. It could be used for further manual or automated inspection.
+You can provide a filename, or set it to `true` to report to a default `externalized-dependencies.json`.
 
 ##### `requestToExternal`
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -135,6 +135,13 @@ Pass `useDefaults: false` to disable the default request handling.
 
 Force `wp-polyfill` to be included in each entry point's dependency list. This would be the same as adding `import '@wordpress/polyfill';` to each entry point.
 
+##### `externalizedReportFile`
+
+-   Type: string
+-   Default: `undefined`
+
+Pass a filename to report all externalized dependencies as an array in JSON format. It could be used for further manual or automated inspection.
+
 ##### `requestToExternal`
 
 -   Type: function

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -147,7 +147,9 @@ class DependencyExtractionWebpackPlugin {
 		if ( externalizedReportFile ) {
 			compilation.emitAsset(
 				externalizedReportFile,
-				new RawSource( JSON.stringify( Array.from( this.externalizedDeps ) ) ),
+				new RawSource(
+					JSON.stringify( Array.from( this.externalizedDeps ) )
+				)
 			);
 		}
 

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -17,13 +17,15 @@ const {
 	defaultRequestToHandle,
 } = require( './util' );
 
+const defaultExternalizedReportFileName = 'externalized-dependencies.json';
+
 class DependencyExtractionWebpackPlugin {
 	constructor( options ) {
 		this.options = Object.assign(
 			{
 				combineAssets: false,
 				combinedOutputFile: null,
-				externalizedReportFile: undefined,
+				externalizedReport: false,
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
@@ -138,13 +140,17 @@ class DependencyExtractionWebpackPlugin {
 		const {
 			combineAssets,
 			combinedOutputFile,
-			externalizedReportFile,
+			externalizedReport,
 			injectPolyfill,
 			outputFormat,
 		} = this.options;
 
 		// Dump actually externalized dependencies to a report file.
-		if ( externalizedReportFile ) {
+		if ( externalizedReport ) {
+			const externalizedReportFile =
+				typeof externalizedReport === 'string'
+					? externalizedReport
+					: defaultExternalizedReportFileName;
 			compilation.emitAsset(
 				externalizedReportFile,
 				new RawSource(

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -23,6 +23,7 @@ class DependencyExtractionWebpackPlugin {
 			{
 				combineAssets: false,
 				combinedOutputFile: null,
+				externalizedReportFile: undefined,
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
@@ -137,9 +138,18 @@ class DependencyExtractionWebpackPlugin {
 		const {
 			combineAssets,
 			combinedOutputFile,
+			externalizedReportFile,
 			injectPolyfill,
 			outputFormat,
 		} = this.options;
+
+		// Dump actually externalized dependencies to a report file.
+		if ( externalizedReportFile ) {
+			compilation.emitAsset(
+				externalizedReportFile,
+				new RawSource( JSON.stringify( Array.from( this.externalizedDeps ) ) ),
+			);
+		}
 
 		const combinedAssetsData = {};
 

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -15,5 +15,5 @@ declare interface DependencyExtractionWebpackPluginOptions {
 	requestToHandle?: ( request: string ) => string | undefined;
 	combinedOutputFile?: string | null;
 	combineAssets?: boolean;
-    externalizedReportFile?: string | undefined;
+	externalizedReportFile?: string | undefined;
 }

--- a/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
+++ b/packages/dependency-extraction-webpack-plugin/lib/types.d.ts
@@ -15,4 +15,5 @@ declare interface DependencyExtractionWebpackPluginOptions {
 	requestToHandle?: ( request: string ) => string | undefined;
 	combinedOutputFile?: string | null;
 	combineAssets?: boolean;
+    externalizedReportFile?: string | undefined;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR adds a new option for plugin config `externalizedReportFile`, to report all dependencies exported for the current project.
I need it as I try to build a tool that helps to inspect, analyze and manage the versions being used for local unit tests, and that runs with WordPress.
To compare the versions used locally, with the versions used in the range of supported WP builds.


----
edit:
 This PR tries to address problem 5. from https://github.com/WordPress/gutenberg/issues/35630
> As a plugin developer, I don't even know what dependencies are extracted, as the list is maintained in the package repo, and not reported while bundling.

Thanks to this PR a developer would at least know which of their local dependencies are extracted and which are not. So for which packages do they need to anticipate different versions.

----


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I run this code against 
https://github.com/woocommerce/google-listings-and-ads repo's webpack config with and without the new option.

0. ```
   git clone https://github.com/woocommerce/google-listings-and-ads.git
   cd google-listings-and-ads
   npm install
   ```
1. Replace `node_modules/@wordpress/dependency-extraction-webpack-plugin` with the changed one from this PR `packages/dependency-extraction-webpack-plugin`.

### Without the new option

2. Use the repo's Webpack config as is https://github.com/woocommerce/google-listings-and-ads/blob/4e69b169953096774dd0d957ba7a4fcecbbf2a89/webpack.config.js#L79-L83
   ```js
		new DependencyExtractionWebpackPlugin( {
			injectPolyfill: true,
			requestToExternal,
			requestToHandle,
		} ),
   ```
3. `npm run build`
4. Check that the `/js/build/index.js` bundle is created as before.

### With the new option

2. Add the `reportExternalized` option to the `/webpack.config.js#L79-L83`:
   ```js
		new DependencyExtractionWebpackPlugin( {
			injectPolyfill: true,
			requestToExternal,
			requestToHandle,
			externalizedReportFile: 'externalized.json',
		} ),
   ```
3. `npm run build`
4. Check that the `/js/build/index.js`  bundle is created as before.
5. Check the `/js/build/externalized.js` is created and contains:
	```json
	["@wordpress/i18n","@wordpress/hooks","@woocommerce/navigation","@woocommerce/wc-admin-settings","@wordpress/element","@woocommerce/components","@wordpress/api-fetch","@wordpress/data","@wordpress/deprecated","@babel/runtime/regenerator","@wordpress/date","lodash","react","@wordpress/html-entities","moment","@wordpress/is-shallow-equal","@wordpress/keycodes","@wordpress/a11y","@wordpress/priority-queue","@wordpress/dom","react-dom","@wordpress/warning","@wordpress/rich-text","@wordpress/data-controls","@wordpress/url"]
	```


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested. - tested manually, I was not able to run tests for this package only, and `npm install` for entire repo fails on my machine
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
