### PR TITLE
Try: Site Logo placeholder tweaks

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -76,7 +76,8 @@ export function MediaPlaceholder( {
 	onFilesPreUpload = noop,
 	onHTMLDrop = noop,
 	children,
-	customMediaLibraryButton,
+	mediaLibraryButton,
+	placeholder,
 } ) {
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -179,7 +180,7 @@ export function MediaPlaceholder( {
 		onFilesUpload( event.target.files );
 	};
 
-	const renderPlaceholder = ( content ) => {
+	const defaultRenderPlaceholder = ( content ) => {
 		let { instructions, title } = labels;
 
 		if ( ! mediaUpload && ! onSelectURL ) {
@@ -253,6 +254,7 @@ export function MediaPlaceholder( {
 			</Placeholder>
 		);
 	};
+	const renderPlaceholder = placeholder ?? defaultRenderPlaceholder;
 
 	const renderDropZone = () => {
 		if ( disableDropZone ) {
@@ -317,8 +319,8 @@ export function MediaPlaceholder( {
 				</Button>
 			);
 		};
-		const libraryButton = customMediaLibraryButton ?? defaultButton;
-		const mediaLibraryButton = (
+		const libraryButton = mediaLibraryButton ?? defaultButton;
+		const uploadMediaLibraryButton = (
 			<MediaUpload
 				addToGallery={ addToGallery }
 				gallery={ multiple && onlyAllowsImages() }
@@ -355,7 +357,7 @@ export function MediaPlaceholder( {
 									>
 										{ __( 'Upload' ) }
 									</Button>
-									{ mediaLibraryButton }
+									{ uploadMediaLibraryButton }
 									{ renderUrlSelectionUI() }
 									{ renderCancelLink() }
 								</>
@@ -383,7 +385,7 @@ export function MediaPlaceholder( {
 					>
 						{ __( 'Upload' ) }
 					</FormFileUpload>
-					{ mediaLibraryButton }
+					{ uploadMediaLibraryButton }
 					{ renderUrlSelectionUI() }
 					{ renderCancelLink() }
 				</>
@@ -391,7 +393,7 @@ export function MediaPlaceholder( {
 			return renderPlaceholder( content );
 		}
 
-		return renderPlaceholder( mediaLibraryButton );
+		return renderPlaceholder( uploadMediaLibraryButton );
 	};
 
 	if ( dropZoneUIOnly || disableMediaButtons ) {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -76,6 +76,7 @@ export function MediaPlaceholder( {
 	onFilesPreUpload = noop,
 	onHTMLDrop = noop,
 	children,
+	customMediaLibraryButton,
 } ) {
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -304,6 +305,19 @@ export function MediaPlaceholder( {
 	};
 
 	const renderMediaUploadChecked = () => {
+		const defaultButton = ( { open } ) => {
+			return (
+				<Button
+					variant="tertiary"
+					onClick={ () => {
+						open();
+					} }
+				>
+					{ __( 'Media Library' ) }
+				</Button>
+			);
+		};
+		const libraryButton = customMediaLibraryButton ?? defaultButton;
 		const mediaLibraryButton = (
 			<MediaUpload
 				addToGallery={ addToGallery }
@@ -316,18 +330,7 @@ export function MediaPlaceholder( {
 						? value.map( ( { id } ) => id )
 						: value.id
 				}
-				render={ ( { open } ) => {
-					return (
-						<Button
-							variant="tertiary"
-							onClick={ () => {
-								open();
-							} }
-						>
-							{ __( 'Media Library' ) }
-						</Button>
-					);
-				} }
+				render={ libraryButton }
 			/>
 		);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -20,6 +20,7 @@ import {
 	ToggleControl,
 	ToolbarButton,
 	Placeholder,
+	Button,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import {
@@ -34,7 +35,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { crop, siteLogo as icon } from '@wordpress/icons';
+import { crop, siteLogo as icon, upload } from '@wordpress/icons';
 import { SVG, Path } from '@wordpress/primitives';
 
 /**
@@ -470,6 +471,17 @@ export default function LogoEdit( {
 						)
 					}
 					onError={ onUploadError }
+					customMediaLibraryButton={ ( { open } ) => {
+						return (
+							<Button
+								icon={ upload }
+								variant="tertiary"
+								onClick={ () => {
+									open();
+								} }
+							/>
+						);
+					} }
 				>
 					<SVG
 						className="components-placeholder__illustration"

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -19,6 +19,7 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarButton,
+	Tooltip,
 	Placeholder,
 	Button,
 } from '@wordpress/components';
@@ -433,32 +434,38 @@ export default function LogoEdit( {
 		);
 
 		return (
-			<Placeholder
-				className={ placeholderClassName }
-				notices={
-					error && (
-						<Notice status="error" isDismissible={ false }>
-							{ error }
-						</Notice>
-					)
-				}
-				preview={ logoImage }
+			<Tooltip
+				position="top center"
+				text={ __( 'Click, or drag and drop, to add a site logo' ) }
+				delay={ 0 }
 			>
-				{
-					<SVG
-						className="components-placeholder__illustration"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 60 60"
-					>
-						<Path
-							vectorEffect="non-scaling-stroke"
-							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
-						/>
-					</SVG>
-				}
-				{ content }
-			</Placeholder>
+				<Placeholder
+					className={ placeholderClassName }
+					notices={
+						error && (
+							<Notice status="error" isDismissible={ false }>
+								{ error }
+							</Notice>
+						)
+					}
+					preview={ logoImage }
+				>
+					{
+						<SVG
+							className="components-placeholder__illustration"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 60 60"
+						>
+							<Path
+								vectorEffect="non-scaling-stroke"
+								d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
+							/>
+						</SVG>
+					}
+					{ content }
+				</Placeholder>
+			</Tooltip>
 		);
 	};
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -24,7 +24,6 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
@@ -452,7 +451,6 @@ export default function LogoEdit( {
 			) }
 			{ ! logoUrl && canUserEdit && (
 				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
 					labels={ {
 						title: label,
 						instructions: __(

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -18,7 +18,6 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarButton,
-	Tooltip,
 	Placeholder,
 	Button,
 } from '@wordpress/components';
@@ -433,41 +432,39 @@ export default function LogoEdit( {
 		);
 
 		return (
-			<Tooltip
-				position="top center"
-				text={ __( 'Click, or drag and drop, to add a site logo' ) }
-				delay={ 0 }
+			<Placeholder
+				className={ placeholderClassName }
+				preview={ logoImage }
 			>
-				<Placeholder
-					className={ placeholderClassName }
-					preview={ logoImage }
-				>
-					{
-						<SVG
-							className="components-placeholder__illustration"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 60 60"
-						>
-							<Path
-								vectorEffect="non-scaling-stroke"
-								d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
-							/>
-						</SVG>
-					}
-					{ content }
-				</Placeholder>
-			</Tooltip>
+				{
+					<SVG
+						className="components-placeholder__illustration"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 60 60"
+					>
+						<Path
+							vectorEffect="non-scaling-stroke"
+							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
+						/>
+					</SVG>
+				}
+				{ content }
+			</Placeholder>
 		);
 	};
 
 	const classes = classnames( className, {
 		'is-default-size': ! width,
 	} );
+
 	const blockProps = useBlockProps( {
 		ref,
 		className: classes,
 	} );
+
+	const label = __( 'Add a site logo' );
+
 	return (
 		<div { ...blockProps }>
 			{ controls }
@@ -492,7 +489,10 @@ export default function LogoEdit( {
 						return (
 							<Button
 								icon={ upload }
-								variant="tertiary"
+								variant="primary"
+								label={ label }
+								showTooltip
+								tooltipPosition="top center"
 								onClick={ () => {
 									open();
 								} }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -35,7 +35,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { crop, siteLogo as icon, upload } from '@wordpress/icons';
+import { crop, upload } from '@wordpress/icons';
 import { SVG, Path } from '@wordpress/primitives';
 
 /**
@@ -405,7 +405,6 @@ export default function LogoEdit( {
 		</BlockControls>
 	);
 
-	const label = __( 'Site Logo' );
 	let logoImage;
 	const isLoading = siteLogoId === undefined || isRequestingMediaItem;
 	if ( isLoading ) {
@@ -427,6 +426,42 @@ export default function LogoEdit( {
 			/>
 		);
 	}
+	const placeholder = ( content ) => {
+		const placeholderClassName = classnames(
+			'block-editor-media-placeholder',
+			className
+		);
+
+		return (
+			<Placeholder
+				className={ placeholderClassName }
+				notices={
+					error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error }
+						</Notice>
+					)
+				}
+				preview={ logoImage }
+			>
+				{
+					<SVG
+						className="components-placeholder__illustration"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 60 60"
+					>
+						<Path
+							vectorEffect="non-scaling-stroke"
+							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
+						/>
+					</SVG>
+				}
+				{ content }
+			</Placeholder>
+		);
+	};
+
 	const classes = classnames( className, {
 		'is-default-size': ! width,
 	} );
@@ -439,11 +474,7 @@ export default function LogoEdit( {
 			{ controls }
 			{ !! logoUrl && logoImage }
 			{ ! logoUrl && ! canUserEdit && (
-				<Placeholder
-					className="site-logo_placeholder"
-					icon={ icon }
-					label={ label }
-				>
+				<Placeholder className="site-logo_placeholder">
 					{ isLoading && (
 						<span className="components-placeholder__preview">
 							<Spinner />
@@ -453,25 +484,12 @@ export default function LogoEdit( {
 			) }
 			{ ! logoUrl && canUserEdit && (
 				<MediaPlaceholder
-					labels={ {
-						title: label,
-						instructions: __(
-							'Upload an image, or pick one from your media library, to be your site logo'
-						),
-					} }
 					onSelect={ onSelectLogo }
 					accept={ ACCEPT_MEDIA_STRING }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					mediaPreview={ logoImage }
-					notices={
-						error && (
-							<Notice status="error" isDismissible={ false }>
-								{ error }
-							</Notice>
-						)
-					}
 					onError={ onUploadError }
-					customMediaLibraryButton={ ( { open } ) => {
+					placeholder={ placeholder }
+					mediaLibraryButton={ ( { open } ) => {
 						return (
 							<Button
 								icon={ upload }
@@ -482,19 +500,7 @@ export default function LogoEdit( {
 							/>
 						);
 					} }
-				>
-					<SVG
-						className="components-placeholder__illustration"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 60 60"
-					>
-						<Path
-							vectorEffect="non-scaling-stroke"
-							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
-						/>
-					</SVG>
-				</MediaPlaceholder>
+				/>
 			) }
 		</div>
 	);

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -35,6 +35,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { crop, siteLogo as icon } from '@wordpress/icons';
+import { SVG, Path } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -469,7 +470,19 @@ export default function LogoEdit( {
 						)
 					}
 					onError={ onUploadError }
-				/>
+				>
+					<SVG
+						className="components-placeholder__illustration"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 60 60"
+					>
+						<Path
+							vectorEffect="non-scaling-stroke"
+							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
+						/>
+					</SVG>
+				</MediaPlaceholder>
 			) }
 		</div>
 	);

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -12,7 +12,6 @@ import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import {
 	MenuItem,
-	Notice,
 	PanelBody,
 	RangeControl,
 	ResizableBox,
@@ -38,6 +37,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { crop, upload } from '@wordpress/icons';
 import { SVG, Path } from '@wordpress/primitives';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -311,7 +311,6 @@ export default function LogoEdit( {
 } ) {
 	const { width } = attributes;
 	const [ logoUrl, setLogoUrl ] = useState();
-	const [ error, setError ] = useState();
 	const ref = useRef();
 
 	const {
@@ -375,7 +374,6 @@ export default function LogoEdit( {
 		if ( ! media.id && media.url ) {
 			// This is a temporary blob image
 			setLogo( undefined );
-			setError( null );
 			setLogoUrl( media.url );
 			return;
 		}
@@ -388,8 +386,9 @@ export default function LogoEdit( {
 		setLogoUrl( undefined );
 	};
 
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const onUploadError = ( message ) => {
-		setError( message[ 2 ] ? message[ 2 ] : null );
+		createErrorNotice( message[ 2 ], { type: 'snackbar' } );
 	};
 
 	const controls = canUserEdit && logoUrl && (
@@ -441,13 +440,6 @@ export default function LogoEdit( {
 			>
 				<Placeholder
 					className={ placeholderClassName }
-					notices={
-						error && (
-							<Notice status="error" isDismissible={ false }>
-								{ error }
-							</Notice>
-						)
-					}
 					preview={ logoImage }
 				>
 					{

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -113,7 +113,8 @@
 		.components-button.components-button {
 			color: inherit;
 			padding: 0;
-			margin: 0;
+			//top and bottom margin to push up tooltip
+			margin: 40px 0 40px 0;
 			display: flex;
 			justify-content: center;
 			align-items: center;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -120,6 +120,11 @@
 			position: relative;
 			z-index: 1;
 
+			// Animation.
+			background: transparent;
+			transition: all 0.1s linear;
+			@include reduce-motion("transition");
+
 			// @todo: needs to be icon button.
 			text-indent: 100%;
 			overflow: hidden;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -94,7 +94,7 @@
 			bottom: 0;
 			left: 0;
 			border: $border-width dashed currentColor;
-			opacity: 0.5;
+			opacity: 0.3;
 			pointer-events: none;
 
 			// Inherit border radius from style variations.
@@ -117,10 +117,25 @@
 			width: $grid-unit-60;
 			height: $grid-unit-60;
 			border-radius: 50%;
+			position: relative;
+			z-index: 1;
 
 			// @todo: needs to be icon button.
 			text-indent: 100%;
 			overflow: hidden;
+		}
+
+		// Style the placeholder illustration.
+		.components-placeholder__illustration {
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			z-index: 0;
+			stroke: currentColor;
+			stroke-dasharray: 3;
+			opacity: 0.3;
 		}
 	}
 
@@ -134,5 +149,4 @@
 		color: $white;
 		opacity: 1;
 	}
-
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -51,14 +51,26 @@
 		border-radius: inherit;
 	}
 
+	// Match the default logo size.
+	&.is-default-size .components-placeholder {
+		height: 120px;
+		width: 120px;
+	}
+
 	.components-placeholder {
 		justify-content: center;
 		align-items: center;
-		min-height: auto;
 		box-shadow: none;
-		height: 120px;
 		padding: 0;
 
+		// Provide a minimum size for the placeholder, for when the logo is resized.
+		// @todo: resizing is currently only possible by adding an image, resizing,
+		// and then removing the image again. We might want to enable resizing on the
+		// placeholder itself.
+		min-height: $grid-unit-60;
+		min-width: $grid-unit-60;
+		height: 100%;
+		width: 100%;
 
 		// Hide the upload button, as it's also available in the media library.
 		.components-form-file-upload {
@@ -135,6 +147,8 @@
 			right: 0;
 			bottom: 0;
 			left: 0;
+			width: 100%;
+			height: 100%;
 			stroke: currentColor;
 			stroke-dasharray: 3;
 			opacity: 0.3;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -49,6 +49,12 @@
 // and provides the on-hover upload button.
 // That would also let it work with with less specificity.
 .wp-block-site-logo.wp-block-site-logo {
+	// Inherit border radius from style variations.
+	.components-placeholder,
+	.components-resizable-box__container {
+		border-radius: inherit;
+	}
+
 	.components-placeholder {
 		justify-content: center;
 		align-items: center;
@@ -57,8 +63,6 @@
 		height: 120px;
 		padding: 0;
 
-		// Inherit border radius from style variations.
-		border-radius: inherit;
 
 		// Hide the upload button, as it's also available in the media library.
 		.components-form-file-upload {

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -123,6 +123,7 @@
 			border-radius: 50%;
 			position: relative;
 			z-index: 1;
+			visibility: hidden;
 
 			// Animation.
 			background: transparent;
@@ -132,6 +133,9 @@
 			// @todo: needs to be icon button.
 			text-indent: 100%;
 			overflow: hidden;
+		}
+		.components-button.components-button > svg {
+			color: $white;
 		}
 
 		// Style the placeholder illustration.
@@ -157,5 +161,6 @@
 		border-style: solid;
 		color: $white;
 		opacity: 1;
+		visibility: visible;
 	}
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -24,7 +24,6 @@
 		}
 	}
 
-
 	.custom-logo-link {
 		cursor: inherit;
 
@@ -42,24 +41,24 @@
 		height: auto;
 		max-width: 100%;
 	}
+}
 
-	// Placeholder improvements.
+// Provide special styling for the placeholder.
+// Mostly a proof of concept. We likely need to extract these styles
+// to a separate component that more intrinsically inherits block styles
+// and provides the on-hover upload button.
+// That would also let it work with with less specificity.
+.wp-block-site-logo.wp-block-site-logo {
 	.components-placeholder {
-		justify-content: flex-start;
+		justify-content: center;
+		align-items: center;
 		min-height: auto;
+		box-shadow: none;
 		height: 120px;
-		padding: $grid-unit-15;
+		padding: 0;
 
-		// Massage the label.
-		.components-placeholder__label {
-			margin-top: $grid-unit-15;
-			white-space: nowrap;
-		}
-
-		.components-placeholder__label .block-editor-block-icon,
-		.components-placeholder__label > svg {
-			margin-right: $grid-unit-05;
-		}
+		// Inherit border radius from style variations.
+		border-radius: inherit;
 
 		// Hide the upload button, as it's also available in the media library.
 		.components-form-file-upload {
@@ -79,9 +78,61 @@
 			justify-content: center;
 		}
 
-		// Hide drag and drop text.
+		// Hide items.
+		.components-placeholder__label,
 		.components-drop-zone__content-text {
 			display: none;
 		}
+
+		// Draw the dashed outline.
+		&::before {
+			content: "";
+			display: block;
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			border: $border-width dashed currentColor;
+			opacity: 0.5;
+			pointer-events: none;
+
+			// Inherit border radius from style variations.
+			border-radius: inherit;
+		}
+
+		// Style the upload button.
+		.components-placeholder__fieldset {
+			width: auto;
+		}
+
+		color: currentColor;
+		.components-button.components-button {
+			color: inherit;
+			padding: 0;
+			margin: 0;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			width: $grid-unit-60;
+			height: $grid-unit-60;
+			border-radius: 50%;
+
+			// @todo: needs to be icon button.
+			text-indent: 100%;
+			overflow: hidden;
+		}
 	}
+
+	// Show upload button on focus/hover.
+	&.is-selected .components-button,
+	.components-placeholder:focus .components-button,
+	.components-placeholder:hover .components-button {
+		background: var(--wp-admin-theme-color);
+		border-color: var(--wp-admin-theme-color);
+		border-style: solid;
+		color: $white;
+		opacity: 1;
+	}
+
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -83,7 +83,6 @@
 		}
 
 		// Hide items.
-		.components-placeholder__label,
 		.components-drop-zone__content-text {
 			display: none;
 		}
@@ -122,7 +121,6 @@
 			height: $grid-unit-60;
 			border-radius: 50%;
 			position: relative;
-			z-index: 1;
 			visibility: hidden;
 
 			// Animation.
@@ -145,7 +143,6 @@
 			right: 0;
 			bottom: 0;
 			left: 0;
-			z-index: 0;
 			stroke: currentColor;
 			stroke-dasharray: 3;
 			opacity: 0.3;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -44,10 +44,6 @@
 }
 
 // Provide special styling for the placeholder.
-// Mostly a proof of concept. We likely need to extract these styles
-// to a separate component that more intrinsically inherits block styles
-// and provides the on-hover upload button.
-// That would also let it work with with less specificity.
 .wp-block-site-logo.wp-block-site-logo {
 	// Inherit border radius from style variations.
 	.components-placeholder,
@@ -113,8 +109,6 @@
 		.components-button.components-button {
 			color: inherit;
 			padding: 0;
-			//top and bottom margin to push up tooltip
-			margin: 40px 0 40px 0;
 			display: flex;
 			justify-content: center;
 			align-items: center;
@@ -128,11 +122,8 @@
 			background: transparent;
 			transition: all 0.1s linear;
 			@include reduce-motion("transition");
-
-			// @todo: needs to be icon button.
-			text-indent: 100%;
-			overflow: hidden;
 		}
+
 		.components-button.components-button > svg {
 			color: $white;
 		}
@@ -150,10 +141,8 @@
 		}
 	}
 
-	// Show upload button on focus/hover.
-	&.is-selected .components-button,
-	.components-placeholder:focus .components-button,
-	.components-placeholder:hover .components-button {
+	// Show upload button on block selection.
+	&.is-selected .components-button.components-button {
 		background: var(--wp-admin-theme-color);
 		border-color: var(--wp-admin-theme-color);
 		border-style: solid;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -96,6 +96,9 @@
 		}
 
 		// Draw the dashed outline.
+		// By setting the dashed border to currentColor, we ensure it's visible
+		// against any background color.
+		color: currentColor;
 		&::before {
 			content: "";
 			display: block;
@@ -117,7 +120,6 @@
 			width: auto;
 		}
 
-		color: currentColor;
 		.components-button.components-button {
 			color: inherit;
 			padding: 0;

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -12,8 +12,8 @@
 	}
 
 	// Inherit border radius from style variations.
-	&.is-default-size a,
-	&.is-default-size img {
+	a,
+	img {
 		border-radius: inherit;
 	}
 

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -9,6 +9,9 @@
 	&.is-default-size img {
 		width: 120px;
 		height: auto;
+
+		// Inherit border radius from style variations.
+		border-radius: inherit;
 	}
 
 	.aligncenter {
@@ -16,7 +19,7 @@
 	}
 
 	// Style variations
-	&.is-style-rounded img {
+	&.is-style-rounded {
 		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 		// to rectangular images. A pill-shape is better than otherwise.
 		border-radius: 9999px;

--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -9,8 +9,11 @@
 	&.is-default-size img {
 		width: 120px;
 		height: auto;
+	}
 
-		// Inherit border radius from style variations.
+	// Inherit border radius from style variations.
+	&.is-default-size a,
+	&.is-default-size img {
 		border-radius: inherit;
 	}
 

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -51,6 +51,7 @@
 	margin: 0 auto;
 	line-height: 0;
 	fill: currentColor;
+	pointer-events: none;
 }
 
 


### PR DESCRIPTION
## Description

Fixes #35096. This improves the setup state of the Site Logo in a few ways. Here's what it looks like in trunk, square and basic:

<img width="823" alt="Screenshot 2021-10-06 at 12 26 13" src="https://user-images.githubusercontent.com/1204802/136198178-a8e5d19a-6d09-4e8d-8ea5-afc411e40d61.png">

Here's what the PR does:

1. It lets the setup state inherit the border radius set on the block itself. Currently by the block style variation ("rounded"), but theoretically by a separate border radius control in the future.
2. It makes the resting state of the block look like a dashed outline version of the Site Logo icon itself.

![site logo](https://user-images.githubusercontent.com/1204802/136359230-e4b806fc-cd10-400a-9f3e-e4fd6254b5d8.gif)

At the moment, you can resize from the default 120px dimensions by adding an image, resizing, then removing the image again, as shown in the GIF above. It's a bit of a roundabout way, but the placeholder is now smart enough to account for that:

<img width="823" alt="Screenshot 2021-10-07 at 11 27 02" src="https://user-images.githubusercontent.com/1204802/136359383-a867dc8b-7540-42aa-90d0-a4a35685f7bd.png">
<img width="790" alt="Screenshot 2021-10-07 at 11 27 08" src="https://user-images.githubusercontent.com/1204802/136359388-4224bf8f-75ac-48cf-92be-a91760936cbe.png">

## How has this been tested?

Insert a site logo, whether on its own or inside a navigation block. Test resizing it, test setting the rounded style, try adding a logo in both styles.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
