### PR TITLE
Animate exit of screens in `Navigator`

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.js
+++ b/packages/components/src/navigator/navigator-provider/component.js
@@ -1,20 +1,32 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useReducer } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { useCx } from '../../utils/hooks/use-cx';
 import { NavigatorContext } from '../context';
+import { gridDeck } from '../styles';
+
+function locationReducer( holding, incoming ) {
+	const isBack = incoming.isBack ?? holding.lastPath === incoming.path;
+	return { ...incoming, isBack, lastPath: holding.path, isFirst: false };
+}
 
 function NavigatorProvider( { initialPath, children } ) {
-	const [ path, setPath ] = useState( { path: initialPath } );
+	const [ location, navigate ] = useReducer( locationReducer, {
+		path: initialPath,
+		isFirst: true,
+	} );
 
 	return (
-		<NavigatorContext.Provider value={ [ path, setPath ] }>
-			{ children }
-		</NavigatorContext.Provider>
+		<div className={ useCx()( gridDeck ) }>
+			<NavigatorContext.Provider value={ [ location, navigate ] }>
+				{ children }
+			</NavigatorContext.Provider>
+		</div>
 	);
 }
 

--- a/packages/components/src/navigator/styles.js
+++ b/packages/components/src/navigator/styles.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { css, keyframes } from '@emotion/react';
+
+/**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+
+const animationDuration = 0.14;
+const animationEase = 'cubic-bezier(0, 0, 0.2, 1)';
+const skimUnit = 'px';
+const skimVector = isRTL() ? 50 : -50;
+
+const fadeKeyframes = ( phase ) => keyframes`${ phase } { opacity: 0 }`;
+
+const skimKeyframes = ( phase, vector ) =>
+	keyframes`${ phase } { transform: translateX(${ vector }${ skimUnit }); }`;
+
+export const animation = ( isCurrent, isBack ) => {
+	const phase = isCurrent ? 'from' : 'to';
+	let vector = isBack ? -skimVector : skimVector;
+	vector *= isCurrent ? -1 : 1;
+	const fade = fadeKeyframes( phase );
+	const skim = skimKeyframes( phase, vector );
+	return css`
+		label: ${ phase }-${ vector === skimVector ? 'aft' : 'fore' };
+		animation-name: ${ fade }, ${ skim };
+		animation-duration: ${ animationDuration }s;
+		animation-timing-function: ${ animationEase };
+		animation-iteration-count: 1;
+	`;
+};
+
+export const pointerNone = css`
+	pointer-events: none;
+`;
+
+export const gridDeck = css`
+	display: grid;
+	grid-template: 1fr/1fr;
+	> * {
+		grid-area: 1/1;
+	}
+`;


### PR DESCRIPTION
Alternative to #35312. This animates through CSS instead of framer-motion.

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/9000376/135796367-1bddeaaa-2f41-4160-9b7b-3cc18d9aa439.mp4

## Types of changes
Enhancment

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
