### PR TITLE
FSE: Use slug as template parts area item key

### DIFF
--- a/packages/edit-site/src/components/sidebar/template-card/template-areas.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-areas.js
@@ -61,7 +61,7 @@ export default function TemplateAreas() {
 
 			<ul className="edit-site-template-card__template-areas-list">
 				{ templateParts.map( ( { templatePart, block } ) => (
-					<li key={ templatePart.area }>
+					<li key={ templatePart.slug }>
 						<TemplateAreaItem
 							area={ templatePart.area }
 							clientId={ block.clientId }

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -126,7 +126,7 @@ export default function TemplateAreas( { closeTemplateDetailsDropdown } ) {
 		>
 			{ templateParts.map( ( { templatePart, block } ) => (
 				<TemplatePartItem
-					key={ templatePart.area }
+					key={ templatePart.slug }
 					clientId={ block.clientId }
 					templatePart={ templatePart }
 					closeTemplateDetailsDropdown={


### PR DESCRIPTION
## Description
The template areas aren't unique, and it can cause React warning when more than one template part for the same area (General) is used on a page.

Themes can also skip defining areas in `theme.json.` In this case, all template parts are from the General area.

P.S. React error was triggered 100+ times by the `TemplateCard` component in the Site Editor. It might be worth investigating why the component re-renders so many times.

## How has this been tested?
1. Go to Site Editor.
2. Edit template.
3. Add two or more template parts from the General area.
4. This shouldn't trigger React warning when the Template sidebar is open.

I tested with TT2, which currently doesn't have `templateParts` [defined](https://github.com/WordPress/twentytwentytwo/pull/137) in the theme.json file.

## Screenshots <!-- if applicable -->
![CleanShot 2021-10-20 at 13 20 30](https://user-images.githubusercontent.com/240569/138066080-8cbcfc37-a6af-40b3-bbfe-3158136a3277.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
