### PR TITLE
Remove active / focussed block outlines in the Site / Template editor

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -148,39 +148,6 @@
 		}
 	}
 
-
-	/**
-	 * Block Layout
-	 */
-
-	// Navigate mode & Focused wrapper.
-	// We're using a pseudo element to overflow placeholder borders
-	// and any border inside the block itself.
-	&:not([contenteditable]):focus {
-		outline: none;
-
-		&::after {
-			position: absolute;
-			z-index: 1;
-			pointer-events: none;
-			content: "";
-			top: $border-width;
-			bottom: $border-width;
-			left: $border-width;
-			right: $border-width;
-
-			// 2px outside.
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-			outline: 2px solid transparent; // This shows up in Windows High Contrast Mode.
-
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
-			}
-		}
-	}
-
 	/**
 	* Block styles and alignments
 	*/
@@ -269,21 +236,6 @@
 
 	&.is-selected {
 		cursor: unset;
-
-		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color); // Selected not focussed.
-			top: $border-width;
-			left: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
-		}
-
-		&:focus {
-			&::after {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Part of #35662.

> The amount of lines shown in the site editor to distinguish active focus, hover focus, current template part focus, etc, is wild. We need to reduce this.

We already removed the dotted outline on ancestor blocks: https://github.com/WordPress/gutenberg/pull/35637/

Of the remaining outlines I suspect the least useful is the one that appears on selection/focus. This is based on the assumption that the presence of the Toolbar is probably an adequate indicator.

### Before
https://user-images.githubusercontent.com/846565/137495552-8c6a81d4-5933-4dc3-abf9-230192186a70.mp4

### After
https://user-images.githubusercontent.com/846565/137495579-12dea816-8311-45ec-8081-0379128fc2dc.mp4

The changes here will likely need an a11y review.