### PR TITLE
Add resizer to template part focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -13,14 +13,9 @@ import {
 	BlockEditorProvider,
 	__experimentalLinkControl,
 	BlockInspector,
-	BlockList,
 	BlockTools,
 	__unstableBlockSettingsMenuFirstItem,
-	__experimentalUseResizeCanvas as useResizeCanvas,
 	__unstableUseTypingObserver as useTypingObserver,
-	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
-	__unstableEditorStyles as EditorStyles,
-	__unstableIframe as Iframe,
 } from '@wordpress/block-editor';
 import { useMergeRefs } from '@wordpress/compose';
 
@@ -34,28 +29,19 @@ import { store as editSiteStore } from '../../store';
 import BlockInspectorButton from './block-inspector-button';
 import EditTemplatePartMenuButton from '../edit-template-part-menu-button';
 import BackButton from './back-button';
-
-const LAYOUT = {
-	type: 'default',
-	// At the root level of the site editor, no alignments should be allowed.
-	alignments: [],
-};
+import ResizableEditor from './resizable-editor';
 
 export default function BlockEditor( { setIsInserterOpen } ) {
-	const { settings, templateType, page, deviceType } = useSelect(
+	const { settings, templateType, page } = useSelect(
 		( select ) => {
-			const {
-				getSettings,
-				getEditedPostType,
-				getPage,
-				__experimentalGetPreviewDeviceType,
-			} = select( editSiteStore );
+			const { getSettings, getEditedPostType, getPage } = select(
+				editSiteStore
+			);
 
 			return {
 				settings: getSettings( setIsInserterOpen ),
 				templateType: getEditedPostType(),
 				page: getPage(),
-				deviceType: __experimentalGetPreviewDeviceType(),
 			};
 		},
 		[ setIsInserterOpen ]
@@ -65,8 +51,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		templateType
 	);
 	const { setPage } = useDispatch( editSiteStore );
-	const resizedCanvasStyles = useResizeCanvas( deviceType, true );
-	const ref = useMouseMoveTypingReset();
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
 
@@ -104,19 +88,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				__unstableContentRef={ contentRef }
 			>
 				<BackButton />
-				<Iframe
-					style={ resizedCanvasStyles }
-					head={ <EditorStyles styles={ settings.styles } /> }
-					ref={ ref }
+
+				<ResizableEditor
+					settings={ settings }
 					contentRef={ mergedRefs }
-					name="editor-canvas"
-					className="edit-site-visual-editor__editor-canvas"
-				>
-					<BlockList
-						className="edit-site-block-editor__block-list wp-site-blocks"
-						__experimentalLayout={ LAYOUT }
-					/>
-				</Iframe>
+				/>
+
 				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (
 						<BlockInspectorButton onClick={ onClose } />

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -17,7 +17,7 @@ import {
 	__unstableBlockSettingsMenuFirstItem,
 	__unstableUseTypingObserver as useTypingObserver,
 } from '@wordpress/block-editor';
-import { useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -53,6 +53,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const { setPage } = useDispatch( editSiteStore );
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 
 	const isTemplatePart = templateType === 'wp_template_part';
 
@@ -90,7 +91,11 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<BackButton />
 
 				<ResizableEditor
-					enabledResizing={ isTemplatePart }
+					enableResizing={
+						isTemplatePart &&
+						// Disable resizing in mobile viewport.
+						! isMobileViewport
+					}
 					settings={ settings }
 					contentRef={ mergedRefs }
 				/>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -90,6 +90,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<BackButton />
 
 				<ResizableEditor
+					enabledResizing={ isTemplatePart }
 					settings={ settings }
 					contentRef={ mergedRefs }
 				/>

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { ResizableBox } from '@wordpress/components';
 import {
 	BlockList,
@@ -11,7 +11,6 @@ import {
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -38,11 +37,11 @@ function ResizableEditor( { enabledResizing, settings, ...props } ) {
 		[]
 	);
 	const resizedCanvasStyles = useResizeCanvas( deviceType ) ?? DEFAULT_STYLES;
-	const previousResizedCanvasStyles = usePrevious( resizedCanvasStyles );
+	const previousResizedCanvasStylesRef = useRef( resizedCanvasStyles );
 	// Keep the height of the canvas when resizing on each device type.
 	const styles =
 		deviceType === RESPONSIVE_DEVICE
-			? previousResizedCanvasStyles
+			? previousResizedCanvasStylesRef.current
 			: resizedCanvasStyles;
 	const [ width, setWidth ] = useState( styles.width );
 	const {
@@ -54,6 +53,7 @@ function ResizableEditor( { enabledResizing, settings, ...props } ) {
 		function setWidthWhenDeviceTypeChanged() {
 			if ( deviceType !== RESPONSIVE_DEVICE ) {
 				setWidth( resizedCanvasStyles.width );
+				previousResizedCanvasStylesRef.current = resizedCanvasStyles;
 			}
 		},
 		[ deviceType, resizedCanvasStyles.width ]

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -1,0 +1,106 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { ResizableBox } from '@wordpress/components';
+import {
+	BlockList,
+	__experimentalUseResizeCanvas as useResizeCanvas,
+	__unstableEditorStyles as EditorStyles,
+	__unstableIframe as Iframe,
+	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
+} from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { usePrevious } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+const LAYOUT = {
+	type: 'default',
+	// At the root level of the site editor, no alignments should be allowed.
+	alignments: [],
+};
+
+const RESPONSIVE_DEVICE = 'responsive';
+
+const DEFAULT_STYLES = {
+	width: '100%',
+	height: '100%',
+};
+
+function ResizableEditor( { settings, ...props } ) {
+	const deviceType = useSelect(
+		( select ) =>
+			select( editSiteStore ).__experimentalGetPreviewDeviceType(),
+		[]
+	);
+	const resizedCanvasStyles = useResizeCanvas( deviceType ) ?? DEFAULT_STYLES;
+	const previousResizedCanvasStyles = usePrevious( resizedCanvasStyles );
+	// Keep the height of the canvas when resizing on each device type.
+	const styles =
+		deviceType === RESPONSIVE_DEVICE
+			? previousResizedCanvasStyles
+			: resizedCanvasStyles;
+	const [ width, setWidth ] = useState( styles.width );
+	const {
+		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
+	} = useDispatch( editSiteStore );
+	const ref = useMouseMoveTypingReset();
+
+	useEffect(
+		function setWidthWhenDeviceTypeChanged() {
+			if ( deviceType !== RESPONSIVE_DEVICE ) {
+				setWidth( resizedCanvasStyles.width );
+			}
+		},
+		[ deviceType, resizedCanvasStyles.width ]
+	);
+
+	return (
+		<ResizableBox
+			size={ {
+				width,
+				height: styles.height,
+			} }
+			onResizeStop={ ( event, direction, element ) => {
+				setWidth( element.style.width );
+				setPreviewDeviceType( RESPONSIVE_DEVICE );
+			} }
+			minWidth={ 300 }
+			maxWidth="100%"
+			enable={ {
+				right: true,
+				left: true,
+			} }
+			// The editor is centered horizontally, resizing it only
+			// moves half the distance. Hence double the ratio to correctly
+			// align the cursor to the resizer handle.
+			resizeRatio={ 2 }
+		>
+			<Iframe
+				style={ {
+					...styles,
+					// We'll be using the size controlled by ResizableBox so resetting them here.
+					width: undefined,
+					height: undefined,
+					margin: undefined,
+				} }
+				head={ <EditorStyles styles={ settings.styles } /> }
+				ref={ ref }
+				name="editor-canvas"
+				className="edit-site-visual-editor__editor-canvas"
+				{ ...props }
+			>
+				<BlockList
+					className="edit-site-block-editor__block-list wp-site-blocks"
+					__experimentalLayout={ LAYOUT }
+				/>
+			</Iframe>
+		</ResizableBox>
+	);
+}
+
+export default ResizableEditor;

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -31,7 +31,7 @@ const DEFAULT_STYLES = {
 	height: '100%',
 };
 
-function ResizableEditor( { settings, ...props } ) {
+function ResizableEditor( { enabledResizing, settings, ...props } ) {
 	const deviceType = useSelect(
 		( select ) =>
 			select( editSiteStore ).__experimentalGetPreviewDeviceType(),
@@ -72,9 +72,10 @@ function ResizableEditor( { settings, ...props } ) {
 			minWidth={ 300 }
 			maxWidth="100%"
 			enable={ {
-				right: true,
-				left: true,
+				right: enabledResizing,
+				left: enabledResizing,
 			} }
+			showHandle={ enabledResizing }
 			// The editor is centered horizontally, resizing it only
 			// moves half the distance. Hence double the ratio to correctly
 			// align the cursor to the resizer handle.

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useState, useEffect, useRef } from '@wordpress/element';
@@ -30,7 +35,7 @@ const DEFAULT_STYLES = {
 	height: '100%',
 };
 
-function ResizableEditor( { enabledResizing, settings, ...props } ) {
+function ResizableEditor( { enableResizing, settings, ...props } ) {
 	const deviceType = useSelect(
 		( select ) =>
 			select( editSiteStore ).__experimentalGetPreviewDeviceType(),
@@ -72,23 +77,20 @@ function ResizableEditor( { enabledResizing, settings, ...props } ) {
 			minWidth={ 300 }
 			maxWidth="100%"
 			enable={ {
-				right: enabledResizing,
-				left: enabledResizing,
+				right: enableResizing,
+				left: enableResizing,
 			} }
-			showHandle={ enabledResizing }
+			showHandle={ enableResizing }
 			// The editor is centered horizontally, resizing it only
 			// moves half the distance. Hence double the ratio to correctly
 			// align the cursor to the resizer handle.
 			resizeRatio={ 2 }
 		>
 			<Iframe
-				style={ {
-					...styles,
+				style={
 					// We'll be using the size controlled by ResizableBox so resetting them here.
-					width: undefined,
-					height: undefined,
-					margin: undefined,
-				} }
+					omit( styles, [ 'width', 'height', 'margin' ] )
+				}
 				head={ <EditorStyles styles={ settings.styles } /> }
 				ref={ ref }
 				name="editor-canvas"

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
+import { VisuallyHidden } from '@wordpress/components';
 
 export default function ResizeHandle( { direction, resizeWidthBy } ) {
 	function handleKeyDown( event ) {
@@ -26,8 +27,14 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 			<button
 				className="resizable-editor__drag-handle-button"
 				aria-label={ __( 'Drag to resize' ) }
+				aria-describedby={ `resizable-editor__resize-help-${ direction }` }
 				onKeyDown={ handleKeyDown }
 			/>
+			<VisuallyHidden
+				id={ `resizable-editor__resize-help-${ direction }` }
+			>
+				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
+			</VisuallyHidden>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { LEFT, RIGHT } from '@wordpress/keycodes';
+
+export default function ResizeHandle( { direction, resizeWidthBy } ) {
+	function handleKeyDown( event ) {
+		const { keyCode } = event;
+
+		if (
+			( direction === 'left' && keyCode === LEFT ) ||
+			( direction === 'right' && keyCode === RIGHT )
+		) {
+			resizeWidthBy( 20 );
+		} else if (
+			( direction === 'left' && keyCode === RIGHT ) ||
+			( direction === 'right' && keyCode === LEFT )
+		) {
+			resizeWidthBy( -20 );
+		}
+	}
+
+	return (
+		<div className={ `resizable-editor__drag-handle is-${ direction }` }>
+			<button
+				className="resizable-editor__drag-handle-button"
+				aria-label={ __( 'Drag to resize' ) }
+				onKeyDown={ handleKeyDown }
+			/>
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -44,14 +44,14 @@
 	position: absolute;
 	top: 0;
 	bottom: 0;
-	width: 20px;
+	width: $grid-unit-60;
 
 	&.is-left {
-		left: -20px;
+		left: -$grid-unit-60;
 	}
 
 	&.is-right {
-		right: -20px;
+		right: -$grid-unit-60;
 	}
 }
 
@@ -59,27 +59,28 @@
 	$height: 100px;
 	position: absolute;
 	top: calc(50% - #{math.div($height, 2)});
-	left: 6px;
+	left: 50%;
+	transform: translateX(-$grid-unit-05);
 	padding: 0;
-	width: 8px;
+	width: $grid-unit-10;
 	height: $height;
 	appearance: none;
 	cursor: grab;
 	outline: none;
-	background: #7e8993;
-	border-radius: 99999px;
-	border: none;
+	background: $gray-700;
+	border-radius: 4px;
+	border: 0;
 
 	&:hover {
-		background: #6c7782;
+		background: $gray-600;
 	}
 
 	&:active {
 		cursor: grabbing;
-		background: #606a74;
+		background: $gray-600;
 	}
 
 	&:focus {
-		box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db;
+		box-shadow: 0 0 0 1px $gray-800, 0 0 0 calc(var(--wp-admin-border-width-focus) + 1px) var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -15,6 +15,8 @@
 .edit-site-visual-editor {
 	position: relative;
 	background-color: $gray-800;
+	// Centralize the editor horizontally (flex-direction is column).
+	align-items: center;
 
 	&.is-focus-mode {
 		padding: 48px 48px 0;

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -39,3 +39,47 @@
 		color: $gray-100;
 	}
 }
+
+.resizable-editor__drag-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 20px;
+
+	&.is-left {
+		left: -20px;
+	}
+
+	&.is-right {
+		right: -20px;
+	}
+}
+
+.resizable-editor__drag-handle-button {
+	$height: 100px;
+	position: absolute;
+	top: calc(50% - #{math.div($height, 2)});
+	left: 6px;
+	padding: 0;
+	width: 8px;
+	height: $height;
+	appearance: none;
+	cursor: grab;
+	outline: none;
+	background: #7e8993;
+	border-radius: 99999px;
+	border: none;
+
+	&:hover {
+		background: #6c7782;
+	}
+
+	&:active {
+		cursor: grabbing;
+		background: #606a74;
+	}
+
+	&:focus {
+		box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db;
+	}
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close https://github.com/WordPress/gutenberg/issues/35249.

Add a horizontal resizer to template part focus mode. Whether a vertical resizer is needed can be discussed in another PR or in https://github.com/WordPress/gutenberg/issues/35512.

The size is synced with the preview options in the header. Manually resizing it will set the device type to `responsive`, a dummy state that will not show on the preview options dropdown, so clicking on the same option can reset to the defined size.

The resize handle is the default one provided by `<ResizableBox>`. We can change this to something more like the one in wp.org though if needed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go to Site Editor
3. Go to template part focus mode of one of the template part
4. Resize the canvas
5. Select an option in the preview options dropdown
6. Resize the canvas again

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/137729066-66ce67af-1069-40c4-9e95-d5a702329cca.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
