### PR TITLE
Remove warning box from post terms.

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -10,7 +10,6 @@ import {
 	AlignmentToolbar,
 	InspectorControls,
 	BlockControls,
-	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Spinner, TextControl } from '@wordpress/components';
@@ -56,7 +55,7 @@ export default function PostTermsEdit( {
 	if ( ! hasPost ) {
 		return (
 			<div { ...blockProps }>
-				<Warning>{ __( 'Post Terms block: post not found.' ) }</Warning>
+				{ __( 'Post Terms block: post not found.' ) }
 			</div>
 		);
 	}


### PR DESCRIPTION
## Description

As the site editor matures, the behavior of blocks when they have content to load vs. when the template is being loaded in isolation could be polished a great deal. 

This PR dips the toes into the water with a minimal change, simply removing the white box around the terms block. Before:

<img width="455" alt="fix this small PR" src="https://user-images.githubusercontent.com/1204802/135417278-5cac71ec-eff3-4e0b-a976-855b919ec1f4.png">

After:

<img width="293" alt="Screenshot 2021-09-30 at 10 28 53" src="https://user-images.githubusercontent.com/1204802/135417304-07cc0f84-b381-4f3d-8d9b-31776a3c6287.png">

It seems the template building experience could be better if more properties were inherited by the theme, to the point that it would be nice to be able to supply a variety of "lorem ipsum" mock values for the purpose. In absence of that, or in the meantime, the Warning did not seem like it added great value.

## How has this been tested?

Open the site editor on the Singular template and observe the post terms block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
