### PR TITLE
Typography Panel: Update typography controls for display in ToolsPanel

### DIFF
--- a/packages/block-editor/src/components/line-height-control/style.scss
+++ b/packages/block-editor/src/components/line-height-control/style.scss
@@ -6,3 +6,13 @@
 		max-width: 60px;
 	}
 }
+
+.components-tools-panel {
+	.block-editor-line-height-control {
+		margin-bottom: 0;
+
+		input {
+			max-width: 100%;
+		}
+	}
+}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### New Feature
 
 -   Add an experimental `Navigator` components ([#34904](https://github.com/WordPress/gutenberg/pull/34904)) as a replacement for the previous `Navigation` related components.
+-   Added `showResetButton` prop to `FontSizePicker` component allowing optional display of the reset button ([35451](https://github.com/WordPress/gutenberg/pull/35451)).
 
 ### Bug Fix
 

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -83,6 +83,15 @@ If onChange is called without any parameter, it should reset the value, attendin
 -   Type: `function`
 -   Required: Yes
 
+### showResetButton
+
+If `true`, a reset button will be displayed alongside the predefined and custom
+font size fields.
+
+-   Type: `Boolean`
+-   Required: no
+-   Default: `true`
+
 ### value
 
 The current font size value.

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -60,6 +60,7 @@ function FontSizePicker(
 		onChange,
 		value,
 		withSlider = false,
+		allowReset = true,
 	},
 	ref
 ) {
@@ -143,17 +144,19 @@ function FontSizePicker(
 						units={ hasUnits ? units : false }
 					/>
 				) }
-				<Button
-					className="components-color-palette__clear"
-					disabled={ value === undefined }
-					onClick={ () => {
-						onChange( undefined );
-					} }
-					isSmall
-					variant="secondary"
-				>
-					{ __( 'Reset' ) }
-				</Button>
+				{ allowReset && (
+					<Button
+						className="components-color-palette__clear"
+						disabled={ value === undefined }
+						onClick={ () => {
+							onChange( undefined );
+						} }
+						isSmall
+						variant="secondary"
+					>
+						{ __( 'Reset' ) }
+					</Button>
+				) }
 			</div>
 			{ withSlider && (
 				<RangeControl

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -60,7 +60,7 @@ function FontSizePicker(
 		onChange,
 		value,
 		withSlider = false,
-		allowReset = true,
+		showResetButton = true,
 	},
 	ref
 ) {
@@ -144,7 +144,7 @@ function FontSizePicker(
 						units={ hasUnits ? units : false }
 					/>
 				) }
-				{ allowReset && (
+				{ showResetButton && (
 					<Button
 						className="components-color-palette__clear"
 						disabled={ value === undefined }

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -5,18 +5,30 @@
 	align-items: center;
 	margin-bottom: $grid-unit-30;
 
+	// Leave the spacing to the ToolsPanel grid layout.
+	.components-tools-panel & {
+		margin-bottom: 0;
+	}
+
 	.components-unit-control-wrapper {
 		margin-right: $grid-unit-10;
+
+		// Remove margin when reset button has been omitted.
+		&:last-child {
+			margin-right: 0;
+		}
 
 		.components-input-control__label {
 			font-weight: 300;
 			padding-bottom: 0 !important;
 			margin-bottom: $grid-unit-10 !important;
+			line-height: 1.4; // Make label line-height consistent between inputs.
 		}
 	}
 
 	.components-custom-select-control__button {
 		min-width: 120px;
+		width: 100%; // Allow the button to stretch when reset button is omitted.
 	}
 
 	// Apply the same height as the isSmall Reset button.
@@ -46,6 +58,7 @@
 
 	// Allow the font-size picker dropdown to grow in width.
 	.components-font-size-picker__select {
+		flex: 1;
 		margin-right: $grid-unit-10;
 	}
 


### PR DESCRIPTION
Depends on:
- https://github.com/WordPress/gutenberg/pull/33744

Related:
- https://github.com/WordPress/gutenberg/pull/35395

## Description

This PR includes:
- Addition of a new `showResetButton` prop for the existing `FontSizePicker` which allows it to be hidden when made redundant by the control's inclusion within a `ToolsPanel`
- Styling tweaks to the `FontSizePicker` so the predefined and custom fields take up available space and line up neatly
- Tweak to the line-height control to remove the bottom margin and leave that to the `ToolsPanel` grid layout.

### Important

_If the new typography controls land before the Typography switch to the `ToolsPanel`, this PR is not required._

## How has this been tested?
Manually. 

- Based this PR off [#33744](https://github.com/WordPress/gutenberg/pull/33744) to see the controls display and function correctly within a `ToolsPanel`
- Applied this PR's patch on trunk and ensured that it didn't break the display of the existing controls

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="278" alt="Screen Shot 2021-10-08 at 5 19 25 pm" src="https://user-images.githubusercontent.com/60436221/136517222-922aee5c-95f5-4979-8682-282c1859120f.png"> | <img width="279" alt="Screen Shot 2021-10-08 at 5 17 48 pm" src="https://user-images.githubusercontent.com/60436221/136517242-7652fb7a-88ca-4d4c-bf38-96fa3e535ce9.png"> |

## Types of changes
New Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
