### PR TITLE
Post Title: Only render link element if we have a post

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -69,7 +69,7 @@ export default function PostTitleEdit( {
 			);
 	}
 
-	if ( isLink ) {
+	if ( isLink && postType && postId ) {
 		titleElement =
 			userCanEdit && ! isDescendentOfQueryLoop ? (
 				<TagName { ...blockProps }>


### PR DESCRIPTION
## Description
PR improves check for rendering link element to avoid error when toggling `isLink` attribute.

Fixes #35174.

## How has this been tested?
1. Go to Site Editor.
2. Choose a Single Post template.
3. Select the Post Title block and enable the "Make title a link" option.
4. Placeholder title should render correctly.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/135596154-614e811d-ff6b-45b6-b2c9-e19dcdfa5291.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
