### PR TITLE
Global Styles: pass only the data the site editor uses

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -140,8 +140,8 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'site-editor' ),
 				),
 
-				'__experimentalGlobalStylesBaseStyles'   => array(
-					'description' => __( 'Global styles settings.', 'gutenberg' ),
+				'__experimentalGlobalStylesBaseConfig'   => array(
+					'description' => __( 'Settings and styles consolidated from core and theme origins.', 'gutenberg' ),
 					'type'        => 'object',
 					'context'     => array( 'site-editor' ),
 				),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -127,7 +127,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
 		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $theme->get_raw_data()['styles'];
-		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_raw_data()['settings'];
+		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_settings();
 	}
 
 	if ( 'other' === $context ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -125,8 +125,9 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$theme       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings, 'theme' );
 		$user_cpt_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 
-		$settings['__experimentalGlobalStylesUserEntityId'] = $user_cpt_id;
-		$settings['__experimentalGlobalStylesBaseStyles']   = $theme->get_raw_data();
+		$settings['__experimentalGlobalStylesUserEntityId']           = $user_cpt_id;
+		$settings['__experimentalGlobalStylesBaseConfig']['styles']   = $theme->get_raw_data()['styles'];
+		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_raw_data()['settings'];
 	}
 
 	if ( 'other' === $context ) {

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -137,7 +137,7 @@ function useGlobalStylesUserConfig() {
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
 		return select( editSiteStore ).getSettings()
-			.__experimentalGlobalStylesBaseStyles;
+			.__experimentalGlobalStylesBaseConfig;
 	}, [] );
 
 	return baseConfig;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -94,7 +94,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalBlockPatternCategories',
 				'__experimentalBlockPatterns',
 				'__experimentalFeatures',
-				'__experimentalGlobalStylesBaseStyles',
+				'__experimentalGlobalStylesBaseConfig',
 				'__experimentalGlobalStylesUserEntityId',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/35264#discussion_r721531059

This PR:

- renames `__experimentalGlobalStylesBaseStyles` to `__experimentalGlobalStylesBaseConfig`
- makes sure `__experimentalGlobalStylesBaseConfig` only contains settings & styles

## Context 

I've realized that we've been dumping some data we don't need at `__experimentalGlobalStylesBaseStyles`. It was originally thought to pass the base styles while now it's used to pass the base config (settings + styles). With the current implementation, though, we also pass any other data (custom templates, etc). This PR is a minor change to make sure we only pass the data in use.

A larger refactoring should consider not passing the settings at all, given that it's data that already lives in `__experimentalFeatures`. I've looked at this but it's a bit convoluted, so thought to do this first.

Note that mobile has a variable named `__experimentalGlobalStylesBaseStyles` which is different from this one. This rename should also help clarifying that.

## How to test

Verify tests still pass.

Do some testing of the site editor and verify that it still works. For example, change colors and save the results. Verify that the front applies the changes, etc.
