### PR TITLE
Global Styles: Don't output preset classes for colors defined by the theme

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -736,6 +736,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array $settings Settings to process.
 	 * @param array $preset_metadata One of the PRESETS_METADATA values.
+	 * @param array $origins List of origins to process.
 	 *
 	 * @return array Array of presets where the key and value are both the slug.
 	 */

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -739,11 +739,11 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @return array Array of presets where the key and value are both the slug.
 	 */
-	private static function get_settings_slugs( $settings, $preset_metadata ) {
+	private static function get_settings_slugs( $settings, $preset_metadata, $origins = self::VALID_ORIGINS ) {
 		$preset_per_origin = _wp_array_get( $settings, $preset_metadata['path'], array() );
 
 		$result = array();
-		foreach ( self::VALID_ORIGINS as $origin ) {
+		foreach ( $origins as $origin ) {
 			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
 				continue;
 			}


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I think this is a regression introduced in https://github.com/WordPress/gutenberg/pull/34334.

Consider a classic theme without a theme.json file, which adds a theme support for `editor-color-palette`. Because these colors get included in the theme.json via `get_from_editor_settings`, when  we call `get_preset_classes` , these color classes from the theme origin are being output. So for example if you are using the "Canard" theme, Global Styles outputs some CSS like this:

```
.has-color-red {
	color: var(--wp--preset--color--red) !important;
}
```

However the CSS variable isn't defined, but it doesn't get ignored, instead it seems to fall back to the broswer default.

So the root of the problem is that the CSS variables used by `get_preset_classes` don't match the variables output by `get_css_variables`. This is because `get_css_variables` only outputs CSS variables defined on the `core` origin, whereas `get_preset_classes` doesn't filter out origins.

This PR adds a filter to `get_settings_slugs` which is used by `get_preset_classes` to only output settings that are defined on the passed origins. The alternative approach would be to remove the filter from `get_settings_values_by_slug` and output the CSS variables for both the theme and core origins. In some ways this is preferable as it lightens the load for themes to opt into Global Styles, but it might create unexpected changes.
 
## How has this been tested?
- Use this PR: https://github.com/Automattic/themes/pull/4797
- Switch to Canard
- Set some colors on your blocks
- Without this PR the colors don't work. With this PR they do

## Screenshots <!-- if applicable -->
Before:
<img width="656" alt="Screenshot 2021-10-11 at 14 52 30" src="https://user-images.githubusercontent.com/275961/136801931-e3d1aa53-36e7-4a15-b95a-cbb4872b1dc4.png">

After:
<img width="621" alt="Screenshot 2021-10-11 at 14 52 55" src="https://user-images.githubusercontent.com/275961/136801972-73d10021-ac15-428a-8977-46ebc755bcae.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
