### PR TITLE
Block gap: Only render CSS variable if corresponding theme setting is enabled

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -267,10 +267,15 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Protected style properties.
 	 *
-	 * These properties are only rendered if a corresponding setting in the
-	 * `PROPERTIES_METADATA` path enables it via a value other than `null`.
+	 * These style properties are only rendered if a setting enables it
+	 * via a value other than `null`.
+	 *
+	 * Each element maps the style property to the corresponding theme.json
+	 * setting key.
 	 */
-	const PROTECTED_PROPERTIES = array( '--wp--style--block-gap' );
+	const PROTECTED_PROPERTIES = array(
+		'spacing.blockGap' => array( 'spacing', 'blockGap' )
+	);
 
 	const ELEMENTS = array(
 		'link' => 'a',
@@ -594,9 +599,14 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $properties as $css_property => $value_path ) {
 			$value = self::get_property_value( $styles, $value_path );
 
+			// Look up protected properties, keyed by value path.
 			// Skip protected properties that are explicitly set to `null`.
-			if ( in_array( $css_property, self::PROTECTED_PROPERTIES, true ) ) {
-				if ( _wp_array_get( $settings, $value_path, null ) === null ) {
+			if ( is_array( $value_path ) ) {
+				$path_string = implode( '.', $value_path );
+				if (
+					isset( self::PROTECTED_PROPERTIES[ $path_string ] ) &&
+					_wp_array_get( $settings, self::PROTECTED_PROPERTIES[ $path_string ], null ) === null
+				) {
 					continue;
 				}
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -268,7 +268,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Protected style properties.
 	 *
 	 * These properties are only rendered if a corresponding setting in the
-	 * `PROPERTIES_METADATA` path enables it.
+	 * `PROPERTIES_METADATA` path enables it via a value other than `null`.
 	 */
 	const PROTECTED_PROPERTIES = array( '--wp--style--block-gap' );
 
@@ -594,8 +594,8 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $properties as $css_property => $value_path ) {
 			$value = self::get_property_value( $styles, $value_path );
 
-			if ( in_array( $css_property, self::PROTECTED_PROPERTIES ) ) {
-				if ( ! _wp_array_get( $settings, $value_path, false ) ) {
+			if ( in_array( $css_property, self::PROTECTED_PROPERTIES, true ) ) {
+				if ( _wp_array_get( $settings, $value_path, null ) === null ) {
 					continue;
 				}
 			}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -274,7 +274,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * setting key.
 	 */
 	const PROTECTED_PROPERTIES = array(
-		'spacing.blockGap' => array( 'spacing', 'blockGap' )
+		'spacing.blockGap' => array( 'spacing', 'blockGap' ),
 	);
 
 	const ELEMENTS = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -594,6 +594,7 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $properties as $css_property => $value_path ) {
 			$value = self::get_property_value( $styles, $value_path );
 
+			// Skip protected properties that are explicitly set to `null`.
 			if ( in_array( $css_property, self::PROTECTED_PROPERTIES, true ) ) {
 				if ( _wp_array_get( $settings, $value_path, null ) === null ) {
 					continue;

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -234,6 +234,63 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_get_stylesheet_skips_disabled_protected_properties() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing'    => array(
+						'blockGap' => null,
+					),
+				),
+				'styles'   => array(
+					'spacing'    => array(
+						'blockGap' => '1em',
+					),
+					'blocks'   => array(
+						'core/columns' => array(
+							'spacing'  => array(
+								'blockGap' => '24px',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( 'block_styles' ) );
+	}
+
+	function test_get_stylesheet_renders_enabled_protected_properties() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing'    => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing'    => array(
+						'blockGap' => '1em',
+					),
+					'blocks'   => array(
+						'core/columns' => array(
+							'spacing'  => array(
+								'blockGap' => '24px',
+							),
+						),
+					),
+				),
+			)
+		);
+		$expected = 'body{--wp--style--block-gap: 1em;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }.wp-block-columns{--wp--style--block-gap: 24px;}';
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( 'block_styles' ) );
+	}
+
 	function test_get_stylesheet() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -239,17 +239,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'spacing'    => array(
+					'spacing' => array(
 						'blockGap' => null,
 					),
 				),
 				'styles'   => array(
-					'spacing'    => array(
+					'spacing' => array(
 						'blockGap' => '1em',
 					),
-					'blocks'   => array(
+					'blocks'  => array(
 						'core/columns' => array(
-							'spacing'  => array(
+							'spacing' => array(
 								'blockGap' => '24px',
 							),
 						),
@@ -268,17 +268,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'spacing'    => array(
+					'spacing' => array(
 						'blockGap' => true,
 					),
 				),
 				'styles'   => array(
-					'spacing'    => array(
+					'spacing' => array(
 						'blockGap' => '1em',
 					),
-					'blocks'   => array(
+					'blocks'  => array(
 						'core/columns' => array(
-							'spacing'  => array(
+							'spacing' => array(
 								'blockGap' => '24px',
 							),
 						),
@@ -286,6 +286,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			)
 		);
+
 		$expected = 'body{--wp--style--block-gap: 1em;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }.wp-block-columns{--wp--style--block-gap: 24px;}';
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( 'block_styles' ) );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #35197

In #35197 it's described that rendering the `--wp--style--block-gap` CSS variable globally when the block gap setting hasn't been explicitly opted in-to, could result in styling regressions on classic themes that use `add_theme_support( 'experimental-link-color' );` if we're to proceed with updating Button block styling to use the new CSS variable.

In this PR, we're exploring skipping rendering the CSS variable if the corresponding setting in `theme.json` is set to `null`. The mechanism is to add a list of protected properties, and for these particular properties, only render them if their corresponding setting in `theme.json` is not null. This behaviour is consistent with the approach in #34491 to opt out of generating block gap styling. The extension here is to also skip rendering the CSS variable itself.

This is just one particular approach to solving the issue, so please let me know if you think it's a bad idea, or if you can think of a better way to handle it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

With TwentyTwentyOne theme enabled, open up the post editor and inspect element, and find the set of four or so `style` elements that sit underneath the visual editor component. Before this PR is applied, you should see that the global `--wp--style--block-gap` CSS variable is rendered.

With this PR applied, it should no longer render that variable with that theme active.

With TT1-Blocks active, and `settings.spacing.blockGap` enabled in the `theme.json` file, then the CSS variable should be rendered.

With TT1-Blocks active, and `settings.spacing.blockGap` set to `null` in the `theme.json` file, then the CSS variable should not be rendered.

## Screenshots <!-- if applicable -->

| TwentyTwentyOne theme before | TwentyTwentyOne theme after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/135223252-fc14eda3-e792-46b5-bf84-1612ff787fd7.png) | ![image](https://user-images.githubusercontent.com/14988353/135223372-ccaaebdf-f15f-4405-98ff-927c6e7309fc.png) |

TT1-Blocks (should remain unaffected when the `settings.spacing.blockGap` setting is enabled in `theme.json`:

![image](https://user-images.githubusercontent.com/14988353/135223495-7dfdefcd-f86c-40f5-84bf-569eebc86d20.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md --> (N/A)
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
