### PR TITLE
Update range control metrics

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -16,7 +16,7 @@ const rangeHeightValue = 30;
 const railHeight = 4;
 const rangeHeight = () =>
 	css( { height: rangeHeightValue, minHeight: rangeHeightValue } );
-const thumbSize = 9;
+const thumbSize = 12;
 
 export const Root = styled.div`
 	-webkit-tap-highlight-color: transparent;

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -201,13 +201,13 @@ const thumbFocus = ( { isFocused } ) => {
 				&::before {
 					content: ' ';
 					position: absolute;
-					background-color: transparent;
-					box-shadow: 0 0 0 1.5px var( --wp-admin-theme-color );
+					background-color: var( --wp-admin-theme-color );
+					opacity: 0.4;
 					border-radius: 50%;
-					height: ${ thumbSize + 4 }px;
-					width: ${ thumbSize + 4 }px;
-					top: -2px;
-					left: -2px;
+					height: ${ thumbSize + 8 }px;
+					width: ${ thumbSize + 8 }px;
+					top: -4px;
+					left: -4px;
 				}
 		  `
 		: '';


### PR DESCRIPTION
## Description

The range control/slider was recently polished to have a smaller visual footprint:

<img width="271" alt="before" src="https://user-images.githubusercontent.com/1204802/136949729-ea9cddc5-175a-430e-b3f2-6ebcafe391d4.png">

However a bug in Chrome means we can't have a 3px tall slider track, and a proper rounded border radius as a radius of 1.5px is rounded down to 1px. So the track was made 4px tall. However with a 9px tall knob, that made the knob offset.

This PR updates the design of the slider based on new metrics from [the Global Styles figma](https://www.figma.com/file/oEkcAyhIvPFMVEAO8EImvA/Global-Styles?node-id=1700%3A0). 

That means a 12px knob:

<img width="271" alt="Screenshot 2021-10-12 at 13 40 58" src="https://user-images.githubusercontent.com/1204802/136949550-db12d49e-913f-480e-8b4b-51bacb3939fe.png">

And 20px focus style:

<img width="264" alt="Screenshot 2021-10-12 at 13 34 37" src="https://user-images.githubusercontent.com/1204802/136949579-d8fbba4d-da07-4cf0-ba25-e9473150133b.png">


## How has this been tested?

Insert a gallery, try the range control in the inspector.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
