### PR TITLE
RNMobile: Add getPxFromCssUnit to Rich Text component.

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -433,7 +433,7 @@ Returns the px value of a cssUnit.
 _Parameters_
 
 -   _cssUnit_ `string`:
--   _options_ `string`:
+-   _options_ `Object`:
 
 _Returns_
 

--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -206,7 +206,7 @@ function convertParsedUnitToPx( parsedUnit, options ) {
  * Returns the px value of a cssUnit.
  *
  * @param {string} cssUnit
- * @param {string} options
+ * @param {Object} options
  * @return {string} returns the cssUnit value in a simple px format.
  */
 function getPxFromCssUnit( cssUnit, options = {} ) {

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { View, Platform } from 'react-native';
+import { View, Platform, Dimensions } from 'react-native';
 import { get, pickBy, debounce } from 'lodash';
 import memize from 'memize';
 
@@ -15,7 +15,7 @@ import {
 	showUserSuggestions,
 	showXpostSuggestions,
 } from '@wordpress/react-native-bridge';
-import { BlockFormatControls } from '@wordpress/block-editor';
+import { BlockFormatControls, getPxFromCssUnit } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -122,6 +122,7 @@ export class RichText extends Component {
 			activeFormats: [],
 			selectedFormat: null,
 			height: 0,
+			dimensions: Dimensions.get( 'window' ),
 		};
 		this.needsSelectionUpdate = false;
 		this.savedContent = '';
@@ -855,19 +856,26 @@ export class RichText extends Component {
 	getFontSize() {
 		const { baseGlobalStyles } = this.props;
 
-		if ( this.props.fontSize ) {
-			return parseFloat( this.props.fontSize );
+		let fontSize = DEFAULT_FONT_SIZE;
+
+		if ( baseGlobalStyles?.typography?.fontSize ) {
+			fontSize = baseGlobalStyles?.typography?.fontSize;
 		}
 
 		if ( this.props.style?.fontSize ) {
-			return parseFloat( this.props.style.fontSize );
+			fontSize = this.props.style.fontSize;
 		}
 
-		if ( baseGlobalStyles?.typography?.fontSize ) {
-			return parseFloat( baseGlobalStyles?.typography?.fontSize );
+		if ( this.props.fontSize ) {
+			fontSize = this.props.fontSize;
 		}
+		const { height, width } = this.state.dimensions;
+		const cssUnitOptions = { height, width, fontSize: DEFAULT_FONT_SIZE };
+		// We need to always convert to px units because the selected value
+		// could be coming from the web where it could be stored as a different unit.
+		const selectedPxValue = getPxFromCssUnit( fontSize, cssUnitOptions );
 
-		return DEFAULT_FONT_SIZE;
+		return parseFloat( selectedPxValue );
 	}
 
 	getLineHeight() {


### PR DESCRIPTION
## Description
This Pr adds the getPxFromCssUnit() to the getFontSize of RichText component so that the edit can properly display the font size in any size that is given to the editor. 

## How has this been tested?
Create a post with the following content. 
```
<!-- wp:paragraph {"style":{"typography":{"fontSize":"2em"}}} -->
<p style="font-size:2em">2em fontsize </p>
<!-- /wp:paragraph -->
```

Notice that the font size is what you would expect it to be. 

## Screenshots <!-- if applicable -->
Before:
<img width="300" src="https://user-images.githubusercontent.com/115071/134997693-ca37576b-8fb2-4410-96ae-f84f7f403b59.png" />
After
<img width="300" src="https://user-images.githubusercontent.com/115071/134997606-fad78b03-0e86-43da-b067-5c0789acaa0e.png" />

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
