### PR TITLE
Docs: Add section on using theme.json schema

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -965,6 +965,15 @@ Currently block variations exist for "header" and "footer" values of the area te
 }
 ```
 
+## Developing with theme.json
+
+It can be difficult to remember the theme.json settings and properties while you develop, so a JSON scheme was created to help. The schema is available at [SchemaStore.org](https://schemastore.org/)
+
+To use the schema, add `"$schema": "https://json.schemastore.org/theme-v1.json"` to the beginning of your theme.json file. Visual Studio Code and other editors will pick up the schema and can provide help like tooltips, autocomplete, or schema validation in the editor.
+
+![Example using validation with schema](https://developer.wordpress.org/files/2021/10/schema-validation.gif)
+
+
 ## Frequently Asked Questions
 
 ### The naming schema of CSS Custom Properties


### PR DESCRIPTION
## Description

A section and example on using the theme.json schema from SchemaStore
for developing with the theme.json in your editor.

## How has this been tested?

Confirm documentation following instructions given in your editor.


## Types of changes

Documentation

