### PR TITLE
Improve focus styles for Link UI preview title

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -171,7 +171,6 @@ $preview-image-height: 140px;
 		flex-direction: row;
 		align-items: flex-start;
 		margin-right: $grid-unit-10;
-		overflow: hidden;
 
 		// Force text to wrap to improve UX when encountering long lines
 		// of text, particular those with no spaces.
@@ -187,10 +186,6 @@ $preview-image-height: 140px;
 
 	&.is-error .block-editor-link-control__search-item-header {
 		align-items: center;
-	}
-
-	.block-editor-link-control__search-item-details {
-		overflow: hidden; // clip to force text ellipsis.
 	}
 
 	.block-editor-link-control__search-item-icon {


### PR DESCRIPTION
Removing unnecessary overflow allows focus to display correctly.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
IN https://github.com/WordPress/gutenberg/pull/35833#issuecomment-948592797 we learnt from @jasmussen that the focus ring on the Link UI's preview was incorrect in that:

1. You cannot see the full focus "ring" (it is clipped).
2. It uses the wrong colors.

This PR ~fixes both of those problems~ currently only fixes the _first_ of those problems whilst I wait on further feedback and clarification.

## How has this been tested?

1. Create link - use `www.wordpress.org` as that brings up a nice rich preview.
2. Click away and the click back to show Link UI preview.
3. Transfer focus to the anchor which surrounds the title of the link in the preview.
4. Check focus ring is fully visible and not clipped.
5. ~Check text color is correct~ (not yet ready!).
6. Check removal of the `overflow: hidden`s hasn't caused any visual regressions. I don't believe it's needed anymore because we wrap the text rather than ellipsis it.

## Screenshots <!-- if applicable -->
<img width="751" alt="Screen Shot 2021-10-21 at 20 12 09 (1)" src="https://user-images.githubusercontent.com/444434/138342854-d1022cc9-3b47-4307-9ba1-c4b3b83f60c1.png">

<img width="498" alt="Screen Shot 2021-10-21 at 20 20 06" src="https://user-images.githubusercontent.com/444434/138343017-62cc9d5a-ec3b-4cd9-bee3-8c621c71ffea.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
