### PR TITLE
Add block.json schema to generated file

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## Unreleased
 
 ### New Features
+
 -   Add passing local directories to --template. ([#35645](https://github.com/WordPress/gutenberg/pull/35645))
 -   Add `slugPascalCase` to the list of variables that can be used in templates ([#35462](https://github.com/WordPress/gutenberg/pull/35462))
+
+-   Add $schema definition to generated `block.json` file.
 
 ## 2.5.0 (2021-07-21)
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -177,6 +177,7 @@ module.exports = {
 
 The following configurable variables are used with the template files. Template authors can change default values to use when users don't provide their data:
 
+-   `$schema` (default: `https://json.schemastore.org/block.json`)
 -   `apiVersion` (default: `2`) - see https://make.wordpress.org/core/2020/11/18/block-api-version-2/.
 -   `slug` (no default)
 -   `namespace` (default: `'create-block'`)

--- a/packages/create-block/lib/init-block-json.js
+++ b/packages/create-block/lib/init-block-json.js
@@ -11,6 +11,7 @@ const { writeFile } = require( 'fs' ).promises;
 const { info } = require( './log' );
 
 module.exports = async ( {
+	$schema,
 	apiVersion,
 	slug,
 	namespace,
@@ -34,6 +35,7 @@ module.exports = async ( {
 		JSON.stringify(
 			omitBy(
 				{
+					$schema,
 					apiVersion,
 					name: namespace + '/' + slug,
 					version,

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -19,6 +19,7 @@ const { code, info, success } = require( './log' );
 module.exports = async (
 	blockTemplate,
 	{
+		$schema,
 		apiVersion,
 		namespace,
 		slug,
@@ -48,6 +49,7 @@ module.exports = async (
 
 	const { outputTemplates, outputAssets } = blockTemplate;
 	const view = {
+		$schema,
 		apiVersion,
 		namespace,
 		namespaceSnakeCase: snakeCase( namespace ),

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -185,6 +185,7 @@ const getBlockTemplate = async ( templateName ) => {
 
 const getDefaultValues = ( blockTemplate ) => {
 	return {
+		$schema: 'https://json.schemastore.org/block.json',
 		apiVersion: 2,
 		namespace: 'create-block',
 		category: 'widgets',


### PR DESCRIPTION
## Description

This adds the schema defintinon to the top of the generated block.json
file:

	"$schema": "https://json.schemastore.org/block.json",

This makes it easier to work with the `block.json` file in devleopment,
with supported editors it offers tooltips, autocomplete, and schema
validation.


## How has this been tested?

To test:

1. Switch to this branch and build.
2. Run the create block script using: ./node_modules/.bin/wp-create-block
3. Confirm the generate block.json file contains the $schema

## Types of changes

Updates the create-block script to add the $schema definition.
No functional change, an improvement for development.

