### PR TITLE
Try: Remove color inheritance specificity.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -41,11 +41,14 @@
 	}
 
 	// Menu item link.
-	// By targetting the markup directly we enable greater global styles compatibility.
-	a {
-		// Inherit colors set by the block color definition.
+	// By adding low specificity, we enable compatibility with link colors set in theme.json,
+	// but still allow them to be overridden by user-set colors.
+	.wp-block-navigation-item__content {
 		color: inherit;
 		display: block;
+
+		// Set the default menu item padding to zero, to allow text-only buttons.
+		padding: 0;
 	}
 
 	// Force links to inherit text decoration applied to navigation block.
@@ -248,11 +251,6 @@
 // We use :where to keep specificity minimal, yet still scope it to only the navigation block.
 // That way if padding is set in theme.json, it still wins.
 // https://css-tricks.com/almanac/selectors/w/where/
-
-// Set the default menu item padding to zero, to allow text-only buttons.
-.wp-block-navigation .wp-block-navigation-item__content {
-	padding: 0;
-}
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -42,8 +42,7 @@
 
 	// Menu item link.
 	// By targetting the markup directly we enable greater global styles compatibility.
-	// The extra container specificity is due to global styles outputting link styles that need overriding.
-	&.wp-block-navigation a {
+	a {
 		// Inherit colors set by the block color definition.
 		color: inherit;
 		display: block;


### PR DESCRIPTION
## Description

Probably fixes #34648.

#31878 heavily refactored the navigation block CSS to reduce specificity of many selectors, so as to allow global styles to override colors. One part of that was also to override inherited colors. I don't recall the specifics, but this was necessary at the time to fix an issue with colors otherwise not inheriting at all. As a result, if you insert a Site Title block inside navigation, and customize its link color, that doesn't work:

<img width="1270" alt="before" src="https://user-images.githubusercontent.com/1204802/137708807-4b03e025-cd9a-4bbe-84c0-b7968a31fecf.png">

That extra specificity _doesn't appear to be necessary anymore_. And in removing it, things appear to work as they should:

<img width="1270" alt="Screenshot 2021-10-18 at 11 46 29" src="https://user-images.githubusercontent.com/1204802/137708877-8a3b6ed7-3940-46bc-868c-1c601250b250.png">

<img width="1270" alt="Screenshot 2021-10-18 at 11 47 14" src="https://user-images.githubusercontent.com/1204802/137708978-0c56c148-da7f-4d3f-9a0a-9ade12afc695.png">
 
<img width="1270" alt="Screenshot 2021-10-18 at 11 47 21" src="https://user-images.githubusercontent.com/1204802/137708982-70e1fccd-6fd1-4219-99b7-e1421141b9c1.png">

Because the rule was necessary at the time, but doesn't appear to be necessary anymore, it would be good to test this one well.

## How has this been tested?

Here's some test content:

```
<!-- wp:navigation {"customTextColor":"#ff0000","customBackgroundColor":"#f5efef"} -->
<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"#0015ff"}}}}} /-->

<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```

Please test in a few themes, including Empty Theme and some block themes. In combination with having a site title with a customized link color, please test most of the navigation properties and features, including all the color options, most notably _submenus_ and the mobile responsive _overlay menu_, and verify that the colors defined on the navigation block apply all the way down the hierarchy, unless overridden by an individual block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
