### PR TITLE
Polish quick inserter

### DIFF
--- a/packages/block-editor/src/components/block-types-list/style.scss
+++ b/packages/block-editor/src/components/block-types-list/style.scss
@@ -1,7 +1,4 @@
 .block-editor-block-types-list > [role="presentation"] {
-	padding: 4px;
-	margin-left: -4px;
-	margin-right: -4px;
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -18,7 +18,6 @@
 	background: transparent;
 	word-break: break-word;
 	border-radius: $radius-block-ui;
-	border: $border-width solid transparent;
 	transition: all 0.05s ease-in-out;
 	@include reduce-motion("transition");
 	position: relative;
@@ -31,8 +30,11 @@
 
 	&:not(:disabled) {
 		&:hover {
-			border-color: var(--wp-admin-theme-color);
 			color: var(--wp-admin-theme-color) !important;
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&.is-active {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -100,7 +100,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__search {
 	background: $white;
-	padding: $grid-unit-20;
+	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
 	position: sticky;
 	top: 0;
 	z-index: z-index(".block-editor-inserter__search");
@@ -173,10 +173,6 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__block-list {
 	flex-grow: 1;
 	position: relative;
-}
-
-.block-editor-inserter__popover .block-editor-block-types-list {
-	margin: -8px;
 }
 
 .block-editor-inserter__reusable-blocks-panel {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -25,19 +25,19 @@ $block-inserter-tabs-height: 44px;
 		border: none;
 
 		.block-editor-inserter__quick-inserter > * {
-			border-left: 1px solid $gray-400;
-			border-right: 1px solid $gray-400;
+			border-left: $border-width solid $gray-400;
+			border-right: $border-width solid $gray-400;
 
 			&:first-child {
-				border-top: 1px solid $gray-400;
+				border-top: $border-width solid $gray-400;
 			}
 
 			&:last-child {
-				border-bottom: 1px solid $gray-400;
+				border-bottom: $border-width solid $gray-400;
 			}
 
 			&.components-button {
-				border: 1px solid $gray-900;
+				border: $border-width solid $gray-900;
 			}
 		}
 	}
@@ -321,7 +321,10 @@ $block-inserter-tabs-height: 44px;
 		color: $gray-400;
 	}
 
-	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 1.5px var(--wp-admin-theme-color), inset 0 0 0 3px #fff;
+	// Specificity is needed for the border color.
+	&.components-button:focus:not(:disabled) {
+		box-shadow: none;
+		background: var(--wp-admin-theme-color);
+		border-color: var(--wp-admin-theme-color);
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -108,6 +108,10 @@ $block-inserter-tabs-height: 44px;
 	.components-search-control__icon {
 		right: $grid-unit-10 + ($grid-unit-60 - $icon-size) * 0.5;
 	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
 }
 
 .block-editor-inserter__tabs {

--- a/packages/components/src/search-control/style.scss
+++ b/packages/components/src/search-control/style.scss
@@ -18,7 +18,7 @@
 
 		&:focus {
 			background: $white;
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&::placeholder {

--- a/packages/customize-widgets/src/components/inserter/style.scss
+++ b/packages/customize-widgets/src/components/inserter/style.scss
@@ -25,7 +25,7 @@
 	// Match the "wp-full-overlay-header" height in core, plus the 1px border.
 	height: 46px;
 	box-sizing: border-box;
-	border-bottom: 1px solid $gray-300;
+	border-bottom: $border-width solid $gray-300;
 
 	.customize-widgets-layout__inserter-panel-header-title {
 		margin: 0;


### PR DESCRIPTION
## Description

Reviewing https://github.com/WordPress/gutenberg/pull/33132/files#r721964593 surfaced a few issues with paddings, margins and focus styles in the quick inserter.

1. There's a lot of space above the items:

<img width="849" alt="Screenshot 2021-10-05 at 10 00 38" src="https://user-images.githubusercontent.com/1204802/135987801-b68dbb9b-ef24-47ef-ae4b-770871f079c9.png">

2. There are nested transparent borders, paddings, and negative margins, all positioning the content in a brittle way, and causing things to not align vertically:

<img width="269" alt="Screenshot 2021-10-05 at 10 02 37" src="https://user-images.githubusercontent.com/1204802/135987952-75579471-f969-4d00-823e-8b700efbd70e.png">

It's most visible in #33132, where it looks like this:

<img width="890" alt="Screenshot 2021-10-05 at 09 30 40" src="https://user-images.githubusercontent.com/1204802/135988014-e23d7194-0f20-4131-8812-4d21c16feee3.png">

The focus style of the Browse all button is a bit layered:

<img width="427" alt="Screenshot 2021-10-05 at 10 10 33" src="https://user-images.githubusercontent.com/1204802/135988146-e720c22e-6a24-4fef-b209-4cf634cb2ee2.png">

This PR addresses that by making a few changes:

- It unifies paddings and margins so things line up
- It creates inset box shadows so there's no need for negative margins and extra padding, which has the added benefit of unifying the border radius of the focus style between search and items
- It simplifies the focus style of the Browse all button

GIF showing the above:

![after](https://user-images.githubusercontent.com/1204802/135988359-73909bd6-2a1b-41ef-9afd-7ed609035926.gif)

## How has this been tested?

Test the quick inserter and verify it works as intended in all cases.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
