### PR TITLE
Prevent CleanWebpackPlugin webpack plugin from deleting webpack assets

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Prevent the `CleanWebpackPlugin` plugin from deleting webpack assets during multi-configuration builds [#35980](https://github.com/WordPress/gutenberg/issues/35980).
+
 ## 19.2.0 (2021-11-15)
 
 ### New Features

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -230,6 +230,9 @@ const config = {
 		// https://github.com/johnagan/clean-webpack-plugin/issues/159
 		new CleanWebpackPlugin( {
 			cleanAfterEveryBuildPatterns: [ '!fonts/**', '!images/**' ],
+			// Prevent it from deleting webpack assets during builds that have
+			// multiple configurations returned in the webpack config.
+			cleanStaleWebpackAssets: false,
 		} ),
 		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents
 		// bundle content as a convenient interactive zoomable treemap.


### PR DESCRIPTION
## Description

Fixes #35980.

## How has this been tested?

The [updated WP webpack configuration](https://github.com/xwp/wp-scripts-webpack-clean-bug/compare/fix/webpack-config?expand=1) prevents the webpack assets from being deleted in the demo repository according [to these GitHub action results](https://github.com/xwp/wp-scripts-webpack-clean-bug/runs/4020400601?check_suite_focus=true).

## Screenshots <!-- if applicable -->

![patch-demo](https://user-images.githubusercontent.com/169055/139040366-06ddc2d1-a4cb-4155-bfd5-0ff878d234ef.png)

## Types of changes

- Bug fix: prevent the webpack build process from deleting webpack assets from different configurations that are part of the same build task.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
