### PR TITLE
Custom Templates: Use "title" from the theme.json

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -59,6 +59,11 @@ function _gutenberg_get_template_file( $template_type, $slug ) {
 			if ( 'wp_template_part' === $template_type ) {
 				return _gutenberg_add_template_part_area_info( $new_template_item );
 			}
+
+			if ( 'wp_template' === $template_type ) {
+				return _gutenberg_add_template_info( $new_template_item );
+			}
+
 			return $new_template_item;
 		}
 	}
@@ -107,13 +112,35 @@ function _gutenberg_get_template_files( $template_type ) {
 
 			if ( 'wp_template_part' === $template_type ) {
 				$template_files[] = _gutenberg_add_template_part_area_info( $new_template_item );
-			} else {
-				$template_files[] = $new_template_item;
+			}
+
+			if ( 'wp_template' === $template_type ) {
+				$template_files[] = _gutenberg_add_template_info( $new_template_item );
 			}
 		}
 	}
 
 	return $template_files;
+}
+
+/**
+ * Attempts to add custom template information to the template item.
+ *
+ * @param array $template_item Template to add information to (requires 'slug' field).
+ * @return array Template
+ */
+function _gutenberg_add_template_info( $template_item ) {
+	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		return $template_item;
+	}
+
+	$theme_data = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_custom_templates();
+	if ( isset( $theme_data[ $template_item['slug'] ] ) ) {
+		$template_item['title']     = $theme_data[ $template_item['slug'] ]['title'];
+		$template_item['postTypes'] = $theme_data[ $template_item['slug'] ]['postTypes'];
+	}
+
+	return $template_item;
 }
 
 /**
@@ -222,7 +249,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;
-	$template->title          = $template_file['slug'];
+	$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 	$template->status         = 'publish';
 	$template->has_theme_file = true;
 


### PR DESCRIPTION
## Description
Updates `_gutenberg_get_template_files` method to merge `customTemplates` definition from the "theme.json."

PR introduces new `_gutenberg_add_template_info` helper method.

Fixes #32818.

## How has this been tested?
1. Install and Activate TT1 Blocks.
2. Create a page.
3. Templates dropdown should display a title - "Page without title" instead of a "slug."

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
| ![CleanShot 2021-10-13 at 16 14 22](https://user-images.githubusercontent.com/240569/137130722-77074cbb-764c-42f7-9ca6-e102a65cfc6c.png) | ![CleanShot 2021-10-13 at 16 15 00](https://user-images.githubusercontent.com/240569/137130730-5431d63d-1041-4da0-92f4-401c46f5f4b5.png) |

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
