### PR TITLE
Global Styles: fix presets that use a callback to validate user data

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -697,7 +697,10 @@ class WP_Theme_JSON_Gutenberg {
 				if ( isset( $preset_metadata['value_key'] ) ) {
 					$value_key = $preset_metadata['value_key'];
 					$value     = $preset[ $value_key ];
-				} elseif ( is_callable( $preset_metadata['value_func'] ) ) {
+				} elseif (
+					isset( $preset_metadata['value_func'] ) &&
+					is_callable( $preset_metadata['value_func'] )
+				) {
 					$value_func = $preset_metadata['value_func'];
 					$value      = call_user_func( $value_func, $preset );
 				} else {
@@ -1310,7 +1313,10 @@ class WP_Theme_JSON_Gutenberg {
 					$value = null;
 					if ( isset( $preset_metadata['value_key'] ) ) {
 						$value = $preset[ $preset_metadata['value_key'] ];
-					} elseif ( isset( $preset_metadata['value_func'] ) ) {
+					} elseif (
+						isset( $preset_metadata['value_func'] ) &&
+						is_callable( $preset_metadata['value_func'] )
+					) {
 						$value = call_user_func( $preset_metadata['value_func'], $preset );
 					}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1307,7 +1307,13 @@ class WP_Theme_JSON_Gutenberg {
 					esc_attr( esc_html( $preset['name'] ) ) === $preset['name'] &&
 					sanitize_html_class( $preset['slug'] ) === $preset['slug']
 				) {
-					$value           = $preset[ $preset_metadata['value_key'] ];
+					$value = null;
+					if ( isset( $preset_metadata['value_key'] ) ) {
+						$value = $preset[ $preset_metadata['value_key'] ];
+					} elseif ( isset( $preset_metadata['value_func'] ) ) {
+						$value = call_user_func( $preset_metadata['value_func'], $preset );
+					}
+
 					$preset_is_valid = true;
 					foreach ( $preset_metadata['properties'] as $property ) {
 						if ( ! self::is_safe_css_declaration( $property, $value ) ) {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/34667
Related https://github.com/WordPress/gutenberg/pull/35228 https://github.com/WordPress/gutenberg/pull/35248/

This PR makes the `remove_insecure_settings` take the value from the callback registered by the preset via `value_func`, if it exists.

Note that for allowing the user to _create_ their own duotones via the global styles sidebar, we'd need to also update or hook into the `safecss_filter_attr` function from WordPress core. I'm not doing this here because we don't need it so far.

## How to test

- Paste the following function at the end of `lib/class-wp-theme-json-gutenberg.php` (alternative create your own function in any file that's in scope):

```php
/**
 * Test function.
 *
 * @param array $preset Color preset.
 *
 * @return string Color value.
 */
function return_color_key_value_from_preset( $preset ) {
	return $preset['color'];
}
```

- In `PRESETS_METADATA`, remove the `value_key` of the first preset (`color.palette`) and paste this instead: `'value_func' => 'return_color_key_value_from_preset',`. This is telling the preset will look up for the value via the callback we created.

Then, run `npm run test-php`: the expected result is that all the tests still pass. Also verify that the tests will fail in `trunk` if we use `value_func` for the `color.palette`.
