### PR TITLE
Update: Use small button on tools panel toggle

### DIFF
--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -69,14 +69,10 @@ export const ToolsPanelHeader = css`
 	 */
 	.components-dropdown-menu {
 		margin: ${ space( -1 ) } 0;
-		height: ${ space( 6 ) };
-
-		.components-dropdown-menu__toggle {
-			padding: 0;
-			height: ${ space( 6 ) };
-			min-width: ${ space( 6 ) };
-			width: ${ space( 6 ) };
-		}
+	}
+	&&&& .components-dropdown-menu__toggle {
+		padding: 0;
+		min-width: ${ space( 6 ) };
 	}
 `;
 

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -153,6 +153,7 @@ const ToolsPanelHeader = (
 					icon={ dropDownMenuIcon }
 					label={ dropDownMenuLabelText }
 					menuProps={ { className: dropdownMenuClassName } }
+					toggleProps={ { isSmall: true } }
 				>
 					{ ( { onClose = noop } ) => (
 						<>


### PR DESCRIPTION
The tools panel toggle button is a small 24px button. We have a prop on the button that when true renders a 24px button. The tools panel was not using this prop and I guess for semantic and consistency we should use it. This PR just applies a small change so the prop is used.

Unfortunately, we still need some specific styles that I hope we get rid of them soon.
