### PR TITLE
Try a special title for the main index template.

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -70,7 +70,8 @@ export default function Header( {
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
-			entityTitle: _entityTitle,
+			// Special case for the default template.
+			entityTitle: record?.slug === 'index' ? __( 'Main' ) : _entityTitle,
 			isLoaded: _isLoaded,
 			template: record,
 			templateType: postType,

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -71,7 +71,7 @@ export default function Header( {
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			// Special case for the default template.
-			entityTitle: record?.slug === 'index' ? __( 'Main' ) : _entityTitle,
+			entityTitle: record?.slug === 'index' ? __( 'Blog' ) : _entityTitle,
 			isLoaded: _isLoaded,
 			template: record,
 			templateType: postType,


### PR DESCRIPTION
## Description

The index template is special. It's the main template, the one which is required by WordPress. this PR refers to it as "Main" in the header, for that reason:

<img width="1270" alt="Screenshot 2021-10-12 at 14 29 11" src="https://user-images.githubusercontent.com/1204802/136956392-78e85a46-722b-4c99-a562-9e4ffe2a92be.png">

Penny for your thoughts?

## How has this been tested?

Open the site editor, browse to the Index template, and verify the site editor's header says "Main".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
