### PR TITLE
Update: Show all color and gradient origins (core, theme, and user).

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -35,6 +35,7 @@ function ColorGradientControlInner( {
 	gradients,
 	disableCustomColors,
 	disableCustomGradients,
+	__experimentalHasMultipleOrigins,
 	className,
 	label,
 	onColorChange,
@@ -104,6 +105,9 @@ function ColorGradientControlInner( {
 									: onColorChange
 							}
 							{ ...{ colors, disableCustomColors } }
+							__experimentalHasMultipleOrigins={
+								__experimentalHasMultipleOrigins
+							}
 							clearable={ clearable }
 						/>
 					) }
@@ -119,6 +123,9 @@ function ColorGradientControlInner( {
 									: onGradientChange
 							}
 							{ ...{ gradients, disableCustomGradients } }
+							__experimentalHasMultipleOrigins={
+								__experimentalHasMultipleOrigins
+							}
 							clearable={ clearable }
 						/>
 					) }

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -60,6 +60,7 @@ export default function ColorPanel( {
 				initialOpen={ false }
 				settings={ settings }
 				showTitle={ showTitle }
+				__experimentalHasMultipleOrigins
 			>
 				{ enableContrastChecking && (
 					<ContrastChecker

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -543,6 +543,7 @@ function CoverEdit( {
 					</PanelBody>
 				) }
 				<PanelColorGradientSettings
+					__experimentalHasMultipleOrigins
 					title={ __( 'Overlay' ) }
 					initialOpen={ true }
 					settings={ [

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -365,6 +365,7 @@ function Navigation( {
 					) }
 					{ hasColorSettings && (
 						<PanelColorSettings
+							__experimentalHasMultipleOrigins
 							title={ __( 'Color' ) }
 							initialOpen={ false }
 							colorSettings={ [

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -7,6 +7,7 @@ import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 const SeparatorSettings = ( { color, setColor } ) => (
 	<InspectorControls>
 		<PanelColorSettings
+			__experimentalHasMultipleOrigins
 			title={ __( 'Color' ) }
 			colorSettings={ [
 				{

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -166,6 +166,7 @@ export function SocialLinksEdit( props ) {
 					/>
 				</PanelBody>
 				<PanelColorSettings
+					__experimentalHasMultipleOrigins
 					title={ __( 'Color' ) }
 					colorSettings={ [
 						{

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -19,19 +19,18 @@ import Dropdown from '../dropdown';
 import { ColorPicker } from '../color-picker';
 import CircularOptionPicker from '../circular-option-picker';
 import { VStack } from '../v-stack';
+import { ColorHeading } from './styles';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
-export default function ColorPalette( {
-	clearable = true,
+function SinglePalette( {
 	className,
+	clearColor,
 	colors,
-	disableCustomColors = false,
-	enableAlpha,
 	onChange,
 	value,
+	actions,
 } ) {
-	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
 	const colorOptions = useMemo( () => {
 		return map( colors, ( { color, name } ) => {
 			const colordColor = colord( color );
@@ -70,6 +69,60 @@ export default function ColorPalette( {
 			);
 		} );
 	}, [ colors, value, onChange, clearColor ] );
+	return (
+		<CircularOptionPicker
+			className={ className }
+			options={ colorOptions }
+			actions={ actions }
+		/>
+	);
+}
+
+function MultiplePalettes( {
+	className,
+	clearColor,
+	colors,
+	onChange,
+	value,
+	actions,
+} ) {
+	return (
+		<VStack spacing={ 3 } className={ className }>
+			{ colors.map( ( { name, colors: colorPalette }, index ) => {
+				return (
+					<VStack spacing={ 2 } key={ index }>
+						<ColorHeading>{ name }</ColorHeading>
+						<SinglePalette
+							clearColor={ clearColor }
+							colors={ colorPalette }
+							onChange={ onChange }
+							value={ value }
+							actions={
+								colors.length === index + 1 ? actions : null
+							}
+						/>
+					</VStack>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+export default function ColorPalette( {
+	clearable = true,
+	className,
+	colors,
+	disableCustomColors = false,
+	enableAlpha,
+	onChange,
+	value,
+	__experimentalHasMultipleOrigins = false,
+} ) {
+	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
+	const Component = __experimentalHasMultipleOrigins
+		? MultiplePalettes
+		: SinglePalette;
+
 	const renderCustomColorPicker = () => (
 		<ColorPicker
 			color={ value }
@@ -97,8 +150,12 @@ export default function ColorPalette( {
 					) }
 				/>
 			) }
-			<CircularOptionPicker
-				options={ colorOptions }
+			<Component
+				clearable={ clearable }
+				clearColor={ clearColor }
+				colors={ colors }
+				onChange={ onChange }
+				value={ value }
 				actions={
 					!! clearable && (
 						<CircularOptionPicker.ButtonAction

--- a/packages/components/src/color-palette/styles.js
+++ b/packages/components/src/color-palette/styles.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { Heading } from '../heading';
+
+export const ColorHeading = styled( Heading )`
+	text-transform: uppercase;
+	line-height: 24px;
+	font-weight: 500;
+	&&& {
+		font-size: 11px;
+		margin-bottom: 0;
+	}
+`;

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -56,7 +56,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
 <VStack
   spacing={3}
 >
-  <CircularOptionPicker
+  <SinglePalette
     actions={
       <ButtonAction
         onClick={[Function]}
@@ -64,53 +64,26 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         Clear
       </ButtonAction>
     }
-    options={
+    clearColor={[Function]}
+    clearable={true}
+    colors={
       Array [
-        <Option
-          aria-label="Color: red"
-          isSelected={true}
-          onClick={[Function]}
-          selectedIconProps={
-            Object {
-              "fill": "#000",
-            }
-          }
-          style={
-            Object {
-              "backgroundColor": "#f00",
-              "color": "#f00",
-            }
-          }
-          tooltipText="red"
-        />,
-        <Option
-          aria-label="Color: white"
-          isSelected={false}
-          onClick={[Function]}
-          selectedIconProps={Object {}}
-          style={
-            Object {
-              "backgroundColor": "#fff",
-              "color": "#fff",
-            }
-          }
-          tooltipText="white"
-        />,
-        <Option
-          aria-label="Color: blue"
-          isSelected={false}
-          onClick={[Function]}
-          selectedIconProps={Object {}}
-          style={
-            Object {
-              "backgroundColor": "#00f",
-              "color": "#00f",
-            }
-          }
-          tooltipText="blue"
-        />,
+        Object {
+          "color": "#f00",
+          "name": "red",
+        },
+        Object {
+          "color": "#fff",
+          "name": "white",
+        },
+        Object {
+          "color": "#00f",
+          "name": "blue",
+        },
       ]
     }
+    onChange={[MockFunction]}
+    value="#f00"
   />
 </VStack>
 `;
@@ -228,7 +201,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             </button>
           </div>
         </Dropdown>
-        <CircularOptionPicker
+        <SinglePalette
           actions={
             <ButtonAction
               onClick={[Function]}
@@ -236,107 +209,118 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               Clear
             </ButtonAction>
           }
-          key=".1"
-          options={
+          clearColor={[Function]}
+          clearable={true}
+          colors={
             Array [
-              <Option
-                aria-label="Color: red"
-                isSelected={true}
-                onClick={[Function]}
-                selectedIconProps={
-                  Object {
-                    "fill": "#000",
-                  }
-                }
-                style={
-                  Object {
-                    "backgroundColor": "#f00",
-                    "color": "#f00",
-                  }
-                }
-                tooltipText="red"
-              />,
-              <Option
-                aria-label="Color: white"
-                isSelected={false}
-                onClick={[Function]}
-                selectedIconProps={Object {}}
-                style={
-                  Object {
-                    "backgroundColor": "#fff",
-                    "color": "#fff",
-                  }
-                }
-                tooltipText="white"
-              />,
-              <Option
-                aria-label="Color: blue"
-                isSelected={false}
-                onClick={[Function]}
-                selectedIconProps={Object {}}
-                style={
-                  Object {
-                    "backgroundColor": "#00f",
-                    "color": "#00f",
-                  }
-                }
-                tooltipText="blue"
-              />,
+              Object {
+                "color": "#f00",
+                "name": "red",
+              },
+              Object {
+                "color": "#fff",
+                "name": "white",
+              },
+              Object {
+                "color": "#00f",
+                "name": "blue",
+              },
             ]
           }
+          key=".1"
+          onChange={[MockFunction]}
+          value="#f00"
         >
-          <div
-            className="components-circular-option-picker"
+          <CircularOptionPicker
+            actions={
+              <ButtonAction
+                onClick={[Function]}
+              >
+                Clear
+              </ButtonAction>
+            }
+            options={
+              Array [
+                <Option
+                  aria-label="Color: red"
+                  isSelected={true}
+                  onClick={[Function]}
+                  selectedIconProps={
+                    Object {
+                      "fill": "#000",
+                    }
+                  }
+                  style={
+                    Object {
+                      "backgroundColor": "#f00",
+                      "color": "#f00",
+                    }
+                  }
+                  tooltipText="red"
+                />,
+                <Option
+                  aria-label="Color: white"
+                  isSelected={false}
+                  onClick={[Function]}
+                  selectedIconProps={Object {}}
+                  style={
+                    Object {
+                      "backgroundColor": "#fff",
+                      "color": "#fff",
+                    }
+                  }
+                  tooltipText="white"
+                />,
+                <Option
+                  aria-label="Color: blue"
+                  isSelected={false}
+                  onClick={[Function]}
+                  selectedIconProps={Object {}}
+                  style={
+                    Object {
+                      "backgroundColor": "#00f",
+                      "color": "#00f",
+                    }
+                  }
+                  tooltipText="blue"
+                />,
+              ]
+            }
           >
             <div
-              className="components-circular-option-picker__swatches"
+              className="components-circular-option-picker"
             >
-              <Option
-                aria-label="Color: red"
-                isSelected={true}
-                key="#f00"
-                onClick={[Function]}
-                selectedIconProps={
-                  Object {
-                    "fill": "#000",
-                  }
-                }
-                style={
-                  Object {
-                    "backgroundColor": "#f00",
-                    "color": "#f00",
-                  }
-                }
-                tooltipText="red"
+              <div
+                className="components-circular-option-picker__swatches"
               >
-                <div
-                  className="components-circular-option-picker__option-wrapper"
+                <Option
+                  aria-label="Color: red"
+                  isSelected={true}
+                  key="#f00"
+                  onClick={[Function]}
+                  selectedIconProps={
+                    Object {
+                      "fill": "#000",
+                    }
+                  }
+                  style={
+                    Object {
+                      "backgroundColor": "#f00",
+                      "color": "#f00",
+                    }
+                  }
+                  tooltipText="red"
                 >
-                  <Tooltip
-                    text="red"
+                  <div
+                    className="components-circular-option-picker__option-wrapper"
                   >
-                    <ForwardRef(Button)
-                      aria-label="Color: red"
-                      className="components-circular-option-picker__option"
-                      isPressed={true}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      style={
-                        Object {
-                          "backgroundColor": "#f00",
-                          "color": "#f00",
-                        }
-                      }
+                    <Tooltip
+                      text="red"
                     >
-                      <button
-                        aria-describedby={null}
+                      <ForwardRef(Button)
                         aria-label="Color: red"
-                        aria-pressed={true}
-                        className="components-button components-circular-option-picker__option is-pressed"
+                        className="components-circular-option-picker__option"
+                        isPressed={true}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onFocus={[Function]}
@@ -349,94 +333,94 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                             "color": "#f00",
                           }
                         }
-                        type="button"
-                      />
-                    </ForwardRef(Button)>
-                  </Tooltip>
-                  <Icon
-                    fill="#000"
-                    icon={
-                      <SVG
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <Path
-                          d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                        <button
+                          aria-describedby={null}
+                          aria-label="Color: red"
+                          aria-pressed={true}
+                          className="components-button components-circular-option-picker__option is-pressed"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "backgroundColor": "#f00",
+                              "color": "#f00",
+                            }
+                          }
+                          type="button"
                         />
-                      </SVG>
-                    }
-                  >
-                    <SVG
+                      </ForwardRef(Button)>
+                    </Tooltip>
+                    <Icon
                       fill="#000"
-                      height={24}
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
+                      icon={
+                        <SVG
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <Path
+                            d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                          />
+                        </SVG>
+                      }
                     >
-                      <svg
-                        aria-hidden={true}
+                      <SVG
                         fill="#000"
-                        focusable={false}
                         height={24}
-                        role="img"
                         viewBox="0 0 24 24"
                         width={24}
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <Path
-                          d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                        <svg
+                          aria-hidden={true}
+                          fill="#000"
+                          focusable={false}
+                          height={24}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={24}
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
+                          <Path
                             d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
-                          />
-                        </Path>
-                      </svg>
-                    </SVG>
-                  </Icon>
-                </div>
-              </Option>
-              <Option
-                aria-label="Color: white"
-                isSelected={false}
-                key="#fff"
-                onClick={[Function]}
-                selectedIconProps={Object {}}
-                style={
-                  Object {
-                    "backgroundColor": "#fff",
-                    "color": "#fff",
+                          >
+                            <path
+                              d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                            />
+                          </Path>
+                        </svg>
+                      </SVG>
+                    </Icon>
+                  </div>
+                </Option>
+                <Option
+                  aria-label="Color: white"
+                  isSelected={false}
+                  key="#fff"
+                  onClick={[Function]}
+                  selectedIconProps={Object {}}
+                  style={
+                    Object {
+                      "backgroundColor": "#fff",
+                      "color": "#fff",
+                    }
                   }
-                }
-                tooltipText="white"
-              >
-                <div
-                  className="components-circular-option-picker__option-wrapper"
+                  tooltipText="white"
                 >
-                  <Tooltip
-                    text="white"
+                  <div
+                    className="components-circular-option-picker__option-wrapper"
                   >
-                    <ForwardRef(Button)
-                      aria-label="Color: white"
-                      className="components-circular-option-picker__option"
-                      isPressed={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      style={
-                        Object {
-                          "backgroundColor": "#fff",
-                          "color": "#fff",
-                        }
-                      }
+                    <Tooltip
+                      text="white"
                     >
-                      <button
-                        aria-describedby={null}
+                      <ForwardRef(Button)
                         aria-label="Color: white"
-                        aria-pressed={false}
-                        className="components-button components-circular-option-picker__option"
+                        className="components-circular-option-picker__option"
+                        isPressed={false}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onFocus={[Function]}
@@ -449,54 +433,54 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                             "color": "#fff",
                           }
                         }
-                        type="button"
-                      />
-                    </ForwardRef(Button)>
-                  </Tooltip>
-                </div>
-              </Option>
-              <Option
-                aria-label="Color: blue"
-                isSelected={false}
-                key="#00f"
-                onClick={[Function]}
-                selectedIconProps={Object {}}
-                style={
-                  Object {
-                    "backgroundColor": "#00f",
-                    "color": "#00f",
+                      >
+                        <button
+                          aria-describedby={null}
+                          aria-label="Color: white"
+                          aria-pressed={false}
+                          className="components-button components-circular-option-picker__option"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "backgroundColor": "#fff",
+                              "color": "#fff",
+                            }
+                          }
+                          type="button"
+                        />
+                      </ForwardRef(Button)>
+                    </Tooltip>
+                  </div>
+                </Option>
+                <Option
+                  aria-label="Color: blue"
+                  isSelected={false}
+                  key="#00f"
+                  onClick={[Function]}
+                  selectedIconProps={Object {}}
+                  style={
+                    Object {
+                      "backgroundColor": "#00f",
+                      "color": "#00f",
+                    }
                   }
-                }
-                tooltipText="blue"
-              >
-                <div
-                  className="components-circular-option-picker__option-wrapper"
+                  tooltipText="blue"
                 >
-                  <Tooltip
-                    text="blue"
+                  <div
+                    className="components-circular-option-picker__option-wrapper"
                   >
-                    <ForwardRef(Button)
-                      aria-label="Color: blue"
-                      className="components-circular-option-picker__option"
-                      isPressed={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      style={
-                        Object {
-                          "backgroundColor": "#00f",
-                          "color": "#00f",
-                        }
-                      }
+                    <Tooltip
+                      text="blue"
                     >
-                      <button
-                        aria-describedby={null}
+                      <ForwardRef(Button)
                         aria-label="Color: blue"
-                        aria-pressed={false}
-                        className="components-button components-circular-option-picker__option"
+                        className="components-circular-option-picker__option"
+                        isPressed={false}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onFocus={[Function]}
@@ -509,38 +493,57 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                             "color": "#00f",
                           }
                         }
-                        type="button"
-                      />
-                    </ForwardRef(Button)>
-                  </Tooltip>
-                </div>
-              </Option>
-            </div>
-            <div
-              className="components-circular-option-picker__custom-clear-wrapper"
-            >
-              <ButtonAction
-                onClick={[Function]}
+                      >
+                        <button
+                          aria-describedby={null}
+                          aria-label="Color: blue"
+                          aria-pressed={false}
+                          className="components-button components-circular-option-picker__option"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "backgroundColor": "#00f",
+                              "color": "#00f",
+                            }
+                          }
+                          type="button"
+                        />
+                      </ForwardRef(Button)>
+                    </Tooltip>
+                  </div>
+                </Option>
+              </div>
+              <div
+                className="components-circular-option-picker__custom-clear-wrapper"
               >
-                <ForwardRef(Button)
-                  className="components-circular-option-picker__clear"
-                  isSmall={true}
+                <ButtonAction
                   onClick={[Function]}
-                  variant="secondary"
                 >
-                  <button
-                    aria-describedby={null}
-                    className="components-button components-circular-option-picker__clear is-secondary is-small"
+                  <ForwardRef(Button)
+                    className="components-circular-option-picker__clear"
+                    isSmall={true}
                     onClick={[Function]}
-                    type="button"
+                    variant="secondary"
                   >
-                    Clear
-                  </button>
-                </ForwardRef(Button)>
-              </ButtonAction>
+                    <button
+                      aria-describedby={null}
+                      className="components-button components-circular-option-picker__clear is-secondary is-small"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Clear
+                    </button>
+                  </ForwardRef(Button)>
+                </ButtonAction>
+              </div>
             </div>
-          </div>
-        </CircularOptionPicker>
+          </CircularOptionPicker>
+        </SinglePalette>
       </div>
     </View>
   </VStack>

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -14,18 +14,18 @@ import { useCallback, useMemo } from '@wordpress/element';
  */
 import CircularOptionPicker from '../circular-option-picker';
 import CustomGradientPicker from '../custom-gradient-picker';
+import { VStack } from '../v-stack';
+import { ColorHeading } from '../color-palette/styles';
 
-export default function GradientPicker( {
+function SingleOrigin( {
 	className,
+	clearGradient,
 	gradients,
 	onChange,
 	value,
-	clearable = true,
-	disableCustomGradients = false,
+	actions,
+	content,
 } ) {
-	const clearGradient = useCallback( () => onChange( undefined ), [
-		onChange,
-	] );
 	const gradientOptions = useMemo( () => {
 		return map( gradients, ( { gradient, name } ) => (
 			<CircularOptionPicker.Option
@@ -57,6 +57,70 @@ export default function GradientPicker( {
 		<CircularOptionPicker
 			className={ className }
 			options={ gradientOptions }
+			actions={ actions }
+		>
+			{ content }
+		</CircularOptionPicker>
+	);
+}
+
+function MultipleOrigin( {
+	className,
+	clearGradient,
+	gradients,
+	onChange,
+	value,
+	actions,
+	content,
+} ) {
+	return (
+		<VStack spacing={ 3 } className={ className }>
+			{ gradients.map( ( { name, gradients: gradientSet }, index ) => {
+				return (
+					<VStack spacing={ 2 } key={ index }>
+						<ColorHeading>{ name }</ColorHeading>
+						<SingleOrigin
+							clearGradient={ clearGradient }
+							gradients={ gradientSet }
+							onChange={ onChange }
+							value={ value }
+							{ ...( gradients.length === index + 1
+								? {
+										actions,
+										content,
+								  }
+								: {} ) }
+						/>
+					</VStack>
+				);
+			} ) }
+		</VStack>
+	);
+}
+
+export default function GradientPicker( {
+	className,
+	gradients,
+	onChange,
+	value,
+	clearable = true,
+	disableCustomGradients = false,
+	__experimentalHasMultipleOrigins,
+} ) {
+	const clearGradient = useCallback( () => onChange( undefined ), [
+		onChange,
+	] );
+	const Component = __experimentalHasMultipleOrigins
+		? MultipleOrigin
+		: SingleOrigin;
+	return (
+		<Component
+			className={ className }
+			clearable={ clearable }
+			clearGradient={ clearGradient }
+			gradients={ gradients }
+			onChange={ onChange }
+			value={ value }
 			actions={
 				clearable && (
 					<CircularOptionPicker.ButtonAction
@@ -66,10 +130,14 @@ export default function GradientPicker( {
 					</CircularOptionPicker.ButtonAction>
 				)
 			}
-		>
-			{ ! disableCustomGradients && (
-				<CustomGradientPicker value={ value } onChange={ onChange } />
-			) }
-		</CircularOptionPicker>
+			content={
+				! disableCustomGradients && (
+					<CustomGradientPicker
+						value={ value }
+						onChange={ onChange }
+					/>
+				)
+			}
+		/>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -6,7 +6,8 @@ import { get, cloneDeep, set, isEqual, has } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useContext, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useContext, useCallback, useMemo } from '@wordpress/element';
 import {
 	getBlockType,
 	__EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE,
@@ -214,4 +215,60 @@ export function getSupportedGlobalStylesPanels( name ) {
 	} );
 
 	return supportKeys;
+}
+
+export function useColorsPerOrigin( name ) {
+	const [ userColors ] = useSetting( 'color.palette.user', name );
+	const [ themeColors ] = useSetting( 'color.palette.theme', name );
+	const [ coreColors ] = useSetting( 'color.palette.core', name );
+	return useMemo( () => {
+		const result = [];
+		if ( coreColors && coreColors.length ) {
+			result.push( {
+				name: __( 'Core' ),
+				colors: coreColors,
+			} );
+		}
+		if ( themeColors && themeColors.length ) {
+			result.push( {
+				name: __( 'Theme' ),
+				colors: themeColors,
+			} );
+		}
+		if ( userColors && userColors.length ) {
+			result.push( {
+				name: __( 'User' ),
+				colors: userColors,
+			} );
+		}
+		return result;
+	}, [ userColors, themeColors, coreColors ] );
+}
+
+export function useGradientsPerOrigin( name ) {
+	const [ userGradients ] = useSetting( 'color.gradients.user', name );
+	const [ themeGradients ] = useSetting( 'color.gradients.theme', name );
+	const [ coreGradients ] = useSetting( 'color.gradients.core', name );
+	return useMemo( () => {
+		const result = [];
+		if ( coreGradients && coreGradients.length ) {
+			result.push( {
+				name: __( 'Core' ),
+				gradients: coreGradients,
+			} );
+		}
+		if ( themeGradients && themeGradients.length ) {
+			result.push( {
+				name: __( 'Theme' ),
+				gradients: themeGradients,
+			} );
+		}
+		if ( userGradients && userGradients.length ) {
+			result.push( {
+				name: __( 'User' ),
+				gradients: userGradients,
+			} );
+		}
+		return result;
+	}, [ userGradients, themeGradients, coreGradients ] );
 }

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -8,7 +8,13 @@ import { __experimentalPanelColorGradientSettings as PanelColorGradientSettings 
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
+import {
+	getSupportedGlobalStylesPanels,
+	useColorsPerOrigin,
+	useGradientsPerOrigin,
+	useSetting,
+	useStyle,
+} from './hooks';
 
 function ScreenBackgroundColor( { name } ) {
 	const parentMenu = name === undefined ? '' : '/blocks/' + name;
@@ -20,6 +26,9 @@ function ScreenBackgroundColor( { name } ) {
 		'color.customGradient',
 		name
 	);
+
+	const colorsPerOrigin = useColorsPerOrigin( name );
+	const gradientsPerOrigin = useGradientsPerOrigin( name );
 
 	const [ isBackgroundEnabled ] = useSetting( 'color.background', name );
 
@@ -89,10 +98,11 @@ function ScreenBackgroundColor( { name } ) {
 			<PanelColorGradientSettings
 				title={ __( 'Color' ) }
 				settings={ settings }
-				colors={ solids }
-				gradients={ gradients }
+				colors={ colorsPerOrigin }
+				gradients={ gradientsPerOrigin }
 				disableCustomColors={ ! areCustomSolidsEnabled }
 				disableCustomGradients={ ! areCustomGradientsEnabled }
+				__experimentalHasMultipleOrigins
 				showTitle={ false }
 			/>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -8,13 +8,20 @@ import { __experimentalPanelColorGradientSettings as PanelColorGradientSettings 
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
+import {
+	getSupportedGlobalStylesPanels,
+	useSetting,
+	useStyle,
+	useColorsPerOrigin,
+} from './hooks';
 
 function ScreenLinkColor( { name } ) {
 	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
+
+	const colorsPerOrigin = useColorsPerOrigin( name );
 
 	const [ isLinkEnabled ] = useSetting( 'color.link', name );
 
@@ -59,8 +66,9 @@ function ScreenLinkColor( { name } ) {
 			<PanelColorGradientSettings
 				title={ __( 'Color' ) }
 				settings={ settings }
-				colors={ solids }
+				colors={ colorsPerOrigin }
 				disableCustomColors={ ! areCustomSolidsEnabled }
+				__experimentalHasMultipleOrigins
 				showTitle={ false }
 			/>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -8,7 +8,12 @@ import { __experimentalPanelColorGradientSettings as PanelColorGradientSettings 
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
+import {
+	getSupportedGlobalStylesPanels,
+	useSetting,
+	useStyle,
+	useColorsPerOrigin,
+} from './hooks';
 
 function ScreenTextColor( { name } ) {
 	const parentMenu = name === undefined ? '' : '/blocks/' + name;
@@ -16,6 +21,8 @@ function ScreenTextColor( { name } ) {
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
 	const [ isTextEnabled ] = useSetting( 'color.text', name );
+
+	const colorsPerOrigin = useColorsPerOrigin( name );
 
 	const hasTextColor =
 		supports.includes( 'color' ) &&
@@ -51,8 +58,9 @@ function ScreenTextColor( { name } ) {
 			<PanelColorGradientSettings
 				title={ __( 'Color' ) }
 				settings={ settings }
-				colors={ solids }
+				colors={ colorsPerOrigin }
 				disableCustomColors={ ! areCustomSolidsEnabled }
+				__experimentalHasMultipleOrigins
 				showTitle={ false }
 			/>
 		</>


### PR DESCRIPTION
This PR changes the color components in the block editor inspector and the global styles to show multiple colors and gradient palettes.


The idea of this PR is that the base components ColorPalette and GradientPicker are changed so the color and gradient props are now an array of color sets with the following format: colors = [ { name: "Core", colors: [..] }, { name: "Theme", colors: [..] }, ... ]. That format is optional and only happens when the property __experimentalHasMultipleOrigins is true, so we are totally back-compatible.


## How has this been tested?
I used a background color on the cover block from different origins and verified things worked as expected.
I used a background gradient on the group block from different origins and verified things worked as expected.
I applied a global text, background, and link, color from different origins, and verified things worked as expected.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/11271197/138929332-ba22a9c4-96bf-43c0-8416-404fda3a8938.png)

![image](https://user-images.githubusercontent.com/11271197/138929634-7f071894-ce31-45de-bcdc-e8395f4090fa.png)


cc: @jasmussen, @pablohoneyhoney would you be able to give a design/UX review to this PR?
cc: @ciampo, @mirka as people components work.

