### PR TITLE
Fix reusable block inserter popup performance issue - Fixes - #35719

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -70,7 +70,6 @@ const {
 	__experimentalGetLastBlockAttributeChanges,
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
-	__experimentalGetParsedReusableBlock,
 	__experimentalGetAllowedPatterns,
 	__experimentalGetPatternsByBlockTypes,
 	__unstableGetClientIdWithClientIdsTree,
@@ -3622,26 +3621,6 @@ describe( 'selectors', () => {
 				wasBlockJustInserted( state, clientId, expectedSource )
 			).toBe( false );
 		} );
-	} );
-} );
-
-describe( '__experimentalGetParsedReusableBlock', () => {
-	const state = {
-		settings: {
-			__experimentalReusableBlocks: [
-				{
-					id: 1,
-					content: { raw: '' },
-				},
-			],
-		},
-	};
-
-	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
-	it( "Should return an empty array if reusable block's content.raw is an empty string", () => {
-		expect( __experimentalGetParsedReusableBlock( state, 1 ) ).toEqual(
-			[]
-		);
 	} );
 } );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The PR addresses the performance issue with the Inserter popup(delayed rendering) when the block editor is used with thousands of reusable blocks. Block editor parses the reusable blocks to identify the icon to be displayed in the block library, and it delays the Inserter popup to appear. The PR replaces the parsing with the string operation to identify the icon.

The detailed information is added in Github issue #35719

## How has this been tested?
I've added the fixes and verified the same in the local environment with 2500+ reusable blocks. The inserter menu opens immediately without any delay after the fix. I've used VVV to verify the changes. The function is not used in other places, so I expect it wouldn't introduce any other issues.

## Screenshots <!-- if applicable -->
Not applicable

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
