### PR TITLE
Release Docs: Remove consecutive RCs warning

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -20,8 +20,6 @@ If critical bugs are discovered on stable versions of the plugin, patch versions
 
 ### Release Tool
 
-> Note that at the time of writing, the tool doesn't support releasing consecutive RC releases. However, it is possible to use the tool for patch releases following the first stable release.
-
 The plugin release process is entirely automated and happens solely on GitHub -- i.e. it doesn't require any steps to be run locally on your machine.
 
 For your convenience, here's an [11-minute video walkthrough](https://youtu.be/TnSgJd3zpJY) that demonstrates the release process. It's recommended to watch this if you're unfamiliar with it. The process is also documented in the following paragraphs.


### PR DESCRIPTION
## Description
As of https://github.com/WordPress/gutenberg/pull/25971, the release process does support releasing multiple RCs.
