### PR TITLE
`Navigator`: hide scrollbars while animating

### DIFF
--- a/packages/components/src/navigator/context.ts
+++ b/packages/components/src/navigator/context.ts
@@ -8,5 +8,10 @@ import { createContext } from '@wordpress/element';
  */
 import type { NavigatorContext as NavigatorContextType } from './types';
 
-const initialContextValue: NavigatorContextType = [ {}, () => {} ];
+const initialContextValue: NavigatorContextType = {
+	navigatorPath: {},
+	setNavigatorPath: () => {},
+	isAnimating: false,
+	setIsAnimating: () => {},
+};
 export const NavigatorContext = createContext( initialContextValue );

--- a/packages/components/src/navigator/context.ts
+++ b/packages/components/src/navigator/context.ts
@@ -9,8 +9,8 @@ import { createContext } from '@wordpress/element';
 import type { NavigatorContext as NavigatorContextType } from './types';
 
 const initialContextValue: NavigatorContextType = {
-	navigatorPath: {},
-	setNavigatorPath: () => {},
+	location: {},
+	setLocation: () => {},
 	isAnimating: false,
 	setIsAnimating: () => {},
 };

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -30,13 +30,21 @@ function NavigatorProvider(
 		'NavigatorProvider'
 	);
 
-	const [ path, setPath ] = useState< NavigatorPath >( {
+	const [ navigatorPath, setNavigatorPath ] = useState< NavigatorPath >( {
 		path: initialPath,
 	} );
+	const [ isAnimating, setIsAnimating ] = useState< boolean >( false );
 
 	return (
 		<View ref={ forwardedRef } { ...otherProps }>
 			<NavigatorContext.Provider value={ [ path, setPath ] }>
+				value={ {
+					navigatorPath,
+					setNavigatorPath,
+					isAnimating,
+					setIsAnimating,
+				} }
+			>
 				{ children }
 			</NavigatorContext.Provider>
 		</View>

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -21,7 +21,7 @@ import {
 import { useCx } from '../../utils/hooks/use-cx';
 import { View } from '../../view';
 import { NavigatorContext } from '../context';
-import type { NavigatorProviderProps, NavigatorPath } from '../types';
+import type { NavigatorProviderProps, NavigatorLocation } from '../types';
 
 function NavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
@@ -34,7 +34,7 @@ function NavigatorProvider(
 		...otherProps
 	} = useContextSystem( props, 'NavigatorProvider' );
 
-	const [ navigatorPath, setNavigatorPath ] = useState< NavigatorPath >( {
+	const [ location, setLocation ] = useState< NavigatorLocation >( {
 		path: initialPath,
 	} );
 	const [ isAnimating, setIsAnimating ] = useState< boolean >( false );
@@ -49,8 +49,8 @@ function NavigatorProvider(
 		<View ref={ forwardedRef } className={ classes } { ...otherProps }>
 			<NavigatorContext.Provider
 				value={ {
-					navigatorPath,
-					setNavigatorPath,
+					location,
+					setLocation,
 					isAnimating,
 					setIsAnimating,
 				} }

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -3,11 +3,12 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
+import { css } from '@emotion/react';
 
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import {
 	useContextSystem,
 	WordPressComponentProps,
 } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
 import { View } from '../../view';
 import { NavigatorContext } from '../context';
 import type { NavigatorProviderProps, NavigatorPath } from '../types';
@@ -25,19 +27,27 @@ function NavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
 	forwardedRef: Ref< any >
 ) {
-	const { initialPath, children, ...otherProps } = useContextSystem(
-		props,
-		'NavigatorProvider'
-	);
+	const {
+		initialPath,
+		children,
+		className,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorProvider' );
 
 	const [ navigatorPath, setNavigatorPath ] = useState< NavigatorPath >( {
 		path: initialPath,
 	} );
 	const [ isAnimating, setIsAnimating ] = useState< boolean >( false );
 
+	const cx = useCx();
+	const classes = useMemo(
+		() => cx( isAnimating && css( { overflow: 'hidden' } ), className ),
+		[ className, isAnimating ]
+	);
+
 	return (
-		<View ref={ forwardedRef } { ...otherProps }>
-			<NavigatorContext.Provider value={ [ path, setPath ] }>
+		<View ref={ forwardedRef } className={ classes } { ...otherProps }>
+			<NavigatorContext.Provider
 				value={ {
 					navigatorPath,
 					setNavigatorPath,

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -9,7 +9,12 @@ import { motion, MotionProps } from 'framer-motion';
 /**
  * WordPress dependencies
  */
-import { useContext, useEffect, useState } from '@wordpress/element';
+import {
+	useContext,
+	useEffect,
+	useState,
+	useCallback,
+} from '@wordpress/element';
 import { useReducedMotion, useFocusOnMount } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 
@@ -56,6 +61,11 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	useEffect( () => {
 		setHasPathChanged( true );
 	}, [ path ] );
+
+	const handleAnimationComplete = useCallback(
+		() => setIsAnimating( false ),
+		[ setIsAnimating ]
+	);
 
 	if ( ! isMatch ) {
 		return null;
@@ -109,6 +119,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	return (
 		<motion.div
 			ref={ hasPathChanged ? ref : undefined }
+			onAnimationComplete={ handleAnimationComplete }
 			{ ...otherProps }
 			{ ...animatedProps }
 		>

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -49,10 +49,10 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	);
 
 	const prefersReducedMotion = useReducedMotion();
-	const { navigatorPath: currentPath, setIsAnimating } = useContext(
+	const { location: currentLocation, setIsAnimating } = useContext(
 		NavigatorContext
 	);
-	const isMatch = currentPath.path === path;
+	const isMatch = currentLocation.path === path;
 	const ref = useFocusOnMount();
 
 	// This flag is used to only apply the focus on mount when the actual path changes.
@@ -91,8 +91,8 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	const initial = {
 		opacity: 0,
 		x:
-			( isRTL() && currentPath.isBack ) ||
-			( ! isRTL() && ! currentPath.isBack )
+			( isRTL() && currentLocation.isBack ) ||
+			( ! isRTL() && ! currentLocation.isBack )
 				? 50
 				: -50,
 	};
@@ -100,8 +100,8 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 		delay: animationExitDelay,
 		opacity: 0,
 		x:
-			( ! isRTL() && currentPath.isBack ) ||
-			( isRTL() && ! currentPath.isBack )
+			( ! isRTL() && currentLocation.isBack ) ||
+			( isRTL() && ! currentLocation.isBack )
 				? 50
 				: -50,
 		transition: {

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -44,7 +44,9 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	);
 
 	const prefersReducedMotion = useReducedMotion();
-	const [ currentPath ] = useContext( NavigatorContext );
+	const { navigatorPath: currentPath, setIsAnimating } = useContext(
+		NavigatorContext
+	);
 	const isMatch = currentPath.path === path;
 	const ref = useFocusOnMount();
 

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -2,6 +2,8 @@
  * Internal dependencies
  */
 import Button from '../../button';
+import { CardBody, CardHeader } from '../../card';
+import { Flyout } from '../../flyout';
 import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
 
 export default {
@@ -23,9 +25,18 @@ const MyNavigation = () => (
 	<NavigatorProvider initialPath="/">
 		<NavigatorScreen path="/">
 			<p>This is the home screen.</p>
+
 			<NavigatorButton isPrimary path="/child">
 				Navigate to child screen.
 			</NavigatorButton>
+
+			<Flyout
+				trigger={ <Button>Click top open test dialog</Button> }
+				placement="bottom-start"
+			>
+				<CardHeader>Go</CardHeader>
+				<CardBody>Stuff</CardBody>
+			</Flyout>
 		</NavigatorScreen>
 
 		<NavigatorScreen path="/child">

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -12,10 +12,12 @@ export type NavigatorPath = NavigatorPathOptions & {
 	path?: string;
 };
 
-export type NavigatorContext = [
-	NavigatorPath,
-	( path: NavigatorPath ) => void
-];
+export type NavigatorContext = {
+	navigatorPath: NavigatorPath;
+	setNavigatorPath: ( path: NavigatorPath ) => void;
+	isAnimating: boolean;
+	setIsAnimating: ( isAnimating: boolean ) => void;
+};
 
 // Returned by the `useNavigator` hook
 export type Navigator = {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -4,24 +4,24 @@
 // eslint-disable-next-line no-restricted-imports
 import type { ReactNode } from 'react';
 
-type NavigatorPathOptions = {
+type NavigatorLocationOptions = {
 	isBack?: boolean;
 };
 
-export type NavigatorPath = NavigatorPathOptions & {
+export type NavigatorLocation = NavigatorLocationOptions & {
 	path?: string;
 };
 
 export type NavigatorContext = {
-	navigatorPath: NavigatorPath;
-	setNavigatorPath: ( path: NavigatorPath ) => void;
+	location: NavigatorLocation;
+	setLocation: ( location: NavigatorLocation ) => void;
 	isAnimating: boolean;
 	setIsAnimating: ( isAnimating: boolean ) => void;
 };
 
 // Returned by the `useNavigator` hook
 export type Navigator = {
-	push: ( path: string, options: NavigatorPathOptions ) => void;
+	push: ( path: string, options: NavigatorLocationOptions ) => void;
 };
 
 export type NavigatorProviderProps = {

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,10 +13,11 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const { setNavigatorPath } = useContext( NavigatorContext );
+	const { setNavigatorPath, setIsAnimating } = useContext( NavigatorContext );
 
 	return {
 		push( path, options ) {
+			setIsAnimating( true );
 			setNavigatorPath( { path, ...options } );
 		},
 	};

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,12 +13,12 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const { setNavigatorPath, setIsAnimating } = useContext( NavigatorContext );
+	const { setLocation, setIsAnimating } = useContext( NavigatorContext );
 
 	return {
 		push( path, options ) {
 			setIsAnimating( true );
-			setNavigatorPath( { path, ...options } );
+			setLocation( { path, ...options } );
 		},
 	};
 }

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,11 +13,11 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const [ , setPath ] = useContext( NavigatorContext );
+	const { setNavigatorPath } = useContext( NavigatorContext );
 
 	return {
 		push( path, options ) {
-			setPath( { path, ...options } );
+			setNavigatorPath( { path, ...options } );
 		},
 	};
 }

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useReducedMotion } from '@wordpress/compose';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -14,10 +15,13 @@ import type { Navigator } from './types';
  */
 function useNavigator(): Navigator {
 	const { setLocation, setIsAnimating } = useContext( NavigatorContext );
+	const prefersReducedMotion = useReducedMotion();
 
 	return {
 		push( path, options ) {
-			setIsAnimating( true );
+			if ( ! prefersReducedMotion ) {
+				setIsAnimating( true );
+			}
 			setLocation( { path, ...options } );
 		},
 	};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR builds on top of #35214 and proposes a fix for the issue raised in https://github.com/WordPress/gutenberg/pull/34904#pullrequestreview-760854463 about the scrollbars appearing during screen animations.

The proposed solution applies the `overflow: hidden` styles on the `NavigatorProvider` wrapper **only while screens are animating** (which addresses the concerns expressed in https://github.com/WordPress/gutenberg/pull/35214#discussion_r719508329).

The main changes are:
- refactoring the shape of `NavigatorContext` from array to object, in order to include the `isAnimating`/`setInsAnimating` props.
- using the `isAnimating`/`setInAnimating` props, apply the `overflow: hidden` styles to the wrapper `div` only while an animation is in progress.
- update the Storybook example to include a modal `Flyout` to show that the overflow rule doesn't affect modals

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Project builds
- Tests pass
- Using storybook, make sure that the issue raised in https://github.com/WordPress/gutenberg/pull/34904#pullrequestreview-760854463 can't be reproduced anymore on this PR branch. For ease of testing, [the `animationEnterDuration` and `animationExitDuration` variables](https://github.com/WordPress/gutenberg/blob/63618851985bd1d0648c78dbebe048342635b9fa/packages/components/src/navigator/navigator-screen/component.tsx#L34-L35) could be changed to a higher value (e.g. `5`).

## Screenshots <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/1083581/134344879-11eb5091-9790-4c9b-a6a6-b8e9bfd51290.mp4

### After

https://user-images.githubusercontent.com/1083581/135836572-fd3b8d45-8dbf-495b-922a-98d1c4a3bb29.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
