### PR TITLE
Submenu item paddings & fixes

### DIFF
--- a/packages/block-library/src/navigation-submenu/editor.scss
+++ b/packages/block-library/src/navigation-submenu/editor.scss
@@ -17,7 +17,7 @@
 			width: auto !important;
 			// These styles are needed to display the dropdown properly when it is empty.
 			position: absolute;
-			left: -1em;
+			left: -1px; // Border width.
 			top: 100%;
 
 			@include break-medium {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -121,11 +121,10 @@
 		// Don't take up space when the menu is collapsed.
 		width: 0;
 		height: 0;
-		overflow: hidden;
 
 		// Submenu items.
 		> .wp-block-navigation-item {
-			> a {
+			> .wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
 
@@ -142,12 +141,12 @@
 		}
 
 		// Spacing in all submenus.
-		a {
+		.wp-block-navigation-item__content {
 			margin: 0;
 		}
 
 		// Submenu indentation when there's no background.
-		left: -1em;
+		left: -1px; // Border width.
 		top: 100%;
 
 		// Indentation for all submenus.
@@ -184,7 +183,6 @@
 		opacity: 1;
 		width: auto;
 		height: auto;
-		overflow: initial;
 		min-width: 200px;
 	}
 
@@ -253,7 +251,7 @@
 // https://css-tricks.com/almanac/selectors/w/where/
 
 // Set the default menu item padding to zero, to allow text-only buttons.
-.wp-block-navigation a {
+.wp-block-navigation .wp-block-navigation-item__content {
 	padding: 0;
 }
 
@@ -264,7 +262,7 @@
 }
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-.wp-block-navigation :where(.wp-block-navigation__submenu-container) a {
+.wp-block-navigation :where(.wp-block-navigation__submenu-container) .wp-block-navigation-item__content {
 	padding: 0.5em 1em;
 }
 


### PR DESCRIPTION
## Description

Fixes #35654.

Nested submenus did not show up when the navigation block was set to open on click. This PR fixes that:

In addition to that, and in this PR being a replacement of #35660, it also fixes:

- Overflow cropping focus styles and hiding submenus in some cases
- Fixed item padding styles so submenu links behave the same as submenu buttons.
- Fix positioning of vertically unfolding menus. 

Before:
<img width="467" alt="before" src="https://user-images.githubusercontent.com/1204802/137686117-8170c9cd-defc-4ef5-8943-638ec7a080b6.png">

After:

<img width="470" alt="after" src="https://user-images.githubusercontent.com/1204802/137686129-cca98d84-1585-4ded-9a23-510d5efb1f36.png">

## How has this been tested?

Create a menu with submenus and nested submenus. Ensure all pages added are published, not drafts. Set the menu to open on click:
<img width="273" alt="Screenshot 2021-10-15 at 09 28 04" src="https://user-images.githubusercontent.com/1204802/137449300-daeac68d-6360-4e15-a4ef-ea193a562498.png">

Here's some test content:

```
<!-- wp:navigation {"openSubmenusOnClick":true} -->
<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-submenu {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelItem":true} -->
<!-- wp:navigation-submenu {"label":"First level submenu","type":"page","id":30428,"url":"http://local-wordpress.local/?page_id=30428","kind":"post-type","isTopLevelItem":false} -->
<!-- wp:navigation-link {"label":"Second level submenu","type":"page","id":30429,"url":"http://local-wordpress.local/?page_id=30429","kind":"post-type","isTopLevelLink":false} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation -->
```

Please test that both in the editor and on the frontend, nested submenus open as intended, on click.

Hover should be unaffected, but for good measure, test that hover/focus to open nested submenus works as well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->