### PR TITLE
FontAppearanceControl: Remove `fieldset` wrapper

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -195,19 +195,17 @@ export default function FontAppearanceControl( props ) {
 	};
 
 	return (
-		<fieldset className="components-font-appearance-control">
-			{ hasStylesOrWeights && (
-				<CustomSelectControl
-					className="components-font-appearance-control__select"
-					label={ getLabel() }
-					describedBy={ getDescribedBy() }
-					options={ selectOptions }
-					value={ currentSelection }
-					onChange={ ( { selectedItem } ) =>
-						onChange( selectedItem.style )
-					}
-				/>
-			) }
-		</fieldset>
+		hasStylesOrWeights && (
+			<CustomSelectControl
+				className="components-font-appearance-control"
+				label={ getLabel() }
+				describedBy={ getDescribedBy() }
+				options={ selectOptions }
+				value={ currentSelection }
+				onChange={ ( { selectedItem } ) =>
+					onChange( selectedItem.style )
+				}
+			/>
+		)
 	);
 }

--- a/packages/block-editor/src/components/font-appearance-control/style.scss
+++ b/packages/block-editor/src/components/font-appearance-control/style.scss
@@ -1,4 +1,4 @@
-.components-font-appearance-control__select {
+.components-font-appearance-control {
 	margin-bottom: 24px;
 
 	ul {


### PR DESCRIPTION
## Description

The `FontAppearanceControl` was wrapped by a `fieldset` tag that relied on a wp-admin CSS reset file (common.css). Rather than encapsulate a style reset within the component, I think it would be better to remove the `fieldset` wrapper since AFAICT it serves no purpose in this particular case. (Might've been copypasta?)

## How has this been tested?

- The `fieldset` styling is gone in the [Storybook](http://localhost:50240/?path=/story/components-experimental-toolspanel--typography-panel).
- No visual regressions in the existing usage (add a Navigation block to a post and check the Typography Tools panel).

## Screenshots <!-- if applicable -->

### Before

<img src="https://user-images.githubusercontent.com/555336/136548656-fc9eba3e-24f1-4ebc-aa95-a0020773ccd7.png" alt="Font Apperance Control with a fieldset border" width="250">

When rendered in an isolated environment, the `fieldset` border is visible.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
