### PR TITLE
Block editor: pass assets through block_editor_settings_all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19746,6 +19746,7 @@
 			"requires": {
 				"@babel/runtime": "^7.13.10",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
+				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -514,6 +514,19 @@ _Related_
 
 Undocumented declaration.
 
+### Placeholder
+
+Placeholder for use in blocks. Creates an admin styling context and a tabbing
+context in the block editor's writing flow.
+
+_Parameters_
+
+-   _props_ `Object`:
+
+_Returns_
+
+-   `WPComponent`: The component
+
 ### PlainText
 
 _Related_

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -51,6 +51,16 @@ function useInitialPosition( clientId ) {
 	);
 }
 
+function useIsMounting() {
+	const isMounting = useRef( true );
+
+	useEffect( () => {
+		isMounting.current = false;
+	}, [] );
+
+	return isMounting.current;
+}
+
 /**
  * Transitions focus to the block or inner tabbable when the block becomes
  * selected and an initial position is set.
@@ -62,6 +72,7 @@ function useInitialPosition( clientId ) {
 export function useFocusFirstElement( clientId ) {
 	const ref = useRef();
 	const initialPosition = useInitialPosition( clientId );
+	const isMounting = useIsMounting();
 
 	useEffect( () => {
 		if ( initialPosition === undefined || initialPosition === null ) {
@@ -89,7 +100,10 @@ export function useFocusFirstElement( clientId ) {
 		// Find all text fields or placeholders within the block.
 		candidates = focus.tabbable
 			.find( target )
-			.filter( ( node ) => isTextField( node ) || node.shadowRoot );
+			.filter(
+				( node ) =>
+					isTextField( node ) || ( isMounting && node.shadowRoot )
+			);
 
 		target = ( isReverse ? last : first )( candidates ) || target;
 
@@ -98,7 +112,7 @@ export function useFocusFirstElement( clientId ) {
 			return;
 		}
 
-		if ( target.shadowRoot ) {
+		if ( isMounting && target.shadowRoot ) {
 			// We must wait for the placeholder content to load.
 			setTimeout( () => {
 				// Find all text fields within the placeholder.

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -112,17 +112,21 @@ export function useFocusFirstElement( clientId ) {
 			return;
 		}
 
-		if ( isMounting && target.shadowRoot ) {
+		if ( target.shadowRoot ) {
+			target.focus();
+
 			// We must wait for the placeholder content to load.
-			setTimeout( () => {
+			const timeoutId = setTimeout( () => {
 				// Find all text fields within the placeholder.
 				candidates = focus.tabbable.find( target.shadowRoot );
 				target = ( isReverse ? last : first )( candidates ) || target;
 				placeCaretAtHorizontalEdge( target, isReverse );
 			} );
-		} else {
-			placeCaretAtHorizontalEdge( target, isReverse );
+
+			return () => clearTimeout( timeoutId );
 		}
+
+		placeCaretAtHorizontalEdge( target, isReverse );
 	}, [ initialPosition ] );
 
 	return ref;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -81,14 +81,13 @@ export function useFocusFirstElement( clientId ) {
 		}
 
 		let target = ref.current;
-		let candidates;
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
 		const isReverse = -1 === initialPosition;
 
 		// Find all text fields or placeholders within the block.
-		candidates = focus.tabbable
+		const candidates = focus.tabbable
 			.find( target )
 			.filter(
 				( node ) =>
@@ -104,20 +103,6 @@ export function useFocusFirstElement( clientId ) {
 		if ( ! isInsideRootBlock( ref.current, target ) ) {
 			ref.current.focus();
 			return;
-		}
-
-		if ( target.shadowRoot ) {
-			target.focus();
-
-			// We must wait for the placeholder content to load.
-			const timeoutId = setTimeout( () => {
-				// Find all text fields within the placeholder.
-				candidates = focus.tabbable.find( target.shadowRoot );
-				target = ( isReverse ? last : first )( candidates ) || target;
-				placeCaretAtHorizontalEdge( target, isReverse );
-			} );
-
-			return () => clearTimeout( timeoutId );
 		}
 
 		placeCaretAtHorizontalEdge( target, isReverse );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -51,16 +51,6 @@ function useInitialPosition( clientId ) {
 	);
 }
 
-function useIsMounting() {
-	const isMounting = useRef( true );
-
-	useEffect( () => {
-		isMounting.current = false;
-	}, [] );
-
-	return isMounting.current;
-}
-
 /**
  * Transitions focus to the block or inner tabbable when the block becomes
  * selected and an initial position is set.
@@ -72,7 +62,7 @@ function useIsMounting() {
 export function useFocusFirstElement( clientId ) {
 	const ref = useRef();
 	const initialPosition = useInitialPosition( clientId );
-	const isMounting = useIsMounting();
+	const isMounting = useRef( true );
 
 	useEffect( () => {
 		if ( initialPosition === undefined || initialPosition === null ) {
@@ -102,7 +92,11 @@ export function useFocusFirstElement( clientId ) {
 			.find( target )
 			.filter(
 				( node ) =>
-					isTextField( node ) || ( isMounting && node.shadowRoot )
+					isTextField( node ) ||
+					( isMounting.current &&
+						node.classList.contains(
+							'wp-block-editor-placeholder'
+						) )
 			);
 
 		target = ( isReverse ? last : first )( candidates ) || target;
@@ -128,6 +122,10 @@ export function useFocusFirstElement( clientId ) {
 
 		placeCaretAtHorizontalEdge( target, isReverse );
 	}, [ initialPosition ] );
+
+	useEffect( () => {
+		isMounting.current = false;
+	}, [] );
 
 	return ref;
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -102,9 +102,7 @@ export function useFocusFirstElement( clientId ) {
 			// We must wait for the placeholder content to load.
 			setTimeout( () => {
 				// Find all text fields within the placeholder.
-				candidates = focus.tabbable
-					.find( target.shadowRoot )
-					.filter( ( node ) => isTextField( node ) );
+				candidates = focus.tabbable.find( target.shadowRoot );
 				target = ( isReverse ? last : first )( candidates ) || target;
 				placeCaretAtHorizontalEdge( target, isReverse );
 			} );

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -25,8 +25,9 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 		contentResizeListener,
 		{ height: contentHeight },
 	] = useResizeObserver();
-	const styles = useSelect( ( select ) => {
-		return select( store ).getSettings().styles;
+	const { styles, assets } = useSelect( ( select ) => {
+		const settings = select( store ).getSettings();
+		return { styles: settings.styles, assets: settings.resolvedAssets };
 	}, [] );
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
@@ -45,7 +46,10 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				} }
 			>
 				<Iframe
-					head={ <EditorStyles styles={ styles } /> }
+					head={
+						<EditorStyles styles={ styles } assets={ assets } />
+					}
+					assets={ assets }
 					contentRef={ useRefEffect( ( bodyElement ) => {
 						const {
 							ownerDocument: { documentElement },

--- a/packages/block-editor/src/components/block-variation-picker/index.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.js
@@ -7,8 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Placeholder } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { layout } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Placeholder from '../placeholder';
 
 function BlockVariationPicker( {
 	icon = layout,

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -66,7 +66,53 @@ function useDarkThemeBodyClassName( styles ) {
 	);
 }
 
-export default function EditorStyles( { styles } ) {
+function useParsedAssets( html ) {
+	return useMemo( () => {
+		const doc = document.implementation.createHTMLDocument( '' );
+		doc.body.innerHTML = html;
+		return Array.from( doc.body.children );
+	}, [ html ] );
+}
+
+function PrefixedStyle( { tagName, href, id, rel, media, textContent } ) {
+	const TagName = tagName.toLowerCase();
+
+	function onLoad( event ) {
+		const { sheet } = event.target;
+		const { cssRules } = sheet;
+
+		let index = 0;
+
+		for ( const rule of cssRules ) {
+			const { type, STYLE_RULE, selectorText, cssText } = rule;
+
+			if ( type !== STYLE_RULE ) {
+				continue;
+			}
+
+			if ( selectorText.includes( EDITOR_STYLES_SELECTOR ) ) {
+				return;
+			}
+
+			sheet.deleteRule( index );
+			sheet.insertRule(
+				'html :where(.editor-styles-wrapper) ' + cssText,
+				index
+			);
+
+			index++;
+		}
+	}
+
+	if ( TagName === 'style' ) {
+		return <TagName { ...{ id, onLoad } }>{ textContent }</TagName>;
+	}
+
+	return <TagName { ...{ href, id, rel, media, onLoad } } />;
+}
+
+export default function EditorStyles( { styles, assets } ) {
+	const _styles = useParsedAssets( assets.styles );
 	const transformedStyles = useMemo(
 		() => transformStyles( styles, EDITOR_STYLES_SELECTOR ),
 		[ styles ]
@@ -77,6 +123,21 @@ export default function EditorStyles( { styles } ) {
 			{ /* Use an empty style element to have a document reference,
 			     but this could be any element. */ }
 			<style ref={ useDarkThemeBodyClassName( styles ) } />
+			{ _styles.map(
+				( { tagName, href, id, rel, media, textContent } ) => (
+					<PrefixedStyle
+						key={ id }
+						{ ...{
+							tagName,
+							href,
+							id,
+							rel,
+							media,
+							textContent,
+						} }
+					/>
+				)
+			) }
 			{ transformedStyles.map( ( css, index ) => (
 				<style key={ index }>{ css }</style>
 			) ) }

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -43,11 +43,26 @@ export default function EmbeddedAdminContext( props ) {
 			setHasFocus( false );
 		}
 
+		function onKeyDown( event ) {
+			if ( element !== event.path[ 0 ] ) return;
+
+			if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+				focus.focusable.find( root )[ 0 ].focus();
+				event.preventDefault();
+			} else if ( event.keyCode === ESCAPE ) {
+				root.host.focus();
+				event.preventDefault();
+				event.stopPropagation();
+			}
+		}
+
 		root.addEventListener( 'focusin', onFocusIn );
 		root.addEventListener( 'focusout', onFocusOut );
+		element.addEventListener( 'keydown', onKeyDown );
 		return () => {
 			root.addEventListener( 'focusin', onFocusIn );
 			root.addEventListener( 'focusout', onFocusOut );
+			element.removeEventListener( 'keydown', onKeyDown );
 		};
 	}, [] );
 	return (
@@ -57,16 +72,6 @@ export default function EmbeddedAdminContext( props ) {
 			tabIndex={ 0 }
 			role="button"
 			aria-pressed={ hasFocus }
-			onKeyDown={ ( event ) => {
-				if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
-					focus.focusable.find( shadow )[ 0 ].focus();
-					event.preventDefault();
-				} else if ( event.keyCode === ESCAPE ) {
-					shadow.host.focus();
-					event.preventDefault();
-					event.stopPropagation();
-				}
-			} }
 		>
 			{ shadow &&
 				createPortal(

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { useState, createPortal } from '@wordpress/element';
+import { ENTER, SPACE, ESCAPE } from '@wordpress/keycodes';
+import { focus } from '@wordpress/dom';
+import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
+
+export default function EmbeddedAdminContext( props ) {
+	const [ shadow, setShadow ] = useState();
+	const [ hasFocus, setHasFocus ] = useState();
+	const ref = useRefEffect( ( element ) => {
+		const root = element.attachShadow( { mode: 'open' } );
+		const style = document.createElement( 'style' );
+		Array.from( document.styleSheets ).forEach( ( styleSheet ) => {
+			if ( styleSheet.ownerNode.getAttribute( 'data-emotion' ) ) {
+				return;
+			}
+
+			// Try to avoid requests for stylesheets of which we already
+			// know the CSS rules.
+			try {
+				let cssText = '';
+
+				for ( const cssRule of styleSheet.cssRules ) {
+					cssText += cssRule.cssText;
+				}
+
+				style.textContent += cssText;
+			} catch ( e ) {
+				root.appendChild( styleSheet.ownerNode.cloneNode( true ) );
+			}
+		} );
+		root.appendChild( style );
+		setShadow( root );
+
+		function onFocusIn() {
+			setHasFocus( true );
+		}
+
+		function onFocusOut() {
+			setHasFocus( false );
+		}
+
+		root.addEventListener( 'focusin', onFocusIn );
+		root.addEventListener( 'focusout', onFocusOut );
+		return () => {
+			root.addEventListener( 'focusin', onFocusIn );
+			root.addEventListener( 'focusout', onFocusOut );
+		};
+	}, [] );
+	return (
+		<div
+			{ ...props }
+			ref={ ref }
+			tabIndex={ 0 }
+			role="button"
+			aria-pressed={ hasFocus }
+			onKeyDown={ ( event ) => {
+				if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+					focus.focusable.find( shadow )[ 0 ].focus();
+					event.preventDefault();
+				} else if ( event.keyCode === ESCAPE ) {
+					shadow.host.focus();
+					event.preventDefault();
+					event.stopPropagation();
+				}
+			} }
+		>
+			{ shadow &&
+				createPortal(
+					<StyleProvider document={ { head: shadow } }>
+						{ props.children }
+					</StyleProvider>,
+					shadow
+				) }
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -79,6 +79,12 @@ export default function EmbeddedAdminContext( props ) {
 			clearTimeout( timeoutId );
 		};
 	}, [] );
+	const content = (
+		<StyleProvider document={ { head: shadow } }>
+			{ props.children }
+		</StyleProvider>
+	);
+
 	return (
 		<div
 			{ ...props }
@@ -87,13 +93,7 @@ export default function EmbeddedAdminContext( props ) {
 			role="button"
 			aria-pressed={ hasFocus }
 		>
-			{ shadow &&
-				createPortal(
-					<StyleProvider document={ { head: shadow } }>
-						{ props.children }
-					</StyleProvider>,
-					shadow
-				) }
+			{ shadow && createPortal( content, shadow ) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -56,13 +56,27 @@ export default function EmbeddedAdminContext( props ) {
 			}
 		}
 
+		let timeoutId;
+
+		// Allow clicking through the placeholder so focus moves to the block
+		// wraper, which can handle delete, enter, etc.
+		function onMouseDown() {
+			element.removeAttribute( 'tabindex' );
+			timeoutId = setTimeout( () =>
+				element.setAttribute( 'tabindex', '0' )
+			);
+		}
+
 		root.addEventListener( 'focusin', onFocusIn );
 		root.addEventListener( 'focusout', onFocusOut );
 		element.addEventListener( 'keydown', onKeyDown );
+		element.addEventListener( 'mousedown', onMouseDown );
 		return () => {
-			root.addEventListener( 'focusin', onFocusIn );
-			root.addEventListener( 'focusout', onFocusOut );
+			root.removeEventListener( 'focusin', onFocusIn );
+			root.removeEventListener( 'focusout', onFocusOut );
 			element.removeEventListener( 'keydown', onKeyDown );
+			element.removeEventListener( 'mousedown', onMouseDown );
+			clearTimeout( timeoutId );
 		};
 	}, [] );
 	return (

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -47,7 +47,7 @@ export default function EmbeddedAdminContext( props ) {
 			if ( element !== event.path[ 0 ] ) return;
 			if ( event.keyCode !== ENTER && event.keyCode !== SPACE ) return;
 
-			focus.focusable.find( root )[ 0 ].focus();
+			focus.tabbable.find( root )[ 0 ].focus();
 			event.preventDefault();
 		}
 

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -45,15 +45,17 @@ export default function EmbeddedAdminContext( props ) {
 
 		function onKeyDown( event ) {
 			if ( element !== event.path[ 0 ] ) return;
+			if ( event.keyCode !== ENTER && event.keyCode !== SPACE ) return;
 
-			if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
-				focus.focusable.find( root )[ 0 ].focus();
-				event.preventDefault();
-			} else if ( event.keyCode === ESCAPE ) {
-				root.host.focus();
-				event.preventDefault();
-				event.stopPropagation();
-			}
+			focus.focusable.find( root )[ 0 ].focus();
+			event.preventDefault();
+		}
+
+		function onRootKeyDown( event ) {
+			if ( event.keyCode !== ESCAPE ) return;
+
+			root.host.focus();
+			event.preventDefault();
 		}
 
 		let timeoutId;
@@ -69,11 +71,13 @@ export default function EmbeddedAdminContext( props ) {
 
 		root.addEventListener( 'focusin', onFocusIn );
 		root.addEventListener( 'focusout', onFocusOut );
+		root.addEventListener( 'keydown', onRootKeyDown );
 		element.addEventListener( 'keydown', onKeyDown );
 		element.addEventListener( 'mousedown', onMouseDown );
 		return () => {
 			root.removeEventListener( 'focusin', onFocusIn );
 			root.removeEventListener( 'focusout', onFocusOut );
+			root.removeEventListener( 'keydown', onRootKeyDown );
 			element.removeEventListener( 'keydown', onKeyDown );
 			element.removeEventListener( 'mousedown', onMouseDown );
 			clearTimeout( timeoutId );

--- a/packages/block-editor/src/components/embedded-admin-context/index.js
+++ b/packages/block-editor/src/components/embedded-admin-context/index.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useRefEffect } from '@wordpress/compose';
+import {
+	useRefEffect,
+	useConstrainedTabbing,
+	useMergeRefs,
+} from '@wordpress/compose';
 import { useState, createPortal } from '@wordpress/element';
 import { ENTER, SPACE, ESCAPE } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
@@ -117,9 +121,25 @@ export default function EmbeddedAdminContext( props ) {
 			clearTimeout( timeoutId );
 		};
 	}, [] );
+
+	const dialogRef = useRefEffect( ( element ) => {
+		if (
+			element.getRootNode().host !== element.ownerDocument.activeElement
+		)
+			return;
+
+		const [ firstTabbable ] = focus.tabbable.find( element );
+		if ( firstTabbable ) firstTabbable.focus();
+	}, [] );
+
 	const content = (
 		<StyleProvider document={ { head: shadow } }>
-			{ props.children }
+			<div
+				role="dialog"
+				ref={ useMergeRefs( [ useConstrainedTabbing(), dialogRef ] ) }
+			>
+				{ props.children }
+			</div>
 		</StyleProvider>
 	);
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -164,12 +164,14 @@ async function loadScript( head, { id, src } ) {
 	} );
 }
 
-function Iframe( { contentRef, children, head, tabIndex = 0, ...props }, ref ) {
+function Iframe(
+	{ contentRef, children, head, tabIndex = 0, assets, ...props },
+	ref
+) {
 	const [ , forceRender ] = useReducer( () => ( {} ) );
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
-	const styles = useParsedAssets( window.__editorAssets?.styles );
-	const scripts = useParsedAssets( window.__editorAssets?.scripts );
+	const scripts = useParsedAssets( assets.scripts );
 	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const setRef = useRefEffect( ( node ) => {
@@ -236,23 +238,6 @@ function Iframe( { contentRef, children, head, tabIndex = 0, ...props }, ref ) {
 	head = (
 		<>
 			<style>{ 'body{margin:0}' }</style>
-			{ styles.map(
-				( { tagName, href, id, rel, media, textContent } ) => {
-					const TagName = tagName.toLowerCase();
-
-					if ( TagName === 'style' ) {
-						return (
-							<TagName { ...{ id } } key={ id }>
-								{ textContent }
-							</TagName>
-						);
-					}
-
-					return (
-						<TagName { ...{ href, id, rel, media } } key={ id } />
-					);
-				}
-			) }
 			{ head }
 		</>
 	);

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -70,6 +70,7 @@ export { default as __experimentalLinkControlSearchItem } from './link-control/s
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
 export { default as MediaReplaceFlow } from './media-replace-flow';
+export { default as Placeholder } from './placeholder';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import {
 	Button,
 	FormFileUpload,
-	Placeholder,
 	DropZone,
 	withFilters,
 } from '@wordpress/components';
@@ -23,6 +22,7 @@ import { keyboardReturn } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import Placeholder from '../placeholder';
 import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';

--- a/packages/block-editor/src/components/placeholder/index.js
+++ b/packages/block-editor/src/components/placeholder/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useConstrainedTabbing } from '@wordpress/compose';
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import EmbeddedAdminContext from '../embedded-admin-context';
+
+/**
+ * Placeholder for use in blocks. Creates an admin styling context and a tabbing
+ * context in the block editor's writing flow.
+ *
+ * @param {Object} props
+ *
+ * @return {WPComponent} The component
+ */
+export default function IsolatedPlaceholder( props ) {
+	return (
+		<EmbeddedAdminContext aria-label={ props.label }>
+			<Placeholder
+				{ ...props }
+				role="dialog"
+				aria-label={ props.label }
+				ref={ useConstrainedTabbing() }
+			/>
+		</EmbeddedAdminContext>
+	);
+}

--- a/packages/block-editor/src/components/placeholder/index.js
+++ b/packages/block-editor/src/components/placeholder/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useConstrainedTabbing } from '@wordpress/compose';
 import { Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -28,11 +27,7 @@ export default function IsolatedPlaceholder( props ) {
 			) }
 			className="wp-block-editor-placeholder"
 		>
-			<Placeholder
-				{ ...props }
-				role="dialog"
-				ref={ useConstrainedTabbing() }
-			/>
+			<Placeholder { ...props } />
 		</EmbeddedAdminContext>
 	);
 }

--- a/packages/block-editor/src/components/placeholder/index.js
+++ b/packages/block-editor/src/components/placeholder/index.js
@@ -3,6 +3,7 @@
  */
 import { useConstrainedTabbing } from '@wordpress/compose';
 import { Placeholder } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,7 +21,11 @@ import EmbeddedAdminContext from '../embedded-admin-context';
 export default function IsolatedPlaceholder( props ) {
 	return (
 		<EmbeddedAdminContext
-			aria-label={ props.label }
+			aria-label={ sprintf(
+				/* translators: %s: what the placeholder is for */
+				__( 'Placeholder: %s' ),
+				props.label
+			) }
 			className="wp-block-editor-placeholder"
 		>
 			<Placeholder

--- a/packages/block-editor/src/components/placeholder/index.js
+++ b/packages/block-editor/src/components/placeholder/index.js
@@ -26,7 +26,6 @@ export default function IsolatedPlaceholder( props ) {
 			<Placeholder
 				{ ...props }
 				role="dialog"
-				aria-label={ props.label }
 				ref={ useConstrainedTabbing() }
 			/>
 		</EmbeddedAdminContext>

--- a/packages/block-editor/src/components/placeholder/index.js
+++ b/packages/block-editor/src/components/placeholder/index.js
@@ -19,7 +19,10 @@ import EmbeddedAdminContext from '../embedded-admin-context';
  */
 export default function IsolatedPlaceholder( props ) {
 	return (
-		<EmbeddedAdminContext aria-label={ props.label }>
+		<EmbeddedAdminContext
+			aria-label={ props.label }
+			className="wp-block-editor-placeholder"
+		>
 			<Placeholder
 				{ ...props }
 				role="dialog"

--- a/packages/block-editor/src/components/rich-text/editor-styles.scss
+++ b/packages/block-editor/src/components/rich-text/editor-styles.scss
@@ -1,0 +1,42 @@
+.rich-text {
+	[data-rich-text-placeholder] {
+		pointer-events: none;
+	}
+
+	[data-rich-text-placeholder]::after {
+		content: attr(data-rich-text-placeholder);
+		// Use opacity to work in various editor styles.
+		// We don't specify the color here, because blocks or editor styles might provide their own.
+		opacity: 0.62;
+	}
+
+	&:focus {
+		// Removes outline added by the browser.
+		outline: none;
+
+		[data-rich-text-format-boundary] {
+			border-radius: 2px;
+		}
+	}
+}
+
+.block-editor-rich-text__editable {
+	> p:first-child {
+		margin-top: 0;
+	}
+}
+
+// Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
+// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
+figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before {
+	opacity: 0.8;
+}
+
+[data-rich-text-script] {
+	display: inline;
+
+	&::before {
+		content: "</>";
+		background: rgb(255, 255, 0);
+	}
+}

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -1,37 +1,3 @@
-.rich-text {
-	[data-rich-text-placeholder] {
-		pointer-events: none;
-	}
-
-	[data-rich-text-placeholder]::after {
-		content: attr(data-rich-text-placeholder);
-		// Use opacity to work in various editor styles.
-		// We don't specify the color here, because blocks or editor styles might provide their own.
-		opacity: 0.62;
-	}
-
-	&:focus {
-		// Removes outline added by the browser.
-		outline: none;
-
-		[data-rich-text-format-boundary] {
-			border-radius: 2px;
-		}
-	}
-}
-
-.block-editor-rich-text__editable {
-	> p:first-child {
-		margin-top: 0;
-	}
-}
-
-// Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
-// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
-figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before {
-	opacity: 0.8;
-}
-
 .components-popover.block-editor-rich-text__inline-format-toolbar {
 	// Set z-index as if it's displayed on the bottom, otherwise the block
 	// switcher popover might overlap if displayed on the bottom.
@@ -84,14 +50,5 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 				content: attr(aria-label);
 			}
 		}
-	}
-}
-
-[data-rich-text-script] {
-	display: inline;
-
-	&::before {
-		content: "</>";
-		background: rgb(255, 255, 0);
 	}
 }

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -12,16 +12,6 @@ import { useRef } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../../store';
 
-function isFormElement( element ) {
-	const { tagName } = element;
-	return (
-		tagName === 'INPUT' ||
-		tagName === 'BUTTON' ||
-		tagName === 'SELECT' ||
-		tagName === 'TEXTAREA'
-	);
-}
-
 export default function useTabNav() {
 	const container = useRef();
 	const focusCaptureBeforeRef = useRef();
@@ -104,8 +94,11 @@ export default function useTabNav() {
 				return;
 			}
 
+			if ( event.target.getAttribute( 'aria-pressed' ) === 'true' ) {
+				return;
+			}
+
 			const isShift = event.shiftKey;
-			const direction = isShift ? 'findPrevious' : 'findNext';
 
 			if ( ! hasMultiSelection() && ! getSelectedBlockClientId() ) {
 				// Preserve the behaviour of entering navigation mode when
@@ -115,18 +108,6 @@ export default function useTabNav() {
 				// focus land on the writing flow container and pressing Tab
 				// will no longer send focus through the focus capture element.
 				if ( event.target === node ) setNavigationMode( true );
-				return;
-			}
-
-			// Allow tabbing between form elements rendered in a block,
-			// such as inside a placeholder. Form elements are generally
-			// meant to be UI rather than part of the content. Ideally
-			// these are not rendered in the content and perhaps in the
-			// future they can be rendered in an iframe or shadow DOM.
-			if (
-				isFormElement( event.target ) &&
-				isFormElement( focus.tabbable[ direction ]( event.target ) )
-			) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -94,7 +94,7 @@ export default function useTabNav() {
 				return;
 			}
 
-			if ( event.target.getAttribute( 'aria-pressed' ) === 'true' ) {
+			if ( event.target.shadowRoot ) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -94,7 +94,9 @@ export default function useTabNav() {
 				return;
 			}
 
-			if ( event.target.shadowRoot ) {
+			if (
+				event.target.classList.contains( 'wp-block-editor-placeholder' )
+			) {
 				return;
 			}
 

--- a/packages/block-editor/src/editor-styles.scss
+++ b/packages/block-editor/src/editor-styles.scss
@@ -1,0 +1,5 @@
+@import "./components/rich-text/editor-styles.scss";
+@import "./components/plain-text/style.scss";
+@import "./components/block-list/style.scss";
+@import "./components/block-list-appender/style.scss";
+@import "./components/inner-blocks/style.scss";

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -234,4 +234,6 @@ export const SETTINGS_DEFAULTS = {
 			slug: 'midnight',
 		},
 	],
+
+	resolvedAssets: { styles: [], scripts: [] },
 };

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -3,9 +3,7 @@
 @import "./components/block-alignment-matrix-control/style.scss";
 @import "./components/block-icon/style.scss";
 @import "./components/block-inspector/style.scss";
-@import "./components/block-list/style.scss";
 @import "./components/block-tools/style.scss";
-@import "./components/block-list-appender/style.scss";
 @import "./components/block-breadcrumb/style.scss";
 @import "./components/block-card/style.scss";
 @import "./components/block-compare/style.scss";
@@ -36,13 +34,11 @@
 @import "./components/link-control/style.scss";
 @import "./components/line-height-control/style.scss";
 @import "./components/image-size-control/style.scss";
-@import "./components/inner-blocks/style.scss";
 @import "./components/inserter-list-item/style.scss";
 @import "./components/list-view/style.scss";
 @import "./components/media-replace-flow/style.scss";
 @import "./components/media-placeholder/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
-@import "./components/plain-text/style.scss";
 @import "./components/responsive-block-control/style.scss";
 @import "./components/rich-text/style.scss";
 @import "./components/skip-to-selected-block/style.scss";

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -14,6 +14,5 @@
 		"customClassName": false,
 		"html": false,
 		"inserter": false
-	},
-	"editorStyle": "wp-block-editor"
+	}
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -8,7 +8,6 @@ import {
 	store as coreStore,
 } from '@wordpress/core-data';
 import {
-	Placeholder,
 	Spinner,
 	ToolbarGroup,
 	ToolbarButton,
@@ -25,6 +24,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	Warning,
+	Placeholder,
 } from '@wordpress/block-editor';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import { ungroup } from '@wordpress/icons';

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -8,10 +8,10 @@ import memoize from 'memize';
  * WordPress dependencies
  */
 import { calendar as icon } from '@wordpress/icons';
-import { Disabled, Placeholder, Spinner } from '@wordpress/components';
+import { Disabled, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import ServerSideRender from '@wordpress/server-side-render';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, Placeholder } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -8,14 +8,17 @@ import { times, unescape } from 'lodash';
  */
 import {
 	PanelBody,
-	Placeholder,
 	Spinner,
 	ToggleControl,
 	VisuallyHidden,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	Placeholder,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Button, Placeholder, ExternalLink } from '@wordpress/components';
-import { BlockIcon } from '@wordpress/block-editor';
+import { Button, ExternalLink } from '@wordpress/components';
+import { BlockIcon, Placeholder } from '@wordpress/block-editor';
 
 const EmbedPlaceholder = ( {
 	icon,

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -12,8 +12,8 @@ import classnames from 'classnames/dedupe';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Placeholder, SandBox } from '@wordpress/components';
-import { RichText, BlockIcon } from '@wordpress/block-editor';
+import { SandBox } from '@wordpress/components';
+import { RichText, BlockIcon, Placeholder } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -11,7 +11,6 @@ import { RawHTML } from '@wordpress/element';
 import {
 	BaseControl,
 	PanelBody,
-	Placeholder,
 	QueryControls,
 	RadioControl,
 	RangeControl,
@@ -28,6 +27,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	useBlockProps,
 	store as blockEditorStore,
+	Placeholder,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { pin, list, grid } from '@wordpress/icons';

--- a/packages/block-library/src/post-comment/edit.js
+++ b/packages/block-library/src/post-comment/edit.js
@@ -2,10 +2,14 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Placeholder, TextControl, Button } from '@wordpress/components';
+import { TextControl, Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { blockDefault } from '@wordpress/icons';
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	Placeholder,
+} from '@wordpress/block-editor';
 
 const ALLOWED_BLOCKS = [
 	'core/comment-author-avatar',

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -5,12 +5,12 @@ import {
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
+	Placeholder,
 } from '@wordpress/block-editor';
 import {
 	Button,
 	Disabled,
 	PanelBody,
-	Placeholder,
 	RangeControl,
 	TextControl,
 	ToggleControl,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -18,7 +18,6 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarButton,
-	Placeholder,
 	Button,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -26,6 +25,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	MediaPlaceholder,
+	Placeholder,
 	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -19,13 +19,13 @@ import {
 	ToggleControl,
 	ToolbarButton,
 	Button,
+	Placeholder,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockControls,
 	InspectorControls,
 	MediaPlaceholder,
-	Placeholder,
 	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -12,11 +12,11 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
+	Placeholder,
 } from '@wordpress/block-editor';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import {
 	PanelBody,
-	Placeholder,
 	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -16,12 +16,12 @@ import {
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalUseBorderProps as useBorderProps,
+	Placeholder,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	PanelBody,
-	Placeholder,
 	TextControl,
 	ToggleControl,
 	ToolbarDropdownMenu,

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -9,9 +9,10 @@ import { find } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Placeholder, Dropdown, Button, Spinner } from '@wordpress/components';
+import { Dropdown, Button, Spinner } from '@wordpress/components';
 import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
+import { Placeholder } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useResizeObserver } from '@wordpress/compose';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,20 +26,24 @@ import Icon from '../icon';
  * @param {Object}    props.notices        A rendered notices list.
  * @param {Object}    props.preview        Preview to be rendered in the placeholder.
  * @param {boolean}   props.isColumnLayout Whether a column layout should be used.
+ * @param {Object}    ref                  Forwarded ref.
  *
  * @return {Object} The rendered placeholder.
  */
-function Placeholder( {
-	icon,
-	children,
-	label,
-	instructions,
-	className,
-	notices,
-	preview,
-	isColumnLayout,
-	...additionalProps
-} ) {
+export function Placeholder(
+	{
+		icon,
+		children,
+		label,
+		instructions,
+		className,
+		notices,
+		preview,
+		isColumnLayout,
+		...additionalProps
+	},
+	ref
+) {
 	const [ resizeListener, { width } ] = useResizeObserver();
 
 	// Since `useResizeObserver` will report a width of `null` until after the
@@ -61,7 +66,7 @@ function Placeholder( {
 		'is-column-layout': isColumnLayout,
 	} );
 	return (
-		<div { ...additionalProps } className={ classes }>
+		<div { ...additionalProps } className={ classes } ref={ ref }>
 			{ resizeListener }
 			{ notices }
 			{ preview && (
@@ -83,4 +88,4 @@ function Placeholder( {
 	);
 }
 
-export default Placeholder;
+export default forwardRef( Placeholder );

--- a/packages/components/src/placeholder/test/index.js
+++ b/packages/components/src/placeholder/test/index.js
@@ -12,7 +12,7 @@ import { useResizeObserver } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import Placeholder from '../';
+import { Placeholder } from '../';
 
 describe( 'Placeholder', () => {
 	beforeEach( () => {

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -122,7 +122,10 @@ export default function SidebarBlockEditor( {
 
 				<CopyHandler>
 					<BlockTools>
-						<EditorStyles styles={ settings.defaultEditorStyles } />
+						<EditorStyles
+							styles={ settings.defaultEditorStyles }
+							assets={ blockEditorSettings.resolvedAssets }
+						/>
 						<BlockSelectionClearer>
 							<WritingFlow className="editor-styles-wrapper">
 								<ObserveTyping>

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -86,14 +86,14 @@ function isValidFocusableArea( element ) {
 /**
  * Returns all focusable elements within a given context.
  *
- * @param {Element} context              Element in which to search.
- * @param {Object}  [options]
- * @param {boolean} [options.sequential] If set, only return elements that are
- *                                       sequentially focusable.
- *                                       Non-interactive elements with a
- *                                       negative `tabindex` are focusable but
- *                                       not sequentially focusable.
- *                                       https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
+ * @param {Element|Document|ShadowRoot} context              Element in which to search.
+ * @param {Object}                      [options]
+ * @param {boolean}                     [options.sequential] If set, only return elements that are
+ *                                                           sequentially focusable.
+ *                                                           Non-interactive elements with a
+ *                                                           negative `tabindex` are focusable but
+ *                                                           not sequentially focusable.
+ *                                                           https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
  *
  * @return {Element[]} Focusable elements.
  */

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -162,7 +162,9 @@ export function find( context ) {
  *                          to the active element.
  */
 export function findPrevious( element ) {
-	const focusables = findFocusable( element.ownerDocument.body );
+	const focusables = findFocusable(
+		/** @type {Document|ShadowRoot} */ ( element.getRootNode() )
+	);
 	const index = focusables.indexOf( element );
 
 	// Remove all focusables after and including `element`.
@@ -178,7 +180,9 @@ export function findPrevious( element ) {
  *                          to the active element.
  */
 export function findNext( element ) {
-	const focusables = findFocusable( element.ownerDocument.body );
+	const focusables = findFocusable(
+		/** @type {Document|ShadowRoot} */ ( element.getRootNode() )
+	);
 	const index = focusables.indexOf( element );
 
 	// Remove all focusables before and including `element`.

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -148,7 +148,8 @@ function filterTabbable( focusables ) {
 }
 
 /**
- * @param {Element} context
+ * @param {Element|Document|ShadowRoot} context
+ *
  * @return {Element[]} Tabbable elements within the context.
  */
 export function find( context ) {

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -107,6 +107,14 @@ _Parameters_
 
 -   _buttonLabel_ `string`: The label to search the button for.
 
+### clickPlaceholderButton
+
+Clicks a button in a placeholder based on the label text.
+
+_Parameters_
+
+-   _buttonText_ `string`: The text that appears on the button to click.
+
 ### closeGlobalBlockInserter
 
 Undocumented declaration.

--- a/packages/e2e-test-utils/src/click-placeholder-button.js
+++ b/packages/e2e-test-utils/src/click-placeholder-button.js
@@ -12,7 +12,7 @@ export async function clickPlaceholderButton( buttonText ) {
 
 			for ( const placeholder of placeholders ) {
 				const buttons = placeholder.shadowRoot.querySelectorAll(
-					'button,label'
+					'button,label,[aria-label]'
 				);
 
 				for ( const button of buttons ) {

--- a/packages/e2e-test-utils/src/click-placeholder-button.js
+++ b/packages/e2e-test-utils/src/click-placeholder-button.js
@@ -1,0 +1,32 @@
+/**
+ * Clicks a button in a placeholder based on the label text.
+ *
+ * @param {string} buttonText The text that appears on the button to click.
+ */
+export async function clickPlaceholderButton( buttonText ) {
+	const _button = await page.waitForFunction(
+		( text ) => {
+			const placeholders = document.querySelectorAll(
+				'.wp-block-editor-placeholder'
+			);
+
+			for ( const placeholder of placeholders ) {
+				const buttons = placeholder.shadowRoot.querySelectorAll(
+					'button,label'
+				);
+
+				for ( const button of buttons ) {
+					if (
+						button.textContent === text ||
+						button.getAttribute( 'aria-label' ) === text
+					) {
+						return button;
+					}
+				}
+			}
+		},
+		{},
+		buttonText
+	);
+	await _button.click();
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -14,6 +14,7 @@ export { clickButton } from './click-button';
 export { clickMenuItem } from './click-menu-item';
 export { clickOnCloseModalButton } from './click-on-close-modal-button';
 export { clickOnMoreMenuItem } from './click-on-more-menu-item';
+export { clickPlaceholderButton } from './click-placeholder-button';
 export { createNewPost } from './create-new-post';
 export { createUser } from './create-user';
 export { createURL } from './create-url';

--- a/packages/e2e-tests/plugins/iframed-editor-style.php
+++ b/packages/e2e-tests/plugins/iframed-editor-style.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Iframed Editor Style
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-iframed-add-editor-style
+ */
+
+// Enable the template editor to test the iframed content.
+add_action(
+	'setup_theme',
+	function() {
+		add_theme_support( 'block-templates' );
+	}
+);
+
+add_filter(
+	'block_editor_settings_all',
+	function( $settings ) {
+		wp_register_style(
+			'my-theme-stylesheet',
+			plugin_dir_url( __FILE__ ) . 'iframed-editor-style/style.css',
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'iframed-editor-style/style.css' )
+		);
+		$settings['assets']['styles'][] = 'my-theme-stylesheet';
+		var_dump( $settings['assets']['styles'] );
+		return $settings;
+	}
+);

--- a/packages/e2e-tests/plugins/iframed-editor-style/style.css
+++ b/packages/e2e-tests/plugins/iframed-editor-style/style.css
@@ -1,0 +1,3 @@
+p {
+    border: 1px solid red
+}

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -16,8 +16,13 @@ describe( 'Columns', () => {
 
 	it( 'restricts all blocks inside the columns block', async () => {
 		await insertBlock( 'Columns' );
+		// Navigate into the placeholder and activate the 50/50 option.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Space' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
 		await closeGlobalBlockInserter();
-		await page.click( '[aria-label="Two columns; equal split"]' );
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnBlockMenuItem = (
 			await page.$x(

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -16,10 +16,6 @@ describe( 'Columns', () => {
 
 	it( 'restricts all blocks inside the columns block', async () => {
 		await insertBlock( 'Columns' );
-		// Navigate into the placeholder and activate the 50/50 option.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'Space' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 		await closeGlobalBlockInserter();

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -7,6 +7,7 @@ import {
 	insertBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Columns', () => {
@@ -16,9 +17,8 @@ describe( 'Columns', () => {
 
 	it( 'restricts all blocks inside the columns block', async () => {
 		await insertBlock( 'Columns' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Space' );
 		await closeGlobalBlockInserter();
+		await clickPlaceholderButton( 'Two columns; equal split' );
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 		const columnBlockMenuItem = (
 			await page.$x(

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -16,6 +16,15 @@ import {
 	clickButton,
 } from '@wordpress/e2e-test-utils';
 
+async function placeholderUpload() {
+	const input = await page.waitForFunction( () =>
+		document
+			.querySelector( '.wp-block-editor-placeholder' )
+			?.shadowRoot.querySelector( 'input[type="file"]' )
+	);
+	return upload( input );
+}
+
 async function upload( handle ) {
 	const testImagePath = path.join(
 		__dirname,
@@ -42,10 +51,7 @@ describe( 'Gallery', () => {
 
 	it( 'can be created using uploaded images', async () => {
 		await insertBlock( 'Gallery' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 
 		const regex = new RegExp(
 			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"full\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image size-full\\"><img src=\\"[^"]+\/${ filename }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
@@ -57,10 +63,7 @@ describe( 'Gallery', () => {
 		const galleryCaption = 'Tested gallery caption';
 
 		await insertBlock( 'Gallery' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		await upload( inputHandle );
+		await placeholderUpload();
 
 		await page.click( '.wp-block-gallery>.blocks-gallery-caption' );
 		await page.keyboard.type( galleryCaption );
@@ -72,10 +75,7 @@ describe( 'Gallery', () => {
 
 	it( "uploaded images' captions can be edited", async () => {
 		await insertBlock( 'Gallery' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		await upload( inputHandle );
+		await placeholderUpload();
 
 		const figureElement = await page.waitForSelector(
 			'.wp-block-gallery .wp-block-image'

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -16,9 +16,7 @@ import {
 	clickButton,
 } from '@wordpress/e2e-test-utils';
 
-async function upload( selector ) {
-	await page.waitForSelector( selector );
-	const inputElement = await page.$( selector );
+async function upload( handle ) {
 	const testImagePath = path.join(
 		__dirname,
 		'..',
@@ -30,7 +28,7 @@ async function upload( selector ) {
 	const filename = uuid();
 	const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
 	fs.copyFileSync( testImagePath, tmpFileName );
-	await inputElement.uploadFile( tmpFileName );
+	await handle.uploadFile( tmpFileName );
 	await page.waitForSelector(
 		`.wp-block-gallery img[src$="${ filename }.png"]`
 	);
@@ -44,7 +42,10 @@ describe( 'Gallery', () => {
 
 	it( 'can be created using uploaded images', async () => {
 		await insertBlock( 'Gallery' );
-		const filename = await upload( '.wp-block-gallery input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 
 		const regex = new RegExp(
 			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"full\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image size-full\\"><img src=\\"[^"]+\/${ filename }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
@@ -56,7 +57,10 @@ describe( 'Gallery', () => {
 		const galleryCaption = 'Tested gallery caption';
 
 		await insertBlock( 'Gallery' );
-		await upload( '.wp-block-gallery input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		await upload( inputHandle );
 
 		await page.click( '.wp-block-gallery>.blocks-gallery-caption' );
 		await page.keyboard.type( galleryCaption );
@@ -68,7 +72,10 @@ describe( 'Gallery', () => {
 
 	it( "uploaded images' captions can be edited", async () => {
 		await insertBlock( 'Gallery' );
-		await upload( '.wp-block-gallery input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-gallery [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		await upload( inputHandle );
 
 		const figureElement = await page.waitForSelector(
 			'.wp-block-gallery .wp-block-image'

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -20,9 +20,7 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
-async function upload( selector ) {
-	await page.waitForSelector( selector );
-	const inputElement = await page.$( selector );
+async function upload( handle ) {
 	const testImagePath = path.join(
 		__dirname,
 		'..',
@@ -34,7 +32,7 @@ async function upload( selector ) {
 	const filename = uuid();
 	const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
 	fs.copyFileSync( testImagePath, tmpFileName );
-	await inputElement.uploadFile( tmpFileName );
+	await handle.uploadFile( tmpFileName );
 	return filename;
 }
 
@@ -65,7 +63,10 @@ describe( 'Image', () => {
 
 	it( 'can be inserted', async () => {
 		await insertBlock( 'Image' );
-		const filename = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 		await waitForImage( filename );
 
 		const regex = new RegExp(
@@ -76,7 +77,10 @@ describe( 'Image', () => {
 
 	it( 'should replace, reset size, and keep selection', async () => {
 		await insertBlock( 'Image' );
-		const filename1 = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename1 = await upload( inputHandle );
 		await waitForImage( filename1 );
 
 		const regex1 = new RegExp(
@@ -95,7 +99,9 @@ describe( 'Image', () => {
 
 		await clickButton( 'Replace' );
 		const filename2 = await upload(
-			'.block-editor-media-replace-flow__options input[type="file"]'
+			await page.$(
+				'.block-editor-media-replace-flow__options input[type="file"]'
+			)
 		);
 		await waitForImage( filename2 );
 
@@ -112,7 +118,10 @@ describe( 'Image', () => {
 
 	it.skip( 'should place caret at end of caption after merging empty paragraph', async () => {
 		await insertBlock( 'Image' );
-		const fileName = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const fileName = await upload( inputHandle );
 		await waitForImage( fileName );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -126,7 +135,10 @@ describe( 'Image', () => {
 
 	it( 'should allow soft line breaks in caption', async () => {
 		await insertBlock( 'Image' );
-		const fileName = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const fileName = await upload( inputHandle );
 		await waitForImage( fileName );
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -139,7 +151,10 @@ describe( 'Image', () => {
 
 	it( 'should have keyboard navigable toolbar for caption', async () => {
 		await insertBlock( 'Image' );
-		const fileName = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const fileName = await upload( inputHandle );
 		await waitForImage( fileName );
 		// Navigate to More, Link, Italic and finally Bold.
 		await pressKeyWithModifier( 'shift', 'Tab' );
@@ -171,7 +186,7 @@ describe( 'Image', () => {
 			document.body.appendChild( input );
 		} );
 
-		const fileName = await upload( '#wp-temp-test-input' );
+		const fileName = await upload( await page.$( '#wp-temp-test-input' ) );
 
 		const paragraphRect = await image.boundingBox();
 		const pX = paragraphRect.x + paragraphRect.width / 2;
@@ -200,7 +215,10 @@ describe( 'Image', () => {
 	it( 'allows zooming using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const filename = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -245,7 +263,10 @@ describe( 'Image', () => {
 	it( 'allows changing aspect ratio using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const filename = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -282,7 +303,10 @@ describe( 'Image', () => {
 	it( 'allows rotating using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const filename = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -313,7 +337,10 @@ describe( 'Image', () => {
 		await insertBlock( 'Image' );
 
 		// Upload an initial image.
-		const filename = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const filename = await upload( inputHandle );
 
 		// Resize the Uploaded Image.
 		await openDocumentSettingsSidebar();
@@ -358,7 +385,10 @@ describe( 'Image', () => {
 
 	it( 'should undo without broken temporary state', async () => {
 		await insertBlock( 'Image' );
-		const fileName = await upload( '.wp-block-image input[type="file"]' );
+		const inputHandle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
+		);
+		const fileName = await upload( inputHandle );
 		await waitForImage( fileName );
 		await pressKeyWithModifier( 'primary', 'z' );
 		// Expect an empty image block (placeholder) rather than one with a

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -20,6 +20,15 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
+async function placeholderUpload() {
+	const input = await page.waitForFunction( () =>
+		document
+			.querySelector( '.wp-block-editor-placeholder' )
+			?.shadowRoot.querySelector( 'input[type="file"]' )
+	);
+	return upload( input );
+}
+
 async function upload( handle ) {
 	const testImagePath = path.join(
 		__dirname,
@@ -63,10 +72,7 @@ describe( 'Image', () => {
 
 	it( 'can be inserted', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 		await waitForImage( filename );
 
 		const regex = new RegExp(
@@ -77,10 +83,7 @@ describe( 'Image', () => {
 
 	it( 'should replace, reset size, and keep selection', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename1 = await upload( inputHandle );
+		const filename1 = await placeholderUpload();
 		await waitForImage( filename1 );
 
 		const regex1 = new RegExp(
@@ -118,10 +121,7 @@ describe( 'Image', () => {
 
 	it.skip( 'should place caret at end of caption after merging empty paragraph', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const fileName = await upload( inputHandle );
+		const fileName = await placeholderUpload();
 		await waitForImage( fileName );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -135,10 +135,7 @@ describe( 'Image', () => {
 
 	it( 'should allow soft line breaks in caption', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const fileName = await upload( inputHandle );
+		const fileName = await placeholderUpload();
 		await waitForImage( fileName );
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -151,10 +148,7 @@ describe( 'Image', () => {
 
 	it( 'should have keyboard navigable toolbar for caption', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const fileName = await upload( inputHandle );
+		const fileName = await placeholderUpload();
 		await waitForImage( fileName );
 		// Navigate to More, Link, Italic and finally Bold.
 		await pressKeyWithModifier( 'shift', 'Tab' );
@@ -215,10 +209,7 @@ describe( 'Image', () => {
 	it( 'allows zooming using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -263,10 +254,7 @@ describe( 'Image', () => {
 	it( 'allows changing aspect ratio using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -303,10 +291,7 @@ describe( 'Image', () => {
 	it( 'allows rotating using the crop tools', async () => {
 		// Insert the block, upload a file and crop.
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 		await waitForImage( filename );
 
 		// Assert that the image is initially unscaled and unedited.
@@ -337,10 +322,7 @@ describe( 'Image', () => {
 		await insertBlock( 'Image' );
 
 		// Upload an initial image.
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const filename = await upload( inputHandle );
+		const filename = await placeholderUpload();
 
 		// Resize the Uploaded Image.
 		await openDocumentSettingsSidebar();
@@ -385,10 +367,7 @@ describe( 'Image', () => {
 
 	it( 'should undo without broken temporary state', async () => {
 		await insertBlock( 'Image' );
-		const inputHandle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-image [role="button"]').shadowRoot.querySelector('input[type="file"]')`
-		);
-		const fileName = await upload( inputHandle );
+		const fileName = await placeholderUpload();
 		await waitForImage( fileName );
 		await pressKeyWithModifier( 'primary', 'z' );
 		// Expect an empty image block (placeholder) rather than one with a

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -10,8 +10,6 @@ import {
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
-const createButtonLabel = 'Create Table';
-
 /**
  * Utility function for changing the selected cell alignment.
  *
@@ -22,56 +20,44 @@ async function changeCellAlignment( align ) {
 	await clickButton( `Align column ${ align.toLowerCase() }` );
 }
 
+async function createTable( columnCount, rowCount ) {
+	await insertBlock( 'Table' );
+
+	// Navigate into the placeholder.
+	await page.keyboard.press( 'ArrowDown' );
+	await page.keyboard.press( 'Space' );
+
+	// Navigate to "Column count"
+	await page.keyboard.press( 'Tab' );
+
+	if ( columnCount ) await page.keyboard.type( columnCount );
+
+	// Navigate to "Row count"
+	await page.keyboard.press( 'Tab' );
+
+	if ( rowCount ) await page.keyboard.type( rowCount );
+
+	// Navigate to "Create Table"
+	await page.keyboard.press( 'Tab' );
+
+	// Create the table.
+	await page.keyboard.press( 'Space' );
+}
+
 describe( 'Table', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
 
 	it( 'displays a form for choosing the row and column count of the table', async () => {
-		await insertBlock( 'Table' );
-
-		// Check for existence of the column count field.
-		const columnCountLabel = await page.$x(
-			"//figure[@data-type='core/table']//label[text()='Column count']"
-		);
-		expect( columnCountLabel ).toHaveLength( 1 );
-
-		// Modify the column count.
-		await columnCountLabel[ 0 ].click();
-		const currentColumnCount = await page.evaluate(
-			() => document.activeElement.value
-		);
-		expect( currentColumnCount ).toBe( '2' );
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.type( '5' );
-
-		// Check for existence of the row count field.
-		const rowCountLabel = await page.$x(
-			"//figure[@data-type='core/table']//label[text()='Row count']"
-		);
-		expect( rowCountLabel ).toHaveLength( 1 );
-
-		// Modify the row count.
-		await rowCountLabel[ 0 ].click();
-		const currentRowCount = await page.evaluate(
-			() => document.activeElement.value
-		);
-		expect( currentRowCount ).toBe( '2' );
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.type( '10' );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
+		await createTable( '5', '10' );
 
 		// Expect the post content to have a correctly sized table.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'allows text to by typed into cells', async () => {
-		await insertBlock( 'Table' );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
+		await createTable();
 
 		// Click the first cell and add some text.
 		await page.click( 'td' );
@@ -94,26 +80,16 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows header and footer rows to be switched on and off', async () => {
-		await insertBlock( 'Table' );
+		await createTable();
 		await openDocumentSettingsSidebar();
 
-		const headerSwitchSelector = "//label[text()='Header section']";
-		const footerSwitchSelector = "//label[text()='Footer section']";
-
-		// Expect the header and footer switches not to be present before the table has been created.
-		let headerSwitch = await page.$x( headerSwitchSelector );
-		let footerSwitch = await page.$x( footerSwitchSelector );
-		expect( headerSwitch ).toHaveLength( 0 );
-		expect( footerSwitch ).toHaveLength( 0 );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
-
 		// Expect the header and footer switches to be present now that the table has been created.
-		headerSwitch = await page.$x( headerSwitchSelector );
-		footerSwitch = await page.$x( footerSwitchSelector );
-		expect( headerSwitch ).toHaveLength( 1 );
-		expect( footerSwitch ).toHaveLength( 1 );
+		const headerSwitch = await page.$x(
+			"//label[text()='Header section']"
+		);
+		const footerSwitch = await page.$x(
+			"//label[text()='Footer section']"
+		);
 
 		// Toggle on the switches and add some content.
 		await headerSwitch[ 0 ].click();
@@ -140,11 +116,8 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows adding and deleting columns across the table header, body and footer', async () => {
-		await insertBlock( 'Table' );
+		await createTable();
 		await openDocumentSettingsSidebar();
-
-		// Create the table.
-		await clickButton( createButtonLabel );
 
 		// Toggle on the switches and add some content.
 		const headerSwitch = await page.$x(
@@ -176,17 +149,7 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows columns to be aligned', async () => {
-		await insertBlock( 'Table' );
-
-		const [ columnCountLabel ] = await page.$x(
-			"//figure[@data-type='core/table']//label[text()='Column count']"
-		);
-		await columnCountLabel.click();
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.type( '4' );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
+		await createTable( '4' );
 
 		// Click the first cell and add some text. Don't align.
 		const cells = await page.$$( 'td,th' );
@@ -214,11 +177,8 @@ describe( 'Table', () => {
 
 	// Testing for regressions of https://github.com/WordPress/gutenberg/issues/14904.
 	it( 'allows cells to be selected when the cell area outside of the RichText is clicked', async () => {
-		await insertBlock( 'Table' );
+		await createTable();
 		await openDocumentSettingsSidebar();
-
-		// Create the table.
-		await clickButton( createButtonLabel );
 
 		// Enable fixed width as it exascerbates the amount of empty space around the RichText.
 		const [ fixedWidthSwitch ] = await page.$x(
@@ -251,10 +211,7 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows a caption to be added', async () => {
-		await insertBlock( 'Table' );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
+		await createTable();
 
 		// Click the first cell and add some text.
 		await page.click( '.wp-block-table figcaption' );
@@ -264,10 +221,7 @@ describe( 'Table', () => {
 	} );
 
 	it( 'up and down arrow navigation', async () => {
-		await insertBlock( 'Table' );
-
-		// Create the table.
-		await clickButton( createButtonLabel );
+		await createTable();
 
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( '1' );

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -23,14 +23,10 @@ async function changeCellAlignment( align ) {
 async function createTable( columnCount, rowCount ) {
 	await insertBlock( 'Table' );
 
-	// Navigate into the placeholder.
-	await page.keyboard.press( 'ArrowDown' );
-	await page.keyboard.press( 'Space' );
-
-	// Navigate to "Column count"
-	await page.keyboard.press( 'Tab' );
-
-	if ( columnCount ) await page.keyboard.type( columnCount );
+	if ( columnCount ) {
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( columnCount );
+	}
 
 	// Navigate to "Row count"
 	await page.keyboard.press( 'Tab' );

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -8,7 +8,10 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	openDocumentSettingsSidebar,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
+
+const createButtonLabel = 'Create Table';
 
 /**
  * Utility function for changing the selected cell alignment.
@@ -20,40 +23,34 @@ async function changeCellAlignment( align ) {
 	await clickButton( `Align column ${ align.toLowerCase() }` );
 }
 
-async function createTable( columnCount, rowCount ) {
-	await insertBlock( 'Table' );
-
-	if ( columnCount ) {
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.type( columnCount );
-	}
-
-	// Navigate to "Row count"
-	await page.keyboard.press( 'Tab' );
-
-	if ( rowCount ) await page.keyboard.type( rowCount );
-
-	// Navigate to "Create Table"
-	await page.keyboard.press( 'Tab' );
-
-	// Create the table.
-	await page.keyboard.press( 'Space' );
-}
-
 describe( 'Table', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
 
 	it( 'displays a form for choosing the row and column count of the table', async () => {
-		await createTable( '5', '10' );
+		await insertBlock( 'Table' );
+
+		await clickPlaceholderButton( 'Column count' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '5' );
+
+		await clickPlaceholderButton( 'Row count' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '10' );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Expect the post content to have a correctly sized table.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'allows text to by typed into cells', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Click the first cell and add some text.
 		await page.click( 'td' );
@@ -76,16 +73,26 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows header and footer rows to be switched on and off', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
 		await openDocumentSettingsSidebar();
 
+		const headerSwitchSelector = "//label[text()='Header section']";
+		const footerSwitchSelector = "//label[text()='Footer section']";
+
+		// Expect the header and footer switches not to be present before the table has been created.
+		let headerSwitch = await page.$x( headerSwitchSelector );
+		let footerSwitch = await page.$x( footerSwitchSelector );
+		expect( headerSwitch ).toHaveLength( 0 );
+		expect( footerSwitch ).toHaveLength( 0 );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
+
 		// Expect the header and footer switches to be present now that the table has been created.
-		const headerSwitch = await page.$x(
-			"//label[text()='Header section']"
-		);
-		const footerSwitch = await page.$x(
-			"//label[text()='Footer section']"
-		);
+		headerSwitch = await page.$x( headerSwitchSelector );
+		footerSwitch = await page.$x( footerSwitchSelector );
+		expect( headerSwitch ).toHaveLength( 1 );
+		expect( footerSwitch ).toHaveLength( 1 );
 
 		// Toggle on the switches and add some content.
 		await headerSwitch[ 0 ].click();
@@ -112,8 +119,11 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows adding and deleting columns across the table header, body and footer', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
 		await openDocumentSettingsSidebar();
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Toggle on the switches and add some content.
 		const headerSwitch = await page.$x(
@@ -145,7 +155,14 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows columns to be aligned', async () => {
-		await createTable( '4' );
+		await insertBlock( 'Table' );
+
+		await clickPlaceholderButton( 'Column count' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Click the first cell and add some text. Don't align.
 		const cells = await page.$$( 'td,th' );
@@ -173,8 +190,11 @@ describe( 'Table', () => {
 
 	// Testing for regressions of https://github.com/WordPress/gutenberg/issues/14904.
 	it( 'allows cells to be selected when the cell area outside of the RichText is clicked', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
 		await openDocumentSettingsSidebar();
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Enable fixed width as it exascerbates the amount of empty space around the RichText.
 		const [ fixedWidthSwitch ] = await page.$x(
@@ -207,7 +227,10 @@ describe( 'Table', () => {
 	} );
 
 	it( 'allows a caption to be added', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		// Click the first cell and add some text.
 		await page.click( '.wp-block-table figcaption' );
@@ -217,7 +240,10 @@ describe( 'Table', () => {
 	} );
 
 	it( 'up and down arrow navigation', async () => {
-		await createTable();
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		await clickPlaceholderButton( createButtonLabel );
 
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( '1' );

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -86,10 +86,18 @@ describe( 'Block variations', () => {
 	test( 'Pick the additional variation in the inserted Columns block', async () => {
 		await insertBlock( 'Columns' );
 
-		const fourColumnsVariation = await page.waitForSelector(
-			'.wp-block[data-type="core/columns"] .block-editor-block-variation-picker__variation[aria-label="Four columns"]'
-		);
-		await fourColumnsVariation.click();
+		// Navigate into the placeholder and activate the 50/50 option.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Space' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
+
 		expect(
 			await page.$$(
 				'.wp-block[data-type="core/columns"] .wp-block[data-type="core/column"]'

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -11,6 +11,7 @@ import {
 	openDocumentSettingsSidebar,
 	togglePreferencesOption,
 	toggleMoreMenu,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block variations', () => {
@@ -85,14 +86,7 @@ describe( 'Block variations', () => {
 	} );
 	test( 'Pick the additional variation in the inserted Columns block', async () => {
 		await insertBlock( 'Columns' );
-
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Space' );
+		await clickPlaceholderButton( 'Four columns' );
 
 		expect(
 			await page.$$(

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -86,10 +86,6 @@ describe( 'Block variations', () => {
 	test( 'Pick the additional variation in the inserted Columns block', async () => {
 		await insertBlock( 'Columns' );
 
-		// Navigate into the placeholder and activate the 50/50 option.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'Space' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -5,6 +5,7 @@ import {
 	activatePlugin,
 	clickBlockToolbarButton,
 	clickMenuItem,
+	clickPlaceholderButton,
 	createNewPost,
 	deactivatePlugin,
 	getEditedPostContent,
@@ -121,14 +122,7 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'can use the global inserter in inner blocks', async () => {
-			await page.evaluate( () => {
-				document
-					.querySelector( '.wp-block-columns > div' )
-					.shadowRoot.querySelector(
-						'[aria-label="Two columns; equal split"]'
-					)
-					.focus();
-			} );
+			await clickPlaceholderButton( 'Two columns; equal split' );
 			await page.keyboard.press( 'Enter' );
 			await page.click(
 				'.wp-block-column .block-editor-button-block-appender'

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -121,7 +121,15 @@ describe( 'cpt locking', () => {
 		} );
 
 		it( 'can use the global inserter in inner blocks', async () => {
-			await page.click( 'button[aria-label="Two columns; equal split"]' );
+			await page.evaluate( () => {
+				document
+					.querySelector( '.wp-block-columns > div' )
+					.shadowRoot.querySelector(
+						'[aria-label="Two columns; equal split"]'
+					)
+					.focus();
+			} );
+			await page.keyboard.press( 'Enter' );
 			await page.click(
 				'.wp-block-column .block-editor-button-block-appender'
 			);

--- a/packages/e2e-tests/specs/editor/plugins/iframed-editor-style.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/iframed-editor-style.test.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+	openDocumentSettingsSidebar,
+	clickButton,
+	canvas,
+} from '@wordpress/e2e-test-utils';
+
+async function getComputedStyle( context ) {
+	return await context.evaluate( () => {
+		const container = document.querySelector( '.wp-block-paragraph' );
+		return window.getComputedStyle( container )[ 'border-width' ];
+	} );
+}
+
+describe( 'iframed editor styles', () => {
+	beforeEach( async () => {
+		await activatePlugin( 'gutenberg-test-iframed-editor-style' );
+		await createNewPost( { postType: 'page' } );
+	} );
+
+	afterEach( async () => {
+		await deactivatePlugin( 'gutenberg-test-iframed-editor-style' );
+	} );
+
+	it( 'should load editor styles through the block editor settings', async () => {
+		await insertBlock( 'Paragraph' );
+
+		// expect( await getComputedStyle( page ) ).toBe( '1px' );
+
+		await openDocumentSettingsSidebar();
+		await clickButton( 'Page' );
+		await clickButton( 'Template' );
+		await clickButton( 'New' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'Iframed Test' );
+		await clickButton( 'Create' );
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		await canvas().waitForSelector( '.wp-block-paragraph' );
+
+		expect( await getComputedStyle( canvas() ) ).toBe( '1px' );
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -12,7 +12,6 @@ import { v4 as uuid } from 'uuid';
 import {
 	activatePlugin,
 	createNewPost,
-	clickButton,
 	deactivatePlugin,
 	insertBlock,
 	openDocumentSettingsSidebar,
@@ -30,7 +29,13 @@ describe( 'changing image size', () => {
 
 	it( 'should insert and change my image size', async () => {
 		await insertBlock( 'Image' );
-		await clickButton( 'Media Library' );
+
+		// Navigate into the placeholder and activate the Media Library option.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Space' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -15,6 +15,7 @@ import {
 	deactivatePlugin,
 	insertBlock,
 	openDocumentSettingsSidebar,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'changing image size', () => {
@@ -29,10 +30,7 @@ describe( 'changing image size', () => {
 
 	it( 'should insert and change my image size', async () => {
 		await insertBlock( 'Image' );
-
-		// Tab to the Media Library option.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Space' );
+		await clickPlaceholderButton( 'Media Library' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );

--- a/packages/e2e-tests/specs/editor/plugins/image-size.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/image-size.test.js
@@ -30,10 +30,7 @@ describe( 'changing image size', () => {
 	it( 'should insert and change my image size', async () => {
 		await insertBlock( 'Image' );
 
-		// Navigate into the placeholder and activate the Media Library option.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'Space' );
-		await page.keyboard.press( 'Tab' );
+		// Tab to the Media Library option.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Space' );
 

--- a/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
+++ b/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
@@ -43,10 +43,10 @@ describe( 'Embed block inside a locked all parent', () => {
 
 	it( 'embed block should be able to embed external content', async () => {
 		await insertBlock( 'Test Inner Blocks Locking All Embed' );
-		const embedInputSelector =
-			'.components-placeholder__input[aria-label="Embed URL"]';
-		await page.waitForSelector( embedInputSelector );
-		await page.click( embedInputSelector );
+		const handle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('input')`
+		);
+		await handle.click( handle );
 		// This URL should not have a trailing slash.
 		await page.keyboard.type( 'https://twitter.com/wordpress' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
+++ b/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
@@ -9,6 +9,7 @@ import {
 	createEmbeddingMatcher,
 	createJSONResponse,
 	setUpResponseMocking,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 const MOCK_RESPONSES = [
@@ -43,10 +44,7 @@ describe( 'Embed block inside a locked all parent', () => {
 
 	it( 'embed block should be able to embed external content', async () => {
 		await insertBlock( 'Test Inner Blocks Locking All Embed' );
-		const handle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('input')`
-		);
-		await handle.click( handle );
+		await clickPlaceholderButton( 'Embed URL' );
 		// This URL should not have a trailing slash.
 		await page.keyboard.type( 'https://twitter.com/wordpress' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -116,7 +116,7 @@ describe( 'block deletion -', () => {
 
 			// Click on the image block so that its wrapper is selected and backspace to delete it.
 			await page.click(
-				'.wp-block[data-type="core/image"] .components-placeholder__label'
+				'.wp-block[data-type="core/image"] [role="button"]'
 			);
 			await page.keyboard.press( 'Backspace' );
 

--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -192,6 +192,7 @@ describe( 'deleting all blocks', () => {
 		// Add and remove a block.
 		await insertBlock( 'Image' );
 		await page.waitForSelector( 'figure[data-type="core/image"]' );
+		await page.click( 'figure[data-type="core/image"]' );
 		await page.keyboard.press( 'Backspace' );
 
 		// Verify there is no selected block.

--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -116,7 +116,7 @@ describe( 'block deletion -', () => {
 
 			// Click on the image block so that its wrapper is selected and backspace to delete it.
 			await page.click(
-				'.wp-block[data-type="core/image"] [role="button"]'
+				'.wp-block[data-type="core/image"] .wp-block-editor-placeholder'
 			);
 			await page.keyboard.press( 'Backspace' );
 
@@ -192,7 +192,6 @@ describe( 'deleting all blocks', () => {
 		// Add and remove a block.
 		await insertBlock( 'Image' );
 		await page.waitForSelector( 'figure[data-type="core/image"]' );
-		await page.click( 'figure[data-type="core/image"]' );
 		await page.keyboard.press( 'Backspace' );
 
 		// Verify there is no selected block.

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -94,6 +94,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate block hierarchy using only the keyboard', async () => {
 		await insertBlock( 'Columns' );
+		await openDocumentSettingsSidebar();
 		await clickPlaceholderButton( 'Two columns; equal split' );
 
 		// Add a paragraph in the first column.
@@ -110,7 +111,6 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Move focus to the sidebar area.
-		await openDocumentSettingsSidebar();
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -37,7 +37,8 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate using the list view sidebar', async () => {
 		await insertBlock( 'Columns' );
-		await page.click( '[aria-label="Two columns; equal split"]' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -93,8 +94,8 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate block hierarchy using only the keyboard', async () => {
 		await insertBlock( 'Columns' );
-		await openDocumentSettingsSidebar();
-		await page.click( '[aria-label="Two columns; equal split"]' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -110,6 +111,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Move focus to the sidebar area.
+		await openDocumentSettingsSidebar();
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
@@ -151,6 +153,7 @@ describe( 'Navigating the block hierarchy', () => {
 		// Create an image block too.
 		await page.keyboard.press( 'Enter' );
 		await insertBlock( 'Image' );
+		await page.keyboard.press( 'Escape' );
 
 		// Return to first block.
 		await openListViewSidebar();

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -8,6 +8,7 @@ import {
 	pressKeyTimes,
 	pressKeyWithModifier,
 	openDocumentSettingsSidebar,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 async function openListViewSidebar() {
@@ -37,8 +38,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate using the list view sidebar', async () => {
 		await insertBlock( 'Columns' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Space' );
+		await clickPlaceholderButton( 'Two columns; equal split' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -94,8 +94,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 	it( 'should navigate block hierarchy using only the keyboard', async () => {
 		await insertBlock( 'Columns' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Space' );
+		await clickPlaceholderButton( 'Two columns; equal split' );
 
 		// Add a paragraph in the first column.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.
@@ -153,7 +152,6 @@ describe( 'Navigating the block hierarchy', () => {
 		// Create an image block too.
 		await page.keyboard.press( 'Enter' );
 		await insertBlock( 'Image' );
-		await page.keyboard.press( 'Escape' );
 
 		// Return to first block.
 		await openListViewSidebar();

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -167,6 +167,12 @@ async function insertEmbed( URL ) {
 		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Embed')]`
 	);
 	await page.keyboard.press( 'Enter' );
+	await page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				setTimeout( resolve );
+			} )
+	);
 	await page.keyboard.type( URL );
 	await page.keyboard.press( 'Enter' );
 }

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -167,12 +167,7 @@ async function insertEmbed( URL ) {
 		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Embed')]`
 	);
 	await page.keyboard.press( 'Enter' );
-	await page.evaluate(
-		() =>
-			new Promise( ( resolve ) => {
-				setTimeout( resolve );
-			} )
-	);
+	await page.evaluate( () => new Promise( requestIdleCallback ) );
 	await page.keyboard.type( URL );
 	await page.keyboard.press( 'Enter' );
 }
@@ -269,6 +264,7 @@ describe( 'Embedding content', () => {
 	it( 'should allow the user to try embedding a failed URL again', async () => {
 		// URL that can't be embedded.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
+		await page.evaluate( () => new Promise( requestIdleCallback ) );
 
 		// Set up a different mock to make sure that try again actually does make the request again.
 		await setUpResponseMocking( [

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -3,7 +3,6 @@
  */
 import {
 	clickBlockAppender,
-	clickButton,
 	createEmbeddingMatcher,
 	createJSONResponse,
 	createNewPost,
@@ -190,22 +189,43 @@ describe( 'Embedding content', () => {
 
 		// Valid provider; invalid content. Should render failed, edit state.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
-		await page.waitForSelector(
-			'input[value="https://twitter.com/wooyaygutenberg123454312"]'
-		);
+		await page.waitForFunction( () => {
+			const embedPlaceholders = document.querySelectorAll(
+				'.wp-block-embed [role="button"]'
+			);
+			const lastEmbedPlaceholder =
+				embedPlaceholders[ embedPlaceholders.length - 1 ];
+			return lastEmbedPlaceholder?.shadowRoot.querySelector(
+				'input[value="https://twitter.com/wooyaygutenberg123454312"]'
+			);
+		} );
 
 		// WordPress invalid content. Should render failed, edit state.
 		await insertEmbed( 'https://wordpress.org/gutenberg/handbook/' );
-		await page.waitForSelector(
-			'input[value="https://wordpress.org/gutenberg/handbook/"]'
-		);
+		await page.waitForFunction( () => {
+			const embedPlaceholders = document.querySelectorAll(
+				'.wp-block-embed [role="button"]'
+			);
+			const lastEmbedPlaceholder =
+				embedPlaceholders[ embedPlaceholders.length - 1 ];
+			return lastEmbedPlaceholder?.shadowRoot.querySelector(
+				'input[value="https://wordpress.org/gutenberg/handbook/"]'
+			);
+		} );
 
 		// Provider whose oembed API has gone wrong. Should render failed, edit
 		// state.
 		await insertEmbed( 'https://twitter.com/thatbunty' );
-		await page.waitForSelector(
-			'input[value="https://twitter.com/thatbunty"]'
-		);
+		await page.waitForFunction( () => {
+			const embedPlaceholders = document.querySelectorAll(
+				'.wp-block-embed [role="button"]'
+			);
+			const lastEmbedPlaceholder =
+				embedPlaceholders[ embedPlaceholders.length - 1 ];
+			return lastEmbedPlaceholder?.shadowRoot.querySelector(
+				'input[value="https://twitter.com/thatbunty"]'
+			);
+		} );
 
 		// WordPress content that can be embedded. Should render valid figure
 		// element.
@@ -234,15 +254,22 @@ describe( 'Embedding content', () => {
 		// URL that can't be embedded.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 
-		// Wait for the request to fail and present an error. Since placeholder
-		// has styles applied which depend on resize observer, wait for the
-		// expected size class to settle before clicking, since otherwise a race
-		// condition could occur on the placeholder layout vs. click intent.
-		await page.waitForSelector(
-			'.components-placeholder.is-large .components-placeholder__error'
-		);
+		await page.waitForFunction( () => {
+			const embedPlaceholders = document.querySelectorAll(
+				'.wp-block-embed [role="button"]'
+			);
+			const lastEmbedPlaceholder =
+				embedPlaceholders[ embedPlaceholders.length - 1 ];
+			return lastEmbedPlaceholder?.shadowRoot.querySelector(
+				'input[value="https://twitter.com/wooyaygutenberg123454312"]'
+			);
+		} );
 
-		await clickButton( 'Convert to link' );
+		const handle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('.components-placeholder__error').lastElementChild`
+		);
+		await handle.click( handle );
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -257,13 +284,16 @@ describe( 'Embedding content', () => {
 		// URL that can't be embedded.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 
-		// Wait for the request to fail and present an error. Since placeholder
-		// has styles applied which depend on resize observer, wait for the
-		// expected size class to settle before clicking, since otherwise a race
-		// condition could occur on the placeholder layout vs. click intent.
-		await page.waitForSelector(
-			'.components-placeholder.is-large .components-placeholder__error'
-		);
+		await page.waitForFunction( () => {
+			const embedPlaceholders = document.querySelectorAll(
+				'.wp-block-embed [role="button"]'
+			);
+			const lastEmbedPlaceholder =
+				embedPlaceholders[ embedPlaceholders.length - 1 ];
+			return lastEmbedPlaceholder?.shadowRoot.querySelector(
+				'input[value="https://twitter.com/wooyaygutenberg123454312"]'
+			);
+		} );
 
 		// Set up a different mock to make sure that try again actually does make the request again.
 		await setUpResponseMocking( [
@@ -276,7 +306,10 @@ describe( 'Embedding content', () => {
 				),
 			},
 		] );
-		await clickButton( 'Try again' );
+		const handle = await page.evaluateHandle(
+			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('button.is-secondary')`
+		);
+		await handle.click( handle );
 		await page.waitForSelector( 'figure.wp-block-embed' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -3,6 +3,7 @@
  */
 import {
 	clickBlockAppender,
+	clickPlaceholderButton,
 	createEmbeddingMatcher,
 	createJSONResponse,
 	createNewPost,
@@ -191,7 +192,7 @@ describe( 'Embedding content', () => {
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 		await page.waitForFunction( () => {
 			const embedPlaceholders = document.querySelectorAll(
-				'.wp-block-embed [role="button"]'
+				'.wp-block-editor-placeholder'
 			);
 			const lastEmbedPlaceholder =
 				embedPlaceholders[ embedPlaceholders.length - 1 ];
@@ -204,7 +205,7 @@ describe( 'Embedding content', () => {
 		await insertEmbed( 'https://wordpress.org/gutenberg/handbook/' );
 		await page.waitForFunction( () => {
 			const embedPlaceholders = document.querySelectorAll(
-				'.wp-block-embed [role="button"]'
+				'.wp-block-editor-placeholder'
 			);
 			const lastEmbedPlaceholder =
 				embedPlaceholders[ embedPlaceholders.length - 1 ];
@@ -218,7 +219,7 @@ describe( 'Embedding content', () => {
 		await insertEmbed( 'https://twitter.com/thatbunty' );
 		await page.waitForFunction( () => {
 			const embedPlaceholders = document.querySelectorAll(
-				'.wp-block-embed [role="button"]'
+				'.wp-block-editor-placeholder'
 			);
 			const lastEmbedPlaceholder =
 				embedPlaceholders[ embedPlaceholders.length - 1 ];
@@ -253,22 +254,7 @@ describe( 'Embedding content', () => {
 	it( 'should allow the user to convert unembeddable URLs to a paragraph with a link in it', async () => {
 		// URL that can't be embedded.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
-
-		await page.waitForFunction( () => {
-			const embedPlaceholders = document.querySelectorAll(
-				'.wp-block-embed [role="button"]'
-			);
-			const lastEmbedPlaceholder =
-				embedPlaceholders[ embedPlaceholders.length - 1 ];
-			return lastEmbedPlaceholder?.shadowRoot.querySelector(
-				'input[value="https://twitter.com/wooyaygutenberg123454312"]'
-			);
-		} );
-
-		const handle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('.components-placeholder__error').lastElementChild`
-		);
-		await handle.click( handle );
+		await clickPlaceholderButton( 'Convert to link' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -284,17 +270,6 @@ describe( 'Embedding content', () => {
 		// URL that can't be embedded.
 		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 
-		await page.waitForFunction( () => {
-			const embedPlaceholders = document.querySelectorAll(
-				'.wp-block-embed [role="button"]'
-			);
-			const lastEmbedPlaceholder =
-				embedPlaceholders[ embedPlaceholders.length - 1 ];
-			return lastEmbedPlaceholder?.shadowRoot.querySelector(
-				'input[value="https://twitter.com/wooyaygutenberg123454312"]'
-			);
-		} );
-
 		// Set up a different mock to make sure that try again actually does make the request again.
 		await setUpResponseMocking( [
 			{
@@ -306,10 +281,7 @@ describe( 'Embedding content', () => {
 				),
 			},
 		] );
-		const handle = await page.evaluateHandle(
-			`document.querySelector('.wp-block-embed [role="button"]').shadowRoot.querySelector('button.is-secondary')`
-		);
-		await handle.click( handle );
+		await clickPlaceholderButton( 'Try again' );
 		await page.waitForSelector( 'figure.wp-block-embed' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -13,11 +13,8 @@ import {
 	saveDraft,
 	transformBlockTo,
 	clickPlaceholderButton,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
-/**
- * Internal dependencies
- */
-import { insertBlock } from '../../../../block-editor/src/store/actions';
 
 async function getSelectedFlatIndices() {
 	return await page.evaluate( () => {
@@ -654,6 +651,7 @@ describe( 'Multi-block selection', () => {
 	} );
 
 	it( 'should gradually multi-select', async () => {
+		await clickBlockAppender();
 		await insertBlock( 'Columns' );
 		await clickPlaceholderButton( 'Two columns; equal split' );
 		// Navigate to appender.

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -12,7 +12,12 @@ import {
 	clickMenuItem,
 	saveDraft,
 	transformBlockTo,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
+/**
+ * Internal dependencies
+ */
+import { insertBlock } from '../../../../block-editor/src/store/actions';
 
 async function getSelectedFlatIndices() {
 	return await page.evaluate( () => {
@@ -649,13 +654,8 @@ describe( 'Multi-block selection', () => {
 	} );
 
 	it( 'should gradually multi-select', async () => {
-		await clickBlockAppender();
-		await page.keyboard.type( '/columns' );
-		await page.keyboard.press( 'Enter' );
-		// Select two columns.
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'Enter' );
+		await insertBlock( 'Columns' );
+		await clickPlaceholderButton( 'Two columns; equal split' );
 		// Navigate to appender.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -101,7 +101,22 @@ describe( 'Toolbar roving tabindex', () => {
 		// Move focus to the first toolbar item
 		await page.keyboard.press( 'Home' );
 		await expectLabelToHaveFocus( 'Table' );
-		await page.click( '.blocks-table__placeholder-button' );
+
+		// Tab to editor content.
+		await page.keyboard.press( 'Tab' );
+
+		// Navigate into the placeholder.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Space' );
+
+		// Navigate to "Create Table"
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
+		// Create the table.
+		await page.keyboard.press( 'Space' );
+
 		await page.keyboard.press( 'Tab' );
 		await testBlockToolbarKeyboardNavigation( 'Body cell text', 'Table' );
 		await wrapCurrentBlockWithGroup( 'Table' );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -90,6 +90,8 @@ describe( 'Toolbar roving tabindex', () => {
 
 	it( 'ensures image block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Image' );
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'ArrowUp' );
 		await testBlockToolbarKeyboardNavigation( 'Block: Image', 'Image' );
 		await wrapCurrentBlockWithGroup( 'Image' );
 		await testGroupKeyboardNavigation( 'Block: Image', 'Image' );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -7,6 +7,10 @@ import {
 	clickBlockToolbarButton,
 	insertBlock,
 } from '@wordpress/e2e-test-utils';
+/**
+ * Internal dependencies
+ */
+import { clickPlaceholderButton } from '../../../../e2e-test-utils/src';
 
 async function focusBlockToolbar() {
 	await pressKeyWithModifier( 'alt', 'F10' );
@@ -90,8 +94,6 @@ describe( 'Toolbar roving tabindex', () => {
 
 	it( 'ensures image block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Image' );
-		await page.keyboard.press( 'Escape' );
-		await page.keyboard.press( 'ArrowUp' );
 		await testBlockToolbarKeyboardNavigation( 'Block: Image', 'Image' );
 		await wrapCurrentBlockWithGroup( 'Image' );
 		await testGroupKeyboardNavigation( 'Block: Image', 'Image' );
@@ -99,28 +101,11 @@ describe( 'Toolbar roving tabindex', () => {
 
 	it( 'ensures table block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Table' );
-		await page.keyboard.press( 'Escape' );
-		await page.keyboard.press( 'ArrowUp' );
 		await testBlockToolbarKeyboardNavigation( 'Block: Table', 'Table' );
 		// Move focus to the first toolbar item
 		await page.keyboard.press( 'Home' );
 		await expectLabelToHaveFocus( 'Table' );
-
-		// Tab to editor content.
-		await page.keyboard.press( 'Tab' );
-
-		// Navigate into the placeholder.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'Space' );
-
-		// Navigate to "Create Table"
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-
-		// Create the table.
-		await page.keyboard.press( 'Space' );
-
+		await clickPlaceholderButton( 'Create Table' );
 		await page.keyboard.press( 'Tab' );
 		await testBlockToolbarKeyboardNavigation( 'Body cell text', 'Table' );
 		await wrapCurrentBlockWithGroup( 'Table' );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -6,11 +6,8 @@ import {
 	pressKeyWithModifier,
 	clickBlockToolbarButton,
 	insertBlock,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
-/**
- * Internal dependencies
- */
-import { clickPlaceholderButton } from '../../../../e2e-test-utils/src';
 
 async function focusBlockToolbar() {
 	await pressKeyWithModifier( 'alt', 'F10' );

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -97,6 +97,8 @@ describe( 'Toolbar roving tabindex', () => {
 
 	it( 'ensures table block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Table' );
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'ArrowUp' );
 		await testBlockToolbarKeyboardNavigation( 'Block: Table', 'Table' );
 		// Move focus to the first toolbar item
 		await page.keyboard.press( 'Home' );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -26,7 +26,14 @@ const addParagraphsAndColumnsDemo = async () => {
 		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Columns')]`
 	);
 	await page.keyboard.press( 'Enter' );
-	await page.click( ':focus [aria-label="Two columns; equal split"]' );
+
+	// Navigate into the placeholder and activate the 50/50 option.
+	await page.keyboard.press( 'ArrowDown' );
+	await page.keyboard.press( 'Space' );
+	await page.keyboard.press( 'Tab' );
+	await page.keyboard.press( 'Tab' );
+	await page.keyboard.press( 'Space' );
+
 	await page.click( ':focus .block-editor-button-block-appender' );
 	await page.waitForSelector( '.block-editor-inserter__search input:focus' );
 	await page.keyboard.type( 'Paragraph' );
@@ -599,7 +606,9 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.press( 'Enter' );
 		// Move into the placeholder UI.
 		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Space' );
 		// Tab to the "Create table" button.
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		// Create the table.

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -21,16 +21,9 @@ const addParagraphsAndColumnsDemo = async () => {
 	await clickBlockAppender();
 	await page.keyboard.type( 'First paragraph' );
 	await page.keyboard.press( 'Enter' );
-	await page.keyboard.type( '/columns' );
-	await page.waitForXPath(
-		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Columns')]`
-	);
-	await page.keyboard.press( 'Enter' );
+	await insertBlock( 'Columns' );
 
-	// Navigate into the placeholder and activate the 50/50 option.
-	await page.keyboard.press( 'ArrowDown' );
-	await page.keyboard.press( 'Space' );
-	await page.keyboard.press( 'Tab' );
+	// Press the 50/50 option.
 	await page.keyboard.press( 'Tab' );
 	await page.keyboard.press( 'Space' );
 
@@ -557,7 +550,6 @@ describe( 'Writing Flow', () => {
 
 	it( 'should not have a dead zone above an aligned block', async () => {
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/image' );
 		await page.keyboard.press( 'Enter' );
@@ -568,7 +560,9 @@ describe( 'Writing Flow', () => {
 		await wideButton.click();
 
 		// Select the previous block.
-		await page.keyboard.press( 'ArrowUp' );
+		await page.click( '[data-type="core/paragraph"]' );
+
+		await page.keyboard.type( '1' );
 
 		// Confirm correct setup.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -594,21 +588,16 @@ describe( 'Writing Flow', () => {
 		await page.mouse.click( x, lowerInserterY );
 
 		const type = await page.evaluate( () =>
-			document.activeElement.getAttribute( 'data-type' )
+			document.activeElement.getAttribute( 'aria-label' )
 		);
 
-		expect( type ).toBe( 'core/image' );
+		expect( type ).toBe( 'Image' );
 	} );
 
 	it( 'should only consider the content as one tab stop', async () => {
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '/table' );
-		await page.keyboard.press( 'Enter' );
-		// Move into the placeholder UI.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'Space' );
+		await insertBlock( 'Table' );
 		// Tab to the "Create table" button.
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		// Create the table.
@@ -623,10 +612,8 @@ describe( 'Writing Flow', () => {
 		// The content should only have one tab stop.
 		await page.keyboard.press( 'Tab' );
 		expect(
-			await page.evaluate( () =>
-				document.activeElement.getAttribute( 'aria-label' )
-			)
-		).toBe( 'Post' );
+			await page.evaluate( () => document.activeElement.textContent )
+		).toBe( 'Open document settings' );
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		expect(

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	insertBlock,
 	clickBlockToolbarButton,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 const getActiveBlockName = async () =>
@@ -21,12 +22,12 @@ const addParagraphsAndColumnsDemo = async () => {
 	await clickBlockAppender();
 	await page.keyboard.type( 'First paragraph' );
 	await page.keyboard.press( 'Enter' );
-	await insertBlock( 'Columns' );
-
-	// Press the 50/50 option.
-	await page.keyboard.press( 'Tab' );
-	await page.keyboard.press( 'Space' );
-
+	await page.keyboard.type( '/columns' );
+	await page.waitForXPath(
+		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Columns')]`
+	);
+	await page.keyboard.press( 'Enter' );
+	await clickPlaceholderButton( 'Two columns; equal split' );
 	await page.click( ':focus .block-editor-button-block-appender' );
 	await page.waitForSelector( '.block-editor-inserter__search input:focus' );
 	await page.keyboard.type( 'Paragraph' );
@@ -588,20 +589,16 @@ describe( 'Writing Flow', () => {
 		await page.mouse.click( x, lowerInserterY );
 
 		const type = await page.evaluate( () =>
-			document.activeElement.getAttribute( 'aria-label' )
+			document.activeElement.getAttribute( 'data-type' )
 		);
 
-		expect( type ).toBe( 'Image' );
+		expect( type ).toBe( 'core/image' );
 	} );
 
 	it( 'should only consider the content as one tab stop', async () => {
 		await page.keyboard.press( 'Enter' );
 		await insertBlock( 'Table' );
-		// Tab to the "Create table" button.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		// Create the table.
-		await page.keyboard.press( 'Space' );
+		await clickPlaceholderButton( 'Create Table' );
 		// Return focus after focus loss. This should be fixed.
 		await page.keyboard.press( 'Tab' );
 		// Navigate to the second cell.

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -9,11 +9,8 @@ import {
 	trashAllPosts,
 	activateTheme,
 	clickButton,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
-/**
- * Internal dependencies
- */
-import { clickPlaceholderButton } from '../../../e2e-test-utils/src';
 
 /**
  * Internal dependencies

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -10,6 +10,10 @@ import {
 	activateTheme,
 	clickButton,
 } from '@wordpress/e2e-test-utils';
+/**
+ * Internal dependencies
+ */
+import { clickPlaceholderButton } from '../../../e2e-test-utils/src';
 
 /**
  * Internal dependencies
@@ -100,13 +104,7 @@ describe( 'Multi-entity save flow', () => {
 
 			// Add a template part and edit it.
 			await insertBlock( 'Template Part' );
-			await page.waitForFunction( () =>
-				document.activeElement.shadowRoot?.querySelector( 'button' )
-			);
-			await page.keyboard.press( 'Space' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Space' );
+			await clickPlaceholderButton( 'New template part' );
 
 			const confirmTitleButton = await page.waitForSelector(
 				confirmTitleButtonSelector

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -26,8 +26,6 @@ describe( 'Multi-entity save flow', () => {
 	const savePanelSelector = '.entities-saved-states__panel';
 	const closePanelButtonSelector =
 		'.editor-post-publish-panel__header-cancel-button button';
-	const createNewButtonSelector =
-		'//button[contains(text(), "New template part")]';
 
 	// Reusable assertions across Post/Site editors.
 	const assertAllBoxesChecked = async () => {
@@ -102,10 +100,14 @@ describe( 'Multi-entity save flow', () => {
 
 			// Add a template part and edit it.
 			await insertBlock( 'Template Part' );
-			const createNewButton = await page.waitForXPath(
-				createNewButtonSelector
+			await page.waitForFunction( () =>
+				document.activeElement.shadowRoot?.querySelector( 'button' )
 			);
-			await createNewButton.click();
+			await page.keyboard.press( 'Space' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Space' );
+
 			const confirmTitleButton = await page.waitForSelector(
 				confirmTitleButtonSelector
 			);

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -272,10 +272,6 @@ describe( 'Template Part', () => {
 		const templatePartSelector = '*[data-type="core/template-part"]';
 		const activatedTemplatePartSelector = `${ templatePartSelector }.block-editor-block-list__layout`;
 		const testContentSelector = `//p[contains(., "${ testContent }")]`;
-		const createNewButtonSelector =
-			'//button[contains(text(), "New template part")]';
-		const chooseExistingButtonSelector =
-			'//button[contains(text(), "Choose existing")]';
 		const confirmTitleButtonSelector =
 			'.wp-block-template-part__placeholder-create-new__title-form .components-button.is-primary';
 
@@ -284,11 +280,12 @@ describe( 'Template Part', () => {
 			await disablePrePublishChecks();
 			// Create new template part.
 			await insertBlock( 'Template Part' );
-			await page.waitForXPath( chooseExistingButtonSelector );
-			const [ createNewButton ] = await page.$x(
-				createNewButtonSelector
-			);
-			await createNewButton.click();
+			// Navigate into the placeholder and "New template part"
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'Space' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Space' );
 			const confirmTitleButton = await page.waitForSelector(
 				confirmTitleButtonSelector
 			);
@@ -312,10 +309,11 @@ describe( 'Template Part', () => {
 			await createNewPost();
 			// Try to insert the template part we created.
 			await insertBlock( 'Template Part' );
-			const chooseExistingButton = await page.waitForXPath(
-				chooseExistingButtonSelector
-			);
-			await chooseExistingButton.click();
+			// Navigate into the placeholder and "Choose existing"
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'Space' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Space' );
 			const preview = await page.waitForSelector(
 				'[aria-label="Create New"]'
 			);

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -280,8 +280,10 @@ describe( 'Template Part', () => {
 			await disablePrePublishChecks();
 			// Create new template part.
 			await insertBlock( 'Template Part' );
+			await page.waitForFunction( () =>
+				document.activeElement.shadowRoot?.querySelector( 'button' )
+			);
 			// Navigate into the placeholder and "New template part"
-			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'Space' );
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Tab' );
@@ -309,8 +311,10 @@ describe( 'Template Part', () => {
 			await createNewPost();
 			// Try to insert the template part we created.
 			await insertBlock( 'Template Part' );
+			await page.waitForFunction( () =>
+				document.activeElement.shadowRoot?.querySelector( 'button' )
+			);
 			// Navigate into the placeholder and "Choose existing"
-			await page.keyboard.press( 'ArrowDown' );
 			await page.keyboard.press( 'Space' );
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Space' );

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -11,6 +11,7 @@ import {
 	selectBlockByClientId,
 	clickBlockToolbarButton,
 	canvas,
+	clickPlaceholderButton,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -280,14 +281,7 @@ describe( 'Template Part', () => {
 			await disablePrePublishChecks();
 			// Create new template part.
 			await insertBlock( 'Template Part' );
-			await page.waitForFunction( () =>
-				document.activeElement.shadowRoot?.querySelector( 'button' )
-			);
-			// Navigate into the placeholder and "New template part"
-			await page.keyboard.press( 'Space' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Space' );
+			await clickPlaceholderButton( 'New template part' );
 			const confirmTitleButton = await page.waitForSelector(
 				confirmTitleButtonSelector
 			);
@@ -311,13 +305,7 @@ describe( 'Template Part', () => {
 			await createNewPost();
 			// Try to insert the template part we created.
 			await insertBlock( 'Template Part' );
-			await page.waitForFunction( () =>
-				document.activeElement.shadowRoot?.querySelector( 'button' )
-			);
-			// Navigate into the placeholder and "Choose existing"
-			await page.keyboard.press( 'Space' );
-			await page.keyboard.press( 'Tab' );
-			await page.keyboard.press( 'Space' );
+			await clickPlaceholderButton( 'Choose existing' );
 			const preview = await page.waitForSelector(
 				'[aria-label="Create New"]'
 			);

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -539,10 +539,13 @@ describe( 'Widgets Customizer', () => {
 		await footer1Section.click();
 
 		const legacyWidgetBlock = await addBlock( 'Legacy Widget' );
-		const selectLegacyWidgets = await find( {
-			role: 'combobox',
-			name: 'Select a legacy widget to display:',
-		} );
+		const selectLegacyWidgets = await page.evaluateHandle( () =>
+			document
+				.querySelector(
+					'.wp-block-legacy-widget [aria-label="Legacy Widget"]'
+				)
+				.shadowRoot.querySelector( 'select' )
+		);
 		await selectLegacyWidgets.select( 'test_widget' );
 
 		await expect( {

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -539,12 +539,10 @@ describe( 'Widgets Customizer', () => {
 		await footer1Section.click();
 
 		const legacyWidgetBlock = await addBlock( 'Legacy Widget' );
-		const selectLegacyWidgets = await page.evaluateHandle( () =>
+		const selectLegacyWidgets = await page.waitForFunction( () =>
 			document
-				.querySelector(
-					'.wp-block-legacy-widget [aria-label="Legacy Widget"]'
-				)
-				.shadowRoot.querySelector( 'select' )
+				.querySelector( '.wp-block-editor-placeholder' )
+				?.shadowRoot.querySelector( 'select' )
 		);
 		await selectLegacyWidgets.select( 'test_widget' );
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -43,13 +43,21 @@ import { __ } from '@wordpress/i18n';
 import BlockInspectorButton from './block-inspector-button';
 import { store as editPostStore } from '../../store';
 
-function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
+function MaybeIframe( {
+	children,
+	contentRef,
+	shouldIframe,
+	styles,
+	assets,
+	style,
+} ) {
 	const ref = useMouseMoveTypingReset();
+	const editorStyles = <EditorStyles styles={ styles } assets={ assets } />;
 
 	if ( ! shouldIframe ) {
 		return (
 			<>
-				<EditorStyles styles={ styles } />
+				{ editorStyles }
 				<WritingFlow
 					ref={ contentRef }
 					className="editor-styles-wrapper"
@@ -64,7 +72,8 @@ function MaybeIframe( { children, contentRef, shouldIframe, styles, style } ) {
 
 	return (
 		<Iframe
-			head={ <EditorStyles styles={ styles } /> }
+			head={ editorStyles }
+			assets={ assets }
 			ref={ ref }
 			contentRef={ contentRef }
 			style={ { width: '100%', height: '100%', display: 'block' } }
@@ -107,9 +116,12 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const themeSupportsLayout = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return getSettings().supportsLayout;
+	const { themeSupportsLayout, assets } = useSelect( ( select ) => {
+		const _settings = select( blockEditorStore ).getSettings();
+		return {
+			themeSupportsLayout: _settings.supportsLayout,
+			assets: _settings.resolvedAssets,
+		};
 	}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
@@ -219,6 +231,7 @@ export default function VisualEditor( { styles } ) {
 						}
 						contentRef={ contentRef }
 						styles={ styles }
+						assets={ assets }
 						style={ { paddingBottom } }
 					>
 						{ themeSupportsLayout && ! isTemplateMode && (

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -129,7 +129,10 @@ function ResizableEditor( { enableResizing, settings, ...props } ) {
 				style={ enableResizing ? undefined : deviceStyles }
 				head={
 					<>
-						<EditorStyles styles={ settings.styles } />
+						<EditorStyles
+							styles={ settings.styles }
+							assets={ settings.resolvedAssets }
+						/>
 						<style>{
 							// Forming a "block formatting context" to prevent margin collapsing.
 							// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
@@ -137,6 +140,7 @@ function ResizableEditor( { enableResizing, settings, ...props } ) {
 						}</style>
 					</>
 				}
+				assets={ settings.resolvedAssets }
 				ref={ ref }
 				name="editor-canvas"
 				className="edit-site-visual-editor__editor-canvas"

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -40,7 +40,10 @@ export default function WidgetAreasBlockEditorContent( {
 			<Notices />
 			<BlockTools>
 				<KeyboardShortcuts />
-				<EditorStyles styles={ styles } />
+				<EditorStyles
+					styles={ styles }
+					assets={ blockEditorSettings.resolvedAssets }
+				/>
 				<BlockSelectionClearer>
 					<WritingFlow>
 						<ObserveTyping>

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -127,6 +127,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'titlePlaceholder',
 				'supportsLayout',
 				'widgetTypesToHideFromLegacyWidgetBlock',
+				'resolvedAssets',
 			] ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.13.10",
 		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -11,8 +11,9 @@ import { RawHTML, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { Placeholder, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
+import { Placeholder } from '@wordpress/block-editor';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -12,8 +12,9 @@ import {
 	InspectorControls,
 	BlockIcon,
 	store as blockEditorStore,
+	Placeholder,
 } from '@wordpress/block-editor';
-import { Spinner, Placeholder } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -8,9 +8,10 @@ import classnames from 'classnames';
  */
 import { useRefEffect } from '@wordpress/compose';
 import { useEffect, useState } from '@wordpress/element';
-import { Disabled, Placeholder, Spinner } from '@wordpress/components';
+import { Disabled, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { Placeholder } from '@wordpress/block-editor';
 
 export default function Preview( { idBase, instance, isVisible } ) {
 	const [ isLoaded, setIsLoaded ] = useState( false );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

See #35018 and #33212 for discussions.

This PR attempts to solve two problems:

* Currently it is very hard for themes to add styles to the editor through the WP dependency system. `add_editor_style` only accepts URLs, not WP dependency handles for styles. This makes it impossible to use `wp_add_inline_style`. We need a way for themes to be able to add WP dependency handles to the block editor's content (iframe) just like blocks can through registration.
* Currently we hackily load styles and scripts in the iframe through a global. This should be done with block editor settings instead.

The idea: allow anyone (including themes) to add style and script dependencies for the block editor content through the block editor settings.

```php
add_filter(
	'block_editor_settings_all',
	function( $settings ) {
		wp_register_style( 'my-theme-stylesheet', get_stylesheet_uri() );
		$settings['assets']['styles'][] = 'my-theme-stylesheet';
		return $settings;
	}
);
```

And if in the future we make themes that are just CSS and JSON, the use case of inline styles for dynamic styling should disappear.

~~To do: add test with the above example code.~~
To do: load the styles outside iframed editors and prefix the rules.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
