### PR TITLE
Hide horizontal overflow in `Navigator`

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -3,6 +3,7 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
+import { css } from '@emotion/react';
 
 /**
  * WordPress dependencies
@@ -17,6 +18,7 @@ import {
 	useContextSystem,
 	WordPressComponentProps,
 } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
 import { View } from '../../view';
 import { NavigatorContext } from '../context';
 import type { NavigatorProviderProps, NavigatorPath } from '../types';
@@ -25,17 +27,21 @@ function NavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
 	forwardedRef: Ref< any >
 ) {
-	const { initialPath, children, ...otherProps } = useContextSystem(
-		props,
-		'NavigatorProvider'
-	);
+	const {
+		initialPath,
+		children,
+		className,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorProvider' );
 
 	const [ path, setPath ] = useState< NavigatorPath >( {
 		path: initialPath,
 	} );
 
+	const classes = useCx()( css( { overflowX: 'hidden' } ), className );
+
 	return (
-		<View ref={ forwardedRef } { ...otherProps }>
+		<View ref={ forwardedRef } className={ classes } { ...otherProps }>
 			<NavigatorContext.Provider value={ [ path, setPath ] }>
 				{ children }
 			</NavigatorContext.Provider>

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -8,7 +8,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -38,7 +38,12 @@ function NavigatorProvider(
 		path: initialPath,
 	} );
 
-	const classes = useCx()( css( { overflowX: 'hidden' } ), className );
+	const cx = useCx();
+	const classes = useMemo(
+		// Prevents horizontal overflow while animating screen transitions
+		() => cx( css( { overflowX: 'hidden' } ), className ),
+		[ className ]
+	);
 
 	return (
 		<View ref={ forwardedRef } className={ classes } { ...otherProps }>

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -5,6 +5,7 @@
 import type { Ref } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { motion, MotionProps } from 'framer-motion';
+import { css } from '@emotion/react';
 
 /**
  * WordPress dependencies
@@ -21,6 +22,7 @@ import {
 	useContextSystem,
 	WordPressComponentProps,
 } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
 import { View } from '../../view';
 import { NavigatorContext } from '../context';
 import type { NavigatorScreenProps } from '../types';
@@ -38,7 +40,7 @@ type Props = Omit<
 >;
 
 function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
-	const { children, path, ...otherProps } = useContextSystem(
+	const { children, className, path, ...otherProps } = useContextSystem(
 		props,
 		'NavigatorScreen'
 	);
@@ -47,6 +49,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	const [ currentPath ] = useContext( NavigatorContext );
 	const isMatch = currentPath.path === path;
 	const ref = useFocusOnMount();
+	const cx = useCx();
 
 	// This flag is used to only apply the focus on mount when the actual path changes.
 	// It avoids the focus to happen on the first render.
@@ -104,9 +107,12 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 		initial,
 	};
 
+	const classes = cx( css( { overflowX: 'auto' } ), className );
+
 	return (
 		<motion.div
 			ref={ hasPathChanged ? ref : undefined }
+			className={ classes }
 			{ ...otherProps }
 			{ ...animatedProps }
 		>

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -10,7 +10,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { useContext, useEffect, useState } from '@wordpress/element';
+import { useContext, useEffect, useState, useMemo } from '@wordpress/element';
 import { useReducedMotion, useFocusOnMount } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 
@@ -49,7 +49,13 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	const [ currentPath ] = useContext( NavigatorContext );
 	const isMatch = currentPath.path === path;
 	const ref = useFocusOnMount();
+
 	const cx = useCx();
+	const classes = useMemo(
+		// Ensures horizontal overflow is visually accessible
+		() => cx( css( { overflowX: 'auto' } ), className ),
+		[ className ]
+	);
 
 	// This flag is used to only apply the focus on mount when the actual path changes.
 	// It avoids the focus to happen on the first render.
@@ -64,7 +70,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 
 	if ( prefersReducedMotion ) {
 		return (
-			<View ref={ forwardedRef } { ...otherProps }>
+			<View ref={ forwardedRef } className={ classes } { ...otherProps }>
 				{ children }
 			</View>
 		);
@@ -106,8 +112,6 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 		exit,
 		initial,
 	};
-
-	const classes = cx( css( { overflowX: 'auto' } ), className );
 
 	return (
 		<motion.div

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -2,6 +2,8 @@
  * Internal dependencies
  */
 import Button from '../../button';
+import { CardBody, CardHeader } from '../../card';
+import { Flyout } from '../../flyout';
 import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
 
 export default {
@@ -23,9 +25,18 @@ const MyNavigation = () => (
 	<NavigatorProvider initialPath="/">
 		<NavigatorScreen path="/">
 			<p>This is the home screen.</p>
+
 			<NavigatorButton isPrimary path="/child">
 				Navigate to child screen.
 			</NavigatorButton>
+
+			<Flyout
+				trigger={ <Button>Click top open test dialog</Button> }
+				placement="bottom-start"
+			>
+				<CardHeader>Go</CardHeader>
+				<CardBody>Stuff</CardBody>
+			</Flyout>
 		</NavigatorScreen>
 
 		<NavigatorScreen path="/child">

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -30,6 +30,10 @@ const MyNavigation = () => (
 				Navigate to child screen.
 			</NavigatorButton>
 
+			<NavigatorButton isPrimary path="/overflow-child">
+				Navigate to a screen with horizontal overflow.
+			</NavigatorButton>
+
 			<Flyout
 				trigger={ <Button>Click top open test dialog</Button> }
 				placement="bottom-start"
@@ -44,6 +48,27 @@ const MyNavigation = () => (
 			<NavigatorButton isPrimary path="/" isBack>
 				Go back
 			</NavigatorButton>
+		</NavigatorScreen>
+		<NavigatorScreen path="/overflow-child">
+			<NavigatorButton isPrimary path="/" isBack>
+				Go back
+			</NavigatorButton>
+			<div
+				style={ {
+					display: 'inline-block',
+					background: 'papayawhip',
+				} }
+			>
+				<span
+					style={ {
+						color: 'palevioletred',
+						'white-space': 'nowrap',
+						'font-size': '42vw',
+					} }
+				>
+					¯\_(ツ)_/¯
+				</span>
+			</div>
 		</NavigatorScreen>
 	</NavigatorProvider>
 );

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -2,7 +2,8 @@
  * Internal dependencies
  */
 import Button from '../../button';
-import { CardBody, CardHeader } from '../../card';
+import { Card, CardBody, CardHeader } from '../../card';
+import { HStack } from '../../h-stack';
 import { Flyout } from '../../flyout';
 import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
 
@@ -21,57 +22,73 @@ function NavigatorButton( { path, isBack = false, ...props } ) {
 	);
 }
 
-const MyNavigation = () => (
-	<NavigatorProvider initialPath="/">
-		<NavigatorScreen path="/">
-			<p>This is the home screen.</p>
+const MyNavigation = () => {
+	return (
+		<NavigatorProvider initialPath="/">
+			<NavigatorScreen path="/">
+				<Card>
+					<CardBody>
+						<p>This is the home screen.</p>
 
-			<NavigatorButton isPrimary path="/child">
-				Navigate to child screen.
-			</NavigatorButton>
+						<HStack justify="flex-start" wrap>
+							<NavigatorButton isPrimary path="/child">
+								Navigate to child screen.
+							</NavigatorButton>
 
-			<NavigatorButton isPrimary path="/overflow-child">
-				Navigate to a screen with horizontal overflow.
-			</NavigatorButton>
+							<NavigatorButton path="/overflow-child">
+								Navigate to screen with horizontal overflow.
+							</NavigatorButton>
 
-			<Flyout
-				trigger={ <Button>Click top open test dialog</Button> }
-				placement="bottom-start"
-			>
-				<CardHeader>Go</CardHeader>
-				<CardBody>Stuff</CardBody>
-			</Flyout>
-		</NavigatorScreen>
+							<Flyout
+								trigger={ <Button>Open test dialog</Button> }
+								placement="bottom-start"
+							>
+								<CardHeader>Go</CardHeader>
+								<CardBody>Stuff</CardBody>
+							</Flyout>
+						</HStack>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
 
-		<NavigatorScreen path="/child">
-			<p>This is the child screen.</p>
-			<NavigatorButton isPrimary path="/" isBack>
-				Go back
-			</NavigatorButton>
-		</NavigatorScreen>
-		<NavigatorScreen path="/overflow-child">
-			<NavigatorButton isPrimary path="/" isBack>
-				Go back
-			</NavigatorButton>
-			<div
-				style={ {
-					display: 'inline-block',
-					background: 'papayawhip',
-				} }
-			>
-				<span
-					style={ {
-						color: 'palevioletred',
-						whiteSpace: 'nowrap',
-						fontSize: '42vw',
-					} }
-				>
-					¯\_(ツ)_/¯
-				</span>
-			</div>
-		</NavigatorScreen>
-	</NavigatorProvider>
-);
+			<NavigatorScreen path="/child">
+				<Card>
+					<CardBody>
+						<p>This is the child screen.</p>
+						<NavigatorButton isPrimary path="/" isBack>
+							Go back
+						</NavigatorButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+			<NavigatorScreen path="/overflow-child">
+				<Card>
+					<CardBody>
+						<NavigatorButton isPrimary path="/" isBack>
+							Go back
+						</NavigatorButton>
+						<div
+							style={ {
+								display: 'inline-block',
+								background: 'papayawhip',
+							} }
+						>
+							<span
+								style={ {
+									color: 'palevioletred',
+									whiteSpace: 'nowrap',
+									fontSize: '42vw',
+								} }
+							>
+								¯\_(ツ)_/¯
+							</span>
+						</div>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+		</NavigatorProvider>
+	);
+};
 
 export const _default = () => {
 	return <MyNavigation />;

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -62,8 +62,8 @@ const MyNavigation = () => (
 				<span
 					style={ {
 						color: 'palevioletred',
-						'white-space': 'nowrap',
-						'font-size': '42vw',
+						whiteSpace: 'nowrap',
+						fontSize: '42vw',
 					} }
 				>
 					¯\_(ツ)_/¯


### PR DESCRIPTION
Simple alternative to #35317. This adds `overflow-x: hidden` to the root element of `Navigator`.

## Explanation
I think the more complex approach in the aforementioned PR isn't warranted. It came about to make sure popovers inside of `Navigator` wouldn't be clipped or hidden. 

> I don't like overflow: hidden as a way to solve the scrolling issue, we can't use as otherwise we may risk hiding popovers shown inside that div potentially.

https://github.com/WordPress/gutenberg/pull/35214#discussion_r719508329

However, if the popovers are from `@wordpress/components` there's not a risk as they portal to a safe place in the tree. If we are then worried about third-party components, we don't have to. There's no use of `Navigator` in core that has slots for expansion. Even were they to have slots, they are already nested in contexts that would clip a naive dropdown/dialog/popover anyway.

## How has this been tested?
In the Post Editor preferences modal. Also tested in a version of the storybook story I adapted for a sidebar plugin. Seen in the screenshots.

## Screenshots
Before | After
----|----
![before-navigator-overflow-x](https://user-images.githubusercontent.com/9000376/135929549-0f544e02-03bf-4c05-be00-c433d81ef60b.gif) | ![after-navigator-overflow-x](https://user-images.githubusercontent.com/9000376/135929608-3630f168-0e73-4eee-8b3d-f492b51538da.gif)
note the horizontal scrollbar appearing ^ | note there's no horizontal scrollbar

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
