### PR TITLE
Rich text: remove syncing of upgraded formats

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -101,21 +101,6 @@ export function useRichText( {
 
 	if ( ! record.current ) {
 		setRecordFromProps();
-		// Sometimes formats are added programmatically and we need to make
-		// sure it's persisted to the block store / markup. If these formats
-		// are not applied, they could cause inconsistencies between the data
-		// in the visual editor and the frontend. Right now, it's only relevant
-		// to the `core/text-color` format, which is applied at runtime in
-		// certain circunstances. See the `__unstableFilterAttributeValue`
-		// function in `packages/format-library/src/text-color/index.js`.
-		// @todo find a less-hacky way of solving this.
-
-		const hasRelevantInitFormat =
-			record.current?.formats[ 0 ]?.[ 0 ]?.type === 'core/text-color';
-
-		if ( hasRelevantInitFormat ) {
-			handleChangesUponInit( record.current );
-		}
 	} else if (
 		selectionStart !== record.current.start ||
 		selectionEnd !== record.current.end
@@ -160,31 +145,6 @@ export function useRichText( {
 		// We batch both calls to only attempt to rerender once.
 		registry.batch( () => {
 			onSelectionChange( start, end );
-			onChange( _value.current, {
-				__unstableFormats: formats,
-				__unstableText: text,
-			} );
-		} );
-		forceRender();
-	}
-
-	function handleChangesUponInit( newRecord ) {
-		record.current = newRecord;
-
-		_value.current = toHTMLString( {
-			value: __unstableBeforeSerialize
-				? {
-						...newRecord,
-						formats: __unstableBeforeSerialize( newRecord ),
-				  }
-				: newRecord,
-			multilineTag,
-			preserveWhiteSpace,
-		} );
-
-		const { formats, text } = newRecord;
-
-		registry.batch( () => {
 			onChange( _value.current, {
 				__unstableFormats: formats,
 				__unstableText: text,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

See #35516, which added logic to sync rich text values when formatting has upgraded (e.g. from a span to a mark tag).
This makes things more complex for little benefit. If there is text colors with spans in the text, there's no need to update them all, we can leave the old color span intact. We only need to make sure that the color looks fine visually.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
