### PR TITLE
Featured Image: Center placeholder chip contents

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -10,7 +10,7 @@ div[data-type="core/post-featured-image"] {
 	.post-featured-image_placeholder {
 		display: flex;
 		flex-direction: row;
-		align-items: flex-start;
+		align-items: center;
 		border-radius: $radius-block-ui;
 		background-color: $white;
 		box-shadow: inset 0 0 0 $border-width $gray-900;


### PR DESCRIPTION
## Description
Correctly aligns Featured Image placeholder chip contents.

The bug might be hard to spot if the paragraph element has `line-height` applied. However, the issue became more visible after #35273.

Closes #35297.

## How has this been tested?
1. Enable TT1 Blocks or Blockbase theme.
2. Create a page.
3. Insert Query block pattern with Feature Image.
4. Make sure placeholder contents are center-aligned.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
| ![CleanShot 2021-10-07 at 10 29 35](https://user-images.githubusercontent.com/240569/136332773-e007ecf6-e8e3-47cf-9540-b9133de62b57.png) | ![CleanShot 2021-10-07 at 10 34 43](https://user-images.githubusercontent.com/240569/136332778-7dffd6cb-8c69-4871-be3c-f03e8fbb0e28.png) |

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
