### PR TITLE
Add spacing controls to the featured image block

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -33,7 +33,7 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
-		},
+		}
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",
 	"style": "wp-block-post-featured-image"

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -29,7 +29,11 @@
 			"text": false,
 			"background": false
 		},
-		"html": false
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",
 	"style": "wp-block-post-featured-image"


### PR DESCRIPTION
This PR adds spacing controls (margin + padding) to the featured image block, so that block themes have more control over placement. 

## Screenshot:

<img width="841" alt="Screen Shot 2021-10-19 at 12 49 44 PM" src="https://user-images.githubusercontent.com/1202812/137956002-14e3138a-ec4e-42e6-a369-ffdce843048d.png">


## Testing: 

1. Add a featured image block. 
2. Check to see if margin and padding controls are active.

(Your theme will need to opt in to showing both Margin and Padding controls. [Twenty Twenty-Two](https://github.com/WordPress/twentytwentytwo/blob/3a2fe6d9e85e3293158fac671514d601a03a41bc/theme.json#L92-L93) is an example of a theme that does this). 