### PR TITLE
fix/35812: align media button

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -311,14 +311,16 @@ export function MediaPlaceholder( {
 	const renderMediaUploadChecked = () => {
 		const defaultButton = ( { open } ) => {
 			return (
-				<Button
-					variant="tertiary"
-					onClick={ () => {
-						open();
-					} }
-				>
-					{ __( 'Media Library' ) }
-				</Button>
+				<div className="components-form-media-select">
+					<Button
+						variant="tertiary"
+						onClick={ () => {
+							open();
+						} }
+					>
+						{ __( 'Media Library' ) }
+					</Button>
+				</div>
 			);
 		};
 		const libraryButton = mediaLibraryButton ?? defaultButton;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Closes #35812 

## Description
Adds a DIV wrapper similar to its sibling buttons.

## How has this been tested?
I have tested the steps outlined in the issue. I have also tested for small, medium and large sizes. Please see the screenshot below.

## Screenshots
<img width="571" alt="Screen Shot 2021-10-26 at 8 38 17 AM" src="https://user-images.githubusercontent.com/17757960/138802367-48cca53f-1b1d-4d88-acfb-8f5118ff8b13.png">


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
