### PR TITLE
Try: Prepend text to the post date

### DIFF
--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -15,6 +15,9 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"label": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -14,6 +14,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
+	RichText,
 } from '@wordpress/block-editor';
 import {
 	Dropdown,
@@ -29,7 +30,7 @@ import { edit } from '@wordpress/icons';
 import { DOWN } from '@wordpress/keycodes';
 
 export default function PostDateEdit( {
-	attributes: { textAlign, format, isLink },
+	attributes: { textAlign, format, isLink, label },
 	context: { postId, postType, queryId },
 	setAttributes,
 } ) {
@@ -84,6 +85,7 @@ export default function PostDateEdit( {
 			</a>
 		);
 	}
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -155,7 +157,19 @@ export default function PostDateEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...blockProps }>{ postDate }</div>
+			<div { ...blockProps }>
+				<RichText
+					className="wp-block-post-date__label"
+					tagName="span"
+					aria-label={ __( 'Label before the date' ) }
+					placeholder={ __( 'Add a label before the date:' ) }
+					value={ label }
+					onChange={ ( newLabel ) =>
+						setAttributes( { label: newLabel } )
+					}
+				/>
+				{ postDate }
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -25,10 +25,12 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $formatted_date );
 	}
+	$label = empty( $attributes['label'] ) ? '' : $attributes['label'];
 
 	return sprintf(
-		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
+		'<div %1$s>%2$s<time datetime="%3$s">%4$s</time></div>',
 		$wrapper_attributes,
+		$label,
 		get_the_date( 'c', $post_ID ),
 		$formatted_date
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
In the Post Date: Block Enhancement Ideas issue https://github.com/WordPress/gutenberg/issues/24957 it was suggested that the block should have a label such as "Posted on".
This PR adds an editable label before the date. The label only shows on the front if the placeholder text is added.

-Yes, there still needs to be a space between the placeholder and the date. I think the best option would be to add it to the text in the placeholder attribute.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a post date block.
2. Edit the placeholder text, save.
3. View the front and confirm that the text is showing.
4. Re test with the link setting and typography settings.

## Screenshots <!-- if applicable -->
In empty theme: 
![the placeholder text is in light grey, positioned before the date. The text says "Add a label before the date:"](https://user-images.githubusercontent.com/7422055/136377095-655de7c1-1102-4aa8-ac90-c546ca8d6219.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
