### PR TITLE
Fix gap regression in navigation screen.

### DIFF
--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -52,7 +52,7 @@
 			// Fix focus outlines.
 			&.is-selected > .wp-block-navigation-item__content,
 			&.is-selected:hover > .wp-block-navigation-item__content {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
 
 			&.block-editor-block-list__block:not([contenteditable]):focus::after {

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -47,6 +47,10 @@
 				display: none;
 				right: auto;
 				box-sizing: border-box;
+				width: auto;
+				height: auto;
+				overflow: initial;
+				min-width: initial;
 			}
 
 			// Fix focus outlines.

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -29,6 +29,11 @@
 		// This is the default font that is going to be used in the content of the areas (blocks).
 		font-family: $default-font;
 
+		// Customize/zero out the gap.
+		.wp-block-navigation__container {
+			gap: 0;
+		}
+
 		// Increase specificity.
 		.wp-block-navigation-item {
 			display: block;
@@ -75,7 +80,6 @@
 				cursor: text;
 			}
 		}
-
 
 		// Basic Page List support.
 		ul.wp-block-page-list {
@@ -157,7 +161,7 @@
 			flex-direction: column;
 			justify-content: center;
 			height: $grid-unit-50;
-			margin: $grid-unit-10 0;
+			margin: $grid-unit-10 auto $grid-unit-10 0;
 		}
 
 		.block-editor-button-block-appender.block-list-appender__toggle {

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -31,7 +31,8 @@
 
 		// Customize/zero out the gap.
 		.wp-block-navigation__container {
-			gap: 0;
+			// This unsets flex.
+			display: block;
 		}
 
 		// Increase specificity.
@@ -77,6 +78,7 @@
 			.wp-block-navigation-link__placeholder-text {
 				padding: $grid-unit-05;
 				padding-left: $grid-unit-10;
+				line-height: 1;
 			}
 
 			.wp-block-navigation-link__label {
@@ -169,8 +171,7 @@
 		}
 
 		.block-editor-button-block-appender.block-list-appender__toggle {
-			margin: 0 0 0 $grid-unit-30;
-			padding: 0;
+			margin-left: $grid-unit-30;
 		}
 	}
 


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/35026#issuecomment-930762188. Fixes a gap regression in the navigation editor screen.

Before:

<img width="514" alt="before" src="https://user-images.githubusercontent.com/1204802/135389704-b884a181-d54c-4c76-9f70-45ba5d30b361.png">

After:

<img width="602" alt="after" src="https://user-images.githubusercontent.com/1204802/135389722-b5dd836c-2ac1-444c-bd82-73e859d5c8c3.png">

Also followup to https://github.com/WordPress/gutenberg/pull/35077#issuecomment-930770212, fixes a hover regression with the focus style. 

Before:

<img width="633" alt="Screenshot 2021-09-30 at 06 57 51" src="https://user-images.githubusercontent.com/1204802/135390231-a34181fd-1b62-4845-8e2e-18aa4f6dba68.png">

After:

<img width="591" alt="Screenshot 2021-09-30 at 06 58 41" src="https://user-images.githubusercontent.com/1204802/135390240-c5a961a0-0fb3-418e-ab5b-e08f9f562a84.png">

## How has this been tested?

Please test the navigation screen and verify the appender is left aligned, and that the space between main menu items is the same as that of submenu items.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
