### PR TITLE
Add wide + full support to the site tagline block

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -12,6 +12,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "wide", "full" ],
 		"html": false,
 		"color": {
 			"gradients": true


### PR DESCRIPTION
This PR adds wide and full alignment support to the Site Tagline block, to bring it in sync with the Site Title block. 

I can't think of a great reason not to have feature parity between these two blocks. Besides, the designs for Twenty Twenty-Two feature a wide site tagline, and this allows us to achieve that without an extra columns block wrapper hack:

<img width="1308" alt="Screen Shot 2021-10-13 at 7 55 23 AM" src="https://user-images.githubusercontent.com/1202812/137127781-98337c84-5436-4b2b-89a3-6701155d879c.png">

Before|After
---|---
<img width="489" alt="Screen Shot 2021-10-13 at 7 57 26 AM" src="https://user-images.githubusercontent.com/1202812/137128033-064f1ed6-19cd-42c5-b006-f76f888178c1.png">|<img width="491" alt="Screen Shot 2021-10-13 at 7 53 10 AM" src="https://user-images.githubusercontent.com/1202812/137127883-b7fdf94a-49a4-438c-aea6-db6cdf20fc87.png">

