### PR TITLE
RNMobile: Fix column horizonal layout

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -262,6 +262,7 @@ export class BlockList extends Component {
 						{ flex: isRootList ? 1 : 0 },
 						! isRootList && styles.overflowVisible,
 					] }
+					horizontal={ horizontal }
 					extraData={ this.getExtraData() }
 					scrollEnabled={ isRootList }
 					contentContainerStyle={ [


### PR DESCRIPTION
## Description
This PR intendes to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/4081

The regression was due to https://github.com/WordPress/gutenberg/pull/34200.
This PR revert the fix partially. 

## How has this been tested?
1. Load this PR in the mobile editor. 
2. Create a column block and add another column block inside. 
3. Add a buttons block. Notice that it still works as expected.
4. Add Group block. Notice that it still works as expected
Notice that 

## Screenshots <!-- if applicable -->
Before:
![simulator_screenshot_7FC35276-3634-40D9-A68B-B8B606C90B60](https://user-images.githubusercontent.com/115071/136615249-7bf82ca3-019a-4cb5-a079-e8655a917a4d.png)

After:
![simulator_screenshot_EC4882E4-255F-4FA4-B8F5-E8DE8DD7DC1A](https://user-images.githubusercontent.com/115071/136615195-80d03cfb-515b-4f39-8feb-12480c15f8f9.png)

## Types of changes
Bug fix


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
