### PR TITLE
[Block Library - Query Loop]: Fix display of non sticky posts when `sticky` is set to `only`

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -34,6 +34,17 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		}
 	}
 
+	/**
+	 * Passing an empty array to post__in will return have_posts() as true (and all posts will be returned).
+	 * Logic should be used before hand to determine if WP_Query should be used in the event that the array
+	 * being passed to post__in is empty.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/28099
+	 */
+	if ( isset( $query_args['post__in'] ) && count( $query_args['post__in'] ) === 0 ) {
+		return '';
+	}
+
 	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {


### PR DESCRIPTION


Fixes: https://github.com/WordPress/gutenberg/issues/35322

From the issue:
>If a WordPress install has no sticky posts, standard posts are displayed on the front when the query loop setting "Sticky posts" is set to "only".
This leads to an unexpected result if the theme developer has chosen one design for sticky posts, and another for standard posts. If the page has two queries, one for sticky only, and one without sticky, the posts are duplicated.

>It works correctly in the editor.

## Testing instructions
1. Trash or remove sticky from any sticky posts on your WordPress installation
2. Add a query loop in the block editor.
3. Set the Sticky post setting to "only"
4. Confirm that no posts are displaying in the editor. The message "No results found." is shown.
5. Save and view the front. Confirm that non sticky posts are **not** showing on the front.
