### PR TITLE
Fixes #34855 RangeControl style issue in RTL

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -192,7 +192,7 @@ export const ThumbWrapper = styled.span`
 	transform: translateX( 4.5px );
 
 	${ thumbColor };
-	${ rtl( { marginLeft: -10 } ) };
+	${ rtl( { marginLeft: -10 }, { marginRight: 1 } ) };
 `;
 
 const thumbFocus = ( { isFocused } ) => {

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -192,7 +192,7 @@ export const ThumbWrapper = styled.span`
 	transform: translateX( 4.5px );
 
 	${ thumbColor };
-	${ rtl( { marginLeft: -10 }, { marginRight: 1 } ) };
+	${ rtl( { marginLeft: -10 }, { marginRight: -2 } ) };
 `;
 
 const thumbFocus = ( { isFocused } ) => {

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -189,10 +189,13 @@ export const ThumbWrapper = styled.span`
 	user-select: none;
 	width: ${ thumbSize }px;
 	border-radius: 50%;
-	transform: translateX( 4.5px );
 
 	${ thumbColor };
-	${ rtl( { marginLeft: -10 }, { marginRight: -2 } ) };
+	${ rtl( { marginLeft: -10 } ) };
+	${ rtl(
+		{ transform: 'translateX( 4.5px )' },
+		{ transform: 'translateX( -4.5px )' }
+	) };
 `;
 
 const thumbFocus = ( { isFocused } ) => {


### PR DESCRIPTION

## Description
Fixes #34855 RangeControl style issue in RTL


## How has this been tested?
Switch RTL lag (hebrew)
load the space block
check the 

## Screenshots <!-- if applicable -->

## Types of changes
Adjusted style for RTL

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
