### PR TITLE
Navigation: Fix submenus not showing on click.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -194,6 +194,7 @@
 		opacity: 1;
 		width: auto;
 		height: auto;
+		overflow: initial;
 		min-width: 200px;
 	}
 
@@ -203,6 +204,7 @@
 		opacity: 1;
 		width: auto;
 		height: auto;
+		overflow: initial;
 		min-width: 200px;
 	}
 }


### PR DESCRIPTION
## Description

Fixes #35654. _Maybe_ related to #35653.

Nested submenus did not show up when the navigation block was set to open on click. This was due to CSS that applied `overflow: hidden;` on submenus, "cropping off" the nested submenu. This PR fixes that:

![open on click](https://user-images.githubusercontent.com/1204802/137449148-714f3729-70e1-4485-9d62-293d9b680349.gif)

_The visual style discrepancy in the above is unrelated to the issue, the theme in question styles the `a`, but not the `button`._

## How has this been tested?

Create a menu with submenus and nested submenus. Ensure all pages added are published, not drafts. Set the menu to open on click:
<img width="273" alt="Screenshot 2021-10-15 at 09 28 04" src="https://user-images.githubusercontent.com/1204802/137449300-daeac68d-6360-4e15-a4ef-ea193a562498.png">

Here's some test content:

```
<!-- wp:navigation {"openSubmenusOnClick":true} -->
<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-submenu {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelItem":true} -->
<!-- wp:navigation-submenu {"label":"First level submenu","type":"page","id":30428,"url":"http://local-wordpress.local/?page_id=30428","kind":"post-type","isTopLevelItem":false} -->
<!-- wp:navigation-link {"label":"Second level submenu","type":"page","id":30429,"url":"http://local-wordpress.local/?page_id=30429","kind":"post-type","isTopLevelLink":false} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation -->
```

Please test that both in the editor and on the frontend, nested submenus open as intended, on click.

Hover should be unaffected, but for good measure, test that hover/focus to open nested submenus works as well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
