### PR TITLE
Fix overflows of `Navigator`

### DIFF
--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -20,21 +20,29 @@ function NavigatorButton( { path, isBack = false, ...props } ) {
 }
 
 const MyNavigation = () => (
-	<NavigatorProvider initialPath="/">
-		<NavigatorScreen path="/">
-			<p>This is the home screen.</p>
-			<NavigatorButton isPrimary path="/child">
-				Navigate to child screen.
-			</NavigatorButton>
-		</NavigatorScreen>
+	<div style={ { 'overflow-x': 'hidden' } }>
+		<NavigatorProvider initialPath="/">
+			<NavigatorScreen path="/">
+				<p>This is the home screen.</p>
+				<NavigatorButton isPrimary path="/child">
+					Navigate to child screen.
+				</NavigatorButton>
+			</NavigatorScreen>
 
-		<NavigatorScreen path="/child">
-			<p>This is the child screen.</p>
-			<NavigatorButton isPrimary path="/" isBack>
-				Go back
-			</NavigatorButton>
-		</NavigatorScreen>
-	</NavigatorProvider>
+			<NavigatorScreen path="/child">
+				<p>This is the child screen.</p>
+				<NavigatorButton
+					isPrimary
+					path="/"
+					isBack
+					style={ { position: 'sticky', top: '5px' } }
+				>
+					Go back
+				</NavigatorButton>
+				<div style={ { height: '200vh', background: 'papayawhip' } } />
+			</NavigatorScreen>
+		</NavigatorProvider>
+	</div>
 );
 
 export const _default = () => {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -325,10 +325,10 @@ export default function PreferencesModal() {
 		);
 	} else {
 		modalContent = (
-			<Card isBorderless>
-				<CardBody>
-					<NavigatorProvider initialPath="/">
-						<NavigatorScreen path="/">
+			<NavigatorProvider initialPath="/">
+				<NavigatorScreen path="/">
+					<Card isBorderless size="small">
+						<CardBody>
 							<ItemGroup>
 								{ tabs.map( ( tab ) => {
 									return (
@@ -358,13 +358,17 @@ export default function PreferencesModal() {
 									);
 								} ) }
 							</ItemGroup>
-						</NavigatorScreen>
-						{ sections.map( ( section ) => {
-							return (
-								<NavigatorScreen
-									key={ `${ section.name }-menu` }
-									path={ section.name }
-								>
+						</CardBody>
+					</Card>
+				</NavigatorScreen>
+				{ sections.map( ( section ) => {
+					return (
+						<NavigatorScreen
+							key={ `${ section.name }-menu` }
+							path={ section.name }
+						>
+							<Card isBorderless size="large">
+								<CardBody>
 									<NavigationButton
 										path="/"
 										icon={
@@ -376,12 +380,12 @@ export default function PreferencesModal() {
 									</NavigationButton>
 									<h2>{ section.tabLabel }</h2>
 									{ section.content }
-								</NavigatorScreen>
-							);
-						} ) }
-					</NavigatorProvider>
-				</CardBody>
-			</Card>
+								</CardBody>
+							</Card>
+						</NavigatorScreen>
+					);
+				} ) }
+			</NavigatorProvider>
 		);
 	}
 	return (

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -27,46 +27,6 @@ $vertical-tabs-width: 160px;
 		}
 	}
 
-	.components-navigation {
-		padding: 0;
-		max-height: 100%;
-		overflow-y: auto;
-		color: $black;
-
-		> * {
-			// Matches spacing cleared from the modal content element.
-			padding: $grid-unit-30 $grid-unit-40;
-		}
-
-		.components-navigation__menu {
-			margin: 0;
-
-			.components-navigation__item {
-				& > button {
-					padding: 3px $grid-unit-20;
-					height: $grid-unit-60;
-					// Aligns button text instead of button box.
-					margin: 0 #{-$grid-unit-20};
-					width: calc(#{$grid-unit-40} + 100%);
-					&:focus {
-						font-weight: 500;
-					}
-				}
-			}
-			.components-navigation__menu-title-heading {
-				border-bottom: 1px solid $gray-300;
-				padding-left: 0;
-				padding-right: 0;
-			}
-			.components-navigation__back-button {
-				padding-left: 0;
-			}
-			.edit-post-preferences-modal__custom-fields-confirmation-button {
-				width: auto;
-			}
-		}
-	}
-
 	.edit-post-preferences__tabs {
 		.components-tab-panel__tabs {
 			position: absolute;

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -14,10 +14,12 @@ $vertical-tabs-width: 160px;
 		height: 70%;
 	}
 
-	// Clears spacing to flush fit the navigation component to the modal edges.
+	// Clears spacing to flush fit the navigator component to the modal edges.
 	@media (max-width: #{ ($break-medium - 1) }) {
 		.components-modal__content {
 			padding: 0;
+			// Prevents horizontal overflow from showing scrollbars.
+			overflow-x: hidden;
 
 			&::before {
 				content: none;

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -17,6 +17,12 @@
 	}
 }
 
+.edit-site-global-styles-sidebar {
+	> .components-panel {
+		overflow-x: hidden;
+	}
+}
+
 .edit-site-global-styles-sidebar .interface-complementary-area-header .components-button.has-icon {
 	margin-left: 0;
 }


### PR DESCRIPTION
A suggestion for part of #34907, specifically:

> Fix a bug where a horizontal scrollbar would appear during a transition 

Here the issue is solved outside the component so It could be considered a bit of a punt.

I've thrown in some extra changes to improve the Post Editor’s preferences use of `Navigator`. The structure is tweaked and props adjusted to create better alignment. I may include before/after screenshots for that but later…

## How has this been tested?
Manually in Site and Post Editor. I didn't actually test the `Navigator` storybook story yet.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
