### PR TITLE
Block Supports: Add panel specific className

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -10,7 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { cleanEmptyObject } from '../../hooks/utils';
 
-export default function BlockSupportToolsPanel( { children, label } ) {
+export default function BlockSupportToolsPanel( { children, group, label } ) {
 	const { clientId, attributes } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } = select(
 			blockEditorStore
@@ -46,6 +46,7 @@ export default function BlockSupportToolsPanel( { children, label } ) {
 
 	return (
 		<ToolsPanel
+			className={ `${ group }-block-support-panel` }
 			label={ label }
 			resetAll={ resetAll }
 			key={ clientId }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/33744
- https://github.com/WordPress/gutenberg/pull/34027
- https://github.com/WordPress/gutenberg/pull/33743

## Description

This adds a `className` specific to each grouped inspector controls slot. It allows different block supports to override some component styles within the `ToolsPanel` until those components are migrated to the new context system.

## How has this been tested?

Manually.

1. Loaded a post in the block editor that has a cover block and selected that block.
2. Ensured that the dimensions panel had the `dimensions-block-support-panel` class.
3. Tested this with rebased versions of the related PRs linked above.

## Screenshots <!-- if applicable -->

<img width="1061" alt="Screen Shot 2021-10-20 at 5 47 30 pm" src="https://user-images.githubusercontent.com/60436221/138050745-8dc30ae4-6985-4321-b2ce-4d1abef6b6c9.png">

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
