### PR TITLE
[Post template] Update how sticky posts are displayed

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -60,6 +60,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$content = '';
 	while ( $query->have_posts() ) {
 		$query->the_post();
+		// Do not display duplicate sticky posts in the paged result.
+		if ( $page > 1 && is_sticky() ) {
+			continue;
+		}
 		$block_content = (
 			new WP_Block(
 				$block->parsed_block,

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -15,6 +15,14 @@
  * @return string Returns the output of the query, structured using the layout defined by the block's inner blocks.
  */
 function render_block_core_post_template( $attributes, $content, $block ) {
+
+	// Return early if sticky posts are set to only, but there are no sticky posts.
+	if ( isset( $block->context['query']['sticky'] )
+		&& 'only' === $block->context['query']['sticky']
+		&& empty( get_option( 'sticky_posts' ) ) ) {
+		return '';
+	}
+
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### Problem 1
If a WordPress install has no sticky posts, standard posts are displayed on the front when the query loop setting "Sticky posts" is set to "only".

The PR adds an early return depending on the setting and if there are sticky posts or not.

#### How has this been tested?

- Trash or remove sticky from any sticky posts on your WordPress installation
- Add a query loop block to the index in the site editor.
- Set the Sticky post setting to "only".

Sample:
```
<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"only","perPage":3,"inherit":false},"displayLayout":{"type":"list"}} -->
<div class="wp-block-query">
<!-- wp:post-template -->
<!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->
```

- Confirm that no posts are displaying in the editor. The message "No results found." is shown.
- Save and view the front. Confirm that no posts are showing on the front.

Repeat the test with `Inherit query from template` enabled.
Now add a sticky post and make sure it still works correctly.

### Problem 2
When the query block's `Inherit query from template` is not enabled, and Sticky posts is set to include,
the sticky posts are:
1) Not displayed in the editor. **This is incorrect.**
2) Displayed correctly on the homepage
3) Also displayed on top of page 2, and so on in the paged result. **This is incorrect.**

_The PR so far only solves this for the front._

#### How has this been tested?

1. Make sure your installation has sticky posts
2. Add a query loop block with a query pagination block to the index in the site editor.
3. Save and view the front.
4. Note which posts are showing on the first page, and navigate to page 2 or higher.
5. Confirm that the sticky posts are not showing on page 2 or higher.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
