### PR TITLE
Add shortcut provider

### DIFF
--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/block-editor';
 import { Popover, SlotFillProvider } from '@wordpress/components';
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import '@wordpress/format-library';
 
 /**
@@ -29,30 +30,32 @@ function App() {
 
 	return (
 		<div className="playground">
-			<SlotFillProvider>
-				<BlockEditorProvider
-					value={ blocks }
-					onInput={ updateBlocks }
-					onChange={ updateBlocks }
-				>
-					<div className="playground__sidebar">
-						<BlockInspector />
-					</div>
-					<div className="playground__content">
-						<BlockTools>
-							<div className="editor-styles-wrapper">
-								<BlockEditorKeyboardShortcuts.Register />
-								<WritingFlow>
-									<ObserveTyping>
-										<BlockList />
-									</ObserveTyping>
-								</WritingFlow>
-							</div>
-						</BlockTools>
-					</div>
-					<Popover.Slot />
-				</BlockEditorProvider>
-			</SlotFillProvider>
+			<ShortcutProvider>
+				<SlotFillProvider>
+					<BlockEditorProvider
+						value={ blocks }
+						onInput={ updateBlocks }
+						onChange={ updateBlocks }
+					>
+						<div className="playground__sidebar">
+							<BlockInspector />
+						</div>
+						<div className="playground__content">
+							<BlockTools>
+								<div className="editor-styles-wrapper">
+									<BlockEditorKeyboardShortcuts.Register />
+									<WritingFlow>
+										<ObserveTyping>
+											<BlockList />
+										</ObserveTyping>
+									</WritingFlow>
+								</div>
+							</BlockTools>
+						</div>
+						<Popover.Slot />
+					</BlockEditorProvider>
+				</SlotFillProvider>
+			</ShortcutProvider>
 		</div>
 	);
 }


### PR DESCRIPTION
## Description
Adds `ShortcutProvider` to the Playground, in order to fix an error when typing into the editor, which makes the story unusable.

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/1157901/137413279-99c91415-9af7-4493-a0c8-08fe0d61f6e5.png">

## How has this been tested?
- Run `npm run storybook:dev`
- You should be able to use the Block Editor within the Playground story without any errors.
