### PR TITLE
Gallery block: fix problem with caption showing encode tags when not selected

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -16,7 +16,7 @@ figure.wp-block-gallery {
 		flex: 0 0 100%;
 	}
 
-	> .components-form-file-upload {
+	> .blocks-gallery-media-placeholder-wrapper {
 		flex-basis: 100%;
 	}
 

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -11,14 +11,10 @@ import {
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
-import {
-	useState,
-	useEffect,
-	useRef,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
+import { View } from '@wordpress/primitives';
 
 const allowedBlocks = [ 'core/image' ];
 
@@ -43,19 +39,15 @@ export const Gallery = ( props ) => {
 
 	const [ captionFocused, setCaptionFocused ] = useState( false );
 
-	const captionRef = useRef();
-
-	// Need to use a layout effect here as we can't focus the RichText element
-	// until the DOM render cycle is finished.
-	useLayoutEffect( () => {
-		if ( captionFocused && captionRef.current ) {
-			captionRef.current.focus();
-		}
-	}, [ captionFocused ] );
-
 	function onFocusCaption() {
 		if ( ! captionFocused ) {
 			setCaptionFocused( true );
+		}
+	}
+
+	function removeCaptionFocus() {
+		if ( captionFocused ) {
+			setCaptionFocused( false );
 		}
 	}
 
@@ -80,9 +72,14 @@ export const Gallery = ( props ) => {
 			) }
 		>
 			{ children }
-			{ mediaPlaceholder }
+
+			<View
+				className="blocks-gallery-media-placeholder-wrapper"
+				onClick={ removeCaptionFocus }
+			>
+				{ mediaPlaceholder }
+			</View>
 			<RichTextVisibilityHelper
-				captionRef={ captionRef }
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }
 				onFocusCaption={ onFocusCaption }
@@ -116,28 +113,17 @@ function RichTextVisibilityHelper( {
 		return <VisuallyHidden as={ RichText } { ...richTextProps } />;
 	}
 
-	if ( captionFocused ) {
-		return (
-			<RichText
-				ref={ captionRef }
-				value={ value }
-				placeholder={ placeholder }
-				className={ className }
-				tagName={ tagName }
-				isSelected={ captionFocused }
-				{ ...richTextProps }
-			/>
-		);
-	}
-
 	return (
-		<figcaption
-			role="presentation"
-			onClick={ onFocusCaption }
+		<RichText
+			ref={ captionRef }
+			value={ value }
+			placeholder={ placeholder }
 			className={ className }
-		>
-			{ RichText.isEmpty( value ) ? placeholder : value }
-		</figcaption>
+			tagName={ tagName }
+			isSelected={ captionFocused }
+			onClick={ onFocusCaption }
+			{ ...richTextProps }
+		/>
 	);
 }
 


### PR DESCRIPTION
## Description
If logged in as a user without unsafe html privileges the Gallery caption in the refactored Gallery block shows encoded html tags when the caption is not selected. This PR removes the toggle between `RichText` and `figure` and keeps it as `RichText`

Fixes: https://github.com/WordPress/gutenberg/issues/34829

## Testing

- Check out PR and enable Gallery experiment
- Log in with a user without unsafe html privileges, eg. `Author`
- Add a gallery and set a caption with some bold and italic formatting
- Deselect the gallery block and make sure the caption displays as expected
- Also check that the caption formatting toolbar disappears when you deselect the gallery, click a gallery image, or click the media placeholder.

## Screenshots 

Before:
![caption-before](https://user-images.githubusercontent.com/3629020/134830318-7efd29fc-cf47-40aa-b82b-834bcd517559.gif)

After:
![caption-after](https://user-images.githubusercontent.com/3629020/134830324-c8d660e8-4fbb-477d-ab4b-1a61ee19f2ab.gif)

