### PR TITLE
Image Block: Add data-id attribute on server side render for core galleries

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -66,6 +66,8 @@ function gutenberg_reregister_core_block_types() {
 				'comment-template.php'          => 'core/comment-template',
 				'file.php'                      => 'core/file',
 				'home-link.php'                 => 'core/home-link',
+				'image.php'                     => 'core/image',
+				'gallery.php'                   => 'core/gallery',
 				'latest-comments.php'           => 'core/latest-comments',
 				'latest-posts.php'              => 'core/latest-posts',
 				'loginout.php'                  => 'core/loginout',

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -21,8 +21,8 @@ function render_block_core_gallery_data( $parsed_block ) {
 	if ( 'core/gallery' === $parsed_block['blockName'] ) {
 		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
 			if ( 'core/image' === $inner_block['blockName'] ) {
-				if ( ! $parsed_block['innerBlocks'][$key]['attrs']['data-id'] ) {
-					$parsed_block['innerBlocks'][$key]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
+				if ( ! $parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] ) {
+					$parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
 				}
 			}
 		}

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Server-side rendering of the `core/image` block.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Handles backwards compatibility for Gallery Blocks,
+ * whose images feature a `data-id` attribute.
+ *
+ * Now that the Gallery Block contains inner Image Blocks,
+ * we add a custom `data-id` attribute before rendering the gallery
+ * so that the Image Block can pick it up in its render_callback.
+ *
+ * @param  array $parsed_block A single parsed block object.
+ *
+ * @return array               The migrated block object.
+ */
+function render_block_core_gallery_data( $parsed_block ) {
+	if ( 'core/gallery' === $parsed_block['blockName'] ) {
+		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+			if ( 'core/image' === $inner_block['blockName'] ) {
+				if ( ! $parsed_block['innerBlocks'][$key]['attrs']['data-id'] ) {
+					$parsed_block['innerBlocks'][$key]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
+				}
+			}
+		}
+	}
+
+	return $parsed_block;
+}
+
+add_filter( 'render_block_data', 'render_block_core_gallery_data' );

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -32,3 +32,21 @@ function render_block_core_gallery_data( $parsed_block ) {
 }
 
 add_filter( 'render_block_data', 'render_block_core_gallery_data' );
+
+/**
+ * Registers the `core/gallery` block on server.
+ * This render callback needs to be here
+ * so that the gallery styles are loaded in block-based themes.
+ */
+function gutenberg_register_block_core_gallery() {
+	register_block_type_from_metadata(
+		__DIR__ . '/gallery',
+		array(
+			'render_callback' => function ( $attributes, $content ) {
+				return $content;
+			},
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_block_core_gallery', 20 );

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -21,7 +21,7 @@ function render_block_core_gallery_data( $parsed_block ) {
 	if ( 'core/gallery' === $parsed_block['blockName'] ) {
 		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
 			if ( 'core/image' === $inner_block['blockName'] ) {
-				if ( ! $parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] ) {
+				if ( ! isset( $parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] ) && isset( $inner_block['attrs']['id'] ) ) {
 					$parsed_block['innerBlocks'][ $key ]['attrs']['data-id'] = esc_attr( $inner_block['attrs']['id'] );
 				}
 			}

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -29,7 +29,7 @@ function render_block_core_image( $attributes, $content ) {
 
 
 /**
- * Register image block.
+ * Registers the `core/image` block on server.
  */
 function register_block_core_image() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -6,18 +6,20 @@
  */
 
 /**
- * Renders the `core/image` block on the server.
+ * Renders the `core/image` block on the server,
+ * adding a data-id attribute to the element if core/gallery has added on pre-render.
  *
  * @param  array $attributes The block attributes.
  * @param  array $content    The block content.
  * @return string            Returns the block content with the data-id attribute added.
  */
 function render_block_core_image( $attributes, $content ) {
-	if ( isset( $attributes['id'] ) ) {
+	if ( isset( $attributes['data-id'] ) ) {
 		// Add the data-id="$id" attribute to the img element
 		// to provide backwards compatibility for the Gallery Block,
 		// which now wraps Image Blocks within innerBlocks.
-		$data_id_attribute = 'data-id="' . esc_attr( $attributes['id'] ) . '"';
+		// The data-id attribute is added in a core/gallery `render_block_data` hook.
+		$data_id_attribute = 'data-id="' . esc_attr( $attributes['data-id'] ) . '"';
 		if ( ! strpos( $content, $data_id_attribute ) ) {
 			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
 		}

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -8,8 +8,8 @@
 /**
  * Adds a data-id attribute to the core Image block when nested in a Gallery block.
  *
- * @param  WP_Post $post The block attributes.
- * @return string        Returns the block content with the data-id attribute added.
+ * @param  WP_Post $post The WP post.
+ * @return string        Returns the post content with the data-id attribute added to gallery images.
  */
 function get_block_core_image_post_content( $post ) {
 	if ( is_admin() ) {
@@ -19,14 +19,14 @@ function get_block_core_image_post_content( $post ) {
 		$content = $post->post_content;
 		$blocks  = parse_blocks( $content );
 		foreach ( $blocks as $block ) {
-			if ( 'core/gallery' === $block['blockName'] ) {
+			if ( 'core/gallery' === $block['blockName'] && ! empty( $block['innerBlocks'] ) ) {
 				foreach ( $block['innerBlocks'] as $inner_block ) {
 					if ( 'core/image' === $inner_block['blockName'] ) {
 						if ( isset( $inner_block['attrs']['id'] ) ) {
 							$image_id          = esc_attr( $inner_block['attrs']['id'] );
 							$data_id_attribute = 'data-id="' . $image_id . '"';
 							$class_string      = 'class="wp-image-' . $image_id . '"';
-							$content           = str_replace( $class_string, $class_string . ' ' . $data_id_attribute, $content );
+							$content           = str_replace( $class_string, $data_id_attribute . ' ' . $class_string, $content );
 						}
 					}
 				}
@@ -36,4 +36,4 @@ function get_block_core_image_post_content( $post ) {
 	$post->post_content = $content;
 }
 
-add_action( 'the_post', 'get_block_core_image_post_content', 10, 2 );
+add_action( 'the_post', 'get_block_core_image_post_content', 10, 1 );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Server-side rendering of the `core/image` block.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Renders the `core/image` block on the server.
+ *
+ * @param  array $attributes The block attributes.
+ * @param  array $content    The block content.
+ * @return string            Returns the block content with the data-id attribute added.
+ */
+function render_block_core_image( $attributes, $content ) {
+	if ( isset( $attributes['id'] ) ) {
+		// Add the data-id="$id" attribute to the img element
+		// to provide backwards compatibility for the Gallery Block,
+		// which now wraps Image Blocks within innerBlocks.
+		$data_id_attribute = 'data-id="' . esc_attr( $attributes['id'] ) . '"';
+		if ( ! strpos( $content, $data_id_attribute ) ) {
+			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
+		}
+	}
+	return $content;
+}
+
+
+/**
+ * Register image block.
+ */
+function register_block_core_image() {
+	register_block_type_from_metadata(
+		__DIR__ . '/image',
+		array(
+			'render_callback' => 'render_block_core_image',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_image' );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -6,34 +6,35 @@
  */
 
 /**
- * Adds a data-id attribute to the core Image block when nested in a Gallery block.
+ * Renders the `core/image` block on the server.
  *
- * @param  WP_Post $post The WP post.
- * @return string        Returns the post content with the data-id attribute added to gallery images.
+ * @param  array $attributes The block attributes.
+ * @param  array $content    The block content.
+ * @return string            Returns the block content with the data-id attribute added.
  */
-function get_block_core_image_post_content( $post ) {
-	if ( is_admin() ) {
-		return;
-	}
-	if ( has_blocks( $post->post_content ) ) {
-		$content = $post->post_content;
-		$blocks  = parse_blocks( $content );
-		foreach ( $blocks as $block ) {
-			if ( 'core/gallery' === $block['blockName'] && ! empty( $block['innerBlocks'] ) ) {
-				foreach ( $block['innerBlocks'] as $inner_block ) {
-					if ( 'core/image' === $inner_block['blockName'] ) {
-						if ( isset( $inner_block['attrs']['id'] ) ) {
-							$image_id          = esc_attr( $inner_block['attrs']['id'] );
-							$data_id_attribute = 'data-id="' . $image_id . '"';
-							$class_string      = 'class="wp-image-' . $image_id . '"';
-							$content           = str_replace( $class_string, $data_id_attribute . ' ' . $class_string, $content );
-						}
-					}
-				}
-			}
+function render_block_core_image( $attributes, $content ) {
+	if ( isset( $attributes['id'] ) ) {
+		// Add the data-id="$id" attribute to the img element
+		// to provide backwards compatibility for the Gallery Block,
+		// which now wraps Image Blocks within innerBlocks.
+		$data_id_attribute = 'data-id="' . esc_attr( $attributes['id'] ) . '"';
+		if ( ! strpos( $content, $data_id_attribute ) ) {
+			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
 		}
 	}
-	$post->post_content = $content;
+	return $content;
 }
 
-add_action( 'the_post', 'get_block_core_image_post_content', 10, 1 );
+
+/**
+ * Register image block.
+ */
+function register_block_core_image() {
+	register_block_type_from_metadata(
+		__DIR__ . '/image',
+		array(
+			'render_callback' => 'render_block_core_image',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_image' );


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/35907

## Description

This PR renders a `data-id` attribute on the image element of Image Blocks on if a `data-id` property exists in the block's attributes.

The Gallery Block now has a filter `render_block_data` which adds a `data-id` to Image Blocks before the Gallery Block is processed.

Why?

The answer is phrased very succinctly in the [issue](https://github.com/WordPress/gutenberg/issues/35907)

> Block gallery image markup has included a data-id attribute on each gallery image <img> tag since WordPress 5.0. This attribute includes the image attachment post object's id for images hosted locally in the media library. It allows plugins and themes to access other structured data related to the image through the core attachment post type. This can be used in both PHP and JS to pre- or post-process the post content markup.

## Testing

Enable the Gallery experiment on Gutenberg


<img width="600" alt="Screen Shot 2021-10-27 at 11 49 45 am" src="https://user-images.githubusercontent.com/6458278/138997887-33f9273c-be8d-415a-b277-223580b17822.png">


Insert a gallery and a single image into a post.

Make sure that the published gallery images and single image markup includes the data-id attribute on the` <img />` tags.

<img width="712" alt="Screen Shot 2021-10-27 at 2 03 50 pm" src="https://user-images.githubusercontent.com/6458278/138993007-965254e6-a0f2-409b-ad5c-bae9b1f113df.png">

Check that other galleries are still working, e.g., Jetpack tiled gallery.



## Types of changes


<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
