### PR TITLE
Scripts: Increase timeout for e2e tests

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Increase the timeout for e2e tests to 30 seconds ([#35983](https://github.com/WordPress/gutenberg/pull/35983)).
+
 ## 19.0.0 (2021-10-22)
 
 ### Breaking Changes

--- a/packages/scripts/config/jest-e2e.config.js
+++ b/packages/scripts/config/jest-e2e.config.js
@@ -9,21 +9,22 @@ const path = require( 'path' );
 const { hasBabelConfig } = require( '../utils' );
 
 const jestE2EConfig = {
-	testRunner: 'jest-circus/runner',
 	globalSetup: path.join( __dirname, 'jest-environment-puppeteer', 'setup' ),
 	globalTeardown: path.join(
 		__dirname,
 		'jest-environment-puppeteer',
 		'teardown'
 	),
-	testEnvironment: path.join( __dirname, 'jest-environment-puppeteer' ),
-	setupFilesAfterEnv: [ 'expect-puppeteer' ],
-	testMatch: [ '**/specs/**/*.[jt]s', '**/?(*.)spec.[jt]s' ],
-	testPathIgnorePatterns: [ '/node_modules/' ],
 	reporters: [
 		'default',
 		path.join( __dirname, 'jest-github-actions-reporter.js' ),
 	],
+	setupFilesAfterEnv: [ 'expect-puppeteer' ],
+	testEnvironment: path.join( __dirname, 'jest-environment-puppeteer' ),
+	testMatch: [ '**/specs/**/*.[jt]s', '**/?(*.)spec.[jt]s' ],
+	testPathIgnorePatterns: [ '/node_modules/' ],
+	testRunner: 'jest-circus/runner',
+	testTimeout: 30000,
 };
 
 if ( ! hasBabelConfig() ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Let's increase the default timeout for e2e tests to 30 seconds.

```diff
+ testTimeout: 30000,
```

@ryanwelcher tries to integrate e2e tests in https://github.com/WordPress/gutenberg-examples/pull/174. It looks like the default value of 5 seconds doesn't play along well with CI. I don't have a strong opinion about the selected timeout value. I'm happy to update it to anything else that improves the experience.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
