### PR TITLE
Use the block name in the "remove block" menu item in the settings dropdown

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -46,10 +46,14 @@ export function BlockSettingsDropdown( {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
-	const onlyBlock = useSelect(
-		( select ) => 1 === select( blockEditorStore ).getBlockCount(),
-		[]
-	);
+	const { onlyBlock, title } = useSelect( ( select ) => {
+		const { getBlockName } = select( blockEditorStore );
+		const { getBlockType } = select( blocksStore );
+		return {
+			onlyBlock: 1 === select( blockEditorStore ).getBlockCount(),
+			title: getBlockType( getBlockName( firstBlockClientId ) )?.title,
+		};
+	}, [] );
 
 	const shortcuts = useSelect( ( select ) => {
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
@@ -79,15 +83,11 @@ export function BlockSettingsDropdown( {
 		[ __experimentalSelectBlock ]
 	);
 
-	const { getBlockName } = useSelect( blockEditorStore );
-	const { getBlockType } = useSelect( blocksStore );
-	const title = getBlockType( getBlockName( firstBlockClientId ) )?.title;
 	const label = sprintf(
 		/* translators: %s: block name */
 		__( 'Remove %s' ),
 		title
 	);
-
 	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 
 	return (

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,13 +6,13 @@ import { castArray, flow, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
+import { serialize, store as blocksStore } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -79,8 +79,16 @@ export function BlockSettingsDropdown( {
 		[ __experimentalSelectBlock ]
 	);
 
-	const removeBlockLabel =
-		count === 1 ? __( 'Remove block' ) : __( 'Remove blocks' );
+	const { getBlockName } = useSelect( blockEditorStore );
+	const { getBlockType } = useSelect( blocksStore );
+	const title = getBlockType( getBlockName( firstBlockClientId ) )?.title;
+	const label = sprintf(
+		/* translators: %s: block name */
+		__( 'Remove %s' ),
+		title
+	);
+
+	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 
 	return (
 		<BlockActions

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -46,14 +46,18 @@ export function BlockSettingsDropdown( {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
-	const { onlyBlock, title } = useSelect( ( select ) => {
-		const { getBlockName } = select( blockEditorStore );
-		const { getBlockType } = select( blocksStore );
-		return {
-			onlyBlock: 1 === select( blockEditorStore ).getBlockCount(),
-			title: getBlockType( getBlockName( firstBlockClientId ) )?.title,
-		};
-	}, [] );
+	const { onlyBlock, title } = useSelect(
+		( select ) => {
+			const { getBlockCount, getBlockName } = select( blockEditorStore );
+			const { getBlockType } = select( blocksStore );
+			return {
+				onlyBlock: 1 === getBlockCount(),
+				title: getBlockType( getBlockName( firstBlockClientId ) )
+					?.title,
+			};
+		},
+		[ firstBlockClientId ]
+	);
 
 	const shortcuts = useSelect( ( select ) => {
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -41,7 +41,9 @@ describe( 'cpt locking', () => {
 		);
 		await clickBlockToolbarButton( 'Options' );
 		expect(
-			await page.$x( '//button/span[contains(text(), "Remove block")]' )
+			await page.$x(
+				'//button/span[contains(text(), "Remove Paragraph")]'
+			)
 		).toHaveLength( 0 );
 	};
 
@@ -176,7 +178,7 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Remove block' );
+			await clickMenuItem( 'Remove Paragraph' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 
@@ -196,7 +198,7 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'Options' );
-			await clickMenuItem( 'Remove block' );
+			await clickMenuItem( 'Remove Paragraph' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );

--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -45,7 +45,9 @@ const clickOnBlockSettingsMenuRemoveBlockButton = async () => {
 		await page.keyboard.press( 'Tab' );
 
 		isRemoveButton = await page.evaluate( () => {
-			return document.activeElement.innerText.includes( 'Remove block' );
+			return document.activeElement.innerText.includes(
+				'Remove Paragraph'
+			);
 		} );
 
 		// Stop looping once we find the button

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -222,7 +222,7 @@ describe( 'Reusable blocks', () => {
 		// Delete the block, leaving the reusable block empty
 		await clickBlockToolbarButton( 'Options' );
 		const deleteButton = await page.waitForXPath(
-			'//button/span[text()="Remove block"]'
+			'//button/span[text()="Remove Paragraph"]'
 		);
 		deleteButton.click();
 

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -601,7 +601,7 @@ describe( 'Widgets Customizer', () => {
 		await clickBlockToolbarButton( 'Options' );
 		const removeBlockButton = await find( {
 			role: 'menuitem',
-			name: /Remove block/,
+			name: /Remove Legacy Widget/,
 		} );
 		await removeBlockButton.click();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Use "Remove Blockname" instead of "Remove block" in the block settings dropdown.
Fixes https://github.com/WordPress/gutenberg/issues/30740

I believe the tests that use the phrase "Remove block" also needs to be updated and I might need help with that.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Add a block, open the options menu in the toolbar and see that the option says Remove followed by the block name.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Screenshot
![A group block with the settings menu open. "Remove block" is replaced with "Remove Group"](https://user-images.githubusercontent.com/7422055/138431909-e40694e6-0ef3-4151-b652-0df04c98ab0f.png)



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
