### PR TITLE
Allow customization of the ARTIFACTS_PATH via WP_ARTIFACTS_PATH env var

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   The bundled `jest-dev-server` dependency has been updated to the next major version `^5.0.3` ([#34560](https://github.com/WordPress/gutenberg/pull/34560)).
+-   Allow customization of the `ARTIFACTS_PATH` in the `jest-environment-puppeteer` failed test reporter via the `WP_ARTIFACTS_PATH` environment variable ([#35371](https://github.com/WordPress/gutenberg/pull/35371)).
 
 ## 18.0.1 (2021-09-09)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -377,7 +377,7 @@ We enforce that all tests run serially in the current process using [--runInBand
 
 When tests fail, both a screenshot and an HTML snapshot will be taken of the page and stored in the `artifacts/` directory at the root of your project. These snapshots may help debug failed tests during development or when running tests in a CI environment.
 
-The `artifacts/` directory can be customized by defining the `WP_ARTIFACTS_PATH` environment variable.
+The `artifacts/` directory can be customized by setting the `WP_ARTIFACTS_PATH` environment variable to the relative path of the desired directory within your project's root. For example: to change the default directory from `artifacts/` to `my/custom/artifacts`, you could use `WP_ARTIFACTS_PATH=my/custom/artifacts npm run test:e2e`.
 
 #### Advanced information
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -415,6 +415,12 @@ Jest will look for test files with any of the following popular naming conventio
 -   Files with `.js` (or `.ts`) suffix directly located in `test` folders.
 -   Files with `.test.js` (or `.test.ts`) suffix.
 
+#### Failed Test Artifacts
+
+When tests fail, both a screenshot and an HTML snapshot will be taken of the page and stored in the `artifacts/` directory at the root of your project. These snapshots may help debug failed tests during development or when running tests in a CI environment.
+
+The `artifacts/` directory can be customized by defining the `WP_ARTIFACTS_PATH` environment variable.
+
 #### Advanced information
 
 It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all of its [CLI options](https://jestjs.io/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test:unit --help` or `npm run test:unit:help` (as mentioned above) to view all of the available options. By default, it uses the set of recommended options defined in [@wordpress/jest-preset-default](https://www.npmjs.com/package/@wordpress/jest-preset-default) npm package. You can override them with your own options as described in [Jest documentation](https://jestjs.io/docs/en/configuration). Learn more in the [Advanced Usage](#advanced-usage) section.

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -373,6 +373,12 @@ This script automatically detects the best config to start Puppeteer but sometim
 
 We enforce that all tests run serially in the current process using [--runInBand](https://jestjs.io/docs/en/cli#runinband) Jest CLI option to avoid conflicts between tests caused by the fact that they share the same WordPress instance.
 
+#### Failed Test Artifacts
+
+When tests fail, both a screenshot and an HTML snapshot will be taken of the page and stored in the `artifacts/` directory at the root of your project. These snapshots may help debug failed tests during development or when running tests in a CI environment.
+
+The `artifacts/` directory can be customized by defining the `WP_ARTIFACTS_PATH` environment variable.
+
 #### Advanced information
 
 It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all of its [CLI options](https://jestjs.io/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test:e2e --help` or `npm run test:e2e:help` (as mentioned above) to view all of the available options. Learn more in the [Advanced Usage](#advanced-usage) section.
@@ -414,12 +420,6 @@ Jest will look for test files with any of the following popular naming conventio
 -   Files with `.js` (or `.ts`) suffix located at any level of depth in `__tests__` folders.
 -   Files with `.js` (or `.ts`) suffix directly located in `test` folders.
 -   Files with `.test.js` (or `.test.ts`) suffix.
-
-#### Failed Test Artifacts
-
-When tests fail, both a screenshot and an HTML snapshot will be taken of the page and stored in the `artifacts/` directory at the root of your project. These snapshots may help debug failed tests during development or when running tests in a CI environment.
-
-The `artifacts/` directory can be customized by defining the `WP_ARTIFACTS_PATH` environment variable.
 
 #### Advanced information
 

--- a/packages/scripts/config/jest-environment-puppeteer/index.js
+++ b/packages/scripts/config/jest-environment-puppeteer/index.js
@@ -43,8 +43,10 @@ const KEYS = {
 };
 
 const root = process.env.GITHUB_WORKSPACE || process.cwd();
-const ARTIFACTS_PATH =
-	path.resolve( root, process.env.WP_ARTIFACTS_PATH || 'artifacts' );
+const ARTIFACTS_PATH = path.resolve(
+	root,
+	process.env.WP_ARTIFACTS_PATH || 'artifacts'
+);
 
 class PuppeteerEnvironment extends NodeEnvironment {
 	// Jest is not available here, so we have to reverse engineer

--- a/packages/scripts/config/jest-environment-puppeteer/index.js
+++ b/packages/scripts/config/jest-environment-puppeteer/index.js
@@ -43,7 +43,7 @@ const KEYS = {
 };
 
 const root = process.env.GITHUB_WORKSPACE || process.cwd();
-const ARTIFACTS_PATH = path.join( root, 'artifacts' );
+const ARTIFACTS_PATH = process.env.WP_ARTIFACTS_PATH || path.join( root, 'artifacts' );
 
 class PuppeteerEnvironment extends NodeEnvironment {
 	// Jest is not available here, so we have to reverse engineer

--- a/packages/scripts/config/jest-environment-puppeteer/index.js
+++ b/packages/scripts/config/jest-environment-puppeteer/index.js
@@ -43,7 +43,8 @@ const KEYS = {
 };
 
 const root = process.env.GITHUB_WORKSPACE || process.cwd();
-const ARTIFACTS_PATH = process.env.WP_ARTIFACTS_PATH || path.join( root, 'artifacts' );
+const ARTIFACTS_PATH =
+	process.env.WP_ARTIFACTS_PATH || path.join( root, 'artifacts' );
 
 class PuppeteerEnvironment extends NodeEnvironment {
 	// Jest is not available here, so we have to reverse engineer

--- a/packages/scripts/config/jest-environment-puppeteer/index.js
+++ b/packages/scripts/config/jest-environment-puppeteer/index.js
@@ -44,7 +44,7 @@ const KEYS = {
 
 const root = process.env.GITHUB_WORKSPACE || process.cwd();
 const ARTIFACTS_PATH =
-	process.env.WP_ARTIFACTS_PATH || path.join( root, 'artifacts' );
+	path.resolve( root, process.env.WP_ARTIFACTS_PATH || 'artifacts' );
 
 class PuppeteerEnvironment extends NodeEnvironment {
 	// Jest is not available here, so we have to reverse engineer
@@ -172,7 +172,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
 		await this.global.jestPuppeteer.resetBrowser();
 
 		try {
-			await mkdir( ARTIFACTS_PATH );
+			await mkdir( ARTIFACTS_PATH, { recursive: true } );
 		} catch ( err ) {
 			if ( err.code !== 'EEXIST' ) {
 				throw err;


### PR DESCRIPTION
## Description

Per #34797

Allows 3rd-party customization of the ARTIFACTS_PATH used by `@wordpress/scripts` when running E2E tests by defining WP_ARTIFACTS_PATH as an environment variable.

If the env variable is empty, falls back to the default location.

## How has this been tested?

I've manually patched my code into the `@worpress/scripts` package in my plugin's `node_modules` dir and run my e2e tests, forcing a failure and ran tests once without an env var set to ensure artifacts end up in the intended location and again after adding the new env var to ensure that artifacts end up in the custom location.

Edit: I've also tested this against this repo's `npm run test-e2e` both with the default usage (no ENV var) and with the ENV var set at runtime, eg: `WP_ARTIFACTS_PATH=custom/artifacts npm run test-e2e`

All these tests result in failed tests storing artifacts in the expected location

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
