### PR TITLE
Edit Site: Optimize useSelect calls

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -139,7 +139,7 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 			blockTypes: select( blocksStore ).getBlockTypes(),
 			settings: select( editSiteStore ).getSettings(),
 		};
-	} );
+	}, [] );
 	const { updateSettings } = useDispatch( editSiteStore );
 
 	const blocks = useMemo( () => getBlockMetadata( blockTypes ), [

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
-	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const hasRedo = useSelect(
+		( select ) => select( coreStore ).hasRedo(),
+		[]
+	);
 	const { redo } = useDispatch( coreStore );
 	return (
 		<Button

--- a/packages/edit-site/src/components/header/undo-redo/undo.js
+++ b/packages/edit-site/src/components/header/undo-redo/undo.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function UndoButton() {
-	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const hasUndo = useSelect(
+		( select ) => select( coreStore ).hasUndo(),
+		[]
+	);
 	const { undo } = useDispatch( coreStore );
 	return (
 		<Button

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -19,8 +19,9 @@ import { SIDEBAR_BLOCK } from '../sidebar/constants';
 import { STORE_NAME } from '../../store/constants';
 
 function KeyboardShortcuts() {
-	const isListViewOpen = useSelect( ( select ) =>
-		select( editSiteStore ).isListViewOpened()
+	const isListViewOpen = useSelect(
+		( select ) => select( editSiteStore ).isListViewOpened(),
+		[]
 	);
 	const isBlockInspectorOpen = useSelect(
 		( select ) =>

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -19,7 +19,7 @@ export const {
 export default function NavigationSidebar() {
 	const isNavigationOpen = useSelect( ( select ) => {
 		return select( editSiteStore ).isNavigationOpened();
-	} );
+	}, [] );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -27,7 +27,7 @@ export default function SaveButton( {
 				isSavingEntityRecord( record.kind, record.name, record.key )
 			),
 		};
-	} );
+	}, [] );
 
 	const disabled = ! isDirty || isSaving;
 

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -20,7 +20,7 @@ export default function TemplatePartConverter() {
 			clientIds: selectedBlockClientIds,
 			blocks: getBlocksByClientId( selectedBlockClientIds ),
 		};
-	} );
+	}, [] );
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -72,5 +72,5 @@ function useCurrentPageContext() {
 		}
 
 		return null;
-	} );
+	}, [] );
 }


### PR DESCRIPTION
## Description
Adds missing dependency arrays to `useSelect` calls to memorize selector callbacks in the `@wordpress/edit-site` package.

Similar PR #23255.

## How has this been tested?
The site editor works as expected.

## Types of changes
Code Quality/Perfromance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
