### PR TITLE
Range control marks center aligned

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -139,7 +139,7 @@ export const Mark = styled.span`
 	height: 9px;
 	left: 0;
 	position: absolute;
-	top: -4px;
+	top: -7px;
 	width: 1px;
 
 	${ markFill };


### PR DESCRIPTION
## Description
The top parameter of the marks stylings is set to `top: -7px`, due to which it will align the marks to the center of the track. This is tested in the` storybook`. 

##Screenshot
https://www.awesomescreenshot.com/image/14183951?key=b3ec1c94ec68ebfb5c10903b915778b4

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] I've tested my changes with keyboard and screen readers. 
- [x] My code has proper inline documentation. 
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

