### PR TITLE
Remove "experimental" from URL details REST controller and promote to `v1` namespace

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -19,7 +19,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * Constructs the controller.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp-block-editor/v1';
 		$this->rest_base = 'url-details';
 	}
 

--- a/packages/core-data/src/fetch/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-url-data.js
@@ -45,7 +45,7 @@ const CACHE = new Map();
  * @return {Promise< WPRemoteUrlData[] >} Remote URL data.
  */
 const fetchUrlData = async ( url, options = {} ) => {
-	const endpoint = '/__experimental/url-details';
+	const endpoint = '/wp-block-editor/v1/url-details';
 
 	const args = {
 		url: prependHTTP( url ),

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -20,7 +20,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 	protected static $admin_id;
 	protected static $subscriber_id;
-	protected static $route           = '/__experimental/url-details';
+	protected static $route           = '/wp-block-editor/v1/url-details';
 	protected static $url_placeholder = 'https://placeholder-site.com';
 	protected static $request_args    = array();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
As per https://github.com/WordPress/gutenberg/issues/35756#issuecomment-946974745 this PR removes the experimental status from the URL Details endpoint and promotes it to a first class API endpoint under the `wp-block-editor/v1` namespace.

This PR also updates tests and client side code to utilise the new namespace.

Also includes some fixes to whitespace which were applied automatically. I guess I can get rid of those if it's annoying.

## How has this been tested?

Firstly check all the existing PHP unit tests are passing on this PR for the endpoint.

Next check the client side "rich preview" functionality is still working as expected:

1. New Post.
2. Create a link to some URL (`wordpress.org` brings up a nice rich preview).
3. Open devtools on Network tab and filter by search term `url-details`.
4. Click on link to open Link preview.
5. See link preview retrieved for that URL correctly.
6. See network request sent to the `wp-block-editor/v1/url-details` endpoint.

## Screenshots <!-- if applicable -->
<img width="946" alt="Screen Shot 2021-10-25 at 10 15 37" src="https://user-images.githubusercontent.com/444434/138669724-15895d0f-35ee-4784-a89b-2cc3523f4297.png">

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
