### PR TITLE
[Preferences]: add accessible label to Back button

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -371,6 +371,9 @@ export default function PreferencesModal() {
 											isRTL() ? chevronRight : chevronLeft
 										}
 										isBack
+										aria-label={ __(
+											'Navigate to the previous view'
+										) }
 									>
 										{ __( 'Back' ) }
 									</NavigationButton>

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -175,6 +175,7 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           path="general"
         >
           <NavigationButton
+            aria-label="Navigate to the previous view"
             icon={
               <SVG
                 viewBox="0 0 24 24"
@@ -229,6 +230,7 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           path="blocks"
         >
           <NavigationButton
+            aria-label="Navigate to the previous view"
             icon={
               <SVG
                 viewBox="0 0 24 24"
@@ -274,6 +276,7 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           path="panels"
         >
           <NavigationButton
+            aria-label="Navigate to the previous view"
             icon={
               <SVG
                 viewBox="0 0 24 24"


### PR DESCRIPTION
This is a small follow up of: https://github.com/WordPress/gutenberg/pull/35325 to add the same accessible label to back button for `Preferences`.

## Testing instructions
1. Open the preferences in a smaller viewport in order to render the `smaller` version
2. Check the `aria-label` in back button