### PR TITLE
Templates: Only include templates for the current post types

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -259,6 +259,10 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 		$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
 	}
 
+	if ( 'wp_template' === $template_type && isset( $template_file['postTypes'] ) ) {
+		$template->post_types = $template_file['postTypes'];
+	}
+
 	if ( 'wp_template_part' === $template_type && isset( $template_file['area'] ) ) {
 		$template->area = $template_file['area'];
 	}

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -253,12 +253,12 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 	$template->status         = 'publish';
 	$template->has_theme_file = true;
-	$template->default        = false;
+	$template->is_custom      = true;
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];
 		$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
-		$template->default     = true;
+		$template->is_custom   = false;
 	}
 
 	if ( 'wp_template' === $template_type && isset( $template_file['postTypes'] ) ) {
@@ -280,7 +280,8 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
  * @return WP_Block_Template|WP_Error Template.
  */
 function _gutenberg_build_template_result_from_post( $post ) {
-	$terms = get_the_terms( $post, 'wp_theme' );
+	$default_template_types = gutenberg_get_default_template_types();
+	$terms                  = get_the_terms( $post, 'wp_theme' );
 
 	if ( is_wp_error( $terms ) ) {
 		return $terms;
@@ -306,7 +307,11 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->title          = $post->post_title;
 	$template->status         = $post->post_status;
 	$template->has_theme_file = $has_theme_file;
-	$template->default        = false;
+	$template->is_custom      = true;
+
+	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
+		$template->is_custom = false;
+	}
 
 	if ( 'wp_template_part' === $post->post_type ) {
 		$type_terms = get_the_terms( $post, 'wp_template_part_area' );

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -253,10 +253,12 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 	$template->status         = 'publish';
 	$template->has_theme_file = true;
+	$template->default        = false;
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];
 		$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
+		$template->default     = true;
 	}
 
 	if ( 'wp_template' === $template_type && isset( $template_file['postTypes'] ) ) {
@@ -304,6 +306,7 @@ function _gutenberg_build_template_result_from_post( $post ) {
 	$template->title          = $post->post_title;
 	$template->status         = $post->post_status;
 	$template->has_theme_file = $has_theme_file;
+	$template->default        = false;
 
 	if ( 'wp_template_part' === $post->post_type ) {
 		$type_terms = get_the_terms( $post, 'wp_template_part_area' );

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -145,7 +145,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
 			// Maybe we should do this on `get_block_templates` level based on query?
-			if ( isset( $request['post_type'] ) && $template->default ) {
+			if ( isset( $request['post_type'] ) && ! $template->is_custom ) {
 				continue;
 			}
 

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -487,10 +487,18 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		return array(
-			'context' => $this->get_context_param(),
-			'wp_id'   => array(
+			'context'   => $this->get_context_param(),
+			'wp_id'     => array(
 				'description' => __( 'Limit to the specified post id.', 'gutenberg' ),
 				'type'        => 'integer',
+			),
+			'area'      => array(
+				'description' => __( 'Limit to the specified template part area.', 'gutenberg' ),
+				'type'        => 'string',
+			),
+			'post_type' => array(
+				'description' => __( 'Post type to get the templates for.', 'gutenberg' ),
+				'type'        => 'string',
 			),
 		);
 	}

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -141,22 +141,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		if ( isset( $request['area'] ) ) {
 			$query['area'] = $request['area'];
 		}
+		if ( isset( $request['post_type'] ) ) {
+			$query['post_type'] = $request['post_type'];
+		}
 
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
-			// Maybe we should do this on `get_block_templates` level based on query?
-			if ( isset( $request['post_type'] ) && ! $template->is_custom ) {
-				continue;
-			}
-
-			if (
-				isset( $request['post_type'] ) &&
-				isset( $template->post_types ) &&
-				! in_array( $request['post_type'], $template->post_types, true )
-			) {
-				continue;
-			}
-
 			$data        = $this->prepare_item_for_response( $template, $request );
 			$templates[] = $this->prepare_response_for_collection( $data );
 		}

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -144,6 +144,11 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
+			// Maybe we should do this on `get_block_templates` level based on query?
+			if ( isset( $request['post_type'] ) && $template->default ) {
+				continue;
+			}
+
 			if (
 				isset( $request['post_type'] ) &&
 				isset( $template->post_types ) &&

--- a/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
+++ b/lib/full-site-editing/class-gutenberg-rest-templates-controller.php
@@ -141,8 +141,17 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		if ( isset( $request['area'] ) ) {
 			$query['area'] = $request['area'];
 		}
+
 		$templates = array();
 		foreach ( gutenberg_get_block_templates( $query, $this->post_type ) as $template ) {
+			if (
+				isset( $request['post_type'] ) &&
+				isset( $template->post_types ) &&
+				! in_array( $request['post_type'], $template->post_types, true )
+			) {
+				continue;
+			}
+
 			$data        = $this->prepare_item_for_response( $template, $request );
 			$templates[] = $this->prepare_response_for_collection( $data );
 		}

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -87,4 +87,11 @@ class WP_Block_Template {
 	 * @var boolean
 	 */
 	public $has_theme_file;
+
+	/**
+	 * Whether a template is default WordPress template (e.g. 'index', 'archive').
+	 *
+	 * @var bool
+	 */
+	public $default = false;
 }

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -89,9 +89,9 @@ class WP_Block_Template {
 	public $has_theme_file;
 
 	/**
-	 * Whether a template is default WordPress template (e.g. 'index', 'archive').
+	 * Whether a template is a custom template.
 	 *
 	 * @var bool
 	 */
-	public $default = false;
+	public $is_custom = true;
 }

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -21,6 +21,10 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_t
 
 	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
 	foreach ( $block_templates as $template ) {
+		if ( $template->default ) {
+			continue;
+		}
+
 		if ( isset( $template->post_types ) && ! in_array( $post_type, $template->post_types, true ) ) {
 			continue;
 		}

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -19,16 +19,8 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_t
 		return $templates;
 	}
 
-	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
+	$block_templates = gutenberg_get_block_templates( array( 'post_type' => $post_type ), 'wp_template' );
 	foreach ( $block_templates as $template ) {
-		if ( ! $template->is_custom ) {
-			continue;
-		}
-
-		if ( isset( $template->post_types ) && ! in_array( $post_type, $template->post_types, true ) ) {
-			continue;
-		}
-
 		$templates[ $template->slug ] = $template->title;
 	}
 

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -8,20 +8,26 @@
 /**
  * Load the page templates in Gutenberg.
  *
- * @param array $templates Page templates.
+ * @param string[] $templates Page templates.
+ * @param WP_Theme $theme     WP_Theme instance.
+ * @param WP_Post  $post      The post being edited, provided for context, or null.
+ * @param string   $post_type Post type to get the templates for.
  * @return array (Maybe) modified page templates array.
  */
-function gutenberg_load_block_page_templates( $templates ) {
+function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
 	if ( ! gutenberg_supports_block_templates() ) {
 		return $templates;
 	}
 
 	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
 	foreach ( $block_templates as $template ) {
-		// TODO: exclude templates that are not concerned by the current post type.
+		if ( isset( $template->post_types ) && ! in_array( $post_type, $template->post_types, true ) ) {
+			continue;
+		}
+
 		$templates[ $template->slug ] = $template->title;
 	}
 
 	return $templates;
 }
-add_filter( 'theme_templates', 'gutenberg_load_block_page_templates' );
+add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );

--- a/lib/full-site-editing/page-templates.php
+++ b/lib/full-site-editing/page-templates.php
@@ -21,7 +21,7 @@ function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_t
 
 	$block_templates = gutenberg_get_block_templates( array(), 'wp_template' );
 	foreach ( $block_templates as $template ) {
-		if ( $template->default ) {
+		if ( ! $template->is_custom ) {
 			continue;
 		}
 

--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -47,13 +47,15 @@ export function TemplatePanel() {
 			getCurrentPostType,
 		} = select( editorStore );
 		const { getPostType, getEntityRecords, canUser } = select( coreStore );
-		const _isViewable =
-			getPostType( getCurrentPostType() )?.viewable ?? false;
+		const currentPostType = getCurrentPostType();
+		const _isViewable = getPostType( currentPostType )?.viewable ?? false;
 		const _supportsTemplateMode =
 			select( editorStore ).getEditorSettings().supportsTemplateMode &&
 			_isViewable;
 
-		const wpTemplates = getEntityRecords( 'postType', 'wp_template' );
+		const wpTemplates = getEntityRecords( 'postType', 'wp_template', {
+			post_type: currentPostType,
+		} );
 
 		const newAvailableTemplates = fromPairs(
 			( wpTemplates || [] ).map( ( { slug, title } ) => [


### PR DESCRIPTION
## Description
Updates block templates loading logic only to include templates for the current post type. These post types can be defined using the `customTemplates` [setting](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#customtemplates) in the theme.json.

Fixes #31704

## How has this been tested?
1. Clone TT2 theme and checkout to `update/templates` [branch](https://github.com/WordPress/twentytwentytwo/pull/136).
2. Create a page.
3. The "Single Post (No Separators)" custom template should be available in the template dropdown.

## Screenshots <!-- if applicable -->
![CleanShot 2021-10-20 at 16 06 27](https://user-images.githubusercontent.com/240569/138089527-524bbc09-0aa5-41cf-88c0-b4d52917d05b.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
