### PR TITLE
Navigation: Fix issue with space-between

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -228,6 +228,7 @@
  */
 
 // Menu items with no background.
+.wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container {
 	gap: 0.5em 2em;
@@ -238,6 +239,7 @@
 // That way if padding is set in theme.json, it still wins.
 // https://css-tricks.com/almanac/selectors/w/where/
 .wp-block-navigation:where(.has-background) {
+	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
 		gap: 0 0.5em;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -326,7 +326,10 @@
 	// Horizontal layout
 	display: flex;
 	flex-wrap: wrap;
-	flex: 1;
+
+	.items-justified-space-between & {
+		flex-grow: 1;
+	}
 }
 
 // Vertical layout


### PR DESCRIPTION
## Description

Followup to #34258. Maybe fixes #35549. 

The navigation container block had `flex-grow` assigned on it, to fix a space-between issue. But this caused an issue with with states that were not space-between. Shown here in the before state in the editor, a navigation block with social links inside, next to each other as they are not space betweened:

<img width="534" alt="Screenshot 2021-10-18 at 10 51 52" src="https://user-images.githubusercontent.com/1204802/137699768-eb083615-c165-46ca-b637-8cff439a0e0d.png">

Same state, but frontend, notice how the social links are way on the right:

<img width="914" alt="Screenshot 2021-10-18 at 10 51 58" src="https://user-images.githubusercontent.com/1204802/137699921-f6287a10-7468-4fc2-9b3b-8abe1c5f0097.png">

That's because the nav container was allowed to grow, so it took the space and pushed social links. This PR scopes that so that this growing behavior only affects the space between state. 

Editor after:

<img width="504" alt="Screenshot 2021-10-18 at 10 50 35" src="https://user-images.githubusercontent.com/1204802/137700026-e5c6a5e4-64e4-4c58-9418-714fa5526ac6.png">

Frontend after:

<img width="564" alt="Screenshot 2021-10-18 at 10 50 30" src="https://user-images.githubusercontent.com/1204802/137700046-f7454bc7-967e-47a7-a90a-47d43afca2b9.png">

Space between works the same as before.

Note that this PR also applies a `gap` value to the navigation block itself. This is to add space between menu items and other blocks, like Social Links. This already worked in the editor, but as an extra wrapper is added on the frontend, the extra gap is necessary there.

## How has this been tested?

Here's some test content:

```
<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"jiolkjklæ","service":"wordpress"} /-->

<!-- wp:social-link {"url":"jkljæklj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"jklæjkæl","service":"behance"} /-->

<!-- wp:social-link {"url":"jklækæl","service":"fivehundredpx"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->
```

Test that nav items and social links look good in the default non space between state.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
