### PR TITLE
Border Radius Control: Fix undefined value on first click into RangeControl

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -62,7 +62,10 @@ export default function BorderRadiusControl( { onChange, values } ) {
 	const toggleLinked = () => setIsLinked( ! isLinked );
 
 	const handleSliderChange = ( next ) => {
-		onChange( next !== undefined ? `${ next }${ unit }` : undefined );
+		const currentUnit = unit || 'px';
+		onChange(
+			next !== undefined ? `${ next }${ currentUnit }` : undefined
+		);
 	};
 
 	return (

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -53,7 +53,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
 	} );
-	const unit = getAllUnit( values );
+	const unit = getAllUnit( values ) || 'px';
 	const unitConfig = units && units.find( ( item ) => item.value === unit );
 	const step = unitConfig?.step || 1;
 
@@ -62,10 +62,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 	const toggleLinked = () => setIsLinked( ! isLinked );
 
 	const handleSliderChange = ( next ) => {
-		const currentUnit = unit || 'px';
-		onChange(
-			next !== undefined ? `${ next }${ currentUnit }` : undefined
-		);
+		onChange( next !== undefined ? `${ next }${ unit }` : undefined );
 	};
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #35628

As reported by @ockham, in blocks that opt-in to the border radius control, if you click to set a border radius using the `RangelControl` (the slider) from a fresh state where there isn't already a value, then the value in the code editor view will append `undefined` to the end of the value, instead of a fallback default unit that we'd expect (`px`).

This PR updates the border radius control's `handleSliderChange` method to treat the current unit as `px` if a unit is not currently set.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually in the editor.

1. Insert a block that opts in to the border radius (e.g. Button, Group, Image, Pullquote, Search)
2. From the initial state of the block, go to set a border radius by clicking once into the RangeControl (slider), without sliding left or right
3. Click to view the code editor view of the post.
4. With this PR applied, the border radius value should be added as a `px` value (beforehand, you'd see a value like `41undefined` whereas now it should be `41px`)

Smoke test that this change doesn't affect switching between units, or the behaviour of the UnitControl.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![border-radius-undefined-before](https://user-images.githubusercontent.com/14988353/137408767-5cc5428a-42ae-445d-81a7-f00a13822096.gif) | ![border-radius-undefined-after](https://user-images.githubusercontent.com/14988353/137408786-483b4107-82f1-4fe7-92ec-73acbacdd1e5.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
