### PR TITLE
[RNMobile] Add SafeAreaView to Help & Support view

### DIFF
--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { kebabCase } from 'lodash';
-import { Text, ScrollView, StyleSheet, View } from 'react-native';
+import { Text, SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import { TransitionPresets } from '@react-navigation/stack';
 
 /**
@@ -86,119 +86,125 @@ function EditorHelpTopics( { close, isVisible, onClose } ) {
 			contentStyle={ styles.contentContainer }
 			testID="editor-help-modal"
 		>
-			<BottomSheet.NavigationContainer
-				animate
-				main
-				style={ styles.navigationContainer }
-			>
-				<BottomSheet.NavigationScreen
-					isScrollable
-					fullScreen
-					name="help-topics"
+			<SafeAreaView>
+				<BottomSheet.NavigationContainer
+					animate
+					main
+					style={ styles.navigationContainer }
 				>
-					<View style={ styles.container }>
-						<BottomSheet.NavBar>
-							<BottomSheet.NavBar.DismissButton
-								onPress={ close }
-								iosText={ __( 'Close' ) }
-							/>
-							<BottomSheet.NavBar.Heading>
-								{ title }
-							</BottomSheet.NavBar.Heading>
-						</BottomSheet.NavBar>
-						<BottomSheetConsumer>
-							{ ( { listProps } ) => {
-								const contentContainerStyle = StyleSheet.flatten(
-									listProps.contentContainerStyle
-								);
-								return (
-									<ScrollView
-										{ ...listProps }
-										contentContainerStyle={ {
-											...contentContainerStyle,
-											paddingBottom: Math.max(
-												listProps.safeAreaBottomInset,
-												contentContainerStyle.paddingBottom
-											),
-											/**
-											 * Remove margin set via `hideHeader`. Combining a header
-											 * and navigation in this bottom sheet is at odds with the
-											 * current `BottomSheet` implementation.
-											 */
-											marginTop: 0,
-										} }
-									>
-										<PanelBody>
-											<Text style={ sectionTitle }>
-												{ __( 'The basics' ) }
-											</Text>
-											{ /* Print out help topics */ }
-											{ HELP_TOPICS.map(
-												( { label, icon } ) => {
-													const labelSlug = kebabCase(
-														label
-													);
-													return (
-														<HelpTopicRow
-															key={ labelSlug }
-															label={ label }
-															icon={ icon }
-															screenName={
-																labelSlug
-															}
-														/>
-													);
-												}
-											) }
-											{
+					<BottomSheet.NavigationScreen
+						isScrollable
+						fullScreen
+						name="help-topics"
+					>
+						<View style={ styles.container }>
+							<BottomSheet.NavBar>
+								<BottomSheet.NavBar.DismissButton
+									onPress={ close }
+									iosText={ __( 'Close' ) }
+								/>
+								<BottomSheet.NavBar.Heading>
+									{ title }
+								</BottomSheet.NavBar.Heading>
+							</BottomSheet.NavBar>
+							<BottomSheetConsumer>
+								{ ( { listProps } ) => {
+									const contentContainerStyle = StyleSheet.flatten(
+										listProps.contentContainerStyle
+									);
+									return (
+										<ScrollView
+											{ ...listProps }
+											contentContainerStyle={ {
+												...contentContainerStyle,
+												paddingBottom: Math.max(
+													listProps.safeAreaBottomInset,
+													contentContainerStyle.paddingBottom
+												),
+												/**
+												 * Remove margin set via `hideHeader`. Combining a header
+												 * and navigation in this bottom sheet is at odds with the
+												 * current `BottomSheet` implementation.
+												 */
+												marginTop: 0,
+											} }
+										>
+											<PanelBody>
 												<Text style={ sectionTitle }>
-													{ __( 'Get support' ) }
+													{ __( 'The basics' ) }
 												</Text>
-											}
-											{
-												<HelpGetSupportButton
-													title={ __(
-														'Contact support'
-													) }
-													onPress={
-														requestContactCustomerSupport
+												{ /* Print out help topics */ }
+												{ HELP_TOPICS.map(
+													( { label, icon } ) => {
+														const labelSlug = kebabCase(
+															label
+														);
+														return (
+															<HelpTopicRow
+																key={
+																	labelSlug
+																}
+																label={ label }
+																icon={ icon }
+																screenName={
+																	labelSlug
+																}
+															/>
+														);
 													}
-												/>
-											}
-											{
-												<HelpGetSupportButton
-													title={ __(
-														'More support options'
-													) }
-													onPress={
-														requestGotoCustomerSupportOptions
-													}
-												/>
-											}
-										</PanelBody>
-									</ScrollView>
-								);
-							} }
-						</BottomSheetConsumer>
-					</View>
-				</BottomSheet.NavigationScreen>
-				{ /* Print out help detail screens */ }
-				{ HELP_TOPICS.map( ( { view, label } ) => {
-					const labelSlug = kebabCase( label );
-					return (
-						<HelpDetailNavigationScreen
-							key={ labelSlug }
-							name={ labelSlug }
-							content={ view }
-							label={ label }
-							options={ {
-								gestureEnabled: true,
-								...TransitionPresets.DefaultTransition,
-							} }
-						/>
-					);
-				} ) }
-			</BottomSheet.NavigationContainer>
+												) }
+												{
+													<Text
+														style={ sectionTitle }
+													>
+														{ __( 'Get support' ) }
+													</Text>
+												}
+												{
+													<HelpGetSupportButton
+														title={ __(
+															'Contact support'
+														) }
+														onPress={
+															requestContactCustomerSupport
+														}
+													/>
+												}
+												{
+													<HelpGetSupportButton
+														title={ __(
+															'More support options'
+														) }
+														onPress={
+															requestGotoCustomerSupportOptions
+														}
+													/>
+												}
+											</PanelBody>
+										</ScrollView>
+									);
+								} }
+							</BottomSheetConsumer>
+						</View>
+					</BottomSheet.NavigationScreen>
+					{ /* Print out help detail screens */ }
+					{ HELP_TOPICS.map( ( { view, label } ) => {
+						const labelSlug = kebabCase( label );
+						return (
+							<HelpDetailNavigationScreen
+								key={ labelSlug }
+								name={ labelSlug }
+								content={ view }
+								label={ label }
+								options={ {
+									gestureEnabled: true,
+									...TransitionPresets.DefaultTransition,
+								} }
+							/>
+						);
+					} ) }
+				</BottomSheet.NavigationContainer>
+			</SafeAreaView>
 		</BottomSheet>
 	);
 }


### PR DESCRIPTION
## Related PRs
- [Wrap NavigationContainer with SafeAreaView.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4110)

## Description
[Related issue.](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4030) When the Help view is rotated from portrait to landscape and back to portrait, it should continue to respect the device's Safe Area boundaries.

## How has this been tested?

Prerequisites: iOS device with a notch
1. In the portrait orientation, open the block editor in WPiOS by creating a new post.
2. Tap the three dots at the top right.
3. Tap "Help & Support".
4. Observe that the top of the view is under the notch.
5. Rotate the device into landscape.
6. Rotate the device back to portrait.
7. ℹ️ **Expected:** The top of the sheet view abides by the Safe Area boundaries.

## Screenshots

<img width="1526" alt="SafeArea" src="https://user-images.githubusercontent.com/2092798/138206990-1a2ea697-62ee-464a-896c-f1e765c4ac36.png">

**_See important note below._**

## Types of changes
Bug fix.

## Potential unintended areas of impact
- Android's Help & Support view

## ⚠️ Important note

As demonstrated in the above screenshots, the view will not match its original UI after the rotation sequence. The root problem (which affects all React Native bottom sheet views) has been identified and will be addressed later in a subsequent PR. Though this solution isn't optimal, it's limited in scope to just the Help & Support view and carries less risk.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
