### PR TITLE
Replace tinycolor2 with colord on the bocks package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18178,13 +18178,20 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
+				"colord": "^2.7.0",
 				"hpq": "^1.3.0",
 				"lodash": "^4.17.21",
 				"rememo": "^3.0.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
-				"tinycolor2": "^1.4.2",
 				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"colord": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
+					"integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA=="
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -42,12 +42,12 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
+		"colord": "^2.7.0",
 		"hpq": "^1.3.0",
 		"lodash": "^4.17.21",
 		"rememo": "^3.0.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
-		"tinycolor2": "^1.4.2",
 		"uuid": "^8.3.0"
 	},
 	"publishConfig": {

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, reduce } from 'lodash';
-import { default as tinycolor, mostReadable } from 'tinycolor2';
+import { every, has, isFunction, isString, reduce, maxBy } from 'lodash';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+import a11yPlugin from 'colord/plugins/a11y';
 
 /**
  * WordPress dependencies
@@ -17,6 +19,8 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { BLOCK_ICON_DEFAULT } from './constants';
 import { getBlockType, getDefaultBlockName } from './registration';
 import { createBlock } from './factory';
+
+extend( [ namesPlugin, a11yPlugin ] );
 
 /**
  * Array of icon colors containing a color to be used if the icon color
@@ -96,18 +100,16 @@ export function normalizeIconObject( icon ) {
 	}
 
 	if ( has( icon, [ 'background' ] ) ) {
-		const tinyBgColor = tinycolor( icon.background );
+		const colordBgColor = colord( icon.background );
 
 		return {
 			...icon,
 			foreground: icon.foreground
 				? icon.foreground
-				: mostReadable( tinyBgColor, ICON_COLORS, {
-						includeFallbackColors: true,
-						level: 'AA',
-						size: 'large',
-				  } ).toHexString(),
-			shadowColor: tinyBgColor.setAlpha( 0.3 ).toRgbString(),
+				: maxBy( ICON_COLORS, ( iconColor ) =>
+						colordBgColor.contrast( iconColor )
+				  ),
+			shadowColor: colordBgColor.alpha( 0.3 ).toRgbString(),
 		};
 	}
 


### PR DESCRIPTION
This PR tinycolor2 with colord on the blocks package. 

## How has this been tested?
I used the same test block (https://gist.github.com/jorgefilipecosta/2dd281f9f5f078258f7c8d4ba4cc34cd) created when the icon color functionality was added (on https://github.com/WordPress/gutenberg/pull/7068) and verified things still work.
