### PR TITLE
[RNMobile] Image Block: Enable Parent Blocks to Pass Own Styles to Image's 'ShapeStyle'

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -689,7 +689,9 @@ export class ImageEdit extends Component {
 											}
 											retryMessage={ retryMessage }
 											url={ url }
-											shapeStyle={ styles[ className ] }
+											shapeStyle={
+												styles[ className ] || className
+											}
 											width={ this.getWidth() }
 											{ ...( hasImageContext
 												? additionalImageProps


### PR DESCRIPTION
`Gutenberg-Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4095

## Description

The image block's `shapeStyle` prop currently only works with a `className` that exists in the image block's CSS files. 

With the use of [inner blocks](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/inner-blocks) increasing, there may be times where other blocks want to pass a value to the image block's `shapeStyle` prop without actually editing the block's CSS.

To account for that use case, this PR enables parent blocks the choice of passing their own style objects directly to the image block. 

## How has this been tested?

To ensure there are no regressions in the image block as a result of this change, the following should be tested on both iOS and Android:

* Access the image block's settings and toggle the shape between `default` and `rounded`. 
* Give other settings in the block a whirl to see if there are any unforeseen/unintended side effects.

## Types of changes

A small change has been made to the code as part of this PR:

In order to allow parent blocks to pass their own styles to the image block's `shapeStyle` prop, the prop was updated to accept not only a `className` that exists in its own CSS file, but also a `className` that's referenced in a parent block's CSS file. The `className` will be a style object when passed down from the parent block to the image block. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
