### PR TITLE
Motionate exit of screens in `Navigator`

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.js
+++ b/packages/components/src/navigator/navigator-provider/component.js
@@ -6,15 +6,19 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { useCx } from '../../utils/hooks/use-cx';
 import { NavigatorContext } from '../context';
+import { gridDeck } from '../styles';
 
 function NavigatorProvider( { initialPath, children } ) {
-	const [ path, setPath ] = useState( { path: initialPath } );
+	const [ path, setPath ] = useState( { path: initialPath, isBack: false } );
 
 	return (
-		<NavigatorContext.Provider value={ [ path, setPath ] }>
-			{ children }
-		</NavigatorContext.Provider>
+		<div className={ useCx()( gridDeck ) }>
+			<NavigatorContext.Provider value={ [ path, setPath ] }>
+				{ children }
+			</NavigatorContext.Provider>
+		</div>
 	);
 }
 

--- a/packages/components/src/navigator/styles.js
+++ b/packages/components/src/navigator/styles.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+export const gridDeck = css`
+	display: grid;
+	grid-template: 1fr/1fr;
+	> * {
+		grid-area: 1/1;
+	}
+`;


### PR DESCRIPTION
Alternative to #35311. Here the animation is driven by framer-motion instead of CSS.

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/9000376/135796820-3df8ed33-5efa-4548-bade-69ed216d4734.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
