### PR TITLE
`Item`:  remove `isAction`, use `onClick` to discriminate if it should render as `button`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Removed the deprecated `position` and `menuLabel` from the `DropdownMenu` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
 -   Removed the deprecated `onClickOutside` prop from the `Popover` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).
 -   Changed `RangeControl` component to not apply `shiftStep` to inputs from its `<input type="range"/>` ([35020](https://github.com/WordPress/gutenberg/pull/35020)).
+-   Removed `isAction` prop from `Item`. The component will now rely on `onClick` to render as a `button` ([35152](https://github.com/WordPress/gutenberg/pull/35152)).
 
 ### New Feature
 

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -29,12 +29,11 @@ function Example() {
 
 ## Props
 
-### `isAction`: `boolean`
+### `onClick`: `React.MouseEventHandler<HTMLDivElement>`
 
-Renders the item as an interactive `button` element.
+Even handler for processing `click` events. When defined, the `Item` component will render as a `button` (unless differently specified via the `as` prop).
 
 - Required: No
-- Default: `false`
 
 ### `size`: `'small' | 'medium' | 'large'`
 

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -5,6 +5,11 @@
 import type { ElementType } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
@@ -35,12 +40,16 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 
 	const cx = useCx();
 
-	const classes = cx(
-		as === 'button' && styles.unstyledButton,
-		styles.itemSizes[ size ] || styles.itemSizes.medium,
-		styles.item,
-		spacedAround && styles.spacedAround,
-		className
+	const classes = useMemo(
+		() =>
+			cx(
+				as === 'button' && styles.unstyledButton,
+				styles.itemSizes[ size ] || styles.itemSizes.medium,
+				styles.item,
+				spacedAround && styles.spacedAround,
+				className
+			),
+		[ as, className, size, spacedAround ]
 	);
 
 	const wrapperClassName = cx( styles.itemWrapper );

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -13,26 +13,47 @@ import { useItemGroupContext } from '../context';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { ItemProps } from '../types';
 
+function useDeprecatedProps( {
+	as,
+	isAction = false,
+	...otherProps
+}: WordPressComponentProps< ItemProps, 'div' > ) {
+	let computedAs = as;
+
+	if ( isAction ) {
+		computedAs ??= 'button';
+	}
+
+	return {
+		...otherProps,
+		as: computedAs,
+	};
+}
+
 export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 	const {
-		isAction = false,
 		as: asProp,
 		className,
+		onClick,
 		role = 'listitem',
 		size: sizeProp,
 		...otherProps
-	} = useContextSystem( props, 'Item' );
+	} = useContextSystem( useDeprecatedProps( props ), 'Item' );
 
 	const { spacedAround, size: contextSize } = useItemGroupContext();
 
 	const size = sizeProp || contextSize;
 
-	const as = ( asProp || isAction ? 'button' : 'div' ) as ElementType;
+	const as =
+		asProp ||
+		( ( typeof onClick !== 'undefined'
+			? 'button'
+			: 'div' ) as ElementType );
 
 	const cx = useCx();
 
 	const classes = cx(
-		isAction && styles.unstyledButton,
+		as === 'button' && styles.unstyledButton,
 		styles.itemSizes[ size ] || styles.itemSizes.medium,
 		styles.item,
 		spacedAround && styles.spacedAround,
@@ -44,6 +65,7 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 	return {
 		as,
 		className: classes,
+		onClick,
 		wrapperClassName,
 		role,
 		...otherProps,

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -13,23 +13,6 @@ import { useItemGroupContext } from '../context';
 import { useCx } from '../../utils/hooks/use-cx';
 import type { ItemProps } from '../types';
 
-function useDeprecatedProps( {
-	as,
-	isAction = false,
-	...otherProps
-}: WordPressComponentProps< ItemProps, 'div' > ) {
-	let computedAs = as;
-
-	if ( isAction ) {
-		computedAs ??= 'button';
-	}
-
-	return {
-		...otherProps,
-		as: computedAs,
-	};
-}
-
 export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 	const {
 		as: asProp,
@@ -38,7 +21,7 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 		role = 'listitem',
 		size: sizeProp,
 		...otherProps
-	} = useContextSystem( useDeprecatedProps( props ), 'Item' );
+	} = useContextSystem( props, 'Item' );
 
 	const { spacedAround, size: contextSize } = useItemGroupContext();
 

--- a/packages/components/src/item-group/stories/index.js
+++ b/packages/components/src/item-group/stories/index.js
@@ -56,7 +56,6 @@ export const _default = () => {
 			},
 			PROP_UNSET
 		),
-		isAction: boolean( 'Item 1: isAction', true ),
 	};
 
 	// Do not pass the `size` prop when its value is `undefined`.
@@ -68,16 +67,14 @@ export const _default = () => {
 
 	return (
 		<ItemGroup style={ { width: '350px' } } { ...itemGroupProps }>
-			<Item { ...itemProps } onClick={ () => alert( 'WordPress.org' ) }>
+			<Item { ...itemProps }>Code is Poetry (no click handlers)</Item>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
-				Code is Poetry — Click me!
-			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
 		</ItemGroup>
@@ -90,16 +87,14 @@ export const dropdown = () => (
 		trigger={ <Button>Open Popover</Button> }
 	>
 		<ItemGroup style={ { padding: 4 } }>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
+			<Item>Code is Poetry (no click handlers)</Item>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
-				Code is Poetry — Click me!
-			</Item>
-			<Item isAction onClick={ () => alert( 'WordPress.org' ) }>
+			<Item onClick={ () => alert( 'WordPress.org' ) }>
 				Code is Poetry — Click me!
 			</Item>
 		</ItemGroup>
@@ -141,7 +136,7 @@ export const complexLayouts = () => {
 
 	return (
 		<ItemGroup isBordered isSeparated style={ { width: '250px' } }>
-			<Item isAction onClick={ () => alert( 'Color palette' ) }>
+			<Item onClick={ () => alert( 'Color palette' ) }>
 				<HStack>
 					<FlexBlock>
 						<ZStack isLayered={ false } offset={ -8 }>
@@ -156,7 +151,7 @@ export const complexLayouts = () => {
 				</HStack>
 			</Item>
 
-			<Item isAction onClick={ () => alert( 'Single color setting' ) }>
+			<Item onClick={ () => alert( 'Single color setting' ) }>
 				<HStack justify="flex-start">
 					<FlexItem
 						as={ SimpleColorSwatch }
@@ -169,10 +164,7 @@ export const complexLayouts = () => {
 				</HStack>
 			</Item>
 
-			<Item
-				isAction
-				onClick={ () => alert( 'Single typography setting' ) }
-			>
+			<Item onClick={ () => alert( 'Single typography setting' ) }>
 				<HStack justify="flex-start">
 					<FlexItem>
 						<Icon icon={ typography } size={ 24 } />

--- a/packages/components/src/item-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.js.snap
@@ -33,28 +33,6 @@ Snapshot Diff:
       </div>
 `;
 
-exports[`ItemGroup Item should render a button with the isAction prop is true 1`] = `
-Snapshot Diff:
-- First value
-+ Second value
-
-  <div
-    class="css-dcjs67-itemWrapper"
-    role="listitem"
-  >
--   <div
--     class="components-item css-gqguxs-View-medium-itemWrapper em57xhy0"
-+   <button
-+     class="components-item css-1t39803-View-unstyledButton-medium-itemWrapper em57xhy0"
-      data-wp-c16t="true"
-      data-wp-component="Item"
-    >
-      Code is poetry
--   </div>
-+   </button>
-  </div>
-`;
-
 exports[`ItemGroup Item should use different amounts of padding depending on the value of the size prop 1`] = `
 Snapshot Diff:
 - First value

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -79,18 +79,36 @@ describe( 'ItemGroup', () => {
 	} );
 
 	describe( 'Item', () => {
-		it( 'should render a button with the isAction prop is true', () => {
-			// By default, `isAction` is `false`
-			const { container: normalItem } = render(
-				<Item>Code is poetry</Item>
-			);
-			const { container: actionItem } = render(
-				<Item isAction={ true }>Code is poetry</Item>
+		it( 'should render as a `button` if the `onClick` handler is specified', () => {
+			const spy = jest.fn();
+			render( <Item onClick={ spy }>Code is poetry</Item> );
+
+			const button = screen.getByRole( 'button' );
+
+			expect( button ).toBeInTheDocument();
+
+			fireEvent.click( button );
+
+			expect( spy ).toHaveBeenCalled();
+		} );
+
+		it( 'should give priority to the `as` prop even if the `onClick` handler is specified', () => {
+			const spy = jest.fn();
+			const { rerender } = render(
+				<Item onClick={ spy }>Code is poetry</Item>
 			);
 
-			expect( normalItem.firstChild ).toMatchDiffSnapshot(
-				actionItem.firstChild
+			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'label' ) ).not.toBeInTheDocument();
+
+			rerender(
+				<Item as="a" href="#" onClick={ spy }>
+					Code is poetry
+				</Item>
 			);
+
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'link' ) ).toBeInTheDocument();
 		} );
 
 		it( 'should use different amounts of padding depending on the value of the size prop', () => {
@@ -131,6 +149,33 @@ describe( 'ItemGroup', () => {
 			expect( mediumSize.firstChild ).toMatchDiffSnapshot(
 				largeSize.firstChild
 			);
+		} );
+
+		it( 'should render a button with the isAction prop is true', () => {
+			// By default, `isAction` is `false`
+			const { rerender } = render( <Item>Code is poetry</Item> );
+
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+
+			rerender( <Item isAction>Code is poetry</Item> );
+
+			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should give priority to the `as` prop even if the isAction prop is true', () => {
+			const { rerender } = render( <Item isAction>Code is poetry</Item> );
+
+			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'label' ) ).not.toBeInTheDocument();
+
+			rerender(
+				<Item as="a" href="#" isAction>
+					Code is poetry
+				</Item>
+			);
+
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'link' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -150,32 +150,5 @@ describe( 'ItemGroup', () => {
 				largeSize.firstChild
 			);
 		} );
-
-		it( 'should render a button with the isAction prop is true', () => {
-			// By default, `isAction` is `false`
-			const { rerender } = render( <Item>Code is poetry</Item> );
-
-			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
-
-			rerender( <Item isAction>Code is poetry</Item> );
-
-			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
-		} );
-
-		it( 'should give priority to the `as` prop even if the isAction prop is true', () => {
-			const { rerender } = render( <Item isAction>Code is poetry</Item> );
-
-			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
-			expect( screen.queryByRole( 'label' ) ).not.toBeInTheDocument();
-
-			rerender(
-				<Item as="a" href="#" isAction>
-					Code is poetry
-				</Item>
-			);
-
-			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'link' ) ).toBeInTheDocument();
-		} );
 	} );
 } );

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -42,13 +42,6 @@ export interface ItemProps {
 	 * The children elements.
 	 */
 	children: React.ReactNode;
-	/**
-	 * Renders the item as an interactive `button` element.
-	 *
-	 * @default false
-	 * @deprecated
-	 */
-	isAction?: boolean;
 }
 
 export type ItemGroupContext = {

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -33,12 +33,6 @@ export interface ItemGroupProps {
 
 export interface ItemProps {
 	/**
-	 * Renders the item as an interactive `button` element.
-	 *
-	 * @default false
-	 */
-	isAction?: boolean;
-	/**
 	 * Determines the amount of padding within the component.
 	 *
 	 * @default 'medium'
@@ -48,6 +42,13 @@ export interface ItemProps {
 	 * The children elements.
 	 */
 	children: React.ReactNode;
+	/**
+	 * Renders the item as an interactive `button` element.
+	 *
+	 * @default false
+	 * @deprecated
+	 */
+	isAction?: boolean;
 }
 
 export type ItemGroupContext = {

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -206,11 +206,7 @@ function NavigationButton( {
 } ) {
 	const navigator = useNavigator();
 	return (
-		<Item
-			isAction
-			onClick={ () => navigator.push( path, { isBack } ) }
-			{ ...props }
-		>
+		<Item onClick={ () => navigator.push( path, { isBack } ) } { ...props }>
 			<HStack justify="flex-start">
 				{ icon && (
 					<FlexItem>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR explores an idea that was born in https://github.com/WordPress/gutenberg/pull/35142#discussion_r716507996, where the `isAction` prop is being removed. The `Item` component would instead render as a `button` if the `onClick` prop is present (while still giving priority to the `as` prop in any case when specified).


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Unit tests
- Storybook
- Global Styles Sidebar

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Refactor (including removal of a prop on an experimental component).


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
