### PR TITLE
Block Editor List View: use anchor elements instead of buttons

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -46,9 +46,14 @@ function ListViewBlockSelectButton(
 		siblingBlockCount,
 		level
 	);
-	const onClickHandler = ( event ) => {
-		onClick();
-		event.preventDefault();
+
+	// The `href` attribute triggers the browser's native HTML drag operations.
+	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
+	// We need to clear any HTML drag data to prevent `pasteHandler` from firing
+	// inside the `useOnBlockDrop` hook.
+	const onDragStartHandler = ( event ) => {
+		event.dataTransfer.clearData();
+		onDragStart( event );
 	};
 
 	return (
@@ -58,12 +63,12 @@ function ListViewBlockSelectButton(
 					'block-editor-list-view-block-select-button',
 					className
 				) }
-				onClick={ onClickHandler }
+				onClick={ onClick }
 				aria-describedby={ descriptionId }
 				ref={ ref }
 				tabIndex={ tabIndex }
 				onFocus={ onFocus }
-				onDragStart={ onDragStart }
+				onDragStart={ onDragStartHandler }
 				onDragEnd={ onDragEnd }
 				draggable={ draggable }
 				href={ `#block-${ clientId }` }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, VisuallyHidden } from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -46,15 +46,19 @@ function ListViewBlockSelectButton(
 		siblingBlockCount,
 		level
 	);
+	const onClickHandler = ( event ) => {
+		onClick();
+		event.preventDefault();
+	};
 
 	return (
 		<>
-			<Button
+			<a
 				className={ classnames(
 					'block-editor-list-view-block-select-button',
 					className
 				) }
-				onClick={ onClick }
+				onClick={ onClickHandler }
 				aria-describedby={ descriptionId }
 				ref={ ref }
 				tabIndex={ tabIndex }
@@ -62,6 +66,7 @@ function ListViewBlockSelectButton(
 				onDragStart={ onDragStart }
 				onDragEnd={ onDragEnd }
 				draggable={ draggable }
+				href={ `#block-${ blockInformation?.anchor ?? clientId }` }
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
@@ -76,7 +81,7 @@ function ListViewBlockSelectButton(
 						{ __( '(selected block)' ) }
 					</VisuallyHidden>
 				) }
-			</Button>
+			</a>
 			<div
 				className="block-editor-list-view-block-select-button__description"
 				id={ descriptionId }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { VisuallyHidden } from '@wordpress/components';
+import { Button, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -58,7 +58,7 @@ function ListViewBlockSelectButton(
 
 	return (
 		<>
-			<a
+			<Button
 				className={ classnames(
 					'block-editor-list-view-block-select-button',
 					className
@@ -86,7 +86,7 @@ function ListViewBlockSelectButton(
 						{ __( '(selected block)' ) }
 					</VisuallyHidden>
 				) }
-			</a>
+			</Button>
 			<div
 				className="block-editor-list-view-block-select-button__description"
 				id={ descriptionId }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -66,7 +66,7 @@ function ListViewBlockSelectButton(
 				onDragStart={ onDragStart }
 				onDragEnd={ onDragEnd }
 				draggable={ draggable }
-				href={ `#block-${ blockInformation?.anchor ?? clientId }` }
+				href={ `#block-${ clientId }` }
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -19,6 +19,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { getBlockPositionDescription } from './utils';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
+import { SPACE, ENTER } from '@wordpress/keycodes';
 
 function ListViewBlockSelectButton(
 	{
@@ -30,7 +31,6 @@ function ListViewBlockSelectButton(
 		position,
 		siblingBlockCount,
 		level,
-		tabIndex,
 		onFocus,
 		onDragStart,
 		onDragEnd,
@@ -56,6 +56,13 @@ function ListViewBlockSelectButton(
 		onDragStart( event );
 	};
 
+	function onKeyDownHandler( event ) {
+		if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+			event.preventDefault();
+			onClick( event );
+		}
+	}
+
 	return (
 		<>
 			<Button
@@ -64,9 +71,10 @@ function ListViewBlockSelectButton(
 					className
 				) }
 				onClick={ onClick }
+				onKeyDown={ onKeyDownHandler }
 				aria-describedby={ descriptionId }
 				ref={ ref }
-				tabIndex={ tabIndex }
+				tabIndex="0"
 				onFocus={ onFocus }
 				onDragStart={ onDragStartHandler }
 				onDragEnd={ onDragEnd }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -31,6 +31,7 @@ function ListViewBlockSelectButton(
 		position,
 		siblingBlockCount,
 		level,
+		tabIndex,
 		onFocus,
 		onDragStart,
 		onDragEnd,
@@ -74,7 +75,7 @@ function ListViewBlockSelectButton(
 				onKeyDown={ onKeyDownHandler }
 				aria-describedby={ descriptionId }
 				ref={ ref }
-				tabIndex="0"
+				tabIndex={ tabIndex }
 				onFocus={ onFocus }
 				onDragStart={ onDragStartHandler }
 				onDragEnd={ onDragEnd }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -264,17 +264,6 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button {
-		text-decoration: none;
-		&:hover {
-			color: var(--wp-admin-theme-color);
-		}
-	}
-
-	&.is-selected .block-editor-list-view-block-select-button:hover {
-		color: $white;
-	}
-
 	.block-editor-list-view-block-select-button__anchor {
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -264,6 +264,17 @@
 		}
 	}
 
+	.block-editor-list-view-block-select-button {
+		text-decoration: none;
+		&:hover {
+			color: var(--wp-admin-theme-color);
+		}
+	}
+
+	&.is-selected .block-editor-list-view-block-select-button:hover {
+		color: $white;
+	}
+
 	.block-editor-list-view-block-select-button__anchor {
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -21,7 +21,7 @@ describe( 'Columns', () => {
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnBlockMenuItem = (
 			await page.$x(
-				'//button[contains(concat(" ", @class, " "), " block-editor-list-view-block-select-button ")][text()="Column"]'
+				'//a[contains(concat(" ", @class, " "), " block-editor-list-view-block-select-button ")][text()="Column"]'
 			)
 		 )[ 0 ];
 		await columnBlockMenuItem.click();

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -131,7 +131,7 @@ describe( 'Cover', () => {
 		// Select the cover block.By default the child paragraph gets selected.
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		await page.click(
-			'.block-editor-list-view-block__contents-container button'
+			'.block-editor-list-view-block__contents-container a'
 		);
 
 		const heightInput = (

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -51,7 +51,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnsBlockMenuItem = (
 			await page.$x(
-				"//button[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Columns')]"
+				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Columns')]"
 			)
 		 )[ 0 ];
 		await columnsBlockMenuItem.click();
@@ -75,7 +75,7 @@ describe( 'Navigating the block hierarchy', () => {
 		// Navigate to the last column block.
 		const lastColumnsBlockMenuItem = (
 			await page.$x(
-				"//button[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Column')]"
+				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Column')]"
 			)
 		 )[ 3 ];
 		await lastColumnsBlockMenuItem.click();
@@ -188,7 +188,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const groupMenuItem = (
 			await page.$x(
-				"//button[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Group')]"
+				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Group')]"
 			)
 		 )[ 0 ];
 		await groupMenuItem.click();

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -155,7 +155,7 @@ describe( 'Navigating the block hierarchy', () => {
 		// Return to first block.
 		await openListViewSidebar();
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'Space' );
+		await page.keyboard.press( 'Enter' );
 
 		// Replace its content.
 		await pressKeyWithModifier( 'primary', 'a' );

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -155,7 +155,7 @@ describe( 'Navigating the block hierarchy', () => {
 		// Return to first block.
 		await openListViewSidebar();
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Space' );
 
 		// Replace its content.
 		await pressKeyWithModifier( 'primary', 'a' );

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -42,12 +42,12 @@ describe( 'List view', () => {
 		await pressKeyWithModifier( 'access', 'o' );
 
 		const paragraphBlock = await page.waitForXPath(
-			'//button[contains(., "Paragraph")][@draggable="true"]'
+			'//a[contains(., "Paragraph")][@draggable="true"]'
 		);
 
 		// Drag above the heading block
 		const headingBlock = await page.waitForXPath(
-			'//button[contains(., "Heading")][@draggable="true"]'
+			'//a[contains(., "Heading")][@draggable="true"]'
 		);
 
 		await dragAndDrop( paragraphBlock, headingBlock, -5 );

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -60,7 +60,7 @@ describe( 'Document Settings', () => {
 					'.edit-post-header-toolbar__list-view-toggle'
 				);
 				const headerTemplatePartListViewButton = await page.waitForXPath(
-					'//button[contains(@class, "block-editor-list-view-block-select-button")][contains(., "Header")]'
+					'//a[contains(@class, "block-editor-list-view-block-select-button")][contains(., "Header")]'
 				);
 				headerTemplatePartListViewButton.click();
 				await page.click(

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -249,7 +249,7 @@ describe( 'Multi-entity save flow', () => {
 			// Select the header template part via list view.
 			await page.click( '.edit-site-header-toolbar__list-view-toggle' );
 			const headerTemplatePartListViewButton = await page.waitForXPath(
-				'//button[contains(@class, "block-editor-list-view-block-select-button")][contains(., "Header")]'
+				'//a[contains(@class, "block-editor-list-view-block-select-button")][contains(., "Header")]'
 			);
 			headerTemplatePartListViewButton.click();
 			await page.click( 'button[aria-label="Close list view sidebar"]' );


### PR DESCRIPTION
## Description

Resolves https://github.com/WordPress/gutenberg/issues/11711

Related to https://github.com/WordPress/gutenberg/issues/29733 (tracking issue) and has origins in https://github.com/WordPress/gutenberg/issues/7142

This PR swaps out the `<Button />` element with an `<a />`. The List View tree items are used to navigate to targets on the same page. 

For more reading on Links vs Buttons see:

- https://www.a11yproject.com/posts/2019-02-15-creating-valid-and-accessible-links/
- https://a11y-101.com/design/button-vs-link

If you want a user to navigate to a new page or to a different target on the same page, use an anchor element <a>.

https://user-images.githubusercontent.com/6458278/138374537-193d8de2-f016-40da-a1da-31aff579d4a8.mp4

One point to consider, suggested in https://github.com/WordPress/gutenberg/issues/7142, would be:

> If the markup is changed to a hyperlink then we may need to reconsider text in the hyperlink for it to make more sense as a hyperlink.

## How has this been tested?

Check that:
- There are no glaring regressions in the UI
- There are no regressions in keyboard navigation (Arrow/Tab keys, hitting Enter and Space). Note, seeing as we're changing the element to `<a />` ,  focus actions [are expected to be triggered using the Enter key](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#accessibility_concerns).
- Clicking on an item takes you to that item using the clientId anchor.
- 
## Types of changes
Markup changes to the Block List items for accessibility.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
