### PR TITLE
Post Title: return no markup if title is empty

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -19,7 +19,13 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID          = $block->context['postId'];
+	$post_ID = $block->context['postId'];
+	$title   = get_the_title( $post_ID );
+
+	if ( ! $title ) {
+		return '';
+	}
+
 	$tag_name         = 'h2';
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
@@ -27,7 +33,6 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
 
-	$title = get_the_title( $post_ID );
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$title = sprintf( '<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $title );
 	}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
If a post has an empty title, then the Post Title block should not return any markup.
Closes #35224

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Create a post or page without a title
2. Add a post title block
3. View the front and confirm that there is no markup for the empty title block.
4. Add a title to the item and confirm that it still works correctly.

## Screenshots <!-- if applicable -->
Twenty Twenty Two, single post without title:

![Single posts without title has reduced spacing between the header and separator](https://user-images.githubusercontent.com/7422055/138401219-578bbdd2-b82c-41fa-a27a-d59b66c699db.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
