### PR TITLE
Widgets: Optimize useSelect calls

### DIFF
--- a/packages/customize-widgets/src/components/inserter/index.js
+++ b/packages/customize-widgets/src/components/inserter/index.js
@@ -18,8 +18,10 @@ function Inserter( { setIsOpened } ) {
 		Inserter,
 		'customize-widget-layout__inserter-panel-title'
 	);
-	const insertionPoint = useSelect( ( select ) =>
-		select( customizeWidgetsStore ).__experimentalGetInsertionPoint()
+	const insertionPoint = useSelect(
+		( select ) =>
+			select( customizeWidgetsStore ).__experimentalGetInsertionPoint(),
+		[]
 	);
 
 	return (

--- a/packages/customize-widgets/src/components/inserter/use-inserter.js
+++ b/packages/customize-widgets/src/components/inserter/use-inserter.js
@@ -10,8 +10,9 @@ import { useSelect, useDispatch, select as selectStore } from '@wordpress/data';
 import { store as customizeWidgetsStore } from '../../store';
 
 export default function useInserter( inserter ) {
-	const isInserterOpened = useSelect( ( select ) =>
-		select( customizeWidgetsStore ).isInserterOpened()
+	const isInserterOpened = useSelect(
+		( select ) => select( customizeWidgetsStore ).isInserterOpened(),
+		[]
 	);
 	const { setIsInserterOpened } = useDispatch( customizeWidgetsStore );
 

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -10,19 +10,22 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import Shortcut from './shortcut';
 
 function DynamicShortcut( { name } ) {
-	const { keyCombination, description, aliases } = useSelect( ( select ) => {
-		const {
-			getShortcutKeyCombination,
-			getShortcutDescription,
-			getShortcutAliases,
-		} = select( keyboardShortcutsStore );
+	const { keyCombination, description, aliases } = useSelect(
+		( select ) => {
+			const {
+				getShortcutKeyCombination,
+				getShortcutDescription,
+				getShortcutAliases,
+			} = select( keyboardShortcutsStore );
 
-		return {
-			keyCombination: getShortcutKeyCombination( name ),
-			aliases: getShortcutAliases( name ),
-			description: getShortcutDescription( name ),
-		};
-	}, [ name ] );
+			return {
+				keyCombination: getShortcutKeyCombination( name ),
+				aliases: getShortcutAliases( name ),
+				description: getShortcutDescription( name ),
+			};
+		},
+		[ name ]
+	);
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -22,7 +22,7 @@ function DynamicShortcut( { name } ) {
 			aliases: getShortcutAliases( name ),
 			description: getShortcutDescription( name ),
 		};
-	}, [] );
+	}, [ name ] );
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -22,7 +22,7 @@ function DynamicShortcut( { name } ) {
 			aliases: getShortcutAliases( name ),
 			description: getShortcutDescription( name ),
 		};
-	} );
+	}, [] );
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -35,8 +35,9 @@ function Header() {
 			),
 		[ widgetAreaClientId ]
 	);
-	const isInserterOpened = useSelect( ( select ) =>
-		select( editWidgetsStore ).isInserterOpened()
+	const isInserterOpened = useSelect(
+		( select ) => select( editWidgetsStore ).isInserterOpened(),
+		[]
 	);
 	const { setIsWidgetAreaOpen, setIsInserterOpened } = useDispatch(
 		editWidgetsStore

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
-	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const hasRedo = useSelect(
+		( select ) => select( coreStore ).hasRedo(),
+		[]
+	);
 	const { redo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function UndoButton() {
-	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const hasUndo = useSelect(
+		( select ) => select( coreStore ).hasUndo(),
+		[]
+	);
 	const { undo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -10,19 +10,22 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import Shortcut from './shortcut';
 
 function DynamicShortcut( { name } ) {
-	const { keyCombination, description, aliases } = useSelect( ( select ) => {
-		const {
-			getShortcutKeyCombination,
-			getShortcutDescription,
-			getShortcutAliases,
-		} = select( keyboardShortcutsStore );
+	const { keyCombination, description, aliases } = useSelect(
+		( select ) => {
+			const {
+				getShortcutKeyCombination,
+				getShortcutDescription,
+				getShortcutAliases,
+			} = select( keyboardShortcutsStore );
 
-		return {
-			keyCombination: getShortcutKeyCombination( name ),
-			aliases: getShortcutAliases( name ),
-			description: getShortcutDescription( name ),
-		};
-	}, [ name ] );
+			return {
+				keyCombination: getShortcutKeyCombination( name ),
+				aliases: getShortcutAliases( name ),
+				description: getShortcutDescription( name ),
+			};
+		},
+		[ name ]
+	);
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -22,7 +22,7 @@ function DynamicShortcut( { name } ) {
 			aliases: getShortcutAliases( name ),
 			description: getShortcutDescription( name ),
 		};
-	}, [] );
+	}, [ name ] );
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -22,7 +22,7 @@ function DynamicShortcut( { name } ) {
 			aliases: getShortcutAliases( name ),
 			description: getShortcutDescription( name ),
 		};
-	} );
+	}, [] );
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/edit-widgets/src/components/welcome-guide/index.js
+++ b/packages/edit-widgets/src/components/welcome-guide/index.js
@@ -24,8 +24,10 @@ export default function WelcomeGuide() {
 
 	const { toggleFeature } = useDispatch( interfaceStore );
 
-	const widgetAreas = useSelect( ( select ) =>
-		select( editWidgetsStore ).getWidgetAreas( { per_page: -1 } )
+	const widgetAreas = useSelect(
+		( select ) =>
+			select( editWidgetsStore ).getWidgetAreas( { per_page: -1 } ),
+		[]
 	);
 
 	if ( ! isActive ) {

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -22,11 +22,13 @@ import KeyboardShortcuts from '../keyboard-shortcuts';
 export default function WidgetAreasBlockEditorContent( {
 	blockEditorSettings,
 } ) {
-	const hasThemeStyles = useSelect( ( select ) =>
-		select( interfaceStore ).isFeatureActive(
-			'core/edit-widgets',
-			'themeStyles'
-		)
+	const hasThemeStyles = useSelect(
+		( select ) =>
+			select( interfaceStore ).isFeatureActive(
+				'core/edit-widgets',
+				'themeStyles'
+			),
+		[]
 	);
 
 	const styles = useMemo( () => {

--- a/packages/widgets/src/blocks/widget-group/edit.js
+++ b/packages/widgets/src/blocks/widget-group/edit.js
@@ -16,8 +16,9 @@ import { useSelect } from '@wordpress/data';
 
 export default function Edit( props ) {
 	const { clientId } = props;
-	const { innerBlocks } = useSelect( ( select ) =>
-		select( blockEditorStore ).getBlock( clientId )
+	const { innerBlocks } = useSelect(
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
+		[]
 	);
 
 	return (

--- a/packages/widgets/src/blocks/widget-group/edit.js
+++ b/packages/widgets/src/blocks/widget-group/edit.js
@@ -18,7 +18,7 @@ export default function Edit( props ) {
 	const { clientId } = props;
 	const { innerBlocks } = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
-		[]
+		[ clientId ]
 	);
 
 	return (


### PR DESCRIPTION
## Description
Adds missing dependency arrays to `useSelect` calls to memorize selector callbacks in the Widgets-related packages.

## How has this been tested?
Make sure new Widget screens work correctly.

## Types of changes
Code Quality/Performance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
