### PR TITLE
Docs: Alphabetize the How to Guides section

### DIFF
--- a/docs/how-to-guides/format-api/README.md
+++ b/docs/how-to-guides/format-api/README.md
@@ -1,4 +1,4 @@
-# Introduction to the Format API
+# Formatting Toolbar
 
 The purpose of this tutorial is to introduce you to the Format API. The Format API makes it possible for developers to add custom buttons to the formatting toolbar and have them apply a _format_ to a text selection. Bold is an example of a standard button in the formatting toolbar.
 

--- a/docs/how-to-guides/format-api/README.md
+++ b/docs/how-to-guides/format-api/README.md
@@ -1,4 +1,4 @@
-# Formatting Toolbar
+# Formatting Toolbar API
 
 The purpose of this tutorial is to introduce you to the Format API. The Format API makes it possible for developers to add custom buttons to the formatting toolbar and have them apply a _format_ to a text selection. Bold is an example of a standard button in the formatting toolbar.
 

--- a/docs/how-to-guides/notices/README.md
+++ b/docs/how-to-guides/notices/README.md
@@ -1,4 +1,4 @@
-# Displaying Notices from Your Plugin or Theme
+# Notices
 
 Notices are informational UI displayed near the top of admin pages. WordPress core, themes, and plugins all use notices to indicate the result of an action, or to draw the user's attention to necessary information.
 

--- a/docs/how-to-guides/platform/README.md
+++ b/docs/how-to-guides/platform/README.md
@@ -1,6 +1,6 @@
-# Gutenberg as a Development Platform
+# App Platform
 
-The Gutenberg Project is not only building a better editor for WordPress, but also creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list packages available on npm](https://www.npmjs.com/org/wordpress).
+The Gutenberg Project is not only building a better editor for WordPress, but also creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list of packages available on npm](https://www.npmjs.com/org/wordpress).
 
 ## UI Components
 

--- a/docs/how-to-guides/platform/README.md
+++ b/docs/how-to-guides/platform/README.md
@@ -1,4 +1,4 @@
-# App Platform
+# Development Platform
 
 The Gutenberg Project is not only building a better editor for WordPress, but also creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list of packages available on npm](https://www.npmjs.com/org/wordpress).
 

--- a/docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md
+++ b/docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md
@@ -1,6 +1,6 @@
 # Plugin Sidebar
 
-How to add a sidebar to your plugin. A sidebar is the region to the far right of the editor.Your plugin can add an additional icon next to the InspectorControls (gear icon) that can be expanded.
+How to add a sidebar to your plugin. A sidebar is the region to the far right of the editor. Your plugin can add an additional icon next to the InspectorControls (gear icon) that can be expanded.
 
 ![Example sidebar](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/sidebar-up-and-running.png)
 

--- a/docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md
+++ b/docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md
@@ -1,6 +1,10 @@
-# Creating a Sidebar for Your Plugin
+# Plugin Sidebar
 
-This tutorial starts with you having an existing plugin setup and ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](/docs/how-to-guides/javascript/) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
+How to add a sidebar to your plugin. A sidebar is the region to the far right of the editor.Your plugin can add an additional icon next to the InspectorControls (gear icon) that can be expanded.
+
+![Example sidebar](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/sidebar-up-and-running.png)
+
+**Prerequisite:**: The tutorial assumes you have an existing plugin setup and ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](/docs/how-to-guides/javascript/) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
 
 In the next sections, you're going to create a custom sidebar for a plugin that contains a text control so the user can update a value that is stored in the `post_meta` table.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -192,7 +192,7 @@
 		"parent": "designers"
 	},
 	{
-		"title": "App Platform",
+		"title": "Development Platform",
 		"slug": "platform",
 		"markdown_source": "../docs/how-to-guides/platform/README.md",
 		"parent": "how-to-guides"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -90,142 +90,28 @@
 		"parent": null
 	},
 	{
-		"title": "Getting Started with JavaScript",
-		"slug": "javascript",
-		"markdown_source": "../docs/how-to-guides/javascript/README.md",
+		"title": "Accessibility",
+		"slug": "accessibility",
+		"markdown_source": "../docs/how-to-guides/accessibility.md",
 		"parent": "how-to-guides"
 	},
 	{
-		"title": "Plugins Background",
-		"slug": "plugins-background",
-		"markdown_source": "../docs/how-to-guides/javascript/plugins-background.md",
-		"parent": "javascript"
+		"title": "Backward Compatibility",
+		"slug": "backward-compatibility",
+		"markdown_source": "../docs/how-to-guides/backward-compatibility/README.md",
+		"parent": "how-to-guides"
 	},
 	{
-		"title": "Loading JavaScript",
-		"slug": "loading-javascript",
-		"markdown_source": "../docs/how-to-guides/javascript/loading-javascript.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Extending the Block Editor",
-		"slug": "extending-the-block-editor",
-		"markdown_source": "../docs/how-to-guides/javascript/extending-the-block-editor.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "A first-time setup guide to native mobile development (OSX)",
-		"slug": "osx-setup-guide",
-		"markdown_source": "../docs/how-to-guides/native-mobile/osx-setup-guide.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Troubleshooting",
-		"slug": "troubleshooting",
-		"markdown_source": "../docs/how-to-guides/javascript/troubleshooting.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "JavaScript Versions and Build Step",
-		"slug": "versions-and-building",
-		"markdown_source": "../docs/how-to-guides/javascript/versions-and-building.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Scope Your Code",
-		"slug": "scope-your-code",
-		"markdown_source": "../docs/how-to-guides/javascript/scope-your-code.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "JavaScript Build Setup",
-		"slug": "js-build-setup",
-		"markdown_source": "../docs/how-to-guides/javascript/js-build-setup.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "ESNext Syntax",
-		"slug": "esnext-js",
-		"markdown_source": "../docs/how-to-guides/javascript/esnext-js.md",
-		"parent": "javascript"
+		"title": "Deprecations",
+		"slug": "deprecations",
+		"markdown_source": "../docs/how-to-guides/backward-compatibility/deprecations.md",
+		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Meta Boxes",
-		"slug": "metabox",
-		"markdown_source": "../docs/how-to-guides/metabox/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Store Post Meta with a Block",
-		"slug": "meta-block-1-intro",
-		"markdown_source": "../docs/how-to-guides/metabox/meta-block-1-intro.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Register Meta Field",
-		"slug": "meta-block-2-register-meta",
-		"markdown_source": "../docs/how-to-guides/metabox/meta-block-2-register-meta.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Create Meta Block",
-		"slug": "meta-block-3-add",
-		"markdown_source": "../docs/how-to-guides/metabox/meta-block-3-add.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Use Post Meta Data",
-		"slug": "meta-block-4-use-data",
-		"markdown_source": "../docs/how-to-guides/metabox/meta-block-4-use-data.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Finishing Touches",
-		"slug": "meta-block-5-finishing",
-		"markdown_source": "../docs/how-to-guides/metabox/meta-block-5-finishing.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Displaying Notices from Your Plugin or Theme",
-		"slug": "notices",
-		"markdown_source": "../docs/how-to-guides/notices/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Creating a Sidebar for Your Plugin",
-		"slug": "plugin-sidebar-0",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Get a Sidebar up and Running",
-		"slug": "plugin-sidebar-1-up-and-running",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Tweak the sidebar style and add controls",
-		"slug": "plugin-sidebar-2-styles-and-controls",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Register the Meta Field",
-		"slug": "plugin-sidebar-3-register-meta",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Initialize the Input Control",
-		"slug": "plugin-sidebar-4-initialize-input",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Update the Meta Field When the Input's Content Changes",
-		"slug": "plugin-sidebar-5-update-meta",
-		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
-		"parent": "plugin-sidebar-0"
+		"slug": "meta-box",
+		"markdown_source": "../docs/how-to-guides/backward-compatibility/meta-box.md",
+		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Blocks",
@@ -276,102 +162,6 @@
 		"parent": "block-tutorial"
 	},
 	{
-		"title": "Themes",
-		"slug": "themes",
-		"markdown_source": "../docs/how-to-guides/themes/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Block Theme",
-		"slug": "block-theme-overview",
-		"markdown_source": "../docs/how-to-guides/themes/block-theme-overview.md",
-		"parent": "themes"
-	},
-	{
-		"title": "Create a block theme",
-		"slug": "create-block-theme",
-		"markdown_source": "../docs/how-to-guides/themes/create-block-theme.md",
-		"parent": "themes"
-	},
-	{
-		"title": "Global Settings & Styles (theme.json)",
-		"slug": "theme-json",
-		"markdown_source": "../docs/how-to-guides/themes/theme-json.md",
-		"parent": "themes"
-	},
-	{
-		"title": "Theme Support",
-		"slug": "theme-support",
-		"markdown_source": "../docs/how-to-guides/themes/theme-support.md",
-		"parent": "themes"
-	},
-	{
-		"title": "Feature Flags",
-		"slug": "feature-flags",
-		"markdown_source": "../docs/how-to-guides/feature-flags.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Backward Compatibility",
-		"slug": "backward-compatibility",
-		"markdown_source": "../docs/how-to-guides/backward-compatibility/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Deprecations",
-		"slug": "deprecations",
-		"markdown_source": "../docs/how-to-guides/backward-compatibility/deprecations.md",
-		"parent": "backward-compatibility"
-	},
-	{
-		"title": "Meta Boxes",
-		"slug": "meta-box",
-		"markdown_source": "../docs/how-to-guides/backward-compatibility/meta-box.md",
-		"parent": "backward-compatibility"
-	},
-	{
-		"title": "Introduction to the Format API",
-		"slug": "format-api",
-		"markdown_source": "../docs/how-to-guides/format-api/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Register a New Format",
-		"slug": "1-register-format",
-		"markdown_source": "../docs/how-to-guides/format-api/1-register-format.md",
-		"parent": "format-api"
-	},
-	{
-		"title": "Add a Button to the Toolbar",
-		"slug": "2-toolbar-button",
-		"markdown_source": "../docs/how-to-guides/format-api/2-toolbar-button.md",
-		"parent": "format-api"
-	},
-	{
-		"title": "Apply the Format When the Button Is Clicked",
-		"slug": "3-apply-format",
-		"markdown_source": "../docs/how-to-guides/format-api/3-apply-format.md",
-		"parent": "format-api"
-	},
-	{
-		"title": "Gutenberg as a Development Platform",
-		"slug": "platform",
-		"markdown_source": "../docs/how-to-guides/platform/README.md",
-		"parent": "how-to-guides"
-	},
-	{
-		"title": "Building a custom block editor",
-		"slug": "custom-block-editor",
-		"markdown_source": "../docs/how-to-guides/platform/custom-block-editor/README.md",
-		"parent": "platform"
-	},
-	{
-		"title": "Tutorial: building a custom block editor",
-		"slug": "tutorial",
-		"markdown_source": "../docs/how-to-guides/platform/custom-block-editor/tutorial.md",
-		"parent": "custom-block-editor"
-	},
-	{
 		"title": "Designer Documentation",
 		"slug": "designers",
 		"markdown_source": "../docs/how-to-guides/designers/README.md",
@@ -402,16 +192,226 @@
 		"parent": "designers"
 	},
 	{
-		"title": "Accessibility",
-		"slug": "accessibility",
-		"markdown_source": "../docs/how-to-guides/accessibility.md",
+		"title": "App Platform",
+		"slug": "platform",
+		"markdown_source": "../docs/how-to-guides/platform/README.md",
 		"parent": "how-to-guides"
+	},
+	{
+		"title": "Building a custom block editor",
+		"slug": "custom-block-editor",
+		"markdown_source": "../docs/how-to-guides/platform/custom-block-editor/README.md",
+		"parent": "platform"
+	},
+	{
+		"title": "Tutorial: building a custom block editor",
+		"slug": "tutorial",
+		"markdown_source": "../docs/how-to-guides/platform/custom-block-editor/tutorial.md",
+		"parent": "custom-block-editor"
+	},
+	{
+		"title": "Feature Flags",
+		"slug": "feature-flags",
+		"markdown_source": "../docs/how-to-guides/feature-flags.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Formatting Toolbar",
+		"slug": "format-api",
+		"markdown_source": "../docs/how-to-guides/format-api/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Register a New Format",
+		"slug": "1-register-format",
+		"markdown_source": "../docs/how-to-guides/format-api/1-register-format.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Add a Button to the Toolbar",
+		"slug": "2-toolbar-button",
+		"markdown_source": "../docs/how-to-guides/format-api/2-toolbar-button.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Apply the Format When the Button Is Clicked",
+		"slug": "3-apply-format",
+		"markdown_source": "../docs/how-to-guides/format-api/3-apply-format.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Getting Started with JavaScript",
+		"slug": "javascript",
+		"markdown_source": "../docs/how-to-guides/javascript/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Plugins Background",
+		"slug": "plugins-background",
+		"markdown_source": "../docs/how-to-guides/javascript/plugins-background.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Loading JavaScript",
+		"slug": "loading-javascript",
+		"markdown_source": "../docs/how-to-guides/javascript/loading-javascript.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Extending the Block Editor",
+		"slug": "extending-the-block-editor",
+		"markdown_source": "../docs/how-to-guides/javascript/extending-the-block-editor.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Troubleshooting",
+		"slug": "troubleshooting",
+		"markdown_source": "../docs/how-to-guides/javascript/troubleshooting.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "JavaScript Versions and Build Step",
+		"slug": "versions-and-building",
+		"markdown_source": "../docs/how-to-guides/javascript/versions-and-building.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Scope Your Code",
+		"slug": "scope-your-code",
+		"markdown_source": "../docs/how-to-guides/javascript/scope-your-code.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "JavaScript Build Setup",
+		"slug": "js-build-setup",
+		"markdown_source": "../docs/how-to-guides/javascript/js-build-setup.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "ESNext Syntax",
+		"slug": "esnext-js",
+		"markdown_source": "../docs/how-to-guides/javascript/esnext-js.md",
+		"parent": "javascript"
 	},
 	{
 		"title": "Internationalization",
 		"slug": "internationalization",
 		"markdown_source": "../docs/how-to-guides/internationalization.md",
 		"parent": "how-to-guides"
+	},
+	{
+		"title": "Meta Boxes",
+		"slug": "metabox",
+		"markdown_source": "../docs/how-to-guides/metabox/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Store Post Meta with a Block",
+		"slug": "meta-block-1-intro",
+		"markdown_source": "../docs/how-to-guides/metabox/meta-block-1-intro.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Register Meta Field",
+		"slug": "meta-block-2-register-meta",
+		"markdown_source": "../docs/how-to-guides/metabox/meta-block-2-register-meta.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Create Meta Block",
+		"slug": "meta-block-3-add",
+		"markdown_source": "../docs/how-to-guides/metabox/meta-block-3-add.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Use Post Meta Data",
+		"slug": "meta-block-4-use-data",
+		"markdown_source": "../docs/how-to-guides/metabox/meta-block-4-use-data.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Finishing Touches",
+		"slug": "meta-block-5-finishing",
+		"markdown_source": "../docs/how-to-guides/metabox/meta-block-5-finishing.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "A first-time setup guide to native mobile development (OSX)",
+		"slug": "osx-setup-guide",
+		"markdown_source": "../docs/how-to-guides/native-mobile/osx-setup-guide.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Notices",
+		"slug": "notices",
+		"markdown_source": "../docs/how-to-guides/notices/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Plugin Sidebar",
+		"slug": "plugin-sidebar-0",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Get a Sidebar up and Running",
+		"slug": "plugin-sidebar-1-up-and-running",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Tweak the sidebar style and add controls",
+		"slug": "plugin-sidebar-2-styles-and-controls",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Register the Meta Field",
+		"slug": "plugin-sidebar-3-register-meta",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Initialize the Input Control",
+		"slug": "plugin-sidebar-4-initialize-input",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Update the Meta Field When the Input's Content Changes",
+		"slug": "plugin-sidebar-5-update-meta",
+		"markdown_source": "../docs/how-to-guides/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Themes",
+		"slug": "themes",
+		"markdown_source": "../docs/how-to-guides/themes/README.md",
+		"parent": "how-to-guides"
+	},
+	{
+		"title": "Block Theme",
+		"slug": "block-theme-overview",
+		"markdown_source": "../docs/how-to-guides/themes/block-theme-overview.md",
+		"parent": "themes"
+	},
+	{
+		"title": "Create a block theme",
+		"slug": "create-block-theme",
+		"markdown_source": "../docs/how-to-guides/themes/create-block-theme.md",
+		"parent": "themes"
+	},
+	{
+		"title": "Global Settings & Styles (theme.json)",
+		"slug": "theme-json",
+		"markdown_source": "../docs/how-to-guides/themes/theme-json.md",
+		"parent": "themes"
+	},
+	{
+		"title": "Theme Support",
+		"slug": "theme-support",
+		"markdown_source": "../docs/how-to-guides/themes/theme-support.md",
+		"parent": "themes"
 	},
 	{
 		"title": "Thunks in Core-Data",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -216,7 +216,7 @@
 		"parent": "how-to-guides"
 	},
 	{
-		"title": "Formatting Toolbar",
+		"title": "Formatting Toolbar API",
 		"slug": "format-api",
 		"markdown_source": "../docs/how-to-guides/format-api/README.md",
 		"parent": "how-to-guides"

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -42,59 +42,15 @@
 	},
 	{
 		"docs/how-to-guides/README.md": [
+			{ "docs/how-to-guides/accessibility.md": [] },
+
 			{
-				"docs/how-to-guides/javascript/README.md": [
+				"docs/how-to-guides/backward-compatibility/README.md": [
 					{
-						"docs/how-to-guides/javascript/plugins-background.md": []
+						"docs/how-to-guides/backward-compatibility/deprecations.md": []
 					},
 					{
-						"docs/how-to-guides/javascript/loading-javascript.md": []
-					},
-					{
-						"docs/how-to-guides/javascript/extending-the-block-editor.md": []
-					},
-					{ "docs/how-to-guides/native-mobile/osx-setup-guide.md": [] },
-					{ "docs/how-to-guides/javascript/troubleshooting.md": [] },
-					{
-						"docs/how-to-guides/javascript/versions-and-building.md": []
-					},
-					{ "docs/how-to-guides/javascript/scope-your-code.md": [] },
-					{ "docs/how-to-guides/javascript/js-build-setup.md": [] },
-					{ "docs/how-to-guides/javascript/esnext-js.md": [] }
-				]
-			},
-			{
-				"docs/how-to-guides/metabox/README.md": [
-					{ "docs/how-to-guides/metabox/meta-block-1-intro.md": [] },
-					{
-						"docs/how-to-guides/metabox/meta-block-2-register-meta.md": []
-					},
-					{ "docs/how-to-guides/metabox/meta-block-3-add.md": [] },
-					{
-						"docs/how-to-guides/metabox/meta-block-4-use-data.md": []
-					},
-					{
-						"docs/how-to-guides/metabox/meta-block-5-finishing.md": []
-					}
-				]
-			},
-			{ "docs/how-to-guides/notices/README.md": [] },
-			{
-				"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md": [
-					{
-						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-1-up-and-running.md": []
-					},
-					{
-						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md": []
-					},
-					{
-						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-3-register-meta.md": []
-					},
-					{
-						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-4-initialize-input.md": []
-					},
-					{
-						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-5-update-meta.md": []
+						"docs/how-to-guides/backward-compatibility/meta-box.md": []
 					}
 				]
 			},
@@ -124,31 +80,11 @@
 				]
 			},
 			{
-				"docs/how-to-guides/themes/README.md": [
-					{ "docs/how-to-guides/themes/block-theme-overview.md": [] },
-					{ "docs/how-to-guides/themes/create-block-theme.md": [] },
-					{ "docs/how-to-guides/themes/theme-json.md": [] },
-					{ "docs/how-to-guides/themes/theme-support.md": [] }
-				]
-			},
-			{ "docs/how-to-guides/feature-flags.md": [] },
-			{
-				"docs/how-to-guides/backward-compatibility/README.md": [
-					{
-						"docs/how-to-guides/backward-compatibility/deprecations.md": []
-					},
-					{
-						"docs/how-to-guides/backward-compatibility/meta-box.md": []
-					}
-				]
-			},
-			{
-				"docs/how-to-guides/format-api/README.md": [
-					{
-						"docs/how-to-guides/format-api/1-register-format.md": []
-					},
-					{ "docs/how-to-guides/format-api/2-toolbar-button.md": [] },
-					{ "docs/how-to-guides/format-api/3-apply-format.md": [] }
+				"docs/how-to-guides/designers/README.md": [
+					{ "docs/how-to-guides/designers/block-design.md": [] },
+					{ "docs/how-to-guides/designers/user-interface.md": [] },
+					{ "docs/how-to-guides/designers/design-resources.md": [] },
+					{ "docs/how-to-guides/designers/animation.md": [] }
 				]
 			},
 			{
@@ -162,16 +98,81 @@
 					}
 				]
 			},
+			{ "docs/how-to-guides/feature-flags.md": [] },
 			{
-				"docs/how-to-guides/designers/README.md": [
-					{ "docs/how-to-guides/designers/block-design.md": [] },
-					{ "docs/how-to-guides/designers/user-interface.md": [] },
-					{ "docs/how-to-guides/designers/design-resources.md": [] },
-					{ "docs/how-to-guides/designers/animation.md": [] }
+				"docs/how-to-guides/format-api/README.md": [
+					{
+						"docs/how-to-guides/format-api/1-register-format.md": []
+					},
+					{ "docs/how-to-guides/format-api/2-toolbar-button.md": [] },
+					{ "docs/how-to-guides/format-api/3-apply-format.md": [] }
 				]
 			},
-			{ "docs/how-to-guides/accessibility.md": [] },
+			{
+			"docs/how-to-guides/javascript/README.md": [
+					{
+						"docs/how-to-guides/javascript/plugins-background.md": []
+					},
+					{
+						"docs/how-to-guides/javascript/loading-javascript.md": []
+					},
+					{
+						"docs/how-to-guides/javascript/extending-the-block-editor.md": []
+					},
+					{ "docs/how-to-guides/javascript/troubleshooting.md": [] },
+					{
+						"docs/how-to-guides/javascript/versions-and-building.md": []
+					},
+					{ "docs/how-to-guides/javascript/scope-your-code.md": [] },
+					{ "docs/how-to-guides/javascript/js-build-setup.md": [] },
+					{ "docs/how-to-guides/javascript/esnext-js.md": [] }
+				]
+			},
 			{ "docs/how-to-guides/internationalization.md": [] },
+			{
+				"docs/how-to-guides/metabox/README.md": [
+					{ "docs/how-to-guides/metabox/meta-block-1-intro.md": [] },
+					{
+						"docs/how-to-guides/metabox/meta-block-2-register-meta.md": []
+					},
+					{ "docs/how-to-guides/metabox/meta-block-3-add.md": [] },
+					{
+						"docs/how-to-guides/metabox/meta-block-4-use-data.md": []
+					},
+					{
+						"docs/how-to-guides/metabox/meta-block-5-finishing.md": []
+					}
+				]
+			},
+			{ "docs/how-to-guides/native-mobile/osx-setup-guide.md": [] },
+			{ "docs/how-to-guides/notices/README.md": [] },
+			{
+				"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-0.md": [
+					{
+						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-1-up-and-running.md": []
+					},
+					{
+						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md": []
+					},
+					{
+						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-3-register-meta.md": []
+					},
+					{
+						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-4-initialize-input.md": []
+					},
+					{
+						"docs/how-to-guides/sidebar-tutorial/plugin-sidebar-5-update-meta.md": []
+					}
+				]
+			},
+			{
+				"docs/how-to-guides/themes/README.md": [
+					{ "docs/how-to-guides/themes/block-theme-overview.md": [] },
+					{ "docs/how-to-guides/themes/create-block-theme.md": [] },
+					{ "docs/how-to-guides/themes/theme-json.md": [] },
+					{ "docs/how-to-guides/themes/theme-support.md": [] }
+				]
+			},
 			{ "docs/how-to-guides/thunks.md": [] },
 			{
 				"docs/how-to-guides/widgets/README.md": [


### PR DESCRIPTION

## Description

To make it easier to browse and find items in the How to Guides section, this
alphabetizes the list and updates some of the document names to shorter titles
that allow for easier scaning.

Changes are:

- Gutenberg as a Development Platform => App Platform

- Introduction to the Format API => Formatting Toolbar

- Displaying Notices from Your Plugin or Theme => Notices

- Creating a Sidebar for Your Plugin => Plugin Sidebar


In a separate PR I will move the "Getting Started with JavaScript" to the Getting Started section out of the How To Guides, so that was left unchanged.

## How has this been tested?

- Confirm the table of contents organization looks correct (I used cold folding to help wrangle the JSON).
- Confirm new titles are spelled correctly and appropriate.
- Confirm additional text in Plugin Sidebar makes sense.

## Types of changes

- An organization change of table of contents
- Modified titles of four pages
- Added additional context about plugin sidebar

