### PR TITLE
ToolsPanel: Improve unit tests

### DIFF
--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -344,7 +344,7 @@ describe( 'ToolsPanel', () => {
 
 			// When rendered as a placeholder a ToolsPanelItem will just omit
 			// all the item's children. So the container element will still be
-			// there holding it's position but the inner text etc should not be
+			// there holding its position but the inner text etc should not be
 			// there.
 			expect( optionalItem ).not.toBeInTheDocument();
 		} );

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -101,6 +101,7 @@ const renderGroupedItemsInPanel = () => {
 const WrappedItem = ( { text, ...props } ) => {
 	return (
 		<div className="wrapped-panel-item-container">
+			<span>Wrapper</span>
 			<ToolsPanelItem { ...props }>
 				<div>{ text }</div>
 			</ToolsPanelItem>
@@ -117,10 +118,6 @@ const renderWrappedItemInPanel = () => {
 		</ToolsPanel>
 	);
 };
-
-// Attempts to find the tools panel via its CSS class.
-const getPanel = ( container ) =>
-	container.querySelector( '.components-tools-panel' );
 
 // Renders a default tools panel including children that are
 // not to be represented within the panel's menu.
@@ -166,9 +163,9 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'basic rendering', () => {
 		it( 'should render panel', () => {
-			const { container } = renderPanel();
+			renderPanel();
 
-			expect( getPanel( container ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Visible' ) ).toBeInTheDocument();
 		} );
 
 		it( 'should render non panel item child', () => {
@@ -301,7 +298,7 @@ describe( 'ToolsPanel', () => {
 		} );
 
 		it( 'should render appropriate menu groups', async () => {
-			const { container } = render(
+			render(
 				<ToolsPanel { ...defaultProps }>
 					<ToolsPanelItem
 						{ ...controlProps }
@@ -316,16 +313,14 @@ describe( 'ToolsPanel', () => {
 			);
 			openDropdownMenu();
 
-			const menuGroups = container.querySelectorAll(
-				'.components-menu-group'
-			);
+			const menuGroups = screen.getAllByRole( 'group' );
 
 			// Groups should be: default controls, optional controls & reset all.
 			expect( menuGroups.length ).toEqual( 3 );
 		} );
 
-		it( 'should render placeholder items when panel opts into that feature', () => {
-			const { container } = render(
+		it( 'should not render contents of items when in placeholder state', () => {
+			render(
 				<ToolsPanel
 					{ ...defaultProps }
 					shouldRenderPlaceholderItems={ true }
@@ -337,15 +332,12 @@ describe( 'ToolsPanel', () => {
 			);
 
 			const optionalItem = screen.queryByText( 'Optional control' );
-			const placeholder = container.querySelector(
-				'.components-tools-panel-item'
-			);
 
 			// When rendered as a placeholder a ToolsPanelItem will just omit
-			// all the item's children. So we should still find the container
-			// element but not the text etc within.
+			// all the item's children. So the container element will still be
+			// there holding it's position but the inner text etc should not be
+			// there.
 			expect( optionalItem ).not.toBeInTheDocument();
-			expect( placeholder ).toBeInTheDocument();
 		} );
 	} );
 
@@ -429,11 +421,9 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'wrapped panel items within custom components', () => {
 		it( 'should render wrapped items correctly', () => {
-			const { container } = renderWrappedItemInPanel();
+			renderWrappedItemInPanel();
 
-			const wrappers = container.querySelectorAll(
-				'.wrapped-panel-item-container'
-			);
+			const wrappers = screen.getAllByText( 'Wrapper' );
 			const defaultItem = screen.getByText( 'Wrapped 1' );
 			const altItem = screen.queryByText( 'Wrapped 2' );
 

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -301,7 +301,7 @@ describe( 'ToolsPanel', () => {
 			expect( control ).toBeInTheDocument();
 
 			await selectMenuItem( controlProps.label );
-			const resetControl = screen.queryByText( 'Default control' );
+			const resetControl = screen.getByText( 'Default control' );
 
 			expect( resetControl ).toBeInTheDocument();
 		} );

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -537,6 +537,8 @@ describe( 'ToolsPanel', () => {
 			// so it could prevent erroneous registrations and calls to
 			// `onDeselect` etc.
 			//
+			// See: https://github.com/WordPress/gutenberg/pull/35375
+			//
 			// This test simulates this issue by rendering an item within a
 			// contrived `ToolsPanelContext` to reflect the changes the panel
 			// item needs to protect against.

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -406,16 +406,22 @@ describe( 'ToolsPanel', () => {
 			openDropdownMenu();
 
 			const defaultItem = screen.getByText( 'Nested Control 1' );
-			const defaultMenuItem = defaultItem.parentNode;
+			const defaultMenuItem = screen.getByRole( 'menuitemcheckbox', {
+				name: 'Reset Nested Control 1',
+				checked: true,
+			} );
 
 			const altItem = screen.getByText( 'Nested Control 2' );
-			const altMenuItem = altItem.parentNode;
+			const altMenuItem = screen.getByRole( 'menuitemcheckbox', {
+				name: 'Show Nested Control 2',
+				checked: false,
+			} );
 
 			expect( defaultItem ).toBeInTheDocument();
-			expect( defaultMenuItem ).toHaveAttribute( 'aria-checked', 'true' );
+			expect( defaultMenuItem ).toBeInTheDocument();
 
 			expect( altItem ).toBeInTheDocument();
-			expect( altMenuItem ).toHaveAttribute( 'aria-checked', 'false' );
+			expect( altMenuItem ).toBeInTheDocument();
 		} );
 	} );
 
@@ -439,16 +445,22 @@ describe( 'ToolsPanel', () => {
 			openDropdownMenu();
 
 			const defaultItem = screen.getByText( 'Nested Control 1' );
-			const defaultMenuItem = defaultItem.parentNode;
+			const defaultMenuItem = screen.getByRole( 'menuitemcheckbox', {
+				name: 'Reset Nested Control 1',
+				checked: true,
+			} );
 
 			const altItem = screen.getByText( 'Nested Control 2' );
-			const altMenuItem = altItem.parentNode;
+			const altMenuItem = screen.getByRole( 'menuitemcheckbox', {
+				name: 'Show Nested Control 2',
+				checked: false,
+			} );
 
 			expect( defaultItem ).toBeInTheDocument();
-			expect( defaultMenuItem ).toHaveAttribute( 'aria-checked', 'true' );
+			expect( defaultMenuItem ).toBeInTheDocument();
 
 			expect( altItem ).toBeInTheDocument();
-			expect( altMenuItem ).toHaveAttribute( 'aria-checked', 'false' );
+			expect( altMenuItem ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -137,14 +137,23 @@ const renderPanel = () => {
 };
 
 /**
+ * Retrieves the panel's dropdown menu toggle button.
+ *
+ * @return {HTMLElement} The menu button.
+ */
+const getMenuButton = () => {
+	return screen.getByRole( 'button', {
+		name: /view([\w\s]+)options/i,
+	} );
+};
+
+/**
  * Helper to find the menu button and simulate a user click.
  *
  * @return {HTMLElement} The menuButton.
  */
 const openDropdownMenu = () => {
-	const menuButton = screen.getByRole( 'button', {
-		name: /view([\w\s]+)options/i,
-	} );
+	const menuButton = getMenuButton();
 	fireEvent.click( menuButton );
 	return menuButton;
 };
@@ -165,15 +174,15 @@ describe( 'ToolsPanel', () => {
 		it( 'should render panel', () => {
 			renderPanel();
 
-			expect( screen.getByText( 'Visible' ) ).toBeInTheDocument();
-		} );
+			const menuButton = getMenuButton();
+			const label = screen.getByText( defaultProps.label );
+			const control = screen.getByText( 'Example control' );
+			const nonToolsPanelItem = screen.getByText( 'Visible' );
 
-		it( 'should render non panel item child', () => {
-			renderPanel();
-
-			const nonPanelItem = screen.queryByText( 'Visible' );
-
-			expect( nonPanelItem ).toBeInTheDocument();
+			expect( menuButton ).toBeInTheDocument();
+			expect( label ).toBeInTheDocument();
+			expect( control ).toBeInTheDocument();
+			expect( nonToolsPanelItem ).toBeInTheDocument();
 		} );
 
 		it( 'should render panel item flagged as default control even without value', () => {

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -100,7 +100,7 @@ const renderGroupedItemsInPanel = () => {
 // to test panel item registration and rendering.
 const WrappedItem = ( { text, ...props } ) => {
 	return (
-		<div className="wrapped-panel-item-container">
+		<div>
 			<span>Wrapper</span>
 			<ToolsPanelItem { ...props }>
 				<div>{ text }</div>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35057

## Description

This PR improves the `ToolsPanel` unit tests so there are no uses of `querySelector`, `querySelectorAll`, and no accessing of parent nodes.

It also simulates a change of block selection with a SlotFill provided control and ensures the `onDeselect` callback isn't called erroneously.

## How has this been tested?

Run `npm run test-unit packages/components/src/tools-panel/test`

## Screenshots <!-- if applicable -->

<img width="1045" alt="Screen Shot 2021-10-15 at 5 02 48 pm" src="https://user-images.githubusercontent.com/60436221/137445904-6560480d-0fa7-42b5-9401-2c5636b32ad0.png">

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
