### PR TITLE
Add adjustable height in focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -33,15 +33,19 @@ import BackButton from './back-button';
 import ResizableEditor from './resizable-editor';
 
 export default function BlockEditor( { setIsInserterOpen } ) {
-	const { settings, templateType, page } = useSelect(
+	const { settings, templateType, templateId, page } = useSelect(
 		( select ) => {
-			const { getSettings, getEditedPostType, getPage } = select(
-				editSiteStore
-			);
+			const {
+				getSettings,
+				getEditedPostType,
+				getEditedPostId,
+				getPage,
+			} = select( editSiteStore );
 
 			return {
 				settings: getSettings( setIsInserterOpen ),
 				templateType: getEditedPostType(),
+				templateId: getEditedPostId(),
 				page: getPage(),
 			};
 		},
@@ -99,6 +103,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 				<BackButton />
 
 				<ResizableEditor
+					// Reinitialize the editor when the template changes.
+					key={ templateId }
 					enableResizing={
 						isTemplatePart &&
 						// Disable resizing in mobile viewport.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
+	BlockList,
 	BlockEditorProvider,
 	__experimentalLinkControl,
 	BlockInspector,
@@ -31,6 +32,12 @@ import BlockInspectorButton from './block-inspector-button';
 import EditTemplatePartMenuButton from '../edit-template-part-menu-button';
 import BackButton from './back-button';
 import ResizableEditor from './resizable-editor';
+
+const LAYOUT = {
+	type: 'default',
+	// At the root level of the site editor, no alignments should be allowed.
+	alignments: [],
+};
 
 export default function BlockEditor( { setIsInserterOpen } ) {
 	const { settings, templateType, templateId, page } = useSelect(
@@ -112,7 +119,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					}
 					settings={ settings }
 					contentRef={ mergedRefs }
-				/>
+				>
+					<BlockList
+						className="edit-site-block-editor__block-list wp-site-blocks"
+						__experimentalLayout={ LAYOUT }
+					/>
+				</ResizableEditor>
 
 				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -2,10 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { LEFT, RIGHT } from '@wordpress/keycodes';
+import { LEFT, RIGHT, UP, DOWN } from '@wordpress/keycodes';
 import { VisuallyHidden } from '@wordpress/components';
 
-export default function ResizeHandle( { direction, resizeWidthBy } ) {
+const DELTA_LENGTH = 10; // The length to resize per keydown in pixels.
+
+export default function ResizeHandle( { direction, resizeBy } ) {
 	function handleKeyDown( event ) {
 		const { keyCode } = event;
 
@@ -13,12 +15,20 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 			( direction === 'left' && keyCode === LEFT ) ||
 			( direction === 'right' && keyCode === RIGHT )
 		) {
-			resizeWidthBy( 20 );
+			// The canvas is centered horizontally, thus resizing it horizontally
+			// needs two times the length.
+			resizeBy( DELTA_LENGTH * 2, 0 );
 		} else if (
 			( direction === 'left' && keyCode === RIGHT ) ||
 			( direction === 'right' && keyCode === LEFT )
 		) {
-			resizeWidthBy( -20 );
+			resizeBy( -DELTA_LENGTH * 2, 0 );
+		} else if ( direction === 'down' ) {
+			if ( keyCode === DOWN ) {
+				resizeBy( 0, DELTA_LENGTH );
+			} else if ( keyCode === UP ) {
+				resizeBy( 0, -DELTA_LENGTH );
+			}
 		}
 	}
 
@@ -33,7 +43,11 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 			<VisuallyHidden
 				id={ `resizable-editor__resize-help-${ direction }` }
 			>
-				{ __( 'Use left and right arrow keys to resize the canvas.' ) }
+				{ direction === 'down'
+					? __( 'Use up and down arrow keys to resize the canvas.' )
+					: __(
+							'Use left and right arrow keys to resize the canvas.'
+					  ) }
 			</VisuallyHidden>
 		</>
 	);

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT, UP, DOWN } from '@wordpress/keycodes';
 import { VisuallyHidden } from '@wordpress/components';
 
-const DELTA_LENGTH = 10; // The length to resize per keydown in pixels.
+const DELTA_DISTANCE = 10; // The distance to resize per keydown in pixels.
 
 export default function ResizeHandle( { direction, resizeBy } ) {
 	function handleKeyDown( event ) {
@@ -16,18 +16,18 @@ export default function ResizeHandle( { direction, resizeBy } ) {
 			( direction === 'right' && keyCode === RIGHT )
 		) {
 			// The canvas is centered horizontally, thus resizing it horizontally
-			// needs two times the length.
-			resizeBy( DELTA_LENGTH * 2, 0 );
+			// needs two times the distance.
+			resizeBy( DELTA_DISTANCE * 2, 0 );
 		} else if (
 			( direction === 'left' && keyCode === RIGHT ) ||
 			( direction === 'right' && keyCode === LEFT )
 		) {
-			resizeBy( -DELTA_LENGTH * 2, 0 );
+			resizeBy( -DELTA_DISTANCE * 2, 0 );
 		} else if ( direction === 'down' ) {
 			if ( keyCode === DOWN ) {
-				resizeBy( 0, DELTA_LENGTH );
+				resizeBy( 0, DELTA_DISTANCE );
 			} else if ( keyCode === UP ) {
-				resizeBy( 0, -DELTA_LENGTH );
+				resizeBy( 0, -DELTA_DISTANCE );
 			}
 		}
 	}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -19,7 +19,7 @@
 	align-items: center;
 
 	&.is-focus-mode {
-		padding: 48px 48px 0;
+		padding: 48px;
 	}
 }
 
@@ -38,6 +38,10 @@
 	&:hover {
 		color: $gray-100;
 	}
+}
+
+.components-resizable-box__container {
+	margin: 0 auto;
 }
 
 .resizable-editor__drag-handle {
@@ -62,6 +66,16 @@
 
 	&.is-right {
 		right: #{-$grid-unit-30 - $grid-unit-05};
+	}
+
+	&.is-down {
+		left: 0;
+		right: 0;
+		margin: 0 auto;
+		top: auto;
+		bottom: #{-$grid-unit-30 - $grid-unit-05};
+		width: $height;
+		height: $grid-unit-10;
 	}
 
 	&:hover {

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -23,8 +23,8 @@
 .edit-site-visual-editor {
 	position: relative;
 	height: 100%;
-	display: flex;
-	flex-flow: column;
+	display: block;
+	overflow: hidden;
 
 	iframe {
 		display: block;

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -100,6 +100,8 @@ export default function Header( {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
+	const isFocusMode = templateType === 'wp_template_part';
+
 	return (
 		<div className="edit-site-header">
 			<div className="edit-site-header_start">
@@ -157,10 +159,12 @@ export default function Header( {
 
 			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">
-					<PreviewOptions
-						deviceType={ deviceType }
-						setDeviceType={ setPreviewDeviceType }
-					/>
+					{ ! isFocusMode && (
+						<PreviewOptions
+							deviceType={ deviceType }
+							setDeviceType={ setPreviewDeviceType }
+						/>
+					) }
 					<SaveButton
 						openEntitiesSavedStates={ openEntitiesSavedStates }
 						isEntitiesSavedStatesOpen={ isEntitiesSavedStatesOpen }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close https://github.com/WordPress/gutenberg/issues/35512. Alternative to https://github.com/WordPress/gutenberg/pull/35856. Implement the design similar to the one in https://github.com/WordPress/gutenberg/issues/35512#issuecomment-949753478.

The height of the canvas is now determined by the template part contents. You can also manually resize the height if needed. The preview options are removed, in the future we can re-implement a new "viewport width" similar to the one in the design of pattern directory.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go to Site Editor
3. Edit a template part (block toolbar -> Edit)
4. Play with the resizer

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/138814439-714fb2ab-f41a-4cc4-9e52-a35cef3d615b.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
