### PR TITLE
Performance: Improve opening of the block inserter via manual token-based analysis of reusable blocks

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1582,9 +1582,11 @@ export const getInserterItems = createSelector(
 			 * type, if available.
 			 */
 			if ( Platform.OS === 'web' ) {
-				const rawBlockMatch = reusableBlock.content.raw.match(
-					blockParserTokenizer
-				);
+				const content =
+					typeof reusableBlock.content.raw === 'string'
+						? reusableBlock.content.raw
+						: reusableBlock.content;
+				const rawBlockMatch = content.match( blockParserTokenizer );
 				if ( rawBlockMatch ) {
 					const [
 						,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1564,16 +1564,26 @@ export const getInserterItems = createSelector(
 		} );
 
 		/*
-		 * @see `@wordpress/block-serialization-default-parser` package
+		 * Matches block comment delimiters amid serialized content.
+		 *
+		 * @see `tokenizer` in `@wordpress/block-serialization-default-parser` package
 		 */
-		const tokenizer = /<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:(?=([^}]+|}+(?=})|(?!}\s+\/?-->)[^])*)\5|[^]*?)}\s+)?(\/)?-->/;
+		const blockParserTokenizer = /<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:(?=([^}]+|}+(?=})|(?!}\s+\/?-->)[^])*)\5|[^]*?)}\s+)?(\/)?-->/;
 
 		const buildReusableBlockInserterItem = ( reusableBlock ) => {
 			let icon = symbol;
 
+			/*
+			 * Instead of always displaying a generic "symbol" icon for every
+			 * reusable block, try to use an icon that represents the first
+			 * outermost block contained in the reusable block. This requires
+			 * scanning the serialized form of the reusable block to find its
+			 * first block delimiter, then looking up the corresponding block
+			 * type, if available.
+			 */
 			if ( Platform.OS === 'web' ) {
 				const rawBlockMatch = reusableBlock.content.raw.match(
-					tokenizer
+					blockParserTokenizer
 				);
 				if ( rawBlockMatch ) {
 					const [

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1566,9 +1566,17 @@ export const getInserterItems = createSelector(
 		/*
 		 * Matches block comment delimiters amid serialized content.
 		 *
-		 * @see `tokenizer` in `@wordpress/block-serialization-default-parser` package
+		 * @see `tokenizer` in `@wordpress/block-serialization-default-parser`
+		 * package
+		 *
+		 * blockParserTokenizer differs from the original tokenizer in the
+		 * following ways:
+		 *
+		 * - removed global flag (/g)
+		 * - prepended ^\s*
+		 *
 		 */
-		const blockParserTokenizer = /<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:(?=([^}]+|}+(?=})|(?!}\s+\/?-->)[^])*)\5|[^]*?)}\s+)?(\/)?-->/;
+		const blockParserTokenizer = /^\s*<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:(?=([^}]+|}+(?=})|(?!}\s+\/?-->)[^])*)\5|[^]*?)}\s+)?(\/)?-->/;
 
 		const buildReusableBlockInserterItem = ( reusableBlock ) => {
 			let icon = symbol;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -70,7 +70,6 @@ const {
 	__experimentalGetLastBlockAttributeChanges,
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
-	__experimentalGetParsedReusableBlock,
 	__experimentalGetAllowedPatterns,
 	__experimentalGetPatternsByBlockTypes,
 	__unstableGetClientIdWithClientIdsTree,
@@ -3622,26 +3621,6 @@ describe( 'selectors', () => {
 				wasBlockJustInserted( state, clientId, expectedSource )
 			).toBe( false );
 		} );
-	} );
-} );
-
-describe( '__experimentalGetParsedReusableBlock', () => {
-	const state = {
-		settings: {
-			__experimentalReusableBlocks: [
-				{
-					id: 1,
-					content: { raw: '' },
-				},
-			],
-		},
-	};
-
-	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
-	it( "Should return an empty array if reusable block's content.raw is an empty string", () => {
-		expect( __experimentalGetParsedReusableBlock( state, 1 ) ).toEqual(
-			[]
-		);
 	} );
 } );
 


### PR DESCRIPTION
Alternative to #35724.
Fixes #35719.

Props @sathyapulse for identifying the bottleneck.

## Description

In the `getInserterItems` block-editor selector, `buildReusableBlockInserterItem` parses every saved reusable block in order to identify its outermost block type, so that the inserter UI can display the icon of said block type.

This function previously relied on parsing every saved reusable block using the full block parser, i.e. `wp.blocks.parse`. This is orders of magnitude slower than _raw parsing_, which excels at only retrieving the block topology, and is made available by `wp.blockSerializationDefaultParser.parse`.

This pull request extracts the tokenizer regular expression used in package `block-serialization-default-parser` and uses it to match the very first block boundary found in a reusable block's markup. This should be significantly faster when a site has thousands of saved reusable blocks.

## How has this been tested?

* **Unchanged:** Verify that the block inserter continues to work as expected. In particular, verify that all reusable blocks are listed under _Reusable Blocks_ and that each one is accompanied by the most appropriate icon. For example, a reusable block made up of a Quote block should sport the Quote block icon.
* **Faster:** Verify that the block inserter performs well under high load — specifically, when around 2500 reusable blocks are loaded into the editor.

## Types of changes
Performance fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
