### PR TITLE
[Block Editor]: Try marking BlockList as non-Root component

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -31,7 +31,11 @@ const elementContext = createContext();
 
 export const IntersectionObserver = createContext();
 
-function Root( { className, ...settings } ) {
+function Root( {
+	className,
+	__experimentalIsRootContainer = true,
+	...settings
+} ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, isNavigationMode } = useSelect(
@@ -55,7 +59,8 @@ function Root( { className, ...settings } ) {
 				useInBetweenInserter(),
 				setElement,
 			] ),
-			className: classnames( 'is-root-container', className, {
+			className: classnames( className, {
+				'is-root-container': __experimentalIsRootContainer,
 				'is-outline-mode': isOutlineMode,
 				'is-focus-mode': isFocusMode && isLargeViewport,
 				'is-navigate-mode': isNavigationMode,

--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -119,9 +119,5 @@
 				}
 			}
 		}
-
-		.block-list-appender {
-			display: none;
-		}
 	}
 }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -16,7 +16,11 @@ import { store } from '../../store';
 // This is used to avoid rendering the block list if the sizes change.
 let MemoizedBlockList;
 
-function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
+function AutoBlockPreview( {
+	viewportWidth,
+	__experimentalPadding,
+	__experimentalIsRootContainer,
+} ) {
 	const [
 		containerResizeListener,
 		{ width: containerWidth },
@@ -65,7 +69,12 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 					} }
 				>
 					{ contentResizeListener }
-					<MemoizedBlockList renderAppender={ false } />
+					<MemoizedBlockList
+						renderAppender={ false }
+						__experimentalIsRootContainer={
+							__experimentalIsRootContainer
+						}
+					/>
 				</Iframe>
 			</Disabled>
 		</div>

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -23,6 +23,7 @@ export function BlockPreview( {
 	viewportWidth = 1200,
 	__experimentalLive = false,
 	__experimentalOnClick,
+	__experimentalIsRootContainer = true,
 } ) {
 	const originalSettings = useSelect(
 		( select ) => select( blockEditorStore ).getSettings(),
@@ -40,11 +41,19 @@ export function BlockPreview( {
 	return (
 		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
 			{ __experimentalLive ? (
-				<LiveBlockPreview onClick={ __experimentalOnClick } />
+				<LiveBlockPreview
+					onClick={ __experimentalOnClick }
+					__experimentalIsRootContainer={
+						__experimentalIsRootContainer
+					}
+				/>
 			) : (
 				<AutoHeightBlockPreview
 					viewportWidth={ viewportWidth }
 					__experimentalPadding={ __experimentalPadding }
+					__experimentalIsRootContainer={
+						__experimentalIsRootContainer
+					}
 				/>
 			) }
 		</BlockEditorProvider>

--- a/packages/block-editor/src/components/block-preview/live.js
+++ b/packages/block-editor/src/components/block-preview/live.js
@@ -8,7 +8,10 @@ import { Disabled } from '@wordpress/components';
  */
 import BlockList from '../block-list';
 
-export default function LiveBlockPreview( { onClick } ) {
+export default function LiveBlockPreview( {
+	onClick,
+	__experimentalIsRootContainer,
+} ) {
 	return (
 		<div
 			tabIndex={ 0 }
@@ -17,7 +20,12 @@ export default function LiveBlockPreview( { onClick } ) {
 			onKeyPress={ onClick }
 		>
 			<Disabled>
-				<BlockList />
+				<BlockList
+					renderAppender={ false }
+					__experimentalIsRootContainer={
+						__experimentalIsRootContainer
+					}
+				/>
 			</Disabled>
 		</div>
 	);

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -158,6 +158,7 @@ export default function PostTemplateEdit( {
 									__experimentalOnClick={ () =>
 										setActiveBlockContext( blockContext )
 									}
+									__experimentalIsRootContainer={ false }
 								/>
 							</li>
 						) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/33248

From the issue:
>While using wide alignment on a Query block the width is only applied to the currently selected post while in the editor. The frontend shows the correct alignment for all posts

Editor | Frontent
--- | ---
<img width="984" alt="Screenshot 2021-07-07 at 10 00 58" src="https://user-images.githubusercontent.com/3593343/124723123-fea7aa00-df0a-11eb-9c62-a24fe76c45b4.png"> | <img width="1623" alt="Screenshot 2021-07-07 at 10 03 26" src="https://user-images.githubusercontent.com/3593343/124723120-fd767d00-df0a-11eb-8b01-08b281592b4a.png">

## The problem
Currently all the `BlockPreviews` use cases (ex Block previews in inserter, Styles, etc..) don't need to be aware of any parent alignments. The exception of that is `Query Loop` and specifically the `Post Template` block (and soon the `Comments Loop` block) which internally use the `BlockPreview` to achieve an emulation of how the final result will look like. I'm not sure if this fix is the right approach, but especially with patterns there might be more cases in the future? 🤔 

An alternative might be using override css, but I don't think it would scale well, as any change in the `root-container` styles would also require change for the overrides.

## Testing instructions
1. Using a block theme that supports alignments (like tt1-blocks)
2. In a page insert `Query Loop` block and set  `full or wide` alignment.
3. Observe that the inactive `posts` of the `Query Loop` respect their parent alignment
