### PR TITLE
ToolsPanelItem: Add panelId check before calling toggle methods

### DIFF
--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -88,7 +88,7 @@ export function useToolsPanelItem(
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.
 	useEffect( () => {
-		if ( isResetting ) {
+		if ( isResetting || currentPanelId !== panelId ) {
 			return;
 		}
 
@@ -99,7 +99,14 @@ export function useToolsPanelItem(
 		if ( ! isMenuItemChecked && wasMenuItemChecked ) {
 			onDeselect?.();
 		}
-	}, [ isMenuItemChecked, wasMenuItemChecked, isValueSet, isResetting ] );
+	}, [
+		currentPanelId,
+		isMenuItemChecked,
+		isResetting,
+		isValueSet,
+		panelId,
+		wasMenuItemChecked,
+	] );
 
 	// The item is shown if it is a default control regardless of whether it
 	// has a value. Optional items are shown when they are checked or have


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

While testing a couple of different blockGap PRs (#34630 and #34546), I noticed that if I select a block and update its block spacing value, then select the same type of block and then back to the original block, the value I set would be cleared out. After adding some `console.log()`s, it appears that the `onSelect` and `onDeselect` functions in the Tools Panel Item were being called (effectively as though we'd toggled the blockGap control).

This PR adds a check before calling the `onSelect` and `onDeselect` functions to ensure that the current panel id hasn't changed before calling the functions. This appears to fix the issue of the blockGap value unexpectedly being cleared.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually in the editor. 

Before testing, switch to an FSE-capable theme (e.g. TT1-Blocks) and enable the `blockGap` feature by updating the `settings.spacing.blockGap` setting in the `theme.json` file. For example, here's how that section of my `theme.json` file looks:

```
		"spacing": {
			"blockGap": true,
			"customPadding": true,
			"customMargin": true,
			"units": [
				"px",
				"em",
				"rem",
				"vh",
				"vw"
			]
		},
```

To replicate, we need to click directly between two blocks with the same dimensions panel, so one way to do this is to add two columns blocks to your post content, and set them to use a background color so that you can click between them. To make it easier for testing, [here's a gist](https://gist.github.com/andrewserong/4a312ca1ebf6bedb5e97cbca61a69c1b) of post content with two columns blocks. Copy and paste it in the code editor view for testing.

Before applying this PR:

1. Select the first columns block and set a value in the block spacing field
2. Directly select the other columns block
3. Click back to the first columns block and notice that the value you previously entered has been removed

It may take clicking back and forth a couple of times before you see the issue.

With this PR applied, the values should not be unexpectedly removed. Also test to make sure that toggling tools panel items in the ToolsPanel menu still works as expected.

## Screenshots <!-- if applicable -->

Note that in the Before screengrab the block spacing value is cleared unexpectedly when clicking between Columns blocks. In the After screengrab the value is not cleared.

| Before | After |
| --- | --- |
| ![blockGap-before-sml](https://user-images.githubusercontent.com/14988353/136125209-b4aa040b-c78e-42d3-b06e-d0fa245f537c.gif) | ![blockGap-after-sml](https://user-images.githubusercontent.com/14988353/136125222-14078ef0-6b3b-4332-ade4-d430996ff4f9.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (manually)
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
