### PR TITLE
Add spacing controls to Post Author block

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -27,6 +27,10 @@
 	"usesContext": [ "postType", "postId", "queryId" ],
 	"supports": {
 		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true


### PR DESCRIPTION

## Description

Add spacing controls (margin/padding) to Post Author block.

Fixes #35695

## How has this been tested?

Using a theme that supports spacing,

1. Add Post Author block and confirm spacing controls are not there.
2. Apply patch and rebuild.
3. Confirm Post Author block now shows spacing contorls.
4. Confirm spacing works in editor and published view.


## Types of changes

- Add supports spacing to Post Author block.json

