### PR TITLE
Update the global styles sidebar's root view to use Card components

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -4,6 +4,9 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	CardBody,
+	Card,
+	CardDivider,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -16,24 +19,32 @@ import ContextMenu from './context-menu';
 
 function ScreenRoot() {
 	return (
-		<>
-			<StylesPreview />
+		<Card size="small">
+			<CardBody>
+				<StylesPreview />
+			</CardBody>
 
-			<ContextMenu />
+			<CardBody>
+				<ContextMenu />
+			</CardBody>
 
-			<ItemGroup>
-				<Item>
-					<p>
-						{ __(
-							'Customize the appearance of specific blocks for the whole site.'
-						) }
-					</p>
-				</Item>
-				<NavigationButton path="/blocks">
-					{ __( 'Blocks' ) }
-				</NavigationButton>
-			</ItemGroup>
-		</>
+			<CardDivider />
+
+			<CardBody>
+				<ItemGroup>
+					<Item>
+						<p>
+							{ __(
+								'Customize the appearance of specific blocks for the whole site.'
+							) }
+						</p>
+					</Item>
+					<NavigationButton path="/blocks">
+						{ __( 'Blocks' ) }
+					</NavigationButton>
+				</ItemGroup>
+			</CardBody>
+		</Card>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -3,7 +3,6 @@
 	align-items: center;
 	justify-content: center;
 	min-height: 152px;
-	margin: $grid-unit-20;
 	line-height: 1;
 
 	.component-color-indicator {


### PR DESCRIPTION
Just a small refactoring to the root view in the global styles sidebar. This leverages the Card component to get closer to the in #34574 

Maybe there's too match padding between adjacent card bodies but I didn't want to rely on custom CSS.

<img width="278" alt="Screen Shot 2021-10-12 at 1 28 09 PM" src="https://user-images.githubusercontent.com/272444/136956307-a7043451-470c-400e-a98b-1388b06e9fc1.png">
