### PR TITLE
Optimize useSelect calls (last batch)

### DIFF
--- a/packages/block-directory/src/plugins/get-install-missing/install-button.js
+++ b/packages/block-directory/src/plugins/get-install-missing/install-button.js
@@ -13,8 +13,9 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as blockDirectoryStore } from '../../store';
 
 export default function InstallButton( { attributes, block, clientId } ) {
-	const isInstallingBlock = useSelect( ( select ) =>
-		select( blockDirectoryStore ).isInstalling( block.id )
+	const isInstallingBlock = useSelect(
+		( select ) => select( blockDirectoryStore ).isInstalling( block.id ),
+		[ block.id ]
 	);
 	const { installBlockType } = useDispatch( blockDirectoryStore );
 	const { replaceBlock } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -27,7 +27,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	] = useResizeObserver();
 	const styles = useSelect( ( select ) => {
 		return select( store ).getSettings().styles;
-	} );
+	}, [] );
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -21,7 +21,7 @@ export default function BlockSupportToolsPanel( { children, label, header } ) {
 			clientId: selectedBlockClientId,
 			attributes: getBlockAttributes( selectedBlockClientId ),
 		};
-	} );
+	}, [] );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const resetAll = ( resetFilters = [] ) => {

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -53,8 +53,9 @@ function isKeyDownEligibleForStartTyping( event ) {
  * element.
  */
 export function useMouseMoveTypingReset() {
-	const isTyping = useSelect( ( select ) =>
-		select( blockEditorStore ).isTyping()
+	const isTyping = useSelect(
+		( select ) => select( blockEditorStore ).isTyping(),
+		[]
 	);
 	const { stopTyping } = useDispatch( blockEditorStore );
 

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -16,8 +16,9 @@ const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;
 
 export function useTypewriter() {
-	const hasSelectedBlock = useSelect( ( select ) =>
-		select( blockEditorStore ).hasSelectedBlock()
+	const hasSelectedBlock = useSelect(
+		( select ) => select( blockEditorStore ).hasSelectedBlock(),
+		[]
 	);
 
 	return useRefEffect(

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -199,7 +199,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	const imageSizes = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return settings?.imageSizes;
-	} );
+	}, [] );
 	const imageSizeOptions = map(
 		filter( imageSizes, ( { slug } ) =>
 			getImageSourceUrlBySizeSlug( image, slug )

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -10,19 +10,22 @@ export default function Edit( { attributes, context } ) {
 	const { className } = attributes;
 	const { commentId } = context;
 
-	const displayName = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
+	const displayName = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
 
-		const comment = getEntityRecord( 'root', 'comment', commentId );
-		const authorName = comment?.author_name; // eslint-disable-line camelcase
+			const comment = getEntityRecord( 'root', 'comment', commentId );
+			const authorName = comment?.author_name; // eslint-disable-line camelcase
 
-		if ( comment && ! authorName ) {
-			const user = getEntityRecord( 'root', 'user', comment.author );
-			return user?.name ?? __( 'Anonymous' );
-		}
+			if ( comment && ! authorName ) {
+				const user = getEntityRecord( 'root', 'user', comment.author );
+				return user?.name ?? __( 'Anonymous' );
+			}
 
-		return authorName ?? '';
-	} );
+			return authorName ?? '';
+		},
+		[ commentId ]
+	);
 
 	return (
 		<div { ...useBlockProps() }>

--- a/packages/edit-navigation/src/components/header/redo-button.js
+++ b/packages/edit-navigation/src/components/header/redo-button.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
-	const hasRedo = useSelect( ( select ) => select( coreStore ).hasRedo() );
+	const hasRedo = useSelect(
+		( select ) => select( coreStore ).hasRedo(),
+		[]
+	);
 	const { redo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton

--- a/packages/edit-navigation/src/components/header/undo-button.js
+++ b/packages/edit-navigation/src/components/header/undo-button.js
@@ -9,7 +9,10 @@ import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function UndoButton() {
-	const hasUndo = useSelect( ( select ) => select( coreStore ).hasUndo() );
+	const hasUndo = useSelect(
+		( select ) => select( coreStore ).hasUndo(),
+		[]
+	);
 	const { undo } = useDispatch( coreStore );
 	return (
 		<ToolbarButton

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/dynamic-shortcut.js
@@ -10,19 +10,22 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import Shortcut from './shortcut';
 
 function DynamicShortcut( { name } ) {
-	const { keyCombination, description, aliases } = useSelect( ( select ) => {
-		const {
-			getShortcutKeyCombination,
-			getShortcutDescription,
-			getShortcutAliases,
-		} = select( keyboardShortcutsStore );
+	const { keyCombination, description, aliases } = useSelect(
+		( select ) => {
+			const {
+				getShortcutKeyCombination,
+				getShortcutDescription,
+				getShortcutAliases,
+			} = select( keyboardShortcutsStore );
 
-		return {
-			keyCombination: getShortcutKeyCombination( name ),
-			aliases: getShortcutAliases( name ),
-			description: getShortcutDescription( name ),
-		};
-	} );
+			return {
+				keyCombination: getShortcutKeyCombination( name ),
+				aliases: getShortcutAliases( name ),
+				description: getShortcutDescription( name ),
+			};
+		},
+		[ name ]
+	);
 
 	if ( ! keyCombination ) {
 		return null;

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -88,7 +88,7 @@ export default function PluginSidebarEditPost( { className, ...props } ) {
 				'showIconLabels'
 			),
 		};
-	} );
+	}, [] );
 	return (
 		<ComplementaryArea
 			panelClassName={ className }

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -49,60 +49,64 @@ function Editor( {
 		keepCaretInsideBlock,
 		isTemplateMode,
 		template,
-	} = useSelect( ( select ) => {
-		const {
-			isFeatureActive,
-			getPreference,
-			__experimentalGetPreviewDeviceType,
-			isEditingTemplate,
-			getEditedPostTemplate,
-		} = select( editPostStore );
-		const { getEntityRecord, getPostType, getEntityRecords } = select(
-			coreStore
-		);
-		const { getEditorSettings } = select( editorStore );
-		const { getBlockTypes } = select( blocksStore );
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			postType
-		);
-		// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
-		// to avoid the special case.
-		let postObject;
-		if ( isTemplate ) {
-			const posts = getEntityRecords( 'postType', postType, {
-				wp_id: postId,
-			} );
-			postObject = posts?.[ 0 ];
-		} else {
-			postObject = getEntityRecord( 'postType', postType, postId );
-		}
-		const supportsTemplateMode = getEditorSettings().supportsTemplateMode;
-		const isViewable = getPostType( postType )?.viewable ?? false;
+	} = useSelect(
+		( select ) => {
+			const {
+				isFeatureActive,
+				getPreference,
+				__experimentalGetPreviewDeviceType,
+				isEditingTemplate,
+				getEditedPostTemplate,
+			} = select( editPostStore );
+			const { getEntityRecord, getPostType, getEntityRecords } = select(
+				coreStore
+			);
+			const { getEditorSettings } = select( editorStore );
+			const { getBlockTypes } = select( blocksStore );
+			const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
+				postType
+			);
+			// Ideally the initializeEditor function should be called using the ID of the REST endpoint.
+			// to avoid the special case.
+			let postObject;
+			if ( isTemplate ) {
+				const posts = getEntityRecords( 'postType', postType, {
+					wp_id: postId,
+				} );
+				postObject = posts?.[ 0 ];
+			} else {
+				postObject = getEntityRecord( 'postType', postType, postId );
+			}
+			const supportsTemplateMode = getEditorSettings()
+				.supportsTemplateMode;
+			const isViewable = getPostType( postType )?.viewable ?? false;
 
-		return {
-			hasFixedToolbar:
-				isFeatureActive( 'fixedToolbar' ) ||
-				__experimentalGetPreviewDeviceType() !== 'Desktop',
-			focusMode: isFeatureActive( 'focusMode' ),
-			hasReducedUI: isFeatureActive( 'reducedUI' ),
-			hasThemeStyles: isFeatureActive( 'themeStyles' ),
-			preferredStyleVariations: getPreference(
-				'preferredStyleVariations'
-			),
-			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
-			blockTypes: getBlockTypes(),
-			__experimentalLocalAutosaveInterval: getPreference(
-				'localAutosaveInterval'
-			),
-			keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
-			isTemplateMode: isEditingTemplate(),
-			template:
-				supportsTemplateMode && isViewable
-					? getEditedPostTemplate()
-					: null,
-			post: postObject,
-		};
-	} );
+			return {
+				hasFixedToolbar:
+					isFeatureActive( 'fixedToolbar' ) ||
+					__experimentalGetPreviewDeviceType() !== 'Desktop',
+				focusMode: isFeatureActive( 'focusMode' ),
+				hasReducedUI: isFeatureActive( 'reducedUI' ),
+				hasThemeStyles: isFeatureActive( 'themeStyles' ),
+				preferredStyleVariations: getPreference(
+					'preferredStyleVariations'
+				),
+				hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
+				blockTypes: getBlockTypes(),
+				__experimentalLocalAutosaveInterval: getPreference(
+					'localAutosaveInterval'
+				),
+				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
+				isTemplateMode: isEditingTemplate(),
+				template:
+					supportsTemplateMode && isViewable
+						? getEditedPostTemplate()
+						: null,
+				post: postObject,
+			};
+		},
+		[ postType, postId ]
+	);
 
 	const { updatePreferredStyleVariations, setIsInserterOpened } = useDispatch(
 		editPostStore

--- a/packages/editor/src/components/character-count/index.js
+++ b/packages/editor/src/components/character-count/index.js
@@ -10,8 +10,9 @@ import { count as characterCount } from '@wordpress/wordcount';
 import { store as editorStore } from '../../store';
 
 export default function CharacterCount() {
-	const content = useSelect( ( select ) =>
-		select( editorStore ).getEditedPostAttribute( 'content' )
+	const content = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'content' ),
+		[]
 	);
 
 	return characterCount( content, 'characters_including_spaces' );

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -54,7 +54,7 @@ export default function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		};
-	} );
+	}, [] );
 
 	useEffect( () => {
 		/**

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -61,7 +61,7 @@ export default function PostTitle() {
 			isFocusMode: focusMode,
 			hasFixedToolbar: _hasFixedToolbar,
 		};
-	} );
+	}, [] );
 
 	useEffect( () => {
 		if ( ! ref.current ) {

--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -11,8 +11,9 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { store as editorStore } from '../../store';
 
 export default function WordCount() {
-	const content = useSelect( ( select ) =>
-		select( editorStore ).getEditedPostAttribute( 'content' )
+	const content = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'content' ),
+		[]
 	);
 
 	/*

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -110,7 +110,7 @@ function ColorPicker( { name, property, value, onChange } ) {
 	const colors = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return get( getSettings(), [ 'colors' ], [] );
-	} );
+	}, [] );
 	const onColorChange = useCallback(
 		( color ) => {
 			onChange(


### PR DESCRIPTION
## Description
Adds missing dependency arrays to `useSelect` calls to memorize selector callbacks.

I think this is the last batch of updates for now.

Similar PRs #23255, #35213 and #35256.

## Screenshots <!-- if applicable -->

## Types of changes
Code Quality/Performance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
