### PR TITLE
Adds in basic styling for post comment form

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -14,6 +14,7 @@
 	input:not([type="submit"]) {
 		border: 1px solid $gray-600;
 		font-size: 1em;
+		font-family: inherit;
 	}
 
 	textarea,

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -7,3 +7,12 @@
 	text-align: center;
 	overflow-wrap: break-word;
 }
+
+p.logged-in-as {
+	margin-top: $grid-unit-10;
+}
+
+.comment-form-comment #comment {
+	margin-top: $grid-unit-20;
+	width: 100%;
+}

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -14,6 +14,10 @@
 	input:not([type="submit"]) {
 		border: 1px solid $gray-600;
 		font-size: 1em;
+	}
+
+	textarea,
+	input:not([type="submit"]):not([type="checkbox"]) {
 		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
 	}
 
@@ -30,6 +34,15 @@
 		label {
 			display: block;
 			margin-bottom: 0.25em;
+		}
+	}
+
+	.comment-form-cookies-consent {
+		display: flex;
+		gap: 0.25em;
+
+		#wp-comment-cookies-consent {
+			margin-top: 0.35em;
 		}
 	}
 }

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -1,18 +1,35 @@
 // Styles copied from button block styles.
-.wp-block-post-comments-form input[type="submit"] {
-	border: none;
-	box-shadow: none;
-	cursor: pointer;
-	display: inline-block;
-	text-align: center;
-	overflow-wrap: break-word;
-}
+.wp-block-post-comments-form {
 
-p.logged-in-as {
-	margin-top: $grid-unit-10;
-}
+	input[type="submit"] {
+		border: none;
+		box-shadow: none;
+		cursor: pointer;
+		display: inline-block;
+		text-align: center;
+		overflow-wrap: break-word;
+	}
 
-.comment-form-comment #comment {
-	margin-top: $grid-unit-20;
-	width: 100%;
+	textarea,
+	input:not([type="submit"]) {
+		border: 1px solid $gray-600;
+		font-size: 1em;
+		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
+	}
+
+	.comment-form-comment textarea {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+	}
+
+	.comment-form-comment,
+	.comment-form-author,
+	.comment-form-email,
+	.comment-form-url {
+		label {
+			display: block;
+			margin-bottom: 0.25em;
+		}
+	}
 }

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -64,6 +64,15 @@
 		width: 100%;
 	}
 
+	.comment-form-cookies-consent {
+		display: flex;
+		gap: 0.25em;
+
+		#wp-comment-cookies-consent {
+			margin-top: 0.35em;
+		}
+	}
+
 	.reply {
 		font-size: 0.75em;
 		margin-bottom: 1.4em;
@@ -73,6 +82,10 @@
 	input:not([type="submit"]) {
 		border: 1px solid $gray-600;
 		font-size: 1em;
+	}
+
+	textarea,
+	input:not([type="submit"]):not([type="checkbox"]) {
 		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
 	}
 

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -55,6 +55,7 @@
 	.comment-form-url {
 		label {
 			display: block;
+			margin-bottom: 0.25em;
 		}
 	}
 
@@ -69,7 +70,13 @@
 	}
 
 	textarea,
-	input {
+	input:not([type="submit"]) {
 		border: 1px solid $gray-600;
+		font-size: 1em;
+		padding: calc(0.667em + 2px); // The extra 2px is added to match outline buttons.
+	}
+
+	input[type="submit"] {
+		border: none;
 	}
 }

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -82,6 +82,7 @@
 	input:not([type="submit"]) {
 		border: 1px solid $gray-600;
 		font-size: 1em;
+		font-family: inherit;
 	}
 
 	textarea,


### PR DESCRIPTION
This is a reworked version of stale PR #27009 which I closed today.

@kjellr and @jffng looping you in as know tracking this for Twenty Twenty Two.

@colorful-tones I removed all the review points you noted to reduce back as much as I can on styling.

Whilst I do think more styling could be done by default, I have concerns setting any font sizes or anything else at this point, so I really went as minimal as possible. I am open to other options being brought in though as it looks 'simple' to say the least.

![2021-10-16 at 12 34](https://user-images.githubusercontent.com/253067/137585906-067964fa-c16d-4464-b440-95299116a005.png)
