### PR TITLE
Unify theme block placeholder content

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -85,7 +85,7 @@ function Placeholder() {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<p>{ __( 'Post content' ) }</p>
+			<p>{ __( 'Post Content' ) }</p>
 		</div>
 	);
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -85,7 +85,7 @@ function Placeholder() {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<p>{ __( 'This is a placeholder for post content.' ) }</p>
+			<p>{ __( 'Post content' ) }</p>
 		</div>
 	);
 }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -72,7 +72,7 @@ export default function PostDateEdit( {
 			{ dateI18n( resolvedFormat, date ) }
 		</time>
 	) : (
-		__( 'No Date' )
+		__( 'Post date' )
 	);
 	if ( isLink && date ) {
 		postDate = (

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -72,7 +72,7 @@ export default function PostDateEdit( {
 			{ dateI18n( resolvedFormat, date ) }
 		</time>
 	) : (
-		__( 'Post date' )
+		__( 'Post Date' )
 	);
 	if ( isLink && date ) {
 		postDate = (

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -59,9 +59,7 @@ export default function PostExcerptEditor( {
 	if ( ! postType || ! postId ) {
 		return (
 			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Post excerpt' ) }
-				</Warning>
+				<Warning>{ __( 'Post excerpt' ) }</Warning>
 			</div>
 		);
 	}

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -59,7 +59,7 @@ export default function PostExcerptEditor( {
 	if ( ! postType || ! postId ) {
 		return (
 			<div { ...blockProps }>
-				<Warning>{ __( 'Post excerpt' ) }</Warning>
+				<Warning>{ __( 'Post Excerpt' ) }</Warning>
 			</div>
 		);
 	}

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -60,7 +60,7 @@ export default function PostExcerptEditor( {
 		return (
 			<div { ...blockProps }>
 				<Warning>
-					{ __( 'Post excerpt block: no post found.' ) }
+					{ __( 'Post excerpt' ) }
 				</Warning>
 			</div>
 		);

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -52,18 +52,10 @@ export default function PostTermsEdit( {
 		} ),
 	} );
 
-	if ( ! hasPost ) {
+	if ( ! hasPost || ! term ) {
 		return (
 			<div { ...blockProps }>
-				{ __( 'Post Terms block: post not found.' ) }
-			</div>
-		);
-	}
-
-	if ( ! term ) {
-		return (
-			<div { ...blockProps }>
-				{ __( 'Post Terms block: no term specified.' ) }
+				{ __( 'Post Terms' ) }
 			</div>
 		);
 	}

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -53,11 +53,7 @@ export default function PostTermsEdit( {
 	} );
 
 	if ( ! hasPost || ! term ) {
-		return (
-			<div { ...blockProps }>
-				{ __( 'Post Terms' ) }
-			</div>
-		);
+		return <div { ...blockProps }>{ __( 'Post Terms' ) }</div>;
 	}
 
 	return (

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -46,7 +46,7 @@ export default function PostTitleEdit( {
 	} );
 
 	let titleElement = (
-		<TagName { ...blockProps }>{ __( 'An example title' ) }</TagName>
+		<TagName { ...blockProps }>{ __( 'Post title' ) }</TagName>
 	);
 
 	if ( postType && postId ) {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -46,7 +46,7 @@ export default function PostTitleEdit( {
 	} );
 
 	let titleElement = (
-		<TagName { ...blockProps }>{ __( 'Post title' ) }</TagName>
+		<TagName { ...blockProps }>{ __( 'Post Title' ) }</TagName>
 	);
 
 	if ( postType && postId ) {

--- a/packages/block-library/src/term-description/edit.js
+++ b/packages/block-library/src/term-description/edit.js
@@ -37,7 +37,7 @@ export default function TermDescriptionEdit( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className="wp-block-term-description__placeholder">
-					<span>{ __( 'Term description' ) }</span>
+					<span>{ __( 'Term Description' ) }</span>
 				</div>
 			</div>
 		</>

--- a/packages/block-library/src/term-description/edit.js
+++ b/packages/block-library/src/term-description/edit.js
@@ -37,7 +37,7 @@ export default function TermDescriptionEdit( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className="wp-block-term-description__placeholder">
-					<span>{ __( 'Term description.' ) }</span>
+					<span>{ __( 'Term description' ) }</span>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
Part of #35501.

Unifies the content of site editor block placeholder states by simply echoing the block name.

| Before | After | 
| - | - |
| <img width="325" src="https://user-images.githubusercontent.com/846565/136789558-9ddb63e0-86b3-4226-b915-550235bbfa13.png"> | <img width="325" alt="Screenshot 2021-10-11 at 15 59 08" src="https://user-images.githubusercontent.com/846565/136812513-02647694-8f41-4fd4-b09c-0f082d512bc2.png"> |

To test:

* Open Site Editor
* Insert the following blocks, ensuring none of them have data references (the 404 template is a good place to test):
  * Post Title
  * Post Content
  * Post Date
  * Post Excerpt
  * Post Author
  * Term Description
  * Next Post
  * Previous Post
  * Archive Title
  * Post Categories
  * Post Tags
 * Ensure placeholder content matches the screenshot above

Unfortunately Post Categories and Post Tags blocks are variations of the Post Terms block, so I don't think we can be more explicit on the canvas.