### PR TITLE
FSE: Coding standards: DOCTYPE should be the first line/character of any HTML document

### DIFF
--- a/lib/template-canvas.php
+++ b/lib/template-canvas.php
@@ -10,8 +10,7 @@
  * This needs to run before <head> so that blocks can add scripts and styles in wp_head().
  */
 $template_html = gutenberg_get_the_template_html();
-?>
-<!DOCTYPE html>
+?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />


### PR DESCRIPTION
## Description
On Twenty Twenty-Two, I spotted that the DOCTYPE of HTML pages is generated after an empty line.
[According to the HTML specification/living standard, the DOCTYPE should be the very first element of the document.](https://html.spec.whatwg.org/multipage/syntax.html#writing)

## How has this been tested?
Using Twenty Twenty-Two Full site editing templates.

## Types of changes
That's a small fix 😊 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
