### PR TITLE
Polish Card component.

### DIFF
--- a/packages/components/src/card/styles.js
+++ b/packages/components/src/card/styles.js
@@ -9,8 +9,20 @@ import { css } from '@emotion/react';
 import { COLORS, CONFIG } from '../utils';
 
 export const Card = css`
-	box-shadow: inset 0 0 0 1px ${ CONFIG.surfaceBorderColor };
 	outline: none;
+
+	&::before {
+		content: '';
+
+		box-shadow: inset 0 0 0 1px ${ CONFIG.surfaceBorderColor };
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+
+		pointer-events: none;
+	}
 `;
 
 export const Header = css`
@@ -77,7 +89,9 @@ export const borderColor = css`
 `;
 
 export const boxShadowless = css`
-	box-shadow: none;
+	&::before {
+		content: none;
+	}
 `;
 
 export const borderless = css`

--- a/packages/components/src/card/styles.js
+++ b/packages/components/src/card/styles.js
@@ -9,7 +9,7 @@ import { css } from '@emotion/react';
 import { COLORS, CONFIG } from '../utils';
 
 export const Card = css`
-	box-shadow: 0 0 0 1px ${ CONFIG.surfaceBorderColor };
+	box-shadow: inset 0 0 0 1px ${ CONFIG.surfaceBorderColor };
 	outline: none;
 `;
 

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -157,8 +157,8 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="components-surface components-card css-ssx2ib-View-Surface-getBorders-primary-Card-boxShadowless-rounded em57xhy0"
-+     class="components-surface components-card css-1vyvcpq-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+-     class="components-surface components-card css-xq5dej-View-Surface-getBorders-primary-Card-boxShadowless-rounded em57xhy0"
++     class="components-surface components-card css-hsug4u-View-Surface-getBorders-primary-Card-rounded em57xhy0"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -191,6 +191,23 @@ Snapshot Diff:
         </div>
 `;
 
+exports[`Card Card component should remove borders when the isBorderless prop is true 1`] = `
+Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,8 +1,8 @@
+  <div>
+    <div
+-     class="components-surface components-card css-hsug4u-View-Surface-getBorders-primary-Card-rounded em57xhy0"
++     class="components-surface components-card css-xq5dej-View-Surface-getBorders-primary-Card-boxShadowless-rounded em57xhy0"
+      data-wp-c16t="true"
+      data-wp-component="Card"
+    >
+      <div
+        class="css-mgwsf4-View-Content em57xhy0"
+`;
+
 exports[`Card Card component should render correctly 1`] = `
 Object {
   "asFragment": [Function],
@@ -198,9 +215,19 @@ Object {
   background-color: #fff;
   color: #000;
   position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
   border-radius: 2px;
+}
+
+.emotion-0::before {
+  content: '';
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
 }
 
 .emotion-2 {
@@ -454,9 +481,19 @@ Object {
   background-color: #fff;
   color: #000;
   position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
   border-radius: 2px;
+}
+
+.emotion-0::before {
+  content: '';
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
 }
 
 .emotion-2 {
@@ -789,9 +826,19 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
   background-color: #fff;
   color: #000;
   position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
   border-radius: 2px;
+}
+
+.emotion-0::before {
+  content: '';
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
 }
 
 .emotion-2 {

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -39,15 +39,15 @@ describe( 'Card', () => {
 		} );
 
 		it( 'should remove borders when the isBorderless prop is true', () => {
-			const { rerender, container } = render(
+			const { container: withBorders } = render(
 				<Card>Code is Poetry</Card>
 			);
-			expect( container.firstChild ).not.toHaveStyle(
-				'box-shadow: none'
+
+			const { container: withoutBorders } = render(
+				<Card isBorderless>Code is Poetry</Card>
 			);
 
-			rerender( <Card isBorderless={ true }>Code is Poetry</Card> );
-			expect( container.firstChild ).toHaveStyle( 'box-shadow: none' );
+			expect( withBorders ).toMatchDiffSnapshot( withoutBorders );
 		} );
 
 		it( 'should add rounded border when the isRounded prop is true', () => {

--- a/packages/components/src/flyout/test/__snapshots__/index.js.snap
+++ b/packages/components/src/flyout/test/__snapshots__/index.js.snap
@@ -5,9 +5,19 @@ exports[`props should render correctly 1`] = `
   background-color: #fff;
   color: #000;
   position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
   border-radius: 2px;
+}
+
+.emotion-1::before {
+  content: '';
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
 }
 
 .emotion-1 .components-card-body {


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/35219#issuecomment-930220953. The Card component has a bordered option which paints a drop shadow around it.

This drop shadow is outset, so even though it has the correct 2px border radius applied to it, it appears as a 3px border radius. In addition to this, the fact that it is semitransparent is not visible as the color doesn't overlay the background color inside:

<img width="271" alt="before" src="https://user-images.githubusercontent.com/1204802/135422948-f26e0fce-c151-4340-8552-14961f63eaa7.png">

This PR changes that box shadow to be `inset`, which both fixes the radius, and makes it overlay the color, and simply darken it instead:

<img width="273" alt="after" src="https://user-images.githubusercontent.com/1204802/135423016-02ad2303-b0ad-4476-a7ab-c30e1d74a436.png">


## How has this been tested?

Open the site editor, open global styles, observe the style card. It's easiest with a theme that has a colored background, such as TT1 blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
