### PR TITLE
Block Editor: Allow other blocks to use the slash inserter

### DIFF
--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -12,7 +12,7 @@ import {
 	__unstableUseAutocompleteProps as useAutocompleteProps,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
-import { getDefaultBlockName } from '@wordpress/blocks';
+import { getDefaultBlockName, getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -33,7 +33,10 @@ function useCompleters( { completers = EMPTY_ARRAY } ) {
 	return useMemo( () => {
 		let filteredCompleters = completers;
 
-		if ( name === getDefaultBlockName() ) {
+		if (
+			name === getDefaultBlockName() ||
+			getBlockSupport( name, '__experimentalSlashInserter', false )
+		) {
 			filteredCompleters = filteredCompleters.concat( [
 				blockAutocompleter,
 			] );

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -57,7 +57,8 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-navigation-link-editor",
 	"style": "wp-block-navigation-link"


### PR DESCRIPTION
A small part of #34041

> Let's consider supporting / on empty menu labels similar to how empty paragraphs allow both direct writing or switching to a more specific block type.

This PR explores allowing blocks other than the default block to use the slash inserter, starting with navigation links. Note that the slash inserter does not include block variations.

I'm not sure how useful this is in particular for the navigation-link case, but I do think it'd be interesting to allow  more blocks to use the slash inserter.

#### Post Editor

https://user-images.githubusercontent.com/1270189/135158455-453ae0b0-fe4b-4206-93e2-925d45e70ca8.mp4

#### Navigation Editor

https://user-images.githubusercontent.com/1270189/135158480-e1c5dde9-de55-4ead-813a-99520be4ca5e.mp4

#### Widget Editor

https://user-images.githubusercontent.com/1270189/135159129-51704656-c0a8-4d05-82d6-dbf374dd256d.mp4

#### Site Editor

https://user-images.githubusercontent.com/1270189/135159435-193bc126-ce37-4dc1-9048-4be5a5078572.mp4

### Testing Instructions

- Verify that there are no regressions in the paragraph slash inserter
- Verify that only the default block and navigation link may trigger the slash inserter
- Enable the Navigation Editor at `/wp-admin/admin.php?page=gutenberg-experiments`
- Visit `/wp-admin/admin.php?page=gutenberg-navigation` Typing a forward slash should show an option to transform to a submenu
- Visit the post, site or widget editor
- Try adding the Navigation block, then type a forward slash in an empty menu item
- We should see an option to transform to other blocks that are insertable in the navigation block

