### PR TITLE
Fix template part block untranslated strings

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -95,12 +95,14 @@ export default function TemplatePartPlaceholder( {
 						enableSelection
 							? sprintf(
 									// Translators: %s as template part area title ("Header", "Footer", etc.).
-									'Choose an existing %s or create a new one.',
+									__(
+										'Choose an existing %s or create a new one.'
+									),
 									areaLabel.toLowerCase()
 							  )
 							: sprintf(
 									// Translators: %s as template part area title ("Header", "Footer", etc.).
-									'Create a new %s.',
+									__( 'Create a new %s.' ),
 									areaLabel.toLowerCase()
 							  )
 					}
@@ -136,7 +138,7 @@ export default function TemplatePartPlaceholder( {
 									>
 										{ sprintf(
 											// Translators: %s as template part area title ("Header", "Footer", etc.).
-											'New %s',
+											__( 'New %s' ),
 											areaLabel.toLowerCase()
 										) }
 									</Button>

--- a/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
+++ b/packages/block-library/src/template-part/edit/placeholder/patterns-setup.js
@@ -62,7 +62,8 @@ export default function PatternsSetup( {
 			{ isTitleStep && (
 				<Modal
 					title={ sprintf(
-						'Name and create your new %s',
+						// Translators: %s as template part area title ("Header", "Footer", etc.).
+						__( 'Name and create your new %s' ),
 						areaLabel.toLowerCase()
 					) }
 					closeLabel={ __( 'Cancel' ) }
@@ -115,7 +116,7 @@ function StartBlankComponent( { setTitleStep, areaLabel, areaIcon } ) {
 			icon={ areaIcon }
 			instructions={ sprintf(
 				// Translators: %s as template part area title ("Header", "Footer", "Template Part", etc.).
-				'Creating your new %s...',
+				__( 'Creating your new %s…' ),
 				areaLabel.toLowerCase()
 			) }
 		/>

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -149,7 +149,9 @@ function TemplatePartsByArea( {
 			>
 				{ sprintf(
 					// Translators: %s for the template part variation ("Header", "Footer", "Template Part").
-					'There is no other %s available. If you are looking for another type of template part, try searching for it using the input above.',
+					__(
+						'There is no other %s available. If you are looking for another type of template part, try searching for it using the input above.'
+					),
 					area && area !== 'uncategorized'
 						? labelsByArea[ area ] || area
 						: __( 'Template Part' )


### PR DESCRIPTION
## Description
A few user facing strings in the template part block were missing the `__` function. Seems to have been a mistake as they mostly had translation comments.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->