### PR TITLE
[Block Editor]: Fix displaying only the `none` alignment option

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -16,7 +16,7 @@ const WIDE_CONTROLS = [ 'wide', 'full' ];
 export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	// Always add the `none` option if not exists.
 	if ( ! controls.includes( 'none' ) ) {
-		controls.unshift( 'none' );
+		controls = [ 'none', ...controls ];
 	}
 	const { wideControlsEnabled = false, themeSupportsLayout } = useSelect(
 		( select ) => {
@@ -34,9 +34,15 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	const layoutAlignments = layoutType.getAlignments( layout );
 
 	if ( themeSupportsLayout ) {
-		return layoutAlignments.filter( ( { name: alignmentName } ) =>
-			controls.includes( alignmentName )
+		const alignments = layoutAlignments.filter(
+			( { name: alignmentName } ) => controls.includes( alignmentName )
 		);
+		// While we treat `none` as an alignment, we shouldn't return it if no
+		// other alignments exist.
+		if ( alignments.length === 1 && alignments[ 0 ].name === 'none' ) {
+			return [];
+		}
+		return alignments;
 	}
 
 	// Starting here, it's the fallback for themes not supporting the layout config.
@@ -53,6 +59,15 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 				availableAlignments.includes( control )
 		)
 		.map( ( enabledControl ) => ( { name: enabledControl } ) );
+
+	// While we treat `none` as an alignment, we shouldn't return it if no
+	// other alignments exist.
+	if (
+		enabledControls.length === 1 &&
+		enabledControls[ 0 ].name === 'none'
+	) {
+		return [];
+	}
 
 	return enabledControls;
 }

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -63,7 +63,7 @@ export function getValidAlignments(
 		);
 	} else if ( blockAlign === true ) {
 		// `true` includes all alignments...
-		validAlignments = ALL_ALIGNMENTS;
+		validAlignments = [ ...ALL_ALIGNMENTS ];
 	} else {
 		validAlignments = [];
 	}
@@ -117,14 +117,18 @@ export function addAttribute( settings ) {
 export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name: blockName } = props;
-		// Compute the block allowed alignments without taking into account,
-		// if the theme supports wide alignments or not
-		// and without checking the layout for availble alignments.
-		// BlockAlignmentToolbar takes both of these into account.
+		// Compute the block valid alignments by taking into account,
+		// if the theme supports wide alignments or not and the layout's
+		// availble alignments. We do that for conditionally rendering
+		// Slot.
 		const blockAllowedAlignments = getValidAlignments(
 			getBlockSupport( blockName, 'align' ),
 			hasBlockSupport( blockName, 'alignWide', true )
 		);
+
+		const validAlignments = useAvailableAlignments(
+			blockAllowedAlignments
+		).map( ( { name } ) => name );
 
 		const updateAlignment = ( nextAlign ) => {
 			if ( ! nextAlign ) {
@@ -139,7 +143,7 @@ export const withToolbarControls = createHigherOrderComponent(
 
 		return (
 			<>
-				{ blockAllowedAlignments.length > 0 && (
+				{ !! validAlignments.length && (
 					<BlockControls
 						group="block"
 						__experimentalShareWithChildBlocks
@@ -147,7 +151,7 @@ export const withToolbarControls = createHigherOrderComponent(
 						<BlockAlignmentControl
 							value={ props.attributes.align }
 							onChange={ updateAlignment }
-							controls={ blockAllowedAlignments }
+							controls={ validAlignments }
 						/>
 					</BlockControls>
 				) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35341
Fixes: https://github.com/WordPress/gutenberg/issues/35814

Recently a `none` alignment option was added along with some contextual info(when available) for the widths. There are use cases though in site editor where we would end up with the `AlignmentControl` containing only the `none` option.

Such use cases came from [this PR](https://github.com/WordPress/gutenberg/pull/30079) that removed the alignments from the top level of the site editor because at that point there's no defined layout, as they won't do anything. 

In my PR I also bring back the check in `align` hook not to render the toolbar item if there are no alignments available, which was added in above Riad's PR and then [removed here](https://github.com/WordPress/gutenberg/pull/34593)  ( I also had approved the PR and didn't get the reason for that being there).

## Testing instructions
1. In site editor the top level blocks and other blocks where no alignments are available shouldn't render the control with only the `none` option.
2. In post editor everything should work properly as before, both in block themes or not
3. If there is any available alignment, the `none` option should be there as well.

