### PR TITLE
Template title: Include a button and label text when there is no post/page title

### DIFF
--- a/packages/edit-post/src/components/header/template-title/index.js
+++ b/packages/edit-post/src/components/header/template-title/index.js
@@ -28,7 +28,9 @@ function TemplateTitle() {
 		return {
 			template: _isEditing ? getEditedPostTemplate() : null,
 			isEditing: _isEditing,
-			title: getEditedPostAttribute( 'title' ),
+			title: getEditedPostAttribute( 'title' )
+				? getEditedPostAttribute( 'title' )
+				: __( 'Untitled' ),
 		};
 	}, [] );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/32962

-When you create a new template for a post that has no title, the "Edit (title)" button in the toolbar in the template editor 
is printed, but it has no visible text.

This PR adds the text "Untitled" to the label and button text in the template title when the post or page has no title.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. With template editing enabled, create a new post. _Do not add a title to the post._
2. In the Template panel, select "new". Create a template.
3. In the template editor, confirm that that button text is "Untitled".
4. Confirm that the buttons aria-label is "Edit Untitled"
5. Return to the block editor and add a post title, save/publish.
6. Open the template editor and confirm that the post title still displays correctly.

## Screenshots <!-- if applicable -->
Before, when navigating with tab:
![The edit button is not visible](https://user-images.githubusercontent.com/7422055/134913408-f3bacf12-034c-436b-bb7f-ec0f0bae2f51.png)

With the PR applied:

The button is now visible since it has text inside it:
![Edit post button in the template editor](https://user-images.githubusercontent.com/7422055/134912826-203c3c07-5847-4df1-a474-1fabf92b4116.png)

When navigating with tab:
![visible tooltip with the text Edit Untitle](https://user-images.githubusercontent.com/7422055/134913231-a3ebe039-327a-40b1-ae05-e697f3872bd5.png)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
