### PR TITLE
Rich text: formats: allow format to filter value when changing tag name

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -125,5 +125,11 @@ export const textColor = {
 		style: 'style',
 		class: 'class',
 	},
+	__unstableFilterAttributeValue( key, value ) {
+		if ( key !== 'style' ) return value;
+		if ( value && ! value.includes( 'background-color' ) ) return value;
+		const addedCSS = [ 'background-color', 'rgba(0, 0, 0, 0)' ].join( ':' );
+		return value ? [ value, addedCSS ].join( ';' ) : addedCSS;
+	},
 	edit: TextColorEdit,
 };

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -139,7 +139,9 @@ export const textColor = {
 		// We should not add a background-color if it's already set
 		if ( value && value.includes( 'background-color' ) ) return value;
 		const addedCSS = [ 'background-color', 'rgba(0, 0, 0, 0)' ].join( ':' );
-		return value ? [ value, addedCSS ].join( ';' ) : addedCSS;
+		// Prepend `addedCSS` to avoid a double `;;` as any the existing CSS
+		// rules will already include a `;`.
+		return value ? [ addedCSS, value ].join( ';' ) : addedCSS;
 	},
 	edit: TextColorEdit,
 };

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -125,6 +125,15 @@ export const textColor = {
 		style: 'style',
 		class: 'class',
 	},
+	/*
+	 * Since this format relies on the <mark> tag, it's important to
+	 * prevent the default yellow background color applied by most
+	 * browsers. The solution is to detect when this format is used with a
+	 * text color but no background color, and in such cases to override
+	 * the default styling with a transparent background.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/pull/35516
+	 */
 	__unstableFilterAttributeValue( key, value ) {
 		if ( key !== 'style' ) return value;
 		// We should not add a background-color if it's already set

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -127,7 +127,8 @@ export const textColor = {
 	},
 	__unstableFilterAttributeValue( key, value ) {
 		if ( key !== 'style' ) return value;
-		if ( value && ! value.includes( 'background-color' ) ) return value;
+		// We should not add a background-color if it's already set
+		if ( value && value.includes( 'background-color' ) ) return value;
 		const addedCSS = [ 'background-color', 'rgba(0, 0, 0, 0)' ].join( ':' );
 		return value ? [ value, addedCSS ].join( ';' ) : addedCSS;
 	},

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { textColor as settings } from './index';
 
-function parseCSS( css = '' ) {
+export function parseCSS( css = '' ) {
 	return css.split( ';' ).reduce( ( accumulator, rule ) => {
 		if ( rule ) {
 			const [ property, value ] = rule.split( ':' );

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { textColor as settings } from './index';
 
-export function parseCSS( css = '' ) {
+function parseCSS( css = '' ) {
 	return css.split( ';' ).reduce( ( accumulator, rule ) => {
 		if ( rule ) {
 			const [ property, value ] = rule.split( ':' );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -101,6 +101,12 @@ export function useRichText( {
 
 	if ( ! record.current ) {
 		setRecordFromProps();
+		// Sometimes properties are added programmatically
+		// and we need to make sure it's persisted to the
+		// block store / markup.
+		if ( record.current.formats.length > 0 ) {
+			handleChangesUponInit( record.current );
+		}
 	} else if (
 		selectionStart !== record.current.start ||
 		selectionEnd !== record.current.end
@@ -145,6 +151,31 @@ export function useRichText( {
 		// We batch both calls to only attempt to rerender once.
 		registry.batch( () => {
 			onSelectionChange( start, end );
+			onChange( _value.current, {
+				__unstableFormats: formats,
+				__unstableText: text,
+			} );
+		} );
+		forceRender();
+	}
+
+	function handleChangesUponInit( newRecord ) {
+		record.current = newRecord;
+
+		_value.current = toHTMLString( {
+			value: __unstableBeforeSerialize
+				? {
+						...newRecord,
+						formats: __unstableBeforeSerialize( newRecord ),
+				  }
+				: newRecord,
+			multilineTag,
+			preserveWhiteSpace,
+		} );
+
+		const { formats, text } = newRecord;
+
+		registry.batch( () => {
 			onChange( _value.current, {
 				__unstableFormats: formats,
 				__unstableText: text,

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -101,10 +101,19 @@ export function useRichText( {
 
 	if ( ! record.current ) {
 		setRecordFromProps();
-		// Sometimes properties are added programmatically
-		// and we need to make sure it's persisted to the
-		// block store / markup.
-		if ( record.current.formats.length > 0 ) {
+		// Sometimes formats are added programmatically and we need to make
+		// sure it's persisted to the block store / markup. If these formats
+		// are not applied, they could cause inconsistencies between the data
+		// in the visual editor and the frontend. Right now, it's only relevant
+		// to the `core/text-color` format, which is applied at runtime in
+		// certain circunstances. See the `__unstableFilterAttributeValue`
+		// function in `packages/format-library/src/text-color/index.js`.
+		// @todo find a less-hacky way of solving this.
+
+		const hasRelevantInitFormat =
+			record.current.formats[ 0 ]?.[ 0 ]?.type === 'core/text-color';
+
+		if ( hasRelevantInitFormat ) {
 			handleChangesUponInit( record.current );
 		}
 	} else if (

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -111,7 +111,7 @@ export function useRichText( {
 		// @todo find a less-hacky way of solving this.
 
 		const hasRelevantInitFormat =
-			record.current.formats[ 0 ]?.[ 0 ]?.type === 'core/text-color';
+			record.current?.formats[ 0 ]?.[ 0 ]?.type === 'core/text-color';
 
 		if ( hasRelevantInitFormat ) {
 			handleChangesUponInit( record.current );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -43,14 +43,6 @@ function createEmptyValue() {
 	};
 }
 
-function simpleFindKey( object, value ) {
-	for ( const key in object ) {
-		if ( object[ key ] === value ) {
-			return key;
-		}
-	}
-}
-
 function toFormat( { type, attributes } ) {
 	let formatType;
 
@@ -94,15 +86,25 @@ function toFormat( { type, attributes } ) {
 
 	const registeredAttributes = {};
 	const unregisteredAttributes = {};
+	const _attributes = { ...attributes };
 
-	for ( const name in attributes ) {
-		const key = simpleFindKey( formatType.attributes, name );
+	for ( const key in formatType.attributes ) {
+		const name = formatType.attributes[ key ];
+		registeredAttributes[ key ] = _attributes[ name ];
+		delete _attributes[ name ];
 
-		if ( key ) {
-			registeredAttributes[ key ] = attributes[ name ];
-		} else {
-			unregisteredAttributes[ name ] = attributes[ name ];
+		if ( formatType.__unstableFilterAttributeValue ) {
+			registeredAttributes[
+				key
+			] = formatType.__unstableFilterAttributeValue(
+				key,
+				registeredAttributes[ key ]
+			);
 		}
+	}
+
+	for ( const name in _attributes ) {
+		unregisteredAttributes[ name ] = attributes[ name ];
 	}
 
 	return {

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -90,7 +90,13 @@ function toFormat( { type, attributes } ) {
 
 	for ( const key in formatType.attributes ) {
 		const name = formatType.attributes[ key ];
+
+		if ( ! _attributes[ name ] ) continue;
+
 		registeredAttributes[ key ] = _attributes[ name ];
+
+		// delete the attribute and what's left is considered
+		// to be unregistered.
 		delete _attributes[ name ];
 
 		if ( formatType.__unstableFilterAttributeValue ) {

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -91,13 +91,12 @@ function toFormat( { type, attributes } ) {
 	for ( const key in formatType.attributes ) {
 		const name = formatType.attributes[ key ];
 
-		if ( ! _attributes[ name ] ) continue;
-
-		registeredAttributes[ key ] = _attributes[ name ];
-
-		// delete the attribute and what's left is considered
-		// to be unregistered.
-		delete _attributes[ name ];
+		if ( typeof _attributes[ name ] !== 'undefined' ) {
+			registeredAttributes[ key ] = _attributes[ name ];
+			// delete the attribute and what's left is considered
+			// to be unregistered.
+			delete _attributes[ name ];
+		}
 
 		if ( formatType.__unstableFilterAttributeValue ) {
 			registeredAttributes[

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -91,12 +91,7 @@ function toFormat( { type, attributes } ) {
 	for ( const key in formatType.attributes ) {
 		const name = formatType.attributes[ key ];
 
-		if ( typeof _attributes[ name ] !== 'undefined' ) {
-			registeredAttributes[ key ] = _attributes[ name ];
-			// delete the attribute and what's left is considered
-			// to be unregistered.
-			delete _attributes[ name ];
-		}
+		registeredAttributes[ key ] = _attributes[ name ];
 
 		if ( formatType.__unstableFilterAttributeValue ) {
 			registeredAttributes[
@@ -105,6 +100,14 @@ function toFormat( { type, attributes } ) {
 				key,
 				registeredAttributes[ key ]
 			);
+		}
+
+		// delete the attribute and what's left is considered
+		// to be unregistered.
+		delete _attributes[ name ];
+
+		if ( typeof registeredAttributes[ key ] === 'undefined' ) {
+			delete registeredAttributes[ key ];
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Fixes https://github.com/WordPress/gutenberg/pull/34680#issuecomment-934190177.

Problem: when changing the tag name from `span` to `mark` for the highlight format the transparent background color is not added for old highlights that have just a text colour and no background color. The transparent background color is needed to reset the default browser style.

Solution: allow a format type to filter the value to add a transparent background color if none is present.

I'm not quite sure about the future of this API, so I marked it as unstable.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
