### PR TITLE
Remove i18n of help link in navigation editor

### DIFF
--- a/packages/edit-navigation/src/components/header/more-menu.js
+++ b/packages/edit-navigation/src/components/header/more-menu.js
@@ -14,9 +14,7 @@ export default function MoreMenu() {
 					<MenuItem
 						role="menuitem"
 						icon={ external }
-						href={ __(
-							'https://github.com/WordPress/gutenberg/tree/trunk/packages/edit-navigation/docs/user-documentation.md'
-						) }
+						href="https://github.com/WordPress/gutenberg/tree/trunk/packages/edit-navigation/docs/user-documentation.md"
 						target="_blank"
 						rel="noopener noreferrer"
 					>


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/pull/34985#discussion_r720683526.

The `__` was accidentally copy/pasted. This work in progress documentation isn't something that is planned to be internationalized. The final docs will be.