### PR TITLE
Site Logo: Fix center alignment

### DIFF
--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -17,7 +17,7 @@
 		border-radius: inherit;
 	}
 
-	.aligncenter {
+	&.aligncenter {
 		display: table;
 	}
 


### PR DESCRIPTION
The style that is supposed to center-align the site logo currently targets the wrong class, and is never applied. It currently targets `aligncenter` as a child of the `.wp-block-site-logo` block, but that class is actually added to the top level block. 

It works fine in the editor toda, but it is broken in the frontend. 

Before (Frontend)|After (Frontend)
---|---
<img width="702" alt="Screen Shot 2021-10-26 at 2 22 17 PM" src="https://user-images.githubusercontent.com/1202812/138939654-0607c923-37b1-49e9-96eb-faec259dc22a.png">|<img width="687" alt="Screen Shot 2021-10-26 at 2 22 34 PM" src="https://user-images.githubusercontent.com/1202812/138939655-0898fddf-4520-4c3a-97a1-70b8dc87c5e1.png">