### PR TITLE
ToggleGroupControl: Allow custom aria-label

### DIFF
--- a/packages/components/src/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/README.md
@@ -76,3 +76,19 @@ The value of the `ToggleGroupControl`.
 -   Required: No
 
 If this property is added, a help text will be generated using help property as the content.
+
+## ToggleGroupControlOption
+
+### Props
+
+#### `label`
+
+-   Type: `string`
+
+Label for the option. If needed, the `aria-label` prop can be used in addition to specify a different label for assistive technologies.
+
+#### `value`
+
+-   Type: `string | number`
+
+The value of the `ToggleGroupControlOption`.

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -26,7 +26,7 @@ const KNOBS_GROUPS = {
 };
 
 const _default = ( { options } ) => {
-	const [ alignState, setAlignState ] = useState( options[ 0 ].value );
+	const [ value, setValue ] = useState( options[ 0 ].value );
 	const label = text(
 		`${ KNOBS_GROUPS.ToggleGroupControl }: label`,
 		'Toggle Group Control',
@@ -54,7 +54,7 @@ const _default = ( { options } ) => {
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 
-	const alignOptions = options.map( ( opt, index ) => (
+	const controlOptions = options.map( ( opt, index ) => (
 		<ToggleGroupControlOption
 			key={ opt.value }
 			value={ opt.value }
@@ -74,15 +74,15 @@ const _default = ( { options } ) => {
 	return (
 		<View>
 			<ToggleGroupControl
-				onChange={ setAlignState }
-				value={ alignState }
+				onChange={ setValue }
+				value={ value }
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
 				help={ help }
 				isBlock={ isBlock }
 				isAdaptiveWidth={ isAdaptiveWidth }
 			>
-				{ alignOptions }
+				{ controlOptions }
 			</ToggleGroupControl>
 		</View>
 	);
@@ -109,7 +109,7 @@ WithAriaLabel.args = {
 
 export const WithReset = () => {
 	const [ alignState, setAlignState ] = useState();
-	const aligns = Default.args.options.map( ( item ) => item.label );
+	const aligns = [ 'Left', 'Center', 'Right' ];
 	const alignOptions = aligns.map( ( key, index ) => (
 		<ToggleGroupControlOption
 			key={ key }

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -20,19 +20,19 @@ export default {
 	title: 'Components/ToggleGroupControl',
 };
 
-const aligns = [ 'Left', 'Center', 'Right', 'Justify' ];
 const KNOBS_GROUPS = {
 	ToggleGroupControl: 'ToggleGroupControl',
 	ToggleGroupControlOption: 'ToggleGroupControlOption',
 };
 
-export const _default = () => {
-	const [ alignState, setAlignState ] = useState( aligns[ 0 ] );
+const _default = ( { options } ) => {
+	const [ alignState, setAlignState ] = useState( options[ 0 ].value );
 	const label = text(
 		`${ KNOBS_GROUPS.ToggleGroupControl }: label`,
 		'Toggle Group Control',
 		KNOBS_GROUPS.ToggleGroupControl
 	);
+
 	const hideLabelFromVision = boolean(
 		`${ KNOBS_GROUPS.ToggleGroupControl }: hideLabelFromVision`,
 		false,
@@ -54,13 +54,18 @@ export const _default = () => {
 		KNOBS_GROUPS.ToggleGroupControl
 	);
 
-	const alignOptions = aligns.map( ( key, index ) => (
+	const alignOptions = options.map( ( opt, index ) => (
 		<ToggleGroupControlOption
-			key={ key }
-			value={ key }
+			key={ opt.value }
+			value={ opt.value }
 			label={ text(
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }: label`,
-				key,
+				opt.label,
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
+			) }
+			aria-label={ text(
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }: aria-label`,
+				opt[ 'aria-label' ],
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
 			) }
 		/>
@@ -83,8 +88,28 @@ export const _default = () => {
 	);
 };
 
+export const Default = _default.bind( {} );
+Default.args = {
+	options: [
+		{ value: 'left', label: 'Left' },
+		{ value: 'center', label: 'Center' },
+		{ value: 'right', label: 'Right' },
+		{ value: 'justify', label: 'Justify' },
+	],
+};
+
+export const WithAriaLabel = _default.bind( {} );
+WithAriaLabel.args = {
+	...Default.args,
+	options: [
+		{ value: 'asc', label: 'A→Z', 'aria-label': 'Ascending' },
+		{ value: 'desc', label: 'Z→A', 'aria-label': 'Descending' },
+	],
+};
+
 export const WithReset = () => {
 	const [ alignState, setAlignState ] = useState();
+	const aligns = Default.args.options.map( ( item ) => item.label );
 	const alignOptions = aligns.map( ( key, index ) => (
 		<ToggleGroupControlOption
 			key={ key }

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -209,7 +209,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
       >
         <button
           aria-checked="false"
-          aria-label="R"
           class="emotion-10 components-toggle-group-control-option"
           data-value="rigas"
           data-wp-c16t="true"
@@ -241,7 +240,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
       >
         <button
           aria-checked="false"
-          aria-label="J"
           class="emotion-10 components-toggle-group-control-option"
           data-value="jack"
           data-wp-c16t="true"

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -209,6 +209,7 @@ exports[`ToggleGroupControl should render correctly 1`] = `
       >
         <button
           aria-checked="false"
+          aria-label="R"
           class="emotion-10 components-toggle-group-control-option"
           data-value="rigas"
           data-wp-c16t="true"
@@ -240,6 +241,7 @@ exports[`ToggleGroupControl should render correctly 1`] = `
       >
         <button
           aria-checked="false"
+          aria-label="J"
           class="emotion-10 components-toggle-group-control-option"
           data-value="jack"
           data-wp-c16t="true"

--- a/packages/components/src/toggle-group-control/test/index.js
+++ b/packages/components/src/toggle-group-control/test/index.js
@@ -25,7 +25,7 @@ describe( 'ToggleGroupControl', () => {
 	} );
 	it( 'should call onChange with proper value', () => {
 		const mockOnChange = jest.fn();
-		const { getByLabelText } = render(
+		const { getAllByText } = render(
 			<ToggleGroupControl
 				value="jack"
 				onChange={ mockOnChange }
@@ -34,7 +34,7 @@ describe( 'ToggleGroupControl', () => {
 				{ options }
 			</ToggleGroupControl>
 		);
-		const firstButton = getByLabelText( 'R' );
+		const firstButton = getAllByText( 'R' )[ 0 ];
 		fireEvent.click( firstButton );
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );

--- a/packages/components/src/toggle-group-control/test/index.js
+++ b/packages/components/src/toggle-group-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ describe( 'ToggleGroupControl', () => {
 	} );
 	it( 'should call onChange with proper value', () => {
 		const mockOnChange = jest.fn();
-		const { getAllByText } = render(
+		render(
 			<ToggleGroupControl
 				value="jack"
 				onChange={ mockOnChange }
@@ -34,8 +34,8 @@ describe( 'ToggleGroupControl', () => {
 				{ options }
 			</ToggleGroupControl>
 		);
-		const firstButton = getAllByText( 'R' )[ 0 ];
-		fireEvent.click( firstButton );
+		const firstRadio = screen.getByRole( 'radio', { name: 'R' } );
+		fireEvent.click( firstRadio );
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );
 } );

--- a/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
@@ -45,6 +45,7 @@ function ToggleGroupControlButton( {
 			<Radio
 				{ ...props }
 				as="button"
+				aria-label={ props[ 'aria-label' ] ?? label }
 				className={ classes }
 				data-value={ value }
 				ref={ forwardedRef }

--- a/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
@@ -45,7 +45,6 @@ function ToggleGroupControlButton( {
 			<Radio
 				{ ...props }
 				as="button"
-				aria-label={ label }
 				className={ classes }
 				data-value={ value }
 				ref={ forwardedRef }

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -13,6 +13,10 @@ import type { FormElementProps } from '../utils/types';
 
 export type ToggleGroupControlOptionProps = {
 	value: ReactText;
+	/**
+	 * Label for the option. If needed, the `aria-label` prop can be used in addition
+	 * to specify a different label for assistive technologies.
+	 */
 	label: string;
 };
 
@@ -74,12 +78,13 @@ export type ToggleGroupControlButtonProps = {
 	className?: string;
 	forwardedRef?: Ref< any >;
 	/**
-	 * Renders `ToggleGroupControl` is a (CSS) block element.
+	 * Renders `ToggleGroupControl` as a (CSS) block element.
 	 *
 	 * @default false
 	 */
 	isBlock?: boolean;
 	label: string;
+	'aria-label'?: string;
 	showSeparator?: boolean;
 	value?: ReactText;
 	state?: any;


### PR DESCRIPTION
Fixes #35381

## Description

Allows a consumer to set a custom `aria-label` on a `ToggleGroupControlOption`.

The previous implementation explicitly set the `aria-label` to the value of the visible `label`, which I believe is redundant due to the label string always being present as a child node in the accessibility tree.

## How has this been tested?

I added a story in the Storybook with an example use case.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
