### PR TITLE
Add a beta indicator for the global styles sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -221,6 +221,9 @@ export default function GlobalStylesSidebar() {
 			header={
 				<>
 					<strong>{ __( 'Styles' ) }</strong>
+					<span className="edit-site-global-styles-sidebar__beta">
+						{ __( 'Beta' ) }
+					</span>
 					<Button
 						className="edit-site-global-styles-sidebar__reset-button"
 						isSmall

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -76,4 +76,5 @@
 	color: $white;
 	align-items: center;
 	font-size: $helptext-font-size;
+	line-height: 1;
 }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -65,3 +65,15 @@
 .edit-site-global-styles-color-palette-panel {
 	padding: $grid-unit-20;
 }
+
+.edit-site-global-styles-sidebar__beta {
+	display: inline-flex;
+	margin-left: $grid-unit-10;
+	padding: 0 $grid-unit-10;
+	height: $grid-unit-30;
+	border-radius: $radius-block-ui;
+	background-color: $black;
+	color: $white;
+	align-items: center;
+	font-size: $helptext-font-size;
+}


### PR DESCRIPTION
<img width="268" alt="Screen Shot 2021-09-29 at 2 48 08 PM" src="https://user-images.githubusercontent.com/272444/135281854-5a6b055a-48e1-4973-9b1a-b39d0a8e3daa.png">

While we iterate during the 5.9 lifecycle, let's add a "beta" indicator to the global styles sidebar to clarify its status. Once it's a decent state for 5.9, we should be able to remove it.