### PR TITLE
Enable theme supports automatically for FSE theme

### DIFF
--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -8,7 +8,6 @@
 if ( gutenberg_is_fse_theme() ) {
 	add_theme_support( 'post-thumbnails' );
 	add_theme_support( 'responsive-embeds' );
-	add_theme_support( 'wp-block-styles' );
 	add_theme_support( 'editor-styles' );
 	add_theme_support(
 		'html5',
@@ -17,4 +16,6 @@ if ( gutenberg_is_fse_theme() ) {
 			'script',
 		)
 	);
+	add_theme_support( 'automatic-feed-links' );
+	add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 }

--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Loads default theme supports for block themes.
+ *
+ * @package gutenberg
+ */
+
+if ( gutenberg_is_fse_theme() ) {
+	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'responsive-embeds' );
+	add_theme_support( 'wp-block-styles' );
+	add_theme_support( 'editor-styles' );
+	add_theme_support(
+		'html5',
+		array(
+			'style',
+			'script',
+		)
+	);
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -108,6 +108,7 @@ require __DIR__ . '/full-site-editing/template-parts.php';
 require __DIR__ . '/full-site-editing/template-loader.php';
 require __DIR__ . '/full-site-editing/edit-site-page.php';
 require __DIR__ . '/full-site-editing/edit-site-export.php';
+require __DIR__ . '/compat/wordpress-5.9/default-theme-supports.php';
 
 require __DIR__ . '/blocks.php';
 require __DIR__ . '/block-patterns.php';


### PR DESCRIPTION
Related #26901 

We're introducing new kind of themes so it's a good opportunity to rethink what should be the defaults for themes. The idea is that ideally block themes shouldn't need to have a `functions.php` file at all to work properly. And if they need some config/theme supports, theme.json should be preferred.

The latter (theme.json config) is not supported yet in this PR, it will open a new kind of issues as Right now we use theme-supports to generate the final theme.json config used as a last resort cc @oandregal while we want to do the opposite for other theme supports: theme.json informs the value of theme supports. I think the idea here would be to have a `ThemeConfig` object/model that is the result of both `theme.json` and `theme supports` at the same time, and that model should be used consistently in WP's code base instead of relying directly on theme.json file or theme supports.

**Questions**

 - What do you think of the theme supports I chose to enable for all FSE themes?
 - Are there more theme supports to add?
 - Should we remove any?