### PR TITLE
Add a method to disable auto-accepting dialogs

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Added `disablePageDialogAccept` - Disable auto-accepting dialogs enabled by `enablePageDialogAccept` [#35828](https://github.com/WordPress/gutenberg/pull/35828).
+
 ## 5.4.0 (2021-07-21)
 
 ### New Features

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -237,6 +237,10 @@ _Parameters_
 
 Removes the focus loss listener that `enableFocusLossObservation()` adds.
 
+### disablePageDialogAccept
+
+Disable auto-accepting any dialogs.
+
 ### disablePrePublishChecks
 
 Disables Pre-publish checks.
@@ -263,8 +267,7 @@ loss of focus.
 
 ### enablePageDialogAccept
 
-Enables even listener which accepts a page dialog which
-may appear when navigating away from Gutenberg.
+Enables event listener which auto-accepts all dialogs on th page.
 
 ### enablePrePublishChecks
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -267,7 +267,7 @@ loss of focus.
 
 ### enablePageDialogAccept
 
-Enables event listener which auto-accepts all dialogs on th page.
+Enables event listener which auto-accepts all dialogs on the page.
 
 ### enablePrePublishChecks
 

--- a/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
+++ b/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
@@ -9,9 +9,14 @@ async function acceptPageDialog( dialog ) {
 	await dialog.accept();
 }
 /**
- * Enables even listener which accepts a page dialog which
- * may appear when navigating away from Gutenberg.
+ * Enables event listener which auto-accepts all dialogs on th page.
  */
 export function enablePageDialogAccept() {
 	page.on( 'dialog', acceptPageDialog );
+}
+/**
+ * Disable auto-accepting any dialogs.
+ */
+export function disablePageDialogAccept() {
+	page.off( 'dialog', acceptPageDialog );
 }

--- a/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
+++ b/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
@@ -9,7 +9,7 @@ async function acceptPageDialog( dialog ) {
 	await dialog.accept();
 }
 /**
- * Enables event listener which auto-accepts all dialogs on th page.
+ * Enables event listener which auto-accepts all dialogs on the page.
  */
 export function enablePageDialogAccept() {
 	page.on( 'dialog', acceptPageDialog );

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -22,7 +22,10 @@ export { deleteTheme } from './delete-theme';
 export { deleteUser } from './delete-user';
 export { disablePrePublishChecks } from './disable-pre-publish-checks';
 export { dragAndResize } from './drag-and-resize';
-export { enablePageDialogAccept } from './enable-page-dialog-accept';
+export {
+	enablePageDialogAccept,
+	disablePageDialogAccept,
+} from './auto-accept-page-dialogs';
 export { enablePrePublishChecks } from './enable-pre-publish-checks';
 export { ensureSidebarOpened } from './ensure-sidebar-opened';
 export { findSidebarPanelToggleButtonWithTitle } from './find-sidebar-panel-toggle-button-with-title';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

`enablePageDialogAccept` is enabled in `setup-test-framework` which auto-accepts **all** dialogs on the page. I think this is overly aggressive and there's currently no way to disable it either.

This had been brought up in https://github.com/WordPress/wordpress-develop/pull/1746#discussion_r731605776, which at first was very confusing why the dialog kept closing automatically. I believe this method was originally introduced to automatically accept only the "Are you sure you want to leave before saving" dialogs, maybe we should target that individually instead of aggressively closing all dialogs?

Either way, I think it makes sense to still provide a method to disable this functionality. Hence, this PR adds a new API `disablePageDialogAccept` which will do exactly that.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create a new test somewhere with the following content and run it.

```js
it( 'test confirm', async () => {
	disablePageDialogAccept();

	const dialog = await new Promise( ( resolve ) => {
		page.once( 'dialog', resolve );
                 // alert() will pause the execution of JS,
                 // so the promise will never resolve until we call dialog.accept().
		page.evaluate( () => alert( 'ALERT' ) );
	} );

	expect( dialog.message() ).toBe( 'ALERT' );

	await dialog.accept();
} );
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
