### PR TITLE
Try: reword navigation color labels.

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -345,12 +345,12 @@ function Navigation( {
 							{
 								value: overlayTextColor.color,
 								onChange: setOverlayTextColor,
-								label: __( 'Overlay text' ),
+								label: __( 'Submenu & overlay text' ),
 							},
 							{
 								value: overlayBackgroundColor.color,
 								onChange: setOverlayBackgroundColor,
-								label: __( 'Overlay background' ),
+								label: __( 'Submenu & overlay background' ),
 							},
 						] }
 					>


### PR DESCRIPTION
## Description

Fixes #33640. Before:

<img width="333" alt="Screenshot 2021-10-25 at 11 33 55" src="https://user-images.githubusercontent.com/1204802/138672370-b890a6eb-1f84-4ab0-8f37-46268c3aac67.png">

After:

<img width="293" alt="Screenshot 2021-10-25 at 11 35 47" src="https://user-images.githubusercontent.com/1204802/138672390-a5b783da-96d1-4f10-a97c-4ad26ff5f704.png">

There will be a point in the future where the color palettes are collapsed into `ItemGroup`s, at which point the verbiage conversation might resurface ([see thoughts and mockups in this comment](https://github.com/WordPress/gutenberg/issues/33640#issuecomment-948394611)), but in the mean time, this tiny fix makes the color choices more obvious.

## How has this been tested?

Insert the navigation block, observe the color panel in the inspector has new labels.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
