### PR TITLE
[Block Library - Categories]: Add support for showing only top level categories

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -17,6 +17,10 @@
 		"showPostCounts": {
 			"type": "boolean",
 			"default": false
+		},
+		"showOnlyTopLevel": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -21,22 +21,33 @@ import { pin } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
-	attributes: { displayAsDropdown, showHierarchy, showPostCounts },
+	attributes: {
+		displayAsDropdown,
+		showHierarchy,
+		showPostCounts,
+		showOnlyTopLevel,
+	},
 	setAttributes,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
-	const { categories, isRequesting } = useSelect( ( select ) => {
-		const { getEntityRecords, isResolving } = select( coreStore );
-		const query = { per_page: -1, hide_empty: true, context: 'view' };
-		return {
-			categories: getEntityRecords( 'taxonomy', 'category', query ),
-			isRequesting: isResolving( 'getEntityRecords', [
-				'taxonomy',
-				'category',
-				query,
-			] ),
-		};
-	}, [] );
+	const { categories, isRequesting } = useSelect(
+		( select ) => {
+			const { getEntityRecords, isResolving } = select( coreStore );
+			const query = { per_page: -1, hide_empty: true, context: 'view' };
+			if ( showOnlyTopLevel ) {
+				query.parent = 0;
+			}
+			return {
+				categories: getEntityRecords( 'taxonomy', 'category', query ),
+				isRequesting: isResolving( 'getEntityRecords', [
+					'taxonomy',
+					'category',
+					query,
+				] ),
+			};
+		},
+		[ showOnlyTopLevel ]
+	);
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
 			return [];
@@ -134,15 +145,22 @@ export default function CategoriesEdit( {
 						onChange={ toggleAttribute( 'displayAsDropdown' ) }
 					/>
 					<ToggleControl
-						label={ __( 'Show hierarchy' ) }
-						checked={ showHierarchy }
-						onChange={ toggleAttribute( 'showHierarchy' ) }
-					/>
-					<ToggleControl
 						label={ __( 'Show post counts' ) }
 						checked={ showPostCounts }
 						onChange={ toggleAttribute( 'showPostCounts' ) }
 					/>
+					<ToggleControl
+						label={ __( 'Show only top level categories' ) }
+						checked={ showOnlyTopLevel }
+						onChange={ toggleAttribute( 'showOnlyTopLevel' ) }
+					/>
+					{ ! showOnlyTopLevel && (
+						<ToggleControl
+							label={ __( 'Show hierarchy' ) }
+							checked={ showHierarchy }
+							onChange={ toggleAttribute( 'showHierarchy' ) }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			{ isRequesting && (

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -23,6 +23,9 @@ function render_block_core_categories( $attributes ) {
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 	);
+	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
+		$args['parent'] = 0;
+	}
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -6,7 +6,8 @@
 		"attributes": {
 			"displayAsDropdown": false,
 			"showHierarchy": false,
-			"showPostCounts": false
+			"showPostCounts": false,
+			"showOnlyTopLevel": false
 		},
 		"innerBlocks": [],
 		"originalContent": ""


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/35584

This PR just adds a `show only top level categories` option in `Categories` block.

## Testing instructions
1. Insert `Categories` block and check it's settings
2. Verify everything works as expected both in editor and front-end