### PR TITLE
Move the global styles reset action to a dropdown menu

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { DropdownMenu, FlexItem, FlexBlock, Flex } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { styles } from '@wordpress/icons';
+import { styles, moreHorizontal } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import DefaultSidebar from './default-sidebar';
 import { GlobalStylesUI, useGlobalStylesReset } from '../global-styles';
 
 export default function GlobalStylesSidebar() {
-	const [ canRestart, onReset ] = useGlobalStylesReset();
+	const [ canReset, onReset ] = useGlobalStylesReset();
 
 	return (
 		<DefaultSidebar
@@ -22,21 +22,27 @@ export default function GlobalStylesSidebar() {
 			icon={ styles }
 			closeLabel={ __( 'Close global styles sidebar' ) }
 			header={
-				<>
-					<strong>{ __( 'Styles' ) }</strong>
-					<span className="edit-site-global-styles-sidebar__beta">
-						{ __( 'Beta' ) }
-					</span>
-					<Button
-						className="edit-site-global-styles-sidebar__reset-button"
-						isSmall
-						variant="tertiary"
-						disabled={ ! canRestart }
-						onClick={ onReset }
-					>
-						{ __( 'Reset to defaults' ) }
-					</Button>
-				</>
+				<Flex>
+					<FlexBlock>
+						<strong>{ __( 'Styles' ) }</strong>
+						<span className="edit-site-global-styles-sidebar__beta">
+							{ __( 'Beta' ) }
+						</span>
+					</FlexBlock>
+					<FlexItem>
+						<DropdownMenu
+							icon={ moreHorizontal }
+							label={ __( 'More Global Styles Actions' ) }
+							toggleProps={ { disabled: ! canReset } }
+							controls={ [
+								{
+									title: __( 'Reset to defaults' ),
+									onClick: onReset,
+								},
+							] }
+						/>
+					</FlexItem>
+				</Flex>
 			}
 		>
 			<GlobalStylesUI />

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -3,7 +3,7 @@
  */
 import { DropdownMenu, FlexItem, FlexBlock, Flex } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { styles, moreHorizontal } from '@wordpress/icons';
+import { styles, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ export default function GlobalStylesSidebar() {
 					</FlexBlock>
 					<FlexItem>
 						<DropdownMenu
-							icon={ moreHorizontal }
+							icon={ moreVertical }
 							label={ __( 'More Global Styles Actions' ) }
 							toggleProps={ { disabled: ! canReset } }
 							controls={ [


### PR DESCRIPTION
Related to #34574

This PR moves to "reset global styles action" to an ellipsis menu to make it less prominent and open the door for future actions to be added there.

<img width="281" alt="Screen Shot 2021-10-12 at 5 07 23 PM" src="https://user-images.githubusercontent.com/272444/136991454-b42b6e8d-ddcd-496a-baf6-73076a05db8b.png">
