### PR TITLE
Remove native block inserter onboarding tooltip

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -32,19 +32,9 @@ import { store as blockEditorStore } from '../../store';
 
 const VOICE_OVER_ANNOUNCEMENT_DELAY = 1000;
 
-const defaultRenderToggle = ( {
-	displayEditorOnboardingTooltip,
-	onToggle,
-	disabled,
-	style,
-	onLongPress,
-} ) => (
+const defaultRenderToggle = ( { onToggle, disabled, style, onLongPress } ) => (
 	<ToolbarButton
-		title={
-			displayEditorOnboardingTooltip
-				? __( 'Tap to add content' )
-				: __( 'Add block' )
-		}
+		title={ __( 'Add block' ) }
 		icon={
 			<Icon
 				icon={ plusCircleFilled }
@@ -52,8 +42,6 @@ const defaultRenderToggle = ( {
 				color={ style.color }
 			/>
 		}
-		showTooltip={ displayEditorOnboardingTooltip }
-		tooltipPosition="top right"
 		onClick={ onToggle }
 		extraProps={ {
 			hint: __( 'Double tap to add a block' ),
@@ -227,7 +215,6 @@ export class Inserter extends Component {
 	 */
 	renderInserterToggle( { onToggle, isOpen } ) {
 		const {
-			displayEditorOnboardingTooltip,
 			disabled,
 			renderToggle = defaultRenderToggle,
 			getStylesFromColorScheme,
@@ -274,7 +261,6 @@ export class Inserter extends Component {
 		return (
 			<>
 				{ renderToggle( {
-					displayEditorOnboardingTooltip,
 					onToggle: onPress,
 					isOpen,
 					disabled,
@@ -410,9 +396,6 @@ export default compose( [
 
 		return {
 			blockTypeImpressions: getBlockEditorSettings().impressions,
-			displayEditorOnboardingTooltip:
-				getBlockEditorSettings().editorOnboarding &&
-				getBlockEditorSettings().firstGutenbergEditorSession,
 			destinationRootClientId,
 			insertionIndexDefault: getDefaultInsertionIndex(),
 			insertionIndexBefore,


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4035

## Description
We deemed the tooltip an ineffective solution to the block inserter discovery problem. We removed it to reduce unnecessary complexity in the code.

## How has this been tested?
1. Clone this branch.
1. Apply the provided patch. 
    ```diff
    diff --git a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
    index 8d3874eaa8..112bf826c3 100644
    --- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
    +++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
    @@ -308,8 +308,8 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
                 .mediaFilesCollectionBlock: true,
                 .isAudioBlockMediaUploadEnabled: true,
                 .reusableBlock: false,
    -            .editorOnboarding: false,
    -            .firstGutenbergEditorSession: false,
    +            .editorOnboarding: true,
    +            .firstGutenbergEditorSession: true,
             ]
         }
     
    ```
2. Launch the Metro server and build the iOS Demo app. 
3. Launch the block editor. 
4. **Expected:** Verify a "Tap to add content" tooltip is _not displayed_ above the block inserter <kbd>+</kbd> button. 

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Chore

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
