### PR TITLE
Refactor `gutenberg_initialize_editor` function and remove `block_editor_preload_data` filter

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -76,17 +76,6 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 		array()
 	);
 
-	/**
-	 * Filters the array of data that has been preloaded.
-	 *
-	 * The dynamic portion of the hook name, `$editor_name`, refers to the type of block editor.
-	 *
-	 * @param array $preload_data Array containing the preloaded data.
-	 * @param string $editor_name Current editor name.
-	 * @param array Array containing the filtered preloaded data.
-	 */
-	$preload_data = apply_filters( 'block_editor_preload_data', $preload_data, $editor_name );
-
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -91,7 +91,6 @@ function gutenberg_navigation_init( $hook ) {
 		'/__experimental/menu-locations',
 		array( '/wp/v2/pages', 'OPTIONS' ),
 		array( '/wp/v2/posts', 'OPTIONS' ),
-		gutenberg_navigation_get_menus_endpoint(),
 		gutenberg_navigation_get_types_endpoint(),
 	);
 
@@ -120,6 +119,8 @@ function gutenberg_navigation_init( $hook ) {
 		)
 	);
 
+	gutenberg_navigation_editor_preload_menus();
+
 	wp_enqueue_script( 'wp-edit-navigation' );
 	wp_enqueue_style( 'wp-edit-navigation' );
 	wp_enqueue_script( 'wp-format-library' );
@@ -145,26 +146,22 @@ function gutenberg_navigation_editor_load_block_editor_scripts_and_styles( $is_b
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_navigation_editor_load_block_editor_scripts_and_styles' );
 
 /**
- * This function removes menu-related data from the "common" preloading middleware and calls
- * createMenuPreloadingMiddleware middleware because we need to use custom preloading logic for menus.
+ * This function calls createMenuPreloadingMiddleware middleware because
+ * we need to use custom preloading logic for menus.
  *
- * @param Array  $preload_data Array containing the preloaded data.
- * @param string $context Current editor name.
- * @return array Filtered preload data.
+ * @return void
  */
-function gutenberg_navigation_editor_preload_menus( $preload_data, $context ) {
-	if ( 'navigation_editor' !== $context ) {
-		return $preload_data;
-	}
-
-	$menus_data_path = gutenberg_navigation_get_menus_endpoint();
-	$menus_data      = array();
-	if ( ! empty( $preload_data[ $menus_data_path ] ) ) {
-		$menus_data = array( $menus_data_path => $preload_data[ $menus_data_path ] );
-	}
+function gutenberg_navigation_editor_preload_menus() {
+	$menus_data = array_reduce(
+		array(
+			gutenberg_navigation_get_menus_endpoint(),
+		),
+		'rest_preload_api_request',
+		array()
+	);
 
 	if ( ! $menus_data ) {
-		return $preload_data;
+		return;
 	}
 
 	wp_add_inline_script(
@@ -175,9 +172,4 @@ function gutenberg_navigation_editor_preload_menus( $preload_data, $context ) {
 		),
 		'after'
 	);
-
-	unset( $preload_data[ $menus_data_path ] );
-	return $preload_data;
 }
-
-add_filter( 'block_editor_preload_data', 'gutenberg_navigation_editor_preload_menus', 10, 2 );

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -94,9 +94,6 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 	}
 }
 
-
-
-
 /**
  * This is a utility test class for creating mocks of the callback functions
  */

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -29,8 +29,6 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->callback = $this->createMock( WP_Navigation_Page_Test_Callback::class );
-		add_filter( 'navigation_editor_preload_paths', array( $this->callback, 'preload_paths_callback' ) );
-		add_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
 	}
 
 	public function tearDown() {
@@ -41,6 +39,9 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 	}
 
 	public function test_gutenberg_navigation_init_function_generates_correct_preload_paths() {
+		add_filter( 'navigation_editor_preload_paths', array( $this->callback, 'preload_paths_callback' ) );
+		add_filter( 'wp_get_nav_menus', array( $this->callback, 'wp_nav_menus_callback' ) );
+
 		$menu_id                = mt_rand( 1, 1000 );
 		$expected_preload_paths = array(
 			'/__experimental/menu-locations',

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -14,13 +14,13 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 	/** @var WP_Scripts */
 	private static $wp_scripts;
 
-	public static function setUpBeforeClass(): void {
+	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		global $wp_scripts;
 		static::$wp_scripts = clone $wp_scripts;
 	}
 
-	public static function tearDownAfterClass(): void {
+	public static function tearDownAfterClass() {
 		parent::tearDownAfterClass();
 		global $wp_scripts;
 		$wp_scripts = static::$wp_scripts;
@@ -80,9 +80,10 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		$scripts->remove( $handle );
 		$scripts->add( $handle, 'https://test.test/test.js' );
 		$response = new WP_REST_Response( array( 'someData' ) );
-		$this->callback->expects( $this->once() )
-					   ->method( 'preload_menus_rest_pre_dispatch_callback' )
-						->willReturn( new $response );
+		$this->callback
+			->expects( $this->once() )
+			->method( 'preload_menus_rest_pre_dispatch_callback' )
+			->willReturn( new $response );
 
 		gutenberg_navigation_editor_preload_menus();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR is a follow-up to #24642.
Fixes https://github.com/WordPress/gutenberg/issues/35803
We've added `block_editor_preload_data` filter to the `gutenberg_initialize_editor` function in the scope of https://github.com/WordPress/gutenberg/pull/35402.
This filter is only needed to provide data for the `createMenuPreloadingMiddleware`.
It's not the best solution because we don't want to add filters whose only task is to solve a specific (single) issue.
We can do better.
We need to refactor `gutenberg_initialize_editor` to not use that filter.


## How has this been tested?
1. Open the navigation page (`wp-admin/admin.php?page=gutenberg-navigation`).
2. Make sure that the first menu from the list of menus is selected as the current menu.
3. Make sure there is only 1 fetch/XHR request (see the screenshot below), meaning that the preloading is working.

## Screenshots <!-- if applicable -->
![Screenshot 2021-10-06 at 17 29 11](https://user-images.githubusercontent.com/43744263/136235260-b53acf9c-a0cd-4070-8881-ddeee5c17945.png)
## Screenshots <!-- if applicable -->

## Types of changes
New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
