### PR TITLE
Storybook: Add story for TypographyPanel

### DIFF
--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -169,6 +169,8 @@ export const WithSlotFillItems = () => {
 	);
 };
 
+export { TypographyPanel } from './typography-panel';
+
 const PanelWrapperView = styled.div`
 	max-width: 260px;
 	font-size: 13px;

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -1,0 +1,217 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalFontAppearanceControl as FontAppearanceControl,
+	__experimentalFontFamilyControl as FontFamilyControl,
+	__experimentalLetterSpacingControl as LetterSpacingControl,
+	LineHeightControl,
+} from '@wordpress/block-editor';
+import {
+	FontSizePicker,
+	__experimentalRadio as Radio,
+	__experimentalRadioGroup as RadioGroup,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ToolsPanel, ToolsPanelItem } from '..';
+import Panel from '../../panel';
+import { ControlLabel } from '../../ui/control-label';
+import { FormGroup } from '../../ui/form-group';
+
+// These options match the theme.json typography schema
+const fontFamilies = [
+	{
+		fontFamily:
+			'-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+		slug: 'system-fonts',
+		name: 'System Fonts',
+	},
+	{
+		fontFamily:
+			'Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace',
+		name: 'Monospace',
+		slug: 'monospace',
+	},
+	{
+		fontFamily:
+			'Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif',
+		name: 'Serif',
+		slug: 'hoefler-times-new-roman',
+	},
+];
+const fontSizes = [
+	{
+		slug: 'small',
+		size: '1rem',
+		name: 'Small',
+	},
+	{
+		slug: 'normal',
+		size: '1.25rem',
+		name: 'Normal',
+	},
+	{
+		slug: 'medium',
+		size: '1.5rem',
+		name: 'medium',
+	},
+	{
+		slug: 'large',
+		size: '2rem',
+		name: 'Large',
+	},
+	{
+		slug: 'extra-large',
+		size: '3rem',
+		name: 'Extra large',
+	},
+];
+
+const LetterCaseControl = ( props ) => {
+	return (
+		<FormGroup>
+			<ControlLabel>Letter Case</ControlLabel>
+			<RadioGroup label="Letter Case" { ...props }>
+				<Radio value="uppercase" aria-label="Uppercase">
+					AB
+				</Radio>
+				<Radio value="lowercase" aria-label="Lowercase">
+					ab
+				</Radio>
+				<Radio value="capitalize" aria-label="Capitalize">
+					Ab
+				</Radio>
+			</RadioGroup>
+		</FormGroup>
+	);
+};
+
+export const TypographyPanel = () => {
+	const [ fontFamily, setFontFamily ] = useState();
+	const [ fontSize, setFontSize ] = useState();
+	const [ fontWeight, setFontWeight ] = useState();
+	const [ fontStyle, setFontStyle ] = useState();
+	const [ lineHeight, setLineHeight ] = useState();
+	const [ letterSpacing, setLetterSpacing ] = useState();
+	const [ textTransform, setTextTransform ] = useState();
+
+	return (
+		<>
+			<div style={ { maxWidth: '280px' } }>
+				<Panel>
+					<ToolsPanel label="Typography Tools">
+						<ToolsPanelItem
+							hasValue={ () => !! fontFamily }
+							label="Font"
+							onDeselect={ () => setFontFamily( undefined ) }
+							isShownByDefault={ true }
+						>
+							<FontFamilyControl
+								value={ fontFamily }
+								onChange={ setFontFamily }
+								fontFamilies={ fontFamilies }
+							/>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! fontSize }
+							label="Size"
+							onDeselect={ () => setFontSize( undefined ) }
+							isShownByDefault={ true }
+						>
+							<FontSizePicker
+								value={ fontSize }
+								onChange={ setFontSize }
+								fontSizes={ fontSizes }
+							/>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! fontStyle || !! fontWeight }
+							label="Appearance"
+							onDeselect={ () => {
+								setFontStyle( undefined );
+								setFontWeight( undefined );
+							} }
+							isShownByDefault={ true }
+						>
+							<FontAppearanceControl
+								value={ {
+									fontStyle,
+									fontWeight,
+								} }
+								onChange={ ( {
+									fontStyle: style,
+									fontWeight: weight,
+								} ) => {
+									setFontStyle( style );
+									setFontWeight( weight );
+								} }
+							/>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! lineHeight }
+							label="Line Height"
+							onDeselect={ () => setLineHeight( undefined ) }
+							isShownByDefault={ true }
+						>
+							<LineHeightControl
+								value={ lineHeight }
+								onChange={ setLineHeight }
+							/>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! letterSpacing }
+							label="Letter Spacing"
+							onDeselect={ () => setLetterSpacing( undefined ) }
+							isShownByDefault={ true }
+						>
+							<LetterSpacingControl
+								value={ letterSpacing }
+								onChange={ setLetterSpacing }
+							/>
+						</ToolsPanelItem>
+
+						<ToolsPanelItem
+							hasValue={ () => !! textTransform }
+							label="Letter Case"
+							onDeselect={ () => setTextTransform( undefined ) }
+							isShownByDefault={ true }
+						>
+							<LetterCaseControl
+								onChange={ setTextTransform }
+								checked={ textTransform }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</Panel>
+			</div>
+			<div
+				style={ {
+					marginTop: '1rem',
+					fontFamily,
+					fontSize,
+					fontStyle,
+					fontWeight,
+					lineHeight,
+					letterSpacing,
+					textTransform,
+				} }
+			>
+				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+				enim ad minim veniam, quis nostrud exercitation ullamco laboris
+				nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+				in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+				nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+				sunt in culpa qui officia deserunt mollit anim id est laborum.
+			</div>
+		</>
+	);
+};

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -7,20 +7,18 @@ import {
 	__experimentalLetterSpacingControl as LetterSpacingControl,
 	LineHeightControl,
 } from '@wordpress/block-editor';
-import {
-	FontSizePicker,
-	__experimentalRadio as Radio,
-	__experimentalRadioGroup as RadioGroup,
-} from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { ToolsPanel, ToolsPanelItem } from '..';
+import FontSizePicker from '../../font-size-picker';
 import Panel from '../../panel';
+import Radio from '../../radio';
+import RadioGroup from '../../radio-group';
 import { ControlLabel } from '../../ui/control-label';
 import { FormGroup } from '../../ui/form-group';
+import { ToolsPanel, ToolsPanelItem } from '..';
 
 // These options match the theme.json typography schema
 const fontFamilies = [

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -14,10 +14,10 @@ import { useState } from '@wordpress/element';
  */
 import FontSizePicker from '../../font-size-picker';
 import Panel from '../../panel';
-import Radio from '../../radio';
-import RadioGroup from '../../radio-group';
-import { ControlLabel } from '../../ui/control-label';
-import { FormGroup } from '../../ui/form-group';
+import {
+	ToggleGroupControl,
+	ToggleGroupControlOption,
+} from '../../toggle-group-control';
 import { ToolsPanel, ToolsPanelItem } from '..';
 
 // These options match the theme.json typography schema
@@ -71,20 +71,20 @@ const fontSizes = [
 
 const LetterCaseControl = ( props ) => {
 	return (
-		<FormGroup>
-			<ControlLabel>Letter Case</ControlLabel>
-			<RadioGroup label="Letter Case" { ...props }>
-				<Radio value="uppercase" aria-label="Uppercase">
-					AB
-				</Radio>
-				<Radio value="lowercase" aria-label="Lowercase">
-					ab
-				</Radio>
-				<Radio value="capitalize" aria-label="Capitalize">
-					Ab
-				</Radio>
-			</RadioGroup>
-		</FormGroup>
+		<ToggleGroupControl label="Letter Case" isBlock={ true } { ...props }>
+			{ [
+				{ value: 'uppercase', ariaLabel: 'Uppercase', label: 'AB' },
+				{ value: 'lowercase', ariaLabel: 'Lowercase', label: 'ab' },
+				{ value: 'capitalize', ariaLabel: 'Capitalize', label: 'Ab' },
+			].map( ( { value, ariaLabel, label } ) => (
+				<ToggleGroupControlOption
+					key={ value }
+					label={ label }
+					aria-label={ ariaLabel }
+					value={ value }
+				/>
+			) ) }
+		</ToggleGroupControl>
 	);
 };
 
@@ -184,7 +184,7 @@ export const TypographyPanel = () => {
 						>
 							<LetterCaseControl
 								onChange={ setTextTransform }
-								checked={ textTransform }
+								value={ textTransform }
 							/>
 						</ToolsPanelItem>
 					</ToolsPanel>

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -101,7 +101,7 @@ export const TypographyPanel = () => {
 		<>
 			<div style={ { maxWidth: '280px' } }>
 				<Panel>
-					<ToolsPanel label="Typography Tools">
+					<ToolsPanel label="Typography">
 						<ToolsPanelItem
 							hasValue={ () => !! fontFamily }
 							label="Font"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Adds an exploratory TypographyPanel story under the ToolsPanel section so it can serve as a living guide/playground for the TypographyPanel-related components work. It uses ToolsPanel and other existing components, so it exposes what’s missing design-wise. 

In terms of ToolsPanel, the main gap I'm seeing is the grid/column approach. The `.single-column` class should not be [exposed](https://github.com/WordPress/gutenberg/issues/35058), but whether we're going to provide some kind of grid/column layout methods as a part of ToolsPanelItem, or allow the consumer to use their own wp-component `Grid`s, we'll have to decide. (I'm inclined to choose the latter, as it's more flexible.)

## How has this been tested?

`npm run storybook:dev`

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/555336/136152612-707510f6-fcbe-47f5-a17f-cbaa8a75e8e6.png" alt="Storybook story for the Typography Panel" width="300">

## Types of changes

Storybook-only, non-breaking

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
