### PR TITLE
Storybook: Lazy load LTR/RTL styles for consistent specificity

### DIFF
--- a/storybook/decorators/with-rtl.js
+++ b/storybook/decorators/with-rtl.js
@@ -7,7 +7,13 @@ import { forceReRender } from '@storybook/react';
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useLayoutEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ltrStyles from '../style-ltr.lazy.scss';
+import rtlStyles from '../style-rtl.lazy.scss';
 
 export const WithRTL = ( Story, context ) => {
 	const ref = useRef();
@@ -33,6 +39,19 @@ export const WithRTL = ( Story, context ) => {
 		forceReRender();
 
 		return () => removeFilter( 'i18n.gettext_with_context', 'storybook' );
+	}, [ context.globals.direction ] );
+
+	useLayoutEffect( () => {
+		if ( context.globals.direction === 'rtl' ) {
+			rtlStyles.use();
+		} else {
+			ltrStyles.use();
+		}
+
+		return () => {
+			ltrStyles.unuse();
+			rtlStyles.unuse();
+		};
 	}, [ context.globals.direction ] );
 
 	return (

--- a/storybook/style-ltr.lazy.scss
+++ b/storybook/style-ltr.lazy.scss
@@ -1,0 +1,7 @@
+// @wordpress package styles (ltr)
+@import "../packages/components/build-style/style";
+@import "../packages/block-editor/build-style/style";
+@import "../packages/block-library/build-style/style";
+@import "../packages/block-library/build-style/theme";
+@import "../packages/block-library/build-style/editor";
+@import "../packages/format-library/build-style/style";

--- a/storybook/style-rtl.lazy.scss
+++ b/storybook/style-rtl.lazy.scss
@@ -1,0 +1,7 @@
+// @wordpress package styles (rtl)
+@import "../packages/components/build-style/style-rtl";
+@import "../packages/block-editor/build-style/style-rtl";
+@import "../packages/block-library/build-style/style-rtl";
+@import "../packages/block-library/build-style/theme-rtl";
+@import "../packages/block-library/build-style/editor-rtl";
+@import "../packages/format-library/build-style/style-rtl";

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -9,23 +9,3 @@
 @import "~@wordpress/base-styles/default-custom-properties";
 @import "~@wordpress/base-styles/variables";
 @import "~@wordpress/base-styles/z-index";
-
-html[dir="ltr"] {
-	// @wordpress package styles (ltr)
-	@import "../packages/components/src/style.scss";
-	@import "../packages/block-editor/src/style.scss";
-	@import "../packages/block-library/src/style.scss";
-	@import "../packages/block-library/src/theme.scss";
-	@import "../packages/block-library/src/editor.scss";
-	@import "../packages/format-library/src/style.scss";
-}
-
-html[dir="rtl"] {
-	// @wordpress package styles (rtl)
-	@import "../packages/components/build-style/style-rtl";
-	@import "../packages/block-editor/build-style/style-rtl";
-	@import "../packages/block-library/build-style/style-rtl";
-	@import "../packages/block-library/build-style/theme-rtl";
-	@import "../packages/block-library/build-style/editor-rtl";
-	@import "../packages/format-library/build-style/style-rtl";
-}

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -8,6 +8,24 @@ const path = require( 'path' );
  */
 const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 
+const scssLoaders = ( { isLazy } ) => [
+	{
+		loader: 'style-loader',
+		options: { injectType: isLazy ? 'lazyStyleTag' : 'styleTag' },
+	},
+	'css-loader',
+	{
+		loader: 'postcss-loader',
+		options: {
+			postcssOptions: {
+				ident: 'postcss',
+				plugins: postcssPlugins,
+			},
+		},
+	},
+	'sass-loader',
+];
+
 module.exports = ( { config } ) => {
 	config.module.rules.push(
 		{
@@ -17,20 +35,13 @@ module.exports = ( { config } ) => {
 		},
 		{
 			test: /\.scss$/,
-			use: [
-				'style-loader',
-				'css-loader',
-				{
-					loader: 'postcss-loader',
-					options: {
-						postcssOptions: {
-							ident: 'postcss',
-							plugins: postcssPlugins,
-						},
-					},
-				},
-				'sass-loader',
-			],
+			exclude: /\.lazy\.scss$/,
+			use: scssLoaders( { isLazy: false } ),
+			include: path.resolve( __dirname ),
+		},
+		{
+			test: /\.lazy\.scss$/,
+			use: scssLoaders( { isLazy: true } ),
 			include: path.resolve( __dirname ),
 		}
 	);


### PR DESCRIPTION
## Description

I realized that #35711 introduces subtle visual differences in a few stories, mostly caused by specificity reversals between Emotion styles and static CSS (which now has one level of added specificity due to being scoped within `[dir="rtl"]`). (Related: #23215)

This PR changes the stylesheet switching strategy to use lazy loading, rather than scoping them under `html[dir="rtl"]`. This way we don't have to deal with added specificity complications, and the initial load will be faster.

## How has this been tested?

✅ Works in both `npm run storybook:dev` (HMR) and `npm run storybook:build` (prod build).
✅ The story regressions below are fixed.

- The button icon is too small in `ColorPicker`
- `Popover` is mis-positioned (also seen in `ColorPalette`)
- `ResizableBox` lost its resize handles 

## Screenshots

| Correct | Wrong |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/137941076-7afc9b50-d5a3-4a78-aa5d-28875e71cccb.png" alt="Color Picker" width="400">|<img src="https://user-images.githubusercontent.com/555336/137941084-4551ca0c-4b4b-4ce6-bce3-9cc4a403ca50.png" alt="Color Picker" width="400">|
|![Color Palette](https://user-images.githubusercontent.com/555336/137941088-3c819ee4-28ad-4565-aca1-2bea99e5092a.png)|![Color Palette](https://user-images.githubusercontent.com/555336/137941093-8668e8d2-7547-4a8b-a9bb-828c2d0087c9.png)|
|![Resizable Box](https://user-images.githubusercontent.com/555336/137944602-c55e7cec-3d16-49ed-bdf1-c1b9fce9efcf.png)|![Resizable Box](https://user-images.githubusercontent.com/555336/137944543-81e2310e-8cd4-4dc1-af86-961ee4af7a48.png)|


## Types of changes

Bug fix, Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
