### PR TITLE
Gallery block: unset alignment on new images to prevent it breaking layout

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -139,6 +139,7 @@ function GalleryEdit( props ) {
 			updateBlockAttributes( newImage.clientId, {
 				...buildImageAttributes( false, newImage.attributes ),
 				id: newImage.id,
+				align: undefined,
 			} );
 		} );
 	}, [ newImages ] );


### PR DESCRIPTION
## Description
Currently if an already aligned image is dragged into the refactored Gallery block it breaks the gallery layout. This PR removes the `align` attribute when an image is dragged into the gallery.

Fixes: https://github.com/WordPress/gutenberg/issues/34826

## Testing

- Check out PR and enable the gallery experiment. 
- Add a gallery block with several images
- Add an individual image block and make it right aligned
- Drag the image into the gallery and check that the alignment is removed

## Screenshots 

Before:
![align-before](https://user-images.githubusercontent.com/3629020/134832104-f3610784-e0b0-4f1a-ad89-54ae7a6da973.gif)

After:
![align-after](https://user-images.githubusercontent.com/3629020/134832134-6039314a-dcf5-47b6-9ccd-cd6a0517beb4.gif)

