### PR TITLE
Query Pagination: add an empty wrapper when at first/last page

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -26,7 +26,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
-	$content = '';
+	$content = '<span></span>';
 
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
@@ -40,7 +40,10 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $wp_query->max_num_pages ) {
 			$max_page = $wp_query->max_num_pages;
 		}
-		$content = get_next_posts_link( $label, $max_page );
+		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+		if((int) $wp_query->max_num_pages !== $paged){
+			$content = get_next_posts_link( $label, $max_page );
+		}
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
 		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -26,7 +26,15 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
-	$content = '<span></span>';
+	$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+	if( (int) $wp_query->max_num_pages === $paged ){
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'last-page' ) );
+	}
+	$content = sprintf(
+		'<span %1$s>%2$s</span>',
+		$wrapper_attributes,
+		$label
+	);
 
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
@@ -40,7 +48,6 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $wp_query->max_num_pages ) {
 			$max_page = $wp_query->max_num_pages;
 		}
-		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		if((int) $wp_query->max_num_pages !== $paged){
 			$content = get_next_posts_link( $label, $max_page );
 		}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -25,15 +25,18 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
-	$content = '';
+	$content = '<span></span>';
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-		$content = get_previous_posts_link( $label );
+		if( 1 !== $paged ){
+			$content = get_previous_posts_link( $label );
+		}
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} elseif ( 1 !== $page ) {
 		$content = sprintf(

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -25,11 +25,18 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
-	$content = '<span></span>';
+	$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+	if( 1 === $paged ){
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'first-page' ) );
+	}
+	$content = sprintf(
+		'<span %1$s>%2$s</span>',
+		$wrapper_attributes,
+		$label
+	);
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #34997

To keep the alignments consistent between pages and between the editor and the frontend, I've added an empty wrapper (right now it's a simple span to test the fix, I can add the rest of the wrapper attributes and/or change it to an anchor depending on discussion). 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've used the following markup on emptytheme, tested with `inherit` set to true and false:

```
<!-- wp:query {"queryId":13,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->
```

Adapt your site or your query block so the pagination shows up and navigate to the first and last pages of the loop. The numbers should stay in the center.

## Screenshots <!-- if applicable -->

Editor:

<img width="898" alt="Screenshot 2021-10-07 at 14 00 34" src="https://user-images.githubusercontent.com/3593343/136380088-0da2150e-231c-4b88-b201-73d6e9cce7ac.png">


First page:

Before | After
--- | ---
<img width="957" alt="Screenshot 2021-10-07 at 13 58 45" src="https://user-images.githubusercontent.com/3593343/136379886-a00f91f5-7018-486d-962b-dff56f4efc29.png"> | <img width="939" alt="Screenshot 2021-10-07 at 13 58 56" src="https://user-images.githubusercontent.com/3593343/136379885-e8130def-d9e9-401f-9d63-e8a455f3b563.png">

Last page:

Before | After
--- | ---
<img width="1028" alt="Screenshot 2021-10-07 at 13 58 39" src="https://user-images.githubusercontent.com/3593343/136379888-d88fe96a-cfb3-42ad-9264-dc92d21ba02a.png"> | <img width="1001" alt="Screenshot 2021-10-07 at 13 59 02" src="https://user-images.githubusercontent.com/3593343/136379880-7ab0cb9e-0456-41b9-af0a-6bc899fc10fa.png"> 

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
