### PR TITLE
Register webfonts from theme.json

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -297,6 +297,24 @@ function gutenberg_register_webfonts_from_theme_json() {
 	}
 	$theme_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
 	if ( ! empty( $theme_settings['typography'] ) && ! empty( $theme_settings['typography']['webfonts'] ) ) {
+
+		// Check if webfonts have a "src" param, and if they do account for the use of "file:./".
+		foreach ( $theme_settings['typography']['webfonts'] as $key => $webfont ) {
+			if ( empty( $webfont['src'] ) ) {
+				continue;
+			}
+			$webfont['src'] = (array) $webfont['src'];
+
+			foreach ( $webfont['src'] as $src_key => $url ) {
+				// Tweak the URL to be relative to the theme root.
+				if ( 0 !== strpos( $url, 'file:./' ) ) {
+					continue;
+				}
+				$webfont['src'][ $src_key ] = get_theme_file_uri( str_replace( 'file:./', '', $url ) );
+			}
+
+			$theme_settings['typography']['webfonts'][ $key ] = $webfont;
+		}
 		wp_register_webfonts( $theme_settings['typography']['webfonts'] );
 	}
 }


### PR DESCRIPTION
## Description
This is a proof of concept for the discussion on https://github.com/WordPress/gutenberg/issues/35591

To test:
* WordPress should have the patch from https://github.com/WordPress/wordpress-develop/pull/1736, implementing the webfonts API
* In a `theme.json` file add the following under `settings.typography`:
```json
"webfonts": [
	{
		"fontFamily": "Source Serif Pro",
		"fontWeight": "200 900",
		"fontStyle": "normal",
		"fontStretch": "normal",
		"src": "file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2",
		"provider": "local"
	},
	{
		"fontFamily": "Source Serif Pro",
		"fontWeight": "200 900",
		"fontStyle": "italic",
		"fontStretch": "normal",
		"src": "file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2",
		"provider": "local"
	}
]
```
Easiest way to test is using the TT2 theme from https://github.com/aristath/twentytwentytwo

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
