### PR TITLE
Revert "[Block Library - Query Loop]: Fix display of non sticky posts when `sticky` is set to `only`"

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -34,17 +34,6 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		}
 	}
 
-	/**
-	 * Passing an empty array to post__in will return have_posts() as true (and all posts will be returned).
-	 * Logic should be used before hand to determine if WP_Query should be used in the event that the array
-	 * being passed to post__in is empty.
-	 *
-	 * @see https://core.trac.wordpress.org/ticket/28099
-	 */
-	if ( isset( $query_args['post__in'] ) && count( $query_args['post__in'] ) === 0 ) {
-		return '';
-	}
-
 	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {


### PR DESCRIPTION
Reverts WordPress/gutenberg#35329

Closes: https://github.com/WordPress/gutenberg/issues/35398

It seems this caused a regression so let's revert to have the `inherit` functionality back and revisit the `sticky` problem: https://github.com/WordPress/gutenberg/issues/35322