### PR TITLE
Fix updating the block list after block removal

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -366,6 +366,23 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 				},
 				action.blocks.map( ( b ) => b.clientId )
 			);
+
+			// If there are no replaced blocks, it means we're removing blocks so we need to update their parent.
+			const parentsOfRemovedBlocks = [];
+			for ( const clientId of action.clientIds ) {
+				if (
+					state.parents[ clientId ] !== undefined &&
+					( state.parents[ clientId ] === '' ||
+						newState.byClientId[ state.parents[ clientId ] ] )
+				) {
+					parentsOfRemovedBlocks.push( state.parents[ clientId ] );
+				}
+			}
+			newState.tree = updateParentInnerBlocksInTree(
+				newState,
+				newState.tree,
+				parentsOfRemovedBlocks
+			);
 			break;
 		}
 		case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -788,6 +788,28 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'Replacing the block with an empty list should remove it', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						clientId: 'chicken',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+			const state = blocks( original, {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'chicken' ],
+				blocks: [],
+			} );
+
+			expect( Object.keys( state.byClientId ) ).toHaveLength( 0 );
+			expect( state.tree[ '' ].innerBlocks ).toHaveLength( 0 );
+		} );
+
 		it( 'should replace the block and remove references to its inner blocks', () => {
 			const original = blocks( undefined, {
 				type: 'RESET_BLOCKS',


### PR DESCRIPTION
closes #35624 

The refactoring in #34241 introduce a small bug that happens when the "REPLACE_BLOCKS" action is triggered with an empty block list causing the removal of the replaced block. In this situation, the block list was not being updated properly in the state.

**Testing instructions**

 - Add a quote block followed by a paragraph block
 - Focus the quote block and click backspace to remove the block
 - Check the result in the "code editor". The quote block should be gone.