### PR TITLE
RNMobile: Improve performance of getPxFromCssUnit

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -428,7 +428,7 @@ _Returns_
 
 ### getPxFromCssUnit
 
-Returns the px value of a cssUnit.
+Returns the px value of a cssUnit. The memoized version of getPxFromCssUnit;
 
 _Parameters_
 

--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -131,6 +131,7 @@ function evalMathExpression( cssUnit ) {
 
 	return errorFound ? null : calculate( cssUnit ).toFixed( 0 ) + 'px';
 }
+
 /**
  * Convert a parsedUnit object to px value.
  *
@@ -202,6 +203,7 @@ function convertParsedUnitToPx( parsedUnit, options ) {
 
 	return null;
 }
+
 /**
  * Returns the px value of a cssUnit.
  *
@@ -209,7 +211,7 @@ function convertParsedUnitToPx( parsedUnit, options ) {
  * @param {string} options
  * @return {string} returns the cssUnit value in a simple px format.
  */
-function getPxFromCssUnit( cssUnit, options = {} ) {
+export function getPxFromCssUnit( cssUnit, options = {} ) {
 	if ( Number.isFinite( cssUnit ) ) {
 		return cssUnit.toFixed( 0 ) + 'px';
 	}
@@ -229,4 +231,42 @@ function getPxFromCssUnit( cssUnit, options = {} ) {
 	return convertParsedUnitToPx( parsedUnit, options );
 }
 
-export default getPxFromCssUnit;
+// Use simple cache.
+const cache = {};
+/**
+ * Returns the px value of a cssUnit. The memoized version of getPxFromCssUnit;
+ *
+ * @param {string} cssUnit
+ * @param {string} options
+ * @return {string} returns the cssUnit value in a simple px format.
+ */
+function memoizedGetPxFromCssUnit( cssUnit, options = {} ) {
+	const hash = cssUnit + hashOptions( options );
+
+	if ( ! cache[ hash ] ) {
+		cache[ hash ] = getPxFromCssUnit( cssUnit, options );
+	}
+	return cache[ hash ];
+}
+
+function hashOptions( options ) {
+	let hash = '';
+	if ( options.hasOwnProperty( 'fontSize' ) ) {
+		hash = ':' + options.width;
+	}
+	if ( options.hasOwnProperty( 'lineHeight' ) ) {
+		hash = ':' + options.lineHeight;
+	}
+	if ( options.hasOwnProperty( 'width' ) ) {
+		hash = ':' + options.width;
+	}
+	if ( options.hasOwnProperty( 'height' ) ) {
+		hash = ':' + options.height;
+	}
+	if ( options.hasOwnProperty( 'type' ) ) {
+		hash = ':' + options.type;
+	}
+	return hash;
+}
+
+export default memoizedGetPxFromCssUnit;

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { default as getPxFromCssUnit } from '../parse-css-unit-to-px';
+import {
+	default as memoizedGetPxFromCssUnit,
+	getPxFromCssUnit,
+} from '../parse-css-unit-to-px';
 
 describe( 'getPxFromCssUnit', () => {
 	// Absolute units
@@ -179,5 +182,25 @@ describe( 'getPxFromCssUnit', () => {
 
 	it( 'test not a typo function return null', () => {
 		expect( getPxFromCssUnit( 'calc(12vw * 10px' ) ).toBe( null );
+	} );
+
+	it( 'test performance of memoizedGetPxFromCssUnit function', () => {
+		const start = Date.now();
+		let i = 0;
+		const intervals = 1000;
+		while ( i < intervals ) {
+			getPxFromCssUnit( 'max(25px, 35px)', { width: 200 } );
+			i++;
+		}
+		const rawDuration = Date.now() - start;
+
+		const startM = Date.now();
+		i = 0;
+		// the memoized Version should be at 10X better then the non default one.
+		while ( i < intervals * 10 ) {
+			memoizedGetPxFromCssUnit( 'max(25px, 35px)', { width: 201 } );
+			i++;
+		}
+		expect( rawDuration > Date.now() - startM ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
This PR impoves the performance of the getPxFromCssUnit.

## Description
Once https://github.com/WordPress/gutenberg/pull/35167 is merged we will be calling the `getPxFromCssUnit` a lot more times. This pr makes it so that the function is about 10x more performant. 
The performance gains are due to "caching" the output of the function and storing it in a key-value pair.

## How has this been tested?
We added a unit test that shows that the performance is at least 10x more than the current implementation. 
\
## Types of changes
Performance improvements

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
