### PR TITLE
Allow the specification of blocks allowed within columns

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -13,6 +13,9 @@
 		"width": {
 			"type": "string"
 		},
+		"allowedBlocks": {
+			"type": "array"
+    	},
 		"templateLock": {
 			"enum": [ "all", "insert", false ]
 		}

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -15,7 +15,7 @@
 		},
 		"allowedBlocks": {
 			"type": "array"
-    	},
+		},
 		"templateLock": {
 			"enum": [ "all", "insert", false ]
 		}

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -97,6 +97,7 @@ function ColumnEdit( {
 		{ ...blockProps, 'aria-label': label },
 		{
 			templateLock,
+			allowedBlocks,
 			renderAppender: hasChildBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -25,7 +25,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
 function ColumnEdit( {
-	attributes: { verticalAlignment, width, templateLock = false },
+	attributes: {
+		verticalAlignment,
+		width,
+		templateLock = false,
+	},
 	setAttributes,
 	clientId,
 } ) {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -29,6 +29,7 @@ function ColumnEdit( {
 		verticalAlignment,
 		width,
 		templateLock = false,
+		allowedBlocks,
 	},
 	setAttributes,
 	clientId,

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -80,7 +80,6 @@ function ColumnsEditContainer( {
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		allowedChildBlocks,
 		orientation: 'horizontal',
 		renderAppender: false,
 	} );
@@ -195,9 +194,6 @@ const ColumnsEditContainerWrapper = withDispatch(
 				innerBlocks = [
 					...innerBlocks,
 					...times( newColumns - previousColumns, () => {
-						return createBlock( 'core/column', {
-							allowedBlocks: allowedChildBlocks,
-						} );
 					} ),
 				];
 			} else {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -80,6 +80,7 @@ function ColumnsEditContainer( {
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
+		allowedChildBlocks,
 		orientation: 'horizontal',
 		renderAppender: false,
 	} );

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -193,9 +193,9 @@ const ColumnsEditContainerWrapper = withDispatch(
 			} else if ( isAddingColumn ) {
 				innerBlocks = [
 					...innerBlocks,
-					...times(newColumns - previousColumns, () => {
-						return createBlock('core/column');
-					}),
+					...times( newColumns - previousColumns, () => {
+						return createBlock( 'core/column' );
+					} ),
 				];
 			} else {
 				// The removed column will be the last of the inner blocks.

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -194,7 +194,9 @@ const ColumnsEditContainerWrapper = withDispatch(
 				innerBlocks = [
 					...innerBlocks,
 					...times( newColumns - previousColumns, () => {
-						return createBlock( 'core/column' );
+						return createBlock( 'core/column', {
+							allowedBlocks: allowedChildBlocks,
+						} );
 					} ),
 				];
 			} else {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -193,7 +193,9 @@ const ColumnsEditContainerWrapper = withDispatch(
 			} else if ( isAddingColumn ) {
 				innerBlocks = [
 					...innerBlocks,
-					...times( newColumns - previousColumns, () => {} ),
+					...times(newColumns - previousColumns, () => {
+						return createBlock('core/column');
+					}),
 				];
 			} else {
 				// The removed column will be the last of the inner blocks.

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -193,8 +193,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 			} else if ( isAddingColumn ) {
 				innerBlocks = [
 					...innerBlocks,
-					...times( newColumns - previousColumns, () => {
-					} ),
+					...times( newColumns - previousColumns, () => {} ),
 				];
 			} else {
 				// The removed column will be the last of the inner blocks.


### PR DESCRIPTION
#25778 is outdated and can't be merged as-is due to conflicts.
Unfortunately we are unable to push commits to that branch because it's in a fork, so this PR is a resubmission of the original PR, rebased and addressing the feedback and notes from the original.

Fixes #18161

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
