### PR TITLE
Navigation Block: add block gap support 

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -96,6 +96,16 @@
 			"__experimentalTextTransform": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true
+		},
+		"spacing": {
+			"blockGap": true,
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
 		}
 	},
 	"viewScript": "file:./view.min.js",

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -105,7 +105,10 @@
 				"rem",
 				"vh",
 				"vw"
-			]
+			],
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
 		}
 	},
 	"viewScript": "file:./view.min.js",

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -229,8 +229,7 @@
 .wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container {
-	row-gap: calc(var(--wp--style--block-gap, 2em) / 4);
-	column-gap: var(--wp--style--block-gap, 2em);
+	gap: calc(var(--wp--style--block-gap, 2em) / 4) var(--wp--style--block-gap, 2em);
 }
 
 // Menu items with background.
@@ -241,8 +240,7 @@
 	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
-		row-gap: calc(var(--wp--style--block-gap, 0) / 4);
-		column-gap: var(--wp--style--block-gap, 0.5em);
+		gap: calc(var(--wp--style--block-gap, 0) / 4) var(--wp--style--block-gap, 0.5em);
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -229,7 +229,8 @@
 .wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container {
-	gap: 0.5em 2em;
+	row-gap: calc(var(--wp--style--block-gap, 2em) / 4);
+	column-gap: var(--wp--style--block-gap, 2em);
 }
 
 // Menu items with background.
@@ -240,7 +241,8 @@
 	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
-		gap: 0 0.5em;
+		row-gap: calc(var(--wp--style--block-gap, 0.5em) / 4);
+		column-gap: var(--wp--style--block-gap, 0.5em);
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -241,7 +241,7 @@
 	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
-		row-gap: calc(var(--wp--style--block-gap, 0.5em) / 4);
+		row-gap: calc(var(--wp--style--block-gap, 0) / 4);
 		column-gap: var(--wp--style--block-gap, 0.5em);
 	}
 }


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/33991 has made block gap support available 🎉 

Here we're applying block spacing support to the Navigation Block. More specifically, to the inner flex container surrounding nav items and page list items.

The calculation is to (try to) maintain the original proportional differences between row and column gaps.

Resolves https://github.com/WordPress/gutenberg/issues/34525

## Testing

This might take a while, so grab a drink, get comfortable. Some lo-fi beats often help me, or heavy metal, depending on the weather.

Enable block gap/spacing support in your theme.json under "settings", e.g., 

```json
		"spacing": {
			"blockGap": true,
                         ...

```

Have some posts and pages ready for testing your nav! Also if there are any default `blockGap` spacing values in your `theme.json` ( e.g., `"spacing": { "blockGap": "24px" }`) remove them for now so we can check the CSS defaults.

Insert a Navigation Block, start with an empty menu and add post/page items. 

In the Dimensions Panel in the controls sidebar, adjust the block spacing value.

Repeat the above steps and add a Navigation block, selecting **Add all pages**.

<img width="307" alt="Screen Shot 2021-10-01 at 11 53 16 am" src="https://user-images.githubusercontent.com/6458278/135553492-79487478-e278-450e-8f81-3c9ea66760ff.png">

Check that the block spacing value is applied to the menu items in the editor and for the saved post on the frontend.

Remove all `blockGap` values. Delete them from the input rather than setting to `0`.

Add background colors to your Navigation Blocks.

Check that the block defaults match those defaults in the CSS.

Now, in your theme.json, add the following to the "styles" object:


```json
		"blocks": {
			"core/navigation": {
				"spacing": {
					"blockGap": "25px"
				}
			}
		}
```

Check that the default value of `--wp--style--block-gap` is `25px` and that it is applied to the Navigation container.

Enable responsive menu in the controls sidebar:

<img width="273" alt="Screen Shot 2021-10-01 at 11 50 44 am" src="https://user-images.githubusercontent.com/6458278/135553319-38b71126-9e91-4614-9648-7d6e790e9ece.png">
 
Ensure that the block spacing still applies to the menus in wider-width screens (not the overlay)

## Screenshots


![navigate](https://user-images.githubusercontent.com/6458278/136135636-380fb722-41d4-4150-9d29-ae510b7211a0.gif)

## Types of changes
Adds block spacing support to the navigation block

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
