### PR TITLE
Add regression test for the conversion of text-color spans to mark tags

### DIFF
--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -579,19 +579,17 @@ describe( 'RichText', () => {
 		await switchEditorModeTo( 'Visual' );
 
 		// Confirm editor markup has been properly converted
-		const [
-			editorPresetColorText,
-			editorCustomColorText,
-		] = await page.evaluate( () =>
-			Array.from(
-				document.querySelectorAll(
-					'p[aria-label="Paragraph block"] > *'
-				)
-			).map( ( el ) => ( {
-				tag: el.localName,
-				style: el.getAttribute( 'style' ),
-			} ) )
-		);
+		const [ editorPresetColorText, editorCustomColorText ] =
+			await page.evaluate( () =>
+				Array.from(
+					document.querySelectorAll(
+						'p[aria-label="Paragraph block"] > *'
+					)
+				).map( ( el ) => ( {
+					tag: el.localName,
+					style: el.getAttribute( 'style' ),
+				} ) )
+			);
 
 		expect( editorPresetColorText.tag ).toEqual( 'mark' );
 		expect( editorPresetColorText.style ).toEqual(
@@ -609,23 +607,21 @@ describe( 'RichText', () => {
 		);
 		await Promise.all( [
 			page.waitForNavigation(),
-			viewPostLinks[ 0 ].click()
+			viewPostLinks[ 0 ].click(),
 		] );
 
 		await page.waitForSelector( '.entry-content' );
 
 		// Confirm front end markup has been properly converted
-		const [
-			frontendPresetColorText,
-			frontendCustomColorText,
-		] = await page.evaluate( () =>
-			Array.from(
-				document.querySelectorAll( '.entry-content p  > *' )
-			).map( ( el ) => ( {
-				tag: el.localName,
-				style: el.getAttribute( 'style' ),
-			} ) )
-		);
+		const [ frontendPresetColorText, frontendCustomColorText ] =
+			await page.evaluate( () =>
+				Array.from(
+					document.querySelectorAll( '.entry-content p  > *' )
+				).map( ( el ) => ( {
+					tag: el.localName,
+					style: el.getAttribute( 'style' ),
+				} ) )
+			);
 
 		expect( frontendPresetColorText.tag ).toEqual( 'mark' );
 		expect( frontendPresetColorText.style ).toEqual(

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -607,8 +607,10 @@ describe( 'RichText', () => {
 		const viewPostLinks = await page.$x(
 			"//a[contains(text(), 'View Post')]"
 		);
-		await viewPostLinks[ 0 ].click();
-		await page.waitForNavigation();
+		await Promise.all( [
+			page.waitForNavigation(),
+			viewPostLinks[ 0 ].click()
+		] );
 
 		await page.waitForSelector( '.entry-content' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: #35516

Checks for regressions in the conversion of `<span>` tags to `<mark>`s that was introduced back in v11.7.0. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the `<mark>` tags aren't converted properly it can result in unexpected changes in the content markup and/or appearance. Specifically when this was implemented, there were numerous issues leading to the browser's default `mark` styling being displayed.

## How?
This is actually an old PR I'd set aside at the time and forgotten about, but basically the test will create a post with pre-v11.7.0 formatted text, and confirms that both the editor and front end render `<mark>` tags that will override browser default highlight colors.

## Testing Instructions
Ensure tests pass: `npm run test:e2e -- packages/e2e-tests/specs/editor/various/rich-text.test.js`
