### PR TITLE
Fix class serialization of font-size and colors in dynamic blocks that use block supports

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -92,7 +92,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		}
 		// Apply color class or inline style.
 		if ( $has_named_text_color ) {
-			$classes[] = sprintf( 'has-%s-color', $block_attributes['textColor'] );
+			$classes[] = sprintf( 'has-%s-color', gutenberg_experimental_to_kebab_case( $block_attributes['textColor'] ) );
 		} elseif ( $has_custom_text_color ) {
 			$styles[] = sprintf( 'color: %s;', $block_attributes['style']['color']['text'] );
 		}
@@ -109,7 +109,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		}
 		// Apply background color classes or styles.
 		if ( $has_named_background_color ) {
-			$classes[] = sprintf( 'has-%s-background-color', $block_attributes['backgroundColor'] );
+			$classes[] = sprintf( 'has-%s-background-color', gutenberg_experimental_to_kebab_case( $block_attributes['backgroundColor'] ) );
 		} elseif ( $has_custom_background_color ) {
 			$styles[] = sprintf( 'background-color: %s;', $block_attributes['style']['color']['background'] );
 		}
@@ -125,7 +125,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		}
 		// Apply required background class.
 		if ( $has_named_gradient ) {
-			$classes[] = sprintf( 'has-%s-gradient-background', $block_attributes['gradient'] );
+			$classes[] = sprintf( 'has-%s-gradient-background', gutenberg_experimental_to_kebab_case( $block_attributes['gradient'] ) );
 		} elseif ( $has_custom_gradient ) {
 			$styles[] = sprintf( 'background: %s;', $block_attributes['style']['color']['gradient'] );
 		}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -98,7 +98,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
 		if ( $has_named_font_size ) {
-			$classes[] = sprintf( 'has-%s-font-size', $block_attributes['fontSize'] );
+			$classes[] = sprintf( 'has-%s-font-size', gutenberg_experimental_to_kebab_case( $block_attributes['fontSize'] ) );
 		} elseif ( $has_custom_font_size ) {
 			$styles[] = sprintf( 'font-size: %s;', $block_attributes['style']['typography']['fontSize'] );
 		}

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test the typography block supports.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
+
+	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
+		register_block_type(
+			'test/test-block',
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'textColor' => array(
+						'type' => 'string',
+					),
+					'backgroundColor' => array(
+						'type' => 'string'
+					),
+					'gradient' => array(
+						'type' => 'string'
+					)
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'       => true,
+						'background' => true,
+						'gradients'  => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( 'test/test-block' );
+
+		$block_atts = array( 'textColor' => 'fg1', 'backgroundColor' => 'bg2', 'gradient' => 'gr3' );
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -46,5 +46,6 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );
 
 		$this->assertSame( $expected, $actual );
+		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
 }

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -10,7 +10,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 
 	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
 		register_block_type(
-			'test/test-block',
+			'test/color-slug-with-numbers',
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -34,7 +34,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/test-block' );
+		$block_type = $registry->get_registered( 'test/color-slug-with-numbers' );
 
 		$block_atts = array(
 			'textColor'       => 'fg1',

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -14,15 +14,15 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
-					'textColor' => array(
+					'textColor'       => array(
 						'type' => 'string',
 					),
 					'backgroundColor' => array(
-						'type' => 'string'
+						'type' => 'string',
 					),
-					'gradient' => array(
-						'type' => 'string'
-					)
+					'gradient'        => array(
+						'type' => 'string',
+					),
 				),
 				'supports'    => array(
 					'color' => array(
@@ -36,7 +36,11 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$registry   = WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( 'test/test-block' );
 
-		$block_atts = array( 'textColor' => 'fg1', 'backgroundColor' => 'bg2', 'gradient' => 'gr3' );
+		$block_atts = array(
+			'textColor'       => 'fg1',
+			'backgroundColor' => 'bg2',
+			'gradient'        => 'gr3',
+		);
 
 		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
 		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -10,7 +10,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 
 	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
 		register_block_type(
-			'test/test-block',
+			'test/font-size-slug-with-numbers',
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -26,7 +26,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/test-block' );
+		$block_type = $registry->get_registered( 'test/font-size-slug-with-numbers' );
 
 		$block_atts = array( 'fontSize' => 'h1' );
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -34,5 +34,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-h-1-font-size' );
 
 		$this->assertSame( $expected, $actual );
+		unregister_block_type( 'test/font-size-slug-with-numbers' );
 	}
 }

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test the typography block supports.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
+
+	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
+		register_block_type(
+			'test/test-block',
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'fontSize' => array(
+						'type' => 'string',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'fontSize' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( 'test/test-block' );
+
+		$block_atts = array( 'fontSize' => 'h1' );
+
+		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
+		$expected = array( 'class' => 'has-h-1-font-size' );
+
+		$this->assertSame( $expected, $actual );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/35708

Converting the slug to a kebab-case format has been problematic in the past. In the client, we use lodash's `kebabCase`, which has some peculiarities. In the server, we don't have that, so we created `gutenberg_experimental_to_kebab_case` function to replicate the most common use cases. See https://github.com/WordPress/gutenberg/issues/32347 for details.

Apparently, when that was implemented the block supports didn't get updated. Hence, blocks that are rendered in the server may still generate an incorrect class. This PR fixes the font size class generation.

## How to test

- Use the empty theme and register this font size:
```json
{
    "settings": {
        "typography": {
            "fontSizes": [
                {
                    "slug": "h1",
                    "size": "32px",
                    "name": "Used in H1 titles"
                }
            ]
        }
    }
}
```
- Add a paragraph, a post title, and a site title in the block editor.
- Attach the font size to those blocks.

The expected result at this point is that, in the editor, they have a new class called `.has-h-1-font-size`.

- Publish the post and verify that, in the front end, they still have that class (previous to this PR it'd be rewritten to `.has-h1-font-size`, which is incorrect as per lodash's kebabCase function).

## Related

Font family preset is being fixed at https://github.com/WordPress/gutenberg/pull/31910
