### PR TITLE
Docs: Update the recommendation for the cadence of npm releases

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -152,9 +152,9 @@ The Gutenberg repository mirrors the [WordPress SVN repository](https://make.wor
 
 Release types and their schedule:
 
--   [Synchronizing WordPress Trunk](#synchronizing-wordpress-trunk) (`latest` dist tag) – when there is no "feature-freeze" mode in WordPress Core, publishing happens every two weeks based on the new stable version of the Gutenberg plugin. Otherwise, only bug fixes get manually included and published to npm before every next beta and RC version of the following WordPress release.
+-   [Synchronizing WordPress Trunk](#synchronizing-wordpress-trunk) (`latest` dist tag) – when there is no "feature-freeze" mode in WordPress Core, publishing happens every two weeks based on the newly created RC1 version of the Gutenberg plugin. Otherwise, only bug fixes get manually included and published to npm before every next beta and RC version of the following WordPress release.
 -   [Minor WordPress Releases](#minor-wordpress-releases) (`patch` dist tag) – only when bug fixes or security releases need to be backported into WordPress Core.
--   [Development Releases](#development-releases) (`next` dist tag) – at least every two weeks when the RC version for the Gutenberg plugin is released.
+-   [Development Releases](#development-releases) (`next` dist tag) – when there is a "feature-freeze" mode in WordPress Core, publishing can still happen every two weeks based on the new RC1 version of the Gutenberg plugin. It is also possible to perform development releases at any time when there is a need to test the upcoming changes.
 
 There is also an option to perform [Standalone Bugfix Package Releases](#standalone-bugfix-package-releases) at will. It should be reserved only for critical bug fixes or security releases that must be published to _npm_ outside of a regular WordPress release cycle.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I'm proposing we change the moment when npm publishing is performed in relation to the Gutenberg plugin release. It's a recurring issue that we run into conflicts in the CHANGELOG files because new changes get added between the plugin's RC1 and the actual release. When we publish to npm a week after the plugin's RC1 we often see newer entries attributed to the previous npm release. A recent example would be https://github.com/WordPress/gutenberg/pull/35886.

If we would start doing npm publishing just after the release branch is created for the Gutenberg plugin we would completely remove the chances to mess up with entries in the CHANGELOG files. All changes applied to CHANGELOG files at the time npm publishing would get cherry-picked before any new unreleased entries would get added from the in-progress PRs. In addition to that, the most important is the quality of the Gutenberg plugin and WordPress core so we can consider publishing to npm earlier as a another way to catch any integration issues early on.