### PR TITLE
ToolsPanel: Remove hardcoded classnames

### DIFF
--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -224,6 +224,6 @@ export const WithSlotFillItems = () => {
 export { TypographyPanel } from './typography-panel';
 
 const PanelWrapperView = styled.div`
-	max-width: 260px;
+	max-width: 270px;
 	font-size: 13px;
 `;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -103,7 +103,7 @@ export const ToolsPanelItem = css`
 	}
 
 	/* Remove BaseControl components margins and leave spacing to grid layout */
-	&& > ${ BaseControlWrapper } {
+	&& ${ BaseControlWrapper } {
 		margin-bottom: 0;
 
 		${ BaseControlField } {

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -44,31 +44,20 @@ export const ToolsPanel = css`
  * CSS grid display to be re-established.
  */
 export const ToolsPanelWithInnerWrapper = css`
-	> div {
+	> div:not( :first-of-type ) {
 		${ toolsPanelGrid.container }
 		${ toolsPanelGrid.item.fullWidth }
 	}
 `;
 
 export const ToolsPanelHiddenInnerWrapper = css`
-	> div {
+	> div:not( :first-of-type ) {
 		display: none;
 	}
 `;
 
 export const ToolsPanelHeader = css`
-	align-items: center;
-	display: flex;
-	font-size: inherit;
-	font-weight: 500;
 	${ toolsPanelGrid.item.fullWidth }
-	justify-content: space-between;
-	line-height: normal;
-
-	/* Required to meet specificity requirements to ensure zero margin */
-	&& {
-		margin: 0;
-	}
 
 	/**
 	 * The targeting of dropdown menu component classes here is a temporary
@@ -89,6 +78,17 @@ export const ToolsPanelHeader = css`
 			min-width: ${ space( 6 ) };
 			width: ${ space( 6 ) };
 		}
+	}
+`;
+
+export const ToolsPanelHeading = css`
+	font-size: inherit;
+	font-weight: 500;
+	line-height: normal;
+
+	/* Required to meet specificity requirements to ensure zero margin */
+	&& {
+		margin: 0;
 	}
 `;
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -77,7 +77,7 @@ export const ToolsPanelHeader = css`
 		height: ${ space( 6 ) };
 
 		/* first-child used to overcome specificity of menu toggle styles */
-		> button:first-child {
+		> button:first-of-type {
 			padding: 0;
 			height: ${ space( 6 ) };
 			min-width: ${ space( 6 ) };

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -70,14 +70,20 @@ export const ToolsPanelHeader = css`
 		margin: 0;
 	}
 
-	/* Tweak dropdown menu and toggle button for better alignment */
-	> div {
+	/**
+	 * The targeting of dropdown menu component classes here is a temporary
+	 * measure only.
+	 *
+	 * The following styles should be replaced once the DropdownMenu has been
+	 * refactored and can be targeted via component interpolation.
+	 */
+	.components-dropdown-menu {
 		margin-top: ${ space( -1 ) };
 		margin-bottom: ${ space( -1 ) };
 		height: ${ space( 6 ) };
 
 		/* first-child used to overcome specificity of menu toggle styles */
-		> button:first-of-type {
+		.components-dropdown-menu__toggle {
 			padding: 0;
 			height: ${ space( 6 ) };
 			min-width: ${ space( 6 ) };

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -71,7 +71,6 @@ export const ToolsPanelHeader = css`
 		margin: ${ space( -1 ) } 0;
 		height: ${ space( 6 ) };
 
-		/* first-child used to overcome specificity of menu toggle styles */
 		.components-dropdown-menu__toggle {
 			padding: 0;
 			height: ${ space( 6 ) };

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -6,6 +6,10 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
+import {
+	StyledField as BaseControlField,
+	Wrapper as BaseControlWrapper,
+} from '../base-control/styles/base-control-styles';
 import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
@@ -96,10 +100,11 @@ export const ToolsPanelItem = css`
 		max-width: 100%;
 	}
 
-	& > .components-base-control:last-child {
+	/* Remove BaseControl components margins and leave spacing to grid layout */
+	&& > ${ BaseControlWrapper } {
 		margin-bottom: 0;
 
-		.components-base-control__field {
+		${ BaseControlField } {
 			margin-bottom: 0;
 		}
 	}

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -61,7 +61,8 @@ export const ToolsPanelHeader = css`
 	justify-content: space-between;
 	line-height: normal;
 
-	.components-tools-panel & {
+	/* Required to meet specificity requirements to ensure zero margin */
+	&& {
 		margin: 0;
 	}
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -58,6 +58,7 @@ export const ToolsPanelHiddenInnerWrapper = css`
 
 export const ToolsPanelHeader = css`
 	${ toolsPanelGrid.item.fullWidth }
+	gap: ${ space( 2 ) };
 
 	/**
 	 * The targeting of dropdown menu component classes here is a temporary
@@ -67,8 +68,7 @@ export const ToolsPanelHeader = css`
 	 * refactored and can be targeted via component interpolation.
 	 */
 	.components-dropdown-menu {
-		margin-top: ${ space( -1 ) };
-		margin-bottom: ${ space( -1 ) };
+		margin: ${ space( -1 ) } 0;
 		height: ${ space( 6 ) };
 
 		/* first-child used to overcome specificity of menu toggle styles */

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -70,17 +70,19 @@ export const ToolsPanelHeader = css`
 		margin: 0;
 	}
 
-	.components-dropdown-menu {
+	/* Tweak dropdown menu and toggle button for better alignment */
+	> div {
 		margin-top: ${ space( -1 ) };
 		margin-bottom: ${ space( -1 ) };
 		height: ${ space( 6 ) };
-	}
 
-	.components-dropdown-menu__toggle {
-		padding: 0;
-		height: ${ space( 6 ) };
-		min-width: ${ space( 6 ) };
-		width: ${ space( 6 ) };
+		/* first-child used to overcome specificity of menu toggle styles */
+		> button:first-child {
+			padding: 0;
+			height: ${ space( 6 ) };
+			min-width: ${ space( 6 ) };
+			width: ${ space( 6 ) };
+		}
 	}
 `;
 

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -16,6 +16,8 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import DropdownMenu from '../../dropdown-menu';
 import MenuGroup from '../../menu-group';
 import MenuItem from '../../menu-item';
+import { HStack } from '../../h-stack';
+import { Heading } from '../../heading';
 import { useToolsPanelHeader } from './hook';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import type {
@@ -116,9 +118,10 @@ const ToolsPanelHeader = (
 	forwardedRef: Ref< any >
 ) => {
 	const {
+		areAllOptionalControlsHidden,
 		dropdownMenuClassName,
 		hasMenuItems,
-		areAllOptionalControlsHidden,
+		headingClassName,
 		label: labelText,
 		menuItems,
 		resetAll,
@@ -141,8 +144,10 @@ const ToolsPanelHeader = (
 		: _x( 'View options', 'Button label to reveal tool panel options' );
 
 	return (
-		<h2 { ...headerProps } ref={ forwardedRef }>
-			{ labelText }
+		<HStack { ...headerProps } ref={ forwardedRef }>
+			<Heading level={ 2 } className={ headingClassName }>
+				{ labelText }
+			</Heading>
 			{ hasMenuItems && (
 				<DropdownMenu
 					icon={ dropDownMenuIcon }
@@ -176,7 +181,7 @@ const ToolsPanelHeader = (
 					) }
 				</DropdownMenu>
 			) }
-		</h2>
+		</HStack>
 	);
 };
 

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -29,6 +29,10 @@ export function useToolsPanelHeader(
 		return cx( styles.DropdownMenu );
 	}, [] );
 
+	const headingClassName = useMemo( () => {
+		return cx( styles.ToolsPanelHeading );
+	}, [] );
+
 	const {
 		menuItems,
 		hasMenuItems,
@@ -37,9 +41,10 @@ export function useToolsPanelHeader(
 
 	return {
 		...otherProps,
+		areAllOptionalControlsHidden,
 		dropdownMenuClassName,
 		hasMenuItems,
-		areAllOptionalControlsHidden,
+		headingClassName,
 		menuItems,
 		className: classes,
 	};


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35058

## Description

This PR removes the use of hardcoded CSS classnames from the `ToolsPanel` styles. The one exception is the `single-column` class as this will be removed an a separate PR adopting the Grid component to handle layout for the `ToolsPanel.

## How has this been tested?

Manually.

#### Testing Instructions

1. Checkout this PR and start up Storybook `npm run storybook:dev`
2. Navigate to the `ToolsPanel` story and confirm it still displays and functions correctly
3. On a local site, open the block editor, add a cover block, and select it
4. Confirm the dimensions panel displays and functions correctly

## Screenshots <!-- if applicable -->

<img width="280" alt="Screen Shot 2021-10-07 at 4 09 32 pm" src="https://user-images.githubusercontent.com/60436221/136329130-3c802bf2-793e-44c9-9e44-a23687dde81e.png">

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
