### PR TITLE
useMultiSelection: Avoid crashing editor when block refs aren't available

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -122,6 +122,12 @@ export default function useMultiSelection() {
 				return;
 			}
 
+			// The block refs might not be immediately available
+			// when dragging blocks into another block.
+			if ( ! startRef.current || ! endRef.current ) {
+				return;
+			}
+
 			// For some browsers, like Safari, it is important that focus happens
 			// BEFORE selection.
 			node.focus();


### PR DESCRIPTION
## Description
When dragging multiple blocks into another block (inner blocks area), first and last block refs might not be available and cause the editor to crash.

This PR adds a guard clause for this scenario.

Fixes #34409.
Fixes #34631.
Fixes #35128.

## How has this been tested?
1. Create several blocks in a post.
2. Add "Media & Text" blocks.
3. Select and drag other blocks into the "Media & Text" content area.
4. Editor shouldn't crash with the following error.

```
Uncaught TypeError: Cannot read properties of null (reading 'firstChild') at getDeepestNode
```

## Example blocks
```
<!-- wp:media-text -->
<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size"></p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:heading -->
<h2>Gutenberg</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p><meta charset="utf-8">We call the new editor Gutenberg. The entire editing experience has been rebuilt for media rich pages and posts. Experience the flexibility that blocks will bring, whether you are building your first site, or write code for a living.</p>
<!-- /wp:paragraph -->
```

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/135058245-a14c20a1-9159-4854-bd3b-781604e766c5.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
