### PR TITLE
Fix unexpected movements, and closing on first click in the color picker

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -11,7 +11,6 @@ import namesPlugin from 'colord/plugins/names';
  */
 import { useState, useMemo } from '@wordpress/element';
 import { settings } from '@wordpress/icons';
-import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -33,7 +32,6 @@ import {
 import { ColorDisplay } from './color-display';
 import { ColorInput } from './color-input';
 import { Picker } from './picker';
-import { useControlledValue } from '../utils/hooks';
 
 import type { ColorType } from './types';
 
@@ -59,32 +57,23 @@ const ColorPicker = (
 ) => {
 	const {
 		enableAlpha = false,
-		color: colorProp,
+		color,
 		onChange,
-		defaultValue,
+		defaultValue = '#fff',
 		copyFormat,
 		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
-	const [ color, setColor ] = useControlledValue( {
-		onChange,
-		value: colorProp,
-		defaultValue,
-	} );
-
 	// Use a safe default value for the color and remove the possibility of `undefined`.
 	const safeColordColor = useMemo( () => {
-		return color ? colord( color ) : colord( '#fff' );
-	}, [ color ] );
-
-	// Debounce to prevent rapid changes from conflicting with one another.
-	const debouncedSetColor = useDebounce( setColor );
+		return color ? colord( color ) : colord( defaultValue );
+	}, [ color, defaultValue ] );
 
 	const handleChange = useCallback(
 		( nextValue: Colord ) => {
-			debouncedSetColor( nextValue.toHex() );
+			onChange( nextValue.toHex() );
 		},
-		[ debouncedSetColor ]
+		[ onChange ]
 	);
 
 	const [ showInputs, setShowInputs ] = useState< boolean >( false );

--- a/packages/components/src/color-picker/picker.tsx
+++ b/packages/components/src/color-picker/picker.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { HslColorPicker, HslaColorPicker } from 'react-colorful';
+import { RgbStringColorPicker, RgbaStringColorPicker } from 'react-colorful';
 import { colord, Colord } from 'colord';
 
 /**
@@ -15,12 +15,14 @@ interface PickerProps {
 }
 
 export const Picker = ( { color, enableAlpha, onChange }: PickerProps ) => {
-	const Component = enableAlpha ? HslaColorPicker : HslColorPicker;
-	const hslColor = useMemo( () => color.toHsl(), [ color ] );
+	const Component = enableAlpha
+		? RgbaStringColorPicker
+		: RgbStringColorPicker;
+	const rgbColor = useMemo( () => color.toRgbString(), [ color ] );
 
 	return (
 		<Component
-			color={ hslColor }
+			color={ rgbColor }
 			onChange={ ( nextColor ) => {
 				onChange( colord( nextColor ) );
 			} }

--- a/packages/components/src/color-picker/test/index.js
+++ b/packages/components/src/color-picker/test/index.js
@@ -41,12 +41,6 @@ function moveReactColorfulSlider( sliderElement, from, to ) {
 	fireEvent( sliderElement, new FakeMouseEvent( 'mousemove', to ) );
 }
 
-const sleep = ( ms ) => {
-	const promise = new Promise( ( resolve ) => setTimeout( resolve, ms ) );
-	jest.advanceTimersByTime( ms + 1 );
-	return promise;
-};
-
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),
 	s: expect.any( Number ),
@@ -93,9 +87,6 @@ describe( 'ColorPicker', () => {
 				{ pageX: 10, pageY: 10 }
 			);
 
-			// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
-			await sleep( 1 );
-
 			expect( onChangeComplete ).toHaveBeenCalledWith(
 				legacyColorMatcher
 			);
@@ -116,9 +107,6 @@ describe( 'ColorPicker', () => {
 			{ pageX: 0, pageY: 0 },
 			{ pageX: 10, pageY: 10 }
 		);
-
-		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
-		await sleep( 1 );
 
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.stringMatching( /^#([a-fA-F0-9]{8})$/ )
@@ -149,9 +137,6 @@ describe( 'ColorPicker', () => {
 			{ pageX: 0, pageY: 0 },
 			{ pageX: 10, pageY: 10 }
 		);
-
-		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
-		await sleep( 1 );
 
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.stringMatching( /^#([a-fA-F0-9]{6})$/ )


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35640, https://github.com/WordPress/gutenberg/issues/35677, https://github.com/WordPress/gutenberg/issues/35675

The color picker was having some random movements during small dragging interaction as we can see on this video shared by @mtias

https://user-images.githubusercontent.com/11271197/137486154-694cceb6-483b-49c9-bd54-16093a3df833.mov



At first, I thought it could be related to debouce usage but when I removed the debounce usage the component started to crash. Because of recursive setState calls.

What was happening is that the react-colorful picker components expect that if there are no outside changes in the color the object passed to the component is the same as the component passed on the onChange.
In our usages we receive an object on the onChange then that color is serialized in the block attributes and we pass an object with the same color but the object may have some differences and is not the same object so the component thinks an outside change happened and recomputes the position of the picker that may be some pixels on the side (e.g: multiple pixels may be representing the same color and there is random movement between this pixels).
A simple way to resolve this issue is to use the string-based pickers so we always pass an equivalent string to the one we received on the onChange and the position is not recomputed and the component does not enter on recursive setState so we can remove the debounce.

It is not clear why the issue of the component when inside a popover closing during the first click is fixed. But I guess a combination of the debouce removal and fewer rerenders because of prop changes may explain it.


## Testing

I replicated the steps shared on the video above and verified there are no random movements.
I used the component to choose colors by dragging the color picker fast and verified the UI was responsive so we can remove debounce usage safely.
I opened the color picker in a place where the color was not set before and rapidly clicked on the color area to select some color. I verified the custom color popover did not randomly close.

