### PR TITLE
Polish global styles preview.

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles/preview.js
+++ b/packages/edit-site/src/components/sidebar/global-styles/preview.js
@@ -25,7 +25,7 @@ export const StylePreview = () => {
 			style={ { background: backgroundColor } }
 		>
 			<HStack spacing={ 5 }>
-				<div style={ { lineHeight: '1' } }>
+				<div>
 					<span style={ { fontFamily, fontSize: '80px' } }>A</span>
 					<span style={ { fontFamily, fontSize: '80px' } }>a</span>
 				</div>

--- a/packages/edit-site/src/components/sidebar/global-styles/preview.js
+++ b/packages/edit-site/src/components/sidebar/global-styles/preview.js
@@ -25,7 +25,7 @@ export const StylePreview = () => {
 			style={ { background: backgroundColor } }
 		>
 			<HStack spacing={ 5 }>
-				<div>
+				<div style={ { lineHeight: '1' } }>
 					<span style={ { fontFamily, fontSize: '80px' } }>A</span>
 					<span style={ { fontFamily, fontSize: '80px' } }>a</span>
 				</div>

--- a/packages/edit-site/src/components/sidebar/global-styles/style.scss
+++ b/packages/edit-site/src/components/sidebar/global-styles/style.scss
@@ -4,6 +4,7 @@
 	justify-content: center;
 	min-height: 152px;
 	margin: $grid-unit-20;
+	line-height: 1;
 
 	.component-color-indicator {
 		border-radius: 50%;


### PR DESCRIPTION
## Description

Definitely the department of subtleties. The new Global Styles preview card had an inherited line height, making it look vertially offset in some situations:

<img width="1270" alt="before" src="https://user-images.githubusercontent.com/1204802/135421729-7357e665-9cbb-4176-a0db-70539a6d2cb3.png">

This PR just adds an explicit line height so it doesn't inherit it from a random context, therefore vertically centering it:

<img width="1270" alt="after" src="https://user-images.githubusercontent.com/1204802/135421840-80911669-de17-4ca9-a1ba-9941b30967d5.png">

## How has this been tested?

Open the site editor, view the global styles sidebar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
