### PR TITLE
[RNMobile] Remove unneeded memoization dependency from `useBlockEditorSettings`

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -148,9 +148,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			canUseUnfilteredHTML,
 			undo,
 			hasTemplate,
-
 			userCanCreatePages,
-			createPageEntity,
 		]
 	);
 }


### PR DESCRIPTION
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4064

**Fixes https://github.com/WordPress/gutenberg/issues/35283**

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR removes the dependency `createPageEntity` recently introduced in https://github.com/WordPress/gutenberg/pull/35083 from the array of dependencies of the `useMemo` function used in `useBlockEditorSettings`. The reason for this change is that the value of `createPageEntity` is a function that is created on every call to `useBlockEditorSettings`, so the memoized value will be recomputed on every call as well.

https://github.com/WordPress/gutenberg/blob/d079ba2c16495d6d976f5e08a7b5d259c3f13074/packages/editor/src/components/provider/use-block-editor-settings.js#L81-L88

I couldn't find why this was producing the issue described [here](https://github.com/WordPress/gutenberg/issues/35283), as far as I investigated, it looks related to a potential race condition issue between the force render triggered by `useSelect` and the `EditorProvider` re-renders. Before applying this change, when switching to visual mode after having modified the HTML produces the following trace:

- `stopEditing` is called when switching back to visual mode.
https://github.com/WordPress/gutenberg/blob/e44136777d9ba3be0f6cc6185d3f88197edd528d/packages/components/src/mobile/html-text-input/index.native.js#L68-L73
- `onPersist` is called and dispatches the `resetEditorBlocks` action that internally dispatches the `editPost` action with the blocks modified from the HTML changes.
https://github.com/WordPress/gutenberg/blob/e44136777d9ba3be0f6cc6185d3f88197edd528d/packages/components/src/mobile/html-text-input/index.native.js#L136-L139
https://github.com/WordPress/gutenberg/blob/e44136777d9ba3be0f6cc6185d3f88197edd528d/packages/editor/src/store/actions.js#L564-L606
- On the other hand, in `EditorProvider` we use the hook `useEntityBlockEditor` to get fetch the blocks that will be rendered in the editor.
https://github.com/WordPress/gutenberg/blob/e44136777d9ba3be0f6cc6185d3f88197edd528d/packages/editor/src/components/provider/index.js#L46-L50
- In `useEntityBlockEditor` we use the `useSelect` hook to get the new blocks of the post from the state. At this point by debugging the code, I verified that the `mapSelect` function passed to the hook, it was being called due to the `editPost` action, however, the `blocks` value returned by the hook were the old ones previous to the HTML modification 🙃 .

[**Code reference**](https://github.com/WordPress/gutenberg/blob/e44136777d9ba3be0f6cc6185d3f88197edd528d/packages/core-data/src/entity-provider.js#L150-L160)
```
const { content, blocks } = useSelect(
( select ) => {
    const { getEditedEntityRecord } = select( STORE_NAME );
    const editedEntity = getEditedEntityRecord( kind, type, id );
    // editedEntity.blocks =
    // [
    //     {
    //         "clientId": "c43ef380-4b56-4098-8a50-2b1398a06ece",
    //         "name": "core/paragraph",
    //         "isValid": true,
    //         "attributes": {
    //             "content": "New text",
    //             "dropCap": false
    //         },
    //         "innerBlocks": [],
    //         "originalContent": "<p>New text</p>",
    //         "validationIssues": []
    //     }
    // ]
    return {
        blocks: editedEntity.blocks,
        content: editedEntity.content,
    };
},
[ kind, type, id ],
true
);
// blocks = 
// [
//     {
//         "clientId": "a8b3ea8c-6573-4dc3-8d47-7d5d50b5e658",
//         "name": "core/paragraph",
//         "isValid": true,
//         "attributes": {
//             "content": "Initial text",
//             "dropCap": false
//         },
//         "innerBlocks": []
//     }
// ]
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Verify that HTML changes in HTML mode are reflected when going back to visual mode
1. Open a post/page.
1. Write some text in a Paragraph block.
1. Open the post settings by tapping the three dots button located in the top bar.
1. Tap on "Switch to HTML Mode".
1. Change the text wrapped in the `<p>` element.
1. Open the post settings by tapping the three dots button located in the top bar.
1. Tap on "Switch to Visual Mode".
1. Observe that the change made in the text of the Paragraph block is reflected in the editor.

### Verify that "Enable ability to create Pages from the inline Link UI" feature is not broken
Follow the testing steps described in https://github.com/WordPress/gutenberg/pull/35083.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
