### PR TITLE
Block Settings: Don't render 'Move to' if the block cannot be moved

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -28,12 +28,11 @@ export default function BlockActions( {
 		canInsertBlockType,
 		getBlockRootClientId,
 		getBlocksByClientId,
+		canMoveBlocks,
 		canRemoveBlocks,
-		getTemplateLock,
-	} = useSelect( ( select ) => select( blockEditorStore ), [] );
+	} = useSelect( blockEditorStore );
 	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
-		( select ) => select( blocksStore ),
-		[]
+		blocksStore
 	);
 
 	const blocks = getBlocksByClientId( clientIds );
@@ -51,6 +50,7 @@ export default function BlockActions( {
 		rootClientId
 	);
 
+	const canMove = canMoveBlocks( clientIds, rootClientId );
 	const canRemove = canRemoveBlocks( clientIds, rootClientId );
 
 	const {
@@ -70,8 +70,8 @@ export default function BlockActions( {
 	return children( {
 		canDuplicate,
 		canInsertDefaultBlock,
+		canMove,
 		canRemove,
-		isLocked: !! getTemplateLock( rootClientId ),
 		rootClientId,
 		blocks,
 		onDuplicate() {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -90,11 +90,11 @@ export function BlockSettingsDropdown( {
 			{ ( {
 				canDuplicate,
 				canInsertDefaultBlock,
+				canMove,
 				canRemove,
 				onDuplicate,
 				onInsertAfter,
 				onInsertBefore,
-				isLocked,
 				onRemove,
 				onCopy,
 				onMoveTo,
@@ -157,7 +157,7 @@ export function BlockSettingsDropdown( {
 										</MenuItem>
 									</>
 								) }
-								{ ! isLocked && ! onlyBlock && (
+								{ canMove && ! onlyBlock && (
 									<MenuItem
 										onClick={ flow( onClose, onMoveTo ) }
 									>


### PR DESCRIPTION
## Description
Replaces `isLocked` check with `canMoveBlocks`, latter considers the template lock.

Part of #29864.

P.S. I also update `useSelect` calls to use the new selector getter method.

## How has this been tested?
1. Use the snippet below to insert the locked block.
2. Check that the "Move to" menu item isn't rendered in Block Settings.

## Locked block
```html
<!-- wp:heading {"lock":{"remove":true,"move":true}} -->
<h2>Locked Heading</h2>
<!-- /wp:heading -->
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-10-08 at 15 58 37](https://user-images.githubusercontent.com/240569/136553300-e9243c6c-cb6c-46bb-b991-cb2c4e7cf048.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
