### PR TITLE
Navigation: Fix padding for social links on mobile

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -465,7 +465,7 @@
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.
-			a:not(.wp-block-social-link-anchor) {
+			.wp-block-navigation-item__content {
 				padding: 0;
 			}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -465,7 +465,7 @@
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.
-			a {
+			a:not(.wp-block-social-link-anchor) {
 				padding: 0;
 			}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Resetting padding to 0 for links on the responsive navigation menu was affecting social links as well. This PR avoids applying that rule to social links.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Using emptytheme with the following markup:

```
<!-- wp:paragraph -->
<p>Nav with responsiveness:</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"overlayMenu":"mobile"} -->
<!-- wp:navigation-link {"label":"Google","type":"","id":"","url":"http://Google","kind":"custom","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Text","type":"page","id":2202,"url":"http://free.local/test-6/","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:home-link {"label":"Home"} /-->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"hgjk","service":"wordpress"} /-->

<!-- wp:social-link {"url":"hjklhj","service":"bandcamp"} /-->

<!-- wp:social-link {"url":"hjklhjkl","service":"behance"} /--></ul>
<!-- /wp:social-links -->
<!-- /wp:navigation -->
```

## Screenshots <!-- if applicable -->

Before | After
--- | ---
<img width="406" alt="Screenshot 2021-10-21 at 10 56 38" src="https://user-images.githubusercontent.com/3593343/138245639-fdfab6b6-58ad-4242-875d-5406f1d43ffb.png"> | <img width="415" alt="Screenshot 2021-10-21 at 10 55 14" src="https://user-images.githubusercontent.com/3593343/138245642-e8b0ad64-50a3-4b45-91b4-c85deb198f0a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
