### PR TITLE
RawHTML component: Allow multiple children

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Update `rawHtml` to correctly concatenate multiple strings passed as children
+(see [35532](https://github.com/WordPress/gutenberg/pull/35532))
+
 ## 4.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -294,7 +294,7 @@ aside from `children` are passed.
 
 _Parameters_
 
--   _props_ `RawHTMLProps`: Children should be a string of HTML. Other props will be passed through to div wrapper.
+-   _props_ `RawHTMLProps`: Children should be a string of HTML or an array of strings. Other props will be passed through to the div wrapper.
 
 _Returns_
 

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -12,16 +12,20 @@ import { createElement } from './react';
  * To preserve additional props, a `div` wrapper _will_ be created if any props
  * aside from `children` are passed.
  *
- * @param {RawHTMLProps} props Children should be a string of HTML. Other props
- *                             will be passed through to div wrapper.
+ * @param {RawHTMLProps} props Children should be a string of HTML or an array
+ *                             of strings. Other props will be passed through
+ *                             to the div wrapper.
  *
  * @return {JSX.Element} Dangerously-rendering component.
  */
 export default function RawHTML( { children, ...props } ) {
+	// Concatenate into a single string if children is an array.
+	const rawHtml = Array.isArray( children ) ? children.join( '' ) : children;
+
 	// The DIV wrapper will be stripped by serializer, unless there are
 	// non-children props present.
 	return createElement( 'div', {
-		dangerouslySetInnerHTML: { __html: children },
+		dangerouslySetInnerHTML: { __html: rawHtml },
 		...props,
 	} );
 }

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createElement } from './react';
+import { Children, createElement } from './react';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /** @typedef {{children: string} & import('react').ComponentPropsWithoutRef<'div'>} RawHTMLProps */
@@ -19,11 +19,15 @@ import { createElement } from './react';
  * @return {JSX.Element} Dangerously-rendering component.
  */
 export default function RawHTML( { children, ...props } ) {
-	// Concatenate into a single string if children is an array.
-	const rawHtml = Array.isArray( children ) ? children.join( '' ) : children;
+	let rawHtml = '';
 
-	// The DIV wrapper will be stripped by serializer, unless there are
-	// non-children props present.
+	// Cast children as an array, and concatenate each element if it is a string.
+	Children.toArray( children ).forEach( ( child ) => {
+		if ( typeof child === 'string' ) {
+			rawHtml += child.trim();
+		}
+	} );
+
 	return createElement( 'div', {
 		dangerouslySetInnerHTML: { __html: rawHtml },
 		...props,

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -23,8 +23,8 @@ export default function RawHTML( { children, ...props } ) {
 
 	// Cast children as an array, and concatenate each element if it is a string.
 	Children.toArray( children ).forEach( ( child ) => {
-		if ( typeof child === 'string' ) {
-			rawHtml += child.trim();
+		if ( typeof child === 'string' && child.trim() !== '' ) {
+			rawHtml += child;
 		}
 	} );
 

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -28,6 +28,8 @@ export default function RawHTML( { children, ...props } ) {
 		}
 	} );
 
+	// The `div` wrapper will be stripped by the `renderElement` serializer in
+	// `./serialize.js` unless there are non-children props present.
 	return createElement( 'div', {
 		dangerouslySetInnerHTML: { __html: rawHtml },
 		...props,

--- a/packages/element/src/test/raw-html.js
+++ b/packages/element/src/test/raw-html.js
@@ -17,7 +17,7 @@ describe( 'RawHTML', () => {
 		expect( container.innerHTML ).toBe( expected );
 	} );
 
-	it( 'creates wrapper if assigned other props', () => {
+	it( 'adds other props to container element', () => {
 		const html = '<p>So scary!</p>';
 		const { container } = render(
 			<RawHTML className="foo">{ html }</RawHTML>
@@ -40,6 +40,26 @@ describe( 'RawHTML', () => {
 		);
 
 		const expected = '<div><p>So scary!</p><p>Extra paragraph</p></div>';
+		expect( container.innerHTML ).toBe( expected );
+	} );
+
+	it( 'renders an empty container if there are no children', () => {
+		const { container } = render( <RawHTML></RawHTML> );
+
+		const expected = '<div></div>';
+		expect( container.innerHTML ).toBe( expected );
+	} );
+
+	it( 'ignores non-string based children', () => {
+		const html = '<p>So scary!</p>';
+		const { container } = render(
+			<RawHTML>
+				{ html }
+				<p>Ignore this!</p>
+			</RawHTML>
+		);
+
+		const expected = '<div><p>So scary!</p></div>';
 		expect( container.innerHTML ).toBe( expected );
 	} );
 } );

--- a/packages/element/src/test/raw-html.js
+++ b/packages/element/src/test/raw-html.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -11,20 +11,35 @@ import RawHTML from '../raw-html';
 describe( 'RawHTML', () => {
 	it( 'is dangerous', () => {
 		const html = '<p>So scary!</p>';
-		const element = shallow( <RawHTML>{ html }</RawHTML> );
+		const { container } = render( <RawHTML>{ html }</RawHTML> );
+		const expected = '<div><p>So scary!</p></div>';
 
-		expect( element.type() ).toBe( 'div' );
-		expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
-		expect( element.prop( 'children' ) ).toBe( undefined );
+		expect( container.innerHTML ).toBe( expected );
 	} );
 
 	it( 'creates wrapper if assigned other props', () => {
 		const html = '<p>So scary!</p>';
-		const element = shallow( <RawHTML className="foo">{ html }</RawHTML> );
+		const { container } = render(
+			<RawHTML className="foo">{ html }</RawHTML>
+		);
 
-		expect( element.type() ).toBe( 'div' );
-		expect( element.prop( 'className' ) ).toBe( 'foo' );
-		expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
-		expect( element.prop( 'children' ) ).toBe( undefined );
+		expect( container.innerHTML ).toBe(
+			'<div class="foo"><p>So scary!</p></div>'
+		);
+	} );
+
+	it( 'concatenates children if multiple children present', () => {
+		const html = '<p>So scary!</p>';
+		const html2 = '<p>Extra paragraph</p>';
+
+		const { container } = render(
+			<RawHTML>
+				{ html }
+				{ html2 }
+			</RawHTML>
+		);
+
+		const expected = '<div><p>So scary!</p><p>Extra paragraph</p></div>';
+		expect( container.innerHTML ).toBe( expected );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR updates the RawHTML component to support passing multiple children instead of treating `children` as a string.

This means that if you wish to use the RawHTML component and include raw HTML from a few different variables, you don't need to manually concatenate those string before passing them to the component.

I have also updated the tests for the RawHTML component so that it uses React Testing Library and tests the output of the component, instead of the internal state of the React element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Running tests:

```
npm run test-unit -- --testPathPattern packages/element/src/test/raw-html.js
```

For a concrete example of the issue that I ran into that led to this PR, I was playing around with adding an extra string to the `RawHTML` component used in the post content block's ReadOnlyContent component (rendered when a Post Content block appears as a child of the Query loop block). [Around this line](https://github.com/wordpress/gutenberg/blob/d079ba2c16495d6d976f5e08a7b5d259c3f13074/packages/block-library/src/post-content/edit.js#L36).

Example code:

```
		<div { ...blockProps }>
			<RawHTML key="html">
				{ content?.rendered } { '<p>Another paragraph</p>' }
			</RawHTML>
		</div>
```

The above code, before this PR, results in stray `,` characters being rendered, as the `children` array is joined into a string using `,` characters as a separator. With this PR applied, we concatenate the strings before passing to `dangerouslySetInnerHTML` so there are no stray comma characters.

If you wish to reproduce this, use the above code in line 36 of `/packages/block-library/src/post-content/edit.js` and using a block-based theme like TT1-Blocks, publish a post. Then, open up the site editor and view the post content block within a Query loop block. You should be able to then see the differences in the before/after screenshots below.

## Screenshots

Note the stray comma characters in the Before screenshot, and that they no longer appear in the After screenshot.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/136877080-a72474ba-9050-4ef9-9c71-bf3d6bf72067.png) | ![image](https://user-images.githubusercontent.com/14988353/136877093-189189b3-69cb-44de-9bbc-b94ba2429208.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
