### PR TITLE
Post Comments: Even out the top margin inside the block

### DIFF
--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,5 +1,6 @@
 .wp-block-post-comments {
-	.comment-reply-title {
+	.comment-reply-title,
+	.nocomments {
 		margin-top: 0;
 	}
 

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,4 +1,8 @@
 .wp-block-post-comments {
+	.comment-reply-title {
+		margin-top: 0;
+	}
+
 	.commentlist {
 		list-style: none;
 		margin: 0;

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,6 +1,6 @@
 .wp-block-post-comments {
-	.comment-reply-title,
-	.nocomments {
+	// Remove extraneous top padding added to the first heading of the block.
+	> h3:first-of-type {
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
Depending on whether or not comments are open or closed, the first block within the `.comment-respond` div either has a whole lot of top margin, or very little:

![Margins](https://user-images.githubusercontent.com/1202812/138507698-d27602e6-49f5-4ab7-ac87-590532728389.png)

Gutenberg doesn't define those margins — they're left at the browser defaults. This discrepancy makes it impossible for themes to set a consistent vertical position for the post comments block, without adding custom CSS: 

![Before](https://user-images.githubusercontent.com/1202812/138508382-78ef0054-1fde-4168-b9f5-68e4af801403.png)

This PR removes the top margin from those top items, to allow these titles to even out by default: 

![After](https://user-images.githubusercontent.com/1202812/138508483-991daf00-a37e-4d20-835f-0b088d037242.png)

The `wp-comments` block still has its own native block margins, so I don't think these are really necessary anyway. I don't think this should have a substantial effect on any existing block themes. 
