### PR TITLE
Add filter around fetch link suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18929,6 +18929,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
@@ -154,7 +155,12 @@ const fetchLinkSuggestions = async (
 	}
 
 	return Promise.all( queries ).then( ( results ) => {
-		return results
+		const filteredResults = applyFilters(
+			'editor.fetchLink.suggestions',
+			results,
+			search
+		);
+		return filteredResults
 			.reduce(
 				( accumulator, current ) => accumulator.concat( current ), //flatten list
 				[]

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -154,11 +154,9 @@ const fetchLinkSuggestions = async (
 		);
 	}
 
-	return Promise.all( queries ).then( ( results ) => {
-		const filteredResults = applyFilters(
-			'editor.fetchLink.suggestions',
-			results,
-			search
+	return Promise.all( queries ).then( async ( results ) => {
+		const filteredResults = await Promise.resolve(
+			applyFilters( 'editor.fetchLink.suggestions', results, search )
 		);
 		return filteredResults
 			.reduce(

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -156,7 +156,11 @@ const fetchLinkSuggestions = async (
 
 	return Promise.all( queries ).then( async ( results ) => {
 		const filteredResults = await Promise.resolve(
-			applyFilters( 'editor.fetchLink.suggestions', results, search )
+			applyFilters(
+				'experimentalEditor.fetchLink.suggestions',
+				results,
+				search
+			)
 		);
 		return filteredResults
 			.reduce(

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -236,7 +236,7 @@ describe( 'fetchLinkSuggestions', () => {
 	} );
 	it( 'returns results added by hooks', () => {
 		addFilter(
-			'editor.fetchLink.suggestions',
+			'experimentalEditor.fetchLink.suggestions',
 			'plugin_link_suggestions',
 			( results ) => {
 				return results.concat( [
@@ -258,14 +258,14 @@ describe( 'fetchLinkSuggestions', () => {
 				type: 'custom_link',
 			} );
 			removeFilter(
-				'editor.fetchLink.suggestions',
+				'experimentalEditor.fetchLink.suggestions',
 				'plugin_link_suggestions'
 			);
 		} );
 	} );
 	it( 'returns results added by async hooks', () => {
 		addFilter(
-			'editor.fetchLink.suggestions',
+			'experimentalEditor.fetchLink.suggestions',
 			'plugin_link_suggestions',
 			( results ) => {
 				return new Promise( ( resolve ) => {
@@ -292,7 +292,7 @@ describe( 'fetchLinkSuggestions', () => {
 			} );
 
 			removeFilter(
-				'editor.fetchLink.suggestions',
+				'experimentalEditor.fetchLink.suggestions',
 				'plugin_link_suggestions'
 			);
 		} );

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import fetchLinkSuggestions from '../__experimental-fetch-link-suggestions';
@@ -228,5 +233,68 @@ describe( 'fetchLinkSuggestions', () => {
 				},
 			] )
 		);
+	} );
+	it( 'returns results added by hooks', () => {
+		addFilter(
+			'editor.fetchLink.suggestions',
+			'plugin_link_suggestions',
+			( results ) => {
+				return results.concat( [
+					{
+						id: 'plugin_case',
+						url: 'https://www.example.com/',
+						title: 'Plugin Case',
+						type: 'custom_link',
+					},
+				] );
+			}
+		);
+
+		return fetchLinkSuggestions( '', {} ).then( ( suggestions ) => {
+			expect( suggestions[ suggestions.length - 1 ] ).toEqual( {
+				id: 'plugin_case',
+				title: 'Plugin Case',
+				url: 'https://www.example.com/',
+				type: 'custom_link',
+			} );
+			removeFilter(
+				'editor.fetchLink.suggestions',
+				'plugin_link_suggestions'
+			);
+		} );
+	} );
+	it( 'returns results added by async hooks', () => {
+		addFilter(
+			'editor.fetchLink.suggestions',
+			'plugin_link_suggestions',
+			( results ) => {
+				return new Promise( ( resolve ) => {
+					resolve(
+						results.concat( [
+							{
+								id: 'async_plugin_case',
+								url: 'https://www.example.com/',
+								title: 'Async Plugin Case',
+								type: 'custom_link',
+							},
+						] )
+					);
+				} );
+			}
+		);
+
+		return fetchLinkSuggestions( '', {} ).then( ( suggestions ) => {
+			expect( suggestions[ suggestions.length - 1 ] ).toEqual( {
+				id: 'async_plugin_case',
+				title: 'Async Plugin Case',
+				url: 'https://www.example.com/',
+				type: 'custom_link',
+			} );
+
+			removeFilter(
+				'editor.fetchLink.suggestions',
+				'plugin_link_suggestions'
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
## Description
This PR adds a filter around the suggestions returned by `__experimental-fetch-link-suggestions.js`. This will allow plugins to add additional custom suggestions to the URL input.

Use case: several plugins have custom endpoints and they want to make it easy for users to add links to those endpoints. For example, in WooCommerce we would like to make it easy to link to some endpoint like _Orders_, _Payment methods_, _Log out_...

That's specially important for the Navigation editor/block. In the past, there were hooks for that (#31316), but those hooks are not currently honored by the Navigation block and the PR which added support for them didn't have any movement in the last four months (#31584). So I'm trying a different approach here. :slightly_smiling_face: 

## How has this been tested?

### Testing steps

- Open the Navigation editor.
- Open your browser console and run one of these two code snippets (this is what plugins would do on their end):
<details>
<summary>Sync example</summary>

```JS
wp.hooks.addFilter(
	'editor.fetchLink.suggestions',
	'wikipedia_link_suggestion',
	( results, search ) => {
		const wikiLinks = [
			{
				id: 'wikipedia',
				url: 'https://www.wikipedia.org/',
				title: 'Wikipedia',
				type: 'Wikipedia link',
			},
			{
				id: 'wikipedia_en',
				url: 'https://en.wikipedia.org/',
				title: 'Wikipedia (English)',
				type: 'Wikipedia link',
			},
		].filter( ( link ) =>
			link.title.toLowerCase().includes( search.toLowerCase() )
		);

		return results.concat( wikiLinks );
	}
);
```

</details>
<details>
<summary>Async example</summary>

```JS
wp.hooks.addFilter(
	'editor.fetchLink.suggestions',
	'wikipedia_search_suggestion',
	( results, search ) => {
		return new Promise( ( resolve ) => {
			setTimeout( () => {
				const wikiLinks = [
					{
						id: 'wikipedia',
						url: 'https://www.wikipedia.org/',
						title: 'Wikipedia',
						type: 'custom_link',
					},
					{
						id: 'wikipedia_en',
						url: 'https://en.wikipedia.org/',
						title: 'Wikipedia (English)',
						type: 'custom_link',
					},
				].filter( ( link ) =>
					link.title.toLowerCase().includes( search.toLowerCase() )
				);
				resolve( results.concat( wikiLinks ) );
			}, 300 );
		} );
	}
);
```

</details>

- Add a link inside the Navigation.
- Start typing `wiki`.
- Verify the `Wikipedia` and `Wikipedia (English)` suggestions appear.
- Verify you can add those links, save the page and the links are persisted.
- Repeat the process above inside the post/page editor using the Navigation block.

## Screenshots

https://user-images.githubusercontent.com/3616980/138442146-b2057162-6cec-410c-b3b8-a3a1cbc09afc.mp4

## Types of changes
Introduces a new JS filter: `editor.fetchLink.suggestions`.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
