### PR TITLE
Fix native BlockAlignmentControl

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/test/index.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.native.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from 'test/helpers';
+
+/**
+ * Internal dependencies
+ */
+import BlockAlignmentUI from '../ui';
+
+it( 'should call onChange with undefined, when the control is already active', () => {
+	const onChangeMock = jest.fn();
+	const screen = render(
+		<BlockAlignmentUI value="left" onChange={ onChangeMock } />
+	);
+	const alignButton = screen.getByA11yLabel( 'Align' );
+	fireEvent.press( alignButton );
+	const noneAlignmentButton = screen.getByA11yLabel( 'None' );
+	fireEvent.press( noneAlignmentButton );
+
+	expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
+	expect( onChangeMock ).toHaveBeenCalledWith( undefined );
+} );
+
+it( 'should call onChange with alignment value when the control is inactive', () => {
+	const onChangeMock = jest.fn();
+	const screen = render(
+		<BlockAlignmentUI value="left" onChange={ onChangeMock } />
+	);
+	const alignButton = screen.getByA11yLabel( 'Align' );
+	fireEvent.press( alignButton );
+	const noneAlignmentButton = screen.getByA11yLabel( 'Align center' );
+	fireEvent.press( noneAlignmentButton );
+
+	expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
+	expect( onChangeMock ).toHaveBeenCalledWith( 'center' );
+} );

--- a/packages/block-editor/src/components/block-alignment-control/test/index.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.native.js
@@ -8,7 +8,7 @@ import { render, fireEvent } from 'test/helpers';
  */
 import BlockAlignmentUI from '../ui';
 
-it( 'should call onChange with undefined, when the control is already active', () => {
+it( 'should call onChange with undefined when the control is already active', () => {
 	const onChangeMock = jest.fn();
 	const screen = render(
 		<BlockAlignmentUI value="right" onChange={ onChangeMock } />

--- a/packages/block-editor/src/components/block-alignment-control/test/index.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.native.js
@@ -11,12 +11,12 @@ import BlockAlignmentUI from '../ui';
 it( 'should call onChange with undefined, when the control is already active', () => {
 	const onChangeMock = jest.fn();
 	const screen = render(
-		<BlockAlignmentUI value="left" onChange={ onChangeMock } />
+		<BlockAlignmentUI value="right" onChange={ onChangeMock } />
 	);
 	const alignButton = screen.getByA11yLabel( 'Align' );
 	fireEvent.press( alignButton );
-	const noneAlignmentButton = screen.getByA11yLabel( 'None' );
-	fireEvent.press( noneAlignmentButton );
+	const rightAlignmentButton = screen.getByA11yLabel( 'Align right' );
+	fireEvent.press( rightAlignmentButton );
 
 	expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 	expect( onChangeMock ).toHaveBeenCalledWith( undefined );
@@ -29,8 +29,8 @@ it( 'should call onChange with alignment value when the control is inactive', ()
 	);
 	const alignButton = screen.getByA11yLabel( 'Align' );
 	fireEvent.press( alignButton );
-	const noneAlignmentButton = screen.getByA11yLabel( 'Align center' );
-	fireEvent.press( noneAlignmentButton );
+	const centerAlignmentButton = screen.getByA11yLabel( 'Align center' );
+	fireEvent.press( centerAlignmentButton );
 
 	expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 	expect( onChangeMock ).toHaveBeenCalledWith( 'center' );

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -21,6 +21,7 @@ import {
 	stretchFullWidth,
 	stretchWide,
 } from '@wordpress/icons';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -91,69 +92,72 @@ function BlockAlignmentUI( {
 		label: __( 'Align' ),
 		toggleProps: { describedBy: __( 'Change alignment' ) },
 	};
-	const extraProps = isToolbar
-		? {
-				isCollapsed,
-				controls: enabledControls.map( ( { name: controlName } ) => {
-					return {
-						...BLOCK_ALIGNMENTS_CONTROLS[ controlName ],
-						isActive:
-							value === controlName ||
-							( ! value && controlName === 'none' ),
-						role: isCollapsed ? 'menuitemradio' : undefined,
-						onClick: () => onChangeAlignment( controlName ),
-					};
-				} ),
-		  }
-		: {
-				children: ( { onClose } ) => {
-					return (
-						<>
-							<MenuGroup className="block-editor-block-alignment-control__menu-group">
-								{ enabledControls.map(
-									( { name: controlName, info } ) => {
-										const {
-											icon,
-											title,
-										} = BLOCK_ALIGNMENTS_CONTROLS[
-											controlName
-										];
-										// If no value is provided, mark as selected the `none` option.
-										const isSelected =
-											controlName === value ||
-											( ! value &&
-												controlName === 'none' );
-										return (
-											<MenuItem
-												key={ controlName }
-												icon={ icon }
-												iconPosition="left"
-												className={ classNames(
-													'components-dropdown-menu__menu-item',
-													{
-														'is-active': isSelected,
-													}
-												) }
-												isSelected={ isSelected }
-												onClick={ () => {
-													onChangeAlignment(
-														controlName
-													);
-													onClose();
-												} }
-												role="menuitemradio"
-												info={ info }
-											>
-												{ title }
-											</MenuItem>
-										);
-									}
-								) }
-							</MenuGroup>
-						</>
-					);
-				},
-		  };
+	const extraProps =
+		isToolbar || Platform.isNative
+			? {
+					isCollapsed: isToolbar ? isCollapsed : undefined,
+					controls: enabledControls.map(
+						( { name: controlName } ) => {
+							return {
+								...BLOCK_ALIGNMENTS_CONTROLS[ controlName ],
+								isActive:
+									value === controlName ||
+									( ! value && controlName === 'none' ),
+								role: isCollapsed ? 'menuitemradio' : undefined,
+								onClick: () => onChangeAlignment( controlName ),
+							};
+						}
+					),
+			  }
+			: {
+					children: ( { onClose } ) => {
+						return (
+							<>
+								<MenuGroup className="block-editor-block-alignment-control__menu-group">
+									{ enabledControls.map(
+										( { name: controlName, info } ) => {
+											const {
+												icon,
+												title,
+											} = BLOCK_ALIGNMENTS_CONTROLS[
+												controlName
+											];
+											// If no value is provided, mark as selected the `none` option.
+											const isSelected =
+												controlName === value ||
+												( ! value &&
+													controlName === 'none' );
+											return (
+												<MenuItem
+													key={ controlName }
+													icon={ icon }
+													iconPosition="left"
+													className={ classNames(
+														'components-dropdown-menu__menu-item',
+														{
+															'is-active': isSelected,
+														}
+													) }
+													isSelected={ isSelected }
+													onClick={ () => {
+														onChangeAlignment(
+															controlName
+														);
+														onClose();
+													} }
+													role="menuitemradio"
+													info={ info }
+												>
+													{ title }
+												</MenuItem>
+											);
+										}
+									) }
+								</MenuGroup>
+							</>
+						);
+					},
+			  };
 
 	return <UIComponent { ...commonProps } { ...extraProps } />;
 }

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -135,4 +135,7 @@ module.exports = {
 	buttonNoBg: {
 		color: 'orange',
 	},
+	isSelected: {
+		color: 'blue',
+	},
 };


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4042

## Description
Fixes #35173. Relates to #34710. A recent web-centric change introduced usage of `MenuGroup` and `MenuItem`, both of which are unsupported in the native editor currently. This updates the conditional within `BlockAlignmentControl` to reinstate the previous UI for the native platform.

## How has this been tested?

### Native Alignment

1. Add a Cover block within the editor. 
2. Press the Alignment icon within the block toolbar. 
3. Change the selected alignment from None to another option.
4. **Expected:** Verify the correct alignment is persisted for the block. 

### Web Alignment
Complete Testing Instructions found in https://github.com/WordPress/gutenberg/pull/34710. 

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
