### PR TITLE
Docs: Improve Getting Started landing page

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -16,7 +16,7 @@ Welcome! Let's get started building with blocks. Blocks are at the core of exten
 
 ## Additional Resources
 
--   [What's New in Gutenberg](https://make.wordpress.org/core/tag/gutenberg-new) - follow the Make Core blog to see te latest developments.
+-   [What's New in Gutenberg](https://make.wordpress.org/core/tag/gutenberg-new) - follow the Make Core blog for development news.
 -   [Glossary](/docs/explanations/glossary.md)
 -   [Frequently Asked Questions](/docs/explanations/faq.md)
 -   [Project History](/docs/explanations/history.md)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome! Let's get started building with blocks.
+Welcome! Let's get started building with blocks. Blocks are at the core of extending WordPress. You can create custom blocks, your own block patterns, or combine them together to build a block theme.
 
 ## Tutorials
 
@@ -10,8 +10,13 @@ Welcome! Let's get started building with blocks.
 
 [Full Site Editing](/docs/getting-started/full-site-editing.md) - Full Site Editing (FSE) is an umbrella project name for the collection of features that bring the experience and extendability of blocks to all parts of your site—from settings and styles, to templates and themes, and more.
 
+-   Learn [about using theme.json](/docs/how-to-guides/themes/theme-json.md) to define settings and styles for your theme.
+
+-   [Create a Block Theme](/docs/how-to-guides/themes/create-block-theme.md) - Learn how block themes use blocks to build templates and the theme.json to provide styles.
+
 ## Additional Resources
 
+-   [What's New in Gutenberg](https://make.wordpress.org/core/tag/gutenberg-new) - follow the Make Core blog to see te latest developments.
 -   [Glossary](/docs/explanations/glossary.md)
 -   [Frequently Asked Questions](/docs/explanations/faq.md)
 -   [Project History](/docs/explanations/history.md)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,15 +1,18 @@
 # Getting Started
 
+Welcome! Let's get started building with blocks.
 
 ## Tutorials
 
--   [Development Environment](/docs/getting-started/devenv/README.md)
--   [Create a Block Tutorial](/docs/getting-started/create-block/README.md)
+[Development Environment](/docs/getting-started/devenv/README.md) - A guide to setup your local environment for JavaScript development for creating plugins, themes, and the tools you will need to extend WordPress or contribute to the block editor.
 
-## [Glossary](/docs/explanations/glossary.md)
+[Create a Block Tutorial](/docs/getting-started/create-block/README.md) - Learn how to create your first block for the WordPress block editor.
 
-## [FAQ](/docs/explanations/faq.md)
+[Full Site Editing](/docs/getting-started/full-site-editing.md) - Full Site Editing (FSE) is an umbrella project name for the collection of features that bring the experience and extendability of blocks to all parts of your site—from settings and styles, to templates and themes, and more.
 
-## [History](/docs/explanations/history.md)
+## Additional Resources
 
-## [Outreach](/docs/getting-started/outreach.md)
+-   [Glossary](/docs/explanations/glossary.md)
+-   [Frequently Asked Questions](/docs/explanations/faq.md)
+-   [Project History](/docs/explanations/history.md)
+-   [Outreach](/docs/getting-started/outreach.md)


### PR DESCRIPTION

## Description

The initial page was blank, this fills in some details and improves upon it.

- Adds additional context around initial tutorials.
- Moves links to other pages from headings to list of links


## How has this been tested?

View rich text diff.


## Types of changes

Documentation.

