### PR TITLE
Polish logos only style.

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -18,3 +18,7 @@
 	padding-left: calc((2/3) * 1em);
 	padding-right: calc((2/3) * 1em);
 }
+
+.wp-block-social-links.is-style-logos-only .wp-social-link button {
+	padding: 0;
+}

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -45,6 +45,10 @@
 			padding-left: calc((2/3) * 1em);
 			padding-right: calc((2/3) * 1em);
 		}
+
+		.is-style-logos-only & {
+			padding: 0;
+		}
 	}
 
 	.wp-social-link::before {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -104,8 +104,15 @@
 	.wp-social-link {
 		background: none;
 
+		a {
+			padding: 0;
+		}
+
 		// Make these bigger.
-		padding: 4px;
+		svg {
+			width: 1.25em;
+			height: 1.25em;
+		}
 	}
 
 	@import "../social-link/socials-without-bg.scss";


### PR DESCRIPTION
## Description

Fixes #35581.

This PR revisits the logos only style for social links. The block now uses `gap` to space things out, and some of the original metrics appear to have been lost in the shuffle. This PR tweaks so the logo-only versions are again a little bigger:

Before:
<img width="378" alt="before" src="https://user-images.githubusercontent.com/1204802/137111094-c9cb76ac-9984-474d-8c61-d475b04ec69e.png">

After:

<img width="354" alt="after" src="https://user-images.githubusercontent.com/1204802/137111117-60f3e5eb-0bb1-47d9-bf42-6107013efee0.png">


## How has this been tested?

Observe that the logos only style for social links doesn't space the blocks out too wide, and that the icons are a little bigger than in their circle style.

Here's some test content:

```
<!-- wp:paragraph -->
<p>Default style:</p>
<!-- /wp:paragraph -->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hihp","service":"deviantart"} /-->

<!-- wp:social-link {"url":"hjkl","service":"yelp"} /-->

<!-- wp:social-link {"url":"hjkl","service":"instagram"} /-->

<!-- wp:social-link {"url":"hjkl","service":"mastodon"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:paragraph -->
<p>Logos only:</p>
<!-- /wp:paragraph -->

<!-- wp:social-links {"className":"is-style-logos-only"} -->
<ul class="wp-block-social-links is-style-logos-only"><!-- wp:social-link {"url":"hihp","service":"deviantart"} /-->

<!-- wp:social-link {"url":"hjkl","service":"yelp"} /-->

<!-- wp:social-link {"url":"hjkl","service":"instagram"} /-->

<!-- wp:social-link {"url":"hjkl","service":"mastodon"} /--></ul>
<!-- /wp:social-links -->
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
