### PR TITLE
Cover block: Change dimRatio to 50 if media added and dimRatio is set to 100

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -333,7 +333,7 @@ function CoverEdit( {
 		gradientValue,
 		setGradient,
 	} = __experimentalUseGradient();
-	const onSelectMedia = attributesFromMedia( setAttributes );
+	const onSelectMedia = attributesFromMedia( setAttributes, dimRatio );
 	const isUploadingMedia = isTemporaryMedia( id, url );
 
 	const [ prevMinHeightValue, setPrevMinHeightValue ] = useState( minHeight );

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -190,7 +190,7 @@ const Cover = ( {
 
 	const onSelectMedia = ( media ) => {
 		setDidUploadFail( false );
-		const onSelect = attributesFromMedia( setAttributes );
+		const onSelect = attributesFromMedia( setAttributes, dimRatio );
 		onSelect( media );
 	};
 

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -32,7 +32,7 @@ export function dimRatioToClass( ratio ) {
 		: 'has-background-dim-' + 10 * Math.round( ratio / 10 );
 }
 
-export function attributesFromMedia( setAttributes ) {
+export function attributesFromMedia( setAttributes, dimRatio ) {
 	return ( media ) => {
 		if ( ! media || ! media.url ) {
 			setAttributes( { url: undefined, id: undefined } );
@@ -65,6 +65,7 @@ export function attributesFromMedia( setAttributes ) {
 		}
 
 		setAttributes( {
+			dimRatio: dimRatio === 100 ? 50 : dimRatio,
 			url: media.url,
 			id: media.id,
 			alt: media?.alt,


### PR DESCRIPTION
## Description
Changes the dimRation to 50 if media added and dimRatio is set to 100 to prevent background color obscuring image

Potential fix for: #35766
## To test

- Check out PR to local dev env
- Add a cover block and set background color 
- Add a background image and check that background color opacity was changed to 0.5 to allow image to show through background color

## Screenshots 
Before:

![cover-before](https://user-images.githubusercontent.com/3629020/138025316-619fa134-222b-4376-a3df-39713c1d0606.gif)

After:

![cover-after](https://user-images.githubusercontent.com/3629020/138025355-55fbcf99-5a26-46bb-a379-7eaf4853bdf6.gif)

