### PR TITLE
Gallery block: Only show the gallery upload error message if mixed multiple files uploaded

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -138,6 +138,9 @@ const transforms = {
 			isMatch( files ) {
 				if (
 					files.some(
+						( file ) => file.type.indexOf( 'image/' ) === 0
+					) &&
+					files.some(
 						( file ) => file.type.indexOf( 'image/' ) !== 0
 					)
 				) {

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -136,6 +136,7 @@ const transforms = {
 			// creating a new gallery.
 			type: 'files',
 			isMatch( files ) {
+				// The following check is intended to catch non-image files when dropped together with images.
 				if (
 					files.some(
 						( file ) => file.type.indexOf( 'image/' ) === 0


### PR DESCRIPTION
## Description

The error message that was added to cope with image uploads into the refactored gallery is showing even if single files are uploaded, eg. a single video file. This PR adds an additional check to make sure uploaded files are a mix of image and other formats before showing the error

Fixes: #35366

## Testing

- Checkout Pr to local test env
- Drag and drop a single video file onto editor canvas and make sure no error shown
- Drag and drop a mixed collection of images and other formats and make sure error shows when dropped on both the canvas and an existing gallery

## Screenshots 
Before:
![error-before](https://user-images.githubusercontent.com/3629020/138028891-5fd9550e-9675-4a52-b39a-ea3b3d3e9fd4.gif)

After:
![error-after](https://user-images.githubusercontent.com/3629020/138028909-45187542-4cac-4ffa-8ab6-eb891e86adc7.gif)


