### PR TITLE
Add fontStyle control to Site Tagline block

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -24,8 +24,9 @@
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,
-			"__experimentalFontWeight": true,
 			"__experimentalTextTransform": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true
 		}
 	},


### PR DESCRIPTION
This brings the block in sync with the Site Title block. Since they're often used in tandem, I think it makes sense to include this control visible for both.

Many of the [Twenty Twenty-Two header mockups](https://github.com/WordPress/twentytwentytwo/pull/74) use an italic site tagline, but in `trunk` (where there's currently just a "Weight" dropdown) it's impossible to make that happen via the UI. 

To test: 

- Add a Site Tagline block
- Note that it has an `Appearance` item in the sidebar, with both font weight and font style options. 

## Screenshot:

(Note that the "Weight" control changes to an "Appearance" control on the right)

Before|After
---|---
<img width="279" alt="Screen Shot 2021-10-11 at 8 08 32 AM" src="https://user-images.githubusercontent.com/1202812/136787571-72ae45be-4069-4288-80d7-38480d5ef8f0.png">|<img width="279" alt="Screen Shot 2021-10-11 at 8 08 54 AM" src="https://user-images.githubusercontent.com/1202812/136787578-e9e457e1-db65-4d19-83d0-dc142316c7d3.png">


