### PR TITLE
Add [data-block] to appender.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -87,6 +87,8 @@ function BlockListAppender( {
 				'block-list-appender wp-block',
 				className
 			) }
+			// Many editor styles incorrectly target [data-block] instead of .wp-block.
+			data-block
 		>
 			{ appender }
 		</TagName>

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -87,7 +87,13 @@ function BlockListAppender( {
 				'block-list-appender wp-block',
 				className
 			) }
-			// Many editor styles incorrectly target [data-block] instead of .wp-block.
+			// The appender exists to let you add the first Paragraph before
+			// any is inserted. To that end, this appender should visually be
+			// presented as a block. That means theme CSS should style it as if
+			// it were an empty paragraph block. That means a `wp-block` class to
+			// ensure the width is correct, and a [data-block] attribute to ensure
+			// the correct margin is applied, especially for classic themes which
+			// have commonly targeted that attribute for margins.
 			data-block
 		>
 			{ appender }

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -59,8 +59,8 @@ export function DefaultBlockAppender( {
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 				role="button"
 				aria-label={ __( 'Add block' ) }
-				// The wp-block className is important for editor styles.
-				className="wp-block block-editor-default-block-appender__content"
+				// A wrapping container for this one already has the wp-block className.
+				className="block-editor-default-block-appender__content"
 				onFocus={ onAppend }
 			>
 				{ showPrompt ? value : ZWNBSP }

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 >
   <p
     aria-label="Add block"
-    className="wp-block block-editor-default-block-appender__content"
+    className="block-editor-default-block-appender__content"
     contentEditable={true}
     onFocus={
       [MockFunction] {
@@ -43,7 +43,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
 >
   <p
     aria-label="Add block"
-    className="wp-block block-editor-default-block-appender__content"
+    className="block-editor-default-block-appender__content"
     contentEditable={true}
     onFocus={[MockFunction]}
     role="button"
@@ -67,7 +67,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 >
   <p
     aria-label="Add block"
-    className="wp-block block-editor-default-block-appender__content"
+    className="block-editor-default-block-appender__content"
     contentEditable={true}
     onFocus={[MockFunction]}
     role="button"

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -114,7 +114,7 @@ describe( 'Widgets screen', () => {
 			{ selector: '[data-block]' },
 			{ root: widgetArea }
 		);
-		const lastBlock = childBlocks[ childBlocks.length ];
+		const lastBlock = childBlocks[ childBlocks.length - 2 ];
 		const lastBlockBoundingBox = await lastBlock.boundingBox();
 
 		// TODO: Probably need a more accessible way to select this, maybe a test ID or data attribute.

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -114,6 +114,7 @@ describe( 'Widgets screen', () => {
 			{ selector: '[data-block]' },
 			{ root: widgetArea }
 		);
+		// The initial block appender also has the [data-block] property, adding to the count.
 		const lastBlock = childBlocks[ childBlocks.length - 2 ];
 		const lastBlockBoundingBox = await lastBlock.boundingBox();
 

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -114,7 +114,7 @@ describe( 'Widgets screen', () => {
 			{ selector: '[data-block]' },
 			{ root: widgetArea }
 		);
-		const lastBlock = childBlocks[ childBlocks.length - 1 ];
+		const lastBlock = childBlocks[ childBlocks.length ];
 		const lastBlockBoundingBox = await lastBlock.boundingBox();
 
 		// TODO: Probably need a more accessible way to select this, maybe a test ID or data attribute.


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/33895#issuecomment-894098642. This removes a `wp-block` class, but also adds a `data-block` property to the appender.

Due to limitations that have existed in the editor for some time, many themes have come to target [data-block] for attaching styles to "blocks", notably because the `wp-block` CSS class is not present on blocks like the Paragraph and others.

The need to target [data-block] has not been there for some time, since the classic styles and resets have lowered specificity to the point that you could, and should, target elements like `p` and `h2` etc, just like you would on the frontend. Indeed that is a goal, to not need to write editor-specific styles at all.

One way in which this targetting of [data-block] manifests itself in, is in a jump when you click the first default block appender, like so:

![before](https://user-images.githubusercontent.com/1204802/136036622-6ecd1cf6-6d8c-4756-9f1e-6b5787166d64.gif)

By virtue of removing one class (so there aren't double margins competing), and indeed adding the the data-block property to the other, the shift is fixed:

![after](https://user-images.githubusercontent.com/1204802/136036757-9d6be384-79e2-4b46-8b62-a36d5c68545c.gif)

I have not observed any negative side effects to this, but it fixes a very annoying problem with all the existing themes that have targetted data-block. I would love to see it land.

## How has this been tested?

Please test in a classic theme and observe that when clicking the first paragraph, there's no jump or shift.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
