### PR TITLE
Gallery block: fix Safari image sizing issue

### DIFF
--- a/packages/block-library/src/gallery/deprecated.scss
+++ b/packages/block-library/src/gallery/deprecated.scss
@@ -70,6 +70,7 @@
 	&.is-cropped .blocks-gallery-item {
 		a,
 		img {
+			width: 100%;
 			height: 100%;
 			flex: 1;
 			object-fit: cover;


### PR DESCRIPTION
## Description

A [css width setting was inadvertently removed](https://github.com/WordPress/gutenberg/commit/9506b08dead0bb5676a402706f2c0793e175f5fc#diff-005cc522d6cf154c027a19ac74c38235544bea92685eb7c6187bdbc333bcc535L86) when the IE specific css hacks were removed. This is causing Safari to set the wrong image height in the deprecated Gallery block when the images are linked to media or attachment.

Fixes: https://github.com/Automattic/wp-calypso/issues/56555

## Testing

- Check out this PR to local dev env
- Make sure that the gallery experiment is not enabled
- Add a gallery with several images and set link to `attachment` or `media`, and images to `cropped`
- Make sure the images display as expected in Safari and Chrome

## Screenshots 

Before:
<img width="769" alt="Screen Shot 2021-10-04 at 10 57 45 AM" src="https://user-images.githubusercontent.com/3629020/135772801-a5abd035-c1bd-4b5e-ac13-316e2dee0d61.png">

After:
<img width="679" alt="Screen Shot 2021-10-04 at 10 58 08 AM" src="https://user-images.githubusercontent.com/3629020/135772808-5da953e6-dda4-46c0-a494-e08a4b313143.png">

