### PR TITLE
Fix layout styles not applying in widgets customizer

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -19,6 +19,7 @@ import {
 	WritingFlow,
 	BlockEditorKeyboardShortcuts,
 	__unstableBlockSettingsMenuFirstItem,
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 import { uploadMedia } from '@wordpress/media-utils';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -121,6 +122,7 @@ export default function SidebarBlockEditor( {
 
 				<CopyHandler>
 					<BlockTools>
+						<EditorStyles styles={ settings.defaultEditorStyles } />
 						<BlockSelectionClearer>
 							<WritingFlow className="editor-styles-wrapper">
 								<ObserveTyping>

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -122,7 +122,7 @@ export default function SidebarBlockEditor( {
 				<CopyHandler>
 					<BlockTools>
 						<BlockSelectionClearer>
-							<WritingFlow>
+							<WritingFlow className="editor-styles-wrapper">
 								<ObserveTyping>
 									<BlockList
 										renderAppender={ BlockAppender }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -16,3 +16,16 @@
 	position: fixed;
 	z-index: z-index(".customize-widgets__block-toolbar");
 }
+
+// Copied from block-editor/src/default-editor-styles.scss.
+// Apply default styles to "editor-styles-wrapper" in the customizer block editor.
+.customize-widgets__sidebar-section .editor-styles-wrapper {
+	font-family: $default-font;
+	font-size: 18px;
+	line-height: 1.5;
+	--wp--style--block-gap: 2em;
+
+	p {
+		line-height: 1.8;
+	}
+}

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -16,16 +16,3 @@
 	position: fixed;
 	z-index: z-index(".customize-widgets__block-toolbar");
 }
-
-// Copied from block-editor/src/default-editor-styles.scss.
-// Apply default styles to "editor-styles-wrapper" in the customizer block editor.
-.customize-widgets__sidebar-section .editor-styles-wrapper {
-	font-family: $default-font;
-	font-size: 18px;
-	line-height: 1.5;
-	--wp--style--block-gap: 2em;
-
-	p {
-		line-height: 1.8;
-	}
-}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix a part of https://github.com/WordPress/gutenberg/issues/35826.

Since https://github.com/WordPress/gutenberg/pull/34493, the Social Links block is now using the experimental `flex` layout system. Turns out it requires the editor to have the `editor-styles-wrapper` class. I don't understand why this is requirement though, IMO this should be handled by one of components we're using implicitly.

However, this only solves a part of the issue. The preview is still not having the styles applied.

![image](https://user-images.githubusercontent.com/7753001/138418749-74eea79e-ff2b-4254-bcea-97932a783885.png)

This seems like a separate issue though. The class name for the `flex` layout is generated, but it's not the same as the styles being injected to the page. For instance, the class name on the DOM is `wp-container-61727099e0b13`, while the CSS has `wp-container-6172708e225e0` instead.

This is probably related to the _realtime preview_ nature of the customizer. Maybe [the code](https://github.com/WordPress/gutenberg/blob/311c96e3c2e4a47ae7dae69fe40100fddfe11430/lib/block-supports/layout.php#L131) that generates the ids somehow ran it 2 separate times resulting into 2 different ids. I'll probably need some help digging into this later, as I know very little about this experiment layout thing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Appearance -> Customize -> Widgets
2. Add a Social Links block and add a random social link
3. The style should be the same as the screenshot below

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/7753001/138418310-723d6fbc-73e4-4fa9-9e0a-c038f9d42aa5.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
