### PR TITLE
Quote: update deprecation to expect style block supports

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -28,10 +28,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalSlashInserter": true,
-		"typography": {
-			"fontSize": true
-		}
+		"__experimentalSlashInserter": true
 	},
 	"styles": [
 		{

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -28,7 +28,10 @@
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalSlashInserter": true
+		"__experimentalSlashInserter": true,
+		"typography": {
+			"fontSize": true
+		}
 	},
 	"styles": [
 		{

--- a/packages/block-library/src/quote/deprecated.js
+++ b/packages/block-library/src/quote/deprecated.js
@@ -96,6 +96,16 @@ const deprecated = [
 			},
 		},
 
+		migrate( attributes ) {
+			if ( ! isNaN( parseInt( attributes.style ) ) ) {
+				return {
+					...omit( attributes, [ 'style' ] ),
+				};
+			}
+
+			return attributes;
+		},
+
 		save( { attributes } ) {
 			const { align, value, citation, style } = attributes;
 

--- a/test/integration/fixtures/blocks/core__quote__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__quote__deprecated-1.json
@@ -5,8 +5,7 @@
 		"isValid": true,
 		"attributes": {
 			"value": "<p>Testing deprecated quote block...</p>",
-			"citation": "...with a caption",
-			"style": 1
+			"citation": "...with a caption"
 		},
 		"innerBlocks": [],
 		"originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\">\n\t<p>Testing deprecated quote block...</p>\n\t<footer>...with a caption</footer>\n</blockquote>"


### PR DESCRIPTION
## Description

Over at https://github.com/WordPress/gutenberg/pull/34064, we were hoping to add typography block supports to the Quote Block.

Then we ran into 😱 

<img width="600" alt="Screen Shot 2021-10-14 at 3 01 17 pm" src="https://user-images.githubusercontent.com/6458278/137249599-82530f9f-6b90-4557-8662-06267a0a0c8b.png">

Long ago, in the dark times, the quote block did have an attribute of `{ style: 1 }` to dictate a particular UI block style, e.g., Large or Cheese-Streamers-With-Comic-Sans.

To avoid the legacy `style` attribute hanging around, the Quote Block deprecations needs a teensy tweak to ensure the block is correctly migrated when we it opts-in to block supports that rely on a style attribute

## How has this been tested?

Run `npm run fixtures:generate`. The tests should pass.

If you want to check manually, activate TT1 blocks.

In `quote/block.json`, opt-in to any of the following block supports for the Core Quote Block:

```json
	"supports": {
		"anchor": true,
		"__experimentalSlashInserter": true,
		"color": {
			"gradients": true,
			"link": true
		},
		"spacing": {
			"padding": true,
			"margin": true
		},
		"typography": {
			"fontSize": true
		}
	},
```

You might have to enable support in your `theme.json` file as well, e.g., 

```json
		"spacing": {
			"blockGap": null,
			"customMargin": true,
			"customPadding": true,
			"units": [ "px", "em", "rem", "vh", "vw", "%" ]
		},
```

In the Block Editor code view field, paste the contents of [core__quote__deprecated.html](https://github.com/WordPress/gutenberg/blob/3a227817b79f2d377a6114d546871a5fe1d3223a/test/integration/fixtures/blocks/core__quote__deprecated-1.html)

```html
<!-- wp:core/quote -->
<blockquote class="wp-block-quote blocks-quote-style-1">
	<p>Testing deprecated quote block...</p>
	<footer>...with a caption</footer>
</blockquote>
<!-- /wp:core/quote -->
```

It should match the contents of [core__quote__deprecated-1.serialized.html](https://github.com/WordPress/gutenberg/blob/3a227817b79f2d377a6114d546871a5fe1d3223a/test/integration/fixtures/blocks/core__quote__deprecated-1.serialized.html)

![deprecation-quote](https://user-images.githubusercontent.com/6458278/137251206-1d549ea7-19e9-4a12-9159-2c03579a7fb3.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
