### PR TITLE
[RNMobile] Look for newly available blocks too during E2E tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -323,17 +323,17 @@ class EditorPage {
 
 			if (
 				await this.driver.hasElementByAccessibilityId(
-					blockAccessibilityLabel
+					blockAccessibilityLabelNewBlock
 				)
 			) {
-				return await this.driver.elementByAccessibilityId(
-					blockAccessibilityLabel
-				);
-			} else {
 				return await this.driver.elementByAccessibilityId(
 					blockAccessibilityLabelNewBlock
 				);
 			}
+
+			return await this.driver.elementByAccessibilityId(
+				blockAccessibilityLabel
+			);
 		}
 
 		const blockButton = ( await this.driver.hasElementByAccessibilityId(

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -300,6 +300,7 @@ class EditorPage {
 	// Attempts to find the given block button in the block inserter control.
 	async findBlockButton( blockName ) {
 		const blockAccessibilityLabel = `${ blockName } block`;
+		const blockAccessibilityLabelNewBlock = `${ blockAccessibilityLabel }, newly available`;
 
 		if ( isAndroid() ) {
 			const size = await this.driver.getWindowSize();
@@ -308,6 +309,9 @@ class EditorPage {
 			while (
 				! ( await this.driver.hasElementByAccessibilityId(
 					blockAccessibilityLabel
+				) ) &&
+				! ( await this.driver.hasElementByAccessibilityId(
+					blockAccessibilityLabelNewBlock
 				) )
 			) {
 				swipeFromTo(
@@ -317,14 +321,31 @@ class EditorPage {
 				);
 			}
 
-			return await this.driver.elementByAccessibilityId(
-				blockAccessibilityLabel
-			);
+			if (
+				await this.driver.hasElementByAccessibilityId(
+					blockAccessibilityLabel
+				)
+			) {
+				return await this.driver.elementByAccessibilityId(
+					blockAccessibilityLabel
+				);
+			} else {
+				return await this.driver.elementByAccessibilityId(
+					blockAccessibilityLabelNewBlock
+				);
+			}
 		}
 
-		const blockButton = await this.driver.elementByAccessibilityId(
-			blockAccessibilityLabel
-		);
+		const blockButton = ( await this.driver.hasElementByAccessibilityId(
+			blockAccessibilityLabelNewBlock
+		) )
+			? await this.driver.elementByAccessibilityId(
+					blockAccessibilityLabelNewBlock
+			  )
+			: await this.driver.elementByAccessibilityId(
+					blockAccessibilityLabel
+			  );
+
 		const size = await this.driver.getWindowSize();
 		// The virtual home button covers the bottom 34 in portrait and 21 on landscape on iOS.
 		// We start dragging a bit above it to not trigger home button.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Updates the native mobile E2E "find block in inserter" method to account for newly available blocks too, since [those have a slightly different accessibility ID](https://github.com/WordPress/gutenberg/blob/2aca4fbe12ea6b7b03b19260ca91b152f11d1cbc/packages/components/src/mobile/inserter-button/index.native.js#L61).

After we bumped the mobile Editor Onboarding features [to 100% rollout](https://github.com/WordPress/gutenberg/pull/35201), some E2E tests started failing on `develop` of gutenberg-mobile due to the "newly available" marked blocks escaping the search methods.

### Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4161

## How has this been tested?
* By locally running the Appium `gutenberg-editor-search.test.js` tests
* By running the full e2e testsuite in gutenberg-mobile. The gb-mobile PR needs to be green now.

## Types of changes
Update the `findBlockButton()` method to search for both versions of the block name `${ blockName } block` and `${ blockName } block, newly available`.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
