### PR TITLE
Update README.md format to match the format of the other README files 

### DIFF
--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -99,17 +99,50 @@ const MyNotice = () => (
 
 The following props are used to control the behavior of the component.
 
--   `children`: (string) The displayed message of a notice. Also used as the spoken message for assistive technology, unless `spokenMessage` is provided as an alternative message.
--   `spokenMessage`: (string) Used to provide a custom spoken message in place of the `children` default.
--   `status`: (string) can be `warning` (yellow), `success` (green), `error` (red), or `info`. Defaults to `info`.
--   `onRemove`: function called when dismissing the notice
--   `politeness`: (string) A politeness level for the notice's spoken message. Should be provided as one of the valid options for [an `aria-live` attribute value](https://www.w3.org/TR/wai-aria-1.1/#aria-live). If not provided, a sensible default is used based on the notice status. Note that this value should be considered a suggestion; assistive technologies may override it based on internal heuristics.
-    -   A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
-    -   A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
--   `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
--   `onDismiss` : callback function which is executed when the notice is dismissed. It is distinct from onRemove, which _looks_ like a callback but is actually the function to call to remove the notice from the UI.
--   `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. The default appearance of the button is inferred based on whether `url` or `onClick` are provided, rendering the button as a link if appropriate. A `noDefaultClasses` property value of `true` will remove all default styling. You can denote a primary button action for a notice by passing the `variant` property with a value of `primary`.
+###  `children`: 
+The displayed message of a notice. Also used as the spoken message for assistive technology, unless `spokenMessage` is provided as an alternative message.
+- Type: `String`
+- Required: No
+
+### `spokenMessage`
+Used to provide a custom spoken message in place of the `children` default.
+- Type: `String`
+- Required: No
+
+### `status`: `string`
+Can be `warning` (yellow), `success` (green), `error` (red), or `info`.
+- Type: `String`
+- Required: No
+- Default: "info"
+
+### `onRemove`: 
+Function called when dismissing the notice
+- Type: `Function`
+- Required: No
+
+### `politeness`:
+A politeness level for the notice's spoken message. Should be provided as one of the valid options for [an `aria-live` attribute value](https://www.w3.org/TR/wai-aria-1.1/#aria-live). If not provided, a sensible default is used based on the notice status. Note that this value should be considered a suggestion; assistive technologies may override it based on internal heuristics.
+	- A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
+	- A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
+
+- Type: `String`
+- Required: No
+
+### `isDismissible`:
+Whether the notice should be dismissible or not
+- Type: `Boolean`
+- Required: No
+- Default: `true`
+
+### `onDismiss`:
+Callback function which is executed when the notice is dismissed. It is distinct from onRemove, which _looks_ like a callback but is actually the function to call to remove the notice from the UI.
+- Type: `Function`
+- Required: No
+
+### `actions`:
+An array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. The default appearance of the button is inferred based on whether `url` or `onClick` are provided, rendering the button as a link if appropriate. A `noDefaultClasses` property value of `true` will remove all default styling. You can denote a primary button action for a notice by passing the `variant` property with a value of `primary`.
+- Type: `Array`
+- Required: No
 
 ## Related components
-
 -   To create a more prominent message that requires action, use a Modal.


### PR DESCRIPTION
Update format of readme to match the format of other components.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Props format is not consistent with other components format. This changes modifies the files
to make the format similar to other readme files

## How has this been tested?
Viewed in browser and compared to other readme props format
