### PR TITLE
Remove locations we do not translate from `theme-i18n.json`

### DIFF
--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -6,29 +6,9 @@
 						"name": "Font size name"
 					}
 				],
-				"fontStyles": [
-					{
-						"name": "Font style name"
-					}
-				],
-				"fontWeights": [
-					{
-						"name": "Font weight name"
-					}
-				],
 				"fontFamilies": [
 					{
 						"name": "Font family name"
-					}
-				],
-				"textTransforms": [
-					{
-						"name": "Text transform name"
-					}
-				],
-				"textDecorations": [
-					{
-						"name": "Text decoration name"
 					}
 				]
 		},
@@ -57,29 +37,9 @@
 							"name": "Font size name"
 						}
 					],
-					"fontStyles": [
-						{
-							"name": "Font style name"
-						}
-					],
-					"fontWeights": [
-						{
-							"name": "Font weight name"
-						}
-					],
 					"fontFamilies": [
 						{
 							"name": "Font family name"
-						}
-					],
-					"textTransforms": [
-						{
-							"name": "Text transform name"
-						}
-					],
-					"textDecorations": [
-						{
-							"name": "Text decoration name"
 						}
 					]
 				},

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -50,29 +50,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'context' => 'Font size name',
 			),
 			array(
-				'path'    => array( 'settings', 'typography', 'fontStyles' ),
-				'key'     => 'name',
-				'context' => 'Font style name',
-			),
-			array(
-				'path'    => array( 'settings', 'typography', 'fontWeights' ),
-				'key'     => 'name',
-				'context' => 'Font weight name',
-			),
-			array(
 				'path'    => array( 'settings', 'typography', 'fontFamilies' ),
 				'key'     => 'name',
 				'context' => 'Font family name',
-			),
-			array(
-				'path'    => array( 'settings', 'typography', 'textTransforms' ),
-				'key'     => 'name',
-				'context' => 'Text transform name',
-			),
-			array(
-				'path'    => array( 'settings', 'typography', 'textDecorations' ),
-				'key'     => 'name',
-				'context' => 'Text decoration name',
 			),
 			array(
 				'path'    => array( 'settings', 'color', 'palette' ),
@@ -95,29 +75,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'context' => 'Font size name',
 			),
 			array(
-				'path'    => array( 'settings', 'blocks', '*', 'typography', 'fontStyles' ),
-				'key'     => 'name',
-				'context' => 'Font style name',
-			),
-			array(
-				'path'    => array( 'settings', 'blocks', '*', 'typography', 'fontWeights' ),
-				'key'     => 'name',
-				'context' => 'Font weight name',
-			),
-			array(
 				'path'    => array( 'settings', 'blocks', '*', 'typography', 'fontFamilies' ),
 				'key'     => 'name',
 				'context' => 'Font family name',
-			),
-			array(
-				'path'    => array( 'settings', 'blocks', '*', 'typography', 'textTransforms' ),
-				'key'     => 'name',
-				'context' => 'Text transform name',
-			),
-			array(
-				'path'    => array( 'settings', 'blocks', '*', 'typography', 'textDecorations' ),
-				'key'     => 'name',
-				'context' => 'Text decoration name',
 			),
 			array(
 				'path'    => array( 'settings', 'blocks', '*', 'color', 'palette' ),


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/27380 introduced the `theme-i18n.json` file (`lib/experimental-i18n-theme.json` at the time) to define which strings from a `theme.json` file should be picked up for translation.

At that point, we were experimenting with presets for a number of new things: font styles, font weights, text transforms, and text decorations. Hence, we had those in the i18n file. Later on, the presets were removed at https://github.com/WordPress/gutenberg/pull/27555 but we forgot to also remove them from the i18n file. This PR does that.
