### PR TITLE
Fix `<Text>` component text color value to correct color value for Link UI preview description text

### DIFF
--- a/packages/components/src/heading/test/__snapshots__/index.js.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0 {
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   color: #050505;

--- a/packages/components/src/text/styles.js
+++ b/packages/components/src/text/styles.js
@@ -9,7 +9,7 @@ import { css } from '@emotion/react';
 import { COLORS, CONFIG } from '../utils';
 
 export const Text = css`
-	color: ${ COLORS.black };
+	color: ${ COLORS.darkGray.primary };
 	line-height: ${ CONFIG.fontLineHeightBase };
 	margin: 0;
 `;

--- a/packages/components/src/text/test/__snapshots__/index.js.snap
+++ b/packages/components/src/text/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Text should render highlighted words with highlightCaseSensitive 1`] = `
 .emotion-0 {
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
@@ -30,7 +30,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 
 exports[`Text snapshot tests should render correctly 1`] = `
 .emotion-0 {
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);

--- a/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`props should render correctly 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
@@ -56,7 +56,7 @@ exports[`props should render no truncate 1`] = `
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
   padding-bottom: calc((36px - calc(13px * 1.2)) / 2);
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
@@ -102,7 +102,7 @@ exports[`props should render size 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);

--- a/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`props should render alignLabel 1`] = `
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
   padding-bottom: calc((36px - calc(13px * 1.2)) / 2);
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);
@@ -72,7 +72,7 @@ exports[`props should render vertically 1`] = `
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
   padding-bottom: calc((36px - calc(13px * 1.2)) / 2);
   padding-top: calc((36px - calc(13px * 1.2)) / 2);
-  color: #000;
+  color: #1e1e1e;
   line-height: 1.2;
   margin: 0;
   font-size: calc((13 / 13) * 13px);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/35833#issuecomment-948592797 @jasmussen noticed we are using the wrong text color in the description text of the Link UI preview.

This was because the `<Text>` component uses black and not darkGray from the available color values.

This PR corrects the underlying Text component from `#000` to `$gray-900`. This has the knock on effect of fixing the LinkControl preview.

## How has this been tested?

1. Create link.
2. Click on link to show preview.
3. Inspect link description text.
4. Check color is `$gray-900` (`#1e1e1e`).
5. Check that color is applied via cascade inheriting from the styles on the `<Text>` component (as opposed to any styles applied directly to `<LinkControl>`).

## Screenshots <!-- if applicable -->
<img width="1051" alt="Screen Shot 2021-10-25 at 10 08 08" src="https://user-images.githubusercontent.com/444434/138667884-b0ba83a8-09dd-4d20-aebd-41edd17b79d1.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
