### PR TITLE
Keyboard Shortcuts: Use a new selector getter method

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -13,21 +13,9 @@ import { store as editorStore } from '../../store';
 function SaveShortcut( { resetBlocksOnSave } ) {
 	const { resetEditorBlocks, savePost } = useDispatch( editorStore );
 	const { isEditedPostDirty, getPostEdits, isPostSavingLocked } = useSelect(
-		( select ) => {
-			const {
-				isEditedPostDirty: _isEditedPostDirty,
-				getPostEdits: _getPostEdits,
-				isPostSavingLocked: _isPostSavingLocked,
-			} = select( editorStore );
-
-			return {
-				isEditedPostDirty: _isEditedPostDirty,
-				getPostEdits: _getPostEdits,
-				isPostSavingLocked: _isPostSavingLocked,
-			};
-		},
-		[]
+		editorStore
 	);
+
 	useShortcut( 'core/editor/save', ( event ) => {
 		event.preventDefault();
 


### PR DESCRIPTION
## Description
Use the new selector getter method (#31078) in "Save Shortcut." When returned value is only used in callbacks, we can use this new method.

P.S. Noticed this code last night in different PR but didn't get a chance to suggest this method.

## How has this been tested?
1. Create a post and publish it.
2. Lock post saving
```js
wp.data.dispatch( 'core/editor' ).lockPostSaving( 'futurelock' );
```
3. Add or edit block.
4. Try saving post using shortcut CMD/CTRL + S.
5. The post shouldn't be saved.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
