### PR TITLE
Duotone: Add a type option

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -301,9 +301,9 @@ function gutenberg_render_duotone_filter_preset( $preset ) {
 					"
 				/>
 				<feComponentTransfer color-interpolation-filters="sRGB" >
-					<feFuncR type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
-					<feFuncG type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
-					<feFuncB type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
+					<feFuncR type="<?php echo esc_attr( $duotone_type ); ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
+					<feFuncG type="<?php echo esc_attr( $duotone_type ); ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
+					<feFuncB type="<?php echo esc_attr( $duotone_type ); ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
 				</feComponentTransfer>
 			</filter>
 		</defs>

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -261,6 +261,7 @@ function gutenberg_register_duotone_support( $block_type ) {
 function gutenberg_render_duotone_filter_preset( $preset ) {
 	$duotone_id     = $preset['slug'];
 	$duotone_colors = $preset['colors'];
+	$duotone_type   = empty( $preset['type'] ) ? 'table' : $preset['type'];
 	$filter_id      = 'wp-duotone-' . $duotone_id;
 	$duotone_values = array(
 		'r' => array(),
@@ -300,9 +301,9 @@ function gutenberg_render_duotone_filter_preset( $preset ) {
 					"
 				/>
 				<feComponentTransfer color-interpolation-filters="sRGB" >
-					<feFuncR type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
-					<feFuncG type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
-					<feFuncB type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
+					<feFuncR type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
+					<feFuncG type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
+					<feFuncB type="<?php echo $duotone_type; ?>" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
 				</feComponentTransfer>
 			</filter>
 		</defs>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is an alternative to https://github.com/WordPress/gutenberg/pull/33673. It allows users to change the type of the duotone filter when defining filters in the theme.json.

There are other valid filters: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComponentTransfer
However these require a different format for the SVG. I wonder if it would be better to create an abstraction here, so that we specify "type" as posterize and then let `gutenberg_render_duotone_filter_preset` determine how to handle it.

## How has this been tested
- In Skatepark, add a type key to the duotone definition, of `discrete`, and add an image to the post:
```			"duotone": [
                {
                    "colors": [ "#000", "#B9FB9C" ],
                    "slug": "default-filter",
                    "name": "Default filter",
		    "type": "discrete"
                },
                ....
```

## Screenshots <!-- if applicable -->
![localhost_4759__p=435 (2)](https://user-images.githubusercontent.com/275961/136056561-764f6c7b-ee7c-49f7-ae47-bed727827f14.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
