### PR TITLE
Update the rules to hide/show blocks in the global styles sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -52,6 +52,26 @@ function getPanelTitle( blockName ) {
 	return blockType.title;
 }
 
+function BlockMenuItem( { name, context } ) {
+	const hasTypographyPanel = useHasTypographyPanel( context );
+	const hasColorPanel = useHasColorPanel( context );
+	const hasBorderPanel = useHasBorderPanel( context );
+	const hasDimensionsPanel = useHasDimensionsPanel( context );
+	const hasLayoutPanel = hasBorderPanel || hasDimensionsPanel;
+	const hasBlockMenuItem =
+		hasTypographyPanel || hasColorPanel || hasLayoutPanel;
+
+	if ( ! hasBlockMenuItem ) {
+		return null;
+	}
+
+	return (
+		<NavigationButton path={ '/blocks/' + name }>
+			{ getPanelTitle( name ) }
+		</NavigationButton>
+	);
+}
+
 function GlobalStylesLevelMenu( { context, parentMenu = '' } ) {
 	const hasTypographyPanel = useHasTypographyPanel( context );
 	const hasColorPanel = useHasColorPanel( context );
@@ -235,13 +255,12 @@ export default function GlobalStylesSidebar() {
 
 				<NavigatorScreen path="/blocks">
 					<ScreenHeader back="/" title={ __( 'Blocks' ) } />
-					{ map( blocks, ( _, name ) => (
-						<NavigationButton
-							path={ '/blocks/' + name }
+					{ map( blocks, ( block, name ) => (
+						<BlockMenuItem
+							name={ name }
+							context={ block }
 							key={ 'menu-itemblock-' + name }
-						>
-							{ getPanelTitle( name ) }
-						</NavigationButton>
+						/>
 					) ) }
 				</NavigatorScreen>
 


### PR DESCRIPTION
This changes the rules of whether to show the block panels in the global styles sidebar in two ways:

 - If the block doesn't support any of the panels, its menu item is removed.
 - Removes the check for "block supports" to decide whether a block support a given panel. Rely solely on theme.json. This change is done here to match the actual behavior of theme.json, For instance: if you add a color to a block that doesn't support the "color panel", the theme.json color is still applied to the block. I felt that the panels at the global styles level should match theme.json and allow all customization for all blocks by default (unless we decide to remove some things in the default theme.json)

**Edit**: The second point above has been reverted (see discussion)