### PR TITLE
Fix wording in the Authoring Experience documentation

### DIFF
--- a/docs/getting-started/create-block/author-experience.md
+++ b/docs/getting-started/create-block/author-experience.md
@@ -73,7 +73,7 @@ attributes.message && ! isSelected;
 
 If the message is set and `!isSelected`, meaning we are not editing the block, the focus is elsewhere, then display the message not the text field.
 
-All so this combined together here's what the edit function looks like this:
+All of this combined together, here's what the edit function looks like:
 
 ```jsx
 import { Placeholder, TextControl } from '@wordpress/components';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The current wording does not make sense.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Replaced a couple words to fix it.