### PR TITLE
[RNMobile][Embed block] Fix inline preview cut-off when editing URL

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -217,6 +217,7 @@ const EmbedEdit = ( props ) => {
 	// after the preview has been rendered can result in unwanted
 	// clipping or scrollbars. The `getAttributesFromPreview` function
 	// that `getMergedAttributes` uses is memoized so that we're not
+	// calculating them on every render.
 	const {
 		caption,
 		type,

--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -128,16 +128,19 @@ const EmbedEdit = ( props ) => {
 	);
 
 	/**
-	 * @return {Object} Attributes derived from the preview, merged with the current attributes.
+	 * Returns the attributes derived from the preview, merged with the current attributes.
+	 *
+	 * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
+	 * @return {Object} Merged attributes.
 	 */
-	const getMergedAttributes = () => {
+	const getMergedAttributes = ( ignorePreviousClassName = false ) => {
 		const { allowResponsive, className } = attributes;
 		return {
 			...attributes,
 			...getAttributesFromPreview(
 				preview,
 				title,
-				className,
+				ignorePreviousClassName ? undefined : className,
 				responsive,
 				allowResponsive
 			),
@@ -174,20 +177,10 @@ const EmbedEdit = ( props ) => {
 	useEffect( () => {
 		if ( preview && ! isEditingURL ) {
 			// When obtaining an incoming preview, we set the attributes derived from
-			// the preview data. In this case, we don't use the `getMergedAttributes`
-			// function because we need to specify an empty classname as the previous
-			// classname might not apply to the new preview.
-			const { allowResponsive } = attributes;
-			setAttributes( {
-				...attributes,
-				...getAttributesFromPreview(
-					preview,
-					title,
-					'',
-					responsive,
-					allowResponsive
-				),
-			} );
+			// the preview data. In this case when getting the merged attributes,
+			// we ignore the previous classname because it might not match the expected
+			// classes by the new preview.
+			setAttributes( getMergedAttributes( true ) );
 
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(

--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -225,6 +225,7 @@ const EmbedEdit = ( props ) => {
 	// after the preview has been rendered can result in unwanted
 	// clipping or scrollbars. The `getAttributesFromPreview` function
 	// that `getMergedAttributes` uses is memoized so that we're not
+	// calculating them on every render.
 	const {
 		type,
 		allowResponsive,

--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -173,15 +173,22 @@ const EmbedEdit = ( props ) => {
 	// Handle incoming preview
 	useEffect( () => {
 		if ( preview && ! isEditingURL ) {
-			// Even though we set attributes that get derived from the preview,
-			// we don't access them directly because for the initial render,
-			// the `setAttributes` call will not have taken effect. If we're
-			// rendering responsive content, setting the responsive classes
-			// after the preview has been rendered can result in unwanted
-			// clipping or scrollbars. The `getAttributesFromPreview` function
-			// that `getMergedAttributes` uses is memoized so that we're not
-			// calculating them on every render.
-			setAttributes( getMergedAttributes() );
+			// When obtaining an incoming preview, we set the attributes derived from
+			// the preview data. In this case, we don't use the `getMergedAttributes`
+			// function because we need to specify an empty classname as the previous
+			// classname might not apply to the new preview.
+			const { allowResponsive } = attributes;
+			setAttributes( {
+				...attributes,
+				...getAttributesFromPreview(
+					preview,
+					title,
+					'',
+					responsive,
+					allowResponsive
+				),
+			} );
+
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(
 					props,

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [**] [Embed block] Add the top 5 specific embed blocks to the Block inserter list [#34967]
+-   [*] [Embed block] Fix inline preview cut-off when editing URL [#35321]
 
 1.62.2
 ------


### PR DESCRIPTION
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4072

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR changes the calculation of attributes when handling an incoming preview after editing the URL of an embed block.  Previously, the attributes were obtained from the `getMergedAttributes` function, however, this function could return the classname from the previous embed, which depending on the new embed could lead to rendering issues, as the cut-off mentioned in https://github.com/wordpress-mobile/gutenberg-mobile/issues/4059.

These rendering issues are caused when the previous embed adds the aspect ratio classes to the classname attribute, then after setting a different URL, the new embed expects to have that attribute empty. In the following code references, you can see the flow of how the classname is calculated when handling an incoming preview:

https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/edit.native.js#L184
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/edit.native.js#L137-L143
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L243-L260
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L284-L288
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L177-L227

The calculation is now done in a similar way as the `getMergedAttributes` function but passing an empty classname in `getAttributesFromPreview`. This way we assure that the classname attribute set to the block doesn't preserve the value from the previous embed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Add an Embed block.
1. Set a YouTube URL (example: https://www.youtube.com/watch?v=ssfHW5lwFZg).
1. Observe that the inline preview displays the YouTube embed properly.
1. Tap on the pencil icon button, located in the toolbar, to edit the URL.
1. Set an Instagram URL (example: https://www.instagram.com/p/Bl6LgZgFDOm).
1. Observe that the inline preview displays the Instagram embed properly.

**NOTE:** This can be also reproduced by using a Twitter embed in step 5, although the rendering issue is an unexpected extra padding at the top instead of cut-off.

## Screenshots <!-- if applicable -->

Before|After
--|--
<video src=https://user-images.githubusercontent.com/14905380/135849812-09acb51a-fd54-4751-85d8-1c8b8f71eb62.mp4>|<video src=https://user-images.githubusercontent.com/14905380/135849840-e5347f68-1fb0-4d77-a84c-40febcf5e567.mp4>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
