### PR TITLE
Resizable Iframe: cap content height to 1:1 aspect ratio

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -34,6 +34,14 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 
 	const scale = containerWidth / viewportWidth;
 
+	// Use iframe content height as the iframe height, but cap it to the arbitrary but reasonable aspect ratio of 1:1
+	// see explanation here: https://github.com/WordPress/gutenberg/issues/34729#issuecomment-919949857
+	const cappedContentHeight = Math.min( contentHeight, viewportWidth );
+	const cappedContentHeightScaled = Math.min(
+		contentHeight * scale,
+		containerWidth // container width is already scaled
+	);
+
 	return (
 		<div className="block-editor-block-preview__container">
 			{ containerResizeListener }
@@ -41,7 +49,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				className="block-editor-block-preview__content"
 				style={ {
 					transform: `scale(${ scale })`,
-					height: contentHeight * scale,
+					height: cappedContentHeightScaled,
 				} }
 			>
 				<Iframe
@@ -60,7 +68,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 					style={ {
 						position: 'absolute',
 						width: viewportWidth,
-						height: contentHeight,
+						height: cappedContentHeight,
 						pointerEvents: 'none',
 					} }
 				>


### PR DESCRIPTION
## Description
Use iframe content height as the iframe height, but cap it to the arbitrary but reasonable aspect ratio of 1:1.

This prevents `vh` units from making the iframe grow forever.

## How has this been tested?
Locally on `trunk`. Note that if you can't reproduce this issue locally, try to find the div with the classes `is-light has-parallax block-editor-block-list__block wp-block-cover`, select it in DevTools, and untick the `margin-top-: 0` CSS prop, this will trigger the never-ending loop of vertical growth.

Then apply this diff, and untick it, it will start the growth cycle, but will stop it at AR 1:1.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17054134/138316934-ef140060-37b8-4bbd-ae9f-c74336fdf765.png)

Notice how Large header with text and a button has an AR of 1:1. It's not ideal, but I think it's better than hard-coding the height or only listening to the first N firings of resize observer.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

Fixes: https://github.com/WordPress/gutenberg/issues/34729
