### PR TITLE
Prevent PHP notice from block-supports elements

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -15,7 +15,7 @@
 function gutenberg_render_elements_support( $block_content, $block ) {
 
 	if ( ! $block_content ) {
-		return;
+		return $block_content;
 	}
 
 	$link_color = null;

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -13,6 +13,11 @@
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content, $block ) {
+
+	if ( ! $block_content ) {
+		return;
+	}
+
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When using the Post Tags block and setting a link color, the front end gives PHP errors, when a post is untagged:
`Notice: Undefined offset: 0 in C:\xampp\apps\wordpress\htdocs\wp-content\plugins\gutenberg\lib\block-supports\elements.php on line 47`
This PR adds an early return if there is no block to add the style to.
Closes https://github.com/WordPress/gutenberg/issues/35769

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a post tag block to a post without tags, and add a link color.
2. Add a few other blocks with link color options.
3. View the front and confirm that there is no PHP notice, and that the link colors display correctly.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
