### PR TITLE
Add tooltip to navigation items in a setup state

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -15,6 +15,7 @@ import {
 	TextControl,
 	TextareaControl,
 	ToolbarButton,
+	Tooltip,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
@@ -646,7 +647,12 @@ export default function NavigationLinkEdit( {
 					{ /* eslint-enable */ }
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
-							<span>{ missingText }</span>
+							<Tooltip
+								position="top center"
+								text={ __( 'This item is missing a link' ) }
+							>
+								<span>{ missingText }</span>
+							</Tooltip>
 						</div>
 					) : (
 						<RichText


### PR DESCRIPTION
## Description

If you insert a menu item in a navigation menu, without pointing it to a destination, the item exists in a setup state and will not be published. Emulating grammar tools and linters, this setup state is indicated by a blue wavy underline:

<img width="448" alt="before" src="https://user-images.githubusercontent.com/1204802/134859253-8be445a8-e6d0-4e9a-9db9-bcaa2450d165.png">

This PR adds a tooltip to the item, indicating why there's a wavy underline:

<img width="644" alt="Screenshot 2021-09-27 at 08 54 42" src="https://user-images.githubusercontent.com/1204802/134859314-563118e7-ed9d-4c59-8a64-63eb2f06887b.png">

This will also benefit #35094, which allows a label to exist in the setup state.

## How has this been tested?

Insert a navigation block, click "Start empty". Add a Page Link item, but don't choose a destination, instead click outside or press "Escape". Now hover the menu item and observe the tooltip.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
