### PR TITLE
Add announcement on formatting change for screen readers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19670,11 +19670,13 @@
 			"version": "file:packages/rich-text",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
+				"@wordpress/a11y": "^3.2.3",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
+				"@wordpress/i18n": "^4.2.3",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"classnames": "^2.3.1",

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -51,7 +51,9 @@ const FormatToolbar = () => {
 											toggleProps.className,
 											{ 'is-pressed': hasActive }
 										),
-										describedBy: __( 'Displays more block tools' ),
+										describedBy: __(
+											'Displays more block tools'
+										),
 									} }
 									controls={ orderBy(
 										fills.map( ( [ { props } ] ) => props ),

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -51,6 +51,7 @@ const FormatToolbar = () => {
 											toggleProps.className,
 											{ 'is-pressed': hasActive }
 										),
+										describedBy: __( 'Displays more block tools' ),
 									} }
 									controls={ orderBy(
 										fills.map( ( [ { props } ] ) => props ),

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { toggleFormat } from '@wordpress/rich-text';
 import {
 	RichTextToolbarButton,
@@ -21,6 +22,14 @@ export const bold = {
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
 			onChange( toggleFormat( value, { type: name } ) );
+			// For screen readers, will announce if Bold is active or not. Because isActive is not updated yet, flip the value and then compare type true/false.
+			if ( ! isActive === true ) {
+				// translators: %s: title of the formatting control
+				speak( sprintf( __( '%s applied.' ), title ), 'assertive' );
+			} else {
+				// translators: %s: title of the formatting control
+				speak( sprintf( __( '%s removed.' ), title ), 'assertive' );
+			}
 		}
 
 		function onClick() {

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -24,7 +24,7 @@ export const bold = {
 		}
 
 		function onClick() {
-			onToggle();
+			onChange( toggleFormat( value, { type: name } ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
 import { toggleFormat } from '@wordpress/rich-text';
 import {
 	RichTextToolbarButton,
@@ -21,15 +20,7 @@ export const bold = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name } ) );
-			// For screen readers, will announce if Bold is active or not. Because isActive is not updated yet, flip the value and then compare type true/false.
-			if ( ! isActive === true ) {
-				// translators: %s: title of the formatting control
-				speak( sprintf( __( '%s applied.' ), title ), 'assertive' );
-			} else {
-				// translators: %s: title of the formatting control
-				speak( sprintf( __( '%s removed.' ), title ), 'assertive' );
-			}
+			onChange( toggleFormat( value, { type: name }, title ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -20,7 +20,7 @@ export const bold = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -56,6 +56,7 @@ export const code = {
 				title={ title }
 				onClick={ onClick }
 				isActive={ isActive }
+				role="menuitemcheckbox"
 			/>
 		);
 	},

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -46,7 +46,7 @@ export const code = {
 	},
 	edit( { value, onChange, onFocus, isActive } ) {
 		function onClick() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -46,7 +46,7 @@ export const code = {
 	},
 	edit( { value, onChange, onFocus, isActive } ) {
 		function onClick() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -24,7 +24,7 @@ export const italic = {
 		}
 
 		function onClick() {
-			onToggle();
+			onChange( toggleFormat( value, { type: name } ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -20,7 +20,7 @@ export const italic = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -20,7 +20,7 @@ export const italic = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/keyboard/index.js
+++ b/packages/format-library/src/keyboard/index.js
@@ -30,6 +30,7 @@ export const keyboard = {
 				title={ title }
 				onClick={ onClick }
 				isActive={ isActive }
+				role="menuitemcheckbox"
 			/>
 		);
 	},

--- a/packages/format-library/src/keyboard/index.js
+++ b/packages/format-library/src/keyboard/index.js
@@ -16,7 +16,7 @@ export const keyboard = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/keyboard/index.js
+++ b/packages/format-library/src/keyboard/index.js
@@ -16,7 +16,7 @@ export const keyboard = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -26,6 +26,7 @@ export const strikethrough = {
 				title={ title }
 				onClick={ onClick }
 				isActive={ isActive }
+				role="menuitemcheckbox"
 			/>
 		);
 	},

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -16,7 +16,7 @@ export const strikethrough = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onClick() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -16,7 +16,7 @@ export const strikethrough = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onClick() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 			onFocus();
 		}
 

--- a/packages/format-library/src/subscript/index.js
+++ b/packages/format-library/src/subscript/index.js
@@ -16,7 +16,7 @@ export const subscript = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/subscript/index.js
+++ b/packages/format-library/src/subscript/index.js
@@ -30,6 +30,7 @@ export const subscript = {
 				title={ title }
 				onClick={ onClick }
 				isActive={ isActive }
+				role="menuitemcheckbox"
 			/>
 		);
 	},

--- a/packages/format-library/src/subscript/index.js
+++ b/packages/format-library/src/subscript/index.js
@@ -16,7 +16,7 @@ export const subscript = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/superscript/index.js
+++ b/packages/format-library/src/superscript/index.js
@@ -16,7 +16,7 @@ export const superscript = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name } ) );
+			onChange( toggleFormat( value, { type: name }, title ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/superscript/index.js
+++ b/packages/format-library/src/superscript/index.js
@@ -30,6 +30,7 @@ export const superscript = {
 				title={ title }
 				onClick={ onClick }
 				isActive={ isActive }
+				role="menuitemcheckbox"
 			/>
 		);
 	},

--- a/packages/format-library/src/superscript/index.js
+++ b/packages/format-library/src/superscript/index.js
@@ -16,7 +16,7 @@ export const superscript = {
 	className: null,
 	edit( { isActive, value, onChange, onFocus } ) {
 		function onToggle() {
-			onChange( toggleFormat( value, { type: name }, title ) );
+			onChange( toggleFormat( value, { type: name, title } ) );
 		}
 
 		function onClick() {

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -92,6 +92,7 @@ function TextColorEdit( {
 					<Icon
 						icon={ textColorIcon }
 						style={ colorIndicatorStyle }
+						role="menuitemcheckbox"
 					/>
 				}
 				title={ title }

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -92,7 +92,6 @@ function TextColorEdit( {
 					<Icon
 						icon={ textColorIcon }
 						style={ colorIndicatorStyle }
-						role="menuitemcheckbox"
 					/>
 				}
 				title={ title }
@@ -102,6 +101,7 @@ function TextColorEdit( {
 						? enableIsAddingColor
 						: () => onChange( removeFormat( value, name ) )
 				}
+				role="menuitemcheckbox"
 			/>
 			{ isAddingColor && (
 				<InlineColorUI

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -9,10 +9,11 @@ import {
 } from '@wordpress/block-editor';
 
 const name = 'core/underline';
+const title = __( 'Underline' );
 
 export const underline = {
 	name,
-	title: __( 'Underline' ),
+	title,
 	tagName: 'span',
 	className: null,
 	attributes: {
@@ -21,12 +22,16 @@ export const underline = {
 	edit( { value, onChange } ) {
 		const onToggle = () => {
 			onChange(
-				toggleFormat( value, {
-					type: name,
-					attributes: {
-						style: 'text-decoration: underline;',
+				toggleFormat(
+					value,
+					{
+						type: name,
+						attributes: {
+							style: 'text-decoration: underline;',
+						},
 					},
-				} )
+					title
+				)
 			);
 		};
 

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -22,16 +22,13 @@ export const underline = {
 	edit( { value, onChange } ) {
 		const onToggle = () => {
 			onChange(
-				toggleFormat(
-					value,
-					{
-						type: name,
-						attributes: {
-							style: 'text-decoration: underline;',
-						},
+				toggleFormat( value, {
+					type: name,
+					attributes: {
+						style: 'text-decoration: underline;',
 					},
-					title
-				)
+					title,
+				} )
 			);
 		};
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -322,6 +322,7 @@ _Parameters_
 
 -   _value_ `RichTextValue`: Value to modify.
 -   _format_ `RichTextFormat`: Format to apply or remove.
+-   _title_ `string`: Title of formatting control.
 
 _Returns_
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -322,7 +322,6 @@ _Parameters_
 
 -   _value_ `RichTextValue`: Value to modify.
 -   _format_ `RichTextFormat`: Format to apply or remove.
--   _title_ `string`: Title of formatting control.
 
 _Returns_
 

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -30,11 +30,13 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",
+		"@wordpress/a11y": "^3.2.3",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
+		"@wordpress/i18n": "^4.2.3",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"classnames": "^2.3.1",

--- a/packages/rich-text/src/toggle-format.js
+++ b/packages/rich-text/src/toggle-format.js
@@ -1,4 +1,11 @@
 /**
+ * WordPress dependencies
+ */
+
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 
@@ -14,13 +21,23 @@ import { applyFormat } from './apply-format';
  *
  * @param {RichTextValue}  value  Value to modify.
  * @param {RichTextFormat} format Format to apply or remove.
+ * @param {string} title Title of formatting control.
  *
  * @return {RichTextValue} A new value with the format applied or removed.
  */
-export function toggleFormat( value, format ) {
+export function toggleFormat( value, format, title ) {
 	if ( getActiveFormat( value, format.type ) ) {
+		// For screen readers, will announce if formatting control is disabled.
+		if ( title ) {
+			// translators: %s: title of the formatting control
+			speak( sprintf( __( '%s removed.' ), title ), 'assertive' );
+		}
 		return removeFormat( value, format.type );
 	}
-
+	// For screen readers, will announce if formatting control is enabled.
+	if ( title ) {
+		// translators: %s: title of the formatting control
+		speak( sprintf( __( '%s applied.' ), title ), 'assertive' );
+	}
 	return applyFormat( value, format );
 }

--- a/packages/rich-text/src/toggle-format.js
+++ b/packages/rich-text/src/toggle-format.js
@@ -21,23 +21,22 @@ import { applyFormat } from './apply-format';
  *
  * @param {RichTextValue}  value  Value to modify.
  * @param {RichTextFormat} format Format to apply or remove.
- * @param {string} title Title of formatting control.
  *
  * @return {RichTextValue} A new value with the format applied or removed.
  */
-export function toggleFormat( value, format, title ) {
+export function toggleFormat( value, format ) {
 	if ( getActiveFormat( value, format.type ) ) {
 		// For screen readers, will announce if formatting control is disabled.
-		if ( title ) {
+		if ( format.title ) {
 			// translators: %s: title of the formatting control
-			speak( sprintf( __( '%s removed.' ), title ), 'assertive' );
+			speak( sprintf( __( '%s removed.' ), format.title ), 'assertive' );
 		}
 		return removeFormat( value, format.type );
 	}
 	// For screen readers, will announce if formatting control is enabled.
-	if ( title ) {
+	if ( format.title ) {
 		// translators: %s: title of the formatting control
-		speak( sprintf( __( '%s applied.' ), title ), 'assertive' );
+		speak( sprintf( __( '%s applied.' ), format.title ), 'assertive' );
 	}
 	return applyFormat( value, format );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
When formatting text with items such as Code, Superscript, Subscript, etc, there is now an alert for screen readers to announce that the formatting has been added/removed. I also added this for Bold, Italics, and Underline. However, the alert will only be fired on shortcut key, not button click. Double feedback isn't really needed due to `aria-pressed="true"`.

The only item not modified is text-color/Highlight. That needs it's own set of accessibility enhancements and I will do this in another PR.

I also added description text to the More menu and added `role="menuitemcheckbox"` that way users can tell if an item is enabled or disabled. I kept the alerts here as the More menu closes before checked/unchecked state is read. There is a similar issue for the Alignment Control which I may attempt to fix later.

## How to test

### Test 1
For this test, you will hear that formatting is applied/removed while using the keyboard.
1. Open the Gutenberg editor.
2. Navigate to a block or add a fresh block.
3. Select some text. For this example, I selected some text within a Paragraph block by holding down Shift+Right Arrow until I captured my selection.
4. Toggle Bold with CTRL+B and you should hear "Bold applied."
5. Remove Bold with CTRL+B and you should hear "Bold removed."
6. Try this out with other formatting shortcuts.

### Test 2
In this test, you will explore the block formatting toolbar.
1. Open the Gutenberg editor.
2. Navigate to a block or add a fresh block.
3. Select some text. For this example, I selected some text within a Paragraph block by holding down Shift+Right Arrow until I captured my selection.
4. Press Shift+Tab to focus the Block Toolbar.
5. Press Right Arrow until you hear More. I added some description text to this button, so you should hear "More, Displays more block tools" with NVDA or JAWS. With Voiceover, you should hear "More, this item contains help tag." Of course, what you hear depends on the verbosity setting of the screen reader.
6. Open the More menu by pressing Enter.
7. Notice how the menu items that toggle formatting such as Highlight or Inline Code are now checkboxes that way you can hear the current state of the item and if it is applied to the content you have selected.
8. Try selecting Inline Code. You should hear "Inline Code applied" and the More menu should close. Focus should be placed back on the selected text within the block you are currently editing.
9. Press Shift+Tab to enter the Block Toolbar.
10. Navigate via Right Arrow to the More menu and open it with Enter.
11. Notice how Inline Code currently says "Inline Code, checked" as the formatting option is currently applied.
12. If you select Inline Code again to remove the formatting, you should hear "Inline Code removed" and focus should be placed back on the selected text within the block you are currently editing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested using NVDA in Firefox. I checked to see which code called the function I modified and ensured params were updated.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This is a new feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
