### PR TITLE
Saving post: transparent disabled button.

### DIFF
--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -8,6 +8,8 @@
 	white-space: nowrap;
 
 	// The disabled version of the save state should be legible as an indicator.
+	&.is-saving[aria-disabled="true"],
+	&.is-saving[aria-disabled="true"]:hover,
 	&.is-saved[aria-disabled="true"],
 	&.is-saved[aria-disabled="true"]:hover {
 		background: transparent;


### PR DESCRIPTION
## Description
 
Followup to https://github.com/WordPress/gutenberg/pull/34947#issuecomment-940926807. 

The save state indicator is a disabled button, but has a gray background as shown in the comment above. This PR makes the background transparent. It's a big hard to capture a screenshot of, but it's the brief moment when the document is being _saved_.

<img width="375" alt="Screenshot 2021-10-12 at 13 47 16" src="https://user-images.githubusercontent.com/1204802/136950438-185f2ceb-1158-413d-a97e-9852f560db2d.png">

It's important to note that in both the saving and saved states, the button is inert, but it still serves as a an indicator of the save state, as well as what's going on. So it's important that it's legible in this state.

## How has this been tested?

Write content, then save, and the save button should have a transparent background even when saving.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
