### PR TITLE
Fix site logo block on dark backgrounds.

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -99,6 +99,7 @@
 		// By setting the dashed border to currentColor, we ensure it's visible
 		// against any background color.
 		color: currentColor;
+		background: transparent;
 		&::before {
 			content: "";
 			display: block;


### PR DESCRIPTION
## Description

Followup to #35397 

The Site Logo setup state has dashed outlines and uses `currentColor` to set the color of said outlines. But it looks like this on dark backgrounds:

<img width="807" alt="Screenshot 2021-10-18 at 10 01 58" src="https://user-images.githubusercontent.com/1204802/137692232-9db632e5-69ce-4e8e-8c56-81ac8e2e9eda.png">

That's because the background wasn't made transparent. This PR fixes that:

<img width="891" alt="Screenshot 2021-10-18 at 10 03 12" src="https://user-images.githubusercontent.com/1204802/137692272-afb78f82-6fba-474a-8de3-e29a8f05dff4.png">


## How has this been tested?

Try a theme with a dark background and light text, then to insert an empty Site Logo block. You should not see a white background inside the site Logo. You can also test in TT1, where you should see the green background peeking through the setup state.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
