### PR TITLE
Update `Navigator` styling to facilitate sticky positioning

### DIFF
--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -52,8 +52,16 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 
 	const cx = useCx();
 	const classes = useMemo(
-		// Ensures horizontal overflow is visually accessible
-		() => cx( css( { overflowX: 'auto' } ), className ),
+		() =>
+			cx(
+				css( {
+					// Ensures horizontal overflow is visually accessible
+					overflowX: 'auto',
+					// In case the root has a height, it should not be exceeded
+					maxHeight: '100%',
+				} ),
+				className
+			),
 		[ className ]
 	);
 

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import Button from '../../button';
-import { Card, CardBody, CardHeader } from '../../card';
+import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { HStack } from '../../h-stack';
 import { Flyout } from '../../flyout';
 import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
@@ -22,74 +22,156 @@ function NavigatorButton( { path, isBack = false, ...props } ) {
 	);
 }
 
-const MyNavigation = () => {
-	return (
-		<NavigatorProvider initialPath="/">
-			<NavigatorScreen path="/">
-				<Card>
-					<CardBody>
-						<p>This is the home screen.</p>
+const MyNavigation = () => (
+	<NavigatorProvider
+		initialPath="/"
+		style={ { height: '100vh', maxHeight: '450px' } }
+	>
+		<NavigatorScreen path="/">
+			<Card>
+				<CardBody>
+					<p>This is the home screen.</p>
 
-						<HStack justify="flex-start" wrap>
-							<NavigatorButton isPrimary path="/child">
-								Navigate to child screen.
-							</NavigatorButton>
-
-							<NavigatorButton path="/overflow-child">
-								Navigate to screen with horizontal overflow.
-							</NavigatorButton>
-
-							<Flyout
-								trigger={ <Button>Open test dialog</Button> }
-								placement="bottom-start"
-							>
-								<CardHeader>Go</CardHeader>
-								<CardBody>Stuff</CardBody>
-							</Flyout>
-						</HStack>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
-
-			<NavigatorScreen path="/child">
-				<Card>
-					<CardBody>
-						<p>This is the child screen.</p>
-						<NavigatorButton isPrimary path="/" isBack>
-							Go back
+					<HStack justify="flex-start" wrap>
+						<NavigatorButton variant="primary" path="/child">
+							Navigate to child screen.
 						</NavigatorButton>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
-			<NavigatorScreen path="/overflow-child">
-				<Card>
-					<CardBody>
-						<NavigatorButton isPrimary path="/" isBack>
-							Go back
+
+						<NavigatorButton path="/overflow-child">
+							Navigate to screen with horizontal overflow.
 						</NavigatorButton>
-						<div
+
+						<NavigatorButton path="/stickies">
+							Navigate to screen with sticky content.
+						</NavigatorButton>
+
+						<Flyout
+							trigger={ <Button>Open test dialog</Button> }
+							placement="bottom-start"
+						>
+							<CardHeader>Go</CardHeader>
+							<CardBody>Stuff</CardBody>
+						</Flyout>
+					</HStack>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/child">
+			<Card>
+				<CardBody>
+					<p>This is the child screen.</p>
+					<NavigatorButton path="/" isBack>
+						Go back
+					</NavigatorButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/overflow-child">
+			<Card>
+				<CardBody>
+					<NavigatorButton path="/" isBack>
+						Go back
+					</NavigatorButton>
+					<div
+						style={ {
+							display: 'inline-block',
+							background: 'papayawhip',
+						} }
+					>
+						<span
 							style={ {
-								display: 'inline-block',
-								background: 'papayawhip',
+								color: 'palevioletred',
+								whiteSpace: 'nowrap',
+								fontSize: '42vw',
 							} }
 						>
-							<span
-								style={ {
-									color: 'palevioletred',
-									whiteSpace: 'nowrap',
-									fontSize: '42vw',
-								} }
-							>
-								¯\_(ツ)_/¯
-							</span>
-						</div>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
-		</NavigatorProvider>
-	);
-};
+							¯\_(ツ)_/¯
+						</span>
+					</div>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/stickies">
+			<Card>
+				<Sticky as={ CardHeader } z="2">
+					<NavigatorButton path="/" isBack>
+						Go back
+					</NavigatorButton>
+				</Sticky>
+				<CardBody>
+					<Sticky top="69px" colors="papayawhip/peachpuff">
+						<h2>A wild sticky element appears</h2>
+					</Sticky>
+					<MetaphorIpsum quantity={ 3 } />
+				</CardBody>
+				<CardBody>
+					<Sticky top="69px" colors="azure/paleturquoise">
+						<h2>Another wild sticky element appears</h2>
+					</Sticky>
+					<MetaphorIpsum quantity={ 3 } />
+				</CardBody>
+				<Sticky as={ CardFooter } colors="mistyrose/pink">
+					<Button variant="primary">Primary noop</Button>
+				</Sticky>
+			</Card>
+		</NavigatorScreen>
+	</NavigatorProvider>
+);
 
 export const _default = () => {
 	return <MyNavigation />;
 };
+
+function Sticky( {
+	as: Tag = 'div',
+	bottom = 0,
+	colors = 'whitesmoke/lightgrey',
+	style,
+	top = 0,
+	z: zIndex = 1,
+	...props
+} ) {
+	const [ bgColor, dotColor ] = colors.split( '/' );
+	const strictStyle = {
+		top,
+		bottom,
+		zIndex,
+		display: 'flex',
+		position: 'sticky',
+		background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
+		textAlign: 'center',
+	};
+	const propsOut = { ...props, style: { ...style, ...strictStyle } };
+	return <Tag { ...propsOut } />;
+}
+
+function MetaphorIpsum( { quantity } ) {
+	const list = [
+		'A pan of the particle is assumed to be an untorn trout. We can assume that any instance of a lawyer can be construed as a peevish page. A dietician is a plushest pamphlet. The testy aunt comes from an ebon halibut.',
+		'A dish is the basement of a romania. If this was somewhat unclear, their picture was, in this moment, a rustred sink. A precipitation is a bridgeless need. Before begonias, aprils were only snowflakes.',
+		'Those toes are nothing more than violets. A blithesome map without ghanas is truly a equinox of sicklied squirrels. Those acknowledgments are nothing more than brians. Their salad was, in this moment, a steadfast step-grandmother.',
+		'However, a profit can hardly be considered a doughy subway without also being a maid. They were lost without the pictured melody that composed their cheese. The halibut of a betty becomes a model care. A match is a sunlike owner.',
+		'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.',
+		'Authors often misinterpret the afterthought as a roseless mother-in-law, when in actuality it feels more like an uncapped thunderstorm. In recent years, some posit the tarry bottle to be less than acerb. They were lost without the unkissed timbale that composed their customer. A donna is a springtime breath.',
+		'It’s an undeniable fact, really; their museum was, in this moment, a snotty beef. The swordfishes could be said to resemble prowessed lasagnas. However, the rainier authority comes from a cureless soup. Unfortunately, that is wrong; on the contrary, the cover is a powder.',
+	];
+	// Shuffle the list
+	for ( let i = list.length - 1; i > 0; i-- ) {
+		// eslint-disable-next-line no-restricted-syntax
+		const randomIndex = Math.floor( Math.random() * ( i + 1 ) );
+		[ list[ i ], list[ randomIndex ] ] = [ list[ randomIndex ], list[ i ] ];
+	}
+	quantity = Math.min( list.length, quantity );
+	return (
+		<>
+			{ list.slice( 0, quantity ).map( ( text, key ) => (
+				<p style={ { maxWidth: '20em' } } key={ key }>
+					{ text }
+				</p>
+			) ) }
+		</>
+	);
+}

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -166,20 +166,10 @@ function Sticky( {
 function MetaphorIpsum( { quantity } ) {
 	const cx = useCx();
 	const list = [
-		'A pan of the particle is assumed to be an untorn trout. We can assume that any instance of a lawyer can be construed as a peevish page. A dietician is a plushest pamphlet. The testy aunt comes from an ebon halibut.',
-		'A dish is the basement of a romania. If this was somewhat unclear, their picture was, in this moment, a rustred sink. A precipitation is a bridgeless need. Before begonias, aprils were only snowflakes.',
-		'Those toes are nothing more than violets. A blithesome map without ghanas is truly a equinox of sicklied squirrels. Those acknowledgments are nothing more than brians. Their salad was, in this moment, a steadfast step-grandmother.',
-		'However, a profit can hardly be considered a doughy subway without also being a maid. They were lost without the pictured melody that composed their cheese. The halibut of a betty becomes a model care. A match is a sunlike owner.',
 		'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.',
 		'Authors often misinterpret the afterthought as a roseless mother-in-law, when in actuality it feels more like an uncapped thunderstorm. In recent years, some posit the tarry bottle to be less than acerb. They were lost without the unkissed timbale that composed their customer. A donna is a springtime breath.',
 		'It’s an undeniable fact, really; their museum was, in this moment, a snotty beef. The swordfishes could be said to resemble prowessed lasagnas. However, the rainier authority comes from a cureless soup. Unfortunately, that is wrong; on the contrary, the cover is a powder.',
 	];
-	// Shuffle the list
-	for ( let i = list.length - 1; i > 0; i-- ) {
-		// eslint-disable-next-line no-restricted-syntax
-		const randomIndex = Math.floor( Math.random() * ( i + 1 ) );
-		[ list[ i ], list[ randomIndex ] ] = [ list[ randomIndex ], list[ i ] ];
-	}
 	quantity = Math.min( list.length, quantity );
 	return (
 		<>

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -22,6 +22,7 @@ function NavigatorButton( { path, isBack = false, ...props } ) {
 	const navigator = useNavigator();
 	return (
 		<Button
+			variant="secondary"
 			onClick={ () => navigator.push( path, { isBack } ) }
 			{ ...props }
 		/>
@@ -41,7 +42,7 @@ const MyNavigation = () => {
 						<p>This is the home screen.</p>
 
 						<HStack justify="flex-start" wrap>
-							<NavigatorButton variant="primary" path="/child">
+							<NavigatorButton path="/child">
 								Navigate to child screen.
 							</NavigatorButton>
 
@@ -54,7 +55,11 @@ const MyNavigation = () => {
 							</NavigatorButton>
 
 							<Flyout
-								trigger={ <Button>Open test dialog</Button> }
+								trigger={
+									<Button variant="primary">
+										Open test dialog
+									</Button>
+								}
 								placement="bottom-start"
 							>
 								<CardHeader>Go</CardHeader>

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -94,8 +94,8 @@ const MyNavigation = () => {
 								className={ cx(
 									css( `
 										color: palevioletred;
-										whiteSpace: nowrap;
-										fontSize: 42vw;
+										white-space: nowrap;
+										font-size: 42vw;
 									` )
 								) }
 							>

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -1,10 +1,16 @@
 /**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+/**
  * Internal dependencies
  */
 import Button from '../../button';
 import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { HStack } from '../../h-stack';
 import { Flyout } from '../../flyout';
+import { useCx } from '../../utils/hooks/use-cx';
 import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
 
 export default {
@@ -22,104 +28,111 @@ function NavigatorButton( { path, isBack = false, ...props } ) {
 	);
 }
 
-const MyNavigation = () => (
-	<NavigatorProvider
-		initialPath="/"
-		style={ { height: '100vh', maxHeight: '450px' } }
-	>
-		<NavigatorScreen path="/">
-			<Card>
-				<CardBody>
-					<p>This is the home screen.</p>
+const MyNavigation = () => {
+	const cx = useCx();
+	return (
+		<NavigatorProvider
+			initialPath="/"
+			className={ cx( css( `height: 100vh; max-height: 450px;` ) ) }
+		>
+			<NavigatorScreen path="/">
+				<Card>
+					<CardBody>
+						<p>This is the home screen.</p>
 
-					<HStack justify="flex-start" wrap>
-						<NavigatorButton variant="primary" path="/child">
-							Navigate to child screen.
+						<HStack justify="flex-start" wrap>
+							<NavigatorButton variant="primary" path="/child">
+								Navigate to child screen.
+							</NavigatorButton>
+
+							<NavigatorButton path="/overflow-child">
+								Navigate to screen with horizontal overflow.
+							</NavigatorButton>
+
+							<NavigatorButton path="/stickies">
+								Navigate to screen with sticky content.
+							</NavigatorButton>
+
+							<Flyout
+								trigger={ <Button>Open test dialog</Button> }
+								placement="bottom-start"
+							>
+								<CardHeader>Go</CardHeader>
+								<CardBody>Stuff</CardBody>
+							</Flyout>
+						</HStack>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/child">
+				<Card>
+					<CardBody>
+						<p>This is the child screen.</p>
+						<NavigatorButton path="/" isBack>
+							Go back
 						</NavigatorButton>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
 
-						<NavigatorButton path="/overflow-child">
-							Navigate to screen with horizontal overflow.
+			<NavigatorScreen path="/overflow-child">
+				<Card>
+					<CardBody>
+						<NavigatorButton path="/" isBack>
+							Go back
 						</NavigatorButton>
-
-						<NavigatorButton path="/stickies">
-							Navigate to screen with sticky content.
-						</NavigatorButton>
-
-						<Flyout
-							trigger={ <Button>Open test dialog</Button> }
-							placement="bottom-start"
+						<div
+							className={ cx(
+								css( `
+									display: inline-block;
+									background: papayawhip;
+								` )
+							) }
 						>
-							<CardHeader>Go</CardHeader>
-							<CardBody>Stuff</CardBody>
-						</Flyout>
-					</HStack>
-				</CardBody>
-			</Card>
-		</NavigatorScreen>
+							<span
+								className={ cx(
+									css( `
+										color: palevioletred;
+										whiteSpace: nowrap;
+										fontSize: 42vw;
+									` )
+								) }
+							>
+								¯\_(ツ)_/¯
+							</span>
+						</div>
+					</CardBody>
+				</Card>
+			</NavigatorScreen>
 
-		<NavigatorScreen path="/child">
-			<Card>
-				<CardBody>
-					<p>This is the child screen.</p>
-					<NavigatorButton path="/" isBack>
-						Go back
-					</NavigatorButton>
-				</CardBody>
-			</Card>
-		</NavigatorScreen>
-
-		<NavigatorScreen path="/overflow-child">
-			<Card>
-				<CardBody>
-					<NavigatorButton path="/" isBack>
-						Go back
-					</NavigatorButton>
-					<div
-						style={ {
-							display: 'inline-block',
-							background: 'papayawhip',
-						} }
-					>
-						<span
-							style={ {
-								color: 'palevioletred',
-								whiteSpace: 'nowrap',
-								fontSize: '42vw',
-							} }
-						>
-							¯\_(ツ)_/¯
-						</span>
-					</div>
-				</CardBody>
-			</Card>
-		</NavigatorScreen>
-
-		<NavigatorScreen path="/stickies">
-			<Card>
-				<Sticky as={ CardHeader } z="2">
-					<NavigatorButton path="/" isBack>
-						Go back
-					</NavigatorButton>
-				</Sticky>
-				<CardBody>
-					<Sticky top="69px" colors="papayawhip/peachpuff">
-						<h2>A wild sticky element appears</h2>
+			<NavigatorScreen path="/stickies">
+				<Card>
+					<Sticky as={ CardHeader } z="2">
+						<NavigatorButton path="/" isBack>
+							Go back
+						</NavigatorButton>
 					</Sticky>
-					<MetaphorIpsum quantity={ 3 } />
-				</CardBody>
-				<CardBody>
-					<Sticky top="69px" colors="azure/paleturquoise">
-						<h2>Another wild sticky element appears</h2>
+					<CardBody>
+						<Sticky top="69px" colors="papayawhip/peachpuff">
+							<h2>A wild sticky element appears</h2>
+						</Sticky>
+						<MetaphorIpsum quantity={ 3 } />
+					</CardBody>
+					<CardBody>
+						<Sticky top="69px" colors="azure/paleturquoise">
+							<h2>Another wild sticky element appears</h2>
+						</Sticky>
+						<MetaphorIpsum quantity={ 3 } />
+					</CardBody>
+					<Sticky as={ CardFooter } colors="mistyrose/pink">
+						<Button variant="primary">Primary noop</Button>
 					</Sticky>
-					<MetaphorIpsum quantity={ 3 } />
-				</CardBody>
-				<Sticky as={ CardFooter } colors="mistyrose/pink">
-					<Button variant="primary">Primary noop</Button>
-				</Sticky>
-			</Card>
-		</NavigatorScreen>
-	</NavigatorProvider>
-);
+				</Card>
+			</NavigatorScreen>
+		</NavigatorProvider>
+	);
+};
 
 export const _default = () => {
 	return <MyNavigation />;
@@ -129,26 +142,29 @@ function Sticky( {
 	as: Tag = 'div',
 	bottom = 0,
 	colors = 'whitesmoke/lightgrey',
-	style,
 	top = 0,
 	z: zIndex = 1,
 	...props
 } ) {
+	const cx = useCx();
 	const [ bgColor, dotColor ] = colors.split( '/' );
-	const strictStyle = {
-		top,
-		bottom,
-		zIndex,
-		display: 'flex',
-		position: 'sticky',
-		background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
-		textAlign: 'center',
-	};
-	const propsOut = { ...props, style: { ...style, ...strictStyle } };
+	const className = cx(
+		css( {
+			top,
+			bottom,
+			zIndex,
+			display: 'flex',
+			position: 'sticky',
+			background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
+		} ),
+		props.className
+	);
+	const propsOut = { ...props, className };
 	return <Tag { ...propsOut } />;
 }
 
 function MetaphorIpsum( { quantity } ) {
+	const cx = useCx();
 	const list = [
 		'A pan of the particle is assumed to be an untorn trout. We can assume that any instance of a lawyer can be construed as a peevish page. A dietician is a plushest pamphlet. The testy aunt comes from an ebon halibut.',
 		'A dish is the basement of a romania. If this was somewhat unclear, their picture was, in this moment, a rustred sink. A precipitation is a bridgeless need. Before begonias, aprils were only snowflakes.',
@@ -168,7 +184,7 @@ function MetaphorIpsum( { quantity } ) {
 	return (
 		<>
 			{ list.slice( 0, quantity ).map( ( text, key ) => (
-				<p style={ { maxWidth: '20em' } } key={ key }>
+				<p className={ cx( css( `max-width: 20em;` ) ) } key={ key }>
 					{ text }
 				</p>
 			) ) }


### PR DESCRIPTION
This PR is mostly to expound on a point from #35369 and contains a tiny change with a long story (Storybook). Since #35332, if an implementor of `Navigator` has content styled with `position: sticky` it will have to add some styling to `Navigator` to have it and its first child `NavigatorScreen` not exceed the height of their parent scrollable context. Without doing so, the component itself may overflow and the sticky elements won't stick where intended. For a visual demonstration see the Storybook screen capture here or #35369 for an example within Gutenberg.

This PR proposes a style to ease the implementors task a bit. We can add `max-height: 100%` to `NavigatorScreen` and it's not really opinionated. It does nothing when the component root doesn't have a specified height and facilitates the styling task for an implementor since they only need to specify the height of the root element.

## Alternatives Considered
Add a prop to `Navigator` that adds the styling to match the height of its parent. Example:
```jsx
<Navigator isFullHeight />
```
This could work but depending on the style implementation may not suit every use case. To me, it feels like too much to think about for what seems an uncommon use case.

Another alternative is to simply add a note in the component’s readme to advise about styling for sticky situations.

## How has this been tested?
Manually in Storybook

## Screenshots

### Storybook demonstration
https://user-images.githubusercontent.com/9000376/136818965-efe39d8f-3cef-49f8-a255-bc81877dc28a.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
