### PR TITLE
Remove extra comma character from Tooltip when underlying component is disabled.

### DIFF
--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -38,7 +38,6 @@ const getDisabledElement = ( { eventHandlers, child, childrenWithPopover } ) =>
 			{ cloneElement( child, {
 				children: childrenWithPopover,
 			} ) }
-			,
 		</span>,
 		eventHandlers
 	);


### PR DESCRIPTION
## Description
Fixes #30422 partially.