### PR TITLE
Global Styles: add accessible label to Back button

### DIFF
--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -8,7 +8,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalView as View,
 } from '@wordpress/components';
-import { isRTL } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft, Icon } from '@wordpress/icons';
 
 /**
@@ -31,6 +31,7 @@ function ScreenHeader( { back, title, description } ) {
 						}
 						size="small"
 						isBack
+						aria-label={ __( 'Navigate to the previous view' ) }
 					/>
 				</View>
 				<Spacer>

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -7,18 +7,29 @@ import {
 	FlexItem,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 
 function NavigationButton( {
 	path,
 	icon,
 	children,
+	label: labelProp,
 	isBack = false,
 	...props
 } ) {
 	const navigator = useNavigator();
+
+	const defaultLabel = isBack
+		? __( 'Navigate to the previous screen' )
+		: undefined;
+
 	return (
-		<Item onClick={ () => navigator.push( path, { isBack } ) } { ...props }>
+		<Item
+			onClick={ () => navigator.push( path, { isBack } ) }
+			aria-label={ labelProp ?? defaultLabel }
+			{ ...props }
+		>
 			{ icon && (
 				<HStack justify="flex-start">
 					<FlexItem>

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -21,7 +21,7 @@ function NavigationButton( {
 	const navigator = useNavigator();
 
 	const defaultLabel = isBack
-		? __( 'Navigate to the previous screen' )
+		? __( 'Navigate to the previous view' )
 		: undefined;
 
 	return (

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -7,29 +7,18 @@ import {
 	FlexItem,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 
 function NavigationButton( {
 	path,
 	icon,
 	children,
-	label: labelProp,
 	isBack = false,
 	...props
 } ) {
 	const navigator = useNavigator();
-
-	const defaultLabel = isBack
-		? __( 'Navigate to the previous view' )
-		: undefined;
-
 	return (
-		<Item
-			onClick={ () => navigator.push( path, { isBack } ) }
-			aria-label={ labelProp ?? defaultLabel }
-			{ ...props }
-		>
+		<Item onClick={ () => navigator.push( path, { isBack } ) } { ...props }>
 			{ icon && (
 				<HStack justify="flex-start">
 					<FlexItem>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #35291

Pass an `aria-label` prop to the back button in `ScreenHeader` saying `'Navigate to the previous view'`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Clone this PR's branch on your local machine
- Start docker
- `npm run distclean && npm ci && npm run wp-env start && npm run dev`
- Visit `localhost:8888/wp-admin`, active the `TT1-blocks` theme and open the Site Editor
- Open the Global Styles sidebar and navigate across screens.
- Using the browser devtools, make sure that the navigations buttons (and in particular the "back" icon button) have accessible labels (which means that #35291 can't be reproduced)

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/1083581/135861272-a71220c9-1b85-41dc-89d7-6dea603de58e.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
