### PR TITLE
List View: avoid re-rendering all items on block focus. Enable persistent List View in the widget editor.

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Performance
 
--   Fix block focus time when List View is open. [#35706](https://github.com/WordPress/gutenberg/pull/35706)
+-   Avoid re-rendering all List View items on block focus [#35706](https://github.com/WordPress/gutenberg/pull/35706). These changes speed up block focus time in large posts by 80% when List View is open.
 
 ### Breaking change
 
--   ListView no longer supports the `showOnlyCurrentHierarchy` flag [#35706](https://github.com/WordPress/gutenberg/pull/35706). To display a subset of blocks, use the `blocks` parameter instead.
+-   List View no longer supports the `showOnlyCurrentHierarchy` flag [#35706](https://github.com/WordPress/gutenberg/pull/35706). To display a subset of blocks, use the `blocks` parameter instead.
 
 ## 7.0.0 (2021-07-29)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Performance
+
+-   Fix block focus time when List View is open. [#35706](https://github.com/WordPress/gutenberg/pull/35706)
+
+### Breaking change
+
+-   ListView no longer supports the `showOnlyCurrentHierarchy` flag [#35706](https://github.com/WordPress/gutenberg/pull/35706). To display a subset of blocks, use the `blocks` parameter instead.
+
 ## 7.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -67,7 +67,6 @@ function BlockNavigationDropdown(
 
 					<ListView
 						showNestedBlocks
-						showOnlyCurrentHierarchy
 						__experimentalFeatures={ __experimentalFeatures }
 					/>
 				</div>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -144,9 +144,6 @@ export default function ListViewBlock( {
 		'is-selected': isSelected,
 		'is-branch-selected':
 			withExperimentalPersistentListViewFeatures && isBranchSelected,
-		// 'is-last-of-selected-branch':
-		// 	withExperimentalPersistentListViewFeatures &&
-		// 	isLastOfSelectedBranch,
 		'is-dragging': isDragged,
 	} );
 

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -49,6 +49,7 @@ export default function ListViewBlock( {
 	const {
 		__experimentalFeatures: withExperimentalFeatures,
 		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
+		__experimentalHideContainerBlockActions: hideContainerBlockActions,
 		isTreeGridMounted,
 		expand,
 		collapse,
@@ -140,11 +141,27 @@ export default function ListViewBlock( {
 		[ clientId, expand, collapse, isExpanded ]
 	);
 
+	const showBlockActions =
+		withExperimentalFeatures &&
+		//hide actions for blocks like core/widget-areas
+		( ! hideContainerBlockActions ||
+			( hideContainerBlockActions && level > 1 ) );
+
+	const hideBlockActions = withExperimentalFeatures && ! showBlockActions;
+
+	let colSpan;
+	if ( hasRenderedMovers ) {
+		colSpan = 2;
+	} else if ( hideBlockActions ) {
+		colSpan = 3;
+	}
+
 	const classes = classnames( {
 		'is-selected': isSelected,
 		'is-branch-selected':
 			withExperimentalPersistentListViewFeatures && isBranchSelected,
 		'is-dragging': isDragged,
+		'has-single-cell': hideBlockActions,
 	} );
 
 	return (
@@ -165,7 +182,7 @@ export default function ListViewBlock( {
 			>
 				<TreeGridCell
 					className="block-editor-list-view-block__contents-cell"
-					colSpan={ hasRenderedMovers ? undefined : 2 }
+					colSpan={ colSpan }
 					ref={ cellRef }
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
@@ -217,7 +234,7 @@ export default function ListViewBlock( {
 					</>
 				) }
 
-				{ withExperimentalFeatures && (
+				{ showBlockActions && (
 					<TreeGridCell className={ listViewBlockSettingsClassName }>
 						{ ( { ref, tabIndex, onFocus } ) => (
 							<BlockSettingsDropdown

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -11,7 +11,7 @@ import {
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 
 /**
@@ -33,7 +33,7 @@ export default function ListViewBlock( {
 	isDragged,
 	isBranchSelected,
 	isLastOfSelectedBranch,
-	onClick,
+	selectBlock,
 	onToggleExpanded,
 	position,
 	level,
@@ -82,14 +82,22 @@ export default function ListViewBlock( {
 		? toggleBlockHighlight
 		: () => {};
 
-	const onMouseEnter = () => {
+	const onMouseEnter = useCallback( () => {
 		setIsHovered( true );
 		highlightBlock( clientId, true );
-	};
-	const onMouseLeave = () => {
+	}, [ clientId, setIsHovered, highlightBlock ] );
+	const onMouseLeave = useCallback( () => {
 		setIsHovered( false );
 		highlightBlock( clientId, false );
-	};
+	}, [ clientId, setIsHovered, highlightBlock ] );
+
+	const selectEditorBlock = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			selectBlock( clientId );
+		},
+		[ clientId, selectBlock ]
+	);
 
 	const classes = classnames( {
 		'is-selected': isSelected,
@@ -125,7 +133,7 @@ export default function ListViewBlock( {
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
 							block={ block }
-							onClick={ onClick }
+							onClick={ selectEditorBlock }
 							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
@@ -183,7 +191,7 @@ export default function ListViewBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
-							__experimentalSelectBlock={ onClick }
+							__experimentalSelectBlock={ selectEditorBlock }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -34,7 +34,6 @@ export default function ListViewBlock( {
 	isBranchSelected,
 	isLastOfSelectedBranch,
 	selectBlock,
-	onToggleExpanded,
 	position,
 	level,
 	rowCount,
@@ -59,6 +58,8 @@ export default function ListViewBlock( {
 		__experimentalFeatures: withExperimentalFeatures,
 		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
 		isTreeGridMounted,
+		expand,
+		collapse,
 	} = useListViewContext();
 	const listViewBlockSettingsClassName = classnames(
 		'block-editor-list-view-block__menu-cell',
@@ -99,6 +100,18 @@ export default function ListViewBlock( {
 		[ clientId, selectBlock ]
 	);
 
+	const toggleExpanded = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			if ( isExpanded === true ) {
+				collapse( clientId );
+			} else if ( isExpanded === false ) {
+				expand( clientId );
+			}
+		},
+		[ clientId, expand, collapse, isExpanded ]
+	);
+
 	const classes = classnames( {
 		'is-selected': isSelected,
 		'is-branch-selected':
@@ -134,7 +147,7 @@ export default function ListViewBlock( {
 						<ListViewBlockContents
 							block={ block }
 							onClick={ selectEditorBlock }
-							onToggleExpanded={ onToggleExpanded }
+							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
 							siblingBlockCount={ siblingBlockCount }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, AsyncModeProvider } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -151,92 +151,95 @@ export default function ListViewBlock( {
 	} );
 
 	return (
-		<ListViewLeaf
-			className={ classes }
-			onMouseEnter={ onMouseEnter }
-			onMouseLeave={ onMouseLeave }
-			onFocus={ onMouseEnter }
-			onBlur={ onMouseLeave }
-			level={ level }
-			position={ position }
-			rowCount={ rowCount }
-			path={ path }
-			id={ `list-view-block-${ clientId }` }
-			data-block={ clientId }
-			isExpanded={ isExpanded }
-		>
-			<TreeGridCell
-				className="block-editor-list-view-block__contents-cell"
-				colSpan={ hasRenderedMovers ? undefined : 2 }
-				ref={ cellRef }
+		<AsyncModeProvider value={ ! isSelected }>
+			<ListViewLeaf
+				className={ classes }
+				onMouseEnter={ onMouseEnter }
+				onMouseLeave={ onMouseLeave }
+				onFocus={ onMouseEnter }
+				onBlur={ onMouseLeave }
+				level={ level }
+				position={ position }
+				rowCount={ rowCount }
+				path={ path }
+				id={ `list-view-block-${ clientId }` }
+				data-block={ clientId }
+				isExpanded={ isExpanded }
 			>
-				{ ( { ref, tabIndex, onFocus } ) => (
-					<div className="block-editor-list-view-block__contents-container">
-						<ListViewBlockContents
-							block={ block }
-							onClick={ selectEditorBlock }
-							onToggleExpanded={ toggleExpanded }
-							isSelected={ isSelected }
-							position={ position }
-							siblingBlockCount={ siblingBlockCount }
-							level={ level }
-							ref={ ref }
-							tabIndex={ tabIndex }
-							onFocus={ onFocus }
-						/>
-					</div>
-				) }
-			</TreeGridCell>
-			{ hasRenderedMovers && (
-				<>
-					<TreeGridCell
-						className={ moverCellClassName }
-						withoutGridItem
-					>
-						<TreeGridItem>
-							{ ( { ref, tabIndex, onFocus } ) => (
-								<BlockMoverUpButton
-									orientation="vertical"
-									clientIds={ [ clientId ] }
-									ref={ ref }
-									tabIndex={ tabIndex }
-									onFocus={ onFocus }
-								/>
-							) }
-						</TreeGridItem>
-						<TreeGridItem>
-							{ ( { ref, tabIndex, onFocus } ) => (
-								<BlockMoverDownButton
-									orientation="vertical"
-									clientIds={ [ clientId ] }
-									ref={ ref }
-									tabIndex={ tabIndex }
-									onFocus={ onFocus }
-								/>
-							) }
-						</TreeGridItem>
-					</TreeGridCell>
-				</>
-			) }
-
-			{ withExperimentalFeatures && (
-				<TreeGridCell className={ listViewBlockSettingsClassName }>
+				<TreeGridCell
+					className="block-editor-list-view-block__contents-cell"
+					colSpan={ hasRenderedMovers ? undefined : 2 }
+					ref={ cellRef }
+				>
 					{ ( { ref, tabIndex, onFocus } ) => (
-						<BlockSettingsDropdown
-							clientIds={ [ clientId ] }
-							icon={ moreVertical }
-							toggleProps={ {
-								ref,
-								className: 'block-editor-list-view-block__menu',
-								tabIndex,
-								onFocus,
-							} }
-							disableOpenOnArrowDown
-							__experimentalSelectBlock={ selectEditorBlock }
-						/>
+						<div className="block-editor-list-view-block__contents-container">
+							<ListViewBlockContents
+								block={ block }
+								onClick={ selectEditorBlock }
+								onToggleExpanded={ toggleExpanded }
+								isSelected={ isSelected }
+								position={ position }
+								siblingBlockCount={ siblingBlockCount }
+								level={ level }
+								ref={ ref }
+								tabIndex={ tabIndex }
+								onFocus={ onFocus }
+							/>
+						</div>
 					) }
 				</TreeGridCell>
-			) }
-		</ListViewLeaf>
+				{ hasRenderedMovers && (
+					<>
+						<TreeGridCell
+							className={ moverCellClassName }
+							withoutGridItem
+						>
+							<TreeGridItem>
+								{ ( { ref, tabIndex, onFocus } ) => (
+									<BlockMoverUpButton
+										orientation="vertical"
+										clientIds={ [ clientId ] }
+										ref={ ref }
+										tabIndex={ tabIndex }
+										onFocus={ onFocus }
+									/>
+								) }
+							</TreeGridItem>
+							<TreeGridItem>
+								{ ( { ref, tabIndex, onFocus } ) => (
+									<BlockMoverDownButton
+										orientation="vertical"
+										clientIds={ [ clientId ] }
+										ref={ ref }
+										tabIndex={ tabIndex }
+										onFocus={ onFocus }
+									/>
+								) }
+							</TreeGridItem>
+						</TreeGridCell>
+					</>
+				) }
+
+				{ withExperimentalFeatures && (
+					<TreeGridCell className={ listViewBlockSettingsClassName }>
+						{ ( { ref, tabIndex, onFocus } ) => (
+							<BlockSettingsDropdown
+								clientIds={ [ clientId ] }
+								icon={ moreVertical }
+								toggleProps={ {
+									ref,
+									className:
+										'block-editor-list-view-block__menu',
+									tabIndex,
+									onFocus,
+								} }
+								disableOpenOnArrowDown
+								__experimentalSelectBlock={ selectEditorBlock }
+							/>
+						) }
+					</TreeGridCell>
+				) }
+			</ListViewLeaf>
+		</AsyncModeProvider>
 	);
 }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,6 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		terminatedLevels = [],
 		path = [],
 		isBranchSelected = false,
 		isLastOfBranch = false,
@@ -56,10 +55,6 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const isLastRowAtLevel = rowCount === position;
-				const updatedTerminatedLevels = isLastRowAtLevel
-					? [ ...terminatedLevels, level ]
-					: terminatedLevels;
 				const updatedPath = [ ...path, position ];
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
@@ -112,7 +107,6 @@ export default function ListViewBranch( props ) {
 							rowCount={ rowCount }
 							siblingBlockCount={ blockCount }
 							showBlockMovers={ showBlockMovers }
-							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 							isExpanded={ isExpanded }
 						/>
@@ -127,7 +121,6 @@ export default function ListViewBranch( props ) {
 								showNestedBlocks={ showNestedBlocks }
 								parentBlockClientId={ clientId }
 								level={ level + 1 }
-								terminatedLevels={ updatedTerminatedLevels }
 								path={ updatedPath }
 							/>
 						) }
@@ -140,7 +133,6 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					terminatedLevels={ terminatedLevels }
 					path={ [ ...path, appenderPosition ] }
 				/>
 			) }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -27,7 +27,6 @@ export default function ListViewBranch( props ) {
 	const { expandedState, draggedClientIds } = useListViewContext();
 
 	const filteredBlocks = compact( blocks );
-	// Add +1 to the rowCount to take the block appender into account.
 	const blockCount = filteredBlocks.length;
 
 	return (
@@ -35,7 +34,7 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				// If the string value changes, it's used to trigger an animation change.
+				// This string value is used to trigger an animation change.
 				// This may be removed if we use a different animation library in the future.
 				const updatedPath =
 					path.length > 0
@@ -48,8 +47,6 @@ export default function ListViewBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				// Make updates to the selected or dragged blocks synchronous,
-				// but asynchronous for any other block.
 				const isDragged = !! draggedClientIds?.includes( clientId );
 
 				return (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -25,7 +25,7 @@ export default function ListViewBranch( props ) {
 		showNestedBlocks,
 		parentBlockClientId,
 		level = 1,
-		path = [],
+		path = '',
 		isBranchSelected = false,
 		isLastOfBranch = false,
 	} = props;
@@ -53,7 +53,12 @@ export default function ListViewBranch( props ) {
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 				const position = index + 1;
-				const updatedPath = [ ...path, position ];
+				// If the string value changes, it's used to trigger an animation change.
+				// This may be removed if we use a different animation library in the future.
+				const updatedPath =
+					path.length > 0
+						? `${ path }_${ position }`
+						: `${ position }`;
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const hasNestedAppender = itemHasAppender( clientId );
@@ -121,7 +126,11 @@ export default function ListViewBranch( props ) {
 					position={ rowCount }
 					rowCount={ appenderPosition }
 					level={ level }
-					path={ [ ...path, appenderPosition ] }
+					path={
+						path.length > 0
+							? `${ path }_${ appenderPosition }`
+							: `${ appenderPosition }`
+					}
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -32,8 +32,6 @@ export default function ListViewBranch( props ) {
 
 	const {
 		expandedState,
-		expand,
-		collapse,
 		draggedClientIds,
 		selectedClientIds,
 	} = useListViewContext();
@@ -79,15 +77,6 @@ export default function ListViewBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				const toggleExpanded = ( event ) => {
-					event.stopPropagation();
-					if ( isExpanded === true ) {
-						collapse( clientId );
-					} else if ( isExpanded === false ) {
-						expand( clientId );
-					}
-				};
-
 				// Make updates to the selected or dragged blocks synchronous,
 				// but asynchronous for any other block.
 				const isDragged = !! draggedClientIds?.includes( clientId );
@@ -97,7 +86,6 @@ export default function ListViewBranch( props ) {
 						<ListViewBlock
 							block={ block }
 							selectBlock={ selectBlock }
-							onToggleExpanded={ toggleExpanded }
 							isDragged={ isDragged }
 							isSelected={ isSelected }
 							isBranchSelected={ isSelectedBranch }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -84,11 +84,6 @@ export default function ListViewBranch( props ) {
 					? expandedState[ clientId ] ?? true
 					: undefined;
 
-				const selectBlockWithClientId = ( event ) => {
-					event.stopPropagation();
-					selectBlock( clientId );
-				};
-
 				const toggleExpanded = ( event ) => {
 					event.stopPropagation();
 					if ( isExpanded === true ) {
@@ -106,7 +101,7 @@ export default function ListViewBranch( props ) {
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						<ListViewBlock
 							block={ block }
-							onClick={ selectBlockWithClientId }
+							selectBlock={ selectBlock }
 							onToggleExpanded={ toggleExpanded }
 							isDragged={ isDragged }
 							isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -97,12 +97,18 @@ function ListView(
 		},
 		[ setExpandedState ]
 	);
-	const expandRow = ( row ) => {
-		expand( row?.dataset?.block );
-	};
-	const collapseRow = ( row ) => {
-		collapse( row?.dataset?.block );
-	};
+	const expandRow = useCallback(
+		( row ) => {
+			expand( row?.dataset?.block );
+		},
+		[ expand ]
+	);
+	const collapseRow = useCallback(
+		( row ) => {
+			collapse( row?.dataset?.block );
+		},
+		[ collapse ]
+	);
 
 	const contextValue = useMemo(
 		() => ( {

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -62,11 +62,7 @@ function ListView(
 	},
 	ref
 ) {
-	const {
-		clientIdsTree,
-		selectedClientIds,
-		draggedClientIds,
-	} = useListViewClientIds(
+	const { clientIdsTree, draggedClientIds } = useListViewClientIds(
 		blocks,
 		showOnlyCurrentHierarchy,
 		__experimentalPersistentListViewFeatures
@@ -121,7 +117,6 @@ function ListView(
 			__experimentalPersistentListViewFeatures,
 			isTreeGridMounted: isMounted.current,
 			draggedClientIds,
-			selectedClientIds,
 			expandedState,
 			expand,
 			collapse,
@@ -131,7 +126,6 @@ function ListView(
 			__experimentalPersistentListViewFeatures,
 			isMounted.current,
 			draggedClientIds,
-			selectedClientIds,
 			expandedState,
 			expand,
 			collapse,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -49,6 +49,7 @@ const expanded = ( state, action ) => {
  * @param {boolean}  props.showBlockMovers                          Flag to enable block movers
  * @param {boolean}  props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean}  props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
+ * @param {boolean}  props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
  * @param {Object}   ref                                            Forwarded ref
  */
 function ListView(
@@ -57,6 +58,7 @@ function ListView(
 		onSelect = noop,
 		__experimentalFeatures,
 		__experimentalPersistentListViewFeatures,
+		__experimentalHideContainerBlockActions,
 		showNestedBlocks,
 		showBlockMovers,
 		...props
@@ -118,6 +120,7 @@ function ListView(
 		() => ( {
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
+			__experimentalHideContainerBlockActions,
 			isTreeGridMounted: isMounted.current,
 			draggedClientIds,
 			expandedState,
@@ -127,6 +130,7 @@ function ListView(
 		[
 			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
+			__experimentalHideContainerBlockActions,
 			isMounted.current,
 			draggedClientIds,
 			expandedState,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -45,8 +45,6 @@ const expanded = ( state, action ) => {
  * @param {Object}   props                                          Components props.
  * @param {Array}    props.blocks                                   Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {Function} props.onSelect                                 Block selection callback.
- * @param {boolean}  props.showNestedBlocks                         Flag to enable displaying nested blocks.
- * @param {boolean}  props.showOnlyCurrentHierarchy                 Flag to limit the list to the current hierarchy of blocks.
  * @param {boolean}  props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean}  props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {Object}   ref                                            Forwarded ref
@@ -54,7 +52,6 @@ const expanded = ( state, action ) => {
 function ListView(
 	{
 		blocks,
-		showOnlyCurrentHierarchy,
 		onSelect = noop,
 		__experimentalFeatures,
 		__experimentalPersistentListViewFeatures,
@@ -62,11 +59,7 @@ function ListView(
 	},
 	ref
 ) {
-	const { clientIdsTree, draggedClientIds } = useListViewClientIds(
-		blocks,
-		showOnlyCurrentHierarchy,
-		__experimentalPersistentListViewFeatures
-	);
+	const { clientIdsTree, draggedClientIds } = useListViewClientIds( blocks );
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const selectEditorBlock = useCallback(
 		( clientId ) => {

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -45,6 +45,8 @@ const expanded = ( state, action ) => {
  * @param {Object}   props                                          Components props.
  * @param {Array}    props.blocks                                   Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {Function} props.onSelect                                 Block selection callback.
+ * @param {boolean}  props.showNestedBlocks                         Flag to enable displaying nested blocks.
+ * @param {boolean}  props.showBlockMovers                          Flag to enable block movers
  * @param {boolean}  props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean}  props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {Object}   ref                                            Forwarded ref
@@ -55,6 +57,8 @@ function ListView(
 		onSelect = noop,
 		__experimentalFeatures,
 		__experimentalPersistentListViewFeatures,
+		showNestedBlocks,
+		showBlockMovers,
 		...props
 	},
 	ref
@@ -148,6 +152,8 @@ function ListView(
 					<ListViewBranch
 						blocks={ clientIdsTree }
 						selectBlock={ selectEditorBlock }
+						showNestedBlocks={ showNestedBlocks }
+						showBlockMovers={ showBlockMovers }
 						{ ...props }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -30,7 +30,7 @@ export default function ListViewLeaf( {
 		isSelected,
 		adjustScrolling: false,
 		enableAnimation: true,
-		triggerAnimationOnChange: path.join( '_' ),
+		triggerAnimationOnChange: path,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -57,9 +57,6 @@
 	&.is-branch-selected:not(.is-selected) .block-editor-list-view-block-contents {
 		border-radius: 0;
 	}
-	&.is-branch-selected.is-last-of-selected-branch .block-editor-list-view-block-contents {
-		border-radius: 0 0 2px 2px;
-	}
 
 	&.is-dragging {
 		display: none;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -112,6 +112,11 @@
 			}
 		}
 	}
+	//fix focus styling width when one row has fewer cells
+	&.has-single-cell .block-editor-list-view-block-contents:focus::after {
+		right: 0;
+	}
+
 	.block-editor-list-view-block__menu:focus {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		z-index: 1;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -112,7 +112,7 @@
 			}
 		}
 	}
-	//fix focus styling width when one row has fewer cells
+	// Fix focus styling width when one row has fewer cells.
 	&.has-single-cell .block-editor-list-view-block-contents:focus::after {
 		right: 0;
 	}

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -9,44 +9,19 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
-const useListViewClientIdsTree = ( blocks, showOnlyCurrentHierarchy ) =>
-	useSelect(
+export default function useListViewClientIds( blocks ) {
+	return useSelect(
 		( select ) => {
-			if ( blocks ) {
-				return blocks;
-			}
-
-			const { __unstableGetClientIdsTree } = select( blockEditorStore );
-
-			return __unstableGetClientIdsTree();
-		},
-		[ blocks, showOnlyCurrentHierarchy ]
-	);
-
-export default function useListViewClientIds(
-	blocks,
-	showOnlyCurrentHierarchy,
-	__experimentalPersistentListViewFeatures
-) {
-	const { draggedClientIds } = useSelect(
-		( select ) => {
-			const { getDraggedBlockClientIds } = select( blockEditorStore );
-
-			if ( __experimentalPersistentListViewFeatures ) {
-				return {
-					draggedClientIds: getDraggedBlockClientIds(),
-				};
-			}
+			const {
+				getDraggedBlockClientIds,
+				__unstableGetClientIdsTree,
+			} = select( blockEditorStore );
 
 			return {
 				draggedClientIds: getDraggedBlockClientIds(),
+				clientIdsTree: blocks ? blocks : __unstableGetClientIdsTree(),
 			};
 		},
-		[ __experimentalPersistentListViewFeatures ]
+		[ blocks ]
 	);
-	const clientIdsTree = useListViewClientIdsTree(
-		blocks,
-		showOnlyCurrentHierarchy
-	);
-	return { clientIdsTree, draggedClientIds };
 }

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -7,49 +7,20 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
 
-const useListViewClientIdsTree = (
-	blocks,
-	selectedClientIds,
-	showOnlyCurrentHierarchy
-) =>
+const useListViewClientIdsTree = ( blocks, showOnlyCurrentHierarchy ) =>
 	useSelect(
 		( select ) => {
-			const {
-				getBlockHierarchyRootClientId,
-				__unstableGetClientIdsTree,
-				__unstableGetClientIdWithClientIdsTree,
-			} = select( blockEditorStore );
-
 			if ( blocks ) {
 				return blocks;
 			}
 
-			const isSingleBlockSelected =
-				selectedClientIds && ! Array.isArray( selectedClientIds );
-			if ( ! showOnlyCurrentHierarchy || ! isSingleBlockSelected ) {
-				return __unstableGetClientIdsTree();
-			}
-
-			const rootBlock = __unstableGetClientIdWithClientIdsTree(
-				getBlockHierarchyRootClientId( selectedClientIds )
-			);
-			if ( ! rootBlock ) {
-				return __unstableGetClientIdsTree();
-			}
-
-			const hasHierarchy =
-				! isClientIdSelected( rootBlock.clientId, selectedClientIds ) ||
-				( rootBlock.innerBlocks && rootBlock.innerBlocks.length !== 0 );
-			if ( hasHierarchy ) {
-				return [ rootBlock ];
-			}
+			const { __unstableGetClientIdsTree } = select( blockEditorStore );
 
 			return __unstableGetClientIdsTree();
 		},
-		[ blocks, selectedClientIds, showOnlyCurrentHierarchy ]
+		[ blocks, showOnlyCurrentHierarchy ]
 	);
 
 export default function useListViewClientIds(
@@ -57,23 +28,17 @@ export default function useListViewClientIds(
 	showOnlyCurrentHierarchy,
 	__experimentalPersistentListViewFeatures
 ) {
-	const { selectedClientIds, draggedClientIds } = useSelect(
+	const { draggedClientIds } = useSelect(
 		( select ) => {
-			const {
-				getSelectedBlockClientId,
-				getSelectedBlockClientIds,
-				getDraggedBlockClientIds,
-			} = select( blockEditorStore );
+			const { getDraggedBlockClientIds } = select( blockEditorStore );
 
 			if ( __experimentalPersistentListViewFeatures ) {
 				return {
-					selectedClientIds: getSelectedBlockClientIds(),
 					draggedClientIds: getDraggedBlockClientIds(),
 				};
 			}
 
 			return {
-				selectedClientIds: getSelectedBlockClientId(),
 				draggedClientIds: getDraggedBlockClientIds(),
 			};
 		},
@@ -81,8 +46,7 @@ export default function useListViewClientIds(
 	);
 	const clientIdsTree = useListViewClientIdsTree(
 		blocks,
-		selectedClientIds,
 		showOnlyCurrentHierarchy
 	);
-	return { clientIdsTree, selectedClientIds, draggedClientIds };
+	return { clientIdsTree, draggedClientIds };
 }

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -111,6 +111,10 @@ _Parameters_
 
 Undocumented declaration.
 
+### closeListView
+
+Closes list view
+
 ### createEmbeddingMatcher
 
 Creates a function to determine if a request is embedding a certain URL.
@@ -507,6 +511,10 @@ Clicks on the button in the header which opens Document Settings sidebar when it
 ### openGlobalBlockInserter
 
 Opens the global block inserter.
+
+### openListView
+
+Opens list view
 
 ### openPreviewPage
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -93,5 +93,6 @@ export {
 	rest as __experimentalRest,
 	batch as __experimentalBatch,
 } from './rest-api';
+export { openListView, closeListView } from './list-view';
 
 export * from './mocks';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -43,7 +43,12 @@ async function isGlobalInserterOpen() {
 		// "Add block" selector is required to make sure performance comparison
 		// doesn't fail on older branches where we still had "Add block" as label.
 		return !! document.querySelector(
-			'.edit-post-header [aria-label="Add block"].is-pressed, .edit-site-header [aria-label="Add block"].is-pressed, .edit-post-header [aria-label="Toggle block inserter"].is-pressed, .edit-site-header [aria-label="Toggle block inserter"].is-pressed'
+			'.edit-post-header [aria-label="Add block"].is-pressed,' +
+				'.edit-site-header [aria-label="Add block"].is-pressed,' +
+				'.edit-post-header [aria-label="Toggle block inserter"].is-pressed,' +
+				'.edit-site-header [aria-label="Toggle block inserter"].is-pressed,' +
+				'.edit-widgets-header [aria-label="Toggle block inserter"].is-pressed,' +
+				'.edit-widgets-header [aria-label="Add block"].is-pressed'
 		);
 	} );
 }
@@ -54,7 +59,12 @@ export async function toggleGlobalBlockInserter() {
 	// "Add block" selector is required to make sure performance comparison
 	// doesn't fail on older branches where we still had "Add block" as label.
 	await page.click(
-		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"], .edit-post-header [aria-label="Toggle block inserter"], .edit-site-header [aria-label="Toggle block inserter"]'
+		'.edit-post-header [aria-label="Add block"],' +
+			'.edit-site-header [aria-label="Add block"],' +
+			'.edit-post-header [aria-label="Toggle block inserter"],' +
+			'.edit-site-header [aria-label="Toggle block inserter"],' +
+			'.edit-widgets-header [aria-label="Add block"],' +
+			'.edit-widgets-header [aria-label="Toggle block inserter"]'
 	);
 }
 

--- a/packages/e2e-test-utils/src/list-view.js
+++ b/packages/e2e-test-utils/src/list-view.js
@@ -1,13 +1,13 @@
 async function toggleListView() {
 	await page.click(
-		'.edit-post-header-toolbar__list-view-toggle, .edit-site-header-toolbar__list-view-toggle'
+		'.edit-post-header-toolbar__list-view-toggle, .edit-site-header-toolbar__list-view-toggle, .edit-widgets-header-toolbar__list-view-toggle'
 	);
 }
 
 async function isListViewOpen() {
 	return await page.evaluate( () => {
 		return !! document.querySelector(
-			'.edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-toolbar__list-view-toggle.is-pressed'
+			'.edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-toolbar__list-view-toggle.is-pressed, .edit-widgets-header-toolbar__list-view-toggle.is-pressed'
 		);
 	} );
 }

--- a/packages/e2e-test-utils/src/list-view.js
+++ b/packages/e2e-test-utils/src/list-view.js
@@ -1,0 +1,33 @@
+async function toggleListView() {
+	await page.click(
+		'.edit-post-header-toolbar__list-view-toggle, .edit-site-header-toolbar__list-view-toggle'
+	);
+}
+
+async function isListViewOpen() {
+	return await page.evaluate( () => {
+		return !! document.querySelector(
+			'.edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-toolbar__list-view-toggle.is-pressed'
+		);
+	} );
+}
+
+/**
+ * Opens list view
+ */
+export async function openListView() {
+	const isOpen = await isListViewOpen();
+	if ( ! isOpen ) {
+		await toggleListView();
+	}
+}
+
+/**
+ * Closes list view
+ */
+export async function closeListView() {
+	const isOpen = await isListViewOpen();
+	if ( isOpen ) {
+		await toggleListView();
+	}
+}

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-  Enable persistent List View in the widget editor [#35706](https://github.com/WordPress/gutenberg/pull/35706).
+
 ## 3.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -5,13 +5,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { Button, ToolbarItem, VisuallyHidden } from '@wordpress/components';
 import {
-	BlockNavigationDropdown,
 	NavigableToolbar,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
-import { plus } from '@wordpress/icons';
-import { useRef } from '@wordpress/element';
+import { listView, plus } from '@wordpress/icons';
+import { useCallback, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
@@ -35,16 +34,23 @@ function Header() {
 			),
 		[ widgetAreaClientId ]
 	);
-	const isInserterOpened = useSelect(
-		( select ) => select( editWidgetsStore ).isInserterOpened(),
-		[]
-	);
-	const { setIsWidgetAreaOpen, setIsInserterOpened } = useDispatch(
-		editWidgetsStore
-	);
+	const { isInserterOpen, isListViewOpen } = useSelect( ( select ) => {
+		const { isInserterOpened, isListViewOpened } = select(
+			editWidgetsStore
+		);
+		return {
+			isInserterOpen: isInserterOpened(),
+			isListViewOpen: isListViewOpened(),
+		};
+	}, [] );
+	const {
+		setIsWidgetAreaOpen,
+		setIsInserterOpened,
+		setIsListViewOpened,
+	} = useDispatch( editWidgetsStore );
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const handleClick = () => {
-		if ( isInserterOpened ) {
+		if ( isInserterOpen ) {
 			// Focusing the inserter button closes the inserter popover
 			inserterButton.current.focus();
 		} else {
@@ -62,6 +68,11 @@ function Header() {
 			window.requestAnimationFrame( () => setIsInserterOpened( true ) );
 		}
 	};
+
+	const toggleListView = useCallback(
+		() => setIsListViewOpened( ! isListViewOpen ),
+		[ setIsListViewOpened, isListViewOpen ]
+	);
 
 	return (
 		<>
@@ -89,7 +100,7 @@ function Header() {
 							as={ Button }
 							className="edit-widgets-header-toolbar__inserter-toggle"
 							variant="primary"
-							isPressed={ isInserterOpened }
+							isPressed={ isInserterOpen }
 							onMouseDown={ ( event ) => {
 								event.preventDefault();
 							} }
@@ -106,7 +117,15 @@ function Header() {
 							<>
 								<UndoButton />
 								<RedoButton />
-								<ToolbarItem as={ BlockNavigationDropdown } />
+								<ToolbarItem
+									as={ Button }
+									className="edit-widgets-header-toolbar__list-view-toggle"
+									icon={ listView }
+									isPressed={ isListViewOpen }
+									/* translators: button label text should, if possible, be under 16 characters. */
+									label={ __( 'List View' ) }
+									onClick={ toggleListView }
+								/>
 							</>
 						) }
 					</NavigableToolbar>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -52,7 +52,7 @@ function Header() {
 	const handleClick = () => {
 		if ( isInserterOpen ) {
 			// Focusing the inserter button closes the inserter popover
-			inserterButton.current.focus();
+			setIsInserterOpened( false );
 		} else {
 			if ( ! isLastSelectedWidgetAreaOpen ) {
 				// Select the last selected block if hasn't already.

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -1,16 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
-import {
-	__experimentalUseDialog as useDialog,
-	useViewportMatch,
-} from '@wordpress/compose';
-import { close } from '@wordpress/icons';
-import {
-	__experimentalLibrary as Library,
-	BlockBreadcrumb,
-} from '@wordpress/block-editor';
+import { useViewportMatch } from '@wordpress/compose';
+import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -26,8 +18,8 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  */
 import Header from '../header';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
-import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
 import { store as editWidgetsStore } from '../../store';
+import SecondarySidebar from '../secondary-sidebar';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the widgets screen top bar landmark region. */
@@ -43,15 +35,16 @@ const interfaceLabels = {
 function Interface( { blockEditorSettings } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
-	const { setIsInserterOpened, closeGeneralSidebar } = useDispatch(
-		editWidgetsStore
-	);
-	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
-
+	const {
+		setIsInserterOpened,
+		setIsListViewOpened,
+		closeGeneralSidebar,
+	} = useDispatch( editWidgetsStore );
 	const {
 		hasBlockBreadCrumbsEnabled,
 		hasSidebarEnabled,
 		isInserterOpened,
+		isListViewOpened,
 		previousShortcut,
 		nextShortcut,
 	} = useSelect(
@@ -60,6 +53,7 @@ function Interface( { blockEditorSettings } ) {
 				interfaceStore
 			).getActiveComplementaryArea( editWidgetsStore.name ),
 			isInserterOpened: !! select( editWidgetsStore ).isInserterOpened(),
+			isListViewOpened: !! select( editWidgetsStore ).isListViewOpened(),
 			hasBlockBreadCrumbsEnabled: select(
 				interfaceStore
 			).isFeatureActive( 'core/edit-widgets', 'showBlockBreadcrumbs' ),
@@ -79,47 +73,21 @@ function Interface( { blockEditorSettings } ) {
 	useEffect( () => {
 		if ( hasSidebarEnabled && ! isHugeViewport ) {
 			setIsInserterOpened( false );
+			setIsListViewOpened( false );
 		}
 	}, [ hasSidebarEnabled, isHugeViewport ] );
 
 	useEffect( () => {
-		if ( isInserterOpened && ! isHugeViewport ) {
+		if ( ( isInserterOpened || isListViewOpened ) && ! isHugeViewport ) {
 			closeGeneralSidebar();
 		}
-	}, [ isInserterOpened, isHugeViewport ] );
-
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: () => setIsInserterOpened( false ),
-	} );
+	}, [ isInserterOpened, isListViewOpened, isHugeViewport ] );
 
 	return (
 		<InterfaceSkeleton
 			labels={ interfaceLabels }
 			header={ <Header /> }
-			secondarySidebar={
-				isInserterOpened && (
-					<div
-						ref={ inserterDialogRef }
-						{ ...inserterDialogProps }
-						className="edit-widgets-layout__inserter-panel"
-					>
-						<div className="edit-widgets-layout__inserter-panel-header">
-							<Button
-								icon={ close }
-								onClick={ () => setIsInserterOpened( false ) }
-							/>
-						</div>
-						<div className="edit-widgets-layout__inserter-panel-content">
-							<Library
-								showInserterHelpPanel
-								shouldFocusBlock={ isMobileViewport }
-								rootClientId={ rootClientId }
-								__experimentalInsertionIndex={ insertionIndex }
-							/>
-						</div>
-					</div>
-				)
-			}
+			secondarySidebar={ <SecondarySidebar /> }
 			sidebar={
 				hasSidebarEnabled && (
 					<ComplementaryArea.Slot scope="core/edit-widgets" />

--- a/packages/edit-widgets/src/components/secondary-sidebar/index.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
+/**
+ * Internal dependencies
+ */
+import InserterSidebar from './inserter-sidebar';
+import ListViewSidebar from './list-view-sidebar';
+
+export default function SecondarySidebar() {
+	const { isInserterOpen, isListViewOpen } = useSelect( ( select ) => {
+		const { isInserterOpened, isListViewOpened } = select(
+			editWidgetsStore
+		);
+		return {
+			isInserterOpen: isInserterOpened(),
+			isListViewOpen: isListViewOpened(),
+		};
+	}, [] );
+
+	if ( isInserterOpen ) {
+		return <InserterSidebar />;
+	}
+	if ( isListViewOpen ) {
+		return <ListViewSidebar />;
+	}
+	return null;
+}

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import {
+	useViewportMatch,
+	__experimentalUseDialog as useDialog,
+} from '@wordpress/compose';
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
+import { store as editWidgetsStore } from '../../store';
+
+export default function InserterSidebar() {
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
+
+	const { setIsInserterOpened } = useDispatch( editWidgetsStore );
+
+	const closeInserter = useCallback( () => {
+		return () => setIsInserterOpened( false );
+	}, [ setIsInserterOpened ] );
+
+	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
+		onClose: closeInserter,
+	} );
+
+	return (
+		<div
+			ref={ inserterDialogRef }
+			{ ...inserterDialogProps }
+			className="edit-widgets-layout__inserter-panel"
+		>
+			<div className="edit-widgets-layout__inserter-panel-header">
+				<Button icon={ close } onClick={ closeInserter } />
+			</div>
+			<div className="edit-widgets-layout__inserter-panel-content">
+				<Library
+					showInserterHelpPanel
+					shouldFocusBlock={ isMobileViewport }
+					rootClientId={ rootClientId }
+					__experimentalInsertionIndex={ insertionIndex }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -65,6 +65,7 @@ export default function ListViewSidebar() {
 				<ListView
 					onSelect={ selectEditorBlock }
 					showNestedBlocks
+					__experimentalHideContainerBlockActions
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
 				/>

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalListView as ListView,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import {
+	useFocusOnMount,
+	useFocusReturn,
+	useInstanceId,
+	useMergeRefs,
+} from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { store as editWidgetsStore } from '../../store';
+
+export default function ListViewSidebar() {
+	const { setIsListViewOpened } = useDispatch( editWidgetsStore );
+
+	const { clearSelectedBlock, selectBlock } = useDispatch( blockEditorStore );
+	async function selectEditorBlock( clientId ) {
+		await clearSelectedBlock();
+		selectBlock( clientId, -1 );
+	}
+
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const focusReturnRef = useFocusReturn();
+	function closeOnEscape( event ) {
+		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+			event.preventDefault();
+			setIsListViewOpened( false );
+		}
+	}
+
+	const instanceId = useInstanceId( ListViewSidebar );
+	const labelId = `edit-widgets-editor__list-view-panel-label-${ instanceId }`;
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			aria-labelledby={ labelId }
+			className="edit-widgets-editor__list-view-panel"
+			onKeyDown={ closeOnEscape }
+		>
+			<div className="edit-widgets-editor__list-view-panel-header">
+				<strong id={ labelId }>{ __( 'List view' ) }</strong>
+				<Button
+					icon={ closeSmall }
+					label={ __( 'Close list view sidebar' ) }
+					onClick={ () => setIsListViewOpened( false ) }
+				/>
+			</div>
+			<div
+				className="edit-widgets-editor__list-view-panel-content"
+				ref={ useMergeRefs( [ focusReturnRef, focusOnMountRef ] ) }
+			>
+				<ListView
+					onSelect={ selectEditorBlock }
+					showNestedBlocks
+					__experimentalFeatures
+					__experimentalPersistentListViewFeatures
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/edit-widgets/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-widgets/src/components/secondary-sidebar/style.scss
@@ -1,0 +1,25 @@
+.edit-widgets-editor__list-view-panel {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	// Same width as the Inserter.
+	// @see packages/block-editor/src/components/inserter/style.scss
+	min-width: 350px;
+}
+
+.edit-widgets-editor__list-view-panel-content {
+	// Leave space for the close button
+	height: calc(100% - #{$button-size} - #{$grid-unit-10});
+	overflow-y: auto;
+	padding: $grid-unit-10;
+}
+
+.edit-widgets-editor__list-view-panel-header {
+	align-items: center;
+	border-bottom: $border-width solid $gray-300;
+	display: flex;
+	justify-content: space-between;
+	height: $grid-unit-60;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-05;
+}

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -362,6 +362,19 @@ export function setIsInserterOpened( value ) {
 }
 
 /**
+ * Returns an action object used to open/close the list view.
+ *
+ * @param {boolean} isOpen A boolean representing whether the list view should be opened or closed.
+ * @return {Object} Action object.
+ */
+export function setIsListViewOpened( isOpen ) {
+	return {
+		type: 'SET_IS_LIST_VIEW_OPENED',
+		isOpen,
+	};
+}
+
+/**
  * Returns an action object signalling that the user closed the sidebar.
  *
  * @return {Object} Action creator.

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -31,20 +31,45 @@ export function widgetAreasOpenState( state = {}, action ) {
 }
 
 /**
- * Reducer tracking whether the inserter is open.
+ * Reducer to set the block inserter panel open or closed.
  *
- * @param {boolean|Object} state
- * @param {Object}         action
+ * Note: this reducer interacts with the list view panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
  */
-function blockInserterPanel( state = false, action ) {
+export function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.isOpen ? false : state;
 		case 'SET_IS_INSERTER_OPENED':
 			return action.value;
 	}
 	return state;
 }
 
+/**
+ * Reducer to set the list view panel open or closed.
+ *
+ * Note: this reducer interacts with the inserter panel reducer
+ * to make sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ */
+export function listViewPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value ? false : state;
+		case 'SET_IS_LIST_VIEW_OPENED':
+			return action.isOpen;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	blockInserterPanel,
+	listViewPanel,
 	widgetAreasOpenState,
 } );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -277,3 +277,14 @@ export const canInsertBlockInWidgetArea = createRegistrySelector(
 		);
 	}
 );
+
+/**
+ * Returns true if the list view is opened.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the list view is opened.
+ */
+export function isListViewOpened( state ) {
+	return state.listViewPanel;
+}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -10,6 +10,7 @@
 @import "./components/layout/style.scss";
 @import "./components/welcome-guide/style.scss";
 @import "./components/widget-areas-block-editor-content/style.scss";
+@import "./components/secondary-sidebar/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations


### PR DESCRIPTION
Proposed changes in this PR move the querying of isSelected to the ListViewBlock to avoid slowing down the editor on block focus.

The key thing to highlight is **block focus** on this branch is **221.22 ms** vs  **930.92 ms** on trunk with List View open. Changes here don't affect first render time which still sits in the 3-5 second range to open List View with the performance test post. **Using a form of windowing should cut first render down to a more respectable `200ms` see** https://github.com/WordPress/gutenberg/pull/35230 

### Functionality Changes

The widget editor was the only consumer of the ListView dropdown (BlockNavigationDropdown). This required some isSelected state to render a subset of items. From the scrollbars in the popover seen in `trunk` this isn't a well known usage, so I'm proposing that we use a ListView sidebar instead for consistency. If this change is too large, I can pull out this change to a separate PR.

| before block selected | before with no blocks selected | After Sidebar |
|-----|-----|-----|
| <img width="1241" alt="CleanShot 2021-10-18 at 10 50 28@2x" src="https://user-images.githubusercontent.com/1270189/137781908-671cf694-47d6-4894-a985-167deeaf76ac.png"> |  <img width="1241" alt="CleanShot 2021-10-18 at 10 50 22@2x" src="https://user-images.githubusercontent.com/1270189/137782009-e8248faa-1e7b-46da-bf9a-fcaabdadc3de.png"> | <img width="1308" alt="CleanShot 2021-10-18 at 15 19 52@2x" src="https://user-images.githubusercontent.com/1270189/137814383-bda9c3c8-5a8e-4abd-9ab8-9b37985d15cf.png"> |


### Testing Instructions

- No regressions in list view
- Expand/Collapse works in all list view instances
- No drag regressions
- Animations are still seen when using the mover controls
- Widget editor inserter, list view and general sidebar interact well.

### Full Performance Results

Edit: note that performance suite changes were removed in a rebase to avoid slowing down performance tests in trunk before landing. (What I measured with can be seen at https://github.com/WordPress/gutenberg/pull/35571/commits/c6b08e5e639767094f550daa8a831f039720bb23)

To give us solid numbers on the proposed changes, I've also included changes in the performance tests to have list view open during `focus` and `typing` in addition to a new test that toggles the list view open and closed.

```
>> post-editor

┌──────────────────────┬──────────────────────────────────────────┬──────────────┐
│       (index)        │ 6d49143e3d63aed79b54ccc10ddac1918b432f79 │    trunk     │
├──────────────────────┼──────────────────────────────────────────┼──────────────┤
│    serverResponse    │                '239.1 ms'                │ '225.86 ms'  │
│      firstPaint      │                '56.3 ms'                 │  '46.98 ms'  │
│   domContentLoaded   │               '275.36 ms'                │ '276.96 ms'  │
│        loaded        │               '287.34 ms'                │  '286.4 ms'  │
│ firstContentfulPaint │               '5541.68 ms'               │ '5432.78 ms' │
│      firstBlock      │               '6302.24 ms'               │ '6226.54 ms' │
│         type         │                '59.29 ms'                │  '61.05 ms'  │
│       minType        │                '53.18 ms'                │  '53.41 ms'  │
│       maxType        │                '72.09 ms'                │  '75.38 ms'  │
│        focus         │               '185.12 ms'                │ '936.54 ms'  │
│       minFocus       │                 '1.2 ms'                 │   '1.2 ms'   │
│       maxFocus       │               '238.13 ms'                │ '1613.51 ms' │
│     inserterOpen     │                '78.58 ms'                │  '80.01 ms'  │
│   minInserterOpen    │                '54.4 ms'                 │  '53.94 ms'  │
│   maxInserterOpen    │               '258.84 ms'                │ '249.32 ms'  │
│    inserterSearch    │                '92.41 ms'                │  '87.78 ms'  │
│  minInserterSearch   │                '58.03 ms'                │  '54.26 ms'  │
│  maxInserterSearch   │               '291.23 ms'                │ '290.97 ms'  │
│    inserterHover     │                '38.41 ms'                │  '38.62 ms'  │
│   minInserterHover   │                 '35 ms'                  │  '32.74 ms'  │
│   maxInserterHover   │                '53.24 ms'                │  '45.12 ms'  │
│     listViewOpen     │               '3358.94 ms'               │ '3074.26 ms' │
│   minListViewOpen    │               '2976.39 ms'               │ '2843.87 ms' │
│   maxListViewOpen    │               '4778.34 ms'               │ '4198.85 ms' │
└──────────────────────┴──────────────────────────────────────────┴──────────────┘

>> site-editor

┌──────────────────────┬──────────────────────────────────────────┬─────────────┐
│       (index)        │ 6d49143e3d63aed79b54ccc10ddac1918b432f79 │    trunk    │
├──────────────────────┼──────────────────────────────────────────┼─────────────┤
│    serverResponse    │               '115.13 ms'                │ '145.1 ms'  │
│      firstPaint      │               '388.67 ms'                │ '468.23 ms' │
│   domContentLoaded   │               '427.13 ms'                │ '513.47 ms' │
│        loaded        │                '590.1 ms'                │ '666.93 ms' │
│ firstContentfulPaint │               '388.67 ms'                │ '468.23 ms' │
│      firstBlock      │               '6572.97 ms'               │ '7006.6 ms' │
│         type         │                '39.62 ms'                │  '38.5 ms'  │
│       minType        │                '35.08 ms'                │ '34.38 ms'  │
│       maxType        │                '58.86 ms'                │ '59.57 ms'  │
└──────────────────────┴──────────────────────────────────────────┴─────────────┘
```

### Problem

While experimenting with the windowing technique in https://github.com/WordPress/gutenberg/pull/35230 we discovered some unexpected behavior with block focus time. 

Focusing on a block in the main editor pane will re-render **all ListViewBlock items**. Depending on if list view is open or not, we can see some dramatic differences in how long it takes to resolve a focus event.

| blocks | focus time list view closed | focus time list view open |
|-----|-----|-----|
| 50 | 87 ms | 114ms |
| 250 | 100 ms | 311 ms |
| 900 | 180 ms | 1000 ms |

If we profile using react devtools, here we can spot some slow renders on each block focus. Long story short, we query for selectedIds on the parent ListView component. In React if a parent updates all child components by default will update regardless of prop changes (which may or may result in DOM updates). So on focus, all items updated.

What we changed here was moving the selectedId querying to the child ListViewBlock component, which as we can see from the performance results above cleared up the slow render.

| List View Will Re-render on block focus | |
|-----|-----|
| <img width="1123" alt="137548678-7e3a2534-7253-4a7f-adb3-827340b2dd27" src="https://user-images.githubusercontent.com/1270189/137548758-ef670ba2-1a9d-491a-8e25-b9a0d5966519.png"> | <img src="https://user-images.githubusercontent.com/1270189/137550428-99eb689c-4c25-4471-84fc-fd8d11b166f4.png"/> |

### TODOs
- [x] Confirm logic changes around `useListViewClientIds` We never pass in selectedClientIds, so perhaps we can remove logic there.
- [x] ~Do we still need the appender code in List View? I didn't find any active references~ Appender code is okay to remove
- [x] Fix/confirm some logic for last of branch styling, and other misc classes.
- [x] ~Verify any differences between async/sync rendering. I ended up removing it in this PR since we no longer had selectedId in the branch to mark items to explicitly render sync~ Moved the nested async call to ListViewBlock
- [x] Can we update widget editor to use a sidebar for list view instead of a dropdown
- [x] ~Can we delete BlockNavigationDropdown, or is this needed for backwards compatibility?~ I opted to not remove the component in this PR

Folks are welcome to hop into the branch directly if you're aware of any needed functionality changes.

