### PR TITLE
Mobile Release v1.63.0-alpha2

### DIFF
--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.62.0",
+	"version": "1.63.0-alpha2",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.62.0",
+	"version": "1.63.0-alpha2",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - BVLinearGradient (2.5.6-wp):
+  - BVLinearGradient (2.5.6-wp-1):
     - React-Core
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.64.0)
@@ -12,7 +12,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - Gutenberg (1.62.0):
+  - Gutenberg (1.63.0-alpha2):
     - React-Core (= 0.64.0)
     - React-CoreModules (= 0.64.0)
     - React-RCTImage (= 0.64.0)
@@ -212,22 +212,22 @@ PODS:
   - React-jsinspector (0.64.0)
   - react-native-blur (0.8.0):
     - React-Core
-  - react-native-get-random-values (1.4.0-wp):
+  - react-native-get-random-values (1.4.0-wp-1):
     - React-Core
-  - react-native-keyboard-aware-scroll-view (0.8.8-wp):
+  - react-native-keyboard-aware-scroll-view (0.8.8-wp-1):
     - React-Core
   - react-native-safe-area (0.5.1):
     - React-Core
-  - react-native-safe-area-context (3.2.0-wp):
+  - react-native-safe-area-context (3.2.0-wp-1):
     - React-Core
-  - react-native-slider (3.0.2-wp):
+  - react-native-slider (3.0.2-wp-1):
     - React-Core
-  - react-native-video (5.0.2-wp):
+  - react-native-video (5.0.2-wp-1):
     - React-Core
-    - react-native-video/Video (= 5.0.2-wp)
-  - react-native-video/Video (5.0.2-wp):
+    - react-native-video/Video (= 5.0.2-wp-1)
+  - react-native-video/Video (5.0.2-wp-1):
     - React-Core
-  - react-native-webview (11.6.5-wp):
+  - react-native-webview (11.6.5-wp-1):
     - React-Core
   - React-perflogger (0.64.0)
   - React-RCTActionSheet (0.64.0):
@@ -293,17 +293,17 @@ PODS:
     - React-cxxreact (= 0.64.0)
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
-  - RNCMaskedView (0.1.11-wp):
+  - RNCMaskedView (0.1.11-wp-1):
     - React-Core
-  - RNGestureHandler (1.10.1-wp):
+  - RNGestureHandler (1.10.1-wp-3):
     - React-Core
-  - RNReanimated (1.9.0-wp):
+  - RNReanimated (1.9.0-wp-1):
     - React-Core
-  - RNScreens (2.9.0-wp):
+  - RNScreens (2.9.0-wp-1):
     - React-Core
-  - RNSVG (9.13.7-wp):
+  - RNSVG (9.13.7-wp-1):
     - React-Core
-  - RNTAztecView (1.62.0):
+  - RNTAztecView (1.63.0-alpha2):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - WordPress-Aztec-iOS (1.19.4)
@@ -454,12 +454,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  BVLinearGradient: 2c791e973a3df0df46028210c530fde52c06b717
+  BVLinearGradient: 1e5474c982efcfcaed47f368a61431bb38a4faf8
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 3c357ea1a6e11209364d830bed4ebc7a365842d8
+  FBReactNativeSpec: 483e4a3c2982c1ce57d08e90fea6be852dd5f691
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  Gutenberg: 0ea95bc356704688b56f14f8770654431bfc5f33
+  Gutenberg: 73d21f3814fdef027d8b641540df51c2feb2108e
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -472,13 +472,13 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
   React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
   react-native-blur: ef741a08d020010ba65e411be0ab82d1d325e7ad
-  react-native-get-random-values: 039c6213009a5df04637cf1d156a680031ea314c
-  react-native-keyboard-aware-scroll-view: 9d85917882c9ac0ec66e09234bc23e3ceee70cc1
+  react-native-get-random-values: b3910975884a214fde519ccc0ad060b96d8f4720
+  react-native-keyboard-aware-scroll-view: 0bc6c2dfe9056935a40dc1a70e764b7a1bbf6568
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: a009bc6258899017cc2614c7934aefec8c396a52
-  react-native-slider: 7109c55a87870d6b55e958c3c16a5900d66b4be8
-  react-native-video: a84c5b1d4f2247040b205ea110528c8fdc147bce
-  react-native-webview: a182c691cb1ed627c0d407685630a9a0407a4853
+  react-native-safe-area-context: 2bcfa0394571ebd9b70ecb87d5befe820bad2778
+  react-native-slider: 31130ff825e659fcb1b4e77d24862d6eb11e6fe1
+  react-native-video: 7468eb0a48e7b0bb87d0802b47323de5f1b73697
+  react-native-webview: d316be87c0b8064745a45f76ee7f134e72b2c4e8
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -491,12 +491,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
-  RNCMaskedView: 089bae27289744b9e736c324f0555878282a5c9a
-  RNGestureHandler: fffc3fd24c69f3e682aca052b5559cd309231932
-  RNReanimated: ca6105fdc2739ea1b3a7a5350b6490d8160143bc
-  RNScreens: eb4e23256e7f2a5a1af87ea24dfeb49aea0ef310
-  RNSVG: 1b6dcbec5884b6dbe256bf8c38eeeab0acf05926
-  RNTAztecView: ea6033be7e71f903c345198feb7da2c52dafb083
+  RNCMaskedView: a181e39d197c0bfdc7bf353633b8379e63daa1f9
+  RNGestureHandler: a9e943d7058aa16347895e32c9734e22f09e74a7
+  RNReanimated: 39a9478eb635667c9a4da08ac906add9901b145e
+  RNScreens: 185dcb481fab2f3dc77413f62b43dc3df826029c
+  RNSVG: 9c0db12736608e32841e90fe9773db70ea40de20
+  RNTAztecView: 29dcb58349d9a5e5e78502a6be47e1473800758c
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.62.0",
+	"version": "1.63.0-alpha2",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.63.0-alpha2 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4046

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->