### PR TITLE
Add spacing controls to Post Excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -24,6 +24,10 @@
 			"gradients": true,
 			"link": true
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true


### PR DESCRIPTION

## Description

Add spacing controls to Post Excerpt block.

Fixes #35700


## How has this been tested?

With a theme that supports spacing,

1. Add a post excerpt block.
2. Confirm it does not show margin/padding controls in Inspector.
3. Apply patch and rebuild
4. Confirm margin/padding controls show in Inspector
5. Confir margin/padding show in editor and published view


## Types of changes

- Add supports definition to Post Excerpt block.json

