### PR TITLE
Remove duplicated className in Card component

### DIFF
--- a/packages/components/src/card/card/hook.js
+++ b/packages/components/src/card/card/hook.js
@@ -59,8 +59,6 @@ export function useCard( props ) {
 			styles.Card,
 			isBorderless && styles.boxShadowless,
 			isRounded && styles.rounded,
-			// This classname is added for legacy compatibility reasons.
-			'components-card',
 			className
 		);
 	}, [ className, isBorderless, isRounded ] );

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -157,8 +157,8 @@ Snapshot Diff:
 @@ -1,30 +1,30 @@
   <div>
     <div
--     class="components-surface components-card components-card css-ssx2ib-View-Surface-getBorders-primary-Card-boxShadowless-rounded em57xhy0"
-+     class="components-surface components-card components-card css-1vyvcpq-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+-     class="components-surface components-card css-ssx2ib-View-Surface-getBorders-primary-Card-boxShadowless-rounded em57xhy0"
++     class="components-surface components-card css-1vyvcpq-View-Surface-getBorders-primary-Card-rounded em57xhy0"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -375,7 +375,7 @@ Object {
 <body>
     <div>
       <div
-        class="components-surface components-card components-card emotion-0 emotion-1"
+        class="components-surface components-card emotion-0 emotion-1"
         data-wp-c16t="true"
         data-wp-component="Card"
       >
@@ -630,7 +630,7 @@ Object {
 
 <div>
     <div
-      class="components-surface components-card components-card emotion-0 emotion-1"
+      class="components-surface components-card emotion-0 emotion-1"
       data-wp-c16t="true"
       data-wp-component="Card"
     >
@@ -850,7 +850,7 @@ exports[`Card Card component should warn when the isElevated prop is passed 1`] 
 
 <div>
   <div
-    class="components-surface components-card components-card emotion-0 emotion-1"
+    class="components-surface components-card emotion-0 emotion-1"
     data-wp-c16t="true"
     data-wp-component="Card"
   >

--- a/packages/components/src/flyout/test/__snapshots__/index.js.snap
+++ b/packages/components/src/flyout/test/__snapshots__/index.js.snap
@@ -86,7 +86,7 @@ exports[`props should render correctly 1`] = `
 }
 
 <div
-  class="components-surface components-card components-card emotion-0 emotion-1 emotion-2"
+  class="components-surface components-card emotion-0 emotion-1 emotion-2"
   data-wp-c16t="true"
   data-wp-component="Card"
 >


### PR DESCRIPTION
`Card` has a duplicated classname "components-card". It comes about because it gets one from the `useContextSystem` hook:
https://github.com/WordPress/gutenberg/blob/f45dce14bcb03b46783a826067547aeb698f2fc5/packages/components/src/card/card/hook.js#L53
Then it adds another:
https://github.com/WordPress/gutenberg/blob/f45dce14bcb03b46783a826067547aeb698f2fc5/packages/components/src/card/card/hook.js#L62-L63
This PR simply removes the latter.

Snapshots for Card and Flyout needed updating as well. Those are better than the screenshot for evidence that there is a duplicate classname.

## How has this been tested?
Manually verifying that "components-card" appears only once in the class attribute.

## Screenshots

### Before: duplicated classname 'components-card' shown in inspector
![image](https://user-images.githubusercontent.com/9000376/135941643-12721a9e-5371-499a-8da4-1f9630faf25d.png)

## Types of changes
Code quality

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
