### PR TITLE
Inspector Controls: resort the order of the design tools associated with styles hooks

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -264,9 +264,9 @@ export const withBlockControls = createHigherOrderComponent(
 			<>
 				{ shouldDisplayControls && (
 					<>
+						<ColorEdit { ...props } />
 						<TypographyPanel { ...props } />
 						<BorderPanel { ...props } />
-						<ColorEdit { ...props } />
 						<DimensionsPanel { ...props } />
 					</>
 				) }


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/35541

## Description

This change attempts to sorts the order of block inspector controls according to the following pattern:

1. Layout
2. Color
3. Typography
4. Dimensions
5. Border
6. Advanced

We're dealing with SlotFills, so, like making Bearnaise sauce, the order of execution matters. 

The styles supports – Color, Typography and Border components – [may be reordered.](https://github.com/WordPress/gutenberg/blob/c1b9bbd1984742000e86eabaa8f92a833fdbd816/packages/block-editor/src/hooks/style.js#L267)

The [Dimensions Inspector Controls Group however is rendered as the penultimate SlotFill](https://github.com/WordPress/gutenberg/blob/c1b9bbd1984742000e86eabaa8f92a833fdbd816/packages/block-editor/src/components/block-inspector/index.js#L132), before the Advanced Controls Group.

The consequence is the order is rendered so:

1. Layout
2. Color
3. Typography
4. Border
5. Dimensions
6. Advanced

More excitingly, the reason Layout is currently rendered at the top of the list is [because it's imported after style here](https://github.com/WordPress/gutenberg/blob/69e348ec80dc2cb9d537a8ba3cf6774b48636461/packages/block-editor/src/hooks/index.js#L15).  Last in first out. Moving `import './style';` to the bottom of the import causes the styles supports to be rendered first in the SlotFill.

Anyway, I've left the minor changes to styles as a preliminary PR for now to get us close, but for greater control over order, I think we'll need an immediate followup PR to further explore the use of Inspector Controls groups (introduced in https://github.com/WordPress/gutenberg/pull/34069).

For example, whether we need to create more groups, as queried by @gziolo in https://github.com/WordPress/gutenberg/pull/34069:

```jsx
<InspectorControls.Slot
    __experimentalGroup="layout"
    bubblesVirtually={ bubblesVirtually }
    label={ __( 'Layout' ) }
/>
<InspectorControls.Slot
    __experimentalGroup="dimensions"
    bubblesVirtually={ bubblesVirtually }
    label={ __( 'Dimensions' ) }
/>
<InspectorControls.Slot
    bubblesVirtually={ bubblesVirtually }
    label={ __( 'Border' ) }
/>
```

Or something to that effect. :)

Thank you!

## How has this been tested?

Ensure that you've enabled all block supports in your `theme.json`, i.e., `settings[color|typography|spacing|border]`. 

Next, activate support for a block in its block.json. The Group Block is fine block with which to test. 

Here's how my `supports` object for `group/block.json` looks:

```json
	"supports": {
		"align": [ "wide", "full" ],
		"anchor": true,
		"html": true,
		"color": {
			"gradients": true,
			"background": true,
			"link": true
		},
		"spacing": {
			"padding": true,
			"margin": true,
			"__experimentalDefaultControls": {
				"padding": true
			}
		},
		"typography": {
			"fontSize": true,
			"lineHeight": true,
			"__experimentalFontWeight": true
		},
		"__experimentalBorder": {
			"color": true,
			"radius": true,
			"style": true,
			"width": true
		},
		"__experimentalLayout": true
	},
```

Fire up the Block Editor and insert a Group Block. Select the Group Block and observe the order of the Inspector Controls.

| Before | After |
| ------------- | ------------- |
| <img width="282" alt="Screen Shot 2021-10-13 at 12 13 37 pm" src="https://user-images.githubusercontent.com/6458278/137063507-aea4e07e-4de2-4d04-85b4-8f389ad823ed.png">  | <img width="283" alt="Screen Shot 2021-10-13 at 2 42 25 pm" src="https://user-images.githubusercontent.com/6458278/137063504-caea82fe-b8df-4370-92eb-dcb2d513bd45.png">  |

## Types of changes
Order change in the rendering of style supports components.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
