### PR TITLE
Border panel: Update panel layout

### DIFF
--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -92,6 +92,7 @@ export function BorderColorEdit( props ) {
 			disableCustomColors={ disableCustomColors }
 			disableCustomGradients={ disableCustomGradients }
 			onColorChange={ onChangeColor }
+			clearable={ false }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/border.scss
+++ b/packages/block-editor/src/hooks/border.scss
@@ -1,0 +1,5 @@
+.border-block-support-panel {
+	.single-column {
+		grid-column: span 1;
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -54,6 +54,7 @@
 @import "./components/warning/style.scss";
 @import "./hooks/anchor.scss";
 @import "./hooks/layout.scss";
+@import "./hooks/border.scss";
 @import "./hooks/typography.scss";
 
 @import "./components/block-toolbar/style.scss";

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -176,6 +176,7 @@ export default function BorderPanel( { name } ) {
 						disableCustomColors={ disableCustomColors }
 						disableCustomGradients={ disableCustomGradients }
 						onColorChange={ handleOnChange( setBorderColor ) }
+						clearable={ false }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -39,6 +39,10 @@
 	border: 0;
 }
 
+.edit-site-global-styles-sidebar .components-tools-panel-item.single-column {
+	grid-column: span 1;
+}
+
 .edit-site-global-styles-sidebar__blocks-group {
 	padding-top: $grid-unit-30;
 	border-top: $border-width solid $gray-200;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Depends on:
- https://github.com/WordPress/gutenberg/pull/35621

Related:
- https://github.com/WordPress/gutenberg/pull/33744

## Description
<!-- Please describe what you have changed or added -->

* #35621 will remove the hardcoded single-column class from the ToolsPanel. This PR includes updates to the Border panel to make sure that single column styling is still applied
* Removes the "Clear" button from the border color control, as this should be cleared through the normal ToolsPanel clearing functions.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Checkout this PR and rebase on #35621 to get the ToolsPanel Grid updates
2. Create a post, add a Group block and select it.
2. Toggle on all the border controls from the border block supports panel in the sidebar
3. Verify the panel's controls are laid out correctly and there is no `Clear` button underneath the color control
4. Open the Site Editor and navigate to Global Styles -> Blocks -> Group -> Layout -> Border. Verify the panel looks correct here as well.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="280" alt="Screen Shot 2021-10-25 at 3 51 54 PM" src="https://user-images.githubusercontent.com/63313398/138786004-3942cc24-8052-4c3c-8146-b8ed2283dab8.png"> | <img width="283" alt="Screen Shot 2021-10-25 at 3 46 44 PM" src="https://user-images.githubusercontent.com/63313398/138786017-816f8681-82ff-4183-bbe7-3a534f302dc6.png"> |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
