### PR TITLE
Explore: Multiselection by dragging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53167,6 +53167,11 @@
 				"scheduler": "^0.20.1"
 			}
 		},
+		"react-drag-to-select": {
+			"version": "1.0.3-rc01",
+			"resolved": "https://registry.npmjs.org/react-drag-to-select/-/react-drag-to-select-1.0.3-rc01.tgz",
+			"integrity": "sha512-NxeAuBcLs6PQ8Hd4oo5OPID/NOiRbsl+B3LOd8xmFDXT+e3MKG8mZF6n2zJ9/zrpXnx4VGr/jwNuiaJIO+bW1w=="
+		},
 		"react-draggable": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
 		"@wordpress/viewport": "file:packages/viewport",
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
-		"@wordpress/wordcount": "file:packages/wordcount"
+		"@wordpress/wordcount": "file:packages/wordcount",
+		"react-drag-to-select": "1.0.3-rc01"
 	},
 	"devDependencies": {
 		"@actions/core": "1.4.0",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -55,6 +55,7 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
+		"react-drag-to-select": "1.0.3-rc01",
 		"rememo": "^3.0.0",
 		"uuid": "8.3.0"
 	},


### PR DESCRIPTION
Just a fun idea I had after trying out a few note-taking apps. Selecting multiple blocks by drag&drop seems like a natural interaction to have:

https://user-images.githubusercontent.com/205419/134696866-22aaf33a-acd7-4a5c-bcd2-eaa574391544.mp4

To try it yourself, apply this PR and go to Gutenberg demo editor.

The code is not quite mergeable, that's more of an exploration to start a discussion. I wonder what y'all think.

cc @jasmussen @tellthemachines @talldan @noisysocks @ellatrix @talldan @getdave @kevin940726 @javierarce 