### PR TITLE
List View: fix expand and collapsing when the icon is clicked

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -107,6 +107,7 @@
 			border-radius: inherit;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			z-index: 1;
+			pointer-events: none;
 
 			// Hide focus styles while a user is dragging blocks/files etc.
 			.is-dragging-components-draggable & {


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/35170 this PR fixes handling for expand/collapsing items in list view:

Before:

https://user-images.githubusercontent.com/1270189/136837501-0b0405be-68bf-42ec-bf7d-5c3cb3e80dc9.mp4

After:

https://user-images.githubusercontent.com/1270189/136844635-da208ec8-5e9e-4c79-8783-17e0e29973ae.mp4

### Testing Instructions

- In the Post or Site editor add some blocks with children and open list view
- Try clicking on the collapse icon to collapse items
- Try clicking on the expand icon to expand items
- Keyboard events still work as intended
- No regressions to focus styling or ellipsis functionality
