### PR TITLE
Core Data uses hardcoded baseURL prefix for taxonomies and post types

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -173,12 +173,10 @@ function* loadPostTypeEntities() {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
 		);
-		const namespace = postType?.rest_namespace
-			? postType.rest_namespace
-			: 'wp/v2';
+		const namespace = postType?.rest_namespace ?? 'wp/v2';
 		return {
 			kind: 'postType',
-			baseURL: '/' + namespace + '/' + postType.rest_base,
+			baseURL: `/${ namespace }/${ postType.rest_base }`,
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.labels.singular_name,
@@ -207,12 +205,10 @@ function* loadTaxonomyEntities() {
 		path: '/wp/v2/taxonomies?context=edit',
 	} );
 	return map( taxonomies, ( taxonomy, name ) => {
-		const namespace = taxonomy?.rest_namespace
-			? taxonomy.rest_namespace
-			: 'wp/v2';
+		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
 		return {
 			kind: 'taxonomy',
-			baseURL: '/' + namespace + '/' + taxonomy.rest_base,
+			baseURL: `/${ namespace }/${ taxonomy.rest_base }`,
 			baseURLParams: { context: 'edit' },
 			name,
 			label: taxonomy.labels.singular_name,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -205,7 +205,7 @@ function* loadTaxonomyEntities() {
 		path: '/wp/v2/taxonomies?context=edit',
 	} );
 	return map( taxonomies, ( taxonomy, name ) => {
-		const namespace = taxonomy.rest_namespace ? taxonomy.rest_namespace : 'wp/v2';
+		const namespace = taxonomy?.rest_namespace ? taxonomy.rest_namespace : 'wp/v2';
 		return {
 			kind: 'taxonomy',
 			baseURL: '/' + namespace + '/' + taxonomy.rest_base,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -173,9 +173,10 @@ function* loadPostTypeEntities() {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
 		);
+		const namespace = postType?.rest_namespace ? postType.rest_namespace : 'wp/v2';
 		return {
 			kind: 'postType',
-			baseURL: '/wp/v2/' + postType.rest_base,
+			baseURL: '/' + namespace + '/' + postType.rest_base,
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.labels.singular_name,
@@ -204,9 +205,10 @@ function* loadTaxonomyEntities() {
 		path: '/wp/v2/taxonomies?context=edit',
 	} );
 	return map( taxonomies, ( taxonomy, name ) => {
+		const namespace = taxonomy.rest_namespace ? taxonomy.rest_namespace : 'wp/v2';
 		return {
 			kind: 'taxonomy',
-			baseURL: '/wp/v2/' + taxonomy.rest_base,
+			baseURL: '/' + namespace + '/' + taxonomy.rest_base,
 			baseURLParams: { context: 'edit' },
 			name,
 			label: taxonomy.labels.singular_name,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -173,7 +173,9 @@ function* loadPostTypeEntities() {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
 		);
-		const namespace = postType?.rest_namespace ? postType.rest_namespace : 'wp/v2';
+		const namespace = postType?.rest_namespace
+			? postType.rest_namespace
+			: 'wp/v2';
 		return {
 			kind: 'postType',
 			baseURL: '/' + namespace + '/' + postType.rest_base,
@@ -205,7 +207,9 @@ function* loadTaxonomyEntities() {
 		path: '/wp/v2/taxonomies?context=edit',
 	} );
 	return map( taxonomies, ( taxonomy, name ) => {
-		const namespace = taxonomy.rest_namespace ? taxonomy.rest_namespace : 'wp/v2';
+		const namespace = taxonomy.rest_namespace
+			? taxonomy.rest_namespace
+			: 'wp/v2';
 		return {
 			kind: 'taxonomy',
 			baseURL: '/' + namespace + '/' + taxonomy.rest_base,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Upstream change  [#53656](https://core.trac.wordpress.org/ticket/53656) [#54267](https://core.trac.wordpress.org/ticket/54267)

In the above upstream changes, the namespace is returned as part of the REST API response, this field is present in the response, otherwise default to wp/v2.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->


Fixes #33420 