### PR TITLE
Post Template Block: Move inner blocks container to separate component

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -24,6 +24,12 @@ const TEMPLATE = [
 	[ 'core/post-date' ],
 	[ 'core/post-excerpt' ],
 ];
+
+function PostTemplateInnerBlocks() {
+	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
+	return <li { ...innerBlocksProps } />;
+}
+
 export default function PostTemplateEdit( {
 	clientId,
 	context: {
@@ -125,7 +131,6 @@ export default function PostTemplateEdit( {
 			[ `columns-${ columns }` ]: hasLayoutFlex,
 		} ),
 	} );
-	const innerBlocksProps = useInnerBlocksProps( {}, { template: TEMPLATE } );
 
 	if ( ! posts ) {
 		return (
@@ -149,7 +154,7 @@ export default function PostTemplateEdit( {
 					>
 						{ blockContext ===
 						( activeBlockContext || blockContexts[ 0 ] ) ? (
-							<li { ...innerBlocksProps } />
+							<PostTemplateInnerBlocks />
 						) : (
 							<li>
 								<BlockPreview


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR moves the inner blocks container for the Post Template block to a separate component, to ensure that the result of `useInnerBlocksProps` is always applied to same React node relative to the call to the hook.

I'm not 100% sure why this fixes it, but it resolves the following issue:

Before: in a long Post Template block within a long query loop (e.g. within the Index template of the TT1-Blocks theme with 2+ published posts) if you click on a block within the first post within the loop, then scroll down to click on a similar block within another post within the loop, then the scroll position of the editor moves when the parent Post Template block is selected.

After: on click, the selection changes, but the scroll position does not move away unexpectedly.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Ensure your site has at least two published posts
2. With an FSE theme like TT1-Blocks active, go to the site editor and view a list of posts within a Query Loop block (containing the Post Template block)
3. Click on a block within the Post Template block of the query loop (e.g. click on Post Content)
4. Scroll down the page and click on a similar block in the next post within the query loop
5. Before this PR, note that the scroll position of the page moves when you select the block
6. After this PR, the scroll position shouldn't change

Note: there is a separate issue that on the first click, the Post Template block is selected instead of the target block. That's logged in issue #35944 and is to do with the way the Post Template block only renders one post at a time as live editable blocks (the other posts are rendered as BlockPreviews). This PR only seeks to address the scrolling issue

## Screenshots <!-- if applicable -->

Note: in the before screenshot, after clicking the similar block in the next post, the viewport is scrolled to the bottom of the page unexpectedly. In the After screenshot, the viewport is not scrolled unexpectedly (but it still takes a couple of clicks to activate the desired block as noted in #35944)

| Before | After |
| --- | --- |
| ![Kapture 2021-10-26 at 17 36 59](https://user-images.githubusercontent.com/14988353/138821951-ace537a0-abb6-4a5c-a451-5aedc307e789.gif) | ![Kapture 2021-10-26 at 17 32 54](https://user-images.githubusercontent.com/14988353/138821425-14816441-f0b7-437a-9950-20b6d0ae2557.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
