### PR TITLE
Post Title: Always use blockProps

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -46,9 +46,7 @@ export default function PostTitleEdit( {
 	} );
 
 	let titleElement = (
-		<TagName { ...( isLink ? {} : blockProps ) }>
-			{ __( 'An example title' ) }
-		</TagName>
+		<TagName { ...blockProps }>{ __( 'An example title' ) }</TagName>
 	);
 
 	if ( postType && postId ) {
@@ -60,10 +58,10 @@ export default function PostTitleEdit( {
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }
-					{ ...( isLink ? {} : blockProps ) }
+					{ ...blockProps }
 				/>
 			) : (
-				<TagName { ...( isLink ? {} : blockProps ) }>
+				<TagName { ...blockProps }>
 					<RawHTML key="html">{ fullTitle.rendered }</RawHTML>
 				</TagName>
 			);


### PR DESCRIPTION
## Description
The `blockProps` were applied conditionally based on the `isLink` attribute value. Unfortunately, it was causing missing text alignment when the setting was enabled and making the block hard to select by clicking on the text.

The issue is more visible when testing this PR - #35284.

## How has this been tested?
1. Go to Site Editor.
2. Choose a Single Post template.
3. Select the Post Title block and enable the "Make title a link" option.
4. Text alignment shouldn't change.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
