### PR TITLE
Navigation: Add delete nav menu button

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -43,6 +43,7 @@ import NavigationInnerBlocks from './inner-blocks';
 import NavigationMenuSelector from './navigation-menu-selector';
 import NavigationMenuNameControl from './navigation-menu-name-control';
 import UnsavedInnerBlocks from './unsaved-inner-blocks';
+import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -112,7 +113,7 @@ function Navigation( {
 		[ clientId ]
 	);
 	const hasExistingNavItems = !! innerBlocks.length;
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -298,8 +299,17 @@ function Navigation( {
 				{ listViewModal }
 				<InspectorControls>
 					{ isEntityAvailable && (
-						<PanelBody title={ __( 'Navigation menu name' ) }>
+						<PanelBody title={ __( 'Navigation menu' ) }>
 							<NavigationMenuNameControl />
+							<NavigationMenuDeleteControl
+								onDelete={ () => {
+									replaceInnerBlocks( clientId, [] );
+									setAttributes( {
+										navigationMenuId: undefined,
+									} );
+									setIsPlaceholderShown( true );
+								} }
+							/>
 						</PanelBody>
 					) }
 					{ hasSubmenuIndicatorSetting && (

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
+import {
+	store as coreStore,
+	useEntityId,
+	useEntityProp,
+} from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function NavigationMenuDeleteControl( { onDelete } ) {
+	const [ isConfirmModalVisible, setIsConfirmModalVisible ] = useState(
+		false
+	);
+	const id = useEntityId( 'postType', 'wp_navigation' );
+	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
+	const { deleteEntityRecord } = useDispatch( coreStore );
+
+	return (
+		<>
+			<Button
+				onClick={ () => {
+					setIsConfirmModalVisible( true );
+				} }
+			>
+				{ __( 'Delete menu' ) }
+			</Button>
+			{ isConfirmModalVisible && (
+				<Modal
+					title={ sprintf(
+						/* translators: %s: the name of a menu to delete */
+						__( 'Delete %s' ),
+						title
+					) }
+					closeLabel={ __( 'Cancel' ) }
+					onRequestClose={ () => setIsConfirmModalVisible( false ) }
+				>
+					<p>
+						{ __(
+							'Are you sure you want to delete this navigation menu?'
+						) }
+					</p>
+					<Flex justify="flex-end">
+						<FlexItem>
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									setIsConfirmModalVisible( false );
+								} }
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+						</FlexItem>
+						<FlexItem>
+							<Button
+								variant="primary"
+								onClick={ () => {
+									deleteEntityRecord(
+										'postType',
+										'wp_navigation',
+										id
+									);
+									onDelete();
+								} }
+							>
+								{ __( 'Confirm' ) }
+							</Button>
+						</FlexItem>
+					</Flex>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -22,6 +22,9 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 	return (
 		<>
 			<Button
+				className="wp-block-navigation-delete-menu-button"
+				variant="secondary"
+				isDestructive
 				onClick={ () => {
 					setIsConfirmModalVisible( true );
 				} }

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -64,7 +64,8 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 									deleteEntityRecord(
 										'postType',
 										'wp_navigation',
-										id
+										id,
+										{ force: true }
 									);
 									onDelete();
 								} }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -529,3 +529,8 @@ body.editor-styles-wrapper
 		margin-top: 0;
 	}
 }
+
+.wp-block-navigation-delete-menu-button {
+	width: 100%;
+	justify-content: center;
+}


### PR DESCRIPTION
## Description
Adds a button for deleting 'wp_navigation' posts to the nav block's block inspector:
<img width="277" alt="Screenshot 2021-10-27 at 4 03 03 pm" src="https://user-images.githubusercontent.com/677833/139025252-5f6f8fca-36fd-4725-90d1-fe9b91a993b0.png">

Deleting has a confirm step:
<img width="404" alt="Screenshot 2021-10-27 at 4 05 40 pm" src="https://user-images.githubusercontent.com/677833/139025653-97a11107-9b95-4556-bcc7-4039b711cb0e.png">

<strike>
There's a bug in the multi-entity saving flow that needs to be shipped, preferably before this is shipped. When deleting an entity, it shows in the saving panel as an 'undefined' change 😬 :
<img width="278" alt="Screenshot 2021-10-27 at 4 04 27 pm" src="https://user-images.githubusercontent.com/677833/139025520-78395a32-20ef-4836-a4b0-e657449c9327.png">

This should preferably be filtered out, deleting entities is immediate and doesn't need to be saved.
</strike>

## How has this been tested?
1. Add a nav block
2. Create a new menu
3. Click delete
4. Confirm deletion

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
