### PR TITLE
URL Details: Update regex to include `og:description`

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -310,7 +310,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return '';
 		}
 
-		$description = $this->get_metadata_from_meta_element( $meta_elements, 'name', '\bdescription\b' );
+		$description = $this->get_metadata_from_meta_element( $meta_elements, 'name', '(?:description|og:description)' );
 
 		// Bail out if description not found.
 		if ( '' === $description ) {

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -709,7 +709,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'<meta first="first" name="description" third="third" content="description with other attributes" fifth="fifth">',
 				'description with other attributes',
 			),
-			'with open graph'                          => array(
+			'with open graph'                            => array(
 				'<meta name="og:description" content="This is a OG description." />
 				<meta name="description" content="This is a description.">',
 				'This is a OG description.',

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -577,14 +577,14 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'multiline attributes'                  => array(
 				'<link
 					rel="icon"
-					href="https://wordpress.org/favicon.ico" 
+					href="https://wordpress.org/favicon.ico"
 				/>',
 				'https://wordpress.org/favicon.ico',
 			),
 			'multiline attributes in reverse order' => array(
 				'<link
 					rel="icon"
-					href="https://wordpress.org/favicon.ico" 
+					href="https://wordpress.org/favicon.ico"
 				/>',
 				'https://wordpress.org/favicon.ico',
 			),
@@ -634,7 +634,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'multiline with no href'                => array(
 				'<link
 					rel="icon"
-					href="" 
+					href=""
 				/>',
 				'',
 			),
@@ -709,36 +709,41 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'<meta first="first" name="description" third="third" content="description with other attributes" fifth="fifth">',
 				'description with other attributes',
 			),
+			'with open graph'                          => array(
+				'<meta name="og:description" content="This is a OG description." />
+				<meta name="description" content="This is a description.">',
+				'This is a OG description.',
+			),
 
 			// Happy paths with multiline attributes.
 			'with multiline attributes'                  => array(
 				'<meta
-					name="description" 
+					name="description"
 					content="with multiline attributes"
 				>',
 				'with multiline attributes',
 			),
 			'with multiline attributes in reverse order' => array(
-				'<meta 
+				'<meta
 					content="with multiline attributes in reverse order"
 					name="description"
 				>',
 				'with multiline attributes in reverse order',
 			),
 			'with multiline attributes and another element' => array(
-				'<meta 
-					name="description" 
+				'<meta
+					name="description"
 					content="with multiline attributes"
 				>
 				<meta name="viewport" content="width=device-width, initial-scale=1">',
 				'with multiline attributes',
 			),
 			'with multiline and other attributes'        => array(
-				'<meta 
-					first="first" 
-					name="description" 
-					third="third" 
-					content="description with multiline and other attributes" 
+				'<meta
+					first="first"
+					name="description"
+					third="third"
+					content="description with multiline and other attributes"
 					fifth="fifth"
 				>',
 				'description with multiline and other attributes',
@@ -879,22 +884,22 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'https://wordpress.org/images/myimage.jpg',
 			),
 			'with multiline attributes in reverse order'   => array(
-				'<meta 
+				'<meta
 					content="https://wordpress.org/images/myimage.jpg"
 					property="og:image"
 				>',
 				'https://wordpress.org/images/myimage.jpg',
 			),
 			'with multiline attributes and other elements' => array(
-				'<meta 
-					property="og:image:height" 
-					content="720" 
+				'<meta
+					property="og:image:height"
+					content="720"
 				/>
-				<meta 
-					property="og:image:alt" 
-					content="Ignore this please" 
+				<meta
+					property="og:image:alt"
+					content="Ignore this please"
 				/>
-				<meta 
+				<meta
 					property="og:image"
 					content="https://wordpress.org/images/myimage.jpg"
 				>
@@ -902,10 +907,10 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				'https://wordpress.org/images/myimage.jpg',
 			),
 			'with multiline and other attributes'          => array(
-				'<meta 
-					first="first" 
-					property="og:image:url" 
-					third="third" 
+				'<meta
+					first="first"
+					property="og:image:url"
+					third="third"
 					content="https://wordpress.org/images/myimage.jpg"
 					fifth="fifth"
 				>',


### PR DESCRIPTION
## Description
PR updates regex to include `og:description` when looking for valid site descriptions.

Fixes #33754.

P.S. Sorry about whitespace changes. Let me know if you want me to revert it.

## How has this been tested?
Unit tests are passing.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
