### PR TITLE
Font Appearance: Improve consistency of label in Typography panel

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -56,6 +56,26 @@ const FONT_WEIGHTS = [
 ];
 
 /**
+ * Adjusts font appearance field label in case either font styles or weights
+ * are disabled.
+ *
+ * @param {boolean} hasFontStyles  Whether font styles are enabled and present.
+ * @param {boolean} hasFontWeights Whether font weights are enabled and present.
+ * @return {string} A label representing what font appearance is being edited.
+ */
+export const getFontAppearanceLabel = ( hasFontStyles, hasFontWeights ) => {
+	if ( ! hasFontStyles ) {
+		return __( 'Font weight' );
+	}
+
+	if ( ! hasFontWeights ) {
+		return __( 'Font style' );
+	}
+
+	return __( 'Appearance' );
+};
+
+/**
  * Control to display unified font style and weight options.
  *
  * @param {Object} props Component props.
@@ -70,6 +90,7 @@ export default function FontAppearanceControl( props ) {
 		value: { fontStyle, fontWeight },
 	} = props;
 	const hasStylesOrWeights = hasFontStyles || hasFontWeights;
+	const label = getFontAppearanceLabel( hasFontStyles, hasFontWeights );
 	const defaultOption = {
 		key: 'default',
 		name: __( 'Default' ),
@@ -152,19 +173,6 @@ export default function FontAppearanceControl( props ) {
 				option.style.fontWeight === fontWeight
 		) || selectOptions[ 0 ];
 
-	// Adjusts field label in case either styles or weights are disabled.
-	const getLabel = () => {
-		if ( ! hasFontStyles ) {
-			return __( 'Font weight' );
-		}
-
-		if ( ! hasFontWeights ) {
-			return __( 'Font style' );
-		}
-
-		return __( 'Appearance' );
-	};
-
 	// Adjusts screen reader description based on styles or weights.
 	const getDescribedBy = () => {
 		if ( ! currentSelection ) {
@@ -198,7 +206,7 @@ export default function FontAppearanceControl( props ) {
 		hasStylesOrWeights && (
 			<CustomSelectControl
 				className="components-font-appearance-control"
-				label={ getLabel() }
+				label={ label }
 				describedBy={ getDescribedBy() }
 				options={ selectOptions }
 				value={ currentSelection }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import InspectorControls from '../components/inspector-controls';
+import { getFontAppearanceLabel } from '../components/font-appearance-control';
 
 import {
 	LINE_HEIGHT_SUPPORT_KEY,
@@ -24,6 +25,8 @@ import {
 	hasFontAppearanceValue,
 	resetFontAppearance,
 	useIsFontAppearanceDisabled,
+	useIsFontStyleDisabled,
+	useIsFontWeightDisabled,
 } from './font-appearance';
 import {
 	FONT_FAMILY_SUPPORT_KEY,
@@ -82,6 +85,9 @@ export function TypographyPanel( props ) {
 	const isTextDecorationDisabled = useIsTextDecorationDisabled( props );
 	const isTextTransformDisabled = useIsTextTransformDisabled( props );
 	const isLetterSpacingDisabled = useIsLetterSpacingDisabled( props );
+
+	const hasFontStyles = ! useIsFontStyleDisabled( props );
+	const hasFontWeights = ! useIsFontWeightDisabled( props );
 
 	const isDisabled = useIsTypographyDisabled( props );
 	const isSupported = hasTypographySupport( props.name );
@@ -147,7 +153,10 @@ export function TypographyPanel( props ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ () => hasFontAppearanceValue( props ) }
-					label={ __( 'Appearance' ) }
+					label={ getFontAppearanceLabel(
+						hasFontStyles,
+						hasFontWeights
+					) }
 					onDeselect={ () => resetFontAppearance( props ) }
 					isShownByDefault={ defaultControls?.fontAppearance }
 					resetAllFilter={ ( newAttributes ) => ( {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/33744

## Description

This PR makes the label within the Typography panel's menu for font appearance consistent with the label displayed within the control itself.

When both font styles and weights are present and supported the label will read "Appearance". When only font styles are preset it will read "Font styles" and likewise "Font weights" when only font-weight is supported. If nothing is supported the control/item isn't added to the panel.

See: https://github.com/WordPress/gutenberg/pull/33744#discussion_r734208288

## How has this been tested?

Manually. 

1. Create a new post and add blocks with different levels of font appearance support
    - e.g. Navigation (both style and weight) and Heading (weight only) 
2. Select each block and confirm that the font appearance control works as expected
3. Ensure that the font appearance control remains correctly displayed after switching between blocks
4. Confirm in each case that the label for the control in the panel matches the label for it in the `ToolsPanel` menu

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/138400405-5b031b14-80e7-4b1a-acb4-cee5c1fe4e24.mp4

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
