### PR TITLE
Page List: Show empty placeholder if no items

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -13,7 +13,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
-import { ToolbarButton } from '@wordpress/components';
+import { Placeholder, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -28,6 +28,10 @@ import ConvertToLinksModal from './convert-to-links-modal';
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
+
+const EmptyResponsePlaceholder = () => (
+	<Placeholder label={ __( 'No pages to show.' ) } />
+);
 
 export default function PageListEdit( {
 	context,
@@ -154,6 +158,7 @@ export default function PageListEdit( {
 				<ServerSideRender
 					block="core/page-list"
 					attributes={ attributesWithParentStatus }
+					EmptyResponsePlaceholder={ EmptyResponsePlaceholder }
 				/>
 			</div>
 		</>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -13,7 +13,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
-import { Placeholder, ToolbarButton } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -28,10 +28,6 @@ import ConvertToLinksModal from './convert-to-links-modal';
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
 const MAX_PAGE_COUNT = 100;
-
-const EmptyResponsePlaceholder = () => (
-	<Placeholder label={ __( 'No pages to show.' ) } />
-);
 
 export default function PageListEdit( {
 	context,
@@ -158,7 +154,9 @@ export default function PageListEdit( {
 				<ServerSideRender
 					block="core/page-list"
 					attributes={ attributesWithParentStatus }
-					EmptyResponsePlaceholder={ EmptyResponsePlaceholder }
+					EmptyResponsePlaceholder={ () => (
+						<span>{ __( 'Page List: No pages to show.' ) }</span>
+					) }
 				/>
 			</div>
 		</>

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -281,6 +281,12 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		}
 	}
 
+	// If thare are no top level pages, there is nothing to show.
+	// Return early and empty to trigger EmptyResponsePlaceholder.
+	if ( empty( $top_level_pages ) ) {
+		return;
+	}
+
 	$colors          = block_core_page_list_build_css_colors( $attributes, $block->context );
 	$font_sizes      = block_core_page_list_build_css_font_sizes( $block->context );
 	$classes         = array_merge(

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -250,6 +250,12 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		)
 	);
 
+	// If thare are no pages, there is nothing to show.
+	// Return early and empty to trigger EmptyResponsePlaceholder.
+	if ( empty( $all_pages ) ) {
+		return;
+	}
+
 	$top_level_pages = array();
 
 	$pages_with_children = array();
@@ -279,12 +285,6 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 			);
 
 		}
-	}
-
-	// If thare are no top level pages, there is nothing to show.
-	// Return early and empty to trigger EmptyResponsePlaceholder.
-	if ( empty( $top_level_pages ) ) {
-		return;
 	}
 
 	$colors          = block_core_page_list_build_css_colors( $attributes, $block->context );


### PR DESCRIPTION
## Description

If no pages exist the Page List block will be empty, making it impossible to select in the rendered view in editor. This PR adds an empty placeholder to show where the block would be and allows for selecting in rendered view.

The Page List block can be empty if a user deletes all pages, or while working on #31471 there may be no children when showing a child list.

## How has this been tested?

- Add a Page List to a post or page
- Confirm it shows fine
- Delete all pages from your site
- View post with Page List block and confirm it is not shown
- Apply PR change
- View post again and confirm page list shows

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/45363/136471423-2ed10b57-3db5-47cc-99ee-a27a0c193e20.png)

## Types of changes

- Add empty response placeholder for empty server-side render response
- Updates render_callback to return early and empty if no top level pages

