### PR TITLE
[RNMobile] Inner Block Contexts for Image Block

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -3,7 +3,7 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop" ],
+	"usesContext": [ "allowResize", "imageCrop", "hideSettings" ],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -631,6 +631,7 @@ export class ImageEdit extends Component {
 		const additionalImageProps = {
 			height: '100%',
 			resizeMode: context?.imageCrop ? 'cover' : 'contain',
+			hideSettings: context?.hideSettings,
 		};
 
 		const imageContainerStyles = [ hasImageContext && styles.fixedHeight ];

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -645,7 +645,9 @@ export class ImageEdit extends Component {
 					disabled={ ! isSelected }
 				>
 					<View style={ styles.content }>
-						{ isSelected && getInspectorControls() }
+						{ ! additionalImageProps.hideSettings &&
+							isSelected &&
+							getInspectorControls() }
 						{ isSelected && getMediaOptions() }
 						{ ! this.state.isCaptionSelected &&
 							getToolbarEditButton( openMediaOptions ) }
@@ -702,15 +704,20 @@ export class ImageEdit extends Component {
 						/>
 					</View>
 				</TouchableWithoutFeedback>
-				<BlockCaption
-					clientId={ this.props.clientId }
-					isSelected={ this.state.isCaptionSelected }
-					accessible
-					accessibilityLabelCreator={ this.accessibilityLabelCreator }
-					onFocus={ this.onFocusCaption }
-					onBlur={ this.props.onBlur } // always assign onBlur as props
-					insertBlocksAfter={ this.props.insertBlocksAfter }
-				/>
+
+				{ ! additionalImageProps.hideSettings && (
+					<BlockCaption
+						clientId={ this.props.clientId }
+						isSelected={ this.state.isCaptionSelected }
+						accessible
+						accessibilityLabelCreator={
+							this.accessibilityLabelCreator
+						}
+						onFocus={ this.onFocusCaption }
+						onBlur={ this.props.onBlur } // always assign onBlur as props
+						insertBlocksAfter={ this.props.insertBlocksAfter }
+					/>
+				) }
 			</Badge>
 		);
 


### PR DESCRIPTION
## Description

The React Native version of [Jetpack's Tiled Gallery block](https://jetpack.com/support/tiled-galleries/) will be using [the Inner Block API](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/inner-blocks) to display images in the gallery. As part of this, we need to find a way to prevent some parts of the image block from displaying (the caption and, eventually, the settings tab) as well as style the way the image looks depending on chosen layout. 

We believe that other third-party blocks may face similar use cases in the future if they're pulling in the image block as an inner block.

The [core Gallery block](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/gallery) introduced two contexts in order to get around the challenge of editing/styling the image block as an inner block. Those are `allowResize` and `imageCrop`. `imageCrop` has already come in handy as we worked on the Tiled Gallery block, which supports our thoughts that there's some use to this approach for third-party blocks. 

We're looking to follow a similar approach to the Gallery block with this PR, by introducing another two contexts to the image block, `hideImageCaption` and `fixedHeight`. The code changes are explained more in-depth in the `Type of changes` section below. 

_Note, the goal behind this PR _isn't_ to introduce Jetpack-specific code, but rather to introduce generic changes that will hopefully be useful or re-usable for other third-party blocks. We have tried to be mindful against introducing anything that is specific only to Jetpack to the Gutenberg codebase._

## How has this been tested?

As this PR is part of a wider effort to port the Jetpack Tiled Gallery block to Gutenberg Mobile, steps to specifically test the Jetpack block can be found in the Jetpack repository at https://github.com/Automattic/jetpack/pull/21166, with the central Gutenberg Mobile PR at https://github.com/wordpress-mobile/gutenberg-mobile/pull/4017.

For this specific PR, on the Gutenberg side, the following has been tested in the iOS and Android apps, with this branch checked out from view:

* Ensure the images in the Gallery block are a set height and that there are no regressions.
* Add an Image block and ensure the image displays at the correct size. Play around with the block's various settings, including the round style, and ensure there are no regressions. 

## Screenshots

These screenshots show our specific use cases for using contexts, which is to remove and style parts of the image block when used as an inner block. You'll see we were able to use contexts to make the images appear as squares and remove the caption field:

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/134989742-1b86fb15-1699-4b21-ae22-612527151a21.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/134991240-cfeac12b-4dd7-4466-b3ca-55948d09149a.png" width="100%"> |

## Types of changes

To support the use of inner blocks in two other blocks (Gallery and Tiled Gallery), the following code changes have been made:

* A [new `fixedHeight` context](https://github.com/WordPress/gutenberg/pull/35089/files#diff-aa7f347bbb8d1aa1c43808397ef62ef1d0b789773b127768c01c913d1a956e19R96) has been added to the Gallery block. As explained [here](https://github.com/WordPress/gutenberg/pull/35089/files#r717078745), this change was needed to prevent styles that were specific to the Gallery block from impacting the Tiled Gallery block.
* A [new `hideImageCaption` context](https://github.com/WordPress/gutenberg/pull/35089/files#diff-4e637f96eb9e465696d35d73a41e6a694c7718f15fb805b49d49931262dfc53aR6) has been enabled in the image block. This will be used to help style images as they appear in the Tiled Gallery block. The aim is for it to also be useful/re-usable for other blocks that may pull in the image block via the Inner Blocks API.
* The image block's [`shapeStyle` prop was updated](https://github.com/WordPress/gutenberg/pull/35089/files#diff-7126ae03000a022bcefa0d2a5fb03b6aca56ed4047e3a49d2131babf229cf6c1R696) to accept not only a string, but also full styles. This is to allow third-party blocks, the Tiled Gallery block in this case, to pass styles without needing to make edits directly to the image block's core files.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
