### PR TITLE
Enable/skipped metabox test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -60,7 +60,10 @@ describe( 'Meta boxes', () => {
 		await page.waitForNavigation();
 
 		// Check the the dynamic block appears.
-		const latestPostsBlock = await page.waitForSelector( '.wp-block-latest-posts' );
+		const latestPostsBlock = await page.waitForSelector(
+			'.wp-block-latest-posts'
+		);
+		
 		expect(
 			await latestPostsBlock.evaluate( ( block ) => block.textContent )
 		).toContain( 'A published post' );

--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -39,7 +39,7 @@ describe( 'Meta boxes', () => {
 		await page.waitForSelector( '.editor-post-save-draft' );
 	} );
 
-	it.skip( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async () => {
+	it( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async () => {
 		// Publish a post so there's something for the latest posts dynamic block to render.
 		await page.type( '.editor-post-title__input', 'A published post' );
 		await insertBlock( 'Paragraph' );
@@ -60,7 +60,14 @@ describe( 'Meta boxes', () => {
 		await page.waitForNavigation();
 
 		// Check the the dynamic block appears.
-		await page.waitForSelector( '.wp-block-latest-posts' );
+		const latestPostsBlock = await page.waitForSelector( '.wp-block-latest-posts' );
+		expect(
+			await latestPostsBlock.evaluate( ( block ) => block.textContent )
+		).toContain( 'A published post' );
+
+		expect(
+			await latestPostsBlock.evaluate( ( block ) => block.textContent )
+		).toContain( 'Dynamic block test' );
 	} );
 
 	it( 'Should render the excerpt in meta based on post content if no explicit excerpt exists', async () => {

--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -63,7 +63,7 @@ describe( 'Meta boxes', () => {
 		const latestPostsBlock = await page.waitForSelector(
 			'.wp-block-latest-posts'
 		);
-		
+
 		expect(
 			await latestPostsBlock.evaluate( ( block ) => block.textContent )
 		).toContain( 'A published post' );


### PR DESCRIPTION
## Description

Fix for #32034.

## How has this been tested?
Run `npm run test-e2e -- packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js` locally and check the changed test still passes.

Use `for i in {1..5}; do npm run test-e2e -- packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js; done` to run the test file 5 times, for instance.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
