### PR TITLE
Navigation overlay menu: Fix submenu spacing.

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,12 +1,3 @@
-// Normalize Link and edit containers, to look mostly the same.
-.wp-block-navigation__submenu-container {
-	border-radius: 0;
-
-	// Make it the same height as the appender to prevent a jump.
-	min-height: $button-size;
-}
-
-
 /**
  * Submenus.
  */
@@ -45,10 +36,6 @@
  */
 
 .wp-block-navigation-item {
-	.wp-block-navigation__submenu-container {
-		display: block;
-	}
-
 	.wp-block-navigation-item__content {
 		cursor: text;
 	}
@@ -64,12 +51,6 @@
 		margin-right: auto;
 		margin-bottom: $grid-unit-20;
 		margin-left: $grid-unit-20;
-	}
-}
-
-.wp-block-navigation .block-editor-block-list__block[data-type="core/navigation-link"] {
-	& > .block-editor-block-list__insertion-point {
-		display: none;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -473,8 +473,12 @@
 			.wp-block-navigation__submenu-container,
 			.wp-block-navigation__container {
 				gap: var(--wp--style--block-gap, 2em);
-				padding-top: var(--wp--style--block-gap, 2em);
-				padding-bottom: var(--wp--style--block-gap, 2em);
+
+				// Apply top padding to nested submenus.
+				.wp-block-navigation__submenu-container,
+				.wp-block-navigation__container {
+					padding-top: var(--wp--style--block-gap, 2em);
+				}
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -472,9 +472,9 @@
 			// Space unfolded items using gap and padding for submenus.
 			.wp-block-navigation__submenu-container,
 			.wp-block-navigation__container {
-				gap: 2rem;
-				padding-top: 2rem;
-				padding-bottom: 2rem;
+				gap: var(--wp--style--block-gap, 2em);
+				padding-top: var(--wp--style--block-gap, 2em);
+				padding-bottom: var(--wp--style--block-gap, 2em);
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.


### PR DESCRIPTION
## Description

In the overlay menu, nested menu items were bunched together in the editor:

<img width="1270" alt="before editor" src="https://user-images.githubusercontent.com/1204802/138239929-3f35f2b4-35fd-4715-a650-6d656fb34d11.png">

But on the frontend things looked right:

<img width="1270" alt="before front" src="https://user-images.githubusercontent.com/1204802/138239965-d5e4a33b-cc2e-40b9-abe5-b73d7598ec0d.png">

This PR fixes that, now they both look the same:

<img width="722" alt="Screenshot 2021-10-21 at 10 18 32" src="https://user-images.githubusercontent.com/1204802/138240021-d1da3015-daa7-46ff-b6f5-b00caf057905.png">

## How has this been tested?

Insert a menu with nested submenu items. Test the appearance in the overlay menu, editor and front should look the same.

Also test the navigation screen, as this PR removes some CSS that appeared to be dead. It looks right to me.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
