### PR TITLE
[Block Editor] Remove visual clue from text alignment toolbar

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -56,7 +56,6 @@ exports[`AlignmentUI should allow custom alignment controls to be specified 1`] 
   }
   toggleProps={
     Object {
-      "className": "is-pressed",
       "describedBy": "Change text alignment",
     }
   }
@@ -134,7 +133,6 @@ exports[`AlignmentUI should match snapshot 1`] = `
   }
   toggleProps={
     Object {
-      "className": "is-pressed",
       "describedBy": "Change text alignment",
     }
   }

--- a/packages/block-editor/src/components/alignment-control/ui.js
+++ b/packages/block-editor/src/components/alignment-control/ui.js
@@ -63,10 +63,7 @@ function AlignmentUI( {
 		<UIComponent
 			icon={ setIcon() }
 			label={ label }
-			toggleProps={ {
-				describedBy,
-				className: activeAlignment ? 'is-pressed' : undefined,
-			} }
+			toggleProps={ { describedBy } }
 			popoverProps={ POPOVER_PROPS }
 			controls={ alignmentControls.map( ( control ) => {
 				const { align } = control;


### PR DESCRIPTION
This PR just removes the visual clue from text alignment toolbar per[ this comment ](https://github.com/WordPress/gutenberg/pull/35822#issuecomment-948362099)from @jasmussen 

>On a separate note, and not something to fix here, I noticed text aligns have this "hint" coloration:

<img width="528" alt="Screenshot 2021-10-21 at 10 02 34" src="https://user-images.githubusercontent.com/1204802/138236708-4b83bfaf-fbaa-4a87-89a1-568ee1c9d82a.png">

>It shouldn't, that's toggle/inversion style is only for the inline formatting menu. For these alignments, the icon itself changes, which is sufficient.

## Testing instructions
1. insert a block with `text alignment toolbar` like `Heading or Paragraph`
2. change `text alignment` and observe that the selected alignment is not highlighted