### PR TITLE
Global Styles: allow users to store duotone data

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -247,16 +247,7 @@ class WP_Theme_JSON_Gutenberg {
 		'--wp--style--block-gap'     => array( 'spacing', 'blockGap' ),
 		'text-decoration'            => array( 'typography', 'textDecoration' ),
 		'text-transform'             => array( 'typography', 'textTransform' ),
-	);
-
-	/**
-	 * Metadata for style properties that need to use the duotone selector.
-	 *
-	 * Each element is a direct mapping from the CSS property name to the
-	 * path to the value in theme.json & block attributes.
-	 */
-	const DUOTONE_PROPERTIES_METADATA = array(
-		'filter' => array( 'filter', 'duotone' ),
+		'filter'                     => array( 'filter', 'duotone' ),
 	);
 
 	/**
@@ -981,7 +972,24 @@ class WP_Theme_JSON_Gutenberg {
 			$selector     = $metadata['selector'];
 			$settings     = _wp_array_get( $this->theme_json, array( 'settings' ) );
 			$declarations = self::compute_style_properties( $node, $settings );
+
+			// 1. Separate the ones who use the general selector and the ones who have th
+			$declarations_duotone = array();
+			foreach ( $declarations as $index => $declaration ) {
+				if ( 'filter' === $declaration['name'] ) {
+					unset( $declarations[ $index ] );
+					$declarations_duotone[] = $declaration;
+				}
+			}
+
+			// 2. Generate the general ones.
 			$block_rules .= self::to_ruleset( $selector, $declarations );
+
+			// 3. Generate the duotone ones.
+			if ( isset( $metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
+				$selector_duotone = self::scope_selector( $metadata['selector'], $metadata['duotone'] );
+				$block_rules     .= self::to_ruleset( $selector_duotone, $declarations_duotone );
+			}
 
 			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
 				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
@@ -992,12 +1000,6 @@ class WP_Theme_JSON_Gutenberg {
 				if ( $has_block_gap_support ) {
 					$block_rules .= '.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); margin-bottom: 0; }';
 				}
-			}
-
-			if ( isset( $metadata['duotone'] ) ) {
-				$selector     = self::scope_selector( $metadata['selector'], $metadata['duotone'] );
-				$declarations = self::compute_style_properties( $node, $settings, self::DUOTONE_PROPERTIES_METADATA );
-				$block_rules .= self::to_ruleset( $selector, $declarations );
 			}
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -973,7 +973,8 @@ class WP_Theme_JSON_Gutenberg {
 			$settings     = _wp_array_get( $this->theme_json, array( 'settings' ) );
 			$declarations = self::compute_style_properties( $node, $settings );
 
-			// 1. Separate the ones who use the general selector and the ones who have th
+			// 1. Separate the ones who use the general selector
+			// and the ones who use the duotone selector.
 			$declarations_duotone = array();
 			foreach ( $declarations as $index => $declaration ) {
 				if ( 'filter' === $declaration['name'] ) {
@@ -982,10 +983,10 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 
-			// 2. Generate the general ones.
+			// 2. Generate the rules that use the general selector.
 			$block_rules .= self::to_ruleset( $selector, $declarations );
 
-			// 3. Generate the duotone ones.
+			// 3. Generate the rules that use the duotone selector.
 			if ( isset( $metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
 				$selector_duotone = self::scope_selector( $metadata['selector'], $metadata['duotone'] );
 				$block_rules     .= self::to_ruleset( $selector_duotone, $declarations_duotone );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -274,6 +274,7 @@ function gutenberg_global_styles_filter_post( $content ) {
  */
 function gutenberg_global_styles_kses_init_filters() {
 	add_filter( 'content_save_pre', 'gutenberg_global_styles_filter_post' );
+	add_filter( 'safe_style_css', 'gutenberg_global_styles_include_support_for_duotone', 10, 2 );
 }
 
 /**
@@ -343,6 +344,18 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 		return $allow_css;
 	}
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
+}
+
+/**
+ * This is for using kses to test user data.
+ *
+ * @param array $atts Allowed CSS property names, according to kses.
+ *
+ * @return array The new allowed CSS property names.
+ */
+function gutenberg_global_styles_include_support_for_duotone( $atts ) {
+	$atts[] = 'filter';
+	return $atts;
 }
 
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1041,6 +1041,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								'duotone' => 'var:preset|duotone|blue-red',
 							),
 						),
+						'core/cover'  => array(
+							'filter' => array(
+								'duotone' => 'var(--wp--preset--duotone--blue-red, var(--fallback-unsafe))',
+							),
+						),
 						'core/group'  => array(
 							'color'    => array(
 								'gradient' => 'url(\'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMCcgaGVpZ2h0PScxMCc+PHNjcmlwdD5hbGVydCgnb2snKTwvc2NyaXB0PjxsaW5lYXJHcmFkaWVudCBpZD0nZ3JhZGllbnQnPjxzdG9wIG9mZnNldD0nMTAlJyBzdG9wLWNvbG9yPScjRjAwJy8+PHN0b3Agb2Zmc2V0PSc5MCUnIHN0b3AtY29sb3I9JyNmY2MnLz4gPC9saW5lYXJHcmFkaWVudD48cmVjdCBmaWxsPSd1cmwoI2dyYWRpZW50KScgeD0nMCcgeT0nMCcgd2lkdGg9JzEwMCUnIGhlaWdodD0nMTAwJScvPjwvc3ZnPg==\')',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1078,6 +1078,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 				'blocks'   => array(
+					'core/image' => array(
+						'filter' => array(
+							'duotone' => 'var:preset|duotone|blue-red',
+						),
+					),
 					'core/group' => array(
 						'color'    => array(
 							'text' => 'var:preset|color|dark-gray',


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/34667
Related https://github.com/WordPress/gutenberg/pull/35228 https://github.com/WordPress/gutenberg/pull/35248/ https://github.com/WordPress/gutenberg/pull/35255

With this PR, duotone data provided by the users in the proper format will be stored safely in the CPT that holds the user data. This has no effect on the UI because we still don't have duotone in the global styles sidebar. When we add it, it'll work fine.

## How to test

Test duotone works as expected:

- Use a theme that provides a `theme.json` and add within `styles.blocks` the following code:

```json
"core/image": {
  "filter": {
    "duotone": "var(--wp--preset--duotone--blue-red)"
  }
}
```

- Add two images in the post editor and set a duotone filter for one. Leave the other in the default state.
- Publish the post and verify that both images have the proper filters applied in the post editor and in the front of the site.

Test that the user data filter works as expected:

- Run `npm run test-php` should pass.
