### PR TITLE
Fix/make sure block anchor stays unique

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -153,7 +153,48 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
+/**
+ * Make sure the anchor continues to stay unique when the block is cloned
+ *
+ * @param {string} blockType type of the block
+ * @param {Object} block     cloned block object
+ * @return {Object} modified cloned block object
+ */
+export function cloneAttribute( blockType, block ) {
+	if (
+		hasBlockSupport( blockType, 'anchor' ) &&
+		has( block, 'attributes.anchor' )
+	) {
+		// check wether the anchor already ends with a `-${number}`
+		const index = block.attributes.anchor.lastIndexOf( '-' );
+		const result = block.attributes.anchor.substring( index + 1 );
+
+		// store the anchor without the `-${number}`
+		const shortendAnchor =
+			index > 0
+				? block.attributes.anchor.substring( 0, index )
+				: block.attributes.anchor;
+
+		// generate the suffix number
+		let suffix = 1;
+		if ( result ) {
+			const number = parseInt( result );
+
+			if ( number ) {
+				suffix = number + 1;
+			}
+		}
+
+		// add the suffix to the anchor
+		block.attributes.anchor = `${ shortendAnchor }-${ suffix }`;
+	}
+
+	// return the modified cloned block
+	return block;
+}
+
 addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
+addFilter( 'blocks.cloneBlock', 'core/anchor/clone', cloneAttribute );
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/anchor/with-inspector-control',

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -118,7 +118,14 @@ export function __experimentalCloneSanitizedBlock(
 		}
 	);
 
-	return {
+	/**
+	 * Filters the cloned block.
+	 * The entire new block object is passed and can be modified
+	 *
+	 * @param {string} blockType block type of the block being transformed.
+	 * @param {Object} block     cloned block object
+	 */
+	return applyFilters( 'blocks.cloneBlock', block.name, {
 		...block,
 		clientId,
 		attributes: sanitizedAttributes,
@@ -127,7 +134,7 @@ export function __experimentalCloneSanitizedBlock(
 			block.innerBlocks.map( ( innerBlock ) =>
 				__experimentalCloneSanitizedBlock( innerBlock )
 			),
-	};
+	} );
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR introduces a new filter called `blocks.cloneBlock` which allows you to hook into the `cloneBlock` function and modify the cloned block object.

The rationale behind this new filter is the need to keep the anchor attribute unique and when blocks are duplicated that uniqueness is lost. So this filter is now being used to make the anchor unique by adding a `-1` (automatically increasing the number if you keep cloning an already cloned block)

Closes #35755
 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Locally using the `wp-env`
Using the `core/heading` block and duplicating it with no anchor, a simple single word anchor and an anchor that has special characters including `-` in it.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature: Make sure anchors stay unique when blocks are duplicated
New API: Introduce `blocks.cloneBlock` filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
