### PR TITLE
Fix invisible bottom sheet backdrop on Android

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -16,6 +16,7 @@ import {
 	Children,
 	useRef,
 	cloneElement,
+	Platform,
 } from '@wordpress/element';
 
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
@@ -87,7 +88,14 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 					typeof height !== 'string' ) ||
 				typeof height === 'string'
 			) {
-				performLayoutAnimation( ANIMATION_DURATION );
+				// Animating the opacity for the initial modal results in the backdrop
+				// provided by react-native-modal to never transition from transparent
+				// to partially opaque black. The core issue was not idenfited, but it
+				// may relate to the experimental state of LayoutAnimation for Android.
+				// https://reactnative.dev/docs/layoutanimation
+				if ( ! Platform.isAndroid || currentHeight !== 1 ) {
+					performLayoutAnimation( ANIMATION_DURATION );
+				}
 				setCurrentHeight( height );
 
 				return;

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 -   [*] [Embed block] Fix inline preview cut-off when editing URL [#35321]
 -   [*] [Unsupported Block Editor] Fix text selection bug for Android [#34668]
+-   [*] Fixed missing modal backdrop for Android help section [#35557]
 
 ## 1.63.0
 -   [**] [Embed block] Add the top 5 specific embed blocks to the Block inserter list [#34967]


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4106

## Description
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/4104. Animating the opacity for the initial modal results in the backdrop provided by `react-native-modal` to never transition from transparent to partially opaque black. The core issue was not idenfited, but it may relate to the [experimental state of LayoutAnimation for Android](https://reactnative.dev/docs/layoutanimation). 

## How has this been tested?

### Help modal
1. Launch the block editor on Android in landscape. 
2. Tap the three-dot button in the top-right corner of the editor. 
3. Tap "Help & Support."
4. Tap one of the help article titles. 
5. ℹ️ **Expected:** The Help modal displayed a slightly opaque black backdrop behind the modal. 

### Full-screen Cover Block Edit Focal Point
1. Launch the block editor on Android in landscape orientation. 
2. Add a Cover block. 
3. Add media to the block. 
4. Tap the block's settings cog button. 
5. Tap "Edit focal point." 
3. ℹ️ **Expected:** The focal point settings bottom sheet functions as expected in both landscape and portrait orientation. It includes a slightly opaque black backdrop behind the modal when in landscape orientation. 

### Full-screen Link Picker
1. Launch the block editor on Android in landscape orientation. 
2. Add a Paragraph block. 
3. Add text and tap the link button in the toolbar. 
4. Tap "Link to."
3. ℹ️ **Expected:** The link picker settings bottom sheet functions as expected in both landscape and portrait orientation. It includes a slightly opaque black backdrop behind the modal when in landscape orientation.  

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/438664/136986972-e28be22f-00f7-4c3a-9f88-884553509b4b.jpg) | ![after](https://user-images.githubusercontent.com/438664/136986993-ca8d63c2-b65f-43e5-9a52-08f883b35013.jpg) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
