### PR TITLE
[Patterns]: Featured patterns from pattern directory

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -267,9 +267,12 @@ function gutenberg_load_remote_featured_patterns() {
 	$patterns = $response->get_data();
 	foreach ( $patterns as $pattern ) {
 		$pattern_name = sanitize_title( $pattern['title'] );
-		if ( ! WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_name ) ) {
+		$registry     = WP_Block_Patterns_Registry::get_instance();
+		// Some patterns might be already registerd as `core patterns with the `core` prefix.
+		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
+		if ( ! $is_registered ) {
 			register_block_pattern( $pattern_name, (array) $pattern );
-		};
+		}
 	}
 }
 

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -237,7 +237,7 @@ function load_remote_core_patterns() {
 }
 
 /**
- * Register featured patterns from wordpress.org/patterns.
+ * Register `Featured` (category) patterns from wordpress.org/patterns.
  *
  * @since 5.9.0
  */
@@ -255,34 +255,19 @@ function load_remote_featured_patterns() {
 		return;
 	}
 
-	// TODO: check about the `featured` name.. Should this be reserved?
-	// Also check core logic: https://developer.wordpress.org/reference/classes/wp_block_pattern_categories_registry/
-	// Do we just allow collisions/overide with categories when they have the same name? Needs checking..
-	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'Featured' ) ) {
+	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'featured' ) ) {
 		register_block_pattern_category( 'featured', array( 'label' => __( 'Featured', 'gutenberg' ) ) );
 	}
-
-	$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
-	// TODO: change this with new category id when created in patterns directory..
-	$request->set_param( 'category', 4 ); // temp gallery category id.
-
-	// TODO: check to update the controller here: https://github.com/WordPress/gutenberg/blob/trunk/lib/class-wp-rest-pattern-directory-controller.php#L321
-	// because it unsets the `per_page` param.
-	// $request->set_param( 'per_page', 2 );.
-
-	$response = rest_do_request( $request );
+	$request             = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+	$request['category'] = 26; // This is the `Featured` category id from pattern directory.
+	$response            = rest_do_request( $request );
 	if ( $response->is_error() ) {
 		return;
 	}
 	$patterns = $response->get_data();
-	// check above comment about `per_page`.
-	$patterns = array_slice( $patterns, 0, 2 );
 	foreach ( $patterns as $pattern ) {
 		$pattern_name = sanitize_title( $pattern['title'] );
 		if ( ! WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_name ) ) {
-			// TODO: should we override this one as is done here? If not we should also add the `featured`
-			// category and also check to registere remaing categories if not already registered.
-			$pattern['categories'] = array( 'featured' );
 			register_block_pattern( $pattern_name, (array) $pattern );
 		};
 	}

--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -8,7 +8,7 @@
 /**
  * Register Gutenberg bundled patterns.
  */
-function register_gutenberg_patterns() {
+function gutenberg_register_gutenberg_patterns() {
 	// Register categories used for block patterns.
 	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'query' ) ) {
 		register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
@@ -170,7 +170,7 @@ function register_gutenberg_patterns() {
 /**
  * Deactivate the legacy patterns bundled with WordPress.
  */
-function remove_core_patterns() {
+function gutenberg_remove_core_patterns() {
 	$core_block_patterns = array(
 		'text-two-columns',
 		'two-buttons',
@@ -204,7 +204,7 @@ function remove_core_patterns() {
  *
  * @since 5.8.0
  */
-function load_remote_core_patterns() {
+function gutenberg_load_remote_core_patterns() {
 	// This is the core function that provides the same feature.
 	if ( function_exists( '_load_remote_block_patterns' ) ) {
 		return;
@@ -241,7 +241,7 @@ function load_remote_core_patterns() {
  *
  * @since 5.9.0
  */
-function load_remote_featured_patterns() {
+function gutenberg_load_remote_featured_patterns() {
 	/**
 	 * Filter to disable remote block patterns.
 	 *
@@ -280,8 +280,8 @@ add_action(
 		if ( ! get_theme_support( 'core-block-patterns' ) || ! function_exists( 'unregister_block_pattern' ) ) {
 			return;
 		}
-		remove_core_patterns();
-		register_gutenberg_patterns();
+		gutenberg_remove_core_patterns();
+		gutenberg_register_gutenberg_patterns();
 	}
 );
 
@@ -294,8 +294,8 @@ add_action(
 
 		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
 		if ( $current_screen->is_block_editor || $is_site_editor ) {
-			load_remote_core_patterns();
-			load_remote_featured_patterns();
+			gutenberg_load_remote_core_patterns();
+			gutenberg_load_remote_featured_patterns();
 		}
 	}
 );

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -31,11 +31,19 @@ function BlockPatternsCategory( {
 	// Remove any empty categories
 	const populatedCategories = useMemo(
 		() =>
-			allCategories.filter( ( category ) =>
-				allPatterns.some( ( pattern ) =>
-					pattern.categories?.includes( category.name )
+			allCategories
+				.filter( ( category ) =>
+					allPatterns.some( ( pattern ) =>
+						pattern.categories?.includes( category.name )
+					)
 				)
-			),
+				// TODO: check if we can sort differently. Currently is the registration order.
+				.sort( ( { name: currentName }, { name: nextName } ) => {
+					if ( ! [ currentName, nextName ].includes( 'featured' ) ) {
+						return 0;
+					}
+					return currentName === 'featured' ? -1 : 1;
+				} ),
 		[ allPatterns, allCategories ]
 	);
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -37,7 +37,6 @@ function BlockPatternsCategory( {
 						pattern.categories?.includes( category.name )
 					)
 				)
-				// TODO: check if we can sort differently. Currently is the registration order.
 				.sort( ( { name: currentName }, { name: nextName } ) => {
 					if ( ! [ currentName, nextName ].includes( 'featured' ) ) {
 						return 0;


### PR DESCRIPTION
This PR is just a quick POC for fetching and showing `featured` patterns from [patterns directory](https://wordpress.org/patterns/).

Resolves: https://github.com/WordPress/gutenberg/issues/33046

## Testing instructions
1. in the main inserter go to `patterns` tabs and check the first shown category (`featured`) with patterns from the directory.

## Notes
1. The first pattern that is fetched right now is trying to fetch a non existing image - check the browser console when you are previewing the patterns in the inserter. This means that the validation of patterns submitted in the directory should be checked so as to avoid such issues..
