### PR TITLE
Try: Mobile responsive navigation by default.

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -46,7 +46,7 @@
 		},
 		"overlayMenu": {
 			"type": "string",
-			"default": "never"
+			"default": "mobile"
 		},
 		"__unstableLocation": {
 			"type": "string"

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -7,7 +7,7 @@
 			"orientation": "horizontal",
 			"showSubmenuIcon": true,
 			"openSubmenusOnClick": false,
-			"overlayMenu": "never"
+			"overlayMenu": "mobile"
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"overlayMenu":"mobile"} -->
+<!-- wp:navigation -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"fontFamily":"cambria-georgia"} /-->
+<!-- wp:navigation {"overlayMenu":"never","fontFamily":"cambria-georgia"} /-->


### PR DESCRIPTION
## Description

Fixes #34511. Changes the navigation block to have mobile on by default:

<img width="1270" alt="Screenshot 2021-10-25 at 11 48 28" src="https://user-images.githubusercontent.com/1204802/138674123-6bd5bf5c-b80a-48e2-bc15-aa26adfbdf32.png">

## How has this been tested?

Insert a navigation block, start empty or add all pages, and verify the menu starts out responsive by default.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
