### PR TITLE
Add Padding to the root level of global styles

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -27,6 +27,7 @@ export const ROOT_BLOCK_SUPPORTS = [
 	'lineHeight',
 	'textDecoration',
 	'textTransform',
+	'padding',
 ];
 
 export const PRESET_METADATA = [


### PR DESCRIPTION
Related #34574 

Just a tiny PR to enable the padding config at the root level of global styles. The design is not great but it matches what we currently have per block. We should look at it separately. 