### PR TITLE
List View: render a fixed number of items

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -40,6 +40,7 @@ const config = require( '../config' );
  * @property {number[]} inserterOpen         Average time to open global inserter.
  * @property {number[]} inserterSearch       Average time to search the inserter.
  * @property {number[]} inserterHover        Average time to move mouse between two block item in the inserter.
+ * @property {number[]} listViewOpen         Average time to open listView
  */
 
 /**
@@ -52,7 +53,7 @@ const config = require( '../config' );
  * @property {number=} firstContentfulPaint Represents the time when the browser first renders any text or media.
  * @property {number=} firstBlock           Represents the time when Puppeteer first sees a block selector in the DOM.
  * @property {number=} type                 Average type time.
- * @property {number=} minType              Minium type time.
+ * @property {number=} minType              Minimum type time.
  * @property {number=} maxType              Maximum type time.
  * @property {number=} focus                Average block selection time.
  * @property {number=} minFocus             Min block selection time.
@@ -66,6 +67,9 @@ const config = require( '../config' );
  * @property {number=} inserterHover        Average time to move mouse between two block item in the inserter.
  * @property {number=} minInserterHover     Min time to move mouse between two block item in the inserter.
  * @property {number=} maxInserterHover     Max time to move mouse between two block item in the inserter.
+ * @property {number=} listViewOpen         Average time to open list view.
+ * @property {number=} minListViewOpen      Min time to open list view.
+ * @property {number=} maxListViewOpen      Max time to open list view.
  */
 
 /**
@@ -136,6 +140,9 @@ function curateResults( results ) {
 		inserterHover: average( results.inserterHover ),
 		minInserterHover: Math.min( ...results.inserterHover ),
 		maxInserterHover: Math.max( ...results.inserterHover ),
+		listViewOpen: average( results.listViewOpen ),
+		minListViewOpen: Math.min( ...results.listViewOpen ),
+		maxListViewOpen: Math.max( ...results.listViewOpen ),
 	};
 }
 
@@ -377,6 +384,15 @@ async function runPerformanceTests( branches, options ) {
 					),
 					maxInserterHover: rawResults.map(
 						( r ) => r[ branch ].maxInserterHover
+					),
+					listViewOpen: rawResults.map(
+						( r ) => r[ branch ].listViewOpen
+					),
+					minListViewOpen: rawResults.map(
+						( r ) => r[ branch ].minListViewOpen
+					),
+					maxListViewOpen: rawResults.map(
+						( r ) => r[ branch ].maxListViewOpen
 					),
 				},
 				median

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Performance
 
--   Avoid re-rendering all List View items on block focus [#35706](https://github.com/WordPress/gutenberg/pull/35706). These changes speed up block focus time in large posts by 80% when List View is open.
+-   Avoid re-rendering all List View items on block focus [#35706](https://github.com/WordPress/gutenberg/pull/35706). When List View is open Block focus time is 4 times faster in large posts.
+-   Render fixed number of items in List View [#35706](https://github.com/WordPress/gutenberg/pull/35230). Opening List View is 13 times faster in large posts.
 
 ### Breaking change
 

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -39,6 +39,7 @@ export default function ListViewBlock( {
 	showBlockMovers,
 	path,
 	isExpanded,
+	style,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -184,6 +185,7 @@ export default function ListViewBlock( {
 					className="block-editor-list-view-block__contents-cell"
 					colSpan={ colSpan }
 					ref={ cellRef }
+					style={ style }
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
 						<div className="block-editor-list-view-block__contents-container">

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -39,7 +39,6 @@ export default function ListViewBlock( {
 	showBlockMovers,
 	path,
 	isExpanded,
-	style,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -185,7 +184,6 @@ export default function ListViewBlock( {
 					className="block-editor-list-view-block__contents-cell"
 					colSpan={ colSpan }
 					ref={ cellRef }
-					style={ style }
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
 						<div className="block-editor-list-view-block__contents-container">

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -6,7 +6,7 @@ import { compact } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
+import { Fragment, memo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ const countReducer = ( expandedState, draggedClientIds ) => (
 	return count + 1;
 };
 
-export default function ListViewBranch( props ) {
+function ListViewBranch( props ) {
 	const {
 		blocks,
 		selectBlock,
@@ -82,6 +82,7 @@ export default function ListViewBranch( props ) {
 		}
 
 		const usesWindowing = __experimentalPersistentListViewFeatures;
+
 		const {
 			start,
 			end,
@@ -162,3 +163,5 @@ export default function ListViewBranch( props ) {
 ListViewBranch.defaultProps = {
 	selectBlock: () => {},
 };
+
+export default memo( ListViewBranch );

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, compact } from 'lodash';
+import { compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,6 +14,38 @@ import { Fragment } from '@wordpress/element';
 import ListViewBlock from './block';
 import { useListViewContext } from './context';
 
+function countBlocks( block, expandedState, draggedClientIds ) {
+	const isDragged = draggedClientIds?.includes( block.clientId );
+	if ( isDragged ) {
+		return 0;
+	}
+	const isExpanded = expandedState[ block.clientId ] ?? true;
+	if ( isExpanded ) {
+		return (
+			1 +
+			block.innerBlocks.reduce(
+				countReducer( expandedState, draggedClientIds ),
+				0
+			)
+		);
+	}
+	return 1;
+}
+const countReducer = ( expandedState, draggedClientIds ) => (
+	count,
+	block
+) => {
+	const isDragged = draggedClientIds?.includes( block.clientId );
+	if ( isDragged ) {
+		return count;
+	}
+	const isExpanded = expandedState[ block.clientId ] ?? true;
+	if ( isExpanded && block.innerBlocks.length > 0 ) {
+		return count + countBlocks( block, expandedState, draggedClientIds );
+	}
+	return count + 1;
+};
+
 export default function ListViewBranch( props ) {
 	const {
 		blocks,
@@ -22,62 +54,109 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		level = 1,
 		path = '',
+		listPosition = 0,
+		fixedListWindow,
 	} = props;
 
-	const { expandedState, draggedClientIds } = useListViewContext();
+	const {
+		expandedState,
+		draggedClientIds,
+		__experimentalPersistentListViewFeatures,
+	} = useListViewContext();
 
 	const filteredBlocks = compact( blocks );
 	const blockCount = filteredBlocks.length;
+	let nextPosition = listPosition;
 
-	return (
-		<>
-			{ map( filteredBlocks, ( block, index ) => {
-				const { clientId, innerBlocks } = block;
-				const position = index + 1;
-				// This string value is used to trigger an animation change.
-				// This may be removed if we use a different animation library in the future.
-				const updatedPath =
-					path.length > 0
-						? `${ path }_${ position }`
-						: `${ position }`;
-				const hasNestedBlocks =
-					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
+	const listItems = [];
+	for ( let index = 0; index < filteredBlocks.length; index++ ) {
+		const block = filteredBlocks[ index ];
+		const { clientId, innerBlocks } = block;
 
-				const isExpanded = hasNestedBlocks
-					? expandedState[ clientId ] ?? true
-					: undefined;
+		if ( index > 0 ) {
+			nextPosition += countBlocks(
+				filteredBlocks[ index - 1 ],
+				expandedState,
+				draggedClientIds
+			);
+		}
 
-				const isDragged = !! draggedClientIds?.includes( clientId );
+		const usesWindowing = __experimentalPersistentListViewFeatures;
+		const {
+			start,
+			end,
+			itemInView,
+			startPadding,
+			endPadding,
+		} = fixedListWindow;
 
-				return (
-					<Fragment key={ clientId }>
-						<ListViewBlock
-							block={ block }
-							selectBlock={ selectBlock }
-							isDragged={ isDragged }
-							level={ level }
-							position={ position }
-							rowCount={ blockCount }
-							siblingBlockCount={ blockCount }
-							showBlockMovers={ showBlockMovers }
-							path={ updatedPath }
-							isExpanded={ isExpanded }
-						/>
-						{ hasNestedBlocks && isExpanded && ! isDragged && (
-							<ListViewBranch
-								blocks={ innerBlocks }
-								selectBlock={ selectBlock }
-								showBlockMovers={ showBlockMovers }
-								showNestedBlocks={ showNestedBlocks }
-								level={ level + 1 }
-								path={ updatedPath }
-							/>
-						) }
-					</Fragment>
-				);
-			} ) }
-		</>
-	);
+		const blockInView = ! usesWindowing || itemInView( nextPosition );
+
+		const isDragging = draggedClientIds?.length > 0;
+		if (
+			usesWindowing &&
+			! isDragging &&
+			! blockInView &&
+			nextPosition > start
+		) {
+			// found the end of the window, don't bother processing the rest of the items
+			break;
+		}
+		const style = usesWindowing
+			? {
+					paddingTop: start === nextPosition ? startPadding : 0,
+					paddingBottom: end === nextPosition ? endPadding : 0,
+			  }
+			: undefined;
+
+		const position = index + 1;
+		const updatedPath =
+			path.length > 0 ? `${ path }_${ position }` : `${ position }`;
+		const hasNestedBlocks =
+			showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
+
+		const isExpanded = hasNestedBlocks
+			? expandedState[ clientId ] ?? true
+			: undefined;
+
+		// Make updates to the selected or dragged blocks synchronous,
+		// but asynchronous for any other block.
+		const isDragged = !! draggedClientIds?.includes( clientId );
+
+		listItems.push(
+			<Fragment key={ clientId }>
+				{ ( isDragged || blockInView ) && (
+					<ListViewBlock
+						block={ block }
+						selectBlock={ selectBlock }
+						isDragged={ isDragged }
+						level={ level }
+						position={ position }
+						rowCount={ blockCount }
+						siblingBlockCount={ blockCount }
+						showBlockMovers={ showBlockMovers }
+						path={ updatedPath }
+						isExpanded={ isExpanded }
+						listPosition={ nextPosition }
+						style={ style }
+					/>
+				) }
+				{ hasNestedBlocks && isExpanded && ! isDragged && (
+					<ListViewBranch
+						blocks={ innerBlocks }
+						selectBlock={ selectBlock }
+						showBlockMovers={ showBlockMovers }
+						showNestedBlocks={ showNestedBlocks }
+						level={ level + 1 }
+						path={ updatedPath }
+						listPosition={ nextPosition + 1 }
+						fixedListWindow={ fixedListWindow }
+					/>
+				) }
+			</Fragment>
+		);
+	}
+	return <>{ listItems }</>;
 }
 
 ListViewBranch.defaultProps = {

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -14,6 +14,18 @@ import { Fragment, memo } from '@wordpress/element';
 import ListViewBlock from './block';
 import { useListViewContext } from './context';
 
+/**
+ * Given a block, returns the total number of blocks in that subtree. This is used to help determine
+ * the list position of a block.
+ *
+ * When a block is collapsed, we do not count their children as part of that total. In the current drag
+ * implementation dragged blocks and their children are not counted.
+ *
+ * @param {Object} block            block tree
+ * @param {Object} expandedState    state that notes which branches are collapsed
+ * @param {Array}  draggedClientIds a list of dragged client ids
+ * @return {number} block count
+ */
 function countBlocks( block, expandedState, draggedClientIds ) {
 	const isDragged = draggedClientIds?.includes( block.clientId );
 	if ( isDragged ) {

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -68,96 +68,80 @@ function ListViewBranch( props ) {
 	const blockCount = filteredBlocks.length;
 	let nextPosition = listPosition;
 
-	const listItems = [];
-	for ( let index = 0; index < filteredBlocks.length; index++ ) {
-		const block = filteredBlocks[ index ];
-		const { clientId, innerBlocks } = block;
+	return (
+		<>
+			{ filteredBlocks.map( ( block, index ) => {
+				const { clientId, innerBlocks } = block;
 
-		if ( index > 0 ) {
-			nextPosition += countBlocks(
-				filteredBlocks[ index - 1 ],
-				expandedState,
-				draggedClientIds
-			);
-		}
+				if ( index > 0 ) {
+					nextPosition += countBlocks(
+						filteredBlocks[ index - 1 ],
+						expandedState,
+						draggedClientIds
+					);
+				}
 
-		const usesWindowing = __experimentalPersistentListViewFeatures;
+				const usesWindowing = __experimentalPersistentListViewFeatures;
 
-		const {
-			start,
-			end,
-			itemInView,
-			startPadding,
-			endPadding,
-		} = fixedListWindow;
+				const { itemInView } = fixedListWindow;
 
-		const blockInView = ! usesWindowing || itemInView( nextPosition );
+				const blockInView =
+					! usesWindowing || itemInView( nextPosition );
 
-		const isDragging = draggedClientIds?.length > 0;
-		if (
-			usesWindowing &&
-			! isDragging &&
-			! blockInView &&
-			nextPosition > start
-		) {
-			// found the end of the window, don't bother processing the rest of the items
-			break;
-		}
-		const style = usesWindowing
-			? {
-					paddingTop: start === nextPosition ? startPadding : 0,
-					paddingBottom: end === nextPosition ? endPadding : 0,
-			  }
-			: undefined;
+				const position = index + 1;
+				const updatedPath =
+					path.length > 0
+						? `${ path }_${ position }`
+						: `${ position }`;
+				const hasNestedBlocks =
+					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 
-		const position = index + 1;
-		const updatedPath =
-			path.length > 0 ? `${ path }_${ position }` : `${ position }`;
-		const hasNestedBlocks =
-			showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
+				const isExpanded = hasNestedBlocks
+					? expandedState[ clientId ] ?? true
+					: undefined;
 
-		const isExpanded = hasNestedBlocks
-			? expandedState[ clientId ] ?? true
-			: undefined;
+				const isDragged = !! draggedClientIds?.includes( clientId );
 
-		// Make updates to the selected or dragged blocks synchronous,
-		// but asynchronous for any other block.
-		const isDragged = !! draggedClientIds?.includes( clientId );
-
-		listItems.push(
-			<Fragment key={ clientId }>
-				{ ( isDragged || blockInView ) && (
-					<ListViewBlock
-						block={ block }
-						selectBlock={ selectBlock }
-						isDragged={ isDragged }
-						level={ level }
-						position={ position }
-						rowCount={ blockCount }
-						siblingBlockCount={ blockCount }
-						showBlockMovers={ showBlockMovers }
-						path={ updatedPath }
-						isExpanded={ isExpanded }
-						listPosition={ nextPosition }
-						style={ style }
-					/>
-				) }
-				{ hasNestedBlocks && isExpanded && ! isDragged && (
-					<ListViewBranch
-						blocks={ innerBlocks }
-						selectBlock={ selectBlock }
-						showBlockMovers={ showBlockMovers }
-						showNestedBlocks={ showNestedBlocks }
-						level={ level + 1 }
-						path={ updatedPath }
-						listPosition={ nextPosition + 1 }
-						fixedListWindow={ fixedListWindow }
-					/>
-				) }
-			</Fragment>
-		);
-	}
-	return <>{ listItems }</>;
+				const showBlock = isDragged || blockInView;
+				return (
+					<Fragment key={ clientId }>
+						{ showBlock && (
+							<ListViewBlock
+								block={ block }
+								selectBlock={ selectBlock }
+								isDragged={ isDragged }
+								level={ level }
+								position={ position }
+								rowCount={ blockCount }
+								siblingBlockCount={ blockCount }
+								showBlockMovers={ showBlockMovers }
+								path={ updatedPath }
+								isExpanded={ isExpanded }
+								listPosition={ nextPosition }
+							/>
+						) }
+						{ ! showBlock && (
+							<tr>
+								<td className="block-editor-list-view-placeholder" />
+							</tr>
+						) }
+						{ hasNestedBlocks && isExpanded && ! isDragged && (
+							<ListViewBranch
+								blocks={ innerBlocks }
+								selectBlock={ selectBlock }
+								showBlockMovers={ showBlockMovers }
+								showNestedBlocks={ showNestedBlocks }
+								level={ level + 1 }
+								path={ updatedPath }
+								listPosition={ nextPosition + 1 }
+								fixedListWindow={ fixedListWindow }
+							/>
+						) }
+					</Fragment>
+				);
+			} ) }
+		</>
+	);
 }
 
 ListViewBranch.defaultProps = {

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -102,6 +102,9 @@ function ListView(
 		isMounted.current = true;
 	}, [] );
 
+	// List View renders a fixed number of items and relies on each having a fixed item height of 36px.
+	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
+	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
 	const [ fixedListWindow ] = useFixedWindowList(
 		elementRef,
 		36,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -177,11 +177,6 @@ function ListView(
 				ref={ treeGridRef }
 				onCollapseRow={ collapseRow }
 				onExpandRow={ expandRow }
-				aria-rowcount={
-					__experimentalPersistentListViewFeatures
-						? visibleBlockCount
-						: undefined
-				}
 			>
 				<ListViewContext.Provider value={ contextValue }>
 					<ListViewBranch

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -107,7 +107,6 @@ function ListView(
 		36,
 		visibleBlockCount,
 		{
-			windowOverscan: 1,
 			useWindowing: __experimentalPersistentListViewFeatures,
 		}
 	);

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -62,6 +62,9 @@
 		display: none;
 	}
 
+	// List View renders a fixed number of items and relies on each item having a fixed height of 36px.
+	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
+	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
 	.block-editor-list-view-block-contents {
 		display: flex;
 		align-items: center;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -357,3 +357,9 @@ $block-navigation-max-indent: 8;
 	box-shadow: none;
 }
 
+.block-editor-list-view-placeholder {
+	padding: 0;
+	margin: 0;
+	height: 36px;
+}
+

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -19,8 +19,6 @@ const DEFAULT_INIT_WINDOW_SIZE = 30;
  * @property {number}                  start        Start index of the window
  * @property {number}                  end          End index of the window
  * @property {(index:number)=>boolean} itemInView   Returns true if item is in the window
- * @property {number}                  startPadding Padding in px to add before the start item
- * @property {number}                  endPadding   Padding in px to add after the end item
  */
 
 /**
@@ -55,8 +53,6 @@ export default function useFixedWindowList(
 		itemInView: ( /** @type {number} */ index ) => {
 			return index >= 0 && index <= initWindowSize;
 		},
-		startPadding: 0,
-		endPadding: 0,
 	} );
 
 	useLayoutEffect( () => {
@@ -72,14 +68,13 @@ export default function useFixedWindowList(
 				scrollContainer.clientHeight / itemHeight
 			);
 			const windowOverscan = options?.windowOverscan ?? visibleItems;
-			const start = Math.max(
-				0,
-				Math.floor( scrollContainer.scrollTop / itemHeight ) -
-					windowOverscan
+			const firstViewableIndex = Math.floor(
+				scrollContainer.scrollTop / itemHeight
 			);
+			const start = Math.max( 0, firstViewableIndex - windowOverscan );
 			const end = Math.min(
 				totalItems - 1,
-				start + visibleItems + windowOverscan
+				firstViewableIndex + visibleItems + windowOverscan
 			);
 			setFixedListWindow( ( lastWindow ) => {
 				const nextWindow = {
@@ -89,11 +84,6 @@ export default function useFixedWindowList(
 					itemInView: ( /** @type {number} */ index ) => {
 						return start <= index && index <= end;
 					},
-					startPadding: itemHeight * start,
-					endPadding:
-						totalItems > end
-							? itemHeight * ( totalItems - end - 1 )
-							: 0,
 				};
 				if (
 					lastWindow.start !== nextWindow.start ||

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -81,18 +81,28 @@ export default function useFixedWindowList(
 				totalItems - 1,
 				start + visibleItems + windowOverscan
 			);
-			setFixedListWindow( {
-				visibleItems,
-				start,
-				end,
-				itemInView: ( index ) => {
-					return start <= index && index <= end;
-				},
-				startPadding: itemHeight * start,
-				endPadding:
-					totalItems > end
-						? itemHeight * ( totalItems - end - 1 )
-						: 0,
+			setFixedListWindow( ( lastWindow ) => {
+				const nextWindow = {
+					visibleItems,
+					start,
+					end,
+					itemInView: ( /** @type {number} */ index ) => {
+						return start <= index && index <= end;
+					},
+					startPadding: itemHeight * start,
+					endPadding:
+						totalItems > end
+							? itemHeight * ( totalItems - end - 1 )
+							: 0,
+				};
+				if (
+					lastWindow.start !== nextWindow.start ||
+					lastWindow.end !== nextWindow.end ||
+					lastWindow.visibleItems !== nextWindow.visibleItems
+				) {
+					return nextWindow;
+				}
+				return lastWindow;
 			} );
 		};
 		const handleKeyDown = ( /** @type {KeyboardEvent} */ event ) => {

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import { throttle } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useLayoutEffect } from '@wordpress/element';
+import { getScrollContainer } from '@wordpress/dom';
+import { PAGEUP, PAGEDOWN, HOME, END } from '@wordpress/keycodes';
+
+const DEFAULT_INIT_WINDOW_SIZE = 30;
+
+/**
+ * @typedef {Object} WPFixedWindowList
+ *
+ * @property {number}                  visibleItems Items visible in the current viewport
+ * @property {number}                  start        Start index of the window
+ * @property {number}                  end          End index of the window
+ * @property {(index:number)=>boolean} itemInView   Returns true if item is in the window
+ * @property {number}                  startPadding Padding in px to add before the start item
+ * @property {number}                  endPadding   Padding in px to add after the end item
+ */
+
+/**
+ * @typedef {Object} WPFixedWindowListOptions
+ *
+ * @property {number}  [windowOverscan] Renders windowOverscan number of items before and after the calculated visible window.
+ * @property {boolean} [useWindowing]   When false avoids calculating the window size
+ * @property {number}  [initWindowSize] Initial window size to use on first render before we can calculate the window size.
+ */
+
+/**
+ *
+ * @param {import('react').RefObject<HTMLElement>} elementRef Used to find the closest scroll container that contains element.
+ * @param { number }                               itemHeight Fixed item height in pixels
+ * @param { number }                               totalItems Total items in list
+ * @param { WPFixedWindowListOptions }             [options]  Options object
+ * @return {[ WPFixedWindowList, setFixedListWindow:(nextWindow:WPFixedWindowList)=>void]} Array with the fixed window list and setter
+ */
+export default function useFixedWindowList(
+	elementRef,
+	itemHeight,
+	totalItems,
+	options
+) {
+	const initWindowSize = options?.initWindowSize ?? DEFAULT_INIT_WINDOW_SIZE;
+	const useWindowing = options?.useWindowing ?? true;
+
+	const [ fixedListWindow, setFixedListWindow ] = useState( {
+		visibleItems: initWindowSize,
+		start: 0,
+		end: initWindowSize,
+		itemInView: ( /** @type {number} */ index ) => {
+			return index >= 0 && index <= initWindowSize;
+		},
+		startPadding: 0,
+		endPadding: 0,
+	} );
+
+	useLayoutEffect( () => {
+		if ( ! useWindowing ) {
+			return;
+		}
+		const scrollContainer = getScrollContainer( elementRef.current );
+		const measureWindow = () => {
+			if ( ! scrollContainer ) {
+				return;
+			}
+			const visibleItems = Math.ceil(
+				scrollContainer.clientHeight / itemHeight
+			);
+			const windowOverscan = options?.windowOverscan ?? visibleItems;
+			const start = Math.max(
+				0,
+				Math.floor( scrollContainer.scrollTop / itemHeight ) -
+					windowOverscan
+			);
+			const end = Math.min(
+				totalItems - 1,
+				start + visibleItems + windowOverscan
+			);
+			setFixedListWindow( {
+				visibleItems,
+				start,
+				end,
+				itemInView: ( index ) => {
+					return start <= index && index <= end;
+				},
+				startPadding: itemHeight * start,
+				endPadding:
+					totalItems > end
+						? itemHeight * ( totalItems - end - 1 )
+						: 0,
+			} );
+		};
+		const handleKeyDown = ( /** @type {KeyboardEvent} */ event ) => {
+			switch ( event.keyCode ) {
+				case HOME: {
+					return scrollContainer?.scrollTo( { top: 0 } );
+				}
+				case END: {
+					return scrollContainer?.scrollTo( {
+						top: totalItems * itemHeight,
+					} );
+				}
+				case PAGEUP: {
+					return scrollContainer?.scrollTo( {
+						top:
+							scrollContainer.scrollTop -
+							fixedListWindow.visibleItems * itemHeight,
+					} );
+				}
+				case PAGEDOWN: {
+					return scrollContainer?.scrollTo( {
+						top:
+							scrollContainer.scrollTop +
+							fixedListWindow.visibleItems * itemHeight,
+					} );
+				}
+			}
+		};
+
+		measureWindow();
+		const throttleMeasureList = throttle( () => {
+			measureWindow();
+		}, 16 );
+		scrollContainer?.addEventListener( 'scroll', throttleMeasureList );
+		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
+			'resize',
+			throttleMeasureList
+		);
+		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
+			'resize',
+			throttleMeasureList
+		);
+		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
+			'keydown',
+			handleKeyDown
+		);
+		return () => {
+			scrollContainer?.removeEventListener(
+				'scroll',
+				throttleMeasureList
+			);
+			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
+				'resize',
+				throttleMeasureList
+			);
+			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
+				'keydown',
+				handleKeyDown
+			);
+		};
+	}, [ totalItems, itemHeight, elementRef ] );
+
+	return [ fixedListWindow, setFixedListWindow ];
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -37,3 +37,4 @@ export { default as useMergeRefs } from './hooks/use-merge-refs';
 export { default as useRefEffect } from './hooks/use-ref-effect';
 export { default as __experimentalUseDropZone } from './hooks/use-drop-zone';
 export { default as useFocusableIframe } from './hooks/use-focusable-iframe';
+export { default as __experimentalUseFixedWindowList } from './hooks/use-fixed-window-list';

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -37,6 +37,7 @@ class PerformanceReporter {
 			firstBlock,
 			type,
 			focus,
+			listViewOpen,
 			inserterOpen,
 			inserterHover,
 			inserterSearch,
@@ -87,6 +88,21 @@ Slowest time to select a block: ${ success(
 			) }
 Fastest time to select a block: ${ success(
 				round( Math.min( ...focus ) ) + 'ms'
+			) }` );
+		}
+
+		if ( listViewOpen && listViewOpen.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Opening List View Performance:' ) }
+Average time to open list view: ${ success(
+				round( average( listViewOpen ) ) + 'ms'
+			) }
+Slowest time to open list view: ${ success(
+				round( Math.max( ...listViewOpen ) ) + 'ms'
+			) }
+Fastest time to open list view: ${ success(
+				round( Math.min( ...listViewOpen ) ) + 'ms'
 			) }` );
 		}
 

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -11,6 +11,7 @@ import { sum } from 'lodash';
 import {
 	createNewPost,
 	saveDraft,
+	insertBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
 	openListView,
@@ -120,9 +121,7 @@ describe( 'Post Editor Performance', () => {
 
 	it( 'Typing', async () => {
 		// Measuring typing performance
-		await openListView();
-		await page.click( '.edit-post-visual-editor__post-title-wrapper' );
-		await page.keyboard.press( 'Enter' );
+		await insertBlock( 'Paragraph' );
 		let i = 20;
 		await page.tracing.start( {
 			path: traceFile,
@@ -161,7 +160,6 @@ describe( 'Post Editor Performance', () => {
 	it( 'Selecting blocks', async () => {
 		// Measuring block selection performance
 		await createNewPost();
-		await openListView();
 		await page.evaluate( () => {
 			const { createBlock } = window.wp.blocks;
 			const { dispatch } = window.wp.data;

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -13,7 +13,7 @@ import {
 	canvas,
 	createNewPost,
 	saveDraft,
-	insertBlock,
+	openListView,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -55,6 +55,7 @@ describe( 'Site Editor Performance', () => {
 			inserterOpen: [],
 			inserterHover: [],
 			inserterSearch: [],
+			listViewOpen: [],
 		};
 
 		const html = readFile(
@@ -117,7 +118,13 @@ describe( 'Site Editor Performance', () => {
 		await canvas().click(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
-		await insertBlock( 'Paragraph' );
+		await openListView();
+		await canvas().click(
+			'[data-type="core/post-content"] [data-type="core/paragraph"]'
+		);
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'ArrowUp' );
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
 		await page.tracing.start( {

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -13,7 +13,7 @@ import {
 	canvas,
 	createNewPost,
 	saveDraft,
-	openListView,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -118,13 +118,7 @@ describe( 'Site Editor Performance', () => {
 		await canvas().click(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
-		await openListView();
-		await canvas().click(
-			'[data-type="core/post-content"] [data-type="core/paragraph"]'
-		);
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'ArrowUp' );
+		await insertBlock( 'Paragraph' );
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
 		await page.tracing.start( {


### PR DESCRIPTION
This PR explores using the windowing technique in list view where we render a fixed number of items at a time instead of every block. This change should help stabilize the max time required for block focus (it should no longer grow with the number of blocks in the document) when list view is open, and should unblock other drag experiments in https://github.com/WordPress/gutenberg/pull/34022

### Performance

I've modified the spec on this branch to run the typing and focus tests with list view open. I also added a new test to toggle list view open and closed. Runs show around a 10x improvement in open time,  ~7x improvement in focus time, and a modest improvement in typing speed when list view is open.

To verify visual changes to the performance tests we can run it with:

```jsx
npm run test-performance -- --wordpress-base-url=http://e2e.local/ --wordpress-username=<username>--wordpress-password=<password> --puppeteer-interactive packages/e2e-tests/specs/performance/post-editor.test.js

npm run test-performance -- --wordpress-base-url=http://e2e.local/ --wordpress-username=<username>--wordpress-password=<password> --puppeteer-interactive packages/e2e-tests/specs/performance/site-editor.test.js
```

perf specs need to be written carefully since inserting blocks with the global inserter will hide the list view.

```
>> post-editor

┌──────────────────────┬──────────────────────────────────────────┬──────────────┐
│       (index)        │ 4bd8deab66b68f3a26e8fe02c36e841dfc6b2ac8 │    trunk     │
├──────────────────────┼──────────────────────────────────────────┼──────────────┤
│    serverResponse    │               '221.84 ms'                │ '204.52 ms'  │
│      firstPaint      │                '17.06 ms'                │  '28.46 ms'  │
│   domContentLoaded   │               '232.86 ms'                │ '239.48 ms'  │
│        loaded        │               '241.54 ms'                │ '247.94 ms'  │
│ firstContentfulPaint │               '5010.56 ms'               │ '4995.18 ms' │
│      firstBlock      │               '5693.28 ms'               │ '5699.52 ms' │
│         type         │                '43.34 ms'                │  '58.95 ms'  │
│       minType        │                '40.7 ms'                 │  '54.53 ms'  │
│       maxType        │                '49.77 ms'                │  '72.45 ms'  │
│        focus         │               '148.87 ms'                │ '840.75 ms'  │
│       minFocus       │                '1.04 ms'                 │  '1.19 ms'   │
│       maxFocus       │               '203.61 ms'                │ '1090.06 ms' │
│     inserterOpen     │                '76.71 ms'                │  '77.07 ms'  │
│   minInserterOpen    │                '55.07 ms'                │  '56.43 ms'  │
│   maxInserterOpen    │               '234.56 ms'                │ '234.25 ms'  │
│    inserterSearch    │                '68.54 ms'                │  '91.16 ms'  │
│  minInserterSearch   │                '56.99 ms'                │  '57.99 ms'  │
│  maxInserterSearch   │                '73.35 ms'                │  '283.9 ms'  │
│    inserterHover     │                '40.99 ms'                │  '41.75 ms'  │
│   minInserterHover   │                '37.8 ms'                 │  '36.24 ms'  │
│   maxInserterHover   │                '45.15 ms'                │  '51.4 ms'   │
│     listViewOpen     │               '203.01 ms'                │ '2874.56 ms' │
│   minListViewOpen    │               '192.07 ms'                │ '2630.45 ms' │
│   maxListViewOpen    │               '211.94 ms'                │ '4297.52 ms' │
└──────────────────────┴──────────────────────────────────────────┴──────────────┘

>> site-editor

┌──────────────────────┬──────────────────────────────────────────┬─────────────┐
│       (index)        │ 4bd8deab66b68f3a26e8fe02c36e841dfc6b2ac8 │    trunk    │
├──────────────────────┼──────────────────────────────────────────┼─────────────┤
│    serverResponse    │                '125.1 ms'                │ '127.57 ms' │
│      firstPaint      │               '416.63 ms'                │ '402.2 ms'  │
│   domContentLoaded   │                '476.3 ms'                │ '442.6 ms'  │
│        loaded        │                '622.6 ms'                │ '603.73 ms' │
│ firstContentfulPaint │               '416.63 ms'                │ '402.2 ms'  │
│      firstBlock      │               '6050.7 ms'                │ '5869.5 ms' │
│         type         │                '34.46 ms'                │ '41.65 ms'  │
│       minType        │                '30.9 ms'                 │ '37.01 ms'  │
│       maxType        │                '49.61 ms'                │ '59.19 ms'  │
└──────────────────────┴──────────────────────────────────────────┴─────────────┘
```

#### Example with nested items:

https://user-images.githubusercontent.com/1270189/135537879-079b616e-b188-4f77-b79d-06b58e8a6ac1.mp4

#### Performance test post. 

Note how we show blank padding when scrolling quickly. We can optimize for this by trying to render more items (updating the window overscan) or adding maybe some loading placeholders.

https://user-images.githubusercontent.com/1270189/135537907-26bec0b2-4c35-4cc7-855e-84f6c83de7f4.mp4

#### Keyboard support:

https://user-images.githubusercontent.com/1270189/135932414-0c01aa19-0993-4d4c-bf64-caf4f2c4e836.mp4

#### Example of drag scrolling (shown with list position debug numbers)

https://user-images.githubusercontent.com/1270189/136108167-4a54eedf-5b77-4f22-bac8-800870b3b933.mp4

#### Screen reader should read out the same labels for rows and initial table counts:

![CleanShot 2021-10-08 at 10 57 21@2x](https://user-images.githubusercontent.com/1270189/136602234-fd30f884-50cc-4c9f-93df-6efe004c8f4d.png)

### Testing Instructions

- In the Site Editor and Post Editor try adding a number of blocks to the document. Be sure to also add nested bocks
- Verify that there are no regressions with dragging, expanding/collapsing, scrolling and that the ordering of items is correct.
- Verify that there are no changes/regressions using a screenreader to navigate list view
- Verify that windowing is not used on other list view instances, such as on the navigation block (in all editors: widget, site, post, navigation)

| Navigation List View | Modal |
|-----|-----|
| <img width="786" alt="CleanShot 2021-10-08 at 11 11 52@2x" src="https://user-images.githubusercontent.com/1270189/136603341-08006d37-0b01-41bc-b5f1-55739a4242f6.png"> | <img width="491" alt="CleanShot 2021-10-08 at 11 09 03@2x" src="https://user-images.githubusercontent.com/1270189/136603270-2de68d81-da0d-4cc6-870a-2e5a6c5d6170.png"> |

~~TODO:~~
- [x] basic scroll and resize support
- [x] fix keyboard down/up outside of window
- [x] appropriate screenreader label updates to make sure folks know there are more items available
- [x] fix drag scroll
- [x] make sure we don't get scroll thrashing in certain scenarios