### PR TITLE
Navigation: preload more API requests

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -70,16 +70,24 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	 */
 	$preload_paths = apply_filters( "{$editor_name}_preload_paths", $settings['preload_paths'] );
 
-	$preload_data = array_reduce(
+	$preloaded_data = array_reduce(
 		$preload_paths,
 		'rest_preload_api_request',
 		array()
 	);
+
+	/**
+	 * Allows to change the preloaded data.
+	 *
+	 * @param string[] $preload_paths Array with the preloaded data.
+	 */
+	$preloaded_data = apply_filters( "{$editor_name}_preloaded_data", $preloaded_data );
+
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data )
+			wp_json_encode( $preloaded_data )
 		),
 		'after'
 	);

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -81,7 +81,9 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	 *
 	 * The dynamic portion of the hook name, `$editor_name`, refers to the type of block editor.
 	 *
-	 * @param Array $preload_data Array containing the preloaded data.
+	 * @param array $preload_data Array containing the preloaded data.
+	 * @param string $editor_name Current editor name.
+	 * @param array Array containing the filtered preloaded data.
 	 */
 	$preload_data = apply_filters( 'block_editor_preload_data', $preload_data, $editor_name );
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -80,7 +80,7 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	 * Filters the array of data that has been preloaded.
 	 *
 	 * The dynamic portion of the hook name, `$editor_name`, refers to the type of block editor.
-	 * 
+	 *
 	 * @param Array $preload_data Array containing the preloaded data.
 	 */
 	$preload_data = apply_filters( "{$editor_name}_preload_data", $preload_data );

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -83,7 +83,7 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	 *
 	 * @param Array $preload_data Array containing the preloaded data.
 	 */
-	$preload_data = apply_filters( "{$editor_name}_preload_data", $preload_data );
+	$preload_data = apply_filters( 'block_editor_preload_data', $preload_data, $editor_name );
 
 	wp_add_inline_script(
 		'wp-api-fetch',

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -77,9 +77,9 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	);
 
 	/**
-	 * Filters the array of data that has been preloaded
+	 * Filters the array of data that has been preloaded.
 	 *
-	 * @param Array $preload_data Array of the preloaded data
+	 * @param Array $preload_data Array containing the preloaded data.
 	 */
 	$preload_data = apply_filters( "{$editor_name}_preload_data", $preload_data );
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -79,6 +79,8 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	/**
 	 * Filters the array of data that has been preloaded.
 	 *
+	 * The dynamic portion of the hook name, `$editor_name`, refers to the type of block editor.
+	 * 
 	 * @param Array $preload_data Array containing the preloaded data.
 	 */
 	$preload_data = apply_filters( "{$editor_name}_preload_data", $preload_data );

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -70,24 +70,16 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	 */
 	$preload_paths = apply_filters( "{$editor_name}_preload_paths", $settings['preload_paths'] );
 
-	$preloaded_data = array_reduce(
+	$preload_data = array_reduce(
 		$preload_paths,
 		'rest_preload_api_request',
 		array()
 	);
-
-	/**
-	 * Allows to modify the preloaded data.
-	 *
-	 * @param string[] $preload_paths Array with the preloaded data.
-	 */
-	$preloaded_data = apply_filters( "{$editor_name}_preloaded_data", $preloaded_data );
-
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preloaded_data )
+			wp_json_encode( $preload_data )
 		),
 		'after'
 	);

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -77,7 +77,7 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	);
 
 	/**
-	 * Allows to change the preloaded data.
+	 * Allows to modify the preloaded data.
 	 *
 	 * @param string[] $preload_paths Array with the preloaded data.
 	 */

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -75,6 +75,14 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 		'rest_preload_api_request',
 		array()
 	);
+
+	/**
+	 * Filters the array of data that has been preloaded
+	 *
+	 * @param Array $preload_data Array of the preloaded data
+	 */
+	$preload_data = apply_filters( "{$editor_name}_preload_data", $preload_data );
+
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -169,7 +169,13 @@ add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation
  */
 function gutenberg_navigation_editor_preload_menus( $preload_data ) {
 	$menus_data_path = gutenberg_navigation_get_menus_endpoint();
-	$menus_data      = empty( $preload_data[ $menus_data_path ] ) ? array() : $preload_data[ $menus_data_path ];
+	$menus_data      = empty( $preload_data[ $menus_data_path ] ) ?
+			array()
+			:
+			array(
+					$menus_data_path => $preload_data[ $menus_data_path ]
+			);
+
 	if ( ! $menus_data ) {
 		return $preload_data;
 	}

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -36,7 +36,6 @@ function gutenberg_navigation_init( $hook ) {
 		'/__experimental/menu-locations',
 		array( '/wp/v2/pages', 'OPTIONS' ),
 		array( '/wp/v2/posts', 'OPTIONS' ),
-		'/__experimental/menus?per_page=100&context=edit&_locale=user',
 	);
 
 	$settings = array_merge(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -157,7 +157,7 @@ function gutenberg_navigation_editor_preload_menus( $preload_data ) {
 			array()
 			:
 			array(
-					$menus_data_path => $preload_data[ $menus_data_path ]
+				$menus_data_path => $preload_data[ $menus_data_path ],
 			);
 
 	if ( ! $menus_data ) {

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -10,10 +10,11 @@
  *
  * @since 7.8.0
  */
-function gutenberg_navigation_page() {  ?>
+function gutenberg_navigation_page() {
+	?>
 	<div
-			id="navigation-editor"
-			class="edit-navigation"
+		id="navigation-editor"
+		class="edit-navigation"
 	>
 	</div>
 	<?php
@@ -110,7 +111,6 @@ function gutenberg_navigation_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 	do_action( 'enqueue_block_editor_assets' );
 }
-
 add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );
 
 /**
@@ -128,4 +128,3 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 }
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
-

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -29,7 +29,7 @@ function gutenberg_navigation_page() {
  * @return string
  */
 function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
-	return '/__experimental/menus?' . http_build_query(
+	return '/__experimental/menus?' . build_query(
 		array(
 			'per_page' => $results_per_page,
 			'context'  => 'edit',
@@ -47,7 +47,7 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
  * @return string
  */
 function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
-	return "/__experimental/menus/{$menu_id}?" . http_build_query(
+	return "/__experimental/menus/{$menu_id}?" . build_query(
 		array(
 			'context' => 'edit',
 		)
@@ -64,7 +64,7 @@ function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
  * @return string
  */
 function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_page = 100 ) {
-	return '/__experimental/menu-items?' . http_build_query(
+	return '/__experimental/menu-items?' . build_query(
 		array(
 			'context'  => 'edit',
 			'menus'    => $menu_id,
@@ -82,7 +82,7 @@ function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_pa
  * @return string
  */
 function gutenberg_navigation_get_types_endpoint() {
-	return '/wp/v2/types?' . http_build_query(
+	return '/wp/v2/types?' . build_query(
 		array(
 			'context' => 'edit',
 		)

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -20,6 +20,16 @@ function gutenberg_navigation_page() {
 	<?php
 }
 
+function gutenberg_navigation_get_menus_endpoint_url($menu_id = null)
+{
+	return '/__experimental/menus?' . http_build_query(array(
+					'per_page' => 100,
+					'context' => 'edit',
+					'_locale' => 'user',
+
+			));
+}
+
 /**
  * Initialize the Gutenberg Navigation page.
  *
@@ -36,6 +46,7 @@ function gutenberg_navigation_init( $hook ) {
 		'/__experimental/menu-locations',
 		array( '/wp/v2/pages', 'OPTIONS' ),
 		array( '/wp/v2/posts', 'OPTIONS' ),
+		gutenberg_navigation_get_menus_endpoint_url(),
 	);
 
 	$settings = array_merge(
@@ -82,3 +93,9 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 }
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
+
+function gutenberg_navigation_editor_preload_menus_data($preloaded_data)
+{
+
+}
+add_filter('navigation_editor_preloaded_data', 'gutenberg_navigation_editor_preload_menus_data');

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -85,7 +85,7 @@ function gutenberg_navigation_init( $hook ) {
 	}
 
 	$menus         = wp_get_nav_menus();
-	$first_menu_id = count( $menus ) ? $menus[0]->term_id : null;
+	$first_menu_id = ! empty( $menus ) ? $menus[0]->term_id : null;
 
 	$preload_paths = array(
 		'/__experimental/menu-locations',

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -160,6 +160,13 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
 
+/**
+ * This function removes menu-related data from the "common" preloading middleware and calls
+ * createMenuPreloadingMiddleware middleware because we need to use custom preloading logic for menus.
+ *
+ * @param $preload_data Array containing the preloaded data.
+ * @return array Filtered preload data.
+ */
 function gutenberg_navigation_editor_preload_menus( $preload_data ) {
 	$menus_data_path = gutenberg_navigation_get_menus_endpoint();
 	$menus_data      = empty( $preload_data[ $menus_data_path ] ) ? array() : $preload_data[ $menus_data_path ];

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -112,7 +112,6 @@ function gutenberg_navigation_init( $hook ) {
 	);
 
 	if ( $first_menu_id ) {
-		$preload_paths[] = gutenberg_navigation_get_menu_endpoint( $first_menu_id );
 		$preload_paths[] = gutenberg_navigation_get_menu_items_endpoint( $first_menu_id );
 	}
 
@@ -160,3 +159,25 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 }
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
+
+function gutenberg_navigation_editor_preload_menus( $preload_data ) {
+	$menus_data_path = gutenberg_navigation_get_menus_endpoint();
+	$menus_data      = empty( $preload_data[ $menus_data_path ] ) ? array() : $preload_data[ $menus_data_path ];
+	if ( ! $menus_data ) {
+		return $preload_data;
+	}
+
+	wp_add_inline_script(
+		'wp-edit-navigation',
+		sprintf(
+			'wp.apiFetch.use( wp.editNavigation.createMenuPreloadingMiddleware( %s ) );',
+			wp_json_encode( $menus_data )
+		),
+		'after'
+	);
+
+	unset( $preload_data[ $menus_data_path ] );
+	return $preload_data;
+}
+
+add_filter( 'navigation_editor_preload_data', 'gutenberg_navigation_editor_preload_menus' );

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -20,6 +20,12 @@ function gutenberg_navigation_page() {
 	<?php
 }
 
+/**
+ * This function returns an url for the /__experimental/menus endpoint
+ *
+ * @param  int $results_per_page
+ * @return string
+ */
 function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
 	return '/__experimental/menus?' . http_build_query(
 		array(
@@ -30,6 +36,12 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
 	);
 }
 
+/**
+ * This function returns an url for the /__experimental/menus/<menu_id> endpoint
+ *
+ * @param  int $menu_id
+ * @return string
+ */
 function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
 	return "/__experimental/menus/{$menu_id}?" . http_build_query(
 		array(
@@ -38,6 +50,13 @@ function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
 	);
 }
 
+/**
+ * This function returns an url for the /__experimental/menu-items endpoint
+ *
+ * @param int $menu_id
+ * @param int $results_per_page
+ * @return string
+ */
 function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_page = 100 ) {
 	return '/__experimental/menu-items?' . http_build_query(
 		array(
@@ -49,6 +68,11 @@ function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_pa
 	);
 }
 
+/**
+ * This function returns an url for the /wp/v2/types endpoint
+ *
+ * @return string
+ */
 function gutenberg_navigation_get_types_endpoint() {
 	return '/wp/v2/types?' . http_build_query(
 		array(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -148,7 +148,7 @@ add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation
  * This function removes menu-related data from the "common" preloading middleware and calls
  * createMenuPreloadingMiddleware middleware because we need to use custom preloading logic for menus.
  *
- * @param $preload_data Array containing the preloaded data.
+ * @param Array $preload_data Array containing the preloaded data.
  * @return array Filtered preload data.
  */
 function gutenberg_navigation_editor_preload_menus( $preload_data ) {

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -25,7 +25,7 @@ function gutenberg_navigation_page() {
  *
  * @since 11.6.0
  *
- * @param  int $results_per_page
+ * @param  int $results_per_page Results per page.
  * @return string
  */
 function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
@@ -43,7 +43,7 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
  *
  * @since 11.6.0
  *
- * @param  int $menu_id
+ * @param  int $menu_id Menu ID.
  * @return string
  */
 function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
@@ -59,8 +59,8 @@ function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
  *
  * @since 11.6.0
  *
- * @param int $menu_id
- * @param int $results_per_page
+ * @param int $menu_id Menu ID.
+ * @param int $results_per_page Results per page.
  * @return string
  */
 function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_page = 100 ) {

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -48,6 +48,14 @@ function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_pa
 	);
 }
 
+function gutenberg_navigation_get_types_endpoint() {
+	return '/wp/v2/types?' . http_build_query(
+		array(
+			'context' => 'edit',
+		)
+	);
+}
+
 /**
  * Initialize the Gutenberg Navigation page.
  *
@@ -67,6 +75,7 @@ function gutenberg_navigation_init( $hook ) {
 		array( '/wp/v2/pages', 'OPTIONS' ),
 		array( '/wp/v2/posts', 'OPTIONS' ),
 		gutenberg_navigation_get_menus_endpoint(),
+		gutenberg_navigation_get_types_endpoint(),
 	);
 
 	if ( $first_menu_id ) {

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -38,10 +38,11 @@ function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
 }
 
 function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_page = 100 ) {
-	return "/__experimental/menu-items?{$menu_id}&" . http_build_query(
+	return '/__experimental/menu-items?' . http_build_query(
 		array(
-			'per_page' => $results_per_page,
 			'context'  => 'edit',
+			'menus'    => $menu_id,
+			'per_page' => $results_per_page,
 			'_locale'  => 'user',
 		)
 	);

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -148,17 +148,20 @@ add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation
  * This function removes menu-related data from the "common" preloading middleware and calls
  * createMenuPreloadingMiddleware middleware because we need to use custom preloading logic for menus.
  *
- * @param Array $preload_data Array containing the preloaded data.
+ * @param Array  $preload_data Array containing the preloaded data.
+ * @param string $context Current editor name.
  * @return array Filtered preload data.
  */
-function gutenberg_navigation_editor_preload_menus( $preload_data ) {
+function gutenberg_navigation_editor_preload_menus( $preload_data, $context ) {
+	if ( 'navigation_editor' !== $context ) {
+		return $preload_data;
+	}
+
 	$menus_data_path = gutenberg_navigation_get_menus_endpoint();
-	$menus_data      = empty( $preload_data[ $menus_data_path ] ) ?
-			array()
-			:
-			array(
-				$menus_data_path => $preload_data[ $menus_data_path ],
-			);
+	$menus_data      = array();
+	if ( ! empty( $preload_data[ $menus_data_path ] ) ) {
+		$menus_data = array( $menus_data_path => $preload_data[ $menus_data_path ] );
+	}
 
 	if ( ! $menus_data ) {
 		return $preload_data;
@@ -177,4 +180,4 @@ function gutenberg_navigation_editor_preload_menus( $preload_data ) {
 	return $preload_data;
 }
 
-add_filter( 'navigation_editor_preload_data', 'gutenberg_navigation_editor_preload_menus' );
+add_filter( 'block_editor_preload_data', 'gutenberg_navigation_editor_preload_menus', 10, 2 );

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -36,6 +36,7 @@ function gutenberg_navigation_init( $hook ) {
 		'/__experimental/menu-locations',
 		array( '/wp/v2/pages', 'OPTIONS' ),
 		array( '/wp/v2/posts', 'OPTIONS' ),
+		'/__experimental/menus?per_page=100&context=edit&_locale=user',
 	);
 
 	$settings = array_merge(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -23,7 +23,7 @@ function gutenberg_navigation_page() {
 /**
  * This function returns an url for the /__experimental/menus endpoint
  *
- * @since 11.6.0
+ * @since 11.8.0
  *
  * @param  int $results_per_page Results per page.
  * @return string
@@ -41,7 +41,7 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
 /**
  * This function returns an url for the /__experimental/menu-items endpoint
  *
- * @since 11.6.0
+ * @since 11.8.0
  *
  * @param int $menu_id Menu ID.
  * @param int $results_per_page Results per page.
@@ -61,7 +61,7 @@ function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_pa
 /**
  * This function returns an url for the /wp/v2/types endpoint
  *
- * @since 11.6.0
+ * @since 11.8.0
  *
  * @return string
  */

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -170,7 +170,7 @@ function gutenberg_navigation_editor_preload_menus( $preload_data, $context ) {
 	wp_add_inline_script(
 		'wp-edit-navigation',
 		sprintf(
-			'wp.apiFetch.use( wp.editNavigation.createMenuPreloadingMiddleware( %s ) );',
+			'wp.apiFetch.use( wp.editNavigation.__unstableCreateMenuPreloadingMiddleware( %s ) );',
 			wp_json_encode( $menus_data )
 		),
 		'after'

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -39,22 +39,6 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
 }
 
 /**
- * This function returns an url for the /__experimental/menus/<menu_id> endpoint
- *
- * @since 11.6.0
- *
- * @param  int $menu_id Menu ID.
- * @return string
- */
-function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
-	return "/__experimental/menus/{$menu_id}?" . build_query(
-		array(
-			'context' => 'edit',
-		)
-	);
-}
-
-/**
  * This function returns an url for the /__experimental/menu-items endpoint
  *
  * @since 11.6.0

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -23,6 +23,8 @@ function gutenberg_navigation_page() {
 /**
  * This function returns an url for the /__experimental/menus endpoint
  *
+ * @since 11.6.0
+ *
  * @param  int $results_per_page
  * @return string
  */
@@ -39,6 +41,8 @@ function gutenberg_navigation_get_menus_endpoint( $results_per_page = 100 ) {
 /**
  * This function returns an url for the /__experimental/menus/<menu_id> endpoint
  *
+ * @since 11.6.0
+ *
  * @param  int $menu_id
  * @return string
  */
@@ -52,6 +56,8 @@ function gutenberg_navigation_get_menu_endpoint( $menu_id ) {
 
 /**
  * This function returns an url for the /__experimental/menu-items endpoint
+ *
+ * @since 11.6.0
  *
  * @param int $menu_id
  * @param int $results_per_page
@@ -70,6 +76,8 @@ function gutenberg_navigation_get_menu_items_endpoint( $menu_id, $results_per_pa
 
 /**
  * This function returns an url for the /wp/v2/types endpoint
+ *
+ * @since 11.6.0
  *
  * @return string
  */

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -72,8 +72,9 @@ function createPreloadingMiddleware( preloadedData ) {
 				cache[ method ] &&
 				cache[ method ][ path ]
 			) {
-				// Unsetting the cache key ensures that the data is only preloaded a single time
 				const cacheData = cache[ method ][ path ];
+
+				// Unsetting the cache key ensures that the data is only preloaded a single time
 				delete cache[ method ][ path ];
 
 				return Promise.resolve( parse ? cacheData.body : cacheData );

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -72,10 +72,14 @@ function createPreloadingMiddleware( preloadedData ) {
 				cache[ method ] &&
 				cache[ method ][ path ]
 			) {
+				// Unsetting the cache key ensures that the data is only preloaded a single time
+				const cacheData = cache[ method ][ path ];
+				delete cache[ method ][ path ];
+
 				return Promise.resolve(
 					parse
-						? cache[ method ][ path ].body
-						: cache[ method ][ path ]
+						? cacheData.body
+						: cacheData
 				);
 			}
 		}

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -76,11 +76,7 @@ function createPreloadingMiddleware( preloadedData ) {
 				const cacheData = cache[ method ][ path ];
 				delete cache[ method ][ path ];
 
-				return Promise.resolve(
-					parse
-						? cacheData.body
-						: cacheData
-				);
+				return Promise.resolve( parse ? cacheData.body : cacheData );
 			}
 		}
 

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -72,12 +72,11 @@ function createPreloadingMiddleware( preloadedData ) {
 				cache[ method ] &&
 				cache[ method ][ path ]
 			) {
-				const cacheData = cache[ method ][ path ];
-
-				// Unsetting the cache key ensures that the data is only preloaded a single time
-				delete cache[ method ][ path ];
-
-				return Promise.resolve( parse ? cacheData.body : cacheData );
+				return Promise.resolve(
+					parse
+						? cache[ method ][ path ].body
+						: cache[ method ][ path ]
+				);
 			}
 		}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -85,7 +85,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 		// for how the request is made to the REST API.
 
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const path = addQueryArgs( entity.baseURL + '/' + key, {
+		const path = addQueryArgs( entity.baseURL + ( key ? '/' + key : '' ), {
 			...entity.baseURLParams,
 			...query,
 		} );

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -90,3 +90,5 @@ export function initialize( id, settings ) {
 		document.getElementById( id )
 	);
 }
+
+export { createMenuPreloadingMiddleware } from './utils';

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -91,4 +91,4 @@ export function initialize( id, settings ) {
 	);
 }
 
-export { createMenuPreloadingMiddleware } from './utils';
+export { createMenuPreloadingMiddleware as __unstableCreateMenuPreloadingMiddleware } from './utils';

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -46,10 +46,6 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		}
 
 		const key = Object.keys( cache )?.[ 0 ];
-		if ( ! key ) {
-			return next( options );
-		}
-
 		const menuData = cache[ key ]?.body;
 		if ( ! menuData ) {
 			return next( options );

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -3,7 +3,7 @@
  * It uses data that is returned from the /__experimental/menus endpoint for requests
  * to the /__experimental/menu/<menuId> endpoint, because the data is the same.
  * This way, we can avoid making additional REST API requests.
- * This middleware can be removed if/when we implement caching at the wordpress/data level.
+ * This middleware can be removed if/when we implement caching at the wordpress/core-data level.
  *
  * @param {Object} preloadedData
  * @return {Function} Preloading middleware.

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -60,9 +60,13 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 			return id === menuId;
 		} );
 
-		if ( menu ) {
+		if ( 0 < menu.length ) {
 			menuDataLoaded = true;
-			return sendSuccessResponse( menu );
+			// We don't have headers because we "emulate" this request
+			return sendSuccessResponse(
+				{ body: menu[ 0 ], headers: {} },
+				parse
+			);
 		}
 
 		return next( options );

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -56,9 +56,7 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		}
 
 		const menuId = parseInt( matches[ 1 ] );
-		const menu = menuData.filter( ( { id } ) => {
-			return id === menuId;
-		} );
+		const menu = menuData.filter( ( { id } ) => id === menuId );
 
 		if ( 0 < menu.length ) {
 			menuDataLoaded = true;

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -1,4 +1,3 @@
-
 /**
  * The purpose of this function is to create a middleware that is responsible for preloading menu-related data.
  * It uses data that is returned from the /__experimental/menus endpoint for requests

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -58,7 +58,7 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		const menuId = parseInt( matches[ 1 ] );
 		const menu = menuData.filter( ( { id } ) => id === menuId );
 
-		if ( 0 < menu.length ) {
+		if ( menu.length > 0 ) {
 			menuDataLoaded = true;
 			// We don't have headers because we "emulate" this request
 			return sendSuccessResponse(

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -9,6 +9,9 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		return result;
 	}, /** @type {Record<string, any>} */ ( {} ) );
 
+	let menusDataLoaded = false;
+	let menuDataLoaded = false;
+
 	return ( options, next ) => {
 		const { parse = true } = options;
 		if ( 'string' !== typeof options.path ) {
@@ -21,8 +24,13 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		}
 
 		const path = getStablePath( options.path );
-		if ( cache[ path ] ) {
+		if ( ! menusDataLoaded && cache[ path ] ) {
+			menusDataLoaded = true;
 			return sendSuccessResponse( cache[ path ], parse );
+		}
+
+		if ( menuDataLoaded ) {
+			return next( options );
 		}
 
 		const matches = path.match(
@@ -48,6 +56,7 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 		} );
 
 		if ( menu ) {
+			menuDataLoaded = true;
 			return sendSuccessResponse( menu );
 		}
 
@@ -55,6 +64,13 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 	};
 }
 
+/**
+ * This is a helper function that sends a success response.
+ *
+ * @param {Object}  responseData An object with the menu data
+ * @param {boolean} parse        A boolean that controls whether to send a response or just the response data
+ * @return {Object} Resolved promise
+ */
 function sendSuccessResponse( responseData, parse ) {
 	return Promise.resolve(
 		parse

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -1,5 +1,11 @@
 
 /**
+ * The purpose of this function is to create a middleware that is responsible for preloading menu-related data.
+ * It uses data that is returned from the /__experimental/menus endpoint for requests
+ * to the /__experimental/menu/<menuId> endpoint, because the data is the same.
+ * This way, we can avoid making additional REST API requests.
+ * This middleware can be removed if/when we implement caching at the wordpress/data level.
+ *
  * @param {Object} preloadedData
  * @return {Function} Preloading middleware.
  */

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -1,0 +1,103 @@
+
+/**
+ * @param {Object} preloadedData
+ * @return {Function} Preloading middleware.
+ */
+export function createMenuPreloadingMiddleware( preloadedData ) {
+	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
+		result[ getStablePath( path ) ] = preloadedData[ path ];
+		return result;
+	}, /** @type {Record<string, any>} */ ( {} ) );
+
+	return ( options, next ) => {
+		const { parse = true } = options;
+		if ( 'string' !== typeof options.path ) {
+			return next( options );
+		}
+
+		const method = options.method || 'GET';
+		if ( 'GET' !== method ) {
+			return next( options );
+		}
+
+		const path = getStablePath( options.path );
+		if ( cache[ path ] ) {
+			return sendSuccessResponse( cache[ path ], parse );
+		}
+
+		const matches = path.match(
+			/^\/__experimental\/menus\/(\d+)\?context=edit$/
+		);
+		if ( ! matches ) {
+			return next( options );
+		}
+
+		const key = Object.keys( cache )?.[ 0 ];
+		if ( ! key ) {
+			return next( options );
+		}
+
+		const menuData = cache[ key ]?.body;
+		if ( ! menuData ) {
+			return next( options );
+		}
+
+		const menuId = parseInt( matches[ 1 ] );
+		const menu = menuData.filter( ( { id } ) => {
+			return id === menuId;
+		} );
+
+		if ( menu ) {
+			return sendSuccessResponse( menu );
+		}
+
+		return next( options );
+	};
+}
+
+function sendSuccessResponse( responseData, parse ) {
+	return Promise.resolve(
+		parse
+			? responseData.body
+			: new window.Response( JSON.stringify( responseData.body ), {
+					status: 200,
+					statusText: 'OK',
+					headers: responseData.headers,
+			  } )
+	);
+}
+
+/**
+ * Given a path, returns a normalized path where equal query parameter values
+ * will be treated as identical, regardless of order they appear in the original
+ * text.
+ *
+ * @param {string} path Original path.
+ *
+ * @return {string} Normalized path.
+ */
+export function getStablePath( path ) {
+	const splitted = path.split( '?' );
+	const query = splitted[ 1 ];
+	const base = splitted[ 0 ];
+	if ( ! query ) {
+		return base;
+	}
+
+	// 'b=1&c=2&a=5'
+	return (
+		base +
+		'?' +
+		query
+			// [ 'b=1', 'c=2', 'a=5' ]
+			.split( '&' )
+			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
+			.map( ( entry ) => entry.split( '=' ) )
+			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
+			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
+			// [ 'a=5', 'b=1', 'c=2' ]
+			.map( ( pair ) => pair.join( '=' ) )
+			// 'a=5&b=1&c=2'
+			.join( '&' )
+	);
+}

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -1,6 +1,14 @@
 <?php
+/**
+ * This class is supposed to test the functionality of the navigation-page.php
+ *
+ * @package Gutenberg
+ */
 
 class WP_Navigation_Page_Test extends WP_UnitTestCase {
+	/**
+	 * @var WP_Navigation_Page_Test_Callback
+	 */
 	private $callback;
 
 	public function setUp() {
@@ -16,7 +24,8 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		remove_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
 	}
 
-	function test_gutenberg_navigation_get_menus_endpoint() {
+	function test_gutenberg_navigation_init_function_generates_correct_preload_paths() {
+		$menu_id                = mt_rand( 1, 1000 );
 		$expected_preload_paths = array(
 			'/__experimental/menu-locations',
 			array(
@@ -29,6 +38,8 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 			),
 			'/__experimental/menus?per_page=100&context=edit&_locale=user',
 			'/wp/v2/types?context=edit',
+			"/__experimental/menus/{$menu_id}?context=edit",
+			"/__experimental/menu-items?context=edit&menus={$menu_id}&per_page=100&_locale=user",
 		);
 
 		$this->callback->expects( $this->once() )
@@ -36,18 +47,21 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 			->with( $expected_preload_paths )
 			->willReturn( array() );
 
-		$menu_id       = mt_rand( 1, 1000 );
-		$menu          = new StdClass;
+		$menu          = new stdClass();
 		$menu->term_id = $menu_id;
 		$this->callback->expects( $this->once() )
 			->method( 'wp_nav_menus_callback' )
-			->willReturn( new WP_Term() );
+			->with( array() )
+			->willReturn( array( new WP_Term( $menu ) ) );
 
 		set_current_screen( 'gutenberg_page_gutenberg-navigation' );
 		gutenberg_navigation_init( 'gutenberg_page_gutenberg-navigation' );
 	}
 }
 
+/**
+ * This is a utility test class for creating mocks of the callback functions
+ */
 class WP_Navigation_Page_Test_Callback {
 
 	public function preload_paths_callback() {}

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -58,10 +58,22 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 	}
 
 	function test_gutenberg_navigation_editor_preload_menus_function_returns_correct_data() {
-		gutenberg_navigation_editor_preload_menus(array());
-		$this->addToAssertionCount(1);
+		$menus_endpoint = gutenberg_navigation_get_menus_endpoint();
+		$preload_data   = array(
+			'/__experimental/menu-locations' => array( 'some menu locations' ),
+			'OPTIONS'                        => array(
+				array( 'some options requests' ),
+			),
+			$menus_endpoint                  => ( 'some menus' ),
+		);
+
+		$result = gutenberg_navigation_editor_preload_menus( $preload_data );
+		$this->assertArrayHasKey( '/__experimental/menu-locations', $result );
+		$this->assertArrayHasKey( 'OPTIONS', $result );
+		$this->assertArrayNotHasKey( $menus_endpoint, $result );
 	}
 }
+
 
 /**
  * This is a utility test class for creating mocks of the callback functions

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -38,7 +38,6 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 			),
 			'/__experimental/menus?per_page=100&context=edit&_locale=user',
 			'/wp/v2/types?context=edit',
-			"/__experimental/menus/{$menu_id}?context=edit",
 			"/__experimental/menu-items?context=edit&menus={$menu_id}&per_page=100&_locale=user",
 		);
 
@@ -56,6 +55,11 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 
 		set_current_screen( 'gutenberg_page_gutenberg-navigation' );
 		gutenberg_navigation_init( 'gutenberg_page_gutenberg-navigation' );
+	}
+
+	function test_gutenberg_navigation_editor_preload_menus_function_returns_correct_data() {
+		gutenberg_navigation_editor_preload_menus(array());
+		$this->addToAssertionCount(1);
 	}
 }
 

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -1,0 +1,55 @@
+<?php
+
+class WP_Navigation_Page_Test extends WP_UnitTestCase {
+	private $callback;
+
+	public function setUp() {
+		parent::setUp();
+		$this->callback = $this->createMock( WP_Navigation_Page_Test_Callback::class );
+		add_filter( 'navigation_editor_preload_paths', array( $this->callback, 'preload_paths_callback' ) );
+		add_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		remove_filter( 'navigation_editor_preload_paths', array( $this->callback, 'preload_paths_callback' ) );
+		remove_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
+	}
+
+	function test_gutenberg_navigation_get_menus_endpoint() {
+		$expected_preload_paths = array(
+			'/__experimental/menu-locations',
+			array(
+				'/wp/v2/pages',
+				'OPTIONS',
+			),
+			array(
+				'/wp/v2/posts',
+				'OPTIONS',
+			),
+			'/__experimental/menus?per_page=100&context=edit&_locale=user',
+			'/wp/v2/types?context=edit',
+		);
+
+		$this->callback->expects( $this->once() )
+			->method( 'preload_paths_callback' )
+			->with( $expected_preload_paths )
+			->willReturn( array() );
+
+		$menu_id       = mt_rand( 1, 1000 );
+		$menu          = new StdClass;
+		$menu->term_id = $menu_id;
+		$this->callback->expects( $this->once() )
+			->method( 'wp_nav_menus_callback' )
+			->willReturn( new WP_Term() );
+
+		set_current_screen( 'gutenberg_page_gutenberg-navigation' );
+		gutenberg_navigation_init( 'gutenberg_page_gutenberg-navigation' );
+	}
+}
+
+class WP_Navigation_Page_Test_Callback {
+
+	public function preload_paths_callback() {}
+	public function wp_nav_menus_callback() {}
+}

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -67,7 +67,7 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 			$menus_endpoint                  => ( 'some menus' ),
 		);
 
-		$result = gutenberg_navigation_editor_preload_menus( $preload_data );
+		$result = gutenberg_navigation_editor_preload_menus( $preload_data, 'navigation_editor' );
 		$this->assertArrayHasKey( '/__experimental/menu-locations', $result );
 		$this->assertArrayHasKey( 'OPTIONS', $result );
 		$this->assertArrayNotHasKey( $menus_endpoint, $result );

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -24,7 +24,7 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		remove_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
 	}
 
-	function test_gutenberg_navigation_init_function_generates_correct_preload_paths() {
+	public function test_gutenberg_navigation_init_function_generates_correct_preload_paths() {
 		$menu_id                = mt_rand( 1, 1000 );
 		$expected_preload_paths = array(
 			'/__experimental/menu-locations',
@@ -57,7 +57,7 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		gutenberg_navigation_init( 'gutenberg_page_gutenberg-navigation' );
 	}
 
-	function test_gutenberg_navigation_editor_preload_menus_function_returns_correct_data() {
+	public function test_gutenberg_navigation_editor_preload_menus_function_returns_correct_data() {
 		$menus_endpoint = gutenberg_navigation_get_menus_endpoint();
 		$preload_data   = array(
 			'/__experimental/menu-locations' => array( 'some menu locations' ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When loading the Navigation screen, there are a lot of loading spinners due to API requests to /menus and /menu-items. We should preload these requests so that the screen appears faster.
The goal of this PR is to preload these requests.
Also, this PR fixes 2 small bugs in the `core-data` and `api-fetch` modules.
Fixes https://github.com/WordPress/gutenberg/issues/24642

## How has this been tested?
1. Open the navigation page (`wp-admin/admin.php?page=gutenberg-navigation`).
2. Make sure there is only 1 fetch/XHR request (see the screenshot below).

## Screenshots <!-- if applicable -->
Before:
![Screenshot 2021-10-06 at 16 44 50](https://user-images.githubusercontent.com/43744263/136235248-16a0f1ae-0324-4e45-98dd-b7b0d155b288.png)
After:
![Screenshot 2021-10-06 at 17 29 11](https://user-images.githubusercontent.com/43744263/136235260-b53acf9c-a0cd-4070-8881-ddeee5c17945.png)

## Types of changes
New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
