### PR TITLE
Update: Replace tinycolor2 with colord on block library package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18140,12 +18140,19 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.3.1",
+				"colord": "^2.7.0",
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.6",
-				"moment": "^2.22.1",
-				"tinycolor2": "^1.4.2"
+				"moment": "^2.22.1"
+			},
+			"dependencies": {
+				"colord": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
+					"integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA=="
+				}
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -62,12 +62,12 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.3.1",
+		"colord": "^2.7.0",
 		"fast-average-color": "4.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.6",
-		"moment": "^2.22.1",
-		"tinycolor2": "^1.4.2"
+		"moment": "^2.22.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -3,7 +3,8 @@
  */
 import classnames from 'classnames';
 import FastAverageColor from 'fast-average-color';
-import tinycolor from 'tinycolor2';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
 
 /**
  * WordPress dependencies
@@ -64,6 +65,8 @@ import {
 	isContentPositionCenter,
 	getPositionClassName,
 } from './shared';
+
+extend( [ namesPlugin ] );
 
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
@@ -238,7 +241,7 @@ function useCoverIsDark( url, dimRatio = 50, overlayColor, elementRef ) {
 				setIsDark( true );
 				return;
 			}
-			setIsDark( tinycolor( overlayColor ).isDark() );
+			setIsDark( colord( overlayColor ).isDark() );
 		}
 	}, [ overlayColor, dimRatio > 50 || ! url, setIsDark ] );
 	useEffect( () => {


### PR DESCRIPTION
This PR replaces tinycolor2 with colord on the block-library package.



## How has this been tested?
I added a cover block with dark and light overlay colors and verified the block still worked as expected.