### PR TITLE
[Mobile] - HTML Mode - Show block-based theme colors

### DIFF
--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -73,15 +73,22 @@ export class HTMLTextInput extends Component {
 	}
 
 	render() {
-		const { getStylesFromColorScheme } = this.props;
-		const htmlStyle = getStylesFromColorScheme(
-			styles.htmlView,
-			styles.htmlViewDark
-		);
-		const placeholderStyle = getStylesFromColorScheme(
-			styles.placeholder,
-			styles.placeholderDark
-		);
+		const { getStylesFromColorScheme, style } = this.props;
+		const titleStyle = [
+			styles.htmlViewTitle,
+			style?.text && { color: style.text },
+		];
+		const htmlStyle = [
+			getStylesFromColorScheme( styles.htmlView, styles.htmlViewDark ),
+			style?.text && { color: style.text },
+		];
+		const placeholderStyle = {
+			...getStylesFromColorScheme(
+				styles.placeholder,
+				styles.placeholderDark
+			),
+			...( style?.text && { color: style.text } ),
+		};
 		return (
 			<HTMLInputContainer parentHeight={ this.props.parentHeight }>
 				<TextInput
@@ -89,7 +96,7 @@ export class HTMLTextInput extends Component {
 					accessibilityLabel="html-view-title"
 					textAlignVertical="center"
 					numberOfLines={ 1 }
-					style={ styles.htmlViewTitle }
+					style={ titleStyle }
 					value={ this.props.title }
 					placeholder={ __( 'Add title' ) }
 					placeholderTextColor={ placeholderStyle.color }

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -91,7 +91,13 @@ class Layout extends Component {
 	}
 
 	renderHTML() {
-		return <HTMLTextInput parentHeight={ this.state.rootViewHeight } />;
+		const { globalStyles } = this.props;
+		return (
+			<HTMLTextInput
+				parentHeight={ this.state.rootViewHeight }
+				style={ globalStyles }
+			/>
+		);
 	}
 
 	renderVisual() {


### PR DESCRIPTION
## Description
When toggling to HTML mode, if there's a block-based theme activated, the styles for the text might be hard to read since it's using the editor's default ones.

This PR adds support to show a block-based theme's colors when editing in HTML mode.

## How has this been tested?

### Test case 1 - Standard theme

- Open the app
- Toggle to HTML mode
- **Expect** to see the default editor colors for both dark/light mode

### Test case 2 - Block-based theme

- Open the app
- Toggle to HTML mode
- **Expect** to see the current theme's colors in HTML mode

## Screenshots <!-- if applicable -->

Block-based theme|Default light mode|Default dark mode
-|-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/136801867-323a50cd-95e8-48f8-b5a7-a771512e46f7.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/136801881-844f2944-a752-4b63-9a4a-6ec2d5a28a71.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/136801947-6cdda2fe-e23f-45dd-a54a-8e9a7d176489.png" width="200" /></kbd>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
