### PR TITLE
Fix include end format when determining active formats

### DIFF
--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -37,5 +37,5 @@ export function getActiveFormats(
 		return formatsAfter;
 	}
 
-	return formats[ start ] || EMPTY_ACTIVE_FORMATS;
+	return formats[ start ] || formats[ end ] || EMPTY_ACTIVE_FORMATS;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR attempts to fix edge cases surrounding creation of link formats.

When a format is active and you make a _non_-collapsed selection starting within the format and moving to the _left_ then the format becomes _inactive_ as soon as the selection moves _beyond the start_ of the format boundary (ie: on the left hand side). 

Here's a video showing that:

https://user-images.githubusercontent.com/444434/138472097-2b33f323-f42b-43b1-a74f-b907e76b5f22.mp4


This is because [the code that controls the `isActive` state of the Link UI](https://github.com/WordPress/gutenberg/blob/c5cbf3798ca30f76c8c2a4947eeb977972738be9/packages/block-editor/src/components/rich-text/format-edit.js#L20) relies on `getActiveFormats` which [only considers the start index (left hand side) of the formats](https://github.com/WordPress/gutenberg/blob/c5cbf3798ca30f76c8c2a4947eeb977972738be9/packages/rich-text/src/get-active-formats.js#L40) when looking for active formats.

In addition, if you create two _adjacent_ links then making a selection in either direction (left to right or right to left) the link at the `start` index _always_ takes presedence. This causes situations whereby the link you "began" your selection on might be superceeded by another unrelated link.


Here's a video showing that:

https://user-images.githubusercontent.com/444434/138714066-c6062647-142b-4490-8c47-6f22fa1ca297.mp4

The result of all this is that it's very easy to achieve undesirable results such as creating links ontop of other existing links or getting the UI into a state where you're no longer sure which link is selected.


This PR does 3 things to fix this:

- For formats of any type: we allow formats on the _end_ of the selection to be included in `getActiveFormats`. Thus as long as either start _or_ end of the selection are within the format the format remains active. 
- For `core/link` formats only: 
    - we consider the format inactive if _either_ of the two indices (start or end) have no matching format.
    - we consider the format inactive if the formats at the start and the end are not deeply equal to one another (i.e. same format object _reference_).

The bottom line: if any part of the selection moves outside the link format boundary or the link formats at either end don't match exactly then we no longer activate the Link UI.

Here's the fixed version (which is as per this PR)


https://user-images.githubusercontent.com/444434/138714606-7dbccdc5-e245-4b7a-8d27-55ebc6dd3e77.mp4





## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
