### PR TITLE
Post editor: Add some top margin.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -45,7 +45,7 @@
 	}
 
 	// Add extra margin at the top, to push down the Title area in the post editor.
-	margin-top: max(var(--wp--style--block-gap, #{ $grid-unit-10 * 8 }), #{ $grid-unit-10 * 8 });
+	margin-top: 4rem;
 	margin-bottom: var(--wp--style--block-gap);
 }
 

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -44,7 +44,8 @@
 		margin-right: auto;
 	}
 
-	margin-top: var(--wp--style--block-gap);
+	// Add extra margin at the top, to push down the Title area in the post editor.
+	margin-top: max(var(--wp--style--block-gap, #{ $grid-unit-10 * 8 }), #{ $grid-unit-10 * 8 });
 	margin-bottom: var(--wp--style--block-gap);
 }
 


### PR DESCRIPTION
## Description

Followup to #35426. The top margin in the post editor above the title can be a bit small:

<img width="1270" alt="Screenshot 2021-10-18 at 09 42 06" src="https://user-images.githubusercontent.com/1204802/137689837-8ecbc9f3-f584-4111-85b4-6bf6e2b13789.png">

The post editor, unlike the Site Editor, should cater just a little bit more to the writing experience, and pushing the site title down just a bit feels worth it:

<img width="1270" alt="Screenshot 2021-10-18 at 09 46 35" src="https://user-images.githubusercontent.com/1204802/137690540-1484527a-7545-4ee8-993b-4f61bef7ed17.png">

Also tested this with tt and tt1:

<img width="1270" alt="Screenshot 2021-10-18 at 09 47 35" src="https://user-images.githubusercontent.com/1204802/137690616-22467900-6c33-4a66-a225-6d8022878eee.png">

<img width="1270" alt="Screenshot 2021-10-18 at 09 47 42" src="https://user-images.githubusercontent.com/1204802/137690629-f5646b88-6180-4246-9d25-0ed7d9d2d679.png">

And tt1 blocks:

<img width="1270" alt="Screenshot 2021-10-18 at 09 47 49" src="https://user-images.githubusercontent.com/1204802/137690642-e125d6fe-b87e-482a-a67a-7a874e7581e2.png">

## How has this been tested?

Create a new post and observe the post title in the post editor pushed down to a comfortable place.

- Test in classic and block themes
- Ideally test with and without blockGap defined
- Test with and without "Use theme styles" in preferences

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
