### PR TITLE
Update unsaved navigation block flow

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -42,7 +42,7 @@ import ResponsiveWrapper from './responsive-wrapper';
 import NavigationInnerBlocks from './inner-blocks';
 import NavigationMenuSelector from './navigation-menu-selector';
 import NavigationMenuNameControl from './navigation-menu-name-control';
-import UpgradeToNavigationMenu from './upgrade-to-navigation-menu';
+import UnsavedInnerBlocks from './unsaved-inner-blocks';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -74,6 +74,7 @@ function detectColors( colorsDetectionElement, setColor, setBackground ) {
 function Navigation( {
 	attributes,
 	setAttributes,
+	isSelected,
 	clientId,
 	className,
 	backgroundColor,
@@ -201,13 +202,17 @@ function Navigation( {
 
 	// If the block has inner blocks, but no menu id, this was an older
 	// navigation block added before the block used a wp_navigation entity.
-	// Offer a UI to upgrade it to using the entity.
-	if ( hasExistingNavItems && navigationMenuId === undefined ) {
+	// Consider this 'unsaved'. Offer an uncontrolled version of inner blocks,
+	// with a prompt to 'save'.
+	const hasUnsavedBlocks =
+		hasExistingNavItems && navigationMenuId === undefined;
+	if ( hasUnsavedBlocks ) {
 		return (
-			<UpgradeToNavigationMenu
+			<UnsavedInnerBlocks
 				blockProps={ blockProps }
 				blocks={ innerBlocks }
-				onUpgrade={ ( post ) =>
+				isSelected={ isSelected }
+				onSave={ ( post ) =>
 					setAttributes( { navigationMenuId: post.id } )
 				}
 			/>

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -17,10 +17,11 @@ import { __ } from '@wordpress/i18n';
  */
 import NavigationMenuNameModal from './navigation-menu-name-modal';
 
-export default function UpgradeToNavigationMenu( {
+export default function UnsavedInnerBlocks( {
 	blockProps,
 	blocks,
-	onUpgrade,
+	onSave,
+	isSelected,
 } ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		renderAppender: false,
@@ -50,26 +51,26 @@ export default function UpgradeToNavigationMenu( {
 
 	return (
 		<>
-			<Warning
-				actions={ [
-					<Button
-						key="upgrade"
-						onClick={ () => setIsModalVisible( true ) }
-						variant="primary"
-					>
-						{ __( 'Upgrade' ) }
-					</Button>,
-				] }
-			>
-				{ __(
-					'The navigation block has been updated to store data in a similar way to a reusable block. Please use the upgrade option to save your navigation block data and continue editing your block.'
-				) }
-			</Warning>
-			<Disabled>
-				<nav { ...blockProps }>
+			{ isSelected && (
+				<Warning
+					actions={ [
+						<Button
+							key="save"
+							onClick={ () => setIsModalVisible( true ) }
+							variant="primary"
+						>
+							{ __( 'Save as' ) }
+						</Button>,
+					] }
+				>
+					{ __( 'Save this block to continue editing.' ) }
+				</Warning>
+			) }
+			<nav { ...blockProps }>
+				<Disabled>
 					<div { ...innerBlocksProps } />
-				</nav>
-			</Disabled>
+				</Disabled>
+			</nav>
 			{ isModalVisible && (
 				<NavigationMenuNameModal
 					title={ __( 'Name your navigation menu' ) }
@@ -78,7 +79,7 @@ export default function UpgradeToNavigationMenu( {
 					} }
 					onFinish={ async ( title ) => {
 						const menu = await createNavigationMenu( title );
-						onUpgrade( menu );
+						onSave( menu );
 					} }
 				/>
 			) }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -51,22 +51,23 @@ export default function UnsavedInnerBlocks( {
 
 	return (
 		<>
-			{ isSelected && (
-				<Warning
-					actions={ [
-						<Button
-							key="save"
-							onClick={ () => setIsModalVisible( true ) }
-							variant="primary"
-						>
-							{ __( 'Save as' ) }
-						</Button>,
-					] }
-				>
-					{ __( 'Save this block to continue editing.' ) }
-				</Warning>
-			) }
 			<nav { ...blockProps }>
+				{ isSelected && (
+					<Warning
+						className="wp-block-navigation__unsaved-changes-warning"
+						actions={ [
+							<Button
+								key="save"
+								onClick={ () => setIsModalVisible( true ) }
+								variant="primary"
+							>
+								{ __( 'Save as' ) }
+							</Button>,
+						] }
+					>
+						{ __( 'Save this block to continue editing.' ) }
+					</Warning>
+				) }
 				<Disabled>
 					<div { ...innerBlocksProps } />
 				</Disabled>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -521,3 +521,11 @@ body.editor-styles-wrapper
 		margin-top: $grid-unit-20;
 	}
 }
+
+.wp-block-navigation__unsaved-changes-warning {
+	width: 100%;
+
+	.block-editor-warning__actions {
+		margin-top: 0;
+	}
+}


### PR DESCRIPTION
## Description
Improves the problem described in #35947.

#35746 included a prompt for the user to 'Upgrade' a navigation block that uses 'uncontrolled' inner blocks (inner blocks that are not saved to the wp_navigation post type). Unfortunately this prompt was visible in pattern previews.

This PR streamlines the prompt and makes it only show on block selection so that it doesn't appear in the preview of patterns.

I don't intend this to be a perfect fix, but it should at least be an immediate improvement to the way patterns that include the navigation block appear.

## How has this been tested?
1. Use a theme that has a pattern including the Navigation Block. I used 'Armando' from the theme experiments project.
2. Visit the site editor
3. View patterns that include a nav block (e.g. 'Site Header' patterns)
4. The patterns should not include the 'Upgrade' prompt
5. Insert a pattern
6. Select the navigation block
7. A prompt to save the block is now visible only when the block is selected:
<img width="408" alt="Screenshot 2021-10-27 at 12 11 49 pm" src="https://user-images.githubusercontent.com/677833/138998798-56fb34aa-8abd-4171-b757-7fa207b2daac.png">

## Screenshots <!-- if applicable -->
### Before
<img width="331" alt="Screenshot 2021-10-27 at 12 01 55 pm" src="https://user-images.githubusercontent.com/677833/138998186-460c9d27-8970-4690-8468-6005161964d6.png">

### After
<img width="338" alt="Screenshot 2021-10-27 at 12 03 08 pm" src="https://user-images.githubusercontent.com/677833/138998199-cf09583e-0941-43d3-a409-1798d1290563.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
