### PR TITLE
[Block Library - Post Navigation Link]: Add typography settings

### DIFF
--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -27,6 +27,10 @@
 	},
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
 	}
 }


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/34381

This PR just adds the same typography settings with `Query Pagination Next/Previous` blocks.