### PR TITLE
Fix `stripHTML` to preserve leading spaces

### DIFF
--- a/packages/dom/src/dom/strip-html.js
+++ b/packages/dom/src/dom/strip-html.js
@@ -6,9 +6,22 @@
  * @return {string} The text content with any html removed.
  */
 export default function stripHTML( html ) {
+	const leadingSpaces = html.match( /(^\s+)/g );
+
+	// DOM Parser will ignore any space character coming after
+	// the DocType.
+	// see: https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-name-state
+	// As a result any leading space in the provided `html`
+	// argument string will be stripped out.
+	// Manually retrieve these prior to parsing for restoration post-parse.
+	const spacesToRestore = leadingSpaces ? leadingSpaces[ 0 ] : '';
+
 	const document = new window.DOMParser().parseFromString(
 		html,
 		'text/html'
 	);
-	return document.body.textContent || '';
+
+	const content = document.body.textContent || '';
+
+	return spacesToRestore + content;
 }

--- a/packages/dom/src/dom/strip-html.js
+++ b/packages/dom/src/dom/strip-html.js
@@ -6,15 +6,14 @@
  * @return {string} The text content with any html removed.
  */
 export default function stripHTML( html ) {
-	const leadingSpaces = html.match( /(^\s+)/g );
-
 	// DOM Parser will ignore any space character coming after
 	// the DocType.
 	// see: https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-name-state
 	// As a result any leading space in the provided `html`
 	// argument string will be stripped out.
 	// Manually retrieve these prior to parsing for restoration post-parse.
-	const spacesToRestore = leadingSpaces ? leadingSpaces[ 0 ] : '';
+	// @ts-ignore
+	const [ spacesToRestore ] = html.match( /^\s*/ );
 
 	const document = new window.DOMParser().parseFromString(
 		html,

--- a/packages/dom/src/dom/test/strip-html.js
+++ b/packages/dom/src/dom/test/strip-html.js
@@ -4,7 +4,7 @@
 import stripHTML from '../strip-html';
 
 describe( 'stripHTML', () => {
-	it( 'should strip basic HTML', () => {
+	it( 'should strip valid HTML', () => {
 		const input =
 			'<strong>Here is some text</strong> that contains <em>HTML markup</em>.';
 		const output = 'Here is some text that contains HTML markup.';
@@ -29,6 +29,21 @@ describe( 'stripHTML', () => {
 		const input =
 			'<strong>      Here is some text</strong> with <em>leading spaces</em>.';
 		const output = '      Here is some text with leading spaces.';
+		expect( stripHTML( input ) ).toBe( output );
+	} );
+
+	it( 'should preserve new lines in multi-line HTML string', () => {
+		const input = `<div>
+        Here is some
+        <em>text</em>
+        with new lines
+        </div>`;
+
+		const output = `
+        Here is some
+        text
+        with new lines
+        `;
 		expect( stripHTML( input ) ).toBe( output );
 	} );
 } );

--- a/packages/dom/src/dom/test/strip-html.js
+++ b/packages/dom/src/dom/test/strip-html.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import stripHTML from '../strip-html';
+
+describe( 'stripHTML', () => {
+	it( 'should strip HTML attributes', () => {
+		const input =
+			'<strong>Here is some text</strong> that contains <em>HTML markup</em>.';
+		const output = 'Here is some text that contains HTML markup.';
+		expect( stripHTML( input ) ).toBe( output );
+	} );
+
+	it( 'should preserve leading spaces', () => {
+		const input =
+			'       <strong>Here is some text</strong> with <em>leading spaces</em>.';
+		const output = '       Here is some text with leading spaces.';
+		expect( stripHTML( input ) ).toBe( output );
+	} );
+
+	it( 'should preserve leading spaces with HTML', () => {
+		const input =
+			'<strong>      Here is some text</strong> with <em>leading spaces</em>.';
+		const output = '      Here is some text with leading spaces.';
+		expect( stripHTML( input ) ).toBe( output );
+	} );
+} );

--- a/packages/dom/src/dom/test/strip-html.js
+++ b/packages/dom/src/dom/test/strip-html.js
@@ -33,6 +33,13 @@ describe( 'stripHTML', () => {
 			expect( stripHTML( input ) ).toBe( output );
 		} );
 
+		it( 'should preserve trailing spaces with HTML', () => {
+			const input =
+				'<strong>Here is some text</strong> with <em>trailing spaces</em>.          ';
+			const output = 'Here is some text with trailing spaces.          ';
+			expect( stripHTML( input ) ).toBe( output );
+		} );
+
 		it( 'should preserve consequtive spaces within string', () => {
 			const input =
 				'<strong>Here is some          text</strong> with                  <em>a lot of spaces inside</em>.';

--- a/packages/dom/src/dom/test/strip-html.js
+++ b/packages/dom/src/dom/test/strip-html.js
@@ -18,32 +18,42 @@ describe( 'stripHTML', () => {
 		expect( stripHTML( input ) ).toBe( output );
 	} );
 
-	it( 'should preserve leading spaces', () => {
-		const input =
-			'       <strong>Here is some text</strong> with <em>leading spaces</em>.';
-		const output = '       Here is some text with leading spaces.';
-		expect( stripHTML( input ) ).toBe( output );
-	} );
+	describe( 'whitespace preservation', () => {
+		it( 'should preserve leading spaces', () => {
+			const input =
+				'       <strong>Here is some text</strong> with <em>leading spaces</em>.';
+			const output = '       Here is some text with leading spaces.';
+			expect( stripHTML( input ) ).toBe( output );
+		} );
 
-	it( 'should preserve leading spaces with HTML', () => {
-		const input =
-			'<strong>      Here is some text</strong> with <em>leading spaces</em>.';
-		const output = '      Here is some text with leading spaces.';
-		expect( stripHTML( input ) ).toBe( output );
-	} );
+		it( 'should preserve leading spaces with HTML', () => {
+			const input =
+				'<strong>      Here is some text</strong> with <em>leading spaces</em>.';
+			const output = '      Here is some text with leading spaces.';
+			expect( stripHTML( input ) ).toBe( output );
+		} );
 
-	it( 'should preserve new lines in multi-line HTML string', () => {
-		const input = `<div>
+		it( 'should preserve consequtive spaces within string', () => {
+			const input =
+				'<strong>Here is some          text</strong> with                  <em>a lot of spaces inside</em>.';
+			const output =
+				'Here is some          text with                  a lot of spaces inside.';
+			expect( stripHTML( input ) ).toBe( output );
+		} );
+
+		it( 'should preserve new lines in multi-line HTML string', () => {
+			const input = `<div>
         Here is some
         <em>text</em>
         with new lines
         </div>`;
 
-		const output = `
+			const output = `
         Here is some
         text
         with new lines
         `;
-		expect( stripHTML( input ) ).toBe( output );
+			expect( stripHTML( input ) ).toBe( output );
+		} );
 	} );
 } );

--- a/packages/dom/src/dom/test/strip-html.js
+++ b/packages/dom/src/dom/test/strip-html.js
@@ -4,9 +4,16 @@
 import stripHTML from '../strip-html';
 
 describe( 'stripHTML', () => {
-	it( 'should strip HTML attributes', () => {
+	it( 'should strip basic HTML', () => {
 		const input =
 			'<strong>Here is some text</strong> that contains <em>HTML markup</em>.';
+		const output = 'Here is some text that contains HTML markup.';
+		expect( stripHTML( input ) ).toBe( output );
+	} );
+
+	it( 'should strip invalid HTML', () => {
+		const input =
+			'<strong>Here is some text</em> <p></div>that contains HTML markup</p>.';
 		const output = 'Here is some text that contains HTML markup.';
 		expect( stripHTML( input ) ).toBe( output );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/33849 I discovered that [`stripHTML()`](https://github.com/WordPress/gutenberg/blob/ed8a5c86852906795eef161356a547924272ec6d/packages/dom/src/dom/strip-html.js) will also strip any _leading_ space characters from the string.

I believe this is because [the DOM Parser will ignore any space character coming after the DocType](https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-name-state).

I don't believe this is the functionality we would want (or _expect_) from this utility, but let me know if I'm wrong.

This PR captures any spaces at the start of the string and then restores them to the string after the `DOMParser` has completed. This preserves the original whitespace on the string.

I also added some unit tests - although I'm surprised they worked because I didn't think Jest would have access to the `window` 🤔 


## How has this been tested?

Pop open dev tools Console and type in the following (this simulates what we are currently doing in `trunk`):

```js
new window.DOMParser().parseFromString(
    '    a string with leading spaces',
    'text/html'
).body.textContent
```

Notice how the _leading_ spaces are stripped off.

Now run the unit tests on this PR:

```
npm run test-unit:watch packages/dom/src/dom/test/strip-html.js
```

Note how the leading spaces in the tests are now _preserved_.

Check implementation is suitable.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
