### PR TITLE
Fix getPxFromCssUnit test stability and test that memoized function works correctly

### DIFF
--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -8,183 +8,130 @@ import {
 
 describe( 'getPxFromCssUnit', () => {
 	// Absolute units
-	it( 'test px return px unit', () => {
-		expect( getPxFromCssUnit( '25px' ) ).toBe( '25px' );
+	describe( 'absolute unites should return px values', () => {
+		const testData = [
+			{ unit: '25px', expected: '25px' },
+			{ unit: '25.5', expected: '26px' },
+			{ unit: '1cm', expected: '38px' },
+			{ unit: '10mm', expected: '38px' },
+			{ unit: '1in', expected: '96px' },
+			{ unit: '12pt', expected: '16px' },
+			{ unit: '1pc', expected: '16px' },
+			{ unit: '40Q', expected: '38px' }, // 40 Q should be 1 cm
+		];
+
+		testData.forEach( ( data ) => {
+			it( 'test unit ' + data.unit + '', () => {
+				expect( getPxFromCssUnit( data.unit ) ).toBe( data.expected );
+			} );
+			it( 'test unit ' + data.unit + ' - memoized', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit ) ).toBe(
+					data.expected
+				);
+			} );
+			it( 'test unit ' + data.unit + ' - memoized cached', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit ) ).toBe(
+					data.expected
+				);
+			} );
+		} );
 	} );
 
-	it( 'test numeric float return px unit', () => {
-		expect( getPxFromCssUnit( '25.5' ) ).toBe( '26px' );
-	} );
+	describe( 'relative unites should return px values', () => {
+		const settings = {
+			fontSize: 10,
+			width: 100,
+			height: 200,
+			lineHeight: 2,
+			type: 'font',
+		};
 
-	it( 'test cm return px unit', () => {
-		expect( getPxFromCssUnit( '1cm' ) ).toBe( '38px' );
-	} );
+		const testData = [
+			{ unit: '2em', expected: '20px' },
+			{ unit: '2rem', expected: '20px' },
+			{ unit: '20vw', expected: '20px' },
+			{ unit: '20vh', expected: '40px' },
+			{ unit: '20vmin', expected: '20px' },
+			{ unit: '20vmax', expected: '40px' },
+			{ unit: '20lh', expected: '40px' },
+			{ unit: '120%', expected: '12px' },
+		];
 
-	it( 'test mm return px unit', () => {
-		expect( getPxFromCssUnit( '10mm' ) ).toBe( '38px' );
-	} );
-
-	it( 'test in return px unit', () => {
-		expect( getPxFromCssUnit( '1in' ) ).toBe( '96px' );
-	} );
-
-	it( 'test pt return px unit', () => {
-		expect( getPxFromCssUnit( '12pt' ) ).toBe( '16px' );
-	} );
-
-	it( 'test pc return px unit', () => {
-		expect( getPxFromCssUnit( '1pc' ) ).toBe( '16px' );
-	} );
-
-	it( 'test Q return px unit', () => {
-		expect( getPxFromCssUnit( '40Q' ) ).toBe( '38px' ); // 40 Q should be 1 cm
-	} );
-
-	// Relative units
-	it( 'test em return px unit', () => {
-		expect( getPxFromCssUnit( '2em', { fontSize: 10 } ) ).toBe( '20px' );
-	} );
-
-	it( 'test rem return px unit', () => {
-		expect( getPxFromCssUnit( '2rem', { fontSize: 10 } ) ).toBe( '20px' );
-	} );
-
-	it( 'test vw return px unit', () => {
-		expect( getPxFromCssUnit( '20vw', { width: 100 } ) ).toBe( '20px' );
-	} );
-
-	it( 'test vh return px unit', () => {
-		expect( getPxFromCssUnit( '20vh', { height: 200 } ) ).toBe( '40px' );
-	} );
-
-	it( 'test vmin return px unit', () => {
-		expect(
-			getPxFromCssUnit( '20vmin', { height: 200, width: 100 } )
-		).toBe( '20px' );
-	} );
-
-	it( 'test vmax return px unit', () => {
-		expect(
-			getPxFromCssUnit( '20vmax', { height: 200, width: 100 } )
-		).toBe( '40px' );
-	} );
-
-	it( 'test lh return px unit', () => {
-		expect( getPxFromCssUnit( '20lh', { lineHeight: 2 } ) ).toBe( '40px' );
-	} );
-
-	it( 'test % return px unit', () => {
-		expect(
-			getPxFromCssUnit( '120%', {
-				height: 200,
-				width: 100,
-				fontSize: 10,
-				type: 'font',
-			} )
-		).toBe( '12px' );
+		testData.forEach( ( data ) => {
+			it( 'test unit ' + data.unit + '', () => {
+				expect( getPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+			it( 'test unit ' + data.unit + ' - memoized', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+			it( 'test unit ' + data.unit + ' - memoized cached', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+		} );
 	} );
 
 	// Function units
-	it( 'test min() return px unit', () => {
-		expect( getPxFromCssUnit( 'min(20px, 25px)' ) ).toBe( '20px' );
-	} );
 
-	it( 'test min() function with many arguments return px unit', () => {
-		expect( getPxFromCssUnit( 'min(20px, 9px, 12pt, 25px)' ) ).toBe(
-			'9px'
-		);
-	} );
+	describe( 'function unites should return px values', () => {
+		const settings = {
+			fontSize: 10,
+			width: 100,
+			height: 200,
+			lineHeight: 2,
+			type: 'font',
+		};
 
-	it( 'test max() return px unit', () => {
-		expect( getPxFromCssUnit( 'max(20px, 25px)' ) ).toBe( '25px' );
-	} );
+		const testData = [
+			{ unit: 'min(20px, 25px)', expected: '20px' },
+			{ unit: 'min(20px, 9px, 12pt, 25px)', expected: '9px' },
+			{ unit: 'max(20px, 25px)', expected: '25px' },
+			{ unit: 'clamp(10px, 9px, 25px)', expected: '10px' },
+			{ unit: 'clamp(10px, 35px, 25px)', expected: '25px' },
+			{ unit: 'clamp(10px, 15px, 25px)', expected: '15px' },
+			{ unit: 'min(max(20px,25px), 35px)', expected: '25px' },
+			{ unit: 'max(min(20px,25px), 35px)', expected: '35px' },
+			{ unit: '10px + 25px', expected: '35px' },
+			{ unit: 'calc(10px + 25px)', expected: '35px' },
+			{ unit: 'calc( 2 * 20px)', expected: '40px' },
+			{ unit: 'calc(25px - 10px)', expected: '15px' },
+			{ unit: 'min(10px + 25px, 55pt)', expected: '35px' },
+			{ unit: 'calc(12vw * 10px)', expected: '450px' },
+			{ unit: 'calc(45vw / 10px)', expected: '17px' },
+			{ unit: '', expected: null },
+			{ unit: undefined, expected: null },
+			{ unit: 123, expected: '123px' },
+			{ unit: 123.456, expected: '123px' },
+			{ unit: 'abc', expected: null },
+			{ unit: 'console.log("howdy"); + 10px', expected: null },
+			{ unit: 'calc(12vw * 10px', expected: null }, // missing closing bracket
+		];
 
-	it( 'test clamp() lower return px unit', () => {
-		expect( getPxFromCssUnit( 'clamp(10px, 9px, 25px)' ) ).toBe( '10px' );
+		testData.forEach( ( data ) => {
+			it( 'test unit ' + data.unit, () => {
+				expect( getPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+			it( 'test unit ' + data.unit + ' - memoized', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+			it( 'test unit ' + data.unit + ' - memoized cached', () => {
+				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
+					data.expected
+				);
+			} );
+		} );
 	} );
-
-	it( 'test clamp() upper return px unit', () => {
-		expect( getPxFromCssUnit( 'clamp(10px, 35px, 25px)' ) ).toBe( '25px' );
-	} );
-
-	it( 'test clamp() middle return px unit', () => {
-		expect( getPxFromCssUnit( 'clamp(10px, 15px, 25px)' ) ).toBe( '15px' );
-	} );
-
-	it( 'test nested max min function return px unit', () => {
-		expect( getPxFromCssUnit( 'min(max(20px,25px), 35px)' ) ).toBe(
-			'25px'
-		);
-	} );
-
-	it( 'test nested min max function return px unit', () => {
-		expect( getPxFromCssUnit( 'max(min(20px,25px), 35px)' ) ).toBe(
-			'35px'
-		);
-	} );
-
-	it( 'test calculate function return px unit', () => {
-		expect( getPxFromCssUnit( '10px + 25px' ) ).toBe( '35px' );
-	} );
-
-	it( 'test calc(10px + 25px) function return px unit', () => {
-		expect( getPxFromCssUnit( 'calc(10px + 25px)' ) ).toBe( '35px' );
-	} );
-
-	it( 'test calc( number * cssUnit ) return px unit', () => {
-		expect( getPxFromCssUnit( 'calc( 2 * 20px)' ) ).toBe( '40px' );
-	} );
-
-	it( 'test calc(25px - 10px) function return px unit', () => {
-		expect( getPxFromCssUnit( 'calc(25px - 10px)' ) ).toBe( '15px' );
-	} );
-
-	it( 'test min(10px + 25px, 55pt) function return px unit', () => {
-		expect( getPxFromCssUnit( 'min(10px + 25px, 55pt)' ) ).toBe( '35px' );
-	} );
-
-	it( 'test calc(12vw * 10px) function return px unit', () => {
-		expect( getPxFromCssUnit( 'calc(12vw * 10px)' ) ).toBe( '450px' );
-	} );
-
-	it( 'test calc(42vw / 10px) function return px unit', () => {
-		expect( getPxFromCssUnit( 'calc(45vw / 10px)' ) ).toBe( '17px' );
-	} );
-
-	it( 'test empty string', () => {
-		expect( getPxFromCssUnit( '' ) ).toBe( null );
-	} );
-
-	it( 'test undefined string', () => {
-		expect( getPxFromCssUnit( undefined ) ).toBe( null );
-	} );
-	it( 'test integer string', () => {
-		expect( getPxFromCssUnit( 123 ) ).toBe( '123px' );
-	} );
-
-	it( 'test float string', () => {
-		expect( getPxFromCssUnit( 123.456 ) ).toBe( '123px' );
-	} );
-
-	it( 'test text string', () => {
-		expect( getPxFromCssUnit( 'abc' ) ).toBe( null );
-	} );
-
-	it( 'test not non function return null', () => {
-		expect( getPxFromCssUnit( 'abc + num' ) ).toBe( null );
-	} );
-
-	it( 'test not a fishy function return null', () => {
-		expect( getPxFromCssUnit( 'console.log("howdy"); + 10px' ) ).toBe(
-			null
-		);
-	} );
-
-	it( 'test not a typo function return null', () => {
-		expect( getPxFromCssUnit( 'calc(12vw * 10px' ) ).toBe( null );
-	} );
-
-	it( 'test performance of memoizedGetPxFromCssUnit function', () => {
+	// Skip this test it might be useful in dev.
+	it.skip( 'test performance of memoizedGetPxFromCssUnit function', () => {
 		const start = Date.now();
 		let i = 0;
 		const intervals = 1000;

--- a/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/test/parse-css-unit-to-px.js
@@ -10,31 +10,34 @@ describe( 'getPxFromCssUnit', () => {
 	// Absolute units
 	describe( 'absolute unites should return px values', () => {
 		const testData = [
-			{ unit: '25px', expected: '25px' },
-			{ unit: '25.5', expected: '26px' },
-			{ unit: '1cm', expected: '38px' },
-			{ unit: '10mm', expected: '38px' },
-			{ unit: '1in', expected: '96px' },
-			{ unit: '12pt', expected: '16px' },
-			{ unit: '1pc', expected: '16px' },
-			{ unit: '40Q', expected: '38px' }, // 40 Q should be 1 cm
+			[ '25px', '25px' ],
+			[ '25.5', '26px' ],
+			[ '1cm', '38px' ],
+			[ '10mm', '38px' ],
+			[ '1in', '96px' ],
+			[ '12pt', '16px' ],
+			[ '1pc', '16px' ],
+			[ '40Q', '38px' ], // 40 Q should be 1 cm
 		];
 
-		testData.forEach( ( data ) => {
-			it( 'test unit ' + data.unit + '', () => {
-				expect( getPxFromCssUnit( data.unit ) ).toBe( data.expected );
-			} );
-			it( 'test unit ' + data.unit + ' - memoized', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit ) ).toBe(
-					data.expected
-				);
-			} );
-			it( 'test unit ' + data.unit + ' - memoized cached', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit ) ).toBe(
-					data.expected
-				);
-			} );
-		} );
+		test.each( testData )(
+			'test getPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( getPxFromCssUnit( unit ) ).toBe( expected );
+			}
+		);
+		test.each( testData )(
+			'test memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit ) ).toBe( expected );
+			}
+		);
+		test.each( testData )(
+			'test cached memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit ) ).toBe( expected );
+			}
+		);
 	} );
 
 	describe( 'relative unites should return px values', () => {
@@ -47,33 +50,38 @@ describe( 'getPxFromCssUnit', () => {
 		};
 
 		const testData = [
-			{ unit: '2em', expected: '20px' },
-			{ unit: '2rem', expected: '20px' },
-			{ unit: '20vw', expected: '20px' },
-			{ unit: '20vh', expected: '40px' },
-			{ unit: '20vmin', expected: '20px' },
-			{ unit: '20vmax', expected: '40px' },
-			{ unit: '20lh', expected: '40px' },
-			{ unit: '120%', expected: '12px' },
+			[ '2em', '20px' ],
+			[ '2rem', '20px' ],
+			[ '20vw', '20px' ],
+			[ '20vh', '40px' ],
+			[ '20vmin', '20px' ],
+			[ '20vmax', '40px' ],
+			[ '20lh', '40px' ],
+			[ '120%', '12px' ],
 		];
 
-		testData.forEach( ( data ) => {
-			it( 'test unit ' + data.unit + '', () => {
-				expect( getPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
+		test.each( testData )(
+			'test getPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
+			}
+		);
+		test.each( testData )(
+			'test memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
+					expected
 				);
-			} );
-			it( 'test unit ' + data.unit + ' - memoized', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
+			}
+		);
+		test.each( testData )(
+			'test cached memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
+					expected
 				);
-			} );
-			it( 'test unit ' + data.unit + ' - memoized cached', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
-				);
-			} );
-		} );
+			}
+		);
 	} );
 
 	// Function units
@@ -88,47 +96,52 @@ describe( 'getPxFromCssUnit', () => {
 		};
 
 		const testData = [
-			{ unit: 'min(20px, 25px)', expected: '20px' },
-			{ unit: 'min(20px, 9px, 12pt, 25px)', expected: '9px' },
-			{ unit: 'max(20px, 25px)', expected: '25px' },
-			{ unit: 'clamp(10px, 9px, 25px)', expected: '10px' },
-			{ unit: 'clamp(10px, 35px, 25px)', expected: '25px' },
-			{ unit: 'clamp(10px, 15px, 25px)', expected: '15px' },
-			{ unit: 'min(max(20px,25px), 35px)', expected: '25px' },
-			{ unit: 'max(min(20px,25px), 35px)', expected: '35px' },
-			{ unit: '10px + 25px', expected: '35px' },
-			{ unit: 'calc(10px + 25px)', expected: '35px' },
-			{ unit: 'calc( 2 * 20px)', expected: '40px' },
-			{ unit: 'calc(25px - 10px)', expected: '15px' },
-			{ unit: 'min(10px + 25px, 55pt)', expected: '35px' },
-			{ unit: 'calc(12vw * 10px)', expected: '450px' },
-			{ unit: 'calc(45vw / 10px)', expected: '17px' },
-			{ unit: '', expected: null },
-			{ unit: undefined, expected: null },
-			{ unit: 123, expected: '123px' },
-			{ unit: 123.456, expected: '123px' },
-			{ unit: 'abc', expected: null },
-			{ unit: 'console.log("howdy"); + 10px', expected: null },
-			{ unit: 'calc(12vw * 10px', expected: null }, // missing closing bracket
+			[ 'min(20px, 25px)', '20px' ],
+			[ 'min(20px, 9px, 12pt, 25px)', '9px' ],
+			[ 'max(20px, 25px)', '25px' ],
+			[ 'clamp(10px, 9px, 25px)', '10px' ],
+			[ 'clamp(10px, 35px, 25px)', '25px' ],
+			[ 'clamp(10px, 15px, 25px)', '15px' ],
+			[ 'min(max(20px,25px), 35px)', '25px' ],
+			[ 'max(min(20px,25px), 35px)', '35px' ],
+			[ '10px + 25px', '35px' ],
+			[ 'calc(10px + 25px)', '35px' ],
+			[ 'calc( 2 * 20px)', '40px' ],
+			[ 'calc(25px - 10px)', '15px' ],
+			[ 'min(10px + 25px, 55pt)', '35px' ],
+			[ 'calc(12vw * 10px)', '450px' ],
+			[ 'calc(45vw / 10px)', '17px' ],
+			[ '', null ],
+			[ undefined, null ],
+			[ 123, '123px' ],
+			[ 123.456, '123px' ],
+			[ 'abc', null ],
+			[ 'console.log("howdy"); + 10px', null ],
+			[ 'calc(12vw * 10px', null ], // missing closing bracket
 		];
 
-		testData.forEach( ( data ) => {
-			it( 'test unit ' + data.unit, () => {
-				expect( getPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
+		test.each( testData )(
+			'test getPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( getPxFromCssUnit( unit, settings ) ).toBe( expected );
+			}
+		);
+		test.each( testData )(
+			'test memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
+					expected
 				);
-			} );
-			it( 'test unit ' + data.unit + ' - memoized', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
+			}
+		);
+		test.each( testData )(
+			'test cached memoizedGetPxFromCssUnit( %s )',
+			( unit, expected ) => {
+				expect( memoizedGetPxFromCssUnit( unit, settings ) ).toBe(
+					expected
 				);
-			} );
-			it( 'test unit ' + data.unit + ' - memoized cached', () => {
-				expect( memoizedGetPxFromCssUnit( data.unit, settings ) ).toBe(
-					data.expected
-				);
-			} );
-		} );
+			}
+		);
 	} );
 	// Skip this test it might be useful in dev.
 	it.skip( 'test performance of memoizedGetPxFromCssUnit function', () => {


### PR DESCRIPTION
## Description
This Pr updates the getPxFromCssUnit test to include testing the memoized function and makes sure that the cached version returns the same result as the memoized function. 

Run the tests locally.

Related https://github.com/WordPress/gutenberg/pull/35205/files#r734296446 

## Types of changes
Do the tests pass? 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
