### PR TITLE
Add missing doc blocks for the exported members of edit-widgets store

### DIFF
--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -111,7 +111,7 @@ export const saveWidgetAreas = ( widgetAreas ) => async ( {
  * Converts all the blocks from a widget area specified by ID into widgets,
  * and submits a batch request to save everything at once.
  *
- * @param {number} widgetAreaId ID of the widget area to process.
+ * @param {string} widgetAreaId ID of the widget area to process.
  * @return {Function} An action creator.
  */
 export const saveWidgetArea = ( widgetAreaId ) => async ( {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -44,6 +44,14 @@ export const persistStubPost = ( id, blocks ) => ( { registry } ) => {
 	return stubPost;
 };
 
+/**
+ * Converts all the blocks from edited widget areas into widgets,
+ * and submits a batch request to save everything at once.
+ *
+ * Creates a snackbar notice on either success or error.
+ *
+ * @return {Function} An action creator
+ */
 export const saveEditedWidgetAreas = () => async ( {
 	select,
 	dispatch,
@@ -71,6 +79,13 @@ export const saveEditedWidgetAreas = () => async ( {
 	}
 };
 
+/**
+ * Converts all the blocks from specified widget areas into widgets,
+ * and submits a batch request to save everything at once.
+ *
+ * @param {Object[]} widgetAreas Widget areas to save.
+ * @return {Function} An action creator
+ */
 export const saveWidgetAreas = ( widgetAreas ) => async ( {
 	dispatch,
 	registry,
@@ -92,6 +107,13 @@ export const saveWidgetAreas = ( widgetAreas ) => async ( {
 	}
 };
 
+/**
+ * Converts all the blocks from a widget area specified by ID into widgets,
+ * and submits a batch request to save everything at once.
+ *
+ * @param {number} widgetAreaId ID of widget area to process
+ * @return {Function} An action creator
+ */
 export const saveWidgetArea = ( widgetAreaId ) => async ( {
 	dispatch,
 	select,

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -50,7 +50,7 @@ export const persistStubPost = ( id, blocks ) => ( { registry } ) => {
  *
  * Creates a snackbar notice on either success or error.
  *
- * @return {Function} An action creator
+ * @return {Function} An action creator.
  */
 export const saveEditedWidgetAreas = () => async ( {
 	select,
@@ -84,7 +84,7 @@ export const saveEditedWidgetAreas = () => async ( {
  * and submits a batch request to save everything at once.
  *
  * @param {Object[]} widgetAreas Widget areas to save.
- * @return {Function} An action creator
+ * @return {Function} An action creator.
  */
 export const saveWidgetAreas = ( widgetAreas ) => async ( {
 	dispatch,
@@ -111,8 +111,8 @@ export const saveWidgetAreas = ( widgetAreas ) => async ( {
  * Converts all the blocks from a widget area specified by ID into widgets,
  * and submits a batch request to save everything at once.
  *
- * @param {number} widgetAreaId ID of widget area to process
- * @return {Function} An action creator
+ * @param {number} widgetAreaId ID of the widget area to process.
+ * @return {Function} An action creator.
  */
 export const saveWidgetArea = ( widgetAreaId ) => async ( {
 	dispatch,

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -19,13 +19,13 @@ import {
 import { transformWidgetToBlock } from './transformers';
 
 /**
- * Creates a "stub" navigation post reflecting all available widget areas. The
+ * Creates a "stub" widgets post reflecting all available widget areas. The
  * post is meant as a convenient to only exists in runtime and should never be saved. It
  * enables a convenient way of editing the widgets by using a regular post editor.
  *
  * Fetches all widgets from all widgets aras, converts them into blocks, and hydrates a new post with them.
  *
- * @return {Function} An action creator
+ * @return {Function} An action creator.
  */
 export const getWidgetAreas = () => async ( { dispatch, registry } ) => {
 	const query = buildWidgetAreasQuery();
@@ -73,7 +73,7 @@ export const getWidgetAreas = () => async ( { dispatch, registry } ) => {
 /**
  * Fetches all widgets from all widgets ares, and groups them by widget area Id.
  *
- * @return {Function} An action creator
+ * @return {Function} An action creator.
  */
 export const getWidgets = () => async ( { dispatch, registry } ) => {
 	const query = buildWidgetsQuery();

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -18,6 +18,15 @@ import {
 } from './utils';
 import { transformWidgetToBlock } from './transformers';
 
+/**
+ * Creates a "stub" navigation post reflecting all available widget areas. The
+ * post is meant as a convenient to only exists in runtime and should never be saved. It
+ * enables a convenient way of editing the widgets by using a regular post editor.
+ *
+ * Fetches all widgets from all widgets aras, converts them into blocks, and hydrates a new post with them.
+ *
+ * @return {Function} An action creator
+ */
 export const getWidgetAreas = () => async ( { dispatch, registry } ) => {
 	const query = buildWidgetAreasQuery();
 	const widgetAreas = await registry
@@ -61,6 +70,11 @@ export const getWidgetAreas = () => async ( { dispatch, registry } ) => {
 	dispatch( persistStubPost( buildWidgetAreasPostId(), widgetAreaBlocks ) );
 };
 
+/**
+ * Fetches all widgets from all widgets ares, and groups them by widget area Id.
+ *
+ * @return {Function} An action creator
+ */
 export const getWidgets = () => async ( { dispatch, registry } ) => {
 	const query = buildWidgetsQuery();
 	const widgets = await registry

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -24,6 +24,11 @@ import {
 } from './utils';
 import { STORE_NAME as editWidgetsStoreName } from './constants';
 
+/**
+ * Returns all API widgets.
+ *
+ * @return {Object[]} API List of widgets.
+ */
 export const getWidgets = createRegistrySelector( ( select ) => () => {
 	const widgets = select( coreStore ).getEntityRecords(
 		'root',
@@ -48,6 +53,11 @@ export const getWidget = createRegistrySelector(
 	}
 );
 
+/**
+ * Returns all API widget areas.
+ *
+ * @return {Object[]} API List of widget areas.
+ */
 export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 	const query = buildWidgetAreasQuery();
 	return select( coreStore ).getEntityRecords(
@@ -101,6 +111,11 @@ export const getParentWidgetAreaBlock = createRegistrySelector(
 	}
 );
 
+/**
+ * Returns all edited widget area entity records.
+ *
+ * @return {Object[]} List of edited widget area entity records.
+ */
 export const getEditedWidgetAreas = createRegistrySelector(
 	( select ) => ( state, ids ) => {
 		let widgetAreas = select( editWidgetsStoreName ).getWidgetAreas();
@@ -161,6 +176,11 @@ export const getReferenceWidgetBlocks = createRegistrySelector(
 	}
 );
 
+/**
+ * Returns true if any widget area is currently being saved.
+ *
+ * @return {boolean} True if any widget area is currently being saved. False otherwise.
+ */
 export const isSavingWidgetAreas = createRegistrySelector( ( select ) => () => {
 	const widgetAreasIds = select( editWidgetsStoreName )
 		.getWidgetAreas()

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -4,6 +4,12 @@
 import { createBlock, parse, serialize } from '@wordpress/blocks';
 import { addWidgetIdToBlock } from '@wordpress/widgets';
 
+/**
+ * Converts a widget entity record into a block.
+ *
+ * @param {Object} widget The widget entity record.
+ * @return {Object} a block (converted from the entity record).
+ */
 export function transformWidgetToBlock( widget ) {
 	if ( widget.id_base === 'block' ) {
 		const parsedBlocks = parse( widget.instance.raw.content );
@@ -34,6 +40,13 @@ export function transformWidgetToBlock( widget ) {
 	);
 }
 
+/**
+ * Converts a block to a widget entity record.
+ *
+ * @param {Object}  block         The block.
+ * @param {Object?} relatedWidget A related widget entity record from the API (optional).
+ * @return {Object} the widget object (converted from block).
+ */
 export function transformBlockToWidget( block, relatedWidget = {} ) {
 	let widget;
 


### PR DESCRIPTION
This follows up on[ the discussion](https://github.com/WordPress/gutenberg/pull/35110#pullrequestreview-763821000) in #35110 where @noisysocks noticed:

> I noticed we're missing doc comments for most of the exported actions that are being modified here. If you want bonus brownie points, maybe add these missing comments?

I can't say no to brownie points so this PR adds all the missing doc blocks 🍰 
