### PR TITLE
Scripts: Remove inject polyfill by default

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The webpack config was update to no longer include the polyfill by default when creating the assets.php file. If your usage requires the wp-polyfill, you must explictly set it as a dependency. ([#34536](https://github.com/WordPress/gutenberg/pull/35436)]
+- The webpack config was updated to no longer include the polyfill by default when creating the `assets.php` file. If your usage requires the `wp-polyfill`, you must explicitly set it as a dependency. ([#34536](https://github.com/WordPress/gutenberg/pull/35436)]
 
 ### Enhancements
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The webpack config was update to no longer include the polyfill by default when creating the assets.php file. If your usage requires the wp-polyfill, you must explictly set it as a dependency. ([#34536](https://github.com/WordPress/gutenberg/pull/35436)]
+
 ### Enhancements
 
 -   The bundled `jest-dev-server` dependency has been updated to the next major version `^5.0.3` ([#34560](https://github.com/WordPress/gutenberg/pull/34560)).

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -247,7 +247,7 @@ const config = {
 		// WP_NO_EXTERNALS global variable controls whether scripts' assets get
 		// generated, and the default externals set.
 		! process.env.WP_NO_EXTERNALS &&
-			new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+			new DependencyExtractionWebpackPlugin(),
 	].filter( Boolean ),
 	stats: {
 		children: false,


### PR DESCRIPTION

## Description

The default behavior for the scripts when generating the assets.php file was to include the `wp-polyfill` by default. With the dropping of support for IE, this is no longer necessary. So this PR removes adding it by default.

Fixes #35410

## How has this been tested?

Confirm that when using script to generate assets.php script, that `wp-polyfill` is not included in the dependency list.


## Types of changes

This is a breaking change in that any scripts or plugins that rely on the polyfill must now explicitly declare it as a dependency, which they probably should of done in the first place to guarentee compatibility.


