### PR TITLE
Clear selected block when clicking outside in the template part focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -16,6 +16,7 @@ import {
 	BlockTools,
 	__unstableBlockSettingsMenuFirstItem,
 	__unstableUseTypingObserver as useTypingObserver,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
 
@@ -54,6 +55,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const contentRef = useRef();
 	const mergedRefs = useMergeRefs( [ contentRef, useTypingObserver() ] );
 	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	const isTemplatePart = templateType === 'wp_template_part';
 
@@ -87,6 +89,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					'is-focus-mode': isTemplatePart,
 				} ) }
 				__unstableContentRef={ contentRef }
+				onClick={ ( event ) => {
+					// Clear selected block when clicking on the gray background.
+					if ( event.target === event.currentTarget ) {
+						clearSelectedBlock();
+					}
+				} }
 			>
 				<BackButton />
 

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -23,9 +23,9 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 	}
 
 	return (
-		<div className={ `resizable-editor__drag-handle is-${ direction }` }>
+		<>
 			<button
-				className="resizable-editor__drag-handle-button"
+				className={ `resizable-editor__drag-handle is-${ direction }` }
 				aria-label={ __( 'Drag to resize' ) }
 				aria-describedby={ `resizable-editor__resize-help-${ direction }` }
 				onKeyDown={ handleKeyDown }
@@ -35,6 +35,6 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 			>
 				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
 			</VisuallyHidden>
-		</div>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -41,27 +41,12 @@
 }
 
 .resizable-editor__drag-handle {
+	$height: 100px;
 	position: absolute;
 	top: 0;
 	bottom: 0;
-	width: $grid-unit-60;
-
-	&.is-left {
-		left: -$grid-unit-60;
-	}
-
-	&.is-right {
-		right: -$grid-unit-60;
-	}
-}
-
-.resizable-editor__drag-handle-button {
-	$height: 100px;
-	position: absolute;
-	top: calc(50% - #{math.div($height, 2)});
-	left: 50%;
-	transform: translateX(-$grid-unit-05);
 	padding: 0;
+	margin: auto 0;
 	width: $grid-unit-10;
 	height: $height;
 	appearance: none;
@@ -70,6 +55,14 @@
 	background: $gray-700;
 	border-radius: 4px;
 	border: 0;
+
+	&.is-left {
+		left: #{-$grid-unit-30 - $grid-unit-05};
+	}
+
+	&.is-right {
+		right: #{-$grid-unit-30 - $grid-unit-05};
+	}
 
 	&:hover {
 		background: $gray-600;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix https://github.com/WordPress/gutenberg/issues/35753.

Clear selected block when clicking on the gray background in template part focus mode.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go to Site Editor
3. Go to template part focus mode by editing a template part (block tools -> more -> Edit)
4. Select a random block in the focus mode
5. Clicking on the gray background should deselect the block

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
