### PR TITLE
Use text color to render the Aa preview in global styles.

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -26,7 +26,11 @@ const StylesPreview = () => {
 			style={ { background: gradientValue ?? backgroundColor } }
 		>
 			<HStack spacing={ 5 }>
-				<div style={ { fontFamily, fontSize: '80px' } }>Aa</div>
+				<div
+					style={ { fontFamily, fontSize: '80px', color: textColor } }
+				>
+					Aa
+				</div>
 				<VStack spacing={ 2 }>
 					<ColorIndicator colorValue={ textColor } />
 					<ColorIndicator colorValue={ linkColor } />


### PR DESCRIPTION
The Aa in the small preview should be using the text color for the representation.