### PR TITLE
Strip HTML from Post Title when pasting multiline title containing HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18110,6 +18110,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
+				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
+		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -177,7 +177,10 @@ function PostTitle( _, forwardedRef ) {
 				...create( { html: title } ),
 				...selection,
 			};
-			const newValue = insert( value, create( { html: content } ) );
+			const newValue = insert(
+				value,
+				create( { html: stripHTML( content ) } )
+			);
 			onUpdate( toHTMLString( { value: newValue } ) );
 			setSelection( {
 				start: newValue.start,

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -26,6 +26,7 @@ import {
 	insert,
 } from '@wordpress/rich-text';
 import { useMergeRefs } from '@wordpress/compose';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -166,7 +167,7 @@ function PostTitle( _, forwardedRef ) {
 				( firstBlock.name === 'core/heading' ||
 					firstBlock.name === 'core/paragraph' )
 			) {
-				onUpdate( firstBlock.attributes.content );
+				onUpdate( stripHTML( firstBlock.attributes.content ) );
 				onInsertBlockAfter( content.slice( 1 ) );
 			} else {
 				onInsertBlockAfter( content );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In [this forum post](https://wordpress.org/support/topic/title-bug-in-latest-gutenberg-plug), the reporter explains that pasting a _multi_-line string containing HTML into the Post Title field causes the following:

1. The Post Title to contain HTML tags (even though in the editor it appears to have no formatting).
2. The resulting auto-generated post slug to contain HTML tags.

This is a particular problem because in the editor it appears to the user that the Post Title contains no HTML, but when you publish you get a surprise when you see the HTML formatting applied.

This PR addresses this by manually stripping HTML from the string before updating the editor.

⚠️  because this uses `stripHTML` method we will need to wait on https://github.com/WordPress/gutenberg/pull/35539 otherwise it does mean that all leading spaces will be stripped from the post title.

## How has this been tested?

### On Trunk - replicate the bug

1. Go to https://wordpress.org/support/topic/title-bug-in-latest-gutenberg-plug/#post-13789231. 
2. Copy (_both_ of) the _two_ lines in bold starting `Puerto Rican Power...`.
3. New Post.
4. Paste content into Post Title field.
5. See Post Title rendered into editor appears to have no HTML in it (ie: it's not bold).
6. Publish post.
7. See the resulting Post slug contains `<strong>` tags.
8. View post on front end.
9. See rendered **Post Title** result contains HTML tags/formatting (ie: it appears bold).

### On this PR - verify the fix

Go through the steps above again but this time verify that

* The slug does not contain HTML tags.
* The frontend post title does not contain HTML or render with formatting.

## Screenshots <!-- if applicable -->

### Before


https://user-images.githubusercontent.com/444434/138246622-aaf8110d-5a28-4630-bf26-0d9e7c2528ef.mp4

### After


https://user-images.githubusercontent.com/444434/138246641-b469f277-0456-477b-a5cf-e0be67a0b58b.mp4



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
