### PR TITLE
Try: hide search block label when contained

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -62,6 +62,10 @@
 		},
 		"customOverlayTextColor": {
 			"type": "string"
+		},
+		"searchBlockLabel": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"providesContext": {
@@ -78,7 +82,8 @@
 		"showSubmenuIcon": "showSubmenuIcon",
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
-		"orientation": "orientation"
+		"orientation": "orientation",
+		"searchBlockLabel": "searchBlockLabel"
 	},
 	"supports": {
 		"align": [

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -53,5 +53,8 @@
 		"html": false
 	},
 	"editorStyle": "wp-block-search-editor",
-	"style": "wp-block-search"
+	"style": "wp-block-search",
+	"usesContext": [
+		"searchBlockLabel"
+	]
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -87,6 +87,8 @@ export default function SearchEdit( {
 		return wasBlockJustInserted( clientId );
 	} );
 
+	// Save a ref to this value, as it would become outdated
+	// if any other blocks are added.
 	const isNewBlockRef = useRef( isNewBlock );
 
 	if (

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -90,7 +90,7 @@ export default function SearchEdit( {
 	const isNewBlockRef = useRef( isNewBlock );
 
 	if (
-		typeof context.searchBlockLabel !== 'undefined' &&
+		'undefined' !== typeof context.searchBlockLabel &&
 		true === isNewBlockRef.current
 	) {
 		setAttributes( { showLabel: context.searchBlockLabel } );

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -14,6 +14,7 @@ import {
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseColorProps as useColorProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToolbarDropdownMenu,
@@ -27,6 +28,8 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { Icon, search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -54,6 +57,8 @@ const DEFAULT_INNER_PADDING = '4px';
 
 export default function SearchEdit( {
 	className,
+	clientId,
+	context,
 	attributes,
 	setAttributes,
 	toggleSelection,
@@ -75,6 +80,22 @@ export default function SearchEdit( {
 	const borderRadius = style?.border?.radius;
 	const borderColor = style?.border?.color;
 	const borderProps = useBorderProps( attributes );
+
+	const isNewBlock = useSelect( ( select ) => {
+		const { wasBlockJustInserted } = select( blockEditorStore );
+
+		return wasBlockJustInserted( clientId );
+	} );
+
+	const isNewBlockRef = useRef( isNewBlock );
+
+	if (
+		typeof context.searchBlockLabel !== 'undefined' &&
+		true === isNewBlockRef.current
+	) {
+		setAttributes( { showLabel: context.searchBlockLabel } );
+		isNewBlockRef.current = false;
+	}
 
 	// Check for old deprecated numerical border radius. Done as a separate
 	// check so that a borderRadius style won't overwrite the longhand

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -7,7 +7,8 @@
 			"orientation": "horizontal",
 			"showSubmenuIcon": true,
 			"openSubmenusOnClick": false,
-			"overlayMenu": "never"
+			"overlayMenu": "never",
+			"searchBlockLabel": false
 		},
 		"innerBlocks": [],
 		"originalContent": ""


### PR DESCRIPTION
## Description
Addressing https://github.com/WordPress/gutenberg/issues/31127

Labels are shown by default, as established in block.json. This PR adds the possibility for parent blocks to define if they want a search bar label or not, by adding a `searchBarLabel` attribute, and passing it down through using Block Context.

The flip is made:
- Only at insertion.
- When the `showLabel` attribute is `true` (current default in block.json).

## How has this been tested?
- Insert a Search block as a child of another block (Navigation, Group). Label should not be displayed.
- Insert a Search block at the root of the document. Label should be displayed.
- Adjust label display settings on the inserted Search blocks and verify that they're respected after saving and reloading.

## Screenshots <!-- if applicable -->

![Kapture 2021-10-15 at 16 11 01](https://user-images.githubusercontent.com/1157901/137540496-eada75df-99de-4621-930a-1b514b34c321.gif)
