### PR TITLE
Inserter: Fix gap between Search and Tabs

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -117,12 +117,11 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__tabs {
 	display: flex;
 	flex-direction: column;
-	margin-top: -$grid-unit-10;
 
 	.components-tab-panel__tabs {
 		position: sticky;
 		// Computed based off the search input height and paddings
-		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
+		top: $grid-unit-20 + $grid-unit-60;
 		background: $white;
 		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tabs");
 		border-bottom: $border-width solid $gray-300;


### PR DESCRIPTION
## Description
I noticed there's a gap between Search and Tabs in the block inserter.

I'm not sure if this recent regression or something we missed.

## How has this been tested?
1. Create a post.
2. Open block inserter.
3. Make sure there's no gap.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
| ![CleanShot 2021-10-12 at 14 44 34](https://user-images.githubusercontent.com/240569/136943038-ac3134e7-4919-450e-8ff6-74bf1cdd0822.png) | ![CleanShot 2021-10-12 at 14 46 22](https://user-images.githubusercontent.com/240569/136943042-14dbc6ed-79c6-475a-9f7b-8f56db77708f.png) |

## Types of changes
 Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
