### PR TITLE
Chore: Remove now unused tinycolor2 from blockeditor package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18097,7 +18097,6 @@
 				"react-easy-crop": "^3.0.0",
 				"redux-multi": "^0.1.12",
 				"rememo": "^3.0.0",
-				"tinycolor2": "^1.4.2",
 				"traverse": "^0.6.6"
 			},
 			"dependencies": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -71,7 +71,6 @@
 		"react-easy-crop": "^3.0.0",
 		"redux-multi": "^0.1.12",
 		"rememo": "^3.0.0",
-		"tinycolor2": "^1.4.2",
 		"traverse": "^0.6.6"
 	},
 	"publishConfig": {


### PR DESCRIPTION
tinycolor2 was already removed from the block editor package. This PR just removes the dependency from package.json.
