### PR TITLE
File Block: Only display PDF preview height `RangeControl` when embed is enabled.

### DIFF
--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -54,16 +54,18 @@ export default function FileBlockInspector( {
 							checked={ !! displayPreview }
 							onChange={ changeDisplayPreview }
 						/>
-						<RangeControl
-							label={ __( 'Height in pixels' ) }
-							min={ MIN_PREVIEW_HEIGHT }
-							max={ Math.max(
-								MAX_PREVIEW_HEIGHT,
-								previewHeight
-							) }
-							value={ previewHeight }
-							onChange={ changePreviewHeight }
-						/>
+						{ displayPreview && (
+							<RangeControl
+								label={ __( 'Height in pixels' ) }
+								min={ MIN_PREVIEW_HEIGHT }
+								max={ Math.max(
+									MAX_PREVIEW_HEIGHT,
+									previewHeight
+								) }
+								value={ previewHeight }
+								onChange={ changePreviewHeight }
+							/>
+						) }
 					</PanelBody>
 				) }
 				<PanelBody title={ __( 'Text link settings' ) }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Hides the PDF preview height `RangeControl` when embed is not enabled.

Fixes: #35195

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested, with `wp-env`:

- Add File Block
- Select a PDF
- Within the block's settings, in PDF Settings, toggle the preview to disabled.
- Notice that the height control doesn't display
- Toggle the preview to enabled
- Notice that the height control is displayed again 

## Screenshots <!-- if applicable -->
Before:

https://user-images.githubusercontent.com/1034160/135212007-5863bb43-06f5-4a5f-9bba-dce25cb7a072.mov


After:

https://user-images.githubusercontent.com/1034160/135211975-dd51ba61-fd7a-4ace-a446-ee6ab05fccfa.mov


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
