### PR TITLE
Heading: Avoid error on split when the paragraph isn't registered

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import {
 	AlignmentControl,
 	BlockControls,
@@ -111,7 +111,9 @@ function HeadingEdit( {
 							content: value,
 						} );
 					} else {
-						block = createBlock( 'core/paragraph' );
+						block = createBlock(
+							getDefaultBlockName() ?? 'core/heading'
+						);
 					}
 
 					if ( isOriginal ) {


### PR DESCRIPTION
## Description
PR updates `onSplit` logic for the Heading block to use `getDefaultBlockName` instead of the hardcoding `core/paragraph` as default block. When the default block isn't set, it will fall back to the heading.

P.S. I think we need to do a similar update in a few other blocks. I was able to reproduce the issue with the Quote block as well. So I will create a separate P.R. for it.

Fixes #21896.

## How has this been tested?
1. Create a post.
2. Add a Heading block and enter content.
3. Deregister Paragraph block using the snippet below:
```js
wp.blocks.unregisterBlockType( 'core/paragraph' );
```
4. Pressing Enter should create a new Heading block and not trigger an error.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated alP.R.React Native files affected by any refactorings/renamings in this P.R. (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
