### PR TITLE
Add spacing controls to all heading blocks

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -33,8 +33,7 @@
 			"link": true
 		},
 		"spacing": {
-			"margin": true,
-			"padding": true
+			"margin": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -32,6 +32,10 @@
 		"color": {
 			"link": true
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -35,6 +35,10 @@
 			"gradients": true,
 			"link": true
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -36,8 +36,7 @@
 			"link": true
 		},
 		"spacing": {
-			"margin": true,
-			"padding": true
+			"margin": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -24,8 +24,7 @@
 			"gradients": true
 		},
 		"spacing": {
-			"margin": true,
-			"padding": true
+			"margin": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -23,6 +23,10 @@
 		"color": {
 			"gradients": true
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Fixes #35522. 
This is a more expansive version of #35684. 

When creating patterns and templates, I find myself needing padding and/or margin support most frequently on headings. In particular, they tend to require additional space above or below them so that they comfortably flow with the rest of the text. The Site Title block [already has these controls](https://github.com/WordPress/gutenberg/blob/e9a09f1247ecb8519e23fbbf61d887ae3fe83fca/packages/block-library/src/site-title/block.json#L32-L35), but other heading blocks do not. This fixes that by adding margin + padding controls to all blocks that generate headings: 

- Heading
- Post Title
- Query Title

⚠️ **Note:** Left/right margins [may end up breaking the layout](https://github.com/WordPress/gutenberg/pull/33835#issuecomment-891538984) for classic themes when used on the top level of the page. We could limit to just top and bottom margin support, but since this specific issue happens when _any_ block uses margin controls, I consider that more of a global issue and I don't think it should necessarily limit us in this specific PR. Still, we _could_ enable just top/bottom margins if folks think that's a concern. 

## To test: 

Try the following block markup, and note that the padding + margins appear as expected in both the front end and editor: 

```
<!-- wp:heading {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}}}} -->
<h2 id="this-heading-has-margin-padding" style="margin-top:1rem;margin-right:1rem;margin-bottom:1rem;margin-left:1rem;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem">This heading has margin + padding.</h2>
<!-- /wp:heading -->

<!-- wp:post-title {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}}}} /-->

<!-- wp:query-title {"type":"archive","style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}}}} /-->
```

## Screenshot

<img width="1032" alt="Screen Shot 2021-10-19 at 12 00 12 PM" src="https://user-images.githubusercontent.com/1202812/137948349-73239758-c9e2-4b5a-93fa-d5308e2bb3a1.png">

<img width="686" alt="Screen Shot 2021-10-19 at 11 58 49 AM" src="https://user-images.githubusercontent.com/1202812/137948370-1d7a61f1-5c6e-4e64-b0c1-a0b121eb757f.png">


