### PR TITLE
[Block Editor]: Fix shift+click on a child block with its parent selected

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-multi-selection.js
@@ -176,7 +176,6 @@ export function useMultiSelection( clientId ) {
 						blockSelectionStart !== clientId &&
 						! startParents?.includes( clientId )
 					) {
-						toggleRichText( node, false );
 						const startPath = [
 							...startParents,
 							blockSelectionStart,
@@ -187,8 +186,15 @@ export function useMultiSelection( clientId ) {
 						];
 						const depth =
 							Math.min( startPath.length, endPath.length ) - 1;
-						multiSelect( startPath[ depth ], endPath[ depth ] );
-						event.preventDefault();
+						const start = startPath[ depth ];
+						const end = endPath[ depth ];
+						// Handle the case of having selected a parent block and
+						// then sfift+click on a child.
+						if ( start !== end ) {
+							toggleRichText( node, false );
+							multiSelect( start, end );
+							event.preventDefault();
+						}
 					}
 				} else if ( hasMultiSelection() ) {
 					// Allow user to escape out of a multi-selection to a


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/35953

Currently if you have selected a parent block and hold `shift` + click on a child of this block the `RichText` nodes get in multiselect mode, making them non-editable.

This PR handles this by checking if the final calculated `start and end clientIds` are the same before marking the multi-selection. 