### PR TITLE
Mark empty links with a squiggly lines like grammar errors

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -78,6 +78,25 @@
 	font-size: 42px;
 }
 
+// Mark empty links with a red squiggly underline to indicate an error
+.editor-styles-wrapper.editor-styles-wrapper a[href=""] {
+	$blur: 10%;
+	$width: 6%;
+	$stop1: 30%;
+	$stop2: 64%;
+	$angle: 45deg;
+
+	background-image:
+		linear-gradient($angle, transparent ($stop1 - $blur), currentColor $stop1, currentColor ($stop1 + $width), transparent ($stop1 + $width + $blur)),
+		linear-gradient(($angle * 3), transparent ($stop2 - $blur), currentColor $stop2, currentColor ($stop2 + $width), transparent ($stop2 + $width + $blur));
+	background-position: 0 100%;
+	background-size: 6px 3px;
+	background-repeat: repeat-x;
+
+	color: #f00;
+	text-decoration-line: none;
+}
+
 /**
  * Editor Normalization Styles
  *


### PR DESCRIPTION
## Description

This PR is an attempt to indicate empty links in the same way as empty nav items (https://github.com/WordPress/gutenberg/pull/35139)

<img width="1159" alt="CleanShot 2021-10-26 at 15 28 16@2x" src="https://user-images.githubusercontent.com/205419/138888908-859cb305-1f61-441d-a592-d731c32c5b9c.png">

Discussion items:
1. I don't like how these styles now live in block-library, any ideas what would be a good place to put them?
2. The colors are inconsistent with https://github.com/WordPress/gutenberg/pull/35139. I like red better, but I won't insist. Red or blue, I'd like both links and nav links to be consistent.
3. I wonder if there's a way to use the exact same CSS code for both so that we don't have two different implementations of the same feature.

## How has this been tested?

1. Create a new post
2. Add a link
3. Go to code editor and manually set href to ""
4. Return to blocks editor, confirm the link is now red with a squiggly wave underneath.

cc @jasmussen 