### PR TITLE
wp-env: Add install-path command.

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Enhancement
+-   Added command `wp-env install-path` to list the directory used for the environment.
+-   The help entry is now shown when no subcommand is passed to `wp-env`.
+
+### Bug Fix
 -   Updated `yargs` to fix [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807).
 
 ## 4.1.3 (2021-11-07)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -400,6 +400,18 @@ Options:
   --watch    Watch for logs as they happen.            [boolean] [default: true]
 ```
 
+### `wp-env install-path`
+
+Outputs the absolute path to the WordPress environment files.
+
+Example:
+
+```sh
+$ wp-env install-path
+
+/home/user/.wp-env/63263e6506becb7b8613b02d42280a49
+```
+
 ## .wp-env.json
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -201,7 +201,7 @@ module.exports = function cli() {
 		'install-path',
 		'Get the path where environment files are located.',
 		() => {},
-		env.installPath
+		withSpinner( env.installPath )
 	);
 
 	return yargs;

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -197,6 +197,12 @@ module.exports = function cli() {
 		() => {},
 		withSpinner( env.destroy )
 	);
+	yargs.command(
+		'install-path',
+		'Get the path where environment files are located.',
+		() => {},
+		env.installPath
+	);
 
 	return yargs;
 };

--- a/packages/env/lib/commands/index.js
+++ b/packages/env/lib/commands/index.js
@@ -7,6 +7,7 @@ const clean = require( './clean' );
 const run = require( './run' );
 const destroy = require( './destroy' );
 const logs = require( './logs' );
+const installPath = require( './install-path' );
 
 module.exports = {
 	start,
@@ -15,4 +16,5 @@ module.exports = {
 	run,
 	destroy,
 	logs,
+	installPath,
 };

--- a/packages/env/lib/commands/install-path.js
+++ b/packages/env/lib/commands/install-path.js
@@ -8,6 +8,9 @@ const path = require( 'path' );
  */
 const { readConfig } = require( '../config' );
 
+/**
+ * Logs the path to where wp-env files are installed.
+ */
 module.exports = async function installPath() {
 	const { workDirectoryPath } = await readConfig(
 		path.resolve( '.wp-env.json' )

--- a/packages/env/lib/commands/install-path.js
+++ b/packages/env/lib/commands/install-path.js
@@ -1,32 +1,20 @@
 /**
- * External dependencies
- */
-const path = require( 'path' );
-const fs = require( 'fs' );
-
-/**
  * Internal dependencies
  */
-const { readConfig } = require( '../config' );
+const initConfig = require( '../init-config' );
 
 /**
  * Logs the path to where wp-env files are installed.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.spinner
+ * @param {boolean} options.debug
  */
-module.exports = async function installPath() {
-	const configPath = path.resolve( '.wp-env.json' );
-	if ( ! fs.existsSync( configPath ) ) {
-		console.error( 'Error: .wp-env.json file not found.' );
-		return;
-	}
-
-	const { workDirectoryPath } = await readConfig( configPath );
-
-	if ( ! fs.existsSync( workDirectoryPath ) ) {
-		console.error(
-			'Error: Environment has not yet been created. Try running `wp-env start`.'
-		);
-		return;
-	}
-
+module.exports = async function installPath( { spinner, debug } ) {
+	// Stop the spinner so that stdout is not polluted.
+	spinner.stop();
+	// initConfig will fail if wp-env start has not yet been called, so that
+	// edge case is handled.
+	const { workDirectoryPath } = await initConfig( { spinner, debug } );
 	console.log( workDirectoryPath );
 };

--- a/packages/env/lib/commands/install-path.js
+++ b/packages/env/lib/commands/install-path.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const { readConfig } = require( '../config' );
+
+module.exports = async function installPath() {
+	const { workDirectoryPath } = await readConfig(
+		path.resolve( '.wp-env.json' )
+	);
+	console.log( workDirectoryPath );
+};

--- a/packages/env/lib/commands/install-path.js
+++ b/packages/env/lib/commands/install-path.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const path = require( 'path' );
+const fs = require( 'fs' );
 
 /**
  * Internal dependencies
@@ -12,8 +13,20 @@ const { readConfig } = require( '../config' );
  * Logs the path to where wp-env files are installed.
  */
 module.exports = async function installPath() {
-	const { workDirectoryPath } = await readConfig(
-		path.resolve( '.wp-env.json' )
-	);
+	const configPath = path.resolve( '.wp-env.json' );
+	if ( ! fs.existsSync( configPath ) ) {
+		console.error( 'Error: .wp-env.json file not found.' );
+		return;
+	}
+
+	const { workDirectoryPath } = await readConfig( configPath );
+
+	if ( ! fs.existsSync( workDirectoryPath ) ) {
+		console.error(
+			'Error: Environment has not yet been created. Try running `wp-env start`.'
+		);
+		return;
+	}
+
 	console.log( workDirectoryPath );
 };


### PR DESCRIPTION
## Description

I have many `wp-env` instances on my machine for various projects I'm working on. When I go to the `wp-env` folder where all these instances are installed, I'm met with a bunch of hashes and I can't figure out which project is installed where.

This PR adds an `install-path` command that logs to the console where this particular instance's files are.

## Screenshots
![2021-10-14_17-07](https://user-images.githubusercontent.com/43731400/137346267-8142d52c-11f9-4d30-90fe-fbe4d15e033c.png)


## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
