### PR TITLE
Support disabling autosave for native Unsupported Block Editor

### DIFF
--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -42,6 +42,11 @@ export class AutosaveMonitor extends Component {
 			return;
 		}
 
+		if ( this.props.interval !== prevProps.interval ) {
+			clearTimeout( this.timerId );
+			this.setAutosaveTimer();
+		}
+
 		if ( ! this.props.isDirty ) {
 			this.needsAutosave = false;
 			return;

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -36,6 +36,12 @@ describe( 'AutosaveMonitor', () => {
 	} );
 
 	describe( '#componentDidUpdate()', () => {
+		it( 'should clear and restart autosave timer when the interval changes', () => {
+			wrapper.setProps( { interval: 999 } );
+			expect( clearTimeout ).toHaveBeenCalled();
+			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
+		} );
+
 		it( 'should set needsAutosave=true when editReference changes', () => {
 			expect( wrapper.instance().needsAutosave ).toBe( false );
 			wrapper.setProps( {
@@ -95,9 +101,9 @@ describe( 'AutosaveMonitor', () => {
 				isAutosaveable: true,
 				interval: 5,
 			} );
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 1 );
-			wrapper.instance().autosaveTimerHandler();
 			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
+			wrapper.instance().autosaveTimerHandler();
+			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 3 );
 			expect( setTimeout ).lastCalledWith( expect.any( Function ), 5000 );
 		} );
 
@@ -106,9 +112,9 @@ describe( 'AutosaveMonitor', () => {
 				isAutosaveable: false,
 				interval: 5,
 			} );
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 1 );
-			wrapper.instance().autosaveTimerHandler();
 			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
+			wrapper.instance().autosaveTimerHandler();
+			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 3 );
 			expect( setTimeout ).lastCalledWith( expect.any( Function ), 1000 );
 		} );
 


### PR DESCRIPTION
## Description
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/4130. 

Previously, there was no way to disable the autosave timer created within `AutosaveMonitor`'s `componentDidMount` hook, which was added in #23962. This resulted in unexpected remote drafts to be saved from within the native editor's Unsupported Block Editor (UBE) after the timer's 60 seconds elapsed. The UBE loads the web-based editor within a web view and leverages `autosaveInterval` to [prevent autosave creating remote drafts](https://github.com/WordPress/gutenberg/blob/21c9f042c3c0f44ee6147809d74291b67724a395/packages/react-native-bridge/common/gutenberg-web-single-block/prevent-autosaves.js#L2-L5).

This change enables clearing the initial autosave timer by modifying `interval` via `autosaveInterval`. Now, when the `interval` changes the previous timer is cleared and a new timer is created with the new `interval`.

## How has this been tested?

### Unexpected Drafts Not Created
1. Create a Jetpack-connected WordPress site. 
2. Save a draft post containing a block unsupported by the native editor, e.g. Tiled Gallery at time of writing. 
3. Clone this branch. 
4. `npm run build:plugin-zip` to generate an archive of Gutenberg. 
5. Install the archived Gutenberg into the Jetpack-connected site via upload. 
6. Open the same post in the native mobile editor. 
7. Tap the `?` button on the unsupported block. 
8. Leave the web-based Unsupported Block Editor open for 60+ seconds. 
9. Visit/refresh the Draft post list in the web WordPress admin. 
9. ℹ️ **Expected:** No additional drafts are created. 

### Intentional Changes Persisted
Complete steps 1-7 above, then...
1. Modify the unsupported block. 
2. Tap "Continue" to save changes in UBE. 
3. Tap "Update" to save post within native editor. 
4. ℹ️ **Expected:** The modifications are persisted to the posts. 

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
