### PR TITLE
Blocks: Fix relative URLs for inlined styles

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -326,28 +326,7 @@ function gutenberg_maybe_inline_styles() {
 
 			// Check if the style contains relative URLs that need to be modified.
 			// URLs relative to the stylesheet's path should be converted to relative to the site's root.
-			$has_src_results = preg_match_all( '#url\s*\(\s*[\'"]?\s*([^\'"\)]+)#', $style['css'], $src_results );
-			if ( $has_src_results ) {
-				// Loop through the URLs to find relative ones.
-				foreach ( $src_results[1] as $src_index => $src_result ) {
-					// Skip if this is an absolute URL.
-					if ( 0 === strpos( $src_result, 'http' ) ) {
-						continue;
-					}
-
-					// Build the absolute URL.
-					$absolute_url = dirname( $style['src'] ) . '/' . ltrim( $src_result, './' );
-					// Convert to URL related to the site root.
-					$relative_url = wp_make_link_relative( $absolute_url );
-
-					// Replace the URL in the CSS.
-					$style['css'] = str_replace(
-						$src_results[0][ $src_index ],
-						str_replace( $src_result, $relative_url, $src_results[0][ $src_index ] ),
-						$style['css']
-					);
-				}
-			}
+			$style['css'] = _wp_normalize_relative_css_links( $style['css'], $style['src'] );
 
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;
@@ -365,6 +344,46 @@ function gutenberg_maybe_inline_styles() {
 add_action( 'wp_head', 'gutenberg_maybe_inline_styles', 1 );
 // Run for late-loaded styles in the footer.
 add_action( 'wp_footer', 'gutenberg_maybe_inline_styles', 1 );
+
+if ( ! function_exists( '_wp_normalize_relative_css_links' ) ) {
+	/**
+	 * Make URLs relative to the WordPress installation.
+	 *
+	 * @since 5.8.2
+	 *
+	 * @param string $css            The CSS to make URLs relative to the WordPress installation.
+	 * @param string $stylesheet_url The URL to the stylesheet.
+	 *
+	 * @return string The CSS with URLs made relative to the WordPress installation.
+	 */
+	function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
+		$has_src_results = preg_match_all( '#url\s*\(\s*[\'"]?\s*([^\'"\)]+)#', $css, $src_results );
+		if ( $has_src_results ) {
+			// Loop through the URLs to find relative ones.
+			foreach ( $src_results[1] as $src_index => $src_result ) {
+				// Skip if this is an absolute URL.
+				if ( 0 === strpos( $src_result, 'http' ) || 0 === strpos( $src_result, '//' ) ) {
+					continue;
+				}
+
+				// Build the absolute URL.
+				$absolute_url = dirname( $stylesheet_url ) . '/' . $src_result;
+				$absolute_url = str_replace( '/./', '/', $absolute_url );
+				// Convert to URL related to the site root.
+				$relative_url = wp_make_link_relative( $absolute_url );
+
+				// Replace the URL in the CSS.
+				$css = str_replace(
+					$src_results[0][ $src_index ],
+					str_replace( $src_result, $relative_url, $src_results[0][ $src_index ] ),
+					$css
+				);
+			}
+		}
+
+		return $css;
+	}
+}
 
 /**
  * Complements the implementation of block type `core/social-icon`, whether it


### PR DESCRIPTION
## Description
Issue was reported in https://core.trac.wordpress.org/ticket/54243 and a patch was pushed in https://github.com/WordPress/wordpress-develop/pull/1752

This PR backports the same mods to Gutenberg.

When a stylesheets gets inlined, any relative URLs in that stylesheet break. 
The problem is that URLs inside CSS files are relative to the stylesheet's path, and when styles get inlined that relation is lost. This PR fixes the issue by finding relative URLs which then get modified to be relative to the site's root.

## How has this been tested?
Tested by adding the following CSS in a block stylesheet, and then making sure that URLs get properly updated.
Note: The CSS below is wrong and meaningless, but it does test the issue efficiently.
```css
.foo {
  background:url( "image0.svg" );
  background-image: url('./image2.png');
  background-image: url('../image1.jpg');
  background-image: url('http://foo.com/image2.png');
  background-image: url( 'https://bar.com/image2.png');
}
```

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
