### PR TITLE
Image block: Set image display to grid  when no alignment sent to properly align caption on resize

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -74,11 +74,23 @@ figure.wp-block-image:not(.wp-block) {
 	> .wp-block-image {
 		display: grid;
 		grid-template-rows: auto auto;
-		grid-template-columns: min-content;
-
+		grid-template-columns: [resized] min-content [no-resize] auto;
+		.components-placeholder {
+			grid-column: no-resize;
+		}
+		.components-resizable-box__container {
+			grid-column: resized;
+		}
 		> figcaption {
+			grid-column: resized;
 			display: table-caption;
 			caption-side: bottom;
+		}
+	}
+	> .wp-block-image:not(.is-resized) {
+		> .components-resizable-box__container,
+		> figcaption {
+			grid-column: no-resize;
 		}
 	}
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -59,7 +59,8 @@ figure.wp-block-image:not(.wp-block) {
 
 .wp-block[data-align="left"],
 .wp-block[data-align="center"],
-.wp-block[data-align="right"] {
+.wp-block[data-align="right"],
+*:not([data-align]) {
 	> .wp-block-image {
 		display: table;
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -73,24 +73,17 @@ figure.wp-block-image:not(.wp-block) {
 *:not([data-align]) {
 	> .wp-block-image {
 		display: grid;
-		grid-template-rows: auto auto;
-		grid-template-columns: [resized] min-content [no-resize] minmax(0, max-content);
+		grid-template-columns: [image] minmax(0, max-content) [placeholder] auto;
 		.components-placeholder {
-			grid-column: no-resize;
+			grid-column: placeholder;
 		}
 		> div:not(.components-placeholder) {
-			grid-column: resized;
+			grid-column: image;
 		}
 		> figcaption {
-			grid-column: resized;
+			grid-column: image;
 			display: table-caption;
 			caption-side: bottom;
-		}
-	}
-	> .wp-block-image:not(.is-resized) {
-		> div:not(.components-placeholder),
-		> figcaption {
-			grid-column: no-resize;
 		}
 	}
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -78,7 +78,7 @@ figure.wp-block-image:not(.wp-block) {
 		.components-placeholder {
 			grid-column: no-resize;
 		}
-		.components-resizable-box__container {
+		> div:not(.components-placeholder) {
 			grid-column: resized;
 		}
 		> figcaption {
@@ -88,7 +88,7 @@ figure.wp-block-image:not(.wp-block) {
 		}
 	}
 	> .wp-block-image:not(.is-resized) {
-		> .components-resizable-box__container,
+		> div:not(.components-placeholder),
 		> figcaption {
 			grid-column: no-resize;
 		}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -59,10 +59,22 @@ figure.wp-block-image:not(.wp-block) {
 
 .wp-block[data-align="left"],
 .wp-block[data-align="center"],
-.wp-block[data-align="right"],
-*:not([data-align]) {
+.wp-block[data-align="right"] {
 	> .wp-block-image {
 		display: table;
+
+		> figcaption {
+			display: table-caption;
+			caption-side: bottom;
+		}
+	}
+}
+
+*:not([data-align]) {
+	> .wp-block-image {
+		display: grid;
+		grid-template-rows: auto auto;
+		grid-template-columns: min-content;
 
 		> figcaption {
 			display: table-caption;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -74,7 +74,7 @@ figure.wp-block-image:not(.wp-block) {
 	> .wp-block-image {
 		display: grid;
 		grid-template-rows: auto auto;
-		grid-template-columns: [resized] min-content [no-resize] auto;
+		grid-template-columns: [resized] min-content [no-resize] minmax(0, max-content);
 		.components-placeholder {
 			grid-column: no-resize;
 		}

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -197,6 +197,9 @@ describe( 'Cover', () => {
 		await insertBlock( 'Image' );
 		// Upload image and transform to the Cover block
 		await upload( '.wp-block-image' );
+		// Click the block wrapper before trying to convert to make sure figcaption toolbar is not obscuring
+		// the block toolbar.
+		await page.click( '.wp-block-image' );
 		await transformBlockTo( 'Cover' );
 
 		// Get the block's background dim color and its opacity

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -103,8 +103,9 @@ describe( 'Image', () => {
 			`<!-- wp:image {"id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-full"><img src="[^"]+\\/${ filename2 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex3 );
-
-		await page.click( '.wp-block-image' );
+		// For some reason just clicking the block wrapper causes figcaption to get focus
+		// in puppeteer but not in live browser, so clicking on the image wrapper div here instead.
+		await page.click( '.wp-block-image > div' );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toBe( '' );


### PR DESCRIPTION
## Description

Currently the image caption does not align correctly when no alignment is set if the image is small, or resized smaller. This PR adds the same `table` display property as is used when an explicit alignment is set.

Fixes: #17162

## To Test

- Check out PR to local dev env
- Add an image and set caption
- Resize the image and check that the caption stays aligned correctly
- Test other explicit layout options, left, right, centre and make sure they still behave as expected

## Screenshots 
Before:
![caption-before](https://user-images.githubusercontent.com/3629020/138008552-3e87101f-35a6-40f3-beb1-5128481beed8.gif)

After:
![caption-after](https://user-images.githubusercontent.com/3629020/138008657-83011a56-0e6a-4a9a-a3f9-65b782093876.gif)


