### PR TITLE
Navigation: Force text decoration styles on nav item in editor

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -632,6 +632,7 @@ export default function NavigationLinkEdit( {
 								'core/image',
 								'core/strikethrough',
 							] }
+							tagName="span"
 							onClick={ () => {
 								if ( ! url ) {
 									setIsLinkOpen( true );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -632,7 +632,6 @@ export default function NavigationLinkEdit( {
 								'core/image',
 								'core/strikethrough',
 							] }
-							tagName="span"
 							onClick={ () => {
 								if ( ! url ) {
 									setIsLinkOpen( true );

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -18,6 +18,22 @@
 		margin-left: revert;
 		margin-right: revert;
 	}
+
+	// Force user selected text decoration to be applied to navigation items
+	// when edited.The div introduced in the editor within the `<a>` tag,
+	// changes the flow and breaks the inheritance setup within style.scss.
+	// Without the ability to use `inherit` we need to reapply the correct
+	// text decoration style.
+	&[style*="text-decoration: line-through"] {
+		a > div {
+			text-decoration: line-through;
+		}
+	}
+	&[style*="text-decoration: underline"] {
+		a > div {
+			text-decoration: underline;
+		}
+	}
 }
 
 // This element is inline on the frontend but needs to be editable, therefore inline-block, in the editor.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -20,11 +20,6 @@
 	}
 }
 
-// This element is inline on the frontend but needs to be editable, therefore ensure that the RichText field is inline in the editor.
-.wp-block-navigation-item__label {
-	display: inline;
-}
-
 /**
  * Submenus.
  */

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -18,27 +18,11 @@
 		margin-left: revert;
 		margin-right: revert;
 	}
-
-	// Force user selected text decoration to be applied to navigation items
-	// when edited.The div introduced in the editor within the `<a>` tag,
-	// changes the flow and breaks the inheritance setup within style.scss.
-	// Without the ability to use `inherit` we need to reapply the correct
-	// text decoration style.
-	&[style*="text-decoration: line-through"] {
-		a > div {
-			text-decoration: line-through;
-		}
-	}
-	&[style*="text-decoration: underline"] {
-		a > div {
-			text-decoration: underline;
-		}
-	}
 }
 
 // This element is inline on the frontend but needs to be editable, therefore inline-block, in the editor.
 .wp-block-navigation-item__label {
-	display: inline-block;
+	display: inline;
 }
 
 /**

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -20,7 +20,7 @@
 	}
 }
 
-// This element is inline on the frontend but needs to be editable, therefore inline-block, in the editor.
+// This element is inline on the frontend but needs to be editable, therefore ensure that the RichText field is inline in the editor.
 .wp-block-navigation-item__label {
 	display: inline;
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/33744

## Description

This PR removes the `inline-block` style applied to the `RichText` field for navigation items in the editor. This allows text decoration styles to be inherited from the main navigation block when applied via block supports.

## How has this been tested?

Manually.

To replicate the issue, follow the description of the issue outlined in https://github.com/WordPress/gutenberg/pull/33744#pullrequestreview-786395086

To test this PR fixes that problem. 

1. Apply the changes from this PR branch
2. Create a new post, add a navigation block including one page item
3. Select that nav item, then click Edit from the block's toolbar
4. Select the nav block again, toggle on text decoration from the Typography panel's menu
5. Select a text-decoration and ensure it is visually applied to the nav item in the editor
6. Save the post and confirm everything still displays as expected

## Screenshots 

#### Before

https://user-images.githubusercontent.com/60436221/138396286-d8a08c53-5548-44ad-8c70-cefbae278404.mp4

#### After

https://user-images.githubusercontent.com/60436221/138396267-3b57f295-5cf9-4a2d-b961-a32ebd6e256b.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
