### PR TITLE
List View: simplify branch.js props

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,7 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		path = [],
+		path = '',
 		isBranchSelected = false,
 		isLastOfBranch = false,
 	} = props;
@@ -55,7 +55,12 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const updatedPath = [ ...path, position ];
+				// If the string value changes, it's used to trigger an animation change.
+				// This may be removed if we use a different animation library in the future.
+				const updatedPath =
+					path.length > 0
+						? `${ path }_${ position }`
+						: `${ position }`;
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const hasNestedAppender = itemHasAppender( clientId );
@@ -138,7 +143,11 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					path={ [ ...path, appenderPosition ] }
+					path={
+						path.length > 0
+							? `${ path }_${ appenderPosition }`
+							: `${ appenderPosition }`
+					}
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,6 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		terminatedLevels = [],
 		path = [],
 		isBranchSelected = false,
 		isLastOfBranch = false,
@@ -56,10 +55,6 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const isLastRowAtLevel = rowCount === position;
-				const updatedTerminatedLevels = isLastRowAtLevel
-					? [ ...terminatedLevels, level ]
-					: terminatedLevels;
 				const updatedPath = [ ...path, position ];
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
@@ -117,7 +112,6 @@ export default function ListViewBranch( props ) {
 							rowCount={ rowCount }
 							siblingBlockCount={ blockCount }
 							showBlockMovers={ showBlockMovers }
-							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 							isExpanded={ isExpanded }
 						/>
@@ -132,7 +126,6 @@ export default function ListViewBranch( props ) {
 								showNestedBlocks={ showNestedBlocks }
 								parentBlockClientId={ clientId }
 								level={ level + 1 }
-								terminatedLevels={ updatedTerminatedLevels }
 								path={ updatedPath }
 							/>
 						) }
@@ -145,7 +138,6 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					terminatedLevels={ terminatedLevels }
 					path={ [ ...path, appenderPosition ] }
 				/>
 			) }

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -30,7 +30,7 @@ export default function ListViewLeaf( {
 		isSelected,
 		adjustScrolling: false,
 		enableAnimation: true,
-		triggerAnimationOnChange: path.join( '_' ),
+		triggerAnimationOnChange: path,
 	} );
 
 	return (


### PR DESCRIPTION
While exploring https://github.com/WordPress/gutenberg/pull/35230 we noticed that there was an unused `terminatedLevels` prop. I've also updated the `path` prop to be a string rather than an array. Should we need to memo these components later, using an array will cause unneeded updates.

This PR improves code quality, but has no impact on performance. (See prior investigation in https://github.com/WordPress/gutenberg/pull/35683).

### Testing Instructions

- No regressions in List View
- List View animations silll work

https://user-images.githubusercontent.com/1270189/137532377-63a68968-e6e6-4e82-a381-de17634f6708.mp4