### PR TITLE
Fix sibling inserter animation.

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -291,6 +291,9 @@ function InsertionPointPopover( {
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }
+			// Forces a remount of the popover when its position changes
+			// This makes sure the popover doesn't animate from its previous position.
+			key={ nextClientId + '--' + rootClientId }
 		>
 			<motion.div
 				layout={ ! disableMotion }


### PR DESCRIPTION
Related #35662 

This prevents the sibling inserter from animation from its previous position when moving to another place. It's done by ensuring the whole component remounts.

**Testing instructions**

Try moving the mouse in the canvas like the following video, the inserter should not animate from its previous position though.

https://user-images.githubusercontent.com/548849/137457745-ffc2d0e8-b4fe-4eee-bb71-a102fcc18d2d.mov