### PR TITLE
Post title block default CSS: add a break-word rule by default

### DIFF
--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -1,3 +1,4 @@
 .wp-block-post-title a {
 	display: inline-block;
+	word-break: break-word;
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -1,4 +1,7 @@
-.wp-block-post-title a {
-	display: inline-block;
+.wp-block-post-title {
 	word-break: break-word;
+
+	a {
+		display: inline-block;
+	}
 }


### PR DESCRIPTION
## Description
Post title should have a minimal break-word rule by default to avoid content overflow when grid layout is used for query loops.

## How has this been tested?
Using Gutenberg + Twenty-Twenty Two grid layout query loop.
For the content, I used Theme Review Team Unit test data.

## Screenshots <!-- if applicable -->
Before the change:
<img width="1388" alt="" src="https://user-images.githubusercontent.com/1590998/137580753-22d12594-9ca3-4425-96b9-0e9320a226f8.png">

After the change:
<img width="1402" alt="" src="https://user-images.githubusercontent.com/1590998/137580786-c0f4480d-4edb-4a5f-8215-c0a394dcdc85.png">

## Types of changes
Adds a new CSS declaration in the post-title block SCSS stylesheet.
That's not a breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
