### PR TITLE
Post Template: Remove margins from the block

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -5,6 +5,8 @@
 // See: https://github.com/WordPress/gutenberg/pull/32514.
 // TODO: Remove this class when WordPress 5.9 is released.
 .wp-block-query-loop {
+	margin-top: 0;
+	margin-bottom: 0;
 	max-width: 100%;
 	list-style: none;
 	padding: 0;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This removes the top and bottom margins from the post template block. These margins come from the user agent stylesheet for the browser, but they should probably be removed so that they don't cause surprising gaps when used.

## How has this been tested?
- In emptytheme (see screenshots)
- You can also see the impact on other themes here: https://github.com/Automattic/themes/pull/4726

## Screenshots <!-- if applicable -->
<img width="929" alt="Screenshot 2021-09-28 at 17 43 35" src="https://user-images.githubusercontent.com/275961/135130458-97ecbc0c-2ccb-4b21-a5db-3c0aa2795ce2.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
