### PR TITLE
Input Control: Set a color

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -235,6 +235,7 @@
 }
 
 @mixin input-control {
+	color: #2c3338 !important;
 	font-family: $default-font;
 	padding: 6px 8px;
 	@include input-style__neutral();


### PR DESCRIPTION
## Description
When a theme sets a color for form elements, this gets inherited by text control. If the theme uses a dark background and white text for form elements, then it becomes unreadable:

<img width="738" alt="Screenshot 2021-10-08 at 21 05 18" src="https://user-images.githubusercontent.com/275961/136619611-81bfd9aa-0d80-477b-9f47-18ebd69ad609.png">

This PR sets a dark color for text inside input controls, so it looks like this:
<img width="732" alt="Screenshot 2021-10-08 at 21 05 32" src="https://user-images.githubusercontent.com/275961/136619666-aa86e327-004f-4f02-96a7-21610a698581.png">

I have used `!important` to make sure that the theme styles do get overridden. I'm not super keen on this solution as it feels very heavy handed. My preference would be [this fix](https://github.com/WordPress/gutenberg/pull/33494), but maybe a quick fix is worth it?

## How has this been tested?
Checkout the videomaker theme and add a table block.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
