### PR TITLE
Remove font size classes that are enqueued in the global stylesheet

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -8,26 +8,12 @@
 	@include gradient-colors-deprecated();
 }
 
-// Font sizes.
-.has-small-font-size {
-	font-size: 0.8125em;
-}
-
-.has-regular-font-size, // Not used now, kept because of backward compatibility.
-.has-normal-font-size {
+// Font sizes (not used now, kept because of backward compatibility).
+.has-regular-font-size {
 	font-size: 1em;
 }
 
-.has-medium-font-size {
-	font-size: 1.25em;
-}
-
-.has-large-font-size {
-	font-size: 2.25em;
-}
-
-.has-larger-font-size, // Not used now, kept because of backward compatibility.
-.has-huge-font-size {
+.has-larger-font-size {
 	font-size: 2.625em;
 }
 

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -54,28 +54,15 @@
 	@include gradient-colors-deprecated();
 }
 
-// Font sizes.
+// Font sizes (not used now, kept because of backward compatibility).
+//
 // The reason we add the editor class wrapper here is
 // to avoid enqueing the classes twice: here and in ./editor.scss
-.editor-styles-wrapper .has-small-font-size {
-	font-size: 13px;
-}
-
-.editor-styles-wrapper .has-regular-font-size, // Not used now, kept because of backward compatibility.
-.editor-styles-wrapper .has-normal-font-size {
+.editor-styles-wrapper .has-regular-font-size {
 	font-size: 16px;
 }
 
-.editor-styles-wrapper .has-medium-font-size {
-	font-size: 20px;
-}
-
-.editor-styles-wrapper .has-large-font-size {
-	font-size: 36px;
-}
-
-.editor-styles-wrapper .has-larger-font-size, // Not used now, kept because of backward compatibility.
-.editor-styles-wrapper .has-huge-font-size {
+.editor-styles-wrapper .has-larger-font-size {
 	font-size: 42px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/34006
Follows up to what we did for colors https://github.com/WordPress/gutenberg/issues/34138

This removes the CSS classes bundled in the `block-library` package that we're already enqueuing in the global stylesheet, to avoid enqueuing them twice.

## How to test

These classes are only used by themes that don't add a palette on their own, so they use the core presets: small, normal, medium, large, huge.

### Theme with `theme.json`: TT1-blocks

- Use the TT1-blocks.
- Remove the `settings.typography.fontSizes` section.
- Go to the editor (post and/or site) and verify that the font sizes panel has the core sizes available.
- Select one of the sizes for some block and publish.
- The expected behavior is that the size selected is applied both in the editor and frontend.

Also:

- Inspect the contents of the `wp-block-library-css` stylesheet and verify that it only contains classes for `regular` and `larger`.

### Theme without `theme.json`: TwentyTwenty

- Activate the TwentyTwenty theme.
- Open its `functions.php` file and comment this line: `add_theme_support('editor-font-sizes', ... );`
- Go to the editor (post and/or site) and verify that the font sizes panel has the core sizes available.
- Select one of the sizes for some block and publish.
- The expected behavior is that the size selected is applied both in the editor and frontend.

Also:

- Inspect the contents of the `wp-block-library-css` stylesheet and verify that it only contains classes for `regular` and `larger`.