### PR TITLE
Rich text: fix internal paste across multiline and single line instances

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -28,7 +28,7 @@ import { splitValue } from './split-value';
  * Replaces line breaks with line separators if multiline.
  *
  * @param {RichTextValue} value       Value to adjust.
- * @param {boolean}       isMultiline Wether to adjust to multiline or not.
+ * @param {boolean}       isMultiline Whether to adjust to multiline or not.
  *
  * @return {RichTextValue} Adjusted value.
  */

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -104,21 +104,14 @@ export function usePasteHandler( props ) {
 			}
 
 			const files = [ ...getFilesFromDataTransfer( clipboardData ) ];
-			const isInternal = clipboardData.getData( 'rich-text' ) === 'true';
+			const richTextValue = clipboardData._richTextTransferData;
 
 			// If the data comes from a rich text instance, we can directly use it
 			// without filtering the data. The filters are only meant for externally
 			// pasted content and remove inline styles.
-			if ( isInternal ) {
-				const pastedValue = create( {
-					html,
-					multilineTag,
-					multilineWrapperTags:
-						multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
-					preserveWhiteSpace,
-				} );
-				addActiveFormats( pastedValue, value.activeFormats );
-				onChange( insert( value, pastedValue ) );
+			if ( richTextValue ) {
+				addActiveFormats( richTextValue, value.activeFormats );
+				onChange( insert( value, richTextValue ) );
 				return;
 			}
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -100,6 +100,26 @@ exports[`RichText should only mutate text data on input 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should paste list contents into paragraph 1`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>2</li></ul></li></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>1<br>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should paste paragraph contents into list 1`] = `
+"<!-- wp:paragraph -->
+<p>1<br>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>1</li><li>2</li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`RichText should preserve internal formatting 1`] = `
 "<!-- wp:paragraph -->
 <p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -410,13 +410,63 @@ describe( 'RichText', () => {
 		// Copy the colored text.
 		await pressKeyWithModifier( 'primary', 'c' );
 
-		// Collapsed the selection to the end.
+		// Collapse the selection to the end.
 		await page.keyboard.press( 'ArrowRight' );
 
 		// Create a new paragraph.
 		await page.keyboard.press( 'Enter' );
 
 		// Paste the colored text.
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should paste paragraph contents into list', async () => {
+		await clickBlockAppender();
+
+		// Create two lines of text in a paragraph.
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '2' );
+
+		// Select all and copy.
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+
+		// Collapse the selection to the end.
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Create a list.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '* ' );
+
+		// Paste paragraph contents.
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should paste list contents into paragraph', async () => {
+		await clickBlockAppender();
+
+		// Create an indented list of two lines.
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' 2' );
+
+		// Select all and copy.
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+
+		// Collapse the selection to the end.
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Create a paragraph.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		// Paste paragraph contents.
 		await pressKeyWithModifier( 'primary', 'v' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -38,7 +38,7 @@ export function useCopyHandler( props ) {
 			} );
 			event.clipboardData.setData( 'text/plain', plainText );
 			event.clipboardData.setData( 'text/html', html );
-			event.clipboardData.setData( 'rich-text', 'true' );
+			event.clipboardData.setData( 'rich-text', selectedRecord );
 			event.preventDefault();
 		}
 

--- a/packages/rich-text/src/component/use-copy-handler.js
+++ b/packages/rich-text/src/component/use-copy-handler.js
@@ -38,7 +38,11 @@ export function useCopyHandler( props ) {
 			} );
 			event.clipboardData.setData( 'text/plain', plainText );
 			event.clipboardData.setData( 'text/html', html );
-			event.clipboardData.setData( 'rich-text', selectedRecord );
+			event.clipboardData.setData( 'rich-text', 'true' );
+			event.clipboardData.setData(
+				'rich-text-multi-line-tag',
+				multilineTag || ''
+			);
 			event.preventDefault();
 		}
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -511,7 +511,7 @@ function createFromElement( {
  *                                            multiline.
  * @param {Array}   [$1.multilineWrapperTags] Tags where lines can be found if
  *                                            nesting is possible.
- * @param {boolean} [$1.currentWrapperTags]   Whether to prepend a line
+ * @param {Array}   [$1.currentWrapperTags]   Whether to prepend a line
  *                                            separator.
  * @param {boolean} [$1.preserveWhiteSpace]   Whether or not to collapse white
  *                                            space characters.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes #33078.

Problem: the multilineTag context is lost when pasting across rich text instances. This causes the HTML to be parsed wrongly.
Solution: pass the multilineTag through the transferData, so we can recreate the rich text value from the HTML correctly.

I also added a function to replace line separators with line breaks when pasting a multiline value into a single line instance and to replace line breaks with line separators when pasting a single line value into a multiline instance. The latter is already used for external paste.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
