### PR TITLE
Fix controlled inner blocks parent block attributes updates

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -240,14 +240,20 @@ function buildBlockTree( state, blocks ) {
 	return result;
 }
 
-function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
+function updateParentInnerBlocksInTree(
+	state,
+	tree,
+	updatedClientIds,
+	updateChildrenOfUpdatedClientIds = false
+) {
 	const uncontrolledParents = new Set( [] );
 	const controlledParents = new Set();
 	for ( const clientId of updatedClientIds ) {
-		let current = clientId;
+		let current = updateChildrenOfUpdatedClientIds
+			? clientId
+			: state.parents[ clientId ];
 		do {
-			const parent = state.parents[ current ];
-			if ( state.controlledInnerBlocks[ parent ] ) {
+			if ( state.controlledInnerBlocks[ current ] ) {
 				// Should stop on controlled blocks.
 				// If we reach a controlled parent, break out of the loop.
 				controlledParents.add( current );
@@ -313,7 +319,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 					...newState.tree,
 					...subTree,
 				},
-				action.rootClientId ? [ action.rootClientId ] : [ '' ]
+				action.rootClientId ? [ action.rootClientId ] : [ '' ],
+				true
 			);
 			break;
 		}
@@ -327,7 +334,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 						attributes: newState.attributes[ action.clientId ],
 					},
 				},
-				[ action.clientId ]
+				[ action.clientId ],
+				false
 			);
 			break;
 		case 'UPDATE_BLOCK_ATTRIBUTES': {
@@ -347,7 +355,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 					...newState.tree,
 					...newSubTree,
 				},
-				action.clientIds
+				action.clientIds,
+				false
 			);
 			break;
 		}
@@ -366,7 +375,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 					),
 					...subTree,
 				},
-				action.blocks.map( ( b ) => b.clientId )
+				action.blocks.map( ( b ) => b.clientId ),
+				false
 			);
 
 			// If there are no replaced blocks, it means we're removing blocks so we need to update their parent.
@@ -383,7 +393,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 			newState.tree = updateParentInnerBlocksInTree(
 				newState,
 				newState.tree,
-				parentsOfRemovedBlocks
+				parentsOfRemovedBlocks,
+				true
 			);
 			break;
 		}
@@ -408,7 +419,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 						)
 					)
 				),
-				parentsOfRemovedBlocks
+				parentsOfRemovedBlocks,
+				true
 			);
 			break;
 		case 'MOVE_BLOCKS_TO_POSITION': {
@@ -425,7 +437,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 			newState.tree = updateParentInnerBlocksInTree(
 				newState,
 				newState.tree,
-				updatedBlockUids
+				updatedBlockUids,
+				true
 			);
 			break;
 		}
@@ -437,7 +450,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 			newState.tree = updateParentInnerBlocksInTree(
 				newState,
 				newState.tree,
-				updatedBlockUids
+				updatedBlockUids,
+				true
 			);
 			break;
 		}
@@ -464,7 +478,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 						return result;
 					}, {} ),
 				},
-				updatedBlockUids
+				updatedBlockUids,
+				false
 			);
 		}
 	}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -246,15 +246,18 @@ function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
 	for ( const clientId of updatedClientIds ) {
 		let current = clientId;
 		do {
-			if ( state.controlledInnerBlocks[ current ] ) {
-				controlledParents.add( current );
+			clientIds.add( current );
+
+			const parent = state.parents[ current ];
+			if ( state.controlledInnerBlocks[ parent ] ) {
+				// Should stop on controlled blocks.
 				// If we reach a controlled parent, break out of the loop.
+				controlledParents.add( current );
 				break;
 			} else {
-				clientIds.add( current );
+				// else continue traversing up through parents.
+				current = state.parents[ current ];
 			}
-			// Should stop on controlled blocks.
-			current = state.parents[ current ];
 		} while ( current !== undefined );
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -330,6 +330,7 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 				{
 					...newState.tree,
 					[ action.clientId ]: {
+						...newState.tree[ action.clientId ],
 						...newState.byClientId[ action.clientId ],
 						attributes: newState.attributes[ action.clientId ],
 					},

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -241,13 +241,11 @@ function buildBlockTree( state, blocks ) {
 }
 
 function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
-	const clientIds = new Set( [] );
+	const uncontrolledParents = new Set( [] );
 	const controlledParents = new Set();
 	for ( const clientId of updatedClientIds ) {
 		let current = clientId;
 		do {
-			clientIds.add( current );
-
 			const parent = state.parents[ current ];
 			if ( state.controlledInnerBlocks[ parent ] ) {
 				// Should stop on controlled blocks.
@@ -256,6 +254,7 @@ function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
 				break;
 			} else {
 				// else continue traversing up through parents.
+				uncontrolledParents.add( current );
 				current = state.parents[ current ];
 			}
 		} while ( current !== undefined );
@@ -263,12 +262,12 @@ function updateParentInnerBlocksInTree( state, tree, updatedClientIds ) {
 
 	// To make sure the order of assignments doesn't matter,
 	// we first create empty objects and mutates the inner blocks later.
-	for ( const clientId of clientIds ) {
+	for ( const clientId of uncontrolledParents ) {
 		tree[ clientId ] = {
 			...tree[ clientId ],
 		};
 	}
-	for ( const clientId of clientIds ) {
+	for ( const clientId of uncontrolledParents ) {
 		tree[ clientId ].innerBlocks = ( state.order[ clientId ] || [] ).map(
 			( subClientId ) => tree[ subClientId ]
 		);


### PR DESCRIPTION
## Description
Fixes #35664

I bisected and found that the problem was introduced in #34241. I scanned the code and I think I spotted the issue:
```jsx
	for ( const clientId of updatedClientIds ) {
		let current = clientId;
		do {
			if ( state.controlledInnerBlocks[ current ] ) {
				controlledParents.add( current );
				// If we reach a controlled parent, break out of the loop.
				break;
			} else {
				clientIds.add( current );
			}
			// Should stop on controlled blocks.
			current = state.parents[ current ];
		} while ( current !== undefined );
	}
```
	
It looks like the intent here was to traverse up and stop when reaching a block that has controlled inner blocks.

It has an unwanted side effect that if it's only the parent block (and not the controlled inner blocks) that changed the parent is also skipped from being added to the clientIds list.

Instead I think it needs to check the parent on each loop, and only traverse up if the parent isn't a controlled inne rblock

## How has this been tested?
1. Open the site editor
2. Select the Header from List View
3. Change colors from the sidebar
4. Click save. Observe that the sidebar only shows changes to the Header template part
5. Save those changes
6. Reload, observe changes are now retained.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
