### PR TITLE
Fix slashing when creating or updating a menu item

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -181,7 +181,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		}
 		$prepared_nav_item = (array) $prepared_nav_item;
 
-		$nav_menu_item_id = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], $prepared_nav_item );
+		$nav_menu_item_id = wp_update_nav_menu_item( wp_slash( $prepared_nav_item['menu-id'] ), wp_slash( $prepared_nav_item['menu-item-db-id'] ), wp_slash( $prepared_nav_item ) );
 		if ( is_wp_error( $nav_menu_item_id ) ) {
 			if ( 'db_insert_error' === $nav_menu_item_id->get_error_code() ) {
 				$nav_menu_item_id->add_data( array( 'status' => 500 ) );
@@ -271,7 +271,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$prepared_nav_item = (array) $prepared_nav_item;
 
-		$nav_menu_item_id = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], $prepared_nav_item );
+		$nav_menu_item_id = wp_update_nav_menu_item( wp_slash( $prepared_nav_item['menu-id'] ), wp_slash( $prepared_nav_item['menu-item-db-id'] ), wp_slash( $prepared_nav_item ) );
 
 		if ( is_wp_error( $nav_menu_item_id ) ) {
 			if ( 'db_update_error' === $nav_menu_item_id->get_error_code() ) {

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -181,7 +181,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		}
 		$prepared_nav_item = (array) $prepared_nav_item;
 
-		$nav_menu_item_id = wp_update_nav_menu_item( wp_slash( $prepared_nav_item['menu-id'] ), wp_slash( $prepared_nav_item['menu-item-db-id'] ), wp_slash( $prepared_nav_item ) );
+		$nav_menu_item_id = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], wp_slash( $prepared_nav_item ) );
 		if ( is_wp_error( $nav_menu_item_id ) ) {
 			if ( 'db_insert_error' === $nav_menu_item_id->get_error_code() ) {
 				$nav_menu_item_id->add_data( array( 'status' => 500 ) );
@@ -271,7 +271,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		$prepared_nav_item = (array) $prepared_nav_item;
 
-		$nav_menu_item_id = wp_update_nav_menu_item( wp_slash( $prepared_nav_item['menu-id'] ), wp_slash( $prepared_nav_item['menu-item-db-id'] ), wp_slash( $prepared_nav_item ) );
+		$nav_menu_item_id = wp_update_nav_menu_item( $prepared_nav_item['menu-id'], $prepared_nav_item['menu-item-db-id'], wp_slash( $prepared_nav_item ) );
 
 		if ( is_wp_error( $nav_menu_item_id ) ) {
 			if ( 'db_update_error' === $nav_menu_item_id->get_error_code() ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The data passed to `wp_update_nav_menu_item` function is not being slashed when using `WP_REST_Menu_Items_Controller` controller.
The goal of this PR is to slash data before calling the `wp_update_nav_menu_item` function.
Other experimental endpoints have been audited and it seems that the issue only affects this (`__experimental/menu-items`) endpoint.
Fixes https://github.com/WordPress/gutenberg/issues/25094

## How has this been tested?
1. Go to the Gutenberg -> Experiments page and enable `Navigation screen` feature.
2. Save the changes.
3. Go back to your browser, and open the Gutenberg  -> Navigation page.
4.  Run the following JavaScript code in your browser's console:
```javascript
wp.apiFetch( {
    path: '/__experimental/menu-items',
    method: 'POST',
    data: { title: "Some \\\'title", url: 'https://my.test.url' },
} ).then( ( res ) => {
    console.log( res );
} );
```
5. Connect to the database, check the contents of the `wp_posts` table.
**Expected result**:
You should see `Some \'title` in the `post_title` column (not `Some 'title`).

## Screenshots <!-- if applicable -->
No screenshots are needed to test this issue.

## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
