### PR TITLE
Make tooltip delay configurable with prop.

### DIFF
--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -48,7 +48,7 @@ The tooltip text to show on focus or hover.
 
 ### delay
 
-Time in milliseconds over children to wait before showing tooltip.
+Time in milliseconds to wait before showing tooltip after the tooltip's visibility is toggled. This prop is currently only available for the web platforms.
 
 -   Type: `Number`
 -   Required: No

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -46,7 +46,7 @@ The tooltip text to show on focus or hover.
 -   Type: `String`
 -   Required: No
 
-### delay
+### delay (web only)
 
 Time in milliseconds to wait before showing tooltip after the tooltip's visibility is toggled. This prop is currently only available for the web platforms.
 

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -46,6 +46,14 @@ The tooltip text to show on focus or hover.
 -   Type: `String`
 -   Required: No
 
+### delay
+
+Time in milliseconds over children to wait before showing tooltip.
+
+-   Type: `Number`
+-   Required: No
+-   Default: 700
+
 ### visible (native only)
 
 Whether the tooltip should be displayed on initial render. This prop is currently only available for the native mobile app built with React Native.

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -87,7 +87,13 @@ const emitToChild = ( children, eventName, event ) => {
 	}
 };
 
-function Tooltip( { children, position, text, shortcut } ) {
+function Tooltip( {
+	children,
+	position,
+	text,
+	shortcut,
+	delay = TOOLTIP_DELAY,
+} ) {
 	/**
 	 * Whether a mouse is currently pressed, used in determining whether
 	 * to handle a focus event as displaying the tooltip immediately.
@@ -96,7 +102,7 @@ function Tooltip( { children, position, text, shortcut } ) {
 	 */
 	const [ isMouseDown, setIsMouseDown ] = useState( false );
 	const [ isOver, setIsOver ] = useState( false );
-	const delayedSetIsOver = useDebounce( setIsOver, TOOLTIP_DELAY );
+	const delayedSetIsOver = useDebounce( setIsOver, delay );
 
 	const createMouseDown = ( event ) => {
 		// Preserve original child callback behavior

--- a/packages/components/src/tooltip/stories/index.js
+++ b/packages/components/src/tooltip/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, number } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -24,8 +24,9 @@ export const _default = () => {
 	};
 	const tooltipText = text( 'Text', 'More information' );
 	const position = select( 'Position', positionOptions, 'top center' );
+	const delay = number( 'Delay', 700 );
 	return (
-		<Tooltip text={ tooltipText } position={ position }>
+		<Tooltip text={ tooltipText } position={ position } delay={ delay }>
 			<div
 				style={ {
 					margin: '50px auto',

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -152,6 +152,40 @@ describe( 'Tooltip', () => {
 			}, TOOLTIP_DELAY );
 		} );
 
+		it( 'should respect custom delay prop when showing popover', () => {
+			const originalMouseEnter = jest.fn();
+			jest.useFakeTimers();
+			const wrapper = mount(
+				<Tooltip text="Help text" delay={ 2000 }>
+					<button
+						onMouseEnter={ originalMouseEnter }
+						onFocus={ originalMouseEnter }
+					>
+						<span>Hover Me!</span>
+					</button>
+				</Tooltip>
+			);
+
+			const button = wrapper.find( 'button' );
+			button.simulate( 'mouseenter', { type: 'mouseenter' } );
+
+			const popoverBeforeTimeout = wrapper.find( 'Popover' );
+			expect( popoverBeforeTimeout ).toHaveLength( 0 );
+			expect( originalMouseEnter ).toHaveBeenCalledTimes( 1 );
+
+			// Popover does not yet exist after default delay, because custom delay is passed.
+			setTimeout( () => {
+				const popoverBetweenTimeout = wrapper.find( 'Popover' );
+				expect( popoverBetweenTimeout ).toHaveLength( 0 );
+			}, TOOLTIP_DELAY );
+
+			// Popover appears after custom delay.
+			setTimeout( () => {
+				const popoverAfterTimeout = wrapper.find( 'Popover' );
+				expect( popoverAfterTimeout ).toHaveLength( 1 );
+			}, 2000 );
+		} );
+
 		it( 'should show tooltip when an element is disabled', () => {
 			const wrapper = mount(
 				<Tooltip text="Show helpful text here">


### PR DESCRIPTION
## Description
As a developer, based on the designer feedback on my application, I want some components to show the tooltip almost immediately and some components to show tooltip after the default 700 ms delay. Currently this is not possible with `Tooltip` component.

With this PR, I'm doing below things
- Introduce a new prop for the delay
- Set default value for the prop so that it doesn't become a breaking change.
- Update readme to document the new prop.

Fixes #29989

## How has this been tested?
- Storybook updated with the knob so that new delay prop can be tested.
- Unit test updated to test whether the component respect the new prop or not.
- Manual testing (gif attached)

## Screenshots
![2021-09-30 at 19 16 05 - White Yak](https://user-images.githubusercontent.com/2236554/135429900-567ade47-14bf-4040-a58c-3b6b7b3d93d3.gif)

## Types of changes
- Component change for new prop
- Unit test
- Storybook
- Readme change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
