### PR TITLE
UnitControl component: Refactor utils to TypeScript

### DIFF
--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -20,6 +20,10 @@ export default {
 	component: UnitControl,
 };
 
+const ControlWrapperView = styled.div`
+	max-width: 80px;
+`;
+
 function Example() {
 	const [ value, setValue ] = useState( '10px' );
 
@@ -60,6 +64,43 @@ export const _default = () => {
 	return <Example />;
 };
 
-const ControlWrapperView = styled.div`
-	max-width: 80px;
-`;
+export function WithCustomUnits() {
+	const [ value, setValue ] = useState( '10km' );
+
+	const props = {
+		isResetValueOnUnitChange: boolean( 'isResetValueOnUnitChange', true ),
+		label: text( 'label', 'Distance' ),
+		units: object( 'units', [
+			{
+				value: 'km',
+				label: 'km',
+				default: 1,
+			},
+			{
+				value: 'mi',
+				label: 'mi',
+				default: 1,
+			},
+			{
+				value: 'm',
+				label: 'm',
+				default: 1000,
+			},
+			{
+				value: 'yd',
+				label: 'yd',
+				default: 1760,
+			},
+		] ),
+	};
+
+	return (
+		<ControlWrapperView>
+			<UnitControl
+				{ ...props }
+				value={ value }
+				onChange={ ( v ) => setValue( v ) }
+			/>
+		</ControlWrapperView>
+	);
+}

--- a/packages/components/src/unit-control/test/utils.js
+++ b/packages/components/src/unit-control/test/utils.js
@@ -64,6 +64,15 @@ describe( 'UnitControl utils', () => {
 				filterUnitsWithSettings( preferredUnits, availableUnits )
 			).toEqual( [] );
 		} );
+
+		it( 'should return empty array where available units is set to false', () => {
+			const preferredUnits = [ '%', 'px' ];
+			const availableUnits = false;
+
+			expect(
+				filterUnitsWithSettings( preferredUnits, availableUnits )
+			).toEqual( [] );
+		} );
 	} );
 
 	describe( 'getValidParsedUnit', () => {

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -22,3 +22,5 @@ export type WPUnitControlUnit = {
 	 */
 	step?: number;
 };
+
+export type WPUnitControlUnitList = Array< WPUnitControlUnit > | false;

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,0 +1,38 @@
+export interface WPUnitControlUnit {
+	/**
+	 * The value for the unit, used in a CSS value (e.g `px`).
+	 */
+	value: string;
+	/**
+	 * The label used in a dropdown selector for the unit.
+	 */
+	label: string;
+	/**
+	 * Default value for the unit, used when switching units.
+	 */
+	default?: string | number;
+	/**
+	 * An accessible label used by screen readers.
+	 */
+	a11yLabel?: string;
+	/**
+	 * A step value used when incrementing/decrementing the value.
+	 */
+	step?: number;
+}
+
+export interface UseCustomUnitsProps {
+	/**
+	 * Collection of all potentially units, to be filtered by `availableUnits`.
+	 */
+	units?: Array< WPUnitControlUnit >;
+	/**
+	 * Collection of unit value strings. Example: `[ 'px', 'em', 'rem' ]`.
+	 * Typically provided by the `spacing.units` settings path in theme.json.
+	 */
+	availableUnits?: Array< string >;
+	/**
+	 * Collection of default values for defined units. Example: `{ px: '350', em: '15' }`.
+	 */
+	defaultValues: Record< string, string | number >;
+}

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,4 +1,6 @@
-export interface WPUnitControlUnit {
+export type Value = number | string;
+
+export type WPUnitControlUnit = {
 	/**
 	 * The value for the unit, used in a CSS value (e.g `px`).
 	 */
@@ -19,20 +21,4 @@ export interface WPUnitControlUnit {
 	 * A step value used when incrementing/decrementing the value.
 	 */
 	step?: number;
-}
-
-export interface UseCustomUnitsProps {
-	/**
-	 * Collection of all potentially units, to be filtered by `availableUnits`.
-	 */
-	units?: Array< WPUnitControlUnit >;
-	/**
-	 * Collection of unit value strings. Example: `[ 'px', 'em', 'rem' ]`.
-	 * Typically provided by the `spacing.units` settings path in theme.json.
-	 */
-	availableUnits?: Array< string >;
-	/**
-	 * Collection of default values for defined units. Example: `{ px: '350', em: '15' }`.
-	 */
-	defaultValues: Record< string, string | number >;
-}
+};

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -12,7 +12,7 @@ export type WPUnitControlUnit = {
 	/**
 	 * Default value for the unit, used when switching units.
 	 */
-	default?: string | number;
+	default?: Value;
 	/**
 	 * An accessible label used by screen readers.
 	 */

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -7,7 +7,7 @@ import { Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { Value, WPUnitControlUnit } from './types';
+import type { Value, WPUnitControlUnit, WPUnitControlUnitList } from './types';
 
 const isWeb = Platform.OS === 'web';
 
@@ -153,7 +153,7 @@ export const DEFAULT_UNIT = allUnits.px;
 export function getParsedValue(
 	value: Value,
 	unit?: string,
-	units?: Array< WPUnitControlUnit >
+	units?: WPUnitControlUnitList
 ): [ Value, string ] {
 	const initialValue = unit ? `${ value }${ unit }` : value;
 
@@ -166,7 +166,7 @@ export function getParsedValue(
  * @param  units Units to check.
  * @return Whether units are defined.
  */
-export function hasUnits( units: Array< WPUnitControlUnit > | false ): boolean {
+export function hasUnits( units: WPUnitControlUnitList ): boolean {
 	return Array.isArray( units ) && !! units.length;
 }
 
@@ -179,7 +179,7 @@ export function hasUnits( units: Array< WPUnitControlUnit > | false ): boolean {
  */
 export function parseUnit(
 	initialValue: Value,
-	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
+	units: WPUnitControlUnitList = ALL_CSS_UNITS
 ): [ Value, string ] {
 	const value = String( initialValue ).trim();
 
@@ -213,7 +213,7 @@ export function parseUnit(
  */
 export function getValidParsedUnit(
 	next: Value,
-	units: Array< WPUnitControlUnit > | false,
+	units: WPUnitControlUnitList,
 	fallbackValue: Value,
 	fallbackUnit: string
 ) {
@@ -260,11 +260,13 @@ export function parseA11yLabelForUnit( unit: string ): string {
  */
 export function filterUnitsWithSettings(
 	unitSetting: Array< string > = [],
-	units: Array< WPUnitControlUnit > = []
+	units: WPUnitControlUnitList
 ): Array< WPUnitControlUnit > {
-	return units.filter( ( unit ) => {
-		return unitSetting.includes( unit.value );
-	} );
+	return Array.isArray( units )
+		? units.filter( ( unit ) => {
+				return unitSetting.includes( unit.value );
+		  } )
+		: [];
 }
 
 /**
@@ -284,10 +286,10 @@ export const useCustomUnits = ( {
 	availableUnits,
 	defaultValues,
 }: {
-	units?: Array< WPUnitControlUnit >;
+	units?: WPUnitControlUnitList;
 	availableUnits?: Array< string >;
 	defaultValues: Record< string, Value >;
-} ): Array< WPUnitControlUnit > | false => {
+} ): WPUnitControlUnitList => {
 	units = units || ALL_CSS_UNITS;
 	const usedUnits = filterUnitsWithSettings(
 		! availableUnits ? [] : availableUnits,
@@ -323,7 +325,7 @@ export function getUnitsWithCurrentUnit(
 	currentValue: Value,
 	legacyUnit: string | undefined,
 	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
-): Array< WPUnitControlUnit > | false {
+): WPUnitControlUnitList {
 	if ( ! Array.isArray( units ) ) {
 		return units;
 	}

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -7,7 +7,7 @@ import { Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { UseCustomUnitsProps, WPUnitControlUnit } from './types';
+import type { Value, WPUnitControlUnit } from './types';
 
 const isWeb = Platform.OS === 'web';
 
@@ -151,10 +151,10 @@ export const DEFAULT_UNIT = allUnits.px;
  * @return The extracted number and unit.
  */
 export function getParsedValue(
-	value: number | string,
+	value: Value,
 	unit?: string,
 	units?: Array< WPUnitControlUnit >
-): [ number | string, string ] {
+): [ Value, string ] {
 	const initialValue = unit ? `${ value }${ unit }` : value;
 
 	return parseUnit( initialValue, units );
@@ -180,7 +180,7 @@ export function hasUnits( units: Array< WPUnitControlUnit > | false ): boolean {
 export function parseUnit(
 	initialValue: string | number,
 	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
-): [ number | string, string ] {
+): [ Value, string ] {
 	const value = String( initialValue ).trim();
 
 	let num: string | number = parseFloat( value );
@@ -212,9 +212,9 @@ export function parseUnit(
  * @return The extracted value and unit.
  */
 export function getValidParsedUnit(
-	next: number | string,
+	next: Value,
 	units: Array< WPUnitControlUnit > | false,
-	fallbackValue: number | string,
+	fallbackValue: Value,
 	fallbackUnit: string
 ) {
 	const [ parsedValue, parsedUnit ] = parseUnit( next, units );
@@ -283,7 +283,11 @@ export const useCustomUnits = ( {
 	units,
 	availableUnits,
 	defaultValues,
-}: UseCustomUnitsProps ): Array< WPUnitControlUnit > | false => {
+}: {
+	units?: Array< WPUnitControlUnit >;
+	availableUnits?: Array< string >;
+	defaultValues: Record< string, string | number >;
+} ): Array< WPUnitControlUnit > | false => {
 	units = units || ALL_CSS_UNITS;
 	const usedUnits = filterUnitsWithSettings(
 		! availableUnits ? [] : availableUnits,
@@ -316,7 +320,7 @@ export const useCustomUnits = ( {
  * @return A collection of units containing the unit for the current value.
  */
 export function getUnitsWithCurrentUnit(
-	currentValue: number | string,
+	currentValue: Value,
 	legacyUnit: string | undefined,
 	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
 ): Array< WPUnitControlUnit > | false {

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -209,7 +209,7 @@ export function parseUnit(
  * @param  units         Units to derive from.
  * @param  fallbackValue The fallback value.
  * @param  fallbackUnit  The fallback value.
- * @return The extracted number and unit.
+ * @return The extracted value and unit.
  */
 export function getValidParsedUnit(
 	next: number | string,

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -178,12 +178,12 @@ export function hasUnits( units: Array< WPUnitControlUnit > | false ): boolean {
  * @return The extracted number and unit.
  */
 export function parseUnit(
-	initialValue: string | number,
+	initialValue: Value,
 	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
 ): [ Value, string ] {
 	const value = String( initialValue ).trim();
 
-	let num: string | number = parseFloat( value );
+	let num: Value = parseFloat( value );
 	num = isNaN( num ) ? '' : num;
 
 	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
@@ -286,7 +286,7 @@ export const useCustomUnits = ( {
 }: {
 	units?: Array< WPUnitControlUnit >;
 	availableUnits?: Array< string >;
-	defaultValues: Record< string, string | number >;
+	defaultValues: Record< string, Value >;
 } ): Array< WPUnitControlUnit > | false => {
 	units = units || ALL_CSS_UNITS;
 	const usedUnits = filterUnitsWithSettings(

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -1,29 +1,17 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
 
 /**
- * An object containing the details of a unit.
- *
- * @typedef {Object} WPUnitControlUnit
- * @property {string}        value       The value for the unit, used in a CSS value (e.g `px`).
- * @property {string}        label       The label used in a dropdown selector for the unit.
- * @property {string|number} [default]   Default value for the unit, used when switching units.
- * @property {string}        [a11yLabel] An accessible label used by screen readers.
- * @property {number}        [step]      A step value used when incrementing/decrementing the value.
+ * Internal dependencies
  */
+import type { UseCustomUnitsProps, WPUnitControlUnit } from './types';
 
 const isWeb = Platform.OS === 'web';
 
-/** @type {Record<string, WPUnitControlUnit>} */
-const allUnits = {
+const allUnits: Record< string, WPUnitControlUnit > = {
 	px: {
 		value: 'px',
 		label: isWeb ? 'px' : __( 'Pixels (px)' ),
@@ -157,12 +145,16 @@ export const DEFAULT_UNIT = allUnits.px;
  * Moving forward, ideally the value should be a string that contains both
  * the value and unit, example: '10px'
  *
- * @param {number|string}            value Value
- * @param {string}                   unit  Unit value
- * @param {Array<WPUnitControlUnit>} units Units to derive from.
- * @return {Array<number, string>} The extracted number and unit.
+ * @param  value Value
+ * @param  unit  Unit value
+ * @param  units Units to derive from.
+ * @return The extracted number and unit.
  */
-export function getParsedValue( value, unit, units ) {
+export function getParsedValue(
+	value: number | string,
+	unit?: string,
+	units?: Array< WPUnitControlUnit >
+): [ number | string, string ] {
 	const initialValue = unit ? `${ value }${ unit }` : value;
 
 	return parseUnit( initialValue, units );
@@ -171,24 +163,27 @@ export function getParsedValue( value, unit, units ) {
 /**
  * Checks if units are defined.
  *
- * @param {any} units Units to check.
- * @return {boolean} Whether units are defined.
+ * @param  units Units to check.
+ * @return Whether units are defined.
  */
-export function hasUnits( units ) {
-	return ! isEmpty( units ) && units !== false;
+export function hasUnits( units: Array< WPUnitControlUnit > | false ): boolean {
+	return Array.isArray( units ) && !! units.length;
 }
 
 /**
  * Parses a number and unit from a value.
  *
- * @param {string}                   initialValue Value to parse
- * @param {Array<WPUnitControlUnit>} units        Units to derive from.
- * @return {Array<number, string>} The extracted number and unit.
+ * @param  initialValue Value to parse
+ * @param  units        Units to derive from.
+ * @return The extracted number and unit.
  */
-export function parseUnit( initialValue, units = ALL_CSS_UNITS ) {
+export function parseUnit(
+	initialValue: string | number,
+	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
+): [ number | string, string ] {
 	const value = String( initialValue ).trim();
 
-	let num = parseFloat( value, 10 );
+	let num: string | number = parseFloat( value );
 	num = isNaN( num ) ? '' : num;
 
 	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ )[ 1 ];
@@ -196,7 +191,7 @@ export function parseUnit( initialValue, units = ALL_CSS_UNITS ) {
 	let unit = unitMatch !== undefined ? unitMatch : '';
 	unit = unit.toLowerCase();
 
-	if ( hasUnits( units ) ) {
+	if ( hasUnits( units ) && units !== false ) {
 		const match = units.find( ( item ) => item.value === unit );
 		unit = match?.value;
 	} else {
@@ -210,18 +205,23 @@ export function parseUnit( initialValue, units = ALL_CSS_UNITS ) {
  * Parses a number and unit from a value. Validates parsed value, using fallback
  * value if invalid.
  *
- * @param {number|string}            next          The next value.
- * @param {Array<WPUnitControlUnit>} units         Units to derive from.
- * @param {number|string}            fallbackValue The fallback value.
- * @param {string}                   fallbackUnit  The fallback value.
- * @return {Array<number, string>} The extracted number and unit.
+ * @param  next          The next value.
+ * @param  units         Units to derive from.
+ * @param  fallbackValue The fallback value.
+ * @param  fallbackUnit  The fallback value.
+ * @return The extracted number and unit.
  */
-export function getValidParsedUnit( next, units, fallbackValue, fallbackUnit ) {
+export function getValidParsedUnit(
+	next: number | string,
+	units: Array< WPUnitControlUnit > | false,
+	fallbackValue: number | string,
+	fallbackUnit: string
+) {
 	const [ parsedValue, parsedUnit ] = parseUnit( next, units );
 	let baseValue = parsedValue;
-	let baseUnit;
+	let baseUnit: string;
 
-	if ( isNaN( parsedValue ) || parsedValue === '' ) {
+	if ( ! Number.isFinite( parsedValue ) || parsedValue === '' ) {
 		baseValue = fallbackValue;
 	}
 
@@ -242,25 +242,28 @@ export function getValidParsedUnit( next, units, fallbackValue, fallbackUnit ) {
  * Takes a unit value and finds the matching accessibility label for the
  * unit abbreviation.
  *
- * @param {string} unit Unit value (example: px)
- * @return {string} a11y label for the unit abbreviation
+ * @param  unit Unit value (example: px)
+ * @return a11y label for the unit abbreviation
  */
-export function parseA11yLabelForUnit( unit ) {
+export function parseA11yLabelForUnit( unit: string ): string {
 	const match = ALL_CSS_UNITS.find( ( item ) => item.value === unit );
 	return match?.a11yLabel ? match?.a11yLabel : match?.value;
 }
 
 /**
- * Filters available units based on values defined by settings.
+ * Filters available units based on values defined by the unit setting/property.
  *
- * @param {Array} settings Collection of preferred units.
- * @param {Array} units    Collection of available units.
+ * @param  unitSetting Collection of preferred unit value strings.
+ * @param  units       Collection of available unit objects.
  *
- * @return {Array} Filtered units based on settings.
+ * @return Filtered units based on settings.
  */
-export function filterUnitsWithSettings( settings = [], units = [] ) {
+export function filterUnitsWithSettings(
+	unitSetting: Array< string > = [],
+	units: Array< WPUnitControlUnit > = []
+): Array< WPUnitControlUnit > {
 	return units.filter( ( unit ) => {
-		return settings.includes( unit.value );
+		return unitSetting.includes( unit.value );
 	} );
 }
 
@@ -269,14 +272,18 @@ export function filterUnitsWithSettings( settings = [], units = [] ) {
  * TODO: ideally this hook shouldn't be needed
  * https://github.com/WordPress/gutenberg/pull/31822#discussion_r633280823
  *
- * @param {Object}                             args                An object containing units, settingPath & defaultUnits.
- * @param {Array<WPUnitControlUnit>|undefined} args.units          Collection of available units.
- * @param {Array<string>|undefined}            args.availableUnits The setting path. Defaults to 'spacing.units'.
- * @param {Object|undefined}                   args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
+ * @param  args                An object containing units, settingPath & defaultUnits.
+ * @param  args.units          Collection of all potentially available units.
+ * @param  args.availableUnits Collection of unit value strings for filtering available units.
+ * @param  args.defaultValues  Collection of default values for defined units. Example: { px: '350', em: '15' }.
  *
- * @return {Array|boolean} Filtered units based on settings.
+ * @return Filtered units based on settings.
  */
-export const useCustomUnits = ( { units, availableUnits, defaultValues } ) => {
+export const useCustomUnits = ( {
+	units,
+	availableUnits,
+	defaultValues,
+}: UseCustomUnitsProps ): Array< WPUnitControlUnit > | false => {
 	units = units || ALL_CSS_UNITS;
 	const usedUnits = filterUnitsWithSettings(
 		! availableUnits ? [] : availableUnits,
@@ -302,17 +309,17 @@ export const useCustomUnits = ( { units, availableUnits, defaultValues } ) => {
  * accurately displayed in the UI, even if the intention is to hide
  * the availability of that unit.
  *
- * @param {number|string}            currentValue Selected value to parse.
- * @param {string}                   legacyUnit   Legacy unit value, if currentValue needs it appended.
- * @param {Array<WPUnitControlUnit>} units        List of available units.
+ * @param  currentValue Selected value to parse.
+ * @param  legacyUnit   Legacy unit value, if currentValue needs it appended.
+ * @param  units        List of available units.
  *
- * @return {Array<WPUnitControlUnit>} A collection of units containing the unit for the current value.
+ * @return A collection of units containing the unit for the current value.
  */
 export function getUnitsWithCurrentUnit(
-	currentValue,
-	legacyUnit,
-	units = ALL_CSS_UNITS
-) {
+	currentValue: number | string,
+	legacyUnit: string | undefined,
+	units: Array< WPUnitControlUnit > | false = ALL_CSS_UNITS
+): Array< WPUnitControlUnit > | false {
 	if ( ! Array.isArray( units ) ) {
 		return units;
 	}

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -221,6 +221,8 @@ export function getValidParsedUnit(
 	let baseValue = parsedValue;
 	let baseUnit: string;
 
+	// The parsed value from `parseUnit` should now be either a
+	// real number or an empty string. If not, use the fallback value.
 	if ( ! Number.isFinite( parsedValue ) || parsedValue === '' ) {
 		baseValue = fallbackValue;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Following on from discussion in https://github.com/WordPress/gutenberg/pull/34768#pullrequestreview-756120352, this PR refactors the UnitControl component's `utils` file and set of functions to TypeScript and adds a couple of types. To avoid creating a large PR that might make reviewing difficult, I thought we could look at refactoring this component one file at a time, with this one just focusing on the utils for the moment.

It looks like I could safely remove the lodash dependency from the file, too. I've also updated the documentation for some of the attributes where there were some slight inaccuracies.

Something I noticed while working on the file is that often the list of `units` could have a value set to `false` (there were a few places where this is expected). I believe this is to support either `useCustomUnits` returning the false value to switch off custom units, or possibly a `theme.json` file explicitly setting units to `false`. I _think_ I've managed to get this fairly consistent, but I'm very open to feedback if folks think there's a better way to deal with it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Ensure tests pass

```
npm run test-unit -- --testPathPattern packages/components/src/unit-control/test/
```

### Ensure the UnitControl component works correctly

Via Storybook, run `npm run storybook:dev` and then visit http://localhost:50240/?path=/story/components-unitcontrol--default

Or, in the editor, go to edit a block that uses padding and adjust the controls (the Cover block is a good one to try)

### Ensure that a theme's theme.json units settings overrides the available units

With TT1-Blocks applied, you should see that the list of available units does not include `%`, but you can also manually edit the theme.json file's `settings.spacing.units` attribute to a reduced list of unit strings (e.g. `[ 'px', 'em', 'rem' ]` to ensure it works as expected.

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/14988353/134858805-46fb27d6-956d-4c00-b235-e9c3a76d3a6d.png" width=250 />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code quality, non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
