### PR TITLE
Gallery block: Remove the arbitrary alt text that is added to gallery images

### DIFF
--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -3,11 +3,6 @@
  */
 import { get, pick } from 'lodash';
 
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
 export function defaultColumnsNumber( imageCount ) {
 	return imageCount ? Math.min( 3, imageCount ) : 3;
 }
@@ -24,7 +19,5 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	if ( fullUrl ) {
 		imageProps.fullUrl = fullUrl;
 	}
-	imageProps.alt =
-		imageProps.alt !== '' ? imageProps.alt : __( 'Image gallery image' );
 	return imageProps;
 };


### PR DESCRIPTION
## Description
Removes the default alt text that is being added to gallery images with no alt text set based on [this accessibility discussion](https://github.com/WordPress/gutenberg/issues/13164#issuecomment-475050797), and [this comment](https://github.com/WordPress/gutenberg/issues/13164#issuecomment-950435021).

## Testing

- Check out this PR and enable the gallery experiment
- Add a gallery and add some images, some with an alt text set in the media library and some without
- Make sure those images that had an alt text set have the correct alt text copied over to the library and that those that didn't have an empty alt text


