### PR TITLE
List View: improve block focus time by providing stable function references

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -40,6 +40,7 @@ const config = require( '../config' );
  * @property {number[]} inserterOpen         Average time to open global inserter.
  * @property {number[]} inserterSearch       Average time to search the inserter.
  * @property {number[]} inserterHover        Average time to move mouse between two block item in the inserter.
+ * @property {number[]} listViewOpen         Average time to open listView
  */
 
 /**
@@ -52,7 +53,7 @@ const config = require( '../config' );
  * @property {number=} firstContentfulPaint Represents the time when the browser first renders any text or media.
  * @property {number=} firstBlock           Represents the time when Puppeteer first sees a block selector in the DOM.
  * @property {number=} type                 Average type time.
- * @property {number=} minType              Minium type time.
+ * @property {number=} minType              Minimum type time.
  * @property {number=} maxType              Maximum type time.
  * @property {number=} focus                Average block selection time.
  * @property {number=} minFocus             Min block selection time.
@@ -66,6 +67,9 @@ const config = require( '../config' );
  * @property {number=} inserterHover        Average time to move mouse between two block item in the inserter.
  * @property {number=} minInserterHover     Min time to move mouse between two block item in the inserter.
  * @property {number=} maxInserterHover     Max time to move mouse between two block item in the inserter.
+ * @property {number=} listViewOpen         Average time to open list view.
+ * @property {number=} minListViewOpen      Min time to open list view.
+ * @property {number=} maxListViewOpen      Max time to open list view.
  */
 
 /**
@@ -136,6 +140,9 @@ function curateResults( results ) {
 		inserterHover: average( results.inserterHover ),
 		minInserterHover: Math.min( ...results.inserterHover ),
 		maxInserterHover: Math.max( ...results.inserterHover ),
+		listViewOpen: average( results.listViewOpen ),
+		minListViewOpen: Math.min( ...results.listViewOpen ),
+		maxListViewOpen: Math.max( ...results.listViewOpen ),
 	};
 }
 
@@ -377,6 +384,15 @@ async function runPerformanceTests( branches, options ) {
 					),
 					maxInserterHover: rawResults.map(
 						( r ) => r[ branch ].maxInserterHover
+					),
+					listViewOpen: rawResults.map(
+						( r ) => r[ branch ].listViewOpen
+					),
+					minListViewOpen: rawResults.map(
+						( r ) => r[ branch ].minListViewOpen
+					),
+					maxListViewOpen: rawResults.map(
+						( r ) => r[ branch ].maxListViewOpen
 					),
 				},
 				median

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -4,7 +4,7 @@
 import { getBlockType } from '@wordpress/blocks';
 import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -61,6 +61,31 @@ const BlockDraggable = ( {
 		};
 	}, [] );
 
+	const draggableOnDragStart = useCallback(
+		( event ) => {
+			startDraggingBlocks( clientIds );
+			isDragging.current = true;
+
+			startScrolling( event );
+
+			if ( onDragStart ) {
+				onDragStart();
+			}
+		},
+		[ clientIds, startScrolling, onDragStart ]
+	);
+
+	const draggableOnDragEnd = useCallback( () => {
+		stopDraggingBlocks();
+		isDragging.current = false;
+
+		stopScrolling();
+
+		if ( onDragEnd ) {
+			onDragEnd();
+		}
+	}, [ stopDraggingBlocks, isDragging, stopScrolling, onDragEnd ] );
+
 	if ( ! isDraggable ) {
 		return children( { isDraggable: false } );
 	}
@@ -76,27 +101,9 @@ const BlockDraggable = ( {
 			cloneClassname={ cloneClassname }
 			__experimentalTransferDataType="wp-blocks"
 			transferData={ transferData }
-			onDragStart={ ( event ) => {
-				startDraggingBlocks( clientIds );
-				isDragging.current = true;
-
-				startScrolling( event );
-
-				if ( onDragStart ) {
-					onDragStart();
-				}
-			} }
+			onDragStart={ draggableOnDragStart }
 			onDragOver={ scrollOnDragOver }
-			onDragEnd={ () => {
-				stopDraggingBlocks();
-				isDragging.current = false;
-
-				stopScrolling();
-
-				if ( onDragEnd ) {
-					onDragEnd();
-				}
-			} }
+			onDragEnd={ draggableOnDragEnd }
 			__experimentalDragComponent={
 				<BlockDraggableChip count={ clientIds.length } icon={ icon } />
 			}

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -55,8 +55,12 @@ const ListViewBlockContents = forwardRef(
 			'is-dropping-before': isBlockMoveTarget,
 		} );
 
+		const clientIds = useMemo( () => [ block.clientId ], [
+			block.clientId,
+		] );
+
 		return (
-			<BlockDraggable clientIds={ [ block.clientId ] }>
+			<BlockDraggable clientIds={ clientIds }>
 				{ ( { draggable, onDragStart, onDragEnd } ) => (
 					<ListViewBlockSelectButton
 						ref={ ref }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -11,7 +11,7 @@ import {
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 
 /**
@@ -33,7 +33,7 @@ export default function ListViewBlock( {
 	isDragged,
 	isBranchSelected,
 	isLastOfSelectedBranch,
-	onClick,
+	selectBlock,
 	onToggleExpanded,
 	position,
 	level,
@@ -82,14 +82,22 @@ export default function ListViewBlock( {
 		? toggleBlockHighlight
 		: () => {};
 
-	const onMouseEnter = () => {
+	const onMouseEnter = useCallback( () => {
 		setIsHovered( true );
 		highlightBlock( clientId, true );
-	};
-	const onMouseLeave = () => {
+	}, [ clientId, setIsHovered, highlightBlock ] );
+	const onMouseLeave = useCallback( () => {
 		setIsHovered( false );
 		highlightBlock( clientId, false );
-	};
+	}, [ clientId, setIsHovered, highlightBlock ] );
+
+	const selectEditorBlock = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			selectBlock( clientId );
+		},
+		[ clientId, selectBlock ]
+	);
 
 	const classes = classnames( {
 		'is-selected': isSelected,
@@ -125,7 +133,7 @@ export default function ListViewBlock( {
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
 							block={ block }
-							onClick={ onClick }
+							onClick={ selectEditorBlock }
 							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
@@ -183,7 +191,7 @@ export default function ListViewBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
-							__experimentalSelectBlock={ onClick }
+							__experimentalSelectBlock={ selectEditorBlock }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -34,7 +34,6 @@ export default function ListViewBlock( {
 	isBranchSelected,
 	isLastOfSelectedBranch,
 	selectBlock,
-	onToggleExpanded,
 	position,
 	level,
 	rowCount,
@@ -59,6 +58,8 @@ export default function ListViewBlock( {
 		__experimentalFeatures: withExperimentalFeatures,
 		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
 		isTreeGridMounted,
+		expand,
+		collapse,
 	} = useListViewContext();
 	const listViewBlockSettingsClassName = classnames(
 		'block-editor-list-view-block__menu-cell',
@@ -99,6 +100,18 @@ export default function ListViewBlock( {
 		[ clientId, selectBlock ]
 	);
 
+	const toggleExpanded = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			if ( isExpanded === true ) {
+				collapse( clientId );
+			} else if ( isExpanded === false ) {
+				expand( clientId );
+			}
+		},
+		[ clientId, expand, collapse, isExpanded ]
+	);
+
 	const classes = classnames( {
 		'is-selected': isSelected,
 		'is-branch-selected':
@@ -134,7 +147,7 @@ export default function ListViewBlock( {
 						<ListViewBlockContents
 							block={ block }
 							onClick={ selectEditorBlock }
-							onToggleExpanded={ onToggleExpanded }
+							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,6 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		terminatedLevels = [],
 		path = [],
 		isBranchSelected = false,
 		isLastOfBranch = false,
@@ -56,10 +55,6 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const isLastRowAtLevel = rowCount === position;
-				const updatedTerminatedLevels = isLastRowAtLevel
-					? [ ...terminatedLevels, level ]
-					: terminatedLevels;
 				const updatedPath = [ ...path, position ];
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
@@ -112,7 +107,6 @@ export default function ListViewBranch( props ) {
 							rowCount={ rowCount }
 							siblingBlockCount={ blockCount }
 							showBlockMovers={ showBlockMovers }
-							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 							isExpanded={ isExpanded }
 						/>
@@ -127,7 +121,6 @@ export default function ListViewBranch( props ) {
 								showNestedBlocks={ showNestedBlocks }
 								parentBlockClientId={ clientId }
 								level={ level + 1 }
-								terminatedLevels={ updatedTerminatedLevels }
 								path={ updatedPath }
 							/>
 						) }
@@ -140,7 +133,6 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					terminatedLevels={ terminatedLevels }
 					path={ [ ...path, appenderPosition ] }
 				/>
 			) }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,7 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		path = [],
+		path = '',
 		isBranchSelected = false,
 		isLastOfBranch = false,
 	} = props;
@@ -53,7 +53,12 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const updatedPath = [ ...path, position ];
+				// If the string value changes, it's used to trigger an animation change.
+				// This may be removed if we use a different animation library in the future.
+				const updatedPath =
+					path.length > 0
+						? `${ path }_${ position }`
+						: `${ position }`;
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const hasNestedAppender = itemHasAppender( clientId );
@@ -121,7 +126,11 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					path={ [ ...path, appenderPosition ] }
+					path={
+						path.length > 0
+							? `${ path }_${ appenderPosition }`
+							: `${ appenderPosition }`
+					}
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -32,8 +32,6 @@ export default function ListViewBranch( props ) {
 
 	const {
 		expandedState,
-		expand,
-		collapse,
 		draggedClientIds,
 		selectedClientIds,
 	} = useListViewContext();
@@ -79,15 +77,6 @@ export default function ListViewBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				const toggleExpanded = ( event ) => {
-					event.stopPropagation();
-					if ( isExpanded === true ) {
-						collapse( clientId );
-					} else if ( isExpanded === false ) {
-						expand( clientId );
-					}
-				};
-
 				// Make updates to the selected or dragged blocks synchronous,
 				// but asynchronous for any other block.
 				const isDragged = !! draggedClientIds?.includes( clientId );
@@ -97,7 +86,6 @@ export default function ListViewBranch( props ) {
 						<ListViewBlock
 							block={ block }
 							selectBlock={ selectBlock }
-							onToggleExpanded={ toggleExpanded }
 							isDragged={ isDragged }
 							isSelected={ isSelected }
 							isBranchSelected={ isSelectedBranch }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -84,11 +84,6 @@ export default function ListViewBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				const selectBlockWithClientId = ( event ) => {
-					event.stopPropagation();
-					selectBlock( clientId );
-				};
-
 				const toggleExpanded = ( event ) => {
 					event.stopPropagation();
 					if ( isExpanded === true ) {
@@ -106,7 +101,7 @@ export default function ListViewBranch( props ) {
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						<ListViewBlock
 							block={ block }
-							onClick={ selectBlockWithClientId }
+							selectBlock={ selectBlock }
 							onToggleExpanded={ toggleExpanded }
 							isDragged={ isDragged }
 							isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -30,7 +30,7 @@ export default function ListViewLeaf( {
 		isSelected,
 		adjustScrolling: false,
 		enableAnimation: true,
-		triggerAnimationOnChange: path.join( '_' ),
+		triggerAnimationOnChange: path,
 	} );
 
 	return (

--- a/packages/components/src/tree-grid/roving-tab-index-item.js
+++ b/packages/components/src/tree-grid/roving-tab-index-item.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, forwardRef } from '@wordpress/element';
+import { useRef, forwardRef, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,7 +24,10 @@ export default forwardRef( function RovingTabIndexItem(
 		tabIndex = lastFocusedElement === ref.current ? 0 : -1;
 	}
 
-	const onFocus = ( event ) => setLastFocusedElement( event.target );
+	const onFocus = useCallback(
+		( event ) => setLastFocusedElement( event.target ),
+		[ setLastFocusedElement ]
+	);
 	const allProps = { ref, tabIndex, onFocus, ...props };
 
 	if ( typeof children === 'function' ) {

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -111,6 +111,10 @@ _Parameters_
 
 Undocumented declaration.
 
+### closeListView
+
+Closes list view
+
 ### createEmbeddingMatcher
 
 Creates a function to determine if a request is embedding a certain URL.
@@ -504,6 +508,10 @@ Clicks on the button in the header which opens Document Settings sidebar when it
 ### openGlobalBlockInserter
 
 Opens the global block inserter.
+
+### openListView
+
+Opens list view
 
 ### openPreviewPage
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -90,5 +90,6 @@ export {
 	rest as __experimentalRest,
 	batch as __experimentalBatch,
 } from './rest-api';
+export { openListView, closeListView } from './list-view';
 
 export * from './mocks';

--- a/packages/e2e-test-utils/src/list-view.js
+++ b/packages/e2e-test-utils/src/list-view.js
@@ -1,0 +1,33 @@
+async function toggleListView() {
+	await page.click(
+		'.edit-post-header-toolbar__list-view-toggle, .edit-site-header-toolbar__list-view-toggle'
+	);
+}
+
+async function isListViewOpen() {
+	return await page.evaluate( () => {
+		return !! document.querySelector(
+			'.edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-toolbar__list-view-toggle.is-pressed'
+		);
+	} );
+}
+
+/**
+ * Opens list view
+ */
+export async function openListView() {
+	const isOpen = await isListViewOpen();
+	if ( ! isOpen ) {
+		await toggleListView();
+	}
+}
+
+/**
+ * Closes list view
+ */
+export async function closeListView() {
+	const isOpen = await isListViewOpen();
+	if ( isOpen ) {
+		await toggleListView();
+	}
+}

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -37,6 +37,7 @@ class PerformanceReporter {
 			firstBlock,
 			type,
 			focus,
+			listViewOpen,
 			inserterOpen,
 			inserterHover,
 			inserterSearch,
@@ -87,6 +88,21 @@ Slowest time to select a block: ${ success(
 			) }
 Fastest time to select a block: ${ success(
 				round( Math.min( ...focus ) ) + 'ms'
+			) }` );
+		}
+
+		if ( listViewOpen && listViewOpen.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Opening List View Performance:' ) }
+Average time to open list view: ${ success(
+				round( average( listViewOpen ) ) + 'ms'
+			) }
+Slowest time to open list view: ${ success(
+				round( Math.max( ...listViewOpen ) ) + 'ms'
+			) }
+Fastest time to open list view: ${ success(
+				round( Math.min( ...listViewOpen ) ) + 'ms'
 			) }` );
 		}
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -13,7 +13,7 @@ import {
 	canvas,
 	createNewPost,
 	saveDraft,
-	insertBlock,
+	openListView,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -55,6 +55,7 @@ describe( 'Site Editor Performance', () => {
 			inserterOpen: [],
 			inserterHover: [],
 			inserterSearch: [],
+			listViewOpen: [],
 		};
 
 		const html = readFile(
@@ -117,7 +118,13 @@ describe( 'Site Editor Performance', () => {
 		await canvas().click(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
-		await insertBlock( 'Paragraph' );
+		await openListView();
+		await canvas().click(
+			'[data-type="core/post-content"] [data-type="core/paragraph"]'
+		);
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'ArrowUp' );
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
 		await page.tracing.start( {


### PR DESCRIPTION
While experimenting with the windowing technique in https://github.com/WordPress/gutenberg/pull/35230 we discovered some unexpected behavior with block focus time. 

Focusing on a block in the main editor pane will re-render **all ListViewBlock items**. Depending on if list view is open or not, we can see some dramatic differences in how long it takes to resolve a focus event.

| blocks | focus time list view closed | focus time list view open |
|-----|-----|-----|
| 50 | 87 ms | 114ms |
| 250 | 100 ms | 311 ms |
| 900 | 180 ms | 1000 ms |

Proposed changes in this PR remove the unused `terminatedLevels` prop, refactors path to be a string instead of an array, and attempts to provide stable references by using `useCallback` and `useMemo` in key areas.

To give us solid numbers on the proposed changes, I've also included changes in the performance tests to have list view open during `focus` and `typing` in addition to a new test that toggles the list view open and closed.

**Since this PR won't help with a first render, we may want to drop related performance test changes before landing.**

#### Testing Instructions

- No regressions in list view
- Expand/Collapse works in all list view instances
- No drag regressions
- Animations are still seen when using the mover controls:

https://user-images.githubusercontent.com/1270189/137532377-63a68968-e6e6-4e82-a381-de17634f6708.mp4

To verify that I've written the performance tests correctly we can verify visual changes with the following:
```
npm run test-performance -- --wordpress-base-url=<localbaseurl> --wordpress-username=<username> --wordpress-password=<password> --puppeteer-interactive packages/e2e-tests/specs/performance/post-editor.test.js

npm run test-performance -- --wordpress-base-url=<localbaseurl> --wordpress-username=<username> --wordpress-password=<password> --puppeteer-interactive packages/e2e-tests/specs/performance/site-editor.test.js
```

#### React Profiling Details

When focusing on a block we can see in the react profiler that we have some initial culprits in branch.js: `onClick`, `onToggleExpanded`, `terminatedLevels` and `path`:

<img width="972" alt="react profiling" src="https://user-images.githubusercontent.com/1270189/137527382-79392edf-ef84-4c33-beba-6088b590dccb.png">

After fixing those we see `onDragStart`, `onDragEnd`, `onFocus` in ListViewBlockSelectButton

<img width="1229" alt="example of animation movers" src="https://user-images.githubusercontent.com/1270189/137527089-13142f10-af4d-44c0-99eb-0541ee0c715c.png">

