### PR TITLE
Move the link color styles to the footer

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -59,8 +59,18 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		$first_element_offset = $html_element_matches[0][1];
 		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
-	return $style . $content;
 
+	// Ideally styles should be loaded in the head, but blocks may be parsed
+	// after that, so loading in the footer for now.
+	// See https://core.trac.wordpress.org/ticket/53494.
+	add_action(
+		'wp_footer',
+		function () use ( $style ) {
+			echo '<style>' . $style . '</style>';
+		}
+	);
+
+	return $content;
 }
 
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -18,6 +18,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useContext, createPortal } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import {
 	getBlockSupport,
@@ -30,6 +31,7 @@ import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import BlockList from '../components/block-list';
 import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import {
@@ -292,16 +294,20 @@ const withElementsStyles = createHigherOrderComponent(
 			blockElementsContainerIdentifier,
 			props.attributes.style?.elements
 		);
+		const element = useContext( BlockList.__unstableElementContext );
 
 		return (
 			<>
-				{ elements && (
-					<style
-						dangerouslySetInnerHTML={ {
-							__html: styles,
-						} }
-					/>
-				) }
+				{ elements &&
+					element &&
+					createPortal(
+						<style
+							dangerouslySetInnerHTML={ {
+								__html: styles,
+							} }
+						/>,
+						element
+					) }
 
 				<BlockListBlock
 					{ ...props }

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -41,7 +41,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<style>.wp-elements-1 a{color: var(--wp--preset--color--subtle-background);}</style>' . "\n" . '<p class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
+			'<p class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 
@@ -71,7 +71,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<style>.wp-elements-1 a{color: red;}</style>' . "\n" . '<p class="wp-elements-1 has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
+			'<p class="wp-elements-1 has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 
@@ -100,7 +100,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<style>.wp-elements-1 a{color: #fff000;}</style>' . "\n" . '<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
+			'<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 }


### PR DESCRIPTION
closes #35353 

The custom link colors are generating inline `<style>` tags which impacts the block gap styles causing unnecessary margins. This PR moves these styles to the footer in frontend and use a portal in the editor (similar to what we do for layout and duotone styles).

**Testing instructions**

 - Try using 2022 theme
 - Notice the header doesn't have an extra margin at the top.