### PR TITLE
Try: Remove segmented control vertical separators

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Change
+### Enhancements
 
--   Removed the separator shown between items. ([#35497](https://github.com/WordPress/gutenberg/pull/35497)).
+-   Removed the separator shown between `ToggleGroupControl` items ([#35497](https://github.com/WordPress/gutenberg/pull/35497)).
 
 ### Breaking Changes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Change
+
+-   Removed the separator shown between items. ([#35497](https://github.com/WordPress/gutenberg/pull/35497)).
+
 ### Breaking Changes
 
 -   Removed the deprecated `position` and `menuLabel` from the `DropdownMenu` component ([#34537](https://github.com/WordPress/gutenberg/pull/34537)).

--- a/packages/components/src/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/README.md
@@ -6,6 +6,8 @@ This feature is still experimental. “Experimental” means this is an early im
 
 `ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use `ToggleGroupControlOption` component.
 
+Only use this control when you know for sure the labels of items inside won't wrap. For items with longer labels, you can consider a Dropdown component instead.
+
 ## Usage
 
 ```js

--- a/packages/components/src/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/README.md
@@ -6,7 +6,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 `ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use `ToggleGroupControlOption` component.
 
-Only use this control when you know for sure the labels of items inside won't wrap. For items with longer labels, you can consider a Dropdown component instead.
+Only use this control when you know for sure the labels of items inside won't wrap. For items with longer labels, you can consider a `SelectControl` or a `CustomSelectControl` component instead.
 
 ## Usage
 

--- a/packages/components/src/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/styles.ts
@@ -107,17 +107,6 @@ export const ButtonContentView = styled.div`
 	transform: translate( -50%, -50% );
 `;
 
-export const SeparatorView = styled.div`
-	background: ${ CONFIG.colorDivider };
-	height: calc( 100% - 4px - 4px );
-	position: absolute;
-	right: 0;
-	top: 4px;
-	transition: background ${ CONFIG.transitionDuration } linear;
-	${ reduceMotion( 'transition' ) }
-	width: 1px;
-`;
-
 export const separatorActive = css`
 	background: transparent;
 `;

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -152,24 +152,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
   visibility: hidden;
 }
 
-.emotion-15 {
-  background: rgba(0, 0, 0, 0.1);
-  height: calc( 100% - 4px - 4px );
-  position: absolute;
-  right: 0;
-  top: 4px;
-  -webkit-transition: background 200ms linear;
-  transition: background 200ms linear;
-  width: 1px;
-  background: transparent;
-}
-
-@media ( prefers-reduced-motion: reduce ) {
-  .emotion-15 {
-    transition-duration: 0ms;
-  }
-}
-
 <div
   class="components-base-control emotion-0 emotion-1"
 >
@@ -230,10 +212,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
             R
           </div>
         </button>
-        <div
-          aria-hidden="true"
-          class="emotion-15 emotion-16"
-        />
       </div>
       <div
         class="emotion-8 emotion-9"
@@ -262,10 +240,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
             J
           </div>
         </button>
-        <div
-          aria-hidden="true"
-          class="emotion-15 emotion-16"
-        />
       </div>
     </div>
   </div>

--- a/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-button.tsx
@@ -16,19 +16,13 @@ import * as styles from './styles';
 import type { ToggleGroupControlButtonProps } from './types';
 import { useCx } from '../utils/hooks';
 
-const {
-	ButtonContentView,
-	LabelPlaceholderView,
-	LabelView,
-	SeparatorView,
-} = styles;
+const { ButtonContentView, LabelPlaceholderView, LabelView } = styles;
 
 function ToggleGroupControlButton( {
 	className,
 	forwardedRef,
 	isBlock = false,
 	label,
-	showSeparator,
 	value,
 	...props
 }: ToggleGroupControlButtonProps ) {
@@ -56,17 +50,8 @@ function ToggleGroupControlButton( {
 					{ label }
 				</LabelPlaceholderView>
 			</Radio>
-			<ToggleGroupControlSeparator isActive={ ! showSeparator } />
 		</LabelView>
 	);
 }
-
-const ToggleGroupControlSeparator = memo(
-	( { isActive }: { isActive: boolean } ) => {
-		const cx = useCx();
-		const classes = cx( isActive && styles.separatorActive );
-		return <SeparatorView aria-hidden className={ classes } />;
-	}
-);
 
 export default memo( ToggleGroupControlButton );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option.tsx
@@ -13,32 +13,8 @@ import {
 	WordPressComponentProps,
 } from '../ui/context';
 import ToggleGroupControlButton from './toggle-group-control-button';
-import type {
-	ToggleGroupControlOptionProps,
-	ToggleGroupControlContextProps,
-} from './types';
+import type { ToggleGroupControlOptionProps } from './types';
 import { useToggleGroupControlContext } from './toggle-group-control-context';
-
-function getShowSeparator(
-	toggleGroupControlContext: ToggleGroupControlContextProps,
-	index: number
-) {
-	const { currentId, items, state } = toggleGroupControlContext;
-	if ( items.length < 3 ) {
-		return false;
-	}
-	const targetNodeExists =
-		items.find( ( { id } ) => id === currentId )?.ref?.current?.dataset
-			?.value === state;
-	const isLast = index === items.length - 1;
-	// If no target node exists, don't show the separator after the last item.
-	if ( ! targetNodeExists ) {
-		return ! isLast;
-	}
-	const isActive = items[ index ]?.id === currentId;
-	const isNextActive = items[ index + 1 ]?.id === currentId;
-	return ! ( isActive || isNextActive || isLast );
-}
 
 function ToggleGroupControlOption(
 	props: WordPressComponentProps< ToggleGroupControlOptionProps, 'input' >,
@@ -53,17 +29,12 @@ function ToggleGroupControlOption(
 		{ ...props, id },
 		'ToggleGroupControlOption'
 	);
-	const index = toggleGroupControlContext.items.findIndex(
-		( item ) => item.id === buttonProps.id
-	);
-	const showSeparator = getShowSeparator( toggleGroupControlContext, index );
 	return (
 		<ToggleGroupControlButton
 			ref={ forwardedRef }
 			{ ...{
 				...toggleGroupControlContext,
 				...buttonProps,
-				showSeparator,
 			} }
 		/>
 	);

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -85,7 +85,6 @@ export type ToggleGroupControlButtonProps = {
 	isBlock?: boolean;
 	label: string;
 	'aria-label'?: string;
-	showSeparator?: boolean;
 	value?: ReactText;
 	state?: any;
 };


### PR DESCRIPTION
## Description

Inspired by https://github.com/WordPress/gutenberg/pull/35395#issuecomment-938615968, this PR removes the vertical separators from the Segmented Control entirely, as in most examples of its usage I have found them to only add noise.

Before:

<img width="1270" alt="before" src="https://user-images.githubusercontent.com/1204802/136757866-dc51debd-2f8a-4a9d-894a-d470decc232e.png">

After:

<img width="1270" alt="after" src="https://user-images.githubusercontent.com/1204802/136757882-29fe7f33-da2e-4ff8-960d-843fdffc9e37.png">

Especially in the linked font size example where font sizes are labelled in 2 letter same-width abbreviations, this works especially well.

However there's an argument to be made that in the Featured Image example shown here, where label widths aren't uniform but buttons are still uniform-width, the uneven space between items is a downside. 

Let me know your thoughts.

## How has this been tested?

Insert the Featured Image block, add a width, then observe the segmented control.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
