### PR TITLE
Media Placeholder: make component easier to read and reduce required …

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/hooks/use-files-upload.js
+++ b/packages/block-editor/src/components/media-placeholder/hooks/use-files-upload.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+
+export default function useFilesUpload( {
+	addToGallery,
+	handleUpload,
+	onSelect,
+	multiple,
+	onFilesPreUpload,
+	value,
+	allowedTypes,
+	onError,
+} ) {
+	const mediaUpload = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().mediaUpload;
+	}, [] );
+
+	return [
+		mediaUpload,
+		( files ) => {
+			if ( ! handleUpload ) {
+				return onSelect( files );
+			}
+			onFilesPreUpload( files );
+			let setMedia;
+			if ( multiple ) {
+				if ( addToGallery ) {
+					// Since the setMedia function runs multiple times per upload group
+					// and is passed newMedia containing every item in its group each time, we must
+					// filter out whatever this upload group had previously returned to the
+					// gallery before adding and returning the image array with replacement newMedia
+					// values.
+
+					// Define an array to store urls from newMedia between subsequent function calls.
+					let lastMediaPassed = [];
+					setMedia = ( newMedia ) => {
+						// Remove any images this upload group is responsible for (lastMediaPassed).
+						// Their replacements are contained in newMedia.
+						const filteredMedia = ( value ?? [] ).filter(
+							( item ) => {
+								// If Item has id, only remove it if lastMediaPassed has an item with that id.
+								if ( item.id ) {
+									return ! lastMediaPassed.some(
+										// Be sure to convert to number for comparison.
+										( { id } ) =>
+											Number( id ) === Number( item.id )
+									);
+								}
+								// Compare transient images via .includes since gallery may append extra info onto the url.
+								return ! lastMediaPassed.some(
+									( { urlSlug } ) =>
+										item.url.includes( urlSlug )
+								);
+							}
+						);
+						// Return the filtered media array along with newMedia.
+						onSelect( filteredMedia.concat( newMedia ) );
+						// Reset lastMediaPassed and set it with ids and urls from newMedia.
+						lastMediaPassed = newMedia.map( ( media ) => {
+							// Add everything up to '.fileType' to compare via .includes.
+							const cutOffIndex = media.url.lastIndexOf( '.' );
+							const urlSlug = media.url.slice( 0, cutOffIndex );
+							return { id: media.id, urlSlug };
+						} );
+					};
+				} else {
+					setMedia = onSelect;
+				}
+			} else {
+				setMedia = ( [ media ] ) => onSelect( media );
+			}
+			mediaUpload( {
+				allowedTypes,
+				filesList: files,
+				onFileChange: setMedia,
+				onError,
+			} );
+		},
+	];
+}


### PR DESCRIPTION
WIP. Not ready to be looked at. 

Follow up to https://github.com/WordPress/gutenberg/pull/35397 and potentially fixes https://github.com/WordPress/gutenberg/issues/22273

I'll be playing around with a few ideas to make the MediaPlaceholder easier to reason about. We'll need to balance:

1. Providing better out of the box defaults for things like file types, blob preview replacement, loading states, resizing (Many blocks implement this on a case by case basis which will lead to inconsistencies).
2. Still leaving enough wiggle room for customization, and full replacement using the `editor.MediaPlaceholder` filter

I've also noticed that this file is a bit difficult to read. Part of this is from prioritizing code reuse (reused render functions) over composition or more declarative components. This probably happened naturally over time, but I think it's worth revisiting.