### PR TITLE
Fix missing border in the quick inserter.

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -191,7 +191,6 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__no-results {
 	padding: $grid-unit-40;
-	margin-top: $grid-unit-40 * 2;
 	text-align: center;
 }
 
@@ -280,10 +279,6 @@ $block-inserter-tabs-height: 44px;
 	@include break-medium {
 		width: $block-inserter-width;
 	}
-}
-
-.block-editor-inserter__quick-inserter-results {
-	overflow: hidden;
 }
 
 .block-editor-inserter__quick-inserter-results .block-editor-inserter__panel-header {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -282,6 +282,10 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__quick-inserter-results {
+	overflow: hidden;
+}
+
 .block-editor-inserter__quick-inserter-results .block-editor-inserter__panel-header {
 	height: 0;
 	padding: 0;


### PR DESCRIPTION
## Description
In the quick inserter, when no search results are found, there is some left/right border missing. This is caused by some margin applied to the `block-editor-inserter__no-results` div. While this margin could just be removed, I feel it is easier to just apply `overflow: hidden` to the container element. That way the spacing is preserved and should prevent any future issues.

## How has this been tested?
Tested in Gutenberg 11.6 and WordPress 5.8.1

## Screenshots 

Without fix:
![image](https://user-images.githubusercontent.com/4832319/135750798-1d547e4c-0386-49ca-b808-6ba4d0132d9c.png)

With fix:
![image](https://user-images.githubusercontent.com/4832319/135750820-73627b51-5c95-45f4-ab1a-de1854286637.png)


## Types of changes
Bug fix, styling

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
