### PR TITLE
[WIP] Buttons block: Add axial gap support

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -63,7 +63,6 @@
 	.is-selected & {
 		height: auto;
 		overflow: visible;
-		margin-top: $grid-unit-20;
 	}
 }
 

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,9 +1,3 @@
-.wp-block[data-align="center"] > .wp-block-button {
-	text-align: center;
-	margin-left: auto;
-	margin-right: auto;
-}
-
 .wp-block[data-align="right"] > .wp-block-button {
 	/*!rtl:ignore*/
 	text-align: right;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,3 +1,9 @@
+.wp-block[data-align="center"] > .wp-block-button {
+	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .wp-block[data-align="right"] > .wp-block-button {
 	/*!rtl:ignore*/
 	text-align: right;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,7 +34,7 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
-.wp-block-buttons > .wp-block-button {
+.wp-block-button {
 	&.has-custom-width {
 		max-width: none;
 		.wp-block-button__link {
@@ -49,15 +49,15 @@ $blocks-block__margin: 0.5em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.75));
+		width: calc(25% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.5));
+		width: calc(50% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.25));
+		width: calc(75% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25));
 	}
 
 	&.wp-block-button__width-100 {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,7 +34,8 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
-.wp-block-button {
+// Increased specificity needed to override margins.
+.wp-block-buttons > .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
 		.wp-block-button__link {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,7 +34,6 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
-// Increased specificity needed to override margins
 .wp-block-buttons > .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
@@ -50,45 +49,20 @@ $blocks-block__margin: 0.5em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
+		width: calc(25% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.75));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
+		width: calc(50% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.5));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
+		width: calc(75% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.25));
 	}
 
 	&.wp-block-button__width-100 {
-		width: calc(100% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
-
-		&:only-child {
-			width: 100%;
-		}
-	}
-}
-
-// If the browser supports column-gap, use that instead of the margins above.
-@supports ( column-gap:  var(--wp--style--block-gap, $blocks-block__margin)  ) {
-	.wp-block-buttons > .wp-block-button {
-		&.wp-block-button__width-25 {
-			width: calc(25% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.75));
-		}
-
-		&.wp-block-button__width-50 {
-			width: calc(50% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.5));
-		}
-
-		&.wp-block-button__width-75 {
-			width: calc(75% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.25));
-		}
-
-		&.wp-block-button__width-100 {
-			width: 100%;
-			flex-basis: 100%;
-		}
+		width: 100%;
+		flex-basis: 100%;
 	}
 }
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -50,57 +50,44 @@ $blocks-block__margin: 0.5em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - #{ $blocks-block__margin });
+		width: calc(25% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - #{ $blocks-block__margin });
+		width: calc(50% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - #{ $blocks-block__margin });
+		width: calc(75% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
 	}
 
 	&.wp-block-button__width-100 {
-		width: calc(100% - #{ $blocks-block__margin });
+		width: calc(100% - ( var(--wp--style--block-gap, $blocks-block__margin) ));
 
 		&:only-child {
-			margin-right: 0;
 			width: 100%;
 		}
 	}
 }
 
 // If the browser supports column-gap, use that instead of the margins above.
-@supports ( column-gap: #{ $blocks-block__margin } ) {
-	.wp-block-buttons {
-
-		> .wp-block-button,
-		&.is-content-justification-right > .wp-block-button, {
-			// Added (duplicate) specificity needed to override the default button margin.
-			&.wp-block-button {
-				margin-right: 0;
-				margin-left: 0;
-			}
+@supports ( column-gap:  var(--wp--style--block-gap, $blocks-block__margin)  ) {
+	.wp-block-buttons > .wp-block-button {
+		&.wp-block-button__width-25 {
+			width: calc(25% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.75));
 		}
 
-		> .wp-block-button {
-			&.wp-block-button__width-25 {
-				width: calc(25% - #{ $blocks-block__margin * 0.75 });
-			}
+		&.wp-block-button__width-50 {
+			width: calc(50% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.5));
+		}
 
-			&.wp-block-button__width-50 {
-				width: calc(50% - #{ $blocks-block__margin * 0.5 });
-			}
+		&.wp-block-button__width-75 {
+			width: calc(75% - (var(--wp--style--block-gap, $blocks-block__margin) * 0.25));
+		}
 
-			&.wp-block-button__width-75 {
-				width: calc(75% - #{ $blocks-block__margin * 0.25 });
-			}
-
-			&.wp-block-button__width-100 {
-				width: auto;
-				flex-basis: 100%;
-			}
+		&.wp-block-button__width-100 {
+			width: auto;
+			flex-basis: 100%;
 		}
 	}
 }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -92,6 +92,21 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
+// For vertical buttons, gap is not factored into width calculations.
+.wp-block-buttons.is-vertical > .wp-block-button {
+	&.wp-block-button__width-25 {
+		width: 25%;
+	}
+
+	&.wp-block-button__width-50 {
+		width: 50%;
+	}
+
+	&.wp-block-button__width-75 {
+		width: 75%;
+	}
+}
+
 // the first selector is required for old buttons markup
 .wp-block-button.is-style-squared,
 .wp-block-button__link.wp-block-button.is-style-squared {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -49,16 +49,17 @@ $blocks-block__margin: 0.5em;
 		}
 	}
 
+	--column-gap: var(--wp--style--block-column-gap, var(--wp--style-block-gap, $blocks-block__margin));
 	&.wp-block-button__width-25 {
-		width: calc(25% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75));
+		width: calc(25% - (var(--column-gap) * 0.75));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5));
+		width: calc(50% - (var(--column-gap) * 0.5));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25));
+		width: calc(75% - (var(--column-gap) * 0.25));
 	}
 
 	&.wp-block-button__width-100 {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -86,7 +86,7 @@ $blocks-block__margin: 0.5em;
 		}
 
 		&.wp-block-button__width-100 {
-			width: auto;
+			width: 100%;
 			flex-basis: 100%;
 		}
 	}

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -18,7 +18,13 @@
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],
-		"__experimentalExposeControlsToChildren": true
+		"__experimentalExposeControlsToChildren": true,
+		"spacing": {
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-buttons-editor",
 	"style": "wp-block-buttons"

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -20,8 +20,8 @@
 		"align": [ "wide", "full" ],
 		"__experimentalExposeControlsToChildren": true,
 		"spacing": {
-			"blockGap": true,
-			"margin": ["top", "bottom" ],
+			"blockGap": [ "horizontal", "vertical" ],
+			"margin": [ "top", "bottom" ],
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -21,6 +21,7 @@
 		"__experimentalExposeControlsToChildren": true,
 		"spacing": {
 			"blockGap": true,
+			"margin": ["top", "bottom" ],
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -8,8 +8,8 @@ $blocks-block__margin: 1em;
 
 .wp-block-buttons {
 	// Specificity needed to override editor auto block margins.
-	> .wp-block {
-		margin-top: calc(var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5);
+	> .wp-block.wp-block-button {
+		margin: 0;
 	}
 
 	> .block-list-appender {
@@ -47,12 +47,6 @@ $blocks-block__margin: 1em;
 		margin-right: auto;
 		margin-top: 0;
 		width: 100%;
-
-		.wp-block-button {
-			// Some margin hacks are needed, since margin doesn't seem to
-			// collapse in the same way when a parent layout it flex.
-			margin-bottom: 0;
-		}
 	}
 }
 

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -7,11 +7,6 @@ $blocks-block__margin: 0.5em;
 }
 
 .wp-block-buttons {
-	> .wp-block {
-		// Override editor auto block margins.
-		margin-left: 0;
-		margin-right: $blocks-block__margin;
-	}
 	> .block-list-appender {
 		display: inline-flex;
 		align-items: center;
@@ -47,12 +42,6 @@ $blocks-block__margin: 0.5em;
 		margin-right: auto;
 		margin-top: 0;
 		width: 100%;
-
-		.wp-block-button {
-			// Some margin hacks are needed, since margin doesn't seem to
-			// collapse in the same way when a parent layout it flex.
-			margin-bottom: 0;
-		}
 	}
 }
 

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -7,6 +7,11 @@ $blocks-block__margin: 0.5em;
 }
 
 .wp-block-buttons {
+	// Specificity needed to override editor auto block margins.
+	> .wp-block.wp-block-button {
+		margin: 0;
+	}
+
 	> .block-list-appender {
 		display: inline-flex;
 		align-items: center;

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -10,7 +10,6 @@ $blocks-block__margin: 0.5em;
 	> .wp-block {
 		// Override editor auto block margins.
 		margin-left: 0;
-		margin-top: $blocks-block__margin;
 		margin-right: $blocks-block__margin;
 	}
 	> .block-list-appender {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,5 +1,5 @@
 // This variable is repeated across Button, Buttons, and Buttons editor styles.
-$blocks-block__margin: 0.5em;
+$blocks-block__margin: 1em;
 
 .wp-block > .wp-block-buttons {
 	display: flex;
@@ -8,8 +8,8 @@ $blocks-block__margin: 0.5em;
 
 .wp-block-buttons {
 	// Specificity needed to override editor auto block margins.
-	> .wp-block.wp-block-button {
-		margin: 0;
+	> .wp-block {
+		margin-top: calc(var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5);
 	}
 
 	> .block-list-appender {
@@ -47,6 +47,12 @@ $blocks-block__margin: 0.5em;
 		margin-right: auto;
 		margin-top: 0;
 		width: 100%;
+
+		.wp-block-button {
+			// Some margin hacks are needed, since margin doesn't seem to
+			// collapse in the same way when a parent layout it flex.
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,15 +5,25 @@ $blocks-block__margin: 0.5em;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	gap: var(--wp--style--block-gap, $blocks-block__margin);
+	column-gap: var(--wp--style--block-gap, $blocks-block__margin);
 
 	&.is-vertical {
 		flex-direction: column;
+		> .wp-block-button {
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	// Increased specificity to override blocks default margin.
 	> .wp-block-button {
 		display: inline-block;
+		/*rtl:ignore*/
+		margin-left: 0;
+		/*rtl:ignore*/
+		margin-right: 0;
+		margin-bottom: calc(var(--wp--style--block-gap, #{ $blocks-block__margin}) * 0.5);
 	}
 
 	&.is-content-justification-left {
@@ -65,6 +75,7 @@ $blocks-block__margin: 0.5em;
 	/* stylelint-enable indentation */
 		margin-left: auto;
 		margin-right: auto;
+		margin-bottom: calc(var(--wp--style--block-gap, #{ $blocks-block__margin}) * 0.5);
 		width: 100%;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,32 +5,15 @@ $blocks-block__margin: 0.5em;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	column-gap: var(--wp--style--block-gap, $blocks-block__margin);
-	row-gap: var(--wp--style--block-gap, $blocks-block__margin);
+	gap: var(--wp--style--block-gap, $blocks-block__margin);
 
 	&.is-vertical {
 		flex-direction: column;
-		> .wp-block-button {
-			/*rtl:ignore*/
-			margin-right: 0;
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
 	}
 
 	// Increased specificity to override blocks default margin.
 	> .wp-block-button {
 		display: inline-block;
-		/*rtl:ignore*/
-		margin-left: 0;
-		/*rtl:ignore*/
-		margin-right: $blocks-block__margin;
-
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
 	}
 
 	&.is-content-justification-left {
@@ -50,18 +33,6 @@ $blocks-block__margin: 0.5em;
 	&.is-content-justification-right {
 		justify-content: flex-end;
 
-		> .wp-block-button {
-			/*rtl:ignore*/
-			margin-left: $blocks-block__margin;
-			/*rtl:ignore*/
-			margin-right: 0;
-
-			&:first-child {
-				/*rtl:ignore*/
-				margin-left: 0;
-			}
-		}
-
 		&.is-vertical {
 			align-items: flex-end;
 		}
@@ -74,28 +45,6 @@ $blocks-block__margin: 0.5em;
 	// Kept for backward compatibility.
 	&.aligncenter {
 		text-align: center;
-	}
-	&.alignleft .wp-block-button {
-		/*rtl:ignore*/
-		margin-left: 0;
-		/*rtl:ignore*/
-		margin-right: $blocks-block__margin;
-
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
-	}
-	&.alignright .wp-block-button {
-		/*rtl:ignore*/
-		margin-right: 0;
-		/*rtl:ignore*/
-		margin-left: $blocks-block__margin;
-
-		&:first-child {
-			/*rtl:ignore*/
-			margin-left: 0;
-		}
 	}
 
 	// Back compat: Inner button blocks previously had their own alignment

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,25 +5,18 @@ $blocks-block__margin: 0.5em;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	column-gap: var(--wp--style--block-gap, $blocks-block__margin);
+	row-gap: var(--wp--style--block-row-gap, var(--wp--style-block-gap, $blocks-block__margin));
+	column-gap: var(--wp--style--block-column-gap, var(--wp--style--block-gap, $blocks-block__margin));
+	margin-top: 0;
 
 	&.is-vertical {
 		flex-direction: column;
-		> .wp-block-button {
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
 	}
 
 	// Increased specificity to override blocks default margin.
 	> .wp-block-button {
 		display: inline-block;
-		/*rtl:ignore*/
-		margin-left: 0;
-		/*rtl:ignore*/
-		margin-right: 0;
-		margin-bottom: calc(var(--wp--style--block-gap, #{ $blocks-block__margin}) * 0.5);
+		margin: 0;
 	}
 
 	&.is-content-justification-left {
@@ -75,7 +68,6 @@ $blocks-block__margin: 0.5em;
 	/* stylelint-enable indentation */
 		margin-left: auto;
 		margin-right: auto;
-		margin-bottom: calc(var(--wp--style--block-gap, #{ $blocks-block__margin}) * 0.5);
 		width: 100%;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -5,7 +5,8 @@ $blocks-block__margin: 0.5em;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	column-gap: $blocks-block__margin;
+	column-gap: var(--wp--style--block-gap, $blocks-block__margin);
+	row-gap: var(--wp--style--block-gap, $blocks-block__margin);
 
 	&.is-vertical {
 		flex-direction: column;
@@ -25,7 +26,6 @@ $blocks-block__margin: 0.5em;
 		margin-left: 0;
 		/*rtl:ignore*/
 		margin-right: $blocks-block__margin;
-		margin-bottom: $blocks-block__margin;
 
 		&:last-child {
 			/*rtl:ignore*/
@@ -116,7 +116,6 @@ $blocks-block__margin: 0.5em;
 	/* stylelint-enable indentation */
 		margin-left: auto;
 		margin-right: auto;
-		margin-bottom: $blocks-block__margin;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Just breaking this out into a separate PR for ease of testing; uses #35301 which adds axial support for gap and actually opts in for the Buttons block. 


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
See testing instructions on #35301

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
