### PR TITLE
[Automated Testing]: Fix preview e2e tests

### DIFF
--- a/packages/e2e-test-utils/src/publish-post.js
+++ b/packages/e2e-test-utils/src/publish-post.js
@@ -15,8 +15,6 @@ export async function publishPost() {
 	// Publish the post
 	await page.click( '.editor-post-publish-button' );
 
-	// A success notice should show up
-	return page.waitForXPath(
-		'//div[contains(@class, "components-snackbar__content") and contains(text(),"Post published.")]'
-	);
+	// `PostPublishPanelPostpublish` will be visible after the post is published.
+	return page.waitForSelector( '.post-publish-panel__postpublish' );
 }

--- a/packages/e2e-test-utils/src/publish-post.js
+++ b/packages/e2e-test-utils/src/publish-post.js
@@ -16,5 +16,7 @@ export async function publishPost() {
 	await page.click( '.editor-post-publish-button' );
 
 	// A success notice should show up
-	return page.waitForSelector( '.components-snackbar' );
+	return page.waitForXPath(
+		'//div[contains(@class, "components-snackbar__content") and contains(text(),"Post published.")]'
+	);
 }

--- a/packages/e2e-test-utils/src/publish-post.js
+++ b/packages/e2e-test-utils/src/publish-post.js
@@ -15,6 +15,6 @@ export async function publishPost() {
 	// Publish the post
 	await page.click( '.editor-post-publish-button' );
 
-	// `PostPublishPanelPostpublish` will be visible after the post is published.
-	return page.waitForSelector( '.post-publish-panel__postpublish' );
+	// A success notice should show up
+	return page.waitForSelector( '.components-snackbar' );
 }

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -152,11 +152,21 @@ describe( 'Preview', () => {
 
 		// Preview for published post (no unsaved changes) directs to canonical URL for post.
 		await editorPage.bringToFront();
+		/**
+		 * Temp workaround until we find a reliable solution for `publishPost` util.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/pull/35565
+		 */
+		await editorPage.click( '.components-snackbar' );
 		await publishPost();
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
-		await editorPage.type( '.editor-post-title__input', ' And more.' );
+		await editorPage.waitForSelector( '.editor-post-title__input' );
+		await editorPage.click( '.editor-post-title__input' );
+		await pressKeyWithModifier( 'primary', 'A' );
+		await editorPage.keyboard.press( 'ArrowRight' );
+		await editorPage.keyboard.type( ' And more.' );
 		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
 

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -25,9 +25,6 @@ import {
  * @return {Promise} Promise resolving once selector is visible on page.
  */
 async function waitForPreviewDropdownOpen( editorPage ) {
-	await editorPage.waitForSelector(
-		'.block-editor-post-preview__button-toggle:not([disabled]'
-	);
 	await editorPage.click( '.block-editor-post-preview__button-toggle' );
 	return editorPage.waitForSelector(
 		'.edit-post-header-preview__button-external'

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -25,6 +25,9 @@ import {
  * @return {Promise} Promise resolving once selector is visible on page.
  */
 async function waitForPreviewDropdownOpen( editorPage ) {
+	await editorPage.waitForSelector(
+		'.block-editor-post-preview__button-toggle:not([disabled]'
+	);
 	await editorPage.click( '.block-editor-post-preview__button-toggle' );
 	return editorPage.waitForSelector(
 		'.edit-post-header-preview__button-external'


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35387

Previously `publishPost` util relied on waiting for the snackbar to exist, but after https://github.com/WordPress/gutenberg/pull/34731 a snackbar is shown in other cases as well - like saving a draft. This can create unexpected results with race conditions. An example would be the [preview test here](https://github.com/WordPress/gutenberg/blob/17bdf97b7ecfe579dfac10b415b84cf959865fdf/packages/e2e-tests/specs/editor/various/preview.test.js#L155-L161) where:
1. we initiated the save/publish
2. snackbar was there so the promise of `publishPost` resolved sooner than what we wanted
3. started typing in an input
4. the actual save/publish kicks in and `getEditedEntityRecord` gets these edits.

I think I got it right here with the flow.. --cc  @youknowriad ?

This PR changes the util to wait for `PostPublishPanelPostpublish`.

--edit seems PostPublishPanelPostpublish is not doing the trick and should find a better way to reliably know when a post is published..