### PR TITLE
Keyboard shortcut: prevent post saving through keyboard if post saving locked

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -12,20 +12,31 @@ import { store as editorStore } from '../../store';
 
 function SaveShortcut( { resetBlocksOnSave } ) {
 	const { resetEditorBlocks, savePost } = useDispatch( editorStore );
-	const { isEditedPostDirty, getPostEdits } = useSelect( ( select ) => {
-		const {
-			isEditedPostDirty: _isEditedPostDirty,
-			getPostEdits: _getPostEdits,
-		} = select( editorStore );
+	const { isEditedPostDirty, getPostEdits, isPostSavingLocked } = useSelect(
+		( select ) => {
+			const {
+				isEditedPostDirty: _isEditedPostDirty,
+				getPostEdits: _getPostEdits,
+				isPostSavingLocked: _isPostSavingLocked,
+			} = select( editorStore );
 
-		return {
-			isEditedPostDirty: _isEditedPostDirty,
-			getPostEdits: _getPostEdits,
-		};
-	}, [] );
-
+			return {
+				isEditedPostDirty: _isEditedPostDirty,
+				getPostEdits: _getPostEdits,
+				isPostSavingLocked: _isPostSavingLocked,
+			};
+		},
+		[]
+	);
 	useShortcut( 'core/editor/save', ( event ) => {
 		event.preventDefault();
+
+		/**
+		 * Do not save the post if post saving is locked.
+		 */
+		if ( isPostSavingLocked() ) {
+			return;
+		}
 
 		// TODO: This should be handled in the `savePost` effect in
 		// considering `isSaveable`. See note on `isEditedPostSaveable`


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Closes #34864 

## Description
Prevents the post from being saved through `Ctrl + S` or `Cmd + S` if post saving is locked.

## How has this been tested?
Followed instructions from the issue.

## Types of changes
**Bug fix**
The keyboard shortcut `core/editor/save` does not save post if `lockPostSaving` is `true`.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
