### PR TITLE
Fix `ToggleGroupControlOption` not passing `ref` to the underlying element

### DIFF
--- a/packages/components/src/toggle-group-control/toggle-group-control-option.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option.tsx
@@ -31,7 +31,7 @@ function ToggleGroupControlOption(
 	);
 	return (
 		<ToggleGroupControlButton
-			ref={ forwardedRef }
+			forwardedRef={ forwardedRef }
 			{ ...{
 				...toggleGroupControlContext,
 				...buttonProps,


### PR DESCRIPTION
This PR is a small fix to avoid future issues.

The internal `ToggleGroupControlButton` component doesn't accept a `ref` prop. Instead, it expects to receive `forwardedRef`:
https://github.com/WordPress/gutenberg/blob/17bb52bab18046ee13cf7b4bca5d805b3e8e8557/packages/components/src/toggle-group-control/toggle-group-control-button.tsx#L23

Because of this, passing `ref` to `ToggleGroupControlOption` wouldn't work.