### PR TITLE
Heading: Remove anchor map when block unmounts

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -50,6 +50,10 @@ function HeadingEdit( {
 			} );
 		}
 		allHeadingAnchors[ clientId ] = anchor;
+
+		return () => {
+			delete allHeadingAnchors[ clientId ];
+		};
 	}, [ content, anchor ] );
 
 	const onContentChange = ( value ) => {


### PR DESCRIPTION
## Description
Viewing Header block transformation adds anchor to the object map. Therefore, it can cause incorrect anchor generation when the block is transformed.

PR adds `useEffect` cleanup to remove the mapping.

I noticed this issue while investigating flaky Quote block tests.

To reproduce failing tests, run e2e in interactive mode on `trunk`:

```
npm run test-e2e -- packages/e2e-tests/specs/editor/blocks/quote.test.js --puppeteer-interactive
```

Fixes #35623.
Fixes #35644.
Fixes #35707.
Fixes #35748.

## How has this been tested?

1. Add Quote block and include text.
2. Open the "Transforms" menu dropdown.
3. Preview Heading block result and transform.
4. Generated anchor shouldn't have a number suffix.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
