### PR TITLE
Embed block: Fix inline preview cut-off when editing URL

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -99,16 +99,19 @@ const EmbedEdit = ( props ) => {
 	);
 
 	/**
-	 * @return {Object} Attributes derived from the preview, merged with the current attributes.
+	 * Returns the attributes derived from the preview, merged with the current attributes.
+	 *
+	 * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
+	 * @return {Object} Merged attributes.
 	 */
-	const getMergedAttributes = () => {
+	const getMergedAttributes = ( ignorePreviousClassName = false ) => {
 		const { allowResponsive, className } = attributes;
 		return {
 			...attributes,
 			...getAttributesFromPreview(
 				preview,
 				title,
-				className,
+				ignorePreviousClassName ? undefined : className,
 				responsive,
 				allowResponsive
 			),
@@ -146,20 +149,10 @@ const EmbedEdit = ( props ) => {
 	useEffect( () => {
 		if ( preview && ! isEditingURL ) {
 			// When obtaining an incoming preview, we set the attributes derived from
-			// the preview data. In this case, we don't use the `getMergedAttributes`
-			// function because we need to specify an empty classname as the previous
-			// classname might not apply to the new preview.
-			const { allowResponsive } = attributes;
-			setAttributes( {
-				...attributes,
-				...getAttributesFromPreview(
-					preview,
-					title,
-					null,
-					responsive,
-					allowResponsive
-				),
-			} );
+			// the preview data. In this case when getting the merged attributes,
+			// we ignore the previous classname because it might not match the expected
+			// classes by the new preview.
+			setAttributes( getMergedAttributes( true ) );
 
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -5,8 +5,8 @@ import {
 	createUpgradedEmbedBlock,
 	getClassNames,
 	fallback,
-	getAttributesFromPreview,
 	getEmbedInfoByProvider,
+	getMergedAttributesWithPreview,
 } from './util';
 import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
@@ -104,19 +104,14 @@ const EmbedEdit = ( props ) => {
 	 * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
 	 * @return {Object} Merged attributes.
 	 */
-	const getMergedAttributes = ( ignorePreviousClassName = false ) => {
-		const { allowResponsive, className } = attributes;
-		return {
-			...attributes,
-			...getAttributesFromPreview(
-				preview,
-				title,
-				ignorePreviousClassName ? undefined : className,
-				responsive,
-				allowResponsive
-			),
-		};
-	};
+	const getMergedAttributes = ( ignorePreviousClassName = false ) =>
+		getMergedAttributesWithPreview(
+			attributes,
+			preview,
+			title,
+			responsive,
+			ignorePreviousClassName
+		);
 
 	const toggleResponsive = () => {
 		const { allowResponsive, className } = attributes;

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -145,15 +145,22 @@ const EmbedEdit = ( props ) => {
 	// Handle incoming preview.
 	useEffect( () => {
 		if ( preview && ! isEditingURL ) {
-			// Even though we set attributes that get derived from the preview,
-			// we don't access them directly because for the initial render,
-			// the `setAttributes` call will not have taken effect. If we're
-			// rendering responsive content, setting the responsive classes
-			// after the preview has been rendered can result in unwanted
-			// clipping or scrollbars. The `getAttributesFromPreview` function
-			// that `getMergedAttributes` uses is memoized so that we're not
-			// calculating them on every render.
-			setAttributes( getMergedAttributes() );
+			// When obtaining an incoming preview, we set the attributes derived from
+			// the preview data. In this case, we don't use the `getMergedAttributes`
+			// function because we need to specify an empty classname as the previous
+			// classname might not apply to the new preview.
+			const { allowResponsive } = attributes;
+			setAttributes( {
+				...attributes,
+				...getAttributesFromPreview(
+					preview,
+					title,
+					null,
+					responsive,
+					allowResponsive
+				),
+			} );
+
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(
 					props,

--- a/packages/block-library/src/embed/edit.native.js
+++ b/packages/block-library/src/embed/edit.native.js
@@ -5,8 +5,8 @@ import {
 	createUpgradedEmbedBlock,
 	getClassNames,
 	fallback,
-	getAttributesFromPreview,
 	getEmbedInfoByProvider,
+	getMergedAttributesWithPreview,
 } from './util';
 import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
@@ -130,19 +130,14 @@ const EmbedEdit = ( props ) => {
 	 * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
 	 * @return {Object} Merged attributes.
 	 */
-	const getMergedAttributes = ( ignorePreviousClassName = false ) => {
-		const { allowResponsive, className } = attributes;
-		return {
-			...attributes,
-			...getAttributesFromPreview(
-				preview,
-				title,
-				ignorePreviousClassName ? undefined : className,
-				responsive,
-				allowResponsive
-			),
-		};
-	};
+	const getMergedAttributes = ( ignorePreviousClassName = false ) =>
+		getMergedAttributesWithPreview(
+			attributes,
+			preview,
+			title,
+			responsive,
+			ignorePreviousClassName
+		);
 
 	const toggleResponsive = () => {
 		const { allowResponsive, className } = attributes;

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -292,3 +292,33 @@ export const getAttributesFromPreview = memoize(
 		return attributes;
 	}
 );
+
+/**
+ * Returns the attributes derived from the preview, merged with the current attributes.
+ *
+ * @param {Object}  currentAttributes       The current attributes of the block.
+ * @param {Object}  preview                 The preview data.
+ * @param {string}  title                   The block's title, e.g. Twitter.
+ * @param {boolean} isResponsive            Boolean indicating if the block supports responsive content.
+ * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
+ * @return {Object} Merged attributes.
+ */
+export const getMergedAttributesWithPreview = (
+	currentAttributes,
+	preview,
+	title,
+	isResponsive,
+	ignorePreviousClassName = false
+) => {
+	const { allowResponsive, className } = currentAttributes;
+	return {
+		...currentAttributes,
+		...getAttributesFromPreview(
+			preview,
+			title,
+			ignorePreviousClassName ? undefined : className,
+			isResponsive,
+			allowResponsive
+		),
+	};
+};

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -227,11 +227,11 @@ export default function Sandbox( {
 
 	useEffect( () => {
 		trySandbox();
-	}, [ title, type, styles, scripts ] );
+	}, [ title, styles, scripts ] );
 
 	useEffect( () => {
 		trySandbox( true );
-	}, [ html ] );
+	}, [ html, type ] );
 
 	return (
 		<iframe


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR changes the calculation of attributes when handling an incoming preview after editing the URL of an embed block. Previously, the attributes were obtained from the `getMergedAttributes` function, however, this function could return the classname from the previous embed, which depending on the new embed could lead to rendering issues, as the cut-off mentioned in https://github.com/wordpress-mobile/gutenberg-mobile/issues/4059.

These rendering issues are caused when the previous embed adds the aspect ratio classes to the classname attribute, then after setting a different URL, the new embed expects to have that attribute empty. In the following code references, you can see the flow of how the classname is calculated when handling an incoming preview:

https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/edit.native.js#L184
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/edit.native.js#L137-L143
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L243-L260
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L284-L288
https://github.com/WordPress/gutenberg/blob/c357fc7673ca2374a3178f66784996bba3fe36d0/packages/block-library/src/embed/util.js#L177-L227

The calculation is now done in a similar way as the `getMergedAttributes` function but passing an empty classname in `getAttributesFromPreview`. This way we assure that the classname attribute set to the block doesn't preserve the value from the previous embed.

This change also required updating the side-effects of the `Sandbox` component that updates the HTML of the iframe. When the `type` prop is modified (this prop is used to pass the classname), we need to force rendering the HTML of the iframe so it renders the proper aspect ratio styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add an Embed block.
1. Set a YouTube URL (example: https://www.youtube.com/watch?v=ssfHW5lwFZg).
1. Observe that the inline preview displays the YouTube embed properly.
1. Tap on the pencil icon button, located in the toolbar, to edit the URL.
1. Set an Twitter URL (example: https://twitter.com/automattic/status/1395447061336711181).
1. Observe that the inline preview displays the Twitter embed properly.

## Screenshots <!-- if applicable -->

Before|After
--|--
<video src=https://user-images.githubusercontent.com/14905380/135864751-030a2f43-4af8-42d3-9ca3-f8d5c0a9941b.mp4>|<video src=https://user-images.githubusercontent.com/14905380/135864781-1418cde1-a62f-4f4e-8f7e-e13aad632c79.mp4>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
