### PR TITLE
Do not filter template parts by the theme in which they were created

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -325,13 +325,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 		'post_type'      => $template_type,
 		'posts_per_page' => -1,
 		'no_found_rows'  => true,
-		'tax_query'      => array(
-			array(
-				'taxonomy' => 'wp_theme',
-				'field'    => 'name',
-				'terms'    => wp_get_theme()->get_stylesheet(),
-			),
-		),
+		'tax_query'      => array(),
 	);
 
 	if ( 'wp_template_part' === $template_type && isset( $query['area'] ) ) {

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -141,6 +141,11 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		if ( isset( $request['area'] ) ) {
 			$query['area'] = $request['area'];
 		}
+		if ( isset( $request['theme'] ) ) {
+			$query['theme'] = $request['theme'];
+		} elseif ( isset( $request['all_themes'] ) && 'true' === $request['all_themes'] ) {
+			$query['theme'] = null;
+		}
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
 			$data        = $this->prepare_item_for_response( $template, $request );

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -394,20 +394,21 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $template, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$result = array(
-			'id'             => $template->id,
-			'theme'          => $template->theme,
-			'content'        => array( 'raw' => $template->content ),
-			'slug'           => $template->slug,
-			'source'         => $template->source,
-			'type'           => $template->type,
-			'description'    => $template->description,
-			'title'          => array(
+			'id'                    => $template->id,
+			'theme'                 => $template->theme,
+			'content'               => array( 'raw' => $template->content ),
+			'slug'                  => $template->slug,
+			'source'                => $template->source,
+			'type'                  => $template->type,
+			'description'           => $template->description,
+			'title'                 => array(
 				'raw'      => $template->title,
 				'rendered' => $template->title,
 			),
-			'status'         => $template->status,
-			'wp_id'          => $template->wp_id,
-			'has_theme_file' => $template->has_theme_file,
+			'status'                => $template->status,
+			'wp_id'                 => $template->wp_id,
+			'has_theme_file'        => $template->has_theme_file,
+			'is_from_current_theme' => wp_get_theme()->get_stylesheet() === $template->theme,
 		);
 
 		if ( 'wp_template_part' === $template->type ) {

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -52,6 +52,7 @@ function TemplatePartItem( {
 	const {
 		slug,
 		theme,
+		is_from_current_theme: isFromCurrentTheme,
 		title: { rendered: title },
 	} = templatePart;
 	// The 'raw' property is not defined for a brief period in the save cycle.
@@ -93,6 +94,15 @@ function TemplatePartItem( {
 			<BlockPreview blocks={ blocks } />
 			<div className="wp-block-template-part__selection-preview-item-title">
 				{ title || slug }
+
+				{ ! isFromCurrentTheme &&
+					' (' +
+						sprintf(
+							// Translators: %s for the template name (e.g. "tt1-blocks").
+							'From %s',
+							theme
+						) +
+						')' }
 			</div>
 		</CompositeItem>
 	);

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -307,6 +307,7 @@ export default function TemplatePartPreviews( {
 				'wp_template_part',
 				{
 					per_page: -1,
+					all_themes: true,
 				}
 			) || []
 		).filter(

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -267,6 +267,24 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$template_ids = get_template_ids( $templates );
 		$this->assertEquals( array( get_stylesheet() . '//' . 'my_template' ), $template_ids );
 
+		// Filter by slug for all themes.
+		$templates    = gutenberg_get_block_templates(
+			array(
+				'slug__in' => array( 'my_template' ),
+				'theme'    => null,
+			),
+			'wp_template'
+		);
+		$template_ids = get_template_ids( $templates );
+		$this->assertEquals(
+			array(
+				// No specific theme was requested, so other templates are also returned.
+				'this-theme-should-not-resolve//my_template',
+				get_stylesheet() . '//' . 'my_template',
+			),
+			$template_ids
+		);
+
 		// Filter by CPT ID.
 		$templates    = gutenberg_get_block_templates( array( 'wp_id' => self::$post->ID ), 'wp_template' );
 		$template_ids = get_template_ids( $templates );
@@ -282,6 +300,23 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			),
 			$template_ids
 		);
+
+		// Filter template part by theme.
+		$templates    = gutenberg_get_block_templates( array( 'theme' => 'tt1-blocks' ), 'wp_template_part' );
+		$template_ids = get_template_ids( $templates );
+		$this->assertEquals(
+			array(
+				'tt1-blocks//my_template_part',
+				'tt1-blocks//footer',
+				'tt1-blocks//header',
+			),
+			$template_ids
+		);
+
+
+		$templates    = gutenberg_get_block_templates( array( 'theme' => 'fake-theme' ), 'wp_template_part' );
+		$template_ids = get_template_ids( $templates );
+		$this->assertEquals( array( ), $template_ids );
 	}
 
 	/**

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -313,10 +313,9 @@ class Block_Templates_Test extends WP_UnitTestCase {
 			$template_ids
 		);
 
-
 		$templates    = gutenberg_get_block_templates( array( 'theme' => 'fake-theme' ), 'wp_template_part' );
 		$template_ids = get_template_ids( $templates );
-		$this->assertEquals( array( ), $template_ids );
+		$this->assertEquals( array(), $template_ids );
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -63,19 +63,20 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//index',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'index',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//index',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'index',
+				'title'                 => array(
 					'raw'      => 'Index',
 					'rendered' => 'Index',
 				),
-				'description'    => 'The default template used when no other template is available. This is a required template in WordPress.',
-				'status'         => 'publish',
-				'source'         => 'theme',
-				'type'           => 'wp_template',
-				'wp_id'          => null,
-				'has_theme_file' => true,
+				'description'           => 'The default template used when no other template is available. This is a required template in WordPress.',
+				'status'                => 'publish',
+				'source'                => 'theme',
+				'type'                  => 'wp_template',
+				'wp_id'                 => null,
+				'has_theme_file'        => true,
+				'is_from_current_theme' => true,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//index' )
 		);
@@ -87,20 +88,21 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//header',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'header',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//header',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'header',
+				'title'                 => array(
 					'raw'      => 'header',
 					'rendered' => 'header',
 				),
-				'description'    => '',
-				'status'         => 'publish',
-				'source'         => 'theme',
-				'type'           => 'wp_template_part',
-				'wp_id'          => null,
-				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
-				'has_theme_file' => true,
+				'description'           => '',
+				'status'                => 'publish',
+				'source'                => 'theme',
+				'type'                  => 'wp_template_part',
+				'wp_id'                 => null,
+				'area'                  => WP_TEMPLATE_PART_AREA_HEADER,
+				'has_theme_file'        => true,
+				'is_from_current_theme' => true,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -116,19 +118,20 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//index',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'index',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//index',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'index',
+				'title'                 => array(
 					'raw'      => 'Index',
 					'rendered' => 'Index',
 				),
-				'description'    => 'The default template used when no other template is available. This is a required template in WordPress.',
-				'status'         => 'publish',
-				'source'         => 'theme',
-				'type'           => 'wp_template',
-				'wp_id'          => null,
-				'has_theme_file' => true,
+				'description'           => 'The default template used when no other template is available. This is a required template in WordPress.',
+				'status'                => 'publish',
+				'source'                => 'theme',
+				'type'                  => 'wp_template',
+				'wp_id'                 => null,
+				'has_theme_file'        => true,
+				'is_from_current_theme' => true,
 			),
 			$data
 		);
@@ -141,20 +144,21 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 		unset( $data['_links'] );
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//header',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'header',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//header',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'header',
+				'title'                 => array(
 					'raw'      => 'header',
 					'rendered' => 'header',
 				),
-				'description'    => '',
-				'status'         => 'publish',
-				'source'         => 'theme',
-				'type'           => 'wp_template_part',
-				'wp_id'          => null,
-				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
-				'has_theme_file' => true,
+				'description'           => '',
+				'status'                => 'publish',
+				'source'                => 'theme',
+				'type'                  => 'wp_template_part',
+				'wp_id'                 => null,
+				'area'                  => WP_TEMPLATE_PART_AREA_HEADER,
+				'has_theme_file'        => true,
+				'is_from_current_theme' => true,
 			),
 			$data
 		);
@@ -178,21 +182,22 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//my_custom_template',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'my_custom_template',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//my_custom_template',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'my_custom_template',
+				'title'                 => array(
 					'raw'      => 'My Template',
 					'rendered' => 'My Template',
 				),
-				'description'    => 'Just a description',
-				'status'         => 'publish',
-				'source'         => 'custom',
-				'type'           => 'wp_template',
-				'content'        => array(
+				'description'           => 'Just a description',
+				'status'                => 'publish',
+				'source'                => 'custom',
+				'type'                  => 'wp_template',
+				'content'               => array(
 					'raw' => 'Content',
 				),
-				'has_theme_file' => false,
+				'has_theme_file'        => false,
+				'is_from_current_theme' => true,
 			),
 			$data
 		);
@@ -215,22 +220,23 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 		$this->assertEquals(
 			array(
-				'id'             => 'tt1-blocks//my_custom_template_part',
-				'theme'          => 'tt1-blocks',
-				'slug'           => 'my_custom_template_part',
-				'title'          => array(
+				'id'                    => 'tt1-blocks//my_custom_template_part',
+				'theme'                 => 'tt1-blocks',
+				'slug'                  => 'my_custom_template_part',
+				'title'                 => array(
 					'raw'      => 'My Template Part',
 					'rendered' => 'My Template Part',
 				),
-				'description'    => 'Just a description of a template part',
-				'status'         => 'publish',
-				'source'         => 'custom',
-				'type'           => 'wp_template_part',
-				'content'        => array(
+				'description'           => 'Just a description of a template part',
+				'status'                => 'publish',
+				'source'                => 'custom',
+				'type'                  => 'wp_template_part',
+				'content'               => array(
 					'raw' => 'Content',
 				),
-				'area'           => 'header',
-				'has_theme_file' => false,
+				'area'                  => 'header',
+				'has_theme_file'        => false,
+				'is_from_current_theme' => true,
 			),
 			$data
 		);


### PR DESCRIPTION
## Description

[A discussion in 35148](https://github.com/WordPress/gutenberg/pull/35418#issuecomment-944149096) surfaced how filtering template parts by current theme is not that useful. I agree, so in this PR I propose removing the limitation.

## How has this been tested?
1. Insert a new template part block
2. Choose a template part
3. Confirm you can see all the template parts, not just the ones associated with the current theme.
4. Rinse and repeat with Header and Footer blocks

## Screenshots <!-- if applicable -->

**Before:**
<img width="802" alt="CleanShot 2021-10-15 at 13 52 21@2x" src="https://user-images.githubusercontent.com/205419/137483249-2d686b4b-f6f1-4f30-acaa-592e3648b227.png">


**After:**
<img width="815" alt="CleanShot 2021-10-15 at 13 45 59@2x" src="https://user-images.githubusercontent.com/205419/137483244-feb81a8e-4f25-44aa-bc7a-29ecb1844ea5.png">

