### PR TITLE
Cover block: Update placeholder minHeight style to support non-px units

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -116,7 +116,7 @@ function CoverHeightInput( {
 	const handleOnChange = ( unprocessedValue ) => {
 		const inputValue =
 			unprocessedValue !== ''
-				? parseInt( unprocessedValue, 10 )
+				? parseFloat( unprocessedValue )
 				: undefined;
 
 		if ( isNaN( inputValue ) && inputValue !== undefined ) {
@@ -148,7 +148,6 @@ function CoverHeightInput( {
 				onBlur={ handleOnBlur }
 				onChange={ handleOnChange }
 				onUnitChange={ onUnitChange }
-				step="1"
 				style={ { maxWidth: 80 } }
 				unit={ unit }
 				units={ units }
@@ -637,7 +636,12 @@ function CoverEdit( {
 						noticeUI={ noticeUI }
 						onSelectMedia={ onSelectMedia }
 						noticeOperations={ noticeOperations }
-						style={ { minHeight: temporaryMinHeight || minHeight } }
+						style={ {
+							minHeight:
+								temporaryMinHeight ||
+								minHeightWithUnit ||
+								undefined,
+						} }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Following on from #35068, this small PR ensures that the placeholder minimum height styles supports non-px units. Currently, the minimum height value is treated as a `px` value when applied to the placeholder's height, irrespective of the unit selected.

At the same time, for consistency with non-px units, the update logic is changed to use `parseFloat` instead of `parseInt` (to support decimal values in units like `em`, `rem`, `vw`, `vh`), and the hard-coded `step="1"` is removed to also support the fractional default step values for non-px units.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In the editor, add a Cover block. In its placeholder state, go to update the minimum height of the cover, and switch to a non-px unit like `em`. As you increase the number, note that before this PR, the value in the editor is treated as `px`. The real non-px value is still being correctly saved to the post content.

With this PR applied, note that non-px units like `em` and `rem` should work correctly in the Cover block's placeholder state. Also check that the addition of decimal / floating point values doesn't cause any issues.

Check that dragging the ResizableCover control still switches the unit to `px` as expected.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![cover-min-height-unit-before](https://user-images.githubusercontent.com/14988353/137249736-d9be1801-8ba5-4cc2-89e5-9cc08f66adcc.gif) | ![cover-min-height-unit-after](https://user-images.githubusercontent.com/14988353/137249761-c51fc4ea-36ac-49ec-af65-8dcda36979f6.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
