### PR TITLE
List View: try respecting a max width

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -297,7 +297,7 @@
 
 // First level of indentation is aria-level 2, max indent is 8.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
-$block-navigation-max-indent: 8;
+$block-navigation-max-indent: 4;
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
 	margin-left: ( $icon-size ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -295,9 +295,9 @@
 	width: $icon-size;
 }
 
-// First level of indentation is aria-level 2, max indent is 8.
+// First level of indentation is aria-level 2, max indent is 15.
 // Indent is a full icon size, plus 4px which optically aligns child icons to the text label above.
-$block-navigation-max-indent: 4;
+$block-navigation-max-indent: 15;
 .block-editor-list-view-leaf[aria-level] .block-editor-list-view__expander {
 	margin-left: ( $icon-size ) * $block-navigation-max-indent + 4 * ( $block-navigation-max-indent - 1 );
 }

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -46,6 +46,8 @@
 
 .edit-post-editor__list-view-panel-content {
 	overflow-y: auto;
+	overflow-x: auto;
+	max-width: 340px;
 	// The table cells use an extra pixels of space left and right. We compensate for that here.
 	padding: $grid-unit-10 ($grid-unit-10 - $border-width - $border-width);
 }

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -47,5 +47,7 @@
 
 .edit-site-editor__list-view-panel-content {
 	overflow-y: auto;
+	overflow-x: auto;
+	max-width: 350px;
 	padding: $grid-unit-10;
 }


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/35230 we noticed that the persistent list view may expand past 350px in width for the secondary sidebar. This can happen if a block has a particularly long label, or if items are nested deeply.

It'd be ideal if the secondary sidebar width can remain consistent in width. In a follow up being able to resize this to an arbitrary width may make sense too. 

The current max nesting depth is 8. We can see how this behaves in the following video. Any items nested past this point end up on the same visual level. Toggling expansion may change width, but with a max nesting depth it's more difficult to take up all the editor screen space.

https://user-images.githubusercontent.com/1270189/137196146-f4ca34ae-8fa7-4e69-8763-3b5dabfc34c2.mp4

Some challenges I found so far:
- Adding a max-width to the contents pane (and overflow-x scroll) makes it very difficult to access the block list options. So this might not be an ideal path.
- Flex puzzles with text overflow :D (Though I suspect we can't for i18n unfriendliness).
- We could perhaps truncate block labels. We already do this for named reusable blocks and template parts:

<img width="1202" alt="CleanShot 2021-10-13 at 12 01 44@2x" src="https://user-images.githubusercontent.com/1270189/137196941-4fd8064d-301e-445f-9052-4bbdff263f32.png">

This is just an early exploration, but feel free to explore and push directly to the branch if y'all have ideas cc @jasmussen @jameskoster 


