### PR TITLE
Navigation Screen: Truncate long menu names

### DIFF
--- a/packages/edit-navigation/src/components/header/menu-actions.js
+++ b/packages/edit-navigation/src/components/header/menu-actions.js
@@ -43,6 +43,9 @@ export default function MenuActions( { menus, isLoading } ) {
 					size="body"
 					className="edit-navigation-menu-actions__subtitle"
 					as="h2"
+					limit={ 24 }
+					ellipsizeMode="tail"
+					truncate
 				>
 					{ decodeEntities( menuName ) }
 				</Text>

--- a/packages/edit-navigation/src/components/name-display/index.js
+++ b/packages/edit-navigation/src/components/name-display/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useContext } from '@wordpress/element';
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -44,7 +48,9 @@ export default function NameDisplay() {
 						setIsMenuNameEditFocused( true );
 					} }
 				>
-					{ menuName }
+					<Text limit={ 24 } ellipsizeMode="tail" truncate>
+						{ menuName }
+					</Text>
 				</ToolbarButton>
 			</ToolbarGroup>
 		</BlockControls>


### PR DESCRIPTION
## Description
Truncate long menu names after 24 characters.

P.S. We probably need to use a different approach for long menu names in the dropdown.

Partially fixes #34512.

## How has this been tested?
1. Go to Gutenberg > Navigation (beta)
2. Create a Menu with a long name (more than 24 chars).
3. See the menu name truncated in the header and block toolbar.

## Screenshots <!-- if applicable -->
![CleanShot 2021-09-28 at 16 17 10](https://user-images.githubusercontent.com/240569/135085680-b1d89d65-b13c-4a91-a84e-e14328be4d60.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
