### PR TITLE
Mobile - Add support for the Mark HTML tag and updates Aztec iOS to 1.19.5

### DIFF
--- a/packages/react-native-aztec/RNTAztecView.podspec
+++ b/packages/react-native-aztec/RNTAztecView.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.xcconfig         = {'OTHER_LDFLAGS' => '-lxml2',
                         'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
   s.dependency         'React-Core'
-  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.4'
+  s.dependency         'WordPress-Aztec-iOS', '~> 1.19.5'
 
 end

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 - [**] Search block - Text and background color support [#35511]
 - [*] [Embed Block] Fix loading glitch with resolver resolution approach [#35798]
 - [**] Block inserter indicates newly available block types [#35201]
+- [*] Add support for the Mark HTML tag [#35956]
 
 ## 1.64.1
 -   [**] Fix updating the block list after block removal [#35721]

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -305,8 +305,8 @@ PODS:
     - React-Core
   - RNTAztecView (1.64.1):
     - React-Core
-    - WordPress-Aztec-iOS (~> 1.19.4)
-  - WordPress-Aztec-iOS (1.19.4)
+    - WordPress-Aztec-iOS (~> 1.19.5)
+  - WordPress-Aztec-iOS (1.19.5)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -496,8 +496,8 @@ SPEC CHECKSUMS:
   RNReanimated: 39a9478eb635667c9a4da08ac906add9901b145e
   RNScreens: 185dcb481fab2f3dc77413f62b43dc3df826029c
   RNSVG: 9c0db12736608e32841e90fe9773db70ea40de20
-  RNTAztecView: 176373bf98fa6f82beb67f99063767ca83ca84b4
-  WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
+  RNTAztecView: 7dc60600a65f44cc6375a0daad08a4612d39c3d4
+  WordPress-Aztec-iOS: af36d9cb86a0109b568f516874870e2801ba1bd9
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
 PODFILE CHECKSUM: db5f67a29ecba75541dad181ff59246b6da2fb09


### PR DESCRIPTION
- Guteberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4162
- WordPress iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17370

## Description
Updates Aztec iOS to [1.19.5](https://github.com/wordpress-mobile/AztecEditor-iOS/releases/tag/1.19.5), with this and with the recently released [Aztec Android](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.4.0), it adds support for the `mark` HTML tag.

## How has this been tested?
- Open the app with metro running
- Toggle to HTML mode
- Paste the following snippet: 
```
<!-- wp:paragraph -->
<p>Hey <mark style="background-color:#f0c25d;color:#ff0000" class="has-inline-color">there!</mark> this is a test.</p>
<!-- /wp:paragraph -->
```
- Toggle back to Visual mode
- **Expect** to see the text: `Hey there! this is a test` in the editor. It's expected to see the text color (not the background), and the customization for this new format is under development on mobile.

## Screenshots <!-- if applicable -->

Before iOS | After iOS
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/138886783-c2acd9be-b199-43f0-9d68-5fea83ac1926.jpeg" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/138884250-481d5d0a-96b7-499f-816b-27a0134edeee.png" width="200" /></kbd>

Before Android | After Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/138886945-4a1e8962-fd53-4176-9f5e-8eb63524f5ca.jpg" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/138887028-29cf447b-17fb-41ad-89de-efaf63896aa7.png" width="200" /></kbd>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
