### PR TITLE
Try: Fix navigation gap & padding issues.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -231,7 +231,7 @@
 .wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container {
-	gap: calc(var(--wp--style--block-gap, 2em) / 4) var(--wp--style--block-gap, 2em);
+	gap: var(--wp--style--block-gap, 2em);
 }
 
 // Menu items with background.
@@ -242,7 +242,7 @@
 	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
-		gap: calc(var(--wp--style--block-gap, 0) / 4) var(--wp--style--block-gap, 0.5em);
+		gap: var(--wp--style--block-gap, 0.5em);
 	}
 }
 
@@ -256,7 +256,7 @@
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.
-.wp-block-navigation:where(.has-background) a {
+.wp-block-navigation:where(.has-background) .wp-block-navigation-item__content {
 	padding: 0.5em 1em;
 }
 
@@ -465,7 +465,7 @@
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.
-			& :where(.wp-block-navigation__submenu-container) a {
+			a {
 				padding: 0;
 			}
 


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/35277#issuecomment-946520540. 

Fixes two issues:

1. Navigation items did not have any gap if the theme didn't define one — the custom property fallback values didn't work quite right for some reason.
2. When the navigation block has a background color, menu items should have some padding applied, but this padding was zeroed out.

Before:

<img width="943" alt="before" src="https://user-images.githubusercontent.com/1204802/137886020-3b86869d-12ed-4c4d-b84e-d45c26fac0b3.png">

After:

<img width="764" alt="after" src="https://user-images.githubusercontent.com/1204802/137886208-950ebe9d-bd28-4284-b380-2811f9c3009c.png">

## How has this been tested?

Here's some test content:

```
<!-- wp:paragraph -->
<p>Navigation with no background:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>Navigation with background:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"customTextColor":"#ff0000","customBackgroundColor":"#f5efef"} -->
<!-- wp:navigation-link {"label":"Journal","type":"page","id":28540,"url":"http://local-wordpress.local/journal/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Contact","type":"page","id":827,"url":"http://local-wordpress.local/contact/","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```

Test in a few themes, including a block theme that _does_ provide a gap value, and a few themes that don't (such as tt1 blocks and Empty Theme), and test that nav menus with and without background colors all appear harmoniously spaced.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
