### PR TITLE
fix/35709: set admin color scheme to angle color picker

### DIFF
--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -49,7 +49,9 @@ export default function AnglePickerControl( {
 						<Spacer
 							as={ Text }
 							marginRight={ space( 3 ) }
-							color="blue"
+							style={ {
+								color: 'var( --wp-admin-theme-color )',
+							} }
 						>
 							°
 						</Spacer>

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -36,9 +36,9 @@ export const CircleIndicatorWrapper = styled.div`
 `;
 
 export const CircleIndicator = styled.div`
-	background: #3858e9;
+	background: ${ COLORS.admin.theme };
 	border-radius: 50%;
-	border: ${ INNER_CIRCLE_SIZE }px solid #3858e9;
+	border: ${ INNER_CIRCLE_SIZE }px solid ${ COLORS.admin.theme };
 	bottom: 0;
 	box-sizing: border-box;
 	display: block;


### PR DESCRIPTION
Closes #35709

## Description
Uses Admin theme color for AnglePickerControl.

## How has this been tested?
Tested the 'Cover' block which uses this component.

## Screenshots <!-- if applicable -->
<img width="269" alt="Screen Shot 2021-10-25 at 9 34 18 AM" src="https://user-images.githubusercontent.com/17757960/138632955-cb6723a2-dca6-4d02-84f8-0ab03635c8a8.png">


## Types of changes
Styled Component changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
