### PR TITLE
Enqueue preset styles for all themes in the editor

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -129,13 +129,17 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( 'mobile' === $context ) {
 		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
-	} elseif ( 'site-editor' === $context ) {
+	}
+
+	if ( 'site-editor' === $context ) {
 		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $theme->get_raw_data();
-	} else {
+	}
+
+	if ( 'all' === $context ) {
 		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'block_styles' ) );
 		$css_variables = array(
 			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'css_variables' ),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -129,21 +129,13 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( 'mobile' === $context ) {
 		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
-	}
-
-	if ( 'site-editor' === $context ) {
+	} elseif ( 'site-editor' === $context ) {
 		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 
 		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseStyles']   = $theme->get_raw_data();
-	}
-
-	if (
-		'site-editor' !== $context &&
-		'mobile' !== $context &&
-		( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() || get_theme_support( 'experimental-link-color' ) )
-	) {
+	} else {
 		$block_styles  = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'block_styles' ) );
 		$css_variables = array(
 			'css'                     => gutenberg_experimental_global_styles_get_stylesheet( $consolidated, 'css_variables' ),


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/34334

This fixes a bug by which preset classes were not added to the editor for all themes.

In https://github.com/WordPress/gutenberg/pull/34334 I missed enqueueing the preset classes in the editor for all themes. When they were removed from the `base-style` package at https://github.com/WordPress/gutenberg/pull/34510 they started to be missing in the editor.

## Why this wasn't noticeable before

In the editor, when the user selects a color from the preset palette, classes are added to it. The block also gets inline styles for legacy reasons. That we inline styles hid the fact that we were not enqueueing preset classes in the editor.

## Setup affected by this bug

This only affected blocks that don't use our support hooks (so they don't get inline styles) when the active theme is a classic one (no theme.json or legacy link color support) that also delegated the enqueueing of preset classes to core (either because they don't define any preset or because they do but don't enqueue it themselves). A example of this is the Storefront theme.

This was introduced in Gutenberg 11.5.

## How to test

- Use the Storefront theme.
- Add a paragraph block and set some colors.
- Open the devtools and remove the inline styles added to the paragraph in the editor.

The expected result is that the paragrah still has the colors applied (because the classes are now in scope).

Another check you can do is to verify the core classes are present, such as: `.has-vivid-red-color`, `.has-luminous-vivid-orange-background-color`, etc. See [full list of colors](https://github.com/WordPress/gutenberg/blob/trunk/lib/theme.json#L6). The classes generated are in the form of `.has-$slug-color`, `.has-$slug-background-color`.