### PR TITLE
Fix-up Post Editor’s preferences modal

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -13,12 +13,15 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
 	__experimentalTruncate as Truncate,
 	FlexItem,
 	Modal,
 	TabPanel,
 	Button,
 	Card,
+	CardHeader,
 	CardBody,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
@@ -325,10 +328,10 @@ export default function PreferencesModal() {
 		);
 	} else {
 		modalContent = (
-			<Card isBorderless>
-				<CardBody>
-					<NavigatorProvider initialPath="/">
-						<NavigatorScreen path="/">
+			<NavigatorProvider initialPath="/">
+				<NavigatorScreen path="/">
+					<Card isBorderless size="small">
+						<CardBody>
 							<ItemGroup>
 								{ tabs.map( ( tab ) => {
 									return (
@@ -358,12 +361,21 @@ export default function PreferencesModal() {
 									);
 								} ) }
 							</ItemGroup>
-						</NavigatorScreen>
-						{ sections.map( ( section ) => {
-							return (
-								<NavigatorScreen
-									key={ `${ section.name }-menu` }
-									path={ section.name }
+						</CardBody>
+					</Card>
+				</NavigatorScreen>
+				{ sections.map( ( section ) => {
+					return (
+						<NavigatorScreen
+							key={ `${ section.name }-menu` }
+							path={ section.name }
+						>
+							<Card isBorderless size="large">
+								<CardHeader
+									isBorderless={ false }
+									size="small"
+									direction="column"
+									gap="6"
 								>
 									<NavigationButton
 										path="/"
@@ -377,14 +389,18 @@ export default function PreferencesModal() {
 									>
 										{ __( 'Back' ) }
 									</NavigationButton>
-									<h2>{ section.tabLabel }</h2>
-									{ section.content }
-								</NavigatorScreen>
-							);
-						} ) }
-					</NavigatorProvider>
-				</CardBody>
-			</Card>
+									<Spacer marginBottom="0" marginLeft="4">
+										<Text as="h2">
+											{ section.tabLabel }
+										</Text>
+									</Spacer>
+								</CardHeader>
+								<CardBody>{ section.content }</CardBody>
+							</Card>
+						</NavigatorScreen>
+					);
+				} ) }
+			</NavigatorProvider>
 		);
 	}
 	return (

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -386,9 +386,7 @@ export default function PreferencesModal() {
 											'Navigate to the previous view'
 										) }
 									/>
-									<Text size="16" color="#1d2327">
-										{ section.tabLabel }
-									</Text>
+									<Text size="16">{ section.tabLabel }</Text>
 								</CardHeader>
 								<CardBody>{ section.content }</CardBody>
 							</Card>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -13,7 +13,6 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 	__experimentalTruncate as Truncate,
 	FlexItem,
@@ -373,8 +372,8 @@ export default function PreferencesModal() {
 							<Card isBorderless size="large">
 								<CardHeader
 									isBorderless={ false }
+									justify="left"
 									size="small"
-									direction="column"
 									gap="6"
 								>
 									<NavigationButton
@@ -386,14 +385,10 @@ export default function PreferencesModal() {
 										aria-label={ __(
 											'Navigate to the previous view'
 										) }
-									>
-										{ __( 'Back' ) }
-									</NavigationButton>
-									<Spacer marginBottom="0" marginLeft="4">
-										<Text as="h2">
-											{ section.tabLabel }
-										</Text>
-									</Spacer>
+									/>
+									<Text size="16" color="#1d2327">
+										{ section.tabLabel }
+									</Text>
 								</CardHeader>
 								<CardBody>{ section.content }</CardBody>
 							</Card>

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -23,13 +23,17 @@ $vertical-tabs-width: 160px;
 				content: none;
 			}
 		}
+		// Keep the navigator component from overflowing the modal content area
+		// to ensure that sticky position elements stick where intended.
+		.components-navigator-provider {
+			height: 100%;
+			// This may become obselete if the component itself adopts the rule.
+			> .components-navigator-screen {
+				max-height: 100%;
+			}
+		}
 	}
 
-	.components-navigator-provider {
-		// Ensurance that sticky position coordinates are relative to the
-		// rectangle of the modal content.
-		max-height: 100%;
-	}
 
 	.edit-post-preferences__tabs {
 		.components-tab-panel__tabs {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -25,44 +25,9 @@ $vertical-tabs-width: 160px;
 		}
 	}
 
-	.components-navigation {
-		padding: 0;
+	.components-navigator-provider {
 		max-height: 100%;
 		overflow-y: auto;
-		color: $black;
-
-		> * {
-			// Matches spacing cleared from the modal content element.
-			padding: $grid-unit-30 $grid-unit-40;
-		}
-
-		.components-navigation__menu {
-			margin: 0;
-
-			.components-navigation__item {
-				& > button {
-					padding: 3px $grid-unit-20;
-					height: $grid-unit-60;
-					// Aligns button text instead of button box.
-					margin: 0 #{-$grid-unit-20};
-					width: calc(#{$grid-unit-40} + 100%);
-					&:focus {
-						font-weight: 500;
-					}
-				}
-			}
-			.components-navigation__menu-title-heading {
-				border-bottom: 1px solid $gray-300;
-				padding-left: 0;
-				padding-right: 0;
-			}
-			.components-navigation__back-button {
-				padding-left: 0;
-			}
-			.edit-post-preferences-modal__custom-fields-confirmation-button {
-				width: auto;
-			}
-		}
 	}
 
 	.edit-post-preferences__tabs {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -14,7 +14,7 @@ $vertical-tabs-width: 160px;
 		height: 70%;
 	}
 
-	// Clears spacing to flush fit the navigation component to the modal edges.
+	// Clears spacing to flush fit the navigator component to the modal edges.
 	@media (max-width: #{ ($break-medium - 1) }) {
 		.components-modal__content {
 			padding: 0;
@@ -26,8 +26,9 @@ $vertical-tabs-width: 160px;
 	}
 
 	.components-navigator-provider {
+		// Ensurance that sticky position coordinates are relative to the
+		// rectangle of the modal content.
 		max-height: 100%;
-		overflow-y: auto;
 	}
 
 	.edit-post-preferences__tabs {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -27,13 +27,8 @@ $vertical-tabs-width: 160px;
 		// to ensure that sticky position elements stick where intended.
 		.components-navigator-provider {
 			height: 100%;
-			// This may become obselete if the component itself adopts the rule.
-			> .components-navigator-screen {
-				max-height: 100%;
-			}
 		}
 	}
-
 
 	.edit-post-preferences__tabs {
 		.components-tab-panel__tabs {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -67,6 +67,7 @@ $vertical-tabs-width: 160px;
 	&__section-title {
 		font-size: 0.9rem;
 		font-weight: 600;
+		margin-top: 0;
 	}
 
 	&__option {

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -40,16 +40,17 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
   onRequestClose={[Function]}
   title="Preferences"
 >
-  <Card
-    isBorderless={true}
+  <NavigatorProvider
+    initialPath="/"
   >
-    <CardBody>
-      <NavigatorProvider
-        initialPath="/"
+    <NavigatorScreen
+      path="/"
+    >
+      <Card
+        isBorderless={true}
+        size="small"
       >
-        <NavigatorScreen
-          path="/"
-        >
+        <CardBody>
           <ItemGroup>
             <NavigationButton
               as={
@@ -169,10 +170,22 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
               </HStack>
             </NavigationButton>
           </ItemGroup>
-        </NavigatorScreen>
-        <NavigatorScreen
-          key="general-menu"
-          path="general"
+        </CardBody>
+      </Card>
+    </NavigatorScreen>
+    <NavigatorScreen
+      key="general-menu"
+      path="general"
+    >
+      <Card
+        isBorderless={true}
+        size="large"
+      >
+        <CardHeader
+          direction="column"
+          gap="6"
+          isBorderless={false}
+          size="small"
         >
           <NavigationButton
             aria-label="Navigate to the previous view"
@@ -191,9 +204,18 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           >
             Back
           </NavigationButton>
-          <h2>
-            General
-          </h2>
+          <Spacer
+            marginBottom="0"
+            marginLeft="4"
+          >
+            <Text
+              as="h2"
+            >
+              General
+            </Text>
+          </Spacer>
+        </CardHeader>
+        <CardBody>
           <Section
             description="Customize options related to the block editor interface and editing flow."
             title="Appearance"
@@ -224,10 +246,22 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
               label="Display block breadcrumbs"
             />
           </Section>
-        </NavigatorScreen>
-        <NavigatorScreen
-          key="blocks-menu"
-          path="blocks"
+        </CardBody>
+      </Card>
+    </NavigatorScreen>
+    <NavigatorScreen
+      key="blocks-menu"
+      path="blocks"
+    >
+      <Card
+        isBorderless={true}
+        size="large"
+      >
+        <CardHeader
+          direction="column"
+          gap="6"
+          isBorderless={false}
+          size="small"
         >
           <NavigationButton
             aria-label="Navigate to the previous view"
@@ -246,9 +280,18 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           >
             Back
           </NavigationButton>
-          <h2>
-            Blocks
-          </h2>
+          <Spacer
+            marginBottom="0"
+            marginLeft="4"
+          >
+            <Text
+              as="h2"
+            >
+              Blocks
+            </Text>
+          </Spacer>
+        </CardHeader>
+        <CardBody>
           <Section
             description="Customize how you interact with blocks in the block library and editing canvas."
             title="Block interactions"
@@ -270,10 +313,22 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           >
             <WithSelect(BlockManager) />
           </Section>
-        </NavigatorScreen>
-        <NavigatorScreen
-          key="panels-menu"
-          path="panels"
+        </CardBody>
+      </Card>
+    </NavigatorScreen>
+    <NavigatorScreen
+      key="panels-menu"
+      path="panels"
+    >
+      <Card
+        isBorderless={true}
+        size="large"
+      >
+        <CardHeader
+          direction="column"
+          gap="6"
+          isBorderless={false}
+          size="small"
         >
           <NavigationButton
             aria-label="Navigate to the previous view"
@@ -292,9 +347,18 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
           >
             Back
           </NavigationButton>
-          <h2>
-            Panels
-          </h2>
+          <Spacer
+            marginBottom="0"
+            marginLeft="4"
+          >
+            <Text
+              as="h2"
+            >
+              Panels
+            </Text>
+          </Spacer>
+        </CardHeader>
+        <CardBody>
           <Section
             description="Choose what displays in the panel."
             title="Document settings"
@@ -339,9 +403,9 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             description="Add extra areas to the editor."
             title="Additional"
           />
-        </NavigatorScreen>
-      </NavigatorProvider>
-    </CardBody>
-  </Card>
+        </CardBody>
+      </Card>
+    </NavigatorScreen>
+  </NavigatorProvider>
 </Modal>
 `;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -182,9 +182,9 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         size="large"
       >
         <CardHeader
-          direction="column"
           gap="6"
           isBorderless={false}
+          justify="left"
           size="small"
         >
           <NavigationButton
@@ -201,19 +201,12 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             }
             isBack={true}
             path="/"
+          />
+          <Text
+            size="16"
           >
-            Back
-          </NavigationButton>
-          <Spacer
-            marginBottom="0"
-            marginLeft="4"
-          >
-            <Text
-              as="h2"
-            >
-              General
-            </Text>
-          </Spacer>
+            General
+          </Text>
         </CardHeader>
         <CardBody>
           <Section
@@ -258,9 +251,9 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         size="large"
       >
         <CardHeader
-          direction="column"
           gap="6"
           isBorderless={false}
+          justify="left"
           size="small"
         >
           <NavigationButton
@@ -277,19 +270,12 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             }
             isBack={true}
             path="/"
+          />
+          <Text
+            size="16"
           >
-            Back
-          </NavigationButton>
-          <Spacer
-            marginBottom="0"
-            marginLeft="4"
-          >
-            <Text
-              as="h2"
-            >
-              Blocks
-            </Text>
-          </Spacer>
+            Blocks
+          </Text>
         </CardHeader>
         <CardBody>
           <Section
@@ -325,9 +311,9 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
         size="large"
       >
         <CardHeader
-          direction="column"
           gap="6"
           isBorderless={false}
+          justify="left"
           size="small"
         >
           <NavigationButton
@@ -344,19 +330,12 @@ exports[`PreferencesModal should match snapshot when the modal is active small v
             }
             isBack={true}
             path="/"
+          />
+          <Text
+            size="16"
           >
-            Back
-          </NavigationButton>
-          <Spacer
-            marginBottom="0"
-            marginLeft="4"
-          >
-            <Text
-              as="h2"
-            >
-              Panels
-            </Text>
-          </Spacer>
+            Panels
+          </Text>
         </CardHeader>
         <CardBody>
           <Section


### PR DESCRIPTION
Follow-up to #35142. This is meant to do a few things:
- Fix clipping of focus styles and breakage of the sticky positioning of the category titles in the Blocks screen (since #35332).
- Refine visuals of the preferences modal (at < medium breakpoints) closer to what we had before #35142.
- Clean up some outdated CSS for customizing the legacy navigation component and its children.

It's worth noting the approach for the second point on improving visuals is by edits to only component structure and props as opposed to adding custom CSS. The idea is to follow the approach Riad proposed:

> Ideally we shouldn't have to customize things other than with using the regular props offered by the UI components.

https://github.com/WordPress/gutenberg/pull/35142#issuecomment-929020861

While the visuals can be further improved, some of it may be better done with careful improvement to component styles.

## How has this been tested?
Manually.

## Screenshots

### Before (since #35332) clipping and sticky breakage are evident

https://user-images.githubusercontent.com/9000376/136718890-1fc0555b-dda3-4347-ba57-79b265c19b20.mp4

### With this PR clipping and sticky issues resolved

https://user-images.githubusercontent.com/9000376/136718923-62af3e91-31a2-4e8d-a9a6-43ab0acc0db2.mp4

### Blocks screen
| `Before` | `After…` |
| --- | --- |
| ![before-edit-post-prefs-blocks](https://user-images.githubusercontent.com/9000376/136086369-30d695ca-84fc-4fa2-9817-cedaa1ab0520.png) | ![after-edit-post-prefs-blocks](https://user-images.githubusercontent.com/9000376/136086430-a9e740bb-4846-485c-b2f1-7060f9d2a45a.png) |

### Root menu
| `Before` | `After…` |
| --- | --- |
| ![before-edit-post-prefs](https://user-images.githubusercontent.com/9000376/136086887-da9de3cb-0bfd-4a0d-bddc-e791f848bd52.png) | ![after-edit-post-prefs](https://user-images.githubusercontent.com/9000376/136086964-860e7db2-47d7-44c4-8242-62258f9056b0.png) |

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
