### PR TITLE
Storybook: Remove outdated decorator config

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,11 +1,4 @@
 /**
- * External dependencies
- */
-import { addDecorator } from '@storybook/react';
-import { withA11y } from '@storybook/addon-a11y';
-import { withKnobs } from '@storybook/addon-knobs';
-
-/**
  * WordPress dependencies
  */
 /* eslint-disable no-restricted-syntax */
@@ -16,6 +9,3 @@ import '@wordpress/components/build-style/style.css';
  * Internal dependencies
  */
 import './style.scss';
-
-addDecorator( withA11y );
-addDecorator( withKnobs );


### PR DESCRIPTION
In preparation for #35665, #35642, #35649

## Description

Removes outdated Storybook config that was throwing console warnings:

```
index.js:49 You tried to add a duplicate decorator, this is not expected ƒ () {
    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
      args[_key] = arguments[_key];
    }

    // Used without options as .addDecorator(decorator)
```

```
warn @ index.js:49
browser.js:39 withA11y(options) is deprecated, please configure addon-a11y using the addParameter api:

addParameters({
  a11y: options,
});

More at: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#removed-witha11y-decorator
```

Registration of addons were [simplified](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#new-addon-presets) in Storybook 6.0, and now do not need separate `addDecorator` calls.

## How has this been tested?

1. `npm run storybook:dev`.
2. The Knobs and Accessibility panels should still be enabled.
3. DevTools console should not show the two warnings above.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
