### PR TITLE
Try: Remove dotted ancestor border.

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -66,22 +66,6 @@
 	}
 }
 
-// Ensures a border is present when a child block is selected.
-.block-editor-block-list__block[data-type="core/template-part"] {
-	&.has-child-selected {
-		&::after {
-			border: $border-width dotted var(--wp-admin-theme-color);
-		}
-
-		&.is-hovered,
-		&.is-highlighted {
-			&::after {
-				border: none;
-			}
-		}
-	}
-}
-
 .wp-block-template-part__placeholder-create-new__title-form {
 	.wp-block-template-part__placeholder-create-new__title-form-actions {
 		padding-top: $grid-unit-15;


### PR DESCRIPTION
## Description

Tiny PR to pull back on an experiment with dotted ancestor borders:

![no border](https://user-images.githubusercontent.com/1204802/137337952-0217e7e1-7996-4e99-94d3-c1a28b211fe1.gif)

It's always a balance with borders, it easily gets noisy and confuses what actually has focus. 

Thoughts?