### PR TITLE
Post Content: Fix float clearing on entry content

### DIFF
--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,4 +1,4 @@
 // Required to ensure that subsequent blocks clear floats inside entry content.
 .wp-block-post-content {
-	overflow: hidden;
+	overflow: auto;
 }

--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,0 +1,4 @@
+// Required to ensure that subsequent blocks clear floats inside entry content.
+.wp-block-post-content {
+	overflow: hidden;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -31,6 +31,7 @@
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";
+@import "./post-content/style.scss";
 @import "./post-template/style.scss";
 @import "./query-pagination/style.scss";
 @import "./quote/style.scss";


### PR DESCRIPTION
If the last item in post content is a floated element, items below post content will incorrectly flow in next to it. 

## To test: 

1. Try a theme that does _not_ use a spacer directly below the entry content. (Spacer blocks come with `clear:both;`, and don't have this issue. Twenty Twenty Two's page templates work for testing.)
2. Add a single floated element to a post/page, publish.
3. On the front-end, note that the block after post content is no longer pulled up next to the floated element. 

## Screenshots:

Before|After
---|---
<img width="910" alt="Screen Shot 2021-10-26 at 8 54 45 AM" src="https://user-images.githubusercontent.com/1202812/138883081-d6d3c221-2ec7-4b4d-85ab-dfb37e56478d.png">|<img width="910" alt="Screen Shot 2021-10-26 at 8 54 32 AM" src="https://user-images.githubusercontent.com/1202812/138883089-c4438f84-6de5-4f32-8b8c-358bcee5591b.png">

---

Related: https://github.com/WordPress/twentytwentytwo/issues/44
