### PR TITLE
Lower the specificity of border & padding styles for the outline block style in the button block

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -95,8 +95,8 @@ $blocks-block__margin: 0.5em;
 	border-radius: 0 !important;
 }
 
-.is-style-outline > .wp-block-button__link,
-.wp-block-button__link.is-style-outline {
+.is-style-outline > :where(.wp-block-button__link),
+:where(.wp-block-button__link).is-style-outline {
 	border: 2px solid currentColor;
 	padding: 0.667em 1.333em;
 }


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/35438

This PR lowers the specificity of the border & padding styles for outline block styles so it can be overridden by the theme via theme.json.

## How to test

- Create a post that contains two buttons. Set one to the outline style variation.
- Use a theme with `theme.json` and add this to the `styles.blocks` section:

```json
"core/button": {
        "border": {
                "radius": "0",
                "width": "4px",
                "color": "red"
        },
        "spacing": {
                "padding": {
                        "bottom": "1.75rem",
                        "left": "1.5rem",
                        "right": "1.5rem",
                        "top": "1.75rem"
                }
        }
}
```

The expected result is that both buttons have the same padding and the outline style has a red border. Note that, by doing this the two buttons will end up with different heights given that the outlined one has padding + border-width: this is a different issue that needs to be looked at separately.
