### PR TITLE
Add template details to template parts

### DIFF
--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -89,9 +89,10 @@ export const navigationPanel = {
 	},
 
 	async getItemByText( text ) {
-		const selector = `//div[contains(@class, "edit-site-navigation-panel")]//button[contains(., "${ text }")]`;
-		await page.waitForXPath( selector );
-		const [ item ] = await page.$x( selector );
+		const item = await page.waitForXPath(
+			`//div[contains(@class, "edit-site-navigation-panel")]//button[.//*[text()="${ text }"]]`,
+			{ visible: true }
+		);
 		return item;
 	},
 

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -79,7 +79,7 @@ describe( 'Document Settings', () => {
 			// Navigate to a template part
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			await navigationPanel.navigate( [ 'Template Parts', 'Headers' ] );
+			await navigationPanel.navigate( [ 'Template Parts', 'headers' ] );
 			await navigationPanel.clickItemByText( 'header' );
 
 			// Evaluate the document settings title

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -150,7 +150,7 @@ describe( 'Multi-entity editor states', () => {
 
 	it( 'should not dirty an entity by switching to it in the template dropdown', async () => {
 		await siteEditor.visit();
-		await clickTemplateItem( [ 'Template Parts', 'Headers' ], 'header' );
+		await clickTemplateItem( [ 'Template Parts', 'headers' ], 'header' );
 		await page.waitForFunction( () =>
 			Array.from( window.frames ).find(
 				( { name } ) => name === 'editor-canvas'

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -42,7 +42,7 @@ describe( 'Template Part', () => {
 			// Switch to editing the header template part.
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			await navigationPanel.navigate( [ 'Template Parts', 'Headers' ] );
+			await navigationPanel.navigate( [ 'Template Parts', 'headers' ] );
 			await navigationPanel.clickItemByText( 'header' );
 		}
 

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -62,15 +62,11 @@ export default function Header( {
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
 		const record = getEditedEntityRecord( 'postType', postType, postId );
-		const _entityTitle =
-			'wp_template' === postType
-				? getTemplateInfo( record ).title
-				: record?.slug;
 		const _isLoaded = !! postId;
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
-			entityTitle: _entityTitle,
+			entityTitle: getTemplateInfo( record ).title,
 			isLoaded: _isLoaded,
 			template: record,
 			templateType: postType,

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -141,27 +141,22 @@ export default function Header( {
 			</div>
 
 			<div className="edit-site-header_center">
-				{ 'wp_template' === templateType && (
-					<DocumentActions
-						entityTitle={ entityTitle }
-						entityLabel="template"
-						isLoaded={ isLoaded }
-					>
-						{ ( { onClose } ) => (
-							<TemplateDetails
-								template={ template }
-								onClose={ onClose }
-							/>
-						) }
-					</DocumentActions>
-				) }
-				{ 'wp_template_part' === templateType && (
-					<DocumentActions
-						entityTitle={ entityTitle }
-						entityLabel="template part"
-						isLoaded={ isLoaded }
-					/>
-				) }
+				<DocumentActions
+					entityTitle={ entityTitle }
+					entityLabel={
+						templateType === 'wp_template_part'
+							? 'template part'
+							: 'template'
+					}
+					isLoaded={ isLoaded }
+				>
+					{ ( { onClose } ) => (
+						<TemplateDetails
+							template={ template }
+							onClose={ onClose }
+						/>
+					) }
+				</DocumentActions>
 			</div>
 
 			<div className="edit-site-header_end">

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -88,21 +88,21 @@ export const TEMPLATE_PARTS_SUB_MENUS = [
 	{
 		area: TEMPLATE_PART_AREA_HEADER,
 		menu: MENU_TEMPLATE_PARTS_HEADERS,
-		title: __( 'Headers' ),
+		title: __( 'headers' ),
 	},
 	{
 		area: TEMPLATE_PART_AREA_FOOTER,
 		menu: MENU_TEMPLATE_PARTS_FOOTERS,
-		title: __( 'Footers' ),
+		title: __( 'footers' ),
 	},
 	{
 		area: TEMPLATE_PART_AREA_SIDEBAR,
 		menu: MENU_TEMPLATE_PARTS_SIDEBARS,
-		title: __( 'Sidebars' ),
+		title: __( 'sidebars' ),
 	},
 	{
 		area: 'uncategorized',
 		menu: MENU_TEMPLATE_PARTS_GENERAL,
-		title: __( 'General' ),
+		title: __( 'general' ),
 	},
 ];

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts-sub.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts-sub.js
@@ -17,6 +17,7 @@ import { MENU_TEMPLATE_PARTS } from '../constants';
 export default function TemplatePartsSubMenu( { menu, title, templateParts } ) {
 	return (
 		<NavigationMenu
+			className="edit-site-navigation-panel__template-parts"
 			menu={ menu }
 			title={ title }
 			parentMenu={ MENU_TEMPLATE_PARTS }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -69,6 +69,7 @@ export default function TemplatePartsMenu() {
 					TEMPLATE_PARTS_SUB_MENUS.map( ( { title, menu } ) => (
 						<NavigationItem
 							key={ `template-parts-navigate-to-${ menu }` }
+							className="edit-site-navigation-panel__template-part-item"
 							navigateToMenu={ menu }
 							title={ title }
 							hideIfTargetMenuEmpty

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -117,6 +117,14 @@
 	}
 }
 
+.edit-site-navigation-panel__template-parts .components-navigation__menu-title-heading {
+	text-transform: capitalize;
+}
+
+.edit-site-navigation-panel__template-part-item .components-navigation__item-title {
+	text-transform: capitalize;
+}
+
 .components-navigation__item + .edit-site-navigation-panel__template-item {
 	margin-top: $grid-unit-20;
 }

--- a/packages/edit-site/src/components/sidebar/template-card/template-areas.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-areas.js
@@ -46,6 +46,10 @@ export default function TemplateAreas() {
 		[]
 	);
 
+	if ( ! Object.keys( templateAreaBlocks ).length ) {
+		return null;
+	}
+
 	return (
 		<section className="edit-site-template-card__template-areas">
 			<Heading

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -59,6 +59,7 @@ export default function TemplateDetails( { template, onClose } ) {
 					<Text
 						size="body"
 						className="edit-site-template-details__description"
+						as="p"
 					>
 						{ description }
 					</Text>

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -68,7 +68,7 @@ export default function TemplateDetails( { template, onClose } ) {
 			<TemplateAreas />
 
 			{ isTemplateRevertable( template ) && (
-				<MenuGroup className="edit-site-template-details__group">
+				<MenuGroup className="edit-site-template-details__group edit-site-template-details__revert">
 					<MenuItem
 						className="edit-site-template-details__revert-button"
 						info={ __( 'Restore template to theme default' ) }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	Button,
 	MenuGroup,
@@ -16,7 +17,10 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import isTemplateRevertable from '../../utils/is-template-revertable';
-import { MENU_TEMPLATES } from '../navigation-sidebar/navigation-panel/constants';
+import {
+	MENU_TEMPLATES,
+	TEMPLATE_PARTS_SUB_MENUS,
+} from '../navigation-sidebar/navigation-panel/constants';
 import { store as editSiteStore } from '../../store';
 import TemplateAreas from './template-areas';
 
@@ -30,13 +34,23 @@ export default function TemplateDetails( { template, onClose } ) {
 		editSiteStore
 	);
 
+	const templateSubMenu = useMemo( () => {
+		if ( template?.type === 'wp_template' ) {
+			return { title: __( 'templates' ), menu: MENU_TEMPLATES };
+		}
+
+		return TEMPLATE_PARTS_SUB_MENUS.find(
+			( { area } ) => area === template?.area
+		);
+	}, [ template ] );
+
 	if ( ! template ) {
 		return null;
 	}
 
 	const showTemplateInSidebar = () => {
 		onClose();
-		openNavigationPanelToMenu( MENU_TEMPLATES );
+		openNavigationPanelToMenu( templateSubMenu.menu );
 	};
 
 	const revert = () => {
@@ -83,11 +97,19 @@ export default function TemplateDetails( { template, onClose } ) {
 			<Button
 				className="edit-site-template-details__show-all-button"
 				onClick={ showTemplateInSidebar }
-				aria-label={ __(
-					'Browse all templates. This will open the template menu in the navigation side panel.'
+				aria-label={ sprintf(
+					/* translators: %1$s: the template part's area name ("Headers", "Sidebars") or "templates". */
+					__(
+						'Browse all %1$s. This will open the %1$s menu in the navigation side panel.'
+					),
+					templateSubMenu.title
 				) }
 			>
-				{ __( 'Browse all templates' ) }
+				{ sprintf(
+					/* translators: the template part's area name ("Headers", "Sidebars") or "templates". */
+					__( 'Browse all %s' ),
+					templateSubMenu.title
+				) }
 			</Button>
 		</div>
 	);

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -9,11 +9,11 @@
 	}
 
 	.edit-site-template-details__title {
-		margin: 0 0 $grid-unit-15;
+		margin: 0;
 	}
 
 	.edit-site-template-details__description {
-		margin: 0 0 $grid-unit-15;
+		margin: $grid-unit-15 0 0;
 		color: $gray-700;
 	}
 

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -22,9 +22,14 @@
 		padding: $grid-unit-10;
 	}
 
+	.edit-site-template-details__revert {
+		// Make some spaces for the revert button to have some paddings.
+		padding: $grid-unit-15 $grid-unit;
+	}
+
 	.edit-site-template-details__revert-button {
 		height: auto;
-		padding: 0;
+		padding: $grid-unit-05 $grid-unit;
 		text-align: left;
 
 		&:focus:not(:disabled) {

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -391,7 +391,7 @@ export function* revertTemplate( template ) {
 			coreStore,
 			'getEditedEntityRecord',
 			'postType',
-			'wp_template',
+			template.type,
 			template.id
 		);
 		// We are fixing up the undo level here to make sure we can undo
@@ -400,7 +400,7 @@ export function* revertTemplate( template ) {
 			coreStore,
 			'editEntityRecord',
 			'postType',
-			'wp_template',
+			template.type,
 			template.id,
 			{
 				content: serializeBlocks, // required to make the `undo` behave correctly
@@ -417,7 +417,7 @@ export function* revertTemplate( template ) {
 			coreStore,
 			'editEntityRecord',
 			'postType',
-			'wp_template',
+			template.type,
 			fileTemplate.id,
 			{
 				content: serializeBlocks,
@@ -429,7 +429,7 @@ export function* revertTemplate( template ) {
 		const undoRevert = async () => {
 			await dispatch( coreStore ).editEntityRecord(
 				'postType',
-				'wp_template',
+				template.type,
 				edited.id,
 				{
 					content: serializeBlocks,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Related to https://github.com/WordPress/gutenberg/issues/29687. Add template details dropdown to template parts. There's also a revert button in the dropdown.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks`
2. Go to Site Editor
3. Go to edit a template part
4. Should see the dropdown in the top header
5. Activating the dropdown should see the title and the browse button
6. Edit some changes in the template part and save it
7. The dropdown should now contain the revert button

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/7753001/136515630-c09dac69-b994-40d8-9e10-f6e89919ca68.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
