### PR TITLE
Make Link UI inactive if selection extends beyond format bounds or encounters new link

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { getActiveFormat, getActiveObject } from '@wordpress/rich-text';
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
 
 export default function FormatEdit( {
 	formatTypes,
@@ -18,10 +22,35 @@ export default function FormatEdit( {
 		}
 
 		const activeFormat = getActiveFormat( value, name );
-		const isActive = activeFormat !== undefined;
+		let isActive = activeFormat !== undefined;
 		const activeObject = getActiveObject( value );
 		const isObjectActive =
 			activeObject !== undefined && activeObject.type === name;
+
+		// Edge case: link format
+		// If there is a missing link format at either end of the selection
+		// then we shouldn't show the Edit UI because the selection has exeeded
+		// the bounds of the link format.
+		// Also if the format objects don't match then we're dealing with two separate
+		// links so we should not allow the link to be modified over the top.
+		if ( name === 'core/link' ) {
+			const formats = value.formats;
+			const linkFormatAtStart = find( formats[ value.start ], {
+				type: 'core/link',
+			} );
+
+			const linkFormatAtEnd = find( formats[ value.end - 1 ], {
+				type: 'core/link',
+			} );
+
+			if (
+				! linkFormatAtStart ||
+				! linkFormatAtEnd ||
+				linkFormatAtStart !== linkFormatAtEnd
+			) {
+				isActive = false;
+			}
+		}
 
 		return (
 			<Edit

--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { getActiveFormat, getActiveObject } from '@wordpress/rich-text';
+import {
+	getActiveFormat,
+	getActiveObject,
+	isCollapsed,
+} from '@wordpress/rich-text';
 /**
  * External dependencies
  */
@@ -27,14 +31,15 @@ export default function FormatEdit( {
 		const isObjectActive =
 			activeObject !== undefined && activeObject.type === name;
 
-		// Edge case: link format
+		// Edge case: un-collapsed link formats.
 		// If there is a missing link format at either end of the selection
 		// then we shouldn't show the Edit UI because the selection has exeeded
 		// the bounds of the link format.
 		// Also if the format objects don't match then we're dealing with two separate
 		// links so we should not allow the link to be modified over the top.
-		if ( name === 'core/link' ) {
+		if ( name === 'core/link' && ! isCollapsed( value ) ) {
 			const formats = value.formats;
+
 			const linkFormatAtStart = find( formats[ value.start ], {
 				type: 'core/link',
 			} );

--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -33,7 +33,7 @@ export default function FormatEdit( {
 
 		// Edge case: un-collapsed link formats.
 		// If there is a missing link format at either end of the selection
-		// then we shouldn't show the Edit UI because the selection has exeeded
+		// then we shouldn't show the Edit UI because the selection has exceeded
 		// the bounds of the link format.
 		// Also if the format objects don't match then we're dealing with two separate
 		// links so we should not allow the link to be modified over the top.

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -588,4 +588,78 @@ describe( 'Links', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not show the Link UI when selection extends beyond link boundary', async () => {
+		const linkedText = `Gutenberg`;
+		const textBeyondLinkedText = ` and more text.`;
+
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type(
+			`This is ${ linkedText }${ textBeyondLinkedText }`
+		);
+
+		// Move cursor next to end of `linkedText`
+		for ( let index = 0; index < textBeyondLinkedText.length; index++ ) {
+			await page.keyboard.press( 'ArrowLeft' );
+		}
+
+		// Select the linkedText
+		await pressKeyWithModifier( 'shiftAlt', 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Update the link
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+
+		expect(
+			await page.$(
+				'.components-popover__content .block-editor-link-control'
+			)
+		).not.toBeNull();
+
+		// Make selection starting within the link and moving beyond boundary to the left.
+		for ( let index = 0; index < linkedText.length; index++ ) {
+			await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+		}
+
+		// The Link UI should have disappeared (i.e. be inactive).
+		expect(
+			await page.$(
+				'.components-popover__content .block-editor-link-control'
+			)
+		).toBeNull();
+
+		// Cancel selection and move back within the Link.
+		await page.keyboard.press( 'ArrowRight' );
+
+		// We should see the Link UI displayed again.
+		expect(
+			await page.$(
+				'.components-popover__content .block-editor-link-control'
+			)
+		).not.toBeNull();
+
+		// Make selection starting within the link and moving beyond boundary to the right.
+		await pressKeyWithModifier( 'shift', 'ArrowRight' );
+		await pressKeyWithModifier( 'shift', 'ArrowRight' );
+		await pressKeyWithModifier( 'shift', 'ArrowRight' );
+
+		// The Link UI should have disappeared (i.e. be inactive).
+		expect(
+			await page.$(
+				'.components-popover__content .block-editor-link-control'
+			)
+		).toBeNull();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

This PR seeks to solve the problem highlighted by @ellatrix in https://github.com/WordPress/gutenberg/pull/33849#issuecomment-950382732 (and which is currently blocking the merge of that important PR).

Currently if you make a link and then make a selection that begins _inside_ the link and extends either:

- outside the current link boundary.
- into _another_ link.

...then the Link UI will remain active even though you're outside the original format you selected.

This allows you to get into undesirable states such as:

- links created ontop of existing links
- links created that include a portion of an existing link

This PR resolves this. The UX is now that the Link UI will _disappear_ (become inactive) if:

- the selection extends outside the boundary (in _either_ direction) 
- the selection extends into (on top of) _another_ link.


Originally part of https://github.com/WordPress/gutenberg/pull/35882. Now broken out into a seperate PR.



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. New e2e tests added.
2. Manual testing (see below)

### Manual testing

1. New Post --> create two links to two _different_ URLs.
2. Place cursor within the first link. See Link UI appear.
3. Make a selection that expands _beyond_ the link boundary at either end. See Link UI disappear.
4. Create a new paragraph block and create two links to two different URLs that are _immediately adjacent_ to one another with no spaces separating them.
5. Select the first link and make a selection which expands into the second link. See Link UI disappear. Try again but in reverse (2nd --> 1st).

Bottom line: if the selection goes:

- Outside the link boundary
- Into (on top of) another link.

...then the Link UI should disappear.


## Screenshots <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/444434/138842888-884333ef-bfe7-4e7d-bbd0-2091bd9561c6.mov

### After




https://user-images.githubusercontent.com/444434/138843327-c665523e-0fb7-4d93-8d6c-eb62da7cdd25.mov



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
