### PR TITLE
Extract common layout styles

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -54,6 +54,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $content_size || $wide_size ) {
 			$style  = "$selector > * {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
+			$style .= 'margin-left: auto !important;';
+			$style .= 'margin-right: auto !important;';
 			$style .= '}';
 
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -997,11 +997,7 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
-				$block_rules .= 'body { margin: 0; }';
-				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
-				$block_rules .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
-				$block_rules .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
-
+				$block_rules          .= 'body { margin: 0; }';
 				$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
 				if ( $has_block_gap_support ) {
 					$block_rules .= '.wp-site-blocks > * { margin-top: 0; margin-bottom: 0; }';

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -204,13 +204,10 @@ export const withLayoutStyles = createHigherOrderComponent(
 			? defaultThemeLayout
 			: layout || defaultBlockLayout || {};
 		const layoutType = usedLayout.type || 'default';
-		const className = classnames(
-			props?.className,
-			`wp-layout-${ layoutType }`,
-			{
-				[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
-			}
-		);
+		const className = classnames( props?.className, {
+			[ `wp-layout-${ layoutType }` ]: shouldRenderLayoutStyles,
+			[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
+		} );
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -203,9 +203,14 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const usedLayout = layout?.inherit
 			? defaultThemeLayout
 			: layout || defaultBlockLayout || {};
-		const className = classnames( props?.className, {
-			[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
-		} );
+		const layoutType = usedLayout.type || 'default';
+		const className = classnames(
+			props?.className,
+			`wp-layout-${ layoutType }`,
+			{
+				[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
+			}
+		);
 
 		return (
 			<>

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -64,20 +64,12 @@ export default {
 		return (
 			<style>{ `
 				${ appendSelectors( selector ) } {
-					display: flex;
 					gap: ${
 						hasBlockGapStylesSupport
 							? 'var( --wp--style--block-gap, 0.5em )'
 							: '0.5em'
 					};
-					flex-wrap: wrap;
-					align-items: center;
-					flex-direction: row;
 					justify-content: ${ justifyContent };
-				}
-
-				${ appendSelectors( selector, '> *' ) } {
-					margin: 0;
 				}
 			` }</style>
 		);

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -115,6 +115,8 @@ export default {
 				? `
 					${ appendSelectors( selector, '> *' ) } {
 						max-width: ${ contentSize ?? wideSize };
+						margin-left: auto !important;
+						margin-right: auto !important;
 					}
 
 					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -115,32 +115,13 @@ export default {
 				? `
 					${ appendSelectors( selector, '> *' ) } {
 						max-width: ${ contentSize ?? wideSize };
-						margin-left: auto !important;
-						margin-right: auto !important;
 					}
 
 					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
 						max-width: ${ wideSize ?? contentSize };
 					}
-
-					${ appendSelectors( selector, '> [data-align="full"]' ) } {
-						max-width: none;
-					}
 				`
 				: '';
-
-		style += `
-			${ appendSelectors( selector, '> [data-align="left"]' ) } {
-				float: left;
-				margin-right: 2em;
-			}
-
-			${ appendSelectors( selector, '> [data-align="right"]' ) } {
-				float: right;
-				margin-left: 2em;
-			}
-
-		`;
 
 		if ( hasBlockGapStylesSupport ) {
 			style += `

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -91,12 +91,6 @@
 }
 
 // Default Flow Layout
-.wp-site-blocks > *,
-.wp-layout-default > * {
-	margin-left: auto !important;
-	margin-right: auto !important;
-}
-
 .wp-site-blocks > [data-align="full"],
 .wp-layout-default > [data-align="full"] {
 	max-width: none;

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -91,19 +91,19 @@
 }
 
 // Default Flow Layout
-.wp-site-blocks > [data-align="full"],
-.wp-layout-default > [data-align="full"] {
+.wp-site-blocks > .alignfull,
+.wp-layout-default > .alignfull {
 	max-width: none;
 }
 
-.wp-site-blocks > [data-align="left"],
-.wp-layout-default > [data-align="left"] {
+.wp-site-blocks > .alignleft,
+.wp-layout-default > .alignleft {
 	float: left;
 	margin-right: 2em;
 }
 
-.wp-site-blocks > [data-align="right"],
-.wp-layout-default > [data-align="right"] {
+.wp-site-blocks > .alignright,
+.wp-layout-default > .alignright {
 	float: right;
 	margin-left: 2em;
 }

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -89,3 +89,40 @@
 	width: auto;
 	z-index: 100000;
 }
+
+// Default Flow Layout
+.wp-site-blocks > *,
+.wp-layout-default > * {
+	margin-left: auto !important;
+	margin-right: auto !important;
+}
+
+.wp-site-blocks > [data-align="full"],
+.wp-layout-default > [data-align="full"] {
+	max-width: none;
+}
+
+.wp-site-blocks > [data-align="left"],
+.wp-layout-default > [data-align="left"] {
+	float: left;
+	margin-right: 2em;
+}
+
+.wp-site-blocks > [data-align="right"],
+.wp-layout-default > [data-align="right"] {
+	float: right;
+	margin-left: 2em;
+}
+
+// Default Flex Layout
+.wp-layout-flex {
+	display: flex;
+	gap: 0.5em;
+	flex-wrap: wrap;
+	align-items: center;
+	flex-direction: row;
+}
+
+.wp-layout-flex > * {
+	margin: 0;
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -62,9 +62,21 @@
 	font-size: 42px;
 }
 
-/**
- * Editor Normalization Styles
- *
- * These are only output in the editor, but styles here are NOT prefixed .editor-styles-wrapper.
- * This allows us to create normalization styles that are easily overridden by editor styles.
- */
+// Ideally these shouldn't be needed and it should rely on the
+// .alignleft... classnames that are also available on the frontend.
+.wp-site-blocks > [data-align="full"],
+.wp-layout-default > [data-align="full"] {
+	max-width: none !important;
+}
+
+.wp-site-blocks > [data-align="left"],
+.wp-layout-default > [data-align="left"] {
+	float: left;
+	margin-right: 2em !important;
+}
+
+.wp-site-blocks > [data-align="right"],
+.wp-layout-default > [data-align="right"] {
+	float: right;
+	margin-left: 2em !important;
+}

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -227,7 +227,7 @@ export default function VisualEditor( { styles } ) {
 							/>
 						) }
 						{ ! isTemplateMode && (
-							<div className="edit-post-visual-editor__post-title-wrapper">
+							<div className="edit-post-visual-editor__post-title-wrapper wp-layout-default">
 								<PostTitle />
 							</div>
 						) }
@@ -236,7 +236,7 @@ export default function VisualEditor( { styles } ) {
 								className={
 									isTemplateMode
 										? 'wp-site-blocks'
-										: undefined
+										: 'wp-layout-default'
 								}
 								__experimentalLayout={ layout }
 							/>


### PR DESCRIPTION
Right now Gutenberg supports two layout types "flow" (or default) and "flex" (row block). Blocks using these layouts generate inline `<style>` tags because each block can have a different layout configuration.

Things that make the layout styles dynamic:

 - Whether the theme supports block gap or not
 - Widths (content and wide widths)
 - Justification (left, right, space between...)

That said, there are things that are common across layout types, this PR extracts these common styles to the `common.css` stylesheet that is loaded for all themes.

Conceptually speaking, I still have a preference for the "all dynamic" approach we have in trunk but in terms of "purity" of the output, this is probably a bit better so I'm personally hesitant.