### PR TITLE
Use new color picker props

### DIFF
--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -96,14 +96,13 @@ function ColorOption( {
 					renderContent={ () => (
 						<ColorPicker
 							color={ color }
-							onChangeComplete={ ( newColor ) =>
+							onChange={ ( newColor ) =>
 								onChange( {
-									color: newColor.hex,
+									color: newColor,
 									slug,
 									name,
 								} )
 							}
-							disableAlpha
 						/>
 					) }
 				/>

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -70,8 +70,7 @@ export default function ColorPalette( {
 	const renderCustomColorPicker = () => (
 		<ColorPicker
 			color={ value }
-			onChangeComplete={ ( color ) => onChange( color.hex ) }
-			disableAlpha
+			onChange={ ( color ) => onChange( color ) }
 		/>
 	);
 

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -3,7 +3,6 @@
 exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`] = `
 <ColorPicker
   color="#f00"
-  enableAlpha={false}
   onChange={[Function]}
 />
 `;

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -213,14 +213,14 @@ function ControlPoints( {
 					renderContent={ ( { onClose } ) => (
 						<>
 							<ColorPicker
-								disableAlpha={ disableAlpha }
+								enableAlpha={ ! disableAlpha }
 								color={ point.color }
-								onChangeComplete={ ( { rgb } ) => {
+								onChange={ ( color ) => {
 									onChange(
 										updateControlPointColor(
 											controlPoints,
 											index,
-											colord( rgb ).toRgbString()
+											colord( color ).toRgbString()
 										)
 									);
 								} }
@@ -291,14 +291,14 @@ function InsertPoint( {
 			) }
 			renderContent={ () => (
 				<ColorPicker
-					disableAlpha={ disableAlpha }
-					onChangeComplete={ ( { rgb } ) => {
+					enableAlpha={ ! disableAlpha }
+					onChange={ ( color ) => {
 						if ( ! alreadyInsertedPoint ) {
 							onChange(
 								addControlPoint(
 									controlPoints,
 									insertPosition,
-									colord( rgb ).toRgbString()
+									colord( color ).toRgbString()
 								)
 							);
 							setAlreadyInsertedPoint( true );
@@ -307,7 +307,7 @@ function InsertPoint( {
 								updateControlPointColorByPosition(
 									controlPoints,
 									insertPosition,
-									colord( rgb ).toRgbString()
+									colord( color ).toRgbString()
 								)
 							);
 						}


### PR DESCRIPTION
This PR updates our codebase to stop using deprecated ColorPicker properties.


## How has this been tested?
I verified the custom color picker still works as expected on the color palette, global styles palette editor, and the custom gradient picker.
