### PR TITLE
Add featured transforms in Link Control for Navigation Link items.

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -192,6 +192,13 @@ A `suggestion` should have the following shape:
 	)}
 />
 ```
+### renderControlBottom 
+
+-   Type: `Function`
+-   Required: No
+-   Default: null
+
+A render prop that can be used to pass optional controls to be rendered at the bottom of the component.
 
 # LinkControlSearchInput
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -121,6 +121,7 @@ function LinkControl( {
 	createSuggestionButtonText,
 	hasRichPreviews = false,
 	hasTextControl = false,
+	children,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -346,6 +347,7 @@ function LinkControl( {
 					/>
 				</div>
 			) }
+			{ children }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -121,7 +121,7 @@ function LinkControl( {
 	createSuggestionButtonText,
 	hasRichPreviews = false,
 	hasTextControl = false,
-	children,
+	renderControlBottom = null,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -347,7 +347,7 @@ function LinkControl( {
 					/>
 				</div>
 			) }
-			{ children }
+			{ renderControlBottom && renderControlBottom() }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -94,6 +94,7 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
  * @property {boolean=}                   noURLSuggestion            Whether to add a fallback suggestion which treats the search query as a URL.
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
+ * @property {Function}                   renderControlBottom        Optional controls to be rendered at the bottom of the component.
  */
 
 /**

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -283,6 +283,41 @@ function navStripHTML( html ) {
 	return doc.body.textContent || '';
 }
 
+/**
+ * Add transforms to Link Control
+ */
+
+function LinkControlTransforms( { block, transforms, replace } ) {
+	return (
+		<div className="link-control-transform">
+			<h3 className="link-control-transform__subheading">Transform</h3>
+			<Flex
+				justify="space-between"
+				className="link-control-transform__items"
+			>
+				{ transforms.map( ( item, index ) => {
+					return (
+						<FlexItem key={ `transform-${ index }` }>
+							<Button
+								onClick={ () =>
+									replace(
+										block.clientId,
+										switchToBlockType( block, item.name )
+									)
+								}
+								className="link-control-transform__item"
+							>
+								<BlockIcon icon={ item.icon } />
+								{ item.title }
+							</Button>
+						</FlexItem>
+					);
+				} ) }
+			</Flex>
+		</div>
+	);
+}
+
 export default function NavigationLinkEdit( {
 	attributes,
 	isSelected,
@@ -329,7 +364,7 @@ export default function NavigationLinkEdit( {
 		userCanCreatePages,
 		userCanCreatePosts,
 		thisBlock,
-		inserterItems,
+		blockTransforms,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -341,7 +376,7 @@ export default function NavigationLinkEdit( {
 				hasSelectedInnerBlock,
 				getSelectedBlockClientId,
 				getBlockParentsByBlockName,
-				getInserterItems,
+				getBlockTransformItems,
 			} = select( blockEditorStore );
 
 			const selectedBlockId = getSelectedBlockClientId();
@@ -380,7 +415,8 @@ export default function NavigationLinkEdit( {
 					'posts'
 				),
 				thisBlock: getBlock( clientId ),
-				inserterItems: getInserterItems(
+				blockTransforms: getBlockTransformItems(
+					[ getBlock( clientId ) ],
 					getBlockRootClientId( clientId )
 				),
 			};
@@ -414,48 +450,9 @@ export default function NavigationLinkEdit( {
 		'core/social-links',
 		'core/search',
 	];
-	const featuredTransforms = inserterItems.filter( ( item ) => {
+	const featuredTransforms = blockTransforms.filter( ( item ) => {
 		return featuredBlocks.includes( item.name );
 	} );
-	/**
-	 * Add transforms to Link Control
-	 */
-
-	function LinkControlTransforms( { block, transforms } ) {
-		return (
-			<div className="link-control-transform">
-				<h3 className="link-control-transform__subheading">
-					Transform
-				</h3>
-				<Flex
-					justify="space-between"
-					className="link-control-transform__items"
-				>
-					{ transforms.map( ( item, index ) => {
-						return (
-							<FlexItem key={ `transform-${ index }` }>
-								<Button
-									onClick={ () =>
-										replaceBlock(
-											block.clientId,
-											switchToBlockType(
-												block,
-												item.name
-											)
-										)
-									}
-									className="link-control-transform__item"
-								>
-									<BlockIcon icon={ item.icon } />
-									{ item.title }
-								</Button>
-							</FlexItem>
-						);
-					} ) }
-				</Flex>
-			</div>
-		);
-	}
 
 	useEffect( () => {
 		// Show the LinkControl on mount if the URL is empty
@@ -774,6 +771,7 @@ export default function NavigationLinkEdit( {
 													transforms={
 														featuredTransforms
 													}
+													replace={ replaceBlock }
 												/>
 										  )
 										: null

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -10,6 +10,7 @@ import { escape } from 'lodash';
 import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	Button,
 	PanelBody,
 	Popover,
 	TextControl,
@@ -22,6 +23,7 @@ import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
@@ -325,6 +327,7 @@ export default function NavigationLinkEdit( {
 		userCanCreatePages,
 		userCanCreatePosts,
 		thisBlock,
+		inserterItems,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -336,6 +339,7 @@ export default function NavigationLinkEdit( {
 				hasSelectedInnerBlock,
 				getSelectedBlockClientId,
 				getBlockParentsByBlockName,
+				getInserterItems,
 			} = select( blockEditorStore );
 
 			const selectedBlockId = getSelectedBlockClientId();
@@ -374,6 +378,9 @@ export default function NavigationLinkEdit( {
 					'posts'
 				),
 				thisBlock: getBlock( clientId ),
+				inserterItems: getInserterItems(
+					getBlockRootClientId( clientId )
+				),
 			};
 		},
 		[ clientId ]
@@ -400,31 +407,36 @@ export default function NavigationLinkEdit( {
 		replaceBlock( clientId, newSubmenu );
 	}
 
+	const featuredBlocks = [
+		'core/site-logo',
+		'core/social-links',
+		'core/search',
+	];
+	const featuredTransforms = inserterItems.filter( ( item ) => {
+		return featuredBlocks.includes( item.name );
+	} );
 	/**
 	 * Add transforms to Link Control
 	 */
 
-	function LinkControlTransforms( block ) {
-		const featuredTransforms = [
-			'core/site-logo',
-			'core/social-links',
-			'core/search',
-		];
+	function LinkControlTransforms( { block, transforms } ) {
 		return (
 			<>
-				{ featuredTransforms.map( ( item, index ) => {
+				{ transforms.map( ( item, index ) => {
 					return (
-						<button
+						<Button
 							key={ `transform-${ index }` }
 							onClick={ () =>
 								replaceBlock(
-									clientId,
-									switchToBlockType( block, item )
+									block.clientId,
+									switchToBlockType( block, item.name )
 								)
 							}
+							className="link-control-transform__item"
 						>
-							{ item }
-						</button>
+							<BlockIcon icon={ item.icon } />
+							{ item.title }
+						</Button>
 					);
 				} ) }
 			</>
@@ -743,6 +755,7 @@ export default function NavigationLinkEdit( {
 								renderControlBottom={ () => (
 									<LinkControlTransforms
 										block={ thisBlock }
+										transforms={ featuredTransforms }
 									/>
 								) }
 							/>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -7,7 +7,7 @@ import { escape } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	PanelBody,
@@ -324,9 +324,11 @@ export default function NavigationLinkEdit( {
 		hasDescendants,
 		userCanCreatePages,
 		userCanCreatePosts,
+		thisBlock,
 	} = useSelect(
 		( select ) => {
 			const {
+				getBlock,
 				getBlocks,
 				getBlockName,
 				getBlockRootClientId,
@@ -371,6 +373,7 @@ export default function NavigationLinkEdit( {
 					'create',
 					'posts'
 				),
+				thisBlock: getBlock( clientId ),
 			};
 		},
 		[ clientId ]
@@ -395,6 +398,37 @@ export default function NavigationLinkEdit( {
 			innerBlocks
 		);
 		replaceBlock( clientId, newSubmenu );
+	}
+
+	/**
+	 * Add transforms to Link Control
+	 */
+
+	function LinkControlTransforms( block ) {
+		const featuredTransforms = [
+			'core/site-logo',
+			'core/social-links',
+			'core/search',
+		];
+		return (
+			<>
+				{ featuredTransforms.map( ( item, index ) => {
+					return (
+						<button
+							key={ `transform-${ index }` }
+							onClick={ () =>
+								replaceBlock(
+									clientId,
+									switchToBlockType( block, item )
+								)
+							}
+						>
+							{ item }
+						</button>
+					);
+				} ) }
+			</>
+		);
 	}
 
 	useEffect( () => {
@@ -706,6 +740,11 @@ export default function NavigationLinkEdit( {
 									)
 								}
 								onRemove={ removeLink }
+								children={
+									<LinkControlTransforms
+										block={ thisBlock }
+									/>
+								}
 							/>
 						</Popover>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -740,11 +740,11 @@ export default function NavigationLinkEdit( {
 									)
 								}
 								onRemove={ removeLink }
-								children={
+								renderControlBottom={ () => (
 									<LinkControlTransforms
 										block={ thisBlock }
 									/>
-								}
+								) }
 							/>
 						</Popover>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -11,8 +11,6 @@ import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
-	Flex,
-	FlexItem,
 	PanelBody,
 	Popover,
 	TextControl,
@@ -291,29 +289,25 @@ function LinkControlTransforms( { block, transforms, replace } ) {
 	return (
 		<div className="link-control-transform">
 			<h3 className="link-control-transform__subheading">Transform</h3>
-			<Flex
-				justify="space-between"
-				className="link-control-transform__items"
-			>
+			<div className="link-control-transform__items">
 				{ transforms.map( ( item, index ) => {
 					return (
-						<FlexItem key={ `transform-${ index }` }>
-							<Button
-								onClick={ () =>
-									replace(
-										block.clientId,
-										switchToBlockType( block, item.name )
-									)
-								}
-								className="link-control-transform__item"
-							>
-								<BlockIcon icon={ item.icon } />
-								{ item.title }
-							</Button>
-						</FlexItem>
+						<Button
+							key={ `transform-${ index }` }
+							onClick={ () =>
+								replace(
+									block.clientId,
+									switchToBlockType( block, item.name )
+								)
+							}
+							className="link-control-transform__item"
+						>
+							<BlockIcon icon={ item.icon } />
+							{ item.title }
+						</Button>
 					);
 				} ) }
-			</Flex>
+			</div>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -766,12 +766,18 @@ export default function NavigationLinkEdit( {
 									)
 								}
 								onRemove={ removeLink }
-								renderControlBottom={ () => (
-									<LinkControlTransforms
-										block={ thisBlock }
-										transforms={ featuredTransforms }
-									/>
-								) }
+								renderControlBottom={
+									! url
+										? () => (
+												<LinkControlTransforms
+													block={ thisBlock }
+													transforms={
+														featuredTransforms
+													}
+												/>
+										  )
+										: null
+								}
 							/>
 						</Popover>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -11,6 +11,8 @@ import { createBlock, switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
+	Flex,
+	FlexItem,
 	PanelBody,
 	Popover,
 	TextControl,
@@ -421,25 +423,37 @@ export default function NavigationLinkEdit( {
 
 	function LinkControlTransforms( { block, transforms } ) {
 		return (
-			<>
-				{ transforms.map( ( item, index ) => {
-					return (
-						<Button
-							key={ `transform-${ index }` }
-							onClick={ () =>
-								replaceBlock(
-									block.clientId,
-									switchToBlockType( block, item.name )
-								)
-							}
-							className="link-control-transform__item"
-						>
-							<BlockIcon icon={ item.icon } />
-							{ item.title }
-						</Button>
-					);
-				} ) }
-			</>
+			<div className="link-control-transform">
+				<h3 className="link-control-transform__subheading">
+					Transform
+				</h3>
+				<Flex
+					justify="space-between"
+					className="link-control-transform__items"
+				>
+					{ transforms.map( ( item, index ) => {
+						return (
+							<FlexItem key={ `transform-${ index }` }>
+								<Button
+									onClick={ () =>
+										replaceBlock(
+											block.clientId,
+											switchToBlockType(
+												block,
+												item.name
+											)
+										)
+									}
+									className="link-control-transform__item"
+								>
+									<BlockIcon icon={ item.icon } />
+									{ item.title }
+								</Button>
+							</FlexItem>
+						);
+					} ) }
+				</Flex>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -114,7 +114,13 @@
 	margin-bottom: 1.5em;
 }
 
+.link-control-transform__items {
+	display: flex;
+	justify-content: space-between;
+}
+
 .link-control-transform__item {
+	flex-basis: 33%;
 	flex-direction: column;
 	gap: $grid-unit-10;
 	height: auto;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -96,3 +96,26 @@
 		cursor: pointer;
 	}
 }
+
+/**
+* Link Control Transforms
+*/
+
+.link-control-transform {
+	border-top: $border-width solid $gray-400;
+	padding: 0 $grid-unit-20 $grid-unit-10 $grid-unit-20;
+}
+
+.link-control-transform__subheading {
+	font-size: 11px;
+	text-transform: uppercase;
+	font-weight: 500;
+	color: $gray-900;
+	margin-bottom: 1.5em;
+}
+
+.link-control-transform__item {
+	flex-direction: column;
+	gap: $grid-unit-10;
+	height: auto;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Partially addresses #34041

Adds three transform buttons inside the link control for Navigation Links. The blocks to transform to are hardcoded; they're a selection of the options that might be most useful when expanding the Navigation to include more than just links: Search, Site Logo and Social Icons.

Adds a `renderControlBottom` render prop to LinkControl that allows adding extra controls to the bottom of the link popover.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In the Navigation block, add a new link. Check that block transforms are showing in the link popover. 
Open the link popover for an existing navigation link that has a URL set. Transforms should not display.
Link popover should be unchanged for regular links in paragraphs etc..

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
