### PR TITLE
Enable inheritance in search block.

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,75 +1,71 @@
-.wp-block-search {
+.wp-block-search__button {
+	background: #f7f7f7;
+	border: 1px solid #ccc;
+	padding: 0.375em 0.625em;
+	color: #32373c;
+	margin-left: 0.625em;
+	word-break: normal;
+	font-size: inherit;
+	font-family: inherit;
+	line-height: inherit;
 
-	.wp-block-search__button {
-		background: #f7f7f7;
-		border: 1px solid #ccc;
-		padding: 0.375em 0.625em;
-		color: #32373c;
-		margin-left: 0.625em;
-		word-break: normal;
-		font-size: inherit;
-		font-family: inherit;
-		line-height: inherit;
-
-		&.has-icon {
-			line-height: 0;
-		}
-
-		svg {
-			min-width: 1.5em;
-			min-height: 1.5em;
-			fill: currentColor;
-		}
+	&.has-icon {
+		line-height: 0;
 	}
 
-	.wp-block-search__inside-wrapper {
-		display: flex;
-		flex: auto;
-		flex-wrap: nowrap;
-		max-width: 100%;
-	}
-
-	.wp-block-search__label {
-		width: 100%;
-	}
-
-	.wp-block-search__input {
-		padding: 8px;
-		flex-grow: 1;
-		min-width: 3em;
-		border: 1px solid #949494;
-		font-size: inherit;
-		font-family: inherit;
-		line-height: inherit;
-	}
-
-	&.wp-block-search__button-only {
-		.wp-block-search__button {
-			margin-left: 0;
-		}
-	}
-
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-		padding: 4px;
-		border: 1px solid #949494;
-
-		.wp-block-search__input {
-			border-radius: 0;
-			border: none;
-			padding: 0 0 0 0.25em;
-
-			&:focus {
-				outline: none;
-			}
-		}
-
-		.wp-block-search__button {
-			padding: 0.125em 0.5em;
-		}
-	}
-
-	&.aligncenter .wp-block-search__inside-wrapper {
-		margin: auto;
+	svg {
+		min-width: 1.5em;
+		min-height: 1.5em;
+		fill: currentColor;
 	}
 }
 
+.wp-block-search__inside-wrapper {
+	display: flex;
+	flex: auto;
+	flex-wrap: nowrap;
+	max-width: 100%;
+}
+
+.wp-block-search__label {
+	width: 100%;
+}
+
+.wp-block-search__input {
+	padding: 8px;
+	flex-grow: 1;
+	min-width: 3em;
+	border: 1px solid #949494;
+	font-size: inherit;
+	font-family: inherit;
+	line-height: inherit;
+}
+
+.wp-block-search.wp-block-search__button-only {
+	.wp-block-search__button {
+		margin-left: 0;
+	}
+}
+
+.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+	padding: 4px;
+	border: 1px solid #949494;
+
+	.wp-block-search__input {
+		border-radius: 0;
+		border: none;
+		padding: 0 0 0 0.25em;
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	.wp-block-search__button {
+		padding: 0.125em 0.5em;
+	}
+}
+
+.wp-block-search.aligncenter .wp-block-search__inside-wrapper {
+	margin: auto;
+}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -7,6 +7,9 @@
 		color: #32373c;
 		margin-left: 0.625em;
 		word-break: normal;
+		font-size: inherit;
+		font-family: inherit;
+		line-height: inherit;
 
 		&.has-icon {
 			line-height: 0;
@@ -35,6 +38,9 @@
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid #949494;
+		font-size: inherit;
+		font-family: inherit;
+		line-height: inherit;
 	}
 
 	&.wp-block-search__button-only {


### PR DESCRIPTION
## Description

Font family, size, and line heights, are not inherited in the Search block. That makes its visual appearance stand out when used inside the navigation block. Here's Empty Theme with a search inside nav. Editor:

<img width="568" alt="before editor" src="https://user-images.githubusercontent.com/1204802/137706494-90107285-bf07-43bd-a5ec-528449a00f73.png">

Frontend:

<img width="1003" alt="before frontend" src="https://user-images.githubusercontent.com/1204802/137706518-e641b174-0eeb-4570-a9e1-7dd8481add33.png">

The font size discrepancy is less visible in Empty Theme, but can be seen here:

<img width="928" alt="Screenshot 2021-10-18 at 11 35 01" src="https://user-images.githubusercontent.com/1204802/137706588-c2644760-8ef0-483b-95d6-6d8ee399e394.png">

This PR adds inheritance, which also makes the editor more like the frontend:

<img width="595" alt="after editor" src="https://user-images.githubusercontent.com/1204802/137706635-aa9da35b-3bf7-4aa1-8a3f-8e75b1f58212.png">

Frontend:

<img width="920" alt="after frontend" src="https://user-images.githubusercontent.com/1204802/137706662-22e819c9-fe95-4f62-9b19-1ceee0f9ee96.png">

## How has this been tested?

Here's some test content:

```
<!-- wp:paragraph -->
<p>Button inside:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:home-link {"label":"Home"} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>Button outside:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:home-link {"label":"Home"} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search","buttonUseIcon":true} /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>Button outside and with label:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:home-link {"label":"Home"} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search","buttonText":"Search"} /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>With label:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:home-link {"label":"Home"} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:search {"label":"Search","placeholder":"Search","buttonText":"Search"} /-->
<!-- /wp:navigation -->
```

Please test the search block in a variety of situations, including inside the nav block, and in a few themes, and verify that it always feels harmonious to use.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
