### PR TITLE
Add PascalCase slug to create-block template strings

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### New Features
--	Add the block slug in PascalCase to the list of strings that can be used in templates ([#35462](https://github.com/WordPress/gutenberg/pull/35462))
+-	Add `slugPascalCase` to the list of variables that can be used in templates ([#35462](https://github.com/WordPress/gutenberg/pull/35462))
 
 ## 2.5.0 (2021-07-21)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### New Features
+-	Add the block slug in PascalCase to the list of strings that can be used in templates ([#35462](https://github.com/WordPress/gutenberg/pull/35462))
+
 ## 2.5.0 (2021-07-21)
 
 ### Enhancements

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { writeFile } = require( 'fs' ).promises;
-const { snakeCase } = require( 'lodash' );
+const { snakeCase, camelCase, upperFirst } = require( 'lodash' );
 const makeDir = require( 'make-dir' );
 const { render } = require( 'mustache' );
 const { dirname, join } = require( 'path' );
@@ -53,6 +53,7 @@ module.exports = async (
 		namespaceSnakeCase: snakeCase( namespace ),
 		slug,
 		slugSnakeCase: snakeCase( slug ),
+		slugPascalCase: upperFirst( camelCase( slug ) ),
 		title,
 		description,
 		dashicon,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR will make a new token available to the templated files used with `@wordpress/create-block`. It will allow templates to replace `{{slugPascalCase}}` with the extension's slug but in PascalCase.

This could be useful in cases where templates generate classes, These should be written in PascalCase, and currently there's no way to do this.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I have created an example template package, (https://www.npmjs.com/package/blocks-template) the repo for this package is here: https://github.com/opr/blocks-template/ and the `slugPascalCase` is used in the [`$slug.php.mustache`](https://github.com/opr/blocks-template/blob/main/%24slug.php.mustache) file.

From the root of this repo:
1. Run `npx wp-create-block -t blocks-template my-test-extension`.
2. Navigate to `my-test-extension` and view `my-test-extension.php`
3. See the class name generated is `MyTestExtension_Blocks_Integration`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature to the `create-block` package.

## Checklist:
- [x] My code is **[manually]** tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
