### PR TITLE
Editor: Multi-Entity Saving UI Improvements

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -38,10 +38,7 @@ export default function EntityRecordItem( {
 	// Handle templates that might use default descriptive titles
 	const entityRecordTitle = useSelect(
 		( select ) => {
-			if (
-				'postType' !== kind ||
-				! [ 'wp_template', 'wp_template_part' ].includes( name )
-			) {
+			if ( 'postType' !== kind || 'wp_template' !== name ) {
 				return title;
 			}
 
@@ -50,25 +47,9 @@ export default function EntityRecordItem( {
 				name,
 				key
 			);
-
-			if ( name === 'wp_template' ) {
-				return select( editorStore ).__experimentalGetTemplateInfo(
-					template
-				).title;
-			}
-
-			if ( name === 'wp_template_part' ) {
-				const templatePartAreas = select(
-					editorStore
-				).__experimentalGetDefaultTemplatePartAreas();
-
-				return (
-					templatePartAreas.find(
-						( templatePartArea ) =>
-							templatePartArea.area === template.area
-					)?.label ?? title
-				);
-			}
+			return select( editorStore ).__experimentalGetTemplateInfo(
+				template
+			).title;
 		},
 		[ name, kind, title, key ]
 	);

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -38,7 +38,10 @@ export default function EntityRecordItem( {
 	// Handle templates that might use default descriptive titles
 	const entityRecordTitle = useSelect(
 		( select ) => {
-			if ( 'postType' !== kind || 'wp_template' !== name ) {
+			if (
+				'postType' !== kind ||
+				! [ 'wp_template', 'wp_template_part' ].includes( name )
+			) {
 				return title;
 			}
 
@@ -47,9 +50,25 @@ export default function EntityRecordItem( {
 				name,
 				key
 			);
-			return select( editorStore ).__experimentalGetTemplateInfo(
-				template
-			).title;
+
+			if ( name === 'wp_template' ) {
+				return select( editorStore ).__experimentalGetTemplateInfo(
+					template
+				).title;
+			}
+
+			if ( name === 'wp_template_part' ) {
+				const templatePartAreas = select(
+					editorStore
+				).__experimentalGetDefaultTemplatePartAreas();
+
+				return (
+					templatePartAreas.find(
+						( templatePartArea ) =>
+							templatePartArea.area === template.area
+					)?.label ?? title
+				);
+			}
 		},
 		[ name, kind, title, key ]
 	);

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -6,8 +6,9 @@ import { some } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, PanelRow } from '@wordpress/components';
 import { page, layout } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -19,6 +20,13 @@ import EntityRecordItem from './entity-record-item';
 const ENTITY_NAME_ICONS = {
 	site: layout,
 	page,
+};
+
+const ENTITY_NAME_DESCRIPTIONS = {
+	site: __( 'These changes will affect your whole site.' ),
+	wp_template: __(
+		'These changes will affect pages and posts that use these templates.'
+	),
 };
 
 export default function EntityTypeList( {
@@ -34,12 +42,14 @@ export default function EntityTypeList( {
 		[ firstRecord.kind, firstRecord.name ]
 	);
 
-	// Set icon based on type of entity.
+	// Set icon and description based on type of entity.
 	const { name } = firstRecord;
 	const icon = ENTITY_NAME_ICONS[ name ];
+	const description = ENTITY_NAME_DESCRIPTIONS[ name ];
 
 	return (
 		<PanelBody title={ entity.label } initialOpen={ true } icon={ icon }>
+			{ description ? <PanelRow>{ description }</PanelRow> : null }
 			{ list.map( ( record ) => {
 				return (
 					<EntityRecordItem

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -49,13 +49,16 @@ export default function EntityTypeList( {
 			select( coreStore ).getEntity( firstRecord.kind, firstRecord.name ),
 		[ firstRecord.kind, firstRecord.name ]
 	);
-
-	// Set description based on type of entity.
 	const { name } = firstRecord;
+	const entityLabel =
+		name === 'wp_template_part'
+			? _n( 'Template Part', 'Template Parts', list.length )
+			: entity.label;
+	// Set description based on type of entity.
 	const description = getEntityDescription( name, list.length );
 
 	return (
-		<PanelBody title={ entity.label } initialOpen={ true }>
+		<PanelBody title={ entityLabel } initialOpen={ true }>
 			{ description && <PanelRow>{ description }</PanelRow> }
 			{ list.map( ( record ) => {
 				return (

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -17,24 +17,23 @@ import { store as coreStore } from '@wordpress/core-data';
 import EntityRecordItem from './entity-record-item';
 
 function getEntityDescription( entity, length ) {
-	const descriptions = {
-		site: _n(
-			'This change will affect your whole site.',
-			'These changes will affect your whole site.',
-			length
-		),
-		wp_template: _n(
-			'This change will affect pages and posts that use this template.',
-			'These changes will affect pages and posts that use these templates.',
-			length
-		),
-		wp_template_part: '', // No separate description for template parts.
-	};
-
-	return (
-		descriptions[ entity ] ??
-		__( 'The following content has been modified.' )
-	);
+	switch ( entity ) {
+		case 'site':
+			return _n(
+				'This change will affect your whole site.',
+				'These changes will affect your whole site.',
+				length
+			);
+		case 'wp_template':
+			return _n(
+				'This change will affect pages and posts that use this template.',
+				'These changes will affect pages and posts that use these templates.',
+				length
+			);
+		case 'page':
+		case 'post':
+			return __( 'The following content has been modified.' );
+	}
 }
 
 export default function EntityTypeList( {

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -31,7 +31,7 @@ const ENTITY_NAME_DESCRIPTIONS = {
 		),
 	wp_template: ( length ) =>
 		_n(
-			'This change will affect pages and posts that use these templates.',
+			'This change will affect pages and posts that use this template.',
 			'These changes will affect pages and posts that use these templates.',
 			length
 		),

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -9,18 +9,12 @@ import { some } from 'lodash';
 import { _n } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
-import { page, layout } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import EntityRecordItem from './entity-record-item';
-
-const ENTITY_NAME_ICONS = {
-	site: layout,
-	page,
-};
 
 const ENTITY_NAME_DESCRIPTIONS = {
 	site: ( length ) =>
@@ -50,13 +44,12 @@ export default function EntityTypeList( {
 		[ firstRecord.kind, firstRecord.name ]
 	);
 
-	// Set icon and description based on type of entity.
+	// Set description based on type of entity.
 	const { name } = firstRecord;
-	const icon = ENTITY_NAME_ICONS[ name ];
 	const description = ENTITY_NAME_DESCRIPTIONS[ name ]?.( list.length );
 
 	return (
-		<PanelBody title={ entity.label } initialOpen={ true } icon={ icon }>
+		<PanelBody title={ entity.label } initialOpen={ true }>
 			{ description ? <PanelRow>{ description }</PanelRow> : null }
 			{ list.map( ( record ) => {
 				return (

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -28,6 +28,7 @@ function getEntityDescription( entity, length ) {
 			'These changes will affect pages and posts that use these templates.',
 			length
 		),
+		wp_template_part: '', // No separate description for template parts.
 	};
 
 	return (

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -6,7 +6,7 @@ import { some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { _n } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -16,20 +16,25 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import EntityRecordItem from './entity-record-item';
 
-const ENTITY_NAME_DESCRIPTIONS = {
-	site: ( length ) =>
-		_n(
+function getEntityDescription( entity, length ) {
+	const descriptions = {
+		site: _n(
 			'This change will affect your whole site.',
 			'These changes will affect your whole site.',
 			length
 		),
-	wp_template: ( length ) =>
-		_n(
+		wp_template: _n(
 			'This change will affect pages and posts that use this template.',
 			'These changes will affect pages and posts that use these templates.',
 			length
 		),
-};
+	};
+
+	return (
+		descriptions[ entity ] ??
+		__( 'The following content has been modified.' )
+	);
+}
 
 export default function EntityTypeList( {
 	list,
@@ -46,7 +51,7 @@ export default function EntityTypeList( {
 
 	// Set description based on type of entity.
 	const { name } = firstRecord;
-	const description = ENTITY_NAME_DESCRIPTIONS[ name ]?.( list.length );
+	const description = getEntityDescription( name, list.length );
 
 	return (
 		<PanelBody title={ entity.label } initialOpen={ true }>

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -50,7 +50,7 @@ export default function EntityTypeList( {
 
 	return (
 		<PanelBody title={ entity.label } initialOpen={ true }>
-			{ description ? <PanelRow>{ description }</PanelRow> : null }
+			{ description && <PanelRow>{ description }</PanelRow> }
 			{ list.map( ( record ) => {
 				return (
 					<EntityRecordItem

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -6,7 +6,7 @@ import { some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { _n } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { page, layout } from '@wordpress/icons';
@@ -23,10 +23,18 @@ const ENTITY_NAME_ICONS = {
 };
 
 const ENTITY_NAME_DESCRIPTIONS = {
-	site: __( 'These changes will affect your whole site.' ),
-	wp_template: __(
-		'These changes will affect pages and posts that use these templates.'
-	),
+	site: ( length ) =>
+		_n(
+			'This change will affect your whole site.',
+			'These changes will affect your whole site.',
+			length
+		),
+	wp_template: ( length ) =>
+		_n(
+			'This change will affect pages and posts that use these templates.',
+			'These changes will affect pages and posts that use these templates.',
+			length
+		),
 };
 
 export default function EntityTypeList( {
@@ -45,7 +53,7 @@ export default function EntityTypeList( {
 	// Set icon and description based on type of entity.
 	const { name } = firstRecord;
 	const icon = ENTITY_NAME_ICONS[ name ];
-	const description = ENTITY_NAME_DESCRIPTIONS[ name ];
+	const description = ENTITY_NAME_DESCRIPTIONS[ name ]?.( list.length );
 
 	return (
 		<PanelBody title={ entity.label } initialOpen={ true } icon={ icon }>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -172,10 +172,10 @@ export default function EntitiesSavedStates( { close } ) {
 			</div>
 
 			<div className="entities-saved-states__text-prompt">
-				<strong>{ __( 'Select the changes you want to save' ) }</strong>
+				<strong>{ __( 'Are you ready to save?' ) }</strong>
 				<p>
 					{ __(
-						'Some changes may affect other areas of your site.'
+						'The following changes have been made to your site, templates, and content.'
 					) }
 				</p>
 			</div>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -68,9 +68,21 @@ export default function EntitiesSavedStates( { close } ) {
 	} = useDispatch( coreStore );
 
 	// To group entities by type.
-	const partitionedSavables = Object.values(
-		groupBy( dirtyEntityRecords, 'name' )
-	);
+	const partitionedSavables = groupBy( dirtyEntityRecords, 'name' );
+
+	// Sort entity groups.
+	const {
+		site: siteSavables,
+		wp_template: templateSavables,
+		wp_template_part: templatePartSavables,
+		...contentSavables
+	} = partitionedSavables;
+	const sortedPartitionedSavables = [
+		siteSavables,
+		templateSavables,
+		templatePartSavables,
+		...Object.values( contentSavables ),
+	];
 
 	// Unchecked entities to be ignored by save function.
 	const [ unselectedEntities, _setUnselectedEntities ] = useState( [] );
@@ -168,7 +180,7 @@ export default function EntitiesSavedStates( { close } ) {
 				</p>
 			</div>
 
-			{ partitionedSavables.map( ( list ) => {
+			{ sortedPartitionedSavables.map( ( list ) => {
 				return (
 					<EntityTypeList
 						key={ list[ 0 ].name }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -82,7 +82,7 @@ export default function EntitiesSavedStates( { close } ) {
 		templateSavables,
 		templatePartSavables,
 		...Object.values( contentSavables ),
-	];
+	].filter( Array.isArray );
 
 	// Unchecked entities to be ignored by save function.
 	const [ unselectedEntities, _setUnselectedEntities ] = useState( [] );


### PR DESCRIPTION
## Description
Closes part of #31456.

- Update panel header
- Add entity descriptions to site and template sections
- Sort entities (site before templates before template types before content)

## How has this been tested?
- Use the TT1 Blocks theme.
- Go to the Site Editor, and select the Single Post Template to edit.
- Make a few minor changes: Change the site title and tagline; insert a paragraph block with some text near the post content; change the address in the site footer.
- Click 'Save'.

## Screenshots

| Before | After |
|-------|-------|
|![image](https://user-images.githubusercontent.com/96308/138758681-40f3c871-6796-4b51-96e9-f7a60deb45bb.png)|![image](https://user-images.githubusercontent.com/96308/138757208-e625956a-409a-488c-85d8-372f7580274b.png)|

# Follow-up

I'd like to add the second screen from https://github.com/WordPress/gutenberg/issues/31456#issuecomment-888218396 (where users can discard changes they've made) in a follow-up PR.
