### PR TITLE
Site Logo: Add option to set site icon from Site Logo block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -672,7 +672,7 @@ Display a graphic to represent this site. Update the block, and the changes appl
 -	**Name:** core/site-logo
 -	**Category:** theme
 -	**Supports:** align, color (~~background~~, ~~text~~), ~~alignWide~~, ~~html~~
--	**Attributes:** isLink, linkTarget, width
+-	**Attributes:** isLink, linkTarget, shouldSyncIcon, width
 
 ## Site Tagline
 

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -25,7 +25,8 @@
 	"example": {
 		"viewportWidth": 500,
 		"attributes": {
-			"width": 350
+			"width": 350,
+			"className": "block-editor-block-types-list__site-logo-example"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -17,6 +17,9 @@
 		"linkTarget": {
 			"type": "string",
 			"default": "_self"
+		},
+		"shouldSyncIcon": {
+			"type": "boolean"
 		}
 	},
 	"example": {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -266,10 +266,20 @@ const SiteLogo = ( {
 
 	const syncSiteIconHelpText = createInterpolateElement(
 		__(
-			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the Site Icon settings in the <a>Customizer</a>!"
+			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the <a>Site Icon settings</a>!"
 		),
-		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		{ a: <a href={ siteUrl + '/wp-admin/customize.php' } target="blank" /> }
+		{
+			a: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<a
+					href={
+						siteUrl +
+						'/wp-admin/customize.php?autofocus[section]=title_tagline'
+					}
+					target="blank"
+				/>
+			),
+		}
 	);
 
 	return (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -266,7 +266,7 @@ const SiteLogo = ( {
 
 	const syncSiteIconHelpText = createInterpolateElement(
 		__(
-			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the <a>Site Icon settings</a>!"
+			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the <a>Site Icon settings!</a>"
 		),
 		{
 			a: (
@@ -321,7 +321,7 @@ const SiteLogo = ( {
 					{ canUserEdit && (
 						<>
 							<ToggleControl
-								label={ __( 'Use site logo as icon' ) }
+								label={ __( 'Use as site icon' ) }
 								onChange={ ( value ) => {
 									setSyncSiteIcon( value );
 									setIcon( value ? logoId : undefined );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -330,7 +330,7 @@ const SiteLogo = ( {
 									setAttributes( { shouldSyncIcon: value } );
 									setIcon( value ? logoId : undefined );
 								} }
-								checked={ shouldSyncIcon }
+								checked={ !! shouldSyncIcon }
 								help={ syncSiteIconHelpText }
 							/>
 						</>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -345,7 +345,7 @@ export default function LogoEdit( {
 } ) {
 	const { width } = attributes;
 	const [ logoUrl, setLogoUrl ] = useState();
-	const [ syncSiteIcon, setSyncSiteIcon ] = useState();
+	const [ syncSiteIcon, setSyncSiteIcon ] = useState( true );
 	const ref = useRef();
 
 	const {
@@ -402,7 +402,7 @@ export default function LogoEdit( {
 		editEntityRecord( 'root', 'site', undefined, {
 			site_logo: newValue,
 		} );
-	}
+	};
 
 	const setIcon = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -8,7 +8,12 @@ import { includes, pick } from 'lodash';
  * WordPress dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useEffect,
+	useState,
+	useRef,
+} from '@wordpress/element';
 import { __, isRTL } from '@wordpress/i18n';
 import {
 	MenuItem,
@@ -257,8 +262,12 @@ const SiteLogo = ( {
 			</ResizableBox>
 		);
 
-	const syncSiteIconHelpText = __(
-		"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the Site Icon settings!"
+	const syncSiteIconHelpText = createInterpolateElement(
+		__(
+			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the Site Icon settings in the <a>Customizer</a>!"
+		),
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		{ a: <a href={ siteUrl + '/wp-admin/customize.php' } target="blank" /> }
 	);
 
 	return (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -276,7 +276,8 @@ const SiteLogo = ( {
 						siteUrl +
 						'/wp-admin/customize.php?autofocus[section]=title_tagline'
 					}
-					target="blank"
+					target="_blank"
+					rel="noopener noreferrer"
 				/>
 			),
 		}

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -269,7 +269,7 @@ const SiteLogo = ( {
 
 	const syncSiteIconHelpText = createInterpolateElement(
 		__(
-			"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the <a>Site Icon settings!</a>"
+			'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. To use a custom icon that is different from your site logo, use the <a>Site Icon settings</a>.'
 		),
 		{
 			a: (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -368,12 +368,10 @@ export default function LogoEdit( {
 		siteIconId,
 		mediaItemData,
 		isRequestingMediaItem,
-		logoBlockCount,
 	} = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } = select(
 			coreStore
 		);
-		const { getGlobalBlockCount } = select( blockEditorStore );
 		const siteSettings = getEditedEntityRecord( 'root', 'site' );
 		const siteData = getEntityRecord( 'root', '__unstableBase' );
 		const _siteLogo = siteSettings?.site_logo;
@@ -404,10 +402,10 @@ export default function LogoEdit( {
 			},
 			isRequestingMediaItem: _isRequestingMediaItem,
 			siteIconId: _siteIconId,
-			logoBlockCount: getGlobalBlockCount( 'core/site-logo' ),
 		};
 	}, [] );
 
+	const { getGlobalBlockCount } = useSelect( blockEditorStore );
 	const { editEntityRecord } = useDispatch( coreStore );
 
 	useEffect( () => {
@@ -427,9 +425,11 @@ export default function LogoEdit( {
 				return;
 			}
 
+			const logoBlockCount = getGlobalBlockCount( 'core/site-logo' );
+
 			// Only discard unsaved changes if we are removing the last Site Logo block
 			// on the page.
-			if ( logoBlockCount === 1 ) {
+			if ( logoBlockCount === 0 ) {
 				editEntityRecord( 'root', 'site', undefined, {
 					site_logo: undefined,
 					site_icon: undefined,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -66,11 +66,12 @@ const SiteLogo = ( {
 	logoUrl,
 	siteUrl,
 	logoId,
-	setIcon,
 	iconId,
+	setIcon,
+	syncSiteIcon,
+	setSyncSiteIcon,
 	canUserEdit,
 } ) => {
-	const [ syncSiteIcon, setSyncSiteIcon ] = useState( logoId === iconId );
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
@@ -91,6 +92,10 @@ const SiteLogo = ( {
 			title: siteEntities.title,
 			...pick( getSettings(), [ 'imageEditing', 'maxWidth' ] ),
 		};
+	}, [] );
+
+	useEffect( () => {
+		setSyncSiteIcon( logoId === iconId );
 	}, [] );
 
 	useEffect( () => {
@@ -214,10 +219,10 @@ const SiteLogo = ( {
 				naturalHeight={ naturalHeight }
 				clientWidth={ clientWidth }
 				onSaveImage={ ( imageAttributes ) => {
-					setLogo( imageAttributes.id );
 					if ( syncSiteIcon ) {
 						setIcon( imageAttributes.id );
 					}
+					setLogo( imageAttributes.id );
 				} }
 				isEditing={ isEditingImage }
 				onFinishEditing={ () => setIsEditingImage( false ) }
@@ -311,7 +316,7 @@ const SiteLogo = ( {
 							<ToggleControl
 								label={ __( 'Use site logo as icon' ) }
 								onChange={ ( value ) => {
-									setSyncSiteIcon( !! value );
+									setSyncSiteIcon( value );
 									setIcon( value ? logoId : undefined );
 								} }
 								checked={ syncSiteIcon }
@@ -343,6 +348,7 @@ export default function LogoEdit( {
 } ) {
 	const { width } = attributes;
 	const [ logoUrl, setLogoUrl ] = useState();
+	const [ syncSiteIcon, setSyncSiteIcon ] = useState();
 	const ref = useRef();
 
 	const {
@@ -391,17 +397,15 @@ export default function LogoEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const setLogo = ( newValue ) => {
+	const setLogo = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {
 			site_logo: newValue,
 		} );
-	};
 
-	const setIcon = ( newValue ) => {
+	const setIcon = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {
 			site_icon: newValue,
 		} );
-	};
 
 	let alt = null;
 	if ( mediaItemData ) {
@@ -415,6 +419,10 @@ export default function LogoEdit( {
 			return;
 		}
 
+		if ( syncSiteIcon ) {
+			setIcon( media.id );
+		}
+
 		if ( ! media.id && media.url ) {
 			// This is a temporary blob image
 			setLogo( undefined );
@@ -426,6 +434,9 @@ export default function LogoEdit( {
 	};
 
 	const onRemoveLogo = () => {
+		if ( syncSiteIcon ) {
+			setIcon( null );
+		}
 		setLogo( null );
 		setLogoUrl( undefined );
 		setAttributes( { width: undefined } );
@@ -471,6 +482,8 @@ export default function LogoEdit( {
 				iconId={ siteIconId }
 				setIcon={ setIcon }
 				canUserEdit={ canUserEdit }
+				syncSiteIcon={ syncSiteIcon }
+				setSyncSiteIcon={ setSyncSiteIcon }
 			/>
 		);
 	}

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -219,9 +219,6 @@ const SiteLogo = ( {
 				naturalHeight={ naturalHeight }
 				clientWidth={ clientWidth }
 				onSaveImage={ ( imageAttributes ) => {
-					if ( syncSiteIcon ) {
-						setIcon( imageAttributes.id );
-					}
 					setLogo( imageAttributes.id );
 				} }
 				isEditing={ isEditingImage }
@@ -397,10 +394,15 @@ export default function LogoEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const setLogo = ( newValue ) =>
+	const setLogo = ( newValue ) => {
+		if ( syncSiteIcon ) {
+			setIcon( newValue );
+		}
+
 		editEntityRecord( 'root', 'site', undefined, {
 			site_logo: newValue,
 		} );
+	}
 
 	const setIcon = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {
@@ -419,10 +421,6 @@ export default function LogoEdit( {
 			return;
 		}
 
-		if ( syncSiteIcon ) {
-			setIcon( media.id );
-		}
-
 		if ( ! media.id && media.url ) {
 			// This is a temporary blob image
 			setLogo( undefined );
@@ -434,9 +432,6 @@ export default function LogoEdit( {
 	};
 
 	const onRemoveLogo = () => {
-		if ( syncSiteIcon ) {
-			setIcon( null );
-		}
 		setLogo( null );
 		setLogoUrl( undefined );
 		setAttributes( { width: undefined } );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -62,10 +62,10 @@ const SiteLogo = ( {
 	siteUrl,
 	logoId,
 	setIcon,
+	iconId,
 	canUserEdit,
-	syncSiteIcon,
-	setSyncSiteIcon,
 } ) => {
+	const [ syncSiteIcon, setSyncSiteIcon ] = useState( logoId === iconId );
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
@@ -210,6 +210,9 @@ const SiteLogo = ( {
 				clientWidth={ clientWidth }
 				onSaveImage={ ( imageAttributes ) => {
 					setLogo( imageAttributes.id );
+					if ( syncSiteIcon ) {
+						setIcon( imageAttributes.id );
+					}
 				} }
 				isEditing={ isEditingImage }
 				onFinishEditing={ () => setIsEditingImage( false ) }
@@ -300,7 +303,7 @@ const SiteLogo = ( {
 								label={ __( 'Use site logo as icon' ) }
 								onChange={ ( value ) => {
 									setSyncSiteIcon( !! value );
-									setIcon( value ? logoId : null );
+									setIcon( value ? logoId : undefined );
 								} }
 								checked={ syncSiteIcon }
 								help={ syncSiteIconHelpText }
@@ -379,26 +382,10 @@ export default function LogoEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const [ syncSiteIcon, setSyncSiteIcon ] = useState(
-		siteLogoId === siteIconId
-	);
 	const setLogo = ( newValue ) => {
 		editEntityRecord( 'root', 'site', undefined, {
 			site_logo: newValue,
 		} );
-
-		// If the user has the option to sync their site icon enabled, also update
-		// the site icon.
-		if ( syncSiteIcon ) {
-			setIcon( newValue );
-		}
-
-		// If we're setting a new Site Logo for the first time, and there is no
-		// existing site icon, then automatically sync the icon to the logo.
-		if ( ! siteLogoId && ! siteIconId && newValue ) {
-			setIcon( newValue );
-			setSyncSiteIcon( true );
-		}
 	};
 
 	const setIcon = ( newValue ) => {
@@ -472,10 +459,9 @@ export default function LogoEdit( {
 				setLogo={ setLogo }
 				logoId={ mediaItemData?.id || siteLogoId }
 				siteUrl={ url }
+				iconId={ siteIconId }
 				setIcon={ setIcon }
 				canUserEdit={ canUserEdit }
-				syncSiteIcon={ syncSiteIcon }
-				setSyncSiteIcon={ setSyncSiteIcon }
 			/>
 		);
 	}

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -61,7 +61,11 @@ const SiteLogo = ( {
 	logoUrl,
 	siteUrl,
 	logoId,
+	setIcon,
+	iconId,
+	canUserEdit,
 } ) => {
+	const [ isIconSynced, setIsIconSynced ] = useState( iconId === logoId );
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
@@ -250,6 +254,10 @@ const SiteLogo = ( {
 			</ResizableBox>
 		);
 
+	const syncSiteIconHelpText = __(
+		"Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. If you don't have one, you can set your logo to also be your icon. If you do have a custom site icon, you can upload that from the Site Icon settings!"
+	);
+
 	return (
 		<>
 			<InspectorControls>
@@ -286,6 +294,19 @@ const SiteLogo = ( {
 							/>
 						</>
 					) }
+					{ canUserEdit && (
+						<>
+							<ToggleControl
+								label={ __( 'Use site logo as icon' ) }
+								onChange={ ( value ) => {
+									setIsIconSynced( value );
+									setIcon( value );
+								} }
+								checked={ isIconSynced }
+								help={ syncSiteIconHelpText }
+							/>
+						</>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls group="block">
@@ -316,6 +337,7 @@ export default function LogoEdit( {
 		siteLogoId,
 		canUserEdit,
 		url,
+		siteIconId,
 		mediaItemData,
 		isRequestingMediaItem,
 	} = useSelect( ( select ) => {
@@ -328,6 +350,7 @@ export default function LogoEdit( {
 		const _readOnlyLogo = siteData?.site_logo;
 		const _canUserEdit = canUser( 'update', 'settings' );
 		const _siteLogoId = _canUserEdit ? _siteLogo : _readOnlyLogo;
+		const _siteIconId = siteSettings?.site_icon;
 		const mediaItem =
 			_siteLogoId &&
 			select( coreStore ).getMedia( _siteLogoId, {
@@ -349,6 +372,7 @@ export default function LogoEdit( {
 				alt: mediaItem.alt_text,
 			},
 			isRequestingMediaItem: _isRequestingMediaItem,
+			siteIconId: _siteIconId,
 		};
 	}, [] );
 
@@ -356,6 +380,11 @@ export default function LogoEdit( {
 	const setLogo = ( newValue ) =>
 		editEntityRecord( 'root', 'site', undefined, {
 			site_logo: newValue,
+		} );
+
+	const setIcon = ( syncIconToLogo ) =>
+		editEntityRecord( 'root', 'site', undefined, {
+			site_icon: syncIconToLogo ? siteLogoId : null,
 		} );
 
 	let alt = null;
@@ -423,6 +452,9 @@ export default function LogoEdit( {
 				setLogo={ setLogo }
 				logoId={ mediaItemData?.id || siteLogoId }
 				siteUrl={ url }
+				setIcon={ setIcon }
+				iconId={ siteIconId }
+				canUserEdit={ canUserEdit }
 			/>
 		);
 	}

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -66,6 +66,7 @@ const SiteLogo = ( {
 	logoUrl,
 	siteUrl,
 	logoId,
+	iconId,
 	setIcon,
 	canUserEdit,
 } ) => {
@@ -89,6 +90,15 @@ const SiteLogo = ( {
 			title: siteEntities.title,
 			...pick( getSettings(), [ 'imageEditing', 'maxWidth' ] ),
 		};
+	}, [] );
+
+	useEffect( () => {
+		// Turn the `Use as site icon` toggle off if it is on but the logo and icon have
+		// fallen out of sync. This can happen if the toggle is saved in the `on` position,
+		// but changes are later made to the site icon in the Customizer.
+		if ( shouldSyncIcon && logoId !== iconId ) {
+			setAttributes( { shouldSyncIcon: false } );
+		}
 	}, [] );
 
 	useEffect( () => {
@@ -424,7 +434,7 @@ export default function LogoEdit( {
 		// Initialize the syncSiteIcon toggle. If we currently have no Site logo and no
 		// site icon, automatically sync the logo to the icon.
 		if ( shouldSyncIcon === undefined ) {
-			setAttributes( { shouldSyncIcon: ! siteLogoId && ! siteIconId } );
+			setAttributes( { shouldSyncIcon: ! siteIconId } );
 		}
 		onSelectLogo( media );
 	};
@@ -488,6 +498,7 @@ export default function LogoEdit( {
 				logoId={ mediaItemData?.id || siteLogoId }
 				siteUrl={ url }
 				setIcon={ setIcon }
+				iconId={ siteIconId }
 				canUserEdit={ canUserEdit }
 			/>
 		);

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -438,8 +438,10 @@ export default function LogoEdit( {
 		};
 	}, [] );
 
-	const setLogo = ( newValue ) => {
-		if ( shouldSyncIcon ) {
+	const setLogo = ( newValue, shouldForceSync = false ) => {
+		// `shouldForceSync` is used to force syncing when the attribute
+		// may not have updated yet.
+		if ( shouldSyncIcon || shouldForceSync ) {
 			setIcon( newValue );
 		}
 
@@ -465,12 +467,19 @@ export default function LogoEdit( {
 		// Initialize the syncSiteIcon toggle. If we currently have no Site logo and no
 		// site icon, automatically sync the logo to the icon.
 		if ( shouldSyncIcon === undefined ) {
-			setAttributes( { shouldSyncIcon: ! siteIconId } );
+			const shouldForceSync = ! siteIconId;
+			setAttributes( { shouldSyncIcon: shouldForceSync } );
+
+			// Because we cannot rely on the `shouldSyncIcon` attribute to have updated by
+			// the time `setLogo` is called, pass an argument to force the syncing.
+			onSelectLogo( media, shouldForceSync );
+			return;
 		}
+
 		onSelectLogo( media );
 	};
 
-	const onSelectLogo = ( media ) => {
+	const onSelectLogo = ( media, shouldForceSync = false ) => {
 		if ( ! media ) {
 			return;
 		}
@@ -482,7 +491,7 @@ export default function LogoEdit( {
 			return;
 		}
 
-		setLogo( media.id );
+		setLogo( media.id, shouldForceSync );
 	};
 
 	const onRemoveLogo = () => {

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -77,6 +77,25 @@ function register_block_core_site_logo_setting() {
 add_action( 'rest_api_init', 'register_block_core_site_logo_setting', 10 );
 
 /**
+ * Register a core site setting for a site icon
+ */
+function register_block_core_site_icon_setting() {
+	register_setting(
+		'general',
+		'site_icon',
+		array(
+			'show_in_rest' => array(
+				'name' => 'site_icon',
+			),
+			'type'         => 'integer',
+			'description'  => __( 'Site icon.' ),
+		)
+	);
+}
+
+add_action( 'rest_api_init', 'register_block_core_site_icon_setting', 10 );
+
+/**
  * Registers the `core/site-logo` block on the server.
  */
 function register_block_core_site_logo() {

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -84,9 +84,7 @@ function register_block_core_site_icon_setting() {
 		'general',
 		'site_icon',
 		array(
-			'show_in_rest' => array(
-				'name' => 'site_icon',
-			),
+			'show_in_rest' => true,
 			'type'         => 'integer',
 			'description'  => __( 'Site icon.' ),
 		)

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -24,6 +24,7 @@ const TRANSLATED_SITE_PROPERTIES = {
 	title: __( 'Title' ),
 	description: __( 'Tagline' ),
 	site_logo: __( 'Logo' ),
+	site_icon: __( 'Icon' ),
 	show_on_front: __( 'Show on front' ),
 	page_on_front: __( 'Page on front' ),
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Related to: #30406 

## Description
<!-- Please describe what you have changed or added -->
Adds an option in the Inspector Controls of the Site Logo block to sync the site logo image to the Site Icon. When the toggle is switched on, any updates persisted to the Site Logo image are also made to the Icon.

When you set a new Site Logo for the first time (ie add a new Logo block and upload an image when it was previously undefined), _if there is no existing site icon_ this toggle will be automatically turned on and the logo will be synced to the icon. When the user saves the post, they Save prompt makes it clear that they are about to persist changes to the logo and/or icon.

Any unsaved changes to the Logo & Icon are discarded when you remove the last Site Logo block from a post (see testing instructions).

## Notes 
* The help text for the toggle ought to link you to a settings page where you can upload a different image or reset your site icon. Right now it links to the Customizer's Site Identity section.
    *  On blocks themes, the Customizer link is removed from wp-admin, but it can still be linked to directly. There is an issue open for adding a new flow for updating site icons through the site editor (#29126). When this is resolved, this link ought to be updated.
* The link to the Customizer currently opens in a new tab. This is to prevent the blocking alert to Save Changes/losing changes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Test cases for an authorized user:

#### Test initial value of the toggle:
- [ ] Make sure you have no Site Logo or Site Icon set on your site. Open a post and add a Site Logo block. Upload an image and verify in the Inspector controls that the toggle is automatically turned on. Save the post and verify that you are asked if you want to save changes to both the logo and the icon. Verify the changes save correctly.
- [ ] Remove your Site Logo but **make sure you have a Site Icon set**. Open a post and insert a Site Logo block. Upload an image and verify that the toggle is not automatically turned on. Save the post and verify that you are asked if you want to save changes to the logo but **NOT** the icon.

#### Test updating the Site Logo:
- [ ] Replace the Site Logo with a different image and save the post. You should again be prompted to save both the icon and the logo. Verify the changes persist.
- [ ] Remove the Site Logo with the `Reset` option from the `Replace` menu in the block toolbar. You should again be prompted to save both the icon and the logo. Verify changes persist after saving (icon and logo should both be removed).
- [ ] Replace the Site Logo with a new image. Toggle the option to sync off. Save the post. You should only be prompted to save the Logo. Verify that the new Logo is added but the icon is still empty.

#### Test persistence of Toggle state:
- [ ] Toggle the sync option on and upload a new image. Save all entities. Then toggle the option off. You should be able to save the post. When you refresh, the toggle should still be turned off even though both logo and icon are the same image.

#### Test staying synced with changes via the Customizer:
- [ ] Toggle the sync option on and save with a new image. Verify both icon and logo are updated. Then go to the customizer and update the site icon through the Site Identity section. Open the post in the block editor again and verify that the toggle is now OFF.
- [ ] Toggle the sync option and upload a new image. Click 'save' and verify you see prompts to save both icon and logo, but do not actually save. Go to the customizer and upload/publish a new icon. Return to the block editor tab and now hit Save, without refreshing first. Since the toggle is still enabled, the changes to the icon here should override what you saved in the customizer.

#### Test discarding unsaved changes:
- [ ] Insert a Site Logo block into a new post. Update the image and make sure the toggle is on. Verify you see the option to save both Logo & Icon in the pre-save menu, but do not save yet.
- [ ] Insert at least one more Site Logo block. Note that it displays with the updated image.
- [ ] Hover over the 'Default' and 'Rounded' styles in the Controls, and then move the cursor away so the preview renders and then disappears. _This is to test that unmounting the Site Logo block in the preview does not cause unsaved changes to be discarded._ Verify that the Logos in your post still show your unsaved change.
- [ ] Open the large block inserter panel from the `+` in the toolbar. Scroll down to Site Logo and hover over it to make the preview appear, then move the cursor away so it disappears. _This is to test that unmounting the Site Logo block in this preview also does not cause unsaved changes to be discarded._ Again, the Logos in your post should be unaffected.
- [ ] Remove the first Logo block. Because there's still a Logo block on the page, unsaved changes should not be discarded yet.
- [ ] Remove the second/final Logo block. Your unsaved changes should be discarded: you should not see `Logo` or `Icon` in the pre-save menu, and if you insert a new Site Logo block it should display the published logo. Save the post and verify that the changes were not made.
- [ ] Repeat the above tests in the site editor; make sure you include multiple Site Logo blocks in different templates. (For example, add one to the Header and one to the Footer; make an unsaved change; remove one block and verify the change is not discarded; remove the second block and verify that it is).

### Tests as an unauthorized user (for example with the Author role):
- [ ] Insert a Site Logo block in a new post. Verify that you don't see the toggle in the Inspector Controls.

## Screenshots <!-- if applicable -->
Controls (updated to show the new copy):
<img width="283" alt="Screen Shot 2021-12-07 at 1 44 33 PM" src="https://user-images.githubusercontent.com/63313398/145110976-296b9551-3d0b-485c-86c6-66423d45e8ca.png">

Save prompt:
<img width="274" alt="Screen Shot 2021-11-01 at 11 47 20 AM" src="https://user-images.githubusercontent.com/63313398/139724728-0b666199-6acd-4478-a9f1-c3144f87140f.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
