### PR TITLE
Use a dark background for the site editor

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -55,7 +55,7 @@ body.toplevel_page_gutenberg-edit-site {
 	}
 
 	.interface-interface-skeleton__content {
-		background-color: $gray-400;
+		background-color: $gray-800;
 	}
 }
 


### PR DESCRIPTION
Part of #35503.

Updates the site editor background to use the same dark gray as the isolated template part editing view, and the template editor.

### Template part
<img width="1637" alt="Screenshot 2021-10-11 at 17 13 30" src="https://user-images.githubusercontent.com/846565/136822587-892212f1-b496-4072-a611-eed82db438cf.png">

### Template Editor
<img width="1636" alt="Screenshot 2021-10-11 at 17 14 43" src="https://user-images.githubusercontent.com/846565/136822688-52651841-57e4-4b83-948b-ce357324d56d.png">

### Now: Site Editor
![darkbg](https://user-images.githubusercontent.com/846565/136822824-caa366ca-5a8d-40e9-b23c-bbb3227b2b2d.gif)

### Testing
Open the site editor and notice the dark background that's visible while the template loads.
