### PR TITLE
Block Library: enable slash inserter for heading, list, and quote

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -38,7 +38,8 @@
 			"__experimentalFontWeight": true
 		},
 		"__experimentalSelector": "h1,h2,h3,h4,h5,h6",
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-heading-editor",
 	"style": "wp-block-heading"

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -46,7 +46,8 @@
 			"link": true
 		},
 		"__unstablePasteTextInline": true,
-		"__experimentalSelector": "ol,ul"
+		"__experimentalSelector": "ol,ul",
+		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-list-editor",
 	"style": "wp-block-list"

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -27,7 +27,8 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"__experimentalSlashInserter": true
 	},
 	"styles": [
 		{


### PR DESCRIPTION
Follow up to #35196, this enables the slash inserter in the heading, list and quote blocks. Changes here provide folks more ways to transform a block. Do the blocks here feel like good matches for the slash inserter? Are there any other blocks we'd like to enable the slash inserter for?

https://user-images.githubusercontent.com/1270189/136063062-2892d508-0855-4bb9-af60-99e327cf723f.mp4

### Testing Instructions

- Try adding a heading block
- Press <kbd>/</kbd>. The slash inserter should appear.
- Further typing should narrow down block selections. Pressing enter or an option should replace the block entirely with the chosen block.
- Repeat testing for the list and quote blocks.
- Verify that these transformations work in the Post, Site and Widget editors.



 