### PR TITLE
Align the layout of the template card with the block card

### DIFF
--- a/packages/edit-post/src/components/sidebar/template-summary/index.js
+++ b/packages/edit-post/src/components/sidebar/template-summary/index.js
@@ -22,7 +22,7 @@ function TemplateSummary() {
 
 	return (
 		<PanelBody>
-			<Flex align="flex-start">
+			<Flex align="flex-start" gap="3">
 				<FlexItem>
 					<Icon icon={ layout } />
 				</FlexItem>

--- a/packages/edit-post/src/components/sidebar/template-summary/style.scss
+++ b/packages/edit-post/src/components/sidebar/template-summary/style.scss
@@ -1,4 +1,5 @@
 h2.edit-post-template-summary__title {
-	margin: 0;
 	line-height: $icon-size;
+	margin: 0 0 $grid-unit-05;
+	font-weight: 500;
 }

--- a/packages/edit-site/src/components/sidebar/template-card/style.scss
+++ b/packages/edit-site/src/components/sidebar/template-card/style.scss
@@ -5,12 +5,12 @@
 
 .edit-site-template-card__content {
 	flex-grow: 1;
-	margin-bottom: 4px;
+	margin-bottom: $grid-unit-05;
 }
 
 .edit-site-template-card__title {
 	font-weight: 500;
-	line-height: $grid-unit-30;
+	line-height: $icon-size;
 	&.edit-site-template-card__title {
 		margin: 0 0 $grid-unit-05;
 	}

--- a/packages/edit-site/src/components/sidebar/template-card/style.scss
+++ b/packages/edit-site/src/components/sidebar/template-card/style.scss
@@ -5,12 +5,14 @@
 
 .edit-site-template-card__content {
 	flex-grow: 1;
+	margin-bottom: 4px;
 }
 
 .edit-site-template-card__title {
 	font-weight: 500;
+	line-height: $grid-unit-30;
 	&.edit-site-template-card__title {
-		margin: 0 0 5px;
+		margin: 0 0 $grid-unit-05;
 	}
 }
 
@@ -19,10 +21,8 @@
 }
 
 .edit-site-template-card__icon {
-	flex: 0 0 $button-size;
-	margin-left: -2px;
-	margin-right: 10px;
-	padding: 0 3px;
-	width: $button-size;
-	height: $button-size-small;
+	flex: 0 0 $icon-size;
+	margin-right: $grid-unit-15;
+	width: $icon-size;
+	height: $icon-size;
 }


### PR DESCRIPTION
Currently the layout of the Template card in the Inspector does not match the Block card. This is especially apparent when you navigate between each tab.

Interestingly the template and site editor environments have different implementations. Here's an image outlining the various issues:

<img width="774" alt="Screenshot 2021-10-06 at 10 55 39" src="https://user-images.githubusercontent.com/846565/136181485-015b4a04-6fee-47c4-8131-0f18ceddb200.png">

This PR ensures the layout and type styles are aligned with the block card:

<img width="783" alt="Screenshot 2021-10-06 at 10 56 26" src="https://user-images.githubusercontent.com/846565/136181591-d541adb2-d97e-466e-809a-d96cfcb5dbfd.png">


