### PR TITLE
Site Logo: Remove "Reset" button icon

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -35,7 +35,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { crop, reset, siteLogo as icon } from '@wordpress/icons';
+import { crop, siteLogo as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -399,9 +399,7 @@ export default function LogoEdit( {
 				onSelect={ onSelectLogo }
 				onError={ onUploadError }
 			>
-				<MenuItem icon={ reset } onClick={ onRemoveLogo }>
-					{ __( 'Reset' ) }
-				</MenuItem>
+				<MenuItem onClick={ onRemoveLogo }>{ __( 'Reset' ) }</MenuItem>
 			</MediaReplaceFlow>
 		</BlockControls>
 	);


### PR DESCRIPTION
## Description
Follow-up for https://github.com/WordPress/gutenberg/pull/35372#issuecomment-937608899.

PR removes the reset button icon.

I tried group menu items as @jasmussen suggested. But it turns out that `MediaReplaceFlow` [doesn't use](https://github.com/WordPress/gutenberg/pull/19126#discussion_r357765460) the `DropdownMenu` component, and we don't get all styling out of the box.

I'm not sure we want to duplicate all those styles just for a single menu item.

## How has this been tested?
1. Create a post.
2. Add the "Site Logo" block.
3. Verify that reset button appears as a menu item without the icon.

## Screenshots <!-- if applicable -->
![CleanShot 2021-10-07 at 19 11 20](https://user-images.githubusercontent.com/240569/136413522-a4f6fc86-d19c-43a9-8995-4c82db17610f.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
