### PR TITLE
Fix issue with responsive navigation causing wrapping.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -21,6 +21,13 @@
 	}
 
 	// Normalize list styles.
+	ul {
+		margin-top: 0;
+		margin-bottom: 0;
+		margin-left: 0;
+		padding-left: 0;
+	}
+
 	ul,
 	ul li {
 		list-style: none;
@@ -435,6 +442,9 @@
 			display: flex;
 			flex-direction: column;
 			padding: 0;
+
+			// Unset the inherited gap, as it's instead applied individually to the containers here.
+			gap: 0;
 
 			.wp-block-navigation__submenu-icon {
 				display: none;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -230,7 +230,8 @@
 // Menu items with no background.
 .wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
-.wp-block-navigation__container {
+.wp-block-navigation__container,
+.wp-block-navigation__responsive-container-content {
 	gap: var(--wp--style--block-gap, 2em);
 }
 
@@ -331,7 +332,8 @@
 
 // Vertical layout
 .is-vertical .wp-block-page-list, // Page list.
-.is-vertical .wp-block-navigation__container {
+.is-vertical .wp-block-navigation__container,
+.is-vertical .wp-block-navigation__responsive-container-content {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -406,13 +408,17 @@
 	align-items: flex-start;
 	justify-content: flex-start;
 
+	.wp-block-navigation__responsive-container-content {
+		display: flex;
+	}
+
 	// Overlay menu.
 	// Provide an opinionated default style for menu items inside.
 	// Inherit as much as we can regarding colors, fonts, sizes,
 	// but otherwise provide a baseline.
 	// In a future version, we can explore more customizability.
 	&.is-menu-open {
-		display: flex;
+		display: flex; // Needs to be set to override "none".
 		flex-direction: column;
 
 		// Allow modal to scroll.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -443,9 +443,6 @@
 			flex-direction: column;
 			padding: 0;
 
-			// Unset the inherited gap, as it's instead applied individually to the containers here.
-			gap: 0;
-
 			.wp-block-navigation__submenu-icon {
 				display: none;
 			}


### PR DESCRIPTION
## Description

Fixes #35549. 

When the mobile responsive overlay menu was enabled, subsequent child containers such as social links would wrap on a new line:

<img src="https://user-images.githubusercontent.com/1204802/138230358-05fdeace-3f31-4e70-84ec-8082ebf1c229.png">

This PR fixes that:

<img width="693" alt="Screenshot 2021-10-21 at 09 30 28" src="https://user-images.githubusercontent.com/1204802/138231929-96e61357-a0b4-4340-a89d-3565780401d8.png">

<img width="616" alt="Screenshot 2021-10-21 at 09 30 38" src="https://user-images.githubusercontent.com/1204802/138231932-383a48f3-9e8b-411f-b8fa-5e6963d0f769.png">

## How has this been tested?

Here's some test content:

```
<!-- wp:paragraph -->
<p>Nav without responsiveness:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"New Page","type":"page","id":30646,"url":"http://local-wordpress.local/new-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hgjk","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hjklhj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"hjklhjkl","service":"behance"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Nav with responsiveness:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"overlayMenu":"mobile"} -->
<!-- wp:navigation-link {"label":"New Page","type":"page","id":30646,"url":"http://local-wordpress.local/new-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hgjk","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hjklhj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"hjklhjkl","service":"behance"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical"} -->
<!-- wp:navigation-link {"label":"New Page","type":"page","id":30646,"url":"http://local-wordpress.local/new-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hgjk","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hjklhj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"hjklhjkl","service":"behance"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->

<!-- wp:paragraph -->
<p>Vertical responsive:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"orientation":"vertical","overlayMenu":"mobile"} -->
<!-- wp:navigation-link {"label":"New Page","type":"page","id":30646,"url":"http://local-wordpress.local/new-page/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Home","type":"page","id":28543,"url":"http://local-wordpress.local/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"About","type":"page","id":30315,"url":"http://local-wordpress.local/about/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hgjk","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hjklhj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"hjklhjkl","service":"behance"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->
```

Insert a navigation menu with both a few items, and some social links. Enable responsiveness ("mobile"), and verify the layout doesn't change. Verify also for the vertical version. And check that the overlay still looks good.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
