### PR TITLE
Move getStablePath function into the wordrpess/url package

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Removed `getStablePath` function. Please use `normalizePath` from `@wordpress/url` package instead ([#35992](https://github.com/WordPress/gutenberg/pull/35992)).``
+
 ## 5.2.0 (2021-07-21)
 
 ### New feature

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -4,25 +4,12 @@
 import { normalizePath } from '@wordpress/url';
 
 /**
- * Given a path, returns a normalized path where equal query parameter values
- * will be treated as identical, regardless of order they appear in the original
- * text.
- *
- * @param {string} path Original path.
- *
- * @return {string} Normalized path.
- */
-export function getStablePath( path ) {
-	return normalizePath( path );
-}
-
-/**
  * @param {Record<string, any>} preloadedData
  * @return {import('../types').APIFetchMiddleware} Preloading middleware.
  */
 function createPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
-		result[ getStablePath( path ) ] = preloadedData[ path ];
+		result[ normalizePath( path ) ] = preloadedData[ path ];
 		return result;
 	}, /** @type {Record<string, any>} */ ( {} ) );
 
@@ -30,7 +17,7 @@ function createPreloadingMiddleware( preloadedData ) {
 		const { parse = true } = options;
 		if ( typeof options.path === 'string' ) {
 			const method = options.method || 'GET';
-			const path = getStablePath( options.path );
+			const path = normalizePath( options.path );
 
 			if ( 'GET' === method && cache[ path ] ) {
 				const cacheData = cache[ path ];

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { normalizePath } from '@wordpress/url';
+
+/**
  * Given a path, returns a normalized path where equal query parameter values
  * will be treated as identical, regardless of order they appear in the original
  * text.
@@ -8,29 +13,7 @@
  * @return {string} Normalized path.
  */
 export function getStablePath( path ) {
-	const splitted = path.split( '?' );
-	const query = splitted[ 1 ];
-	const base = splitted[ 0 ];
-	if ( ! query ) {
-		return base;
-	}
-
-	// 'b=1&c=2&a=5'
-	return (
-		base +
-		'?' +
-		query
-			// [ 'b=1', 'c=2', 'a=5' ]
-			.split( '&' )
-			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( ( entry ) => entry.split( '=' ) )
-			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
-			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
-			// [ 'a=5', 'b=1', 'c=2' ]
-			.map( ( pair ) => pair.join( '=' ) )
-			// 'a=5&b=1&c=2'
-			.join( '&' )
-	);
+	return normalizePath( path );
 }
 
 /**

--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -1,32 +1,9 @@
 /**
  * Internal dependencies
  */
-import createPreloadingMiddleware, { getStablePath } from '../preloading';
+import createPreloadingMiddleware from '../preloading';
 
 describe( 'Preloading Middleware', () => {
-	describe( 'getStablePath', () => {
-		it( 'returns same value if no query parameters', () => {
-			const path = '/foo/bar';
-
-			expect( getStablePath( path ) ).toBe( path );
-		} );
-
-		it( 'returns a stable path', () => {
-			const abc = getStablePath( '/foo/bar?a=5&b=1&c=2' );
-			const bca = getStablePath( '/foo/bar?b=1&c=2&a=5' );
-			const bac = getStablePath( '/foo/bar?b=1&a=5&c=2' );
-			const acb = getStablePath( '/foo/bar?a=5&c=2&b=1' );
-			const cba = getStablePath( '/foo/bar?c=2&b=1&a=5' );
-			const cab = getStablePath( '/foo/bar?c=2&a=5&b=1' );
-
-			expect( abc ).toBe( bca );
-			expect( bca ).toBe( bac );
-			expect( bac ).toBe( acb );
-			expect( acb ).toBe( cba );
-			expect( cba ).toBe( cab );
-		} );
-	} );
-
 	describe( 'given preloaded data', () => {
 		describe( 'when data is requested from a preloaded endpoint', () => {
 			describe( 'and it is requested for the first time', () => {

--- a/packages/edit-navigation/CHANGELOG.md
+++ b/packages/edit-navigation/CHANGELOG.md
@@ -2,4 +2,10 @@
 
 ## Unreleased
 
--   Initial version of the package.
+### Internal
+
+-   Removed `getStablePath` function. Please use `normalizePath` from `@wordpress/url` package instead ([#35992](https://github.com/WordPress/gutenberg/pull/35992)).
+
+## 1.0.0
+
+- Initial version of the package.

--- a/packages/edit-navigation/src/utils/index.js
+++ b/packages/edit-navigation/src/utils/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { normalizePath } from '@wordpress/url';
+
+/**
  * The purpose of this function is to create a middleware that is responsible for preloading menu-related data.
  * It uses data that is returned from the /__experimental/menus endpoint for requests
  * to the /__experimental/menu/<menuId> endpoint, because the data is the same.
@@ -10,7 +15,7 @@
  */
 export function createMenuPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
-		result[ getStablePath( path ) ] = preloadedData[ path ];
+		result[ normalizePath( path ) ] = preloadedData[ path ];
 		return result;
 	}, /** @type {Record<string, any>} */ ( {} ) );
 
@@ -28,7 +33,7 @@ export function createMenuPreloadingMiddleware( preloadedData ) {
 			return next( options );
 		}
 
-		const path = getStablePath( options.path );
+		const path = normalizePath( options.path );
 		if ( ! menusDataLoaded && cache[ path ] ) {
 			menusDataLoaded = true;
 			return sendSuccessResponse( cache[ path ], parse );
@@ -83,40 +88,5 @@ function sendSuccessResponse( responseData, parse ) {
 					statusText: 'OK',
 					headers: responseData.headers,
 			  } )
-	);
-}
-
-/**
- * Given a path, returns a normalized path where equal query parameter values
- * will be treated as identical, regardless of order they appear in the original
- * text.
- *
- * @param {string} path Original path.
- *
- * @return {string} Normalized path.
- */
-export function getStablePath( path ) {
-	const splitted = path.split( '?' );
-	const query = splitted[ 1 ];
-	const base = splitted[ 0 ];
-	if ( ! query ) {
-		return base;
-	}
-
-	// 'b=1&c=2&a=5'
-	return (
-		base +
-		'?' +
-		query
-			// [ 'b=1', 'c=2', 'a=5' ]
-			.split( '&' )
-			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( ( entry ) => entry.split( '=' ) )
-			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
-			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
-			// [ 'a=5', 'b=1', 'c=2' ]
-			.map( ( pair ) => pair.join( '=' ) )
-			// 'a=5&b=1&c=2'
-			.join( '&' )
 	);
 }

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added new `normalizePath` function ([#35992](https://github.com/WordPress/gutenberg/pull/35992)).
+
 ## 3.2.3 (2021-10-12)
 
 ### Bug Fix

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -449,6 +449,20 @@ _Returns_
 
 -   `boolean`: True if the argument contains a valid query string.
 
+### normalizePath
+
+Given a path, returns a normalized path where equal query parameter values
+will be treated as identical, regardless of order they appear in the original
+text.
+
+_Parameters_
+
+-   _path_ `string`: Original path.
+
+_Returns_
+
+-   `string`: Normalized path.
+
 ### prependHTTP
 
 Prepends "http\://" to a url, if it looks like something that is meant to be a TLD.

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -23,3 +23,4 @@ export { safeDecodeURIComponent } from './safe-decode-uri-component';
 export { filterURLForDisplay } from './filter-url-for-display';
 export { cleanForSlug } from './clean-for-slug';
 export { getFilename } from './get-filename';
+export { normalizePath } from './normalize-path';

--- a/packages/url/src/normalize-path.js
+++ b/packages/url/src/normalize-path.js
@@ -1,0 +1,34 @@
+/**
+ * Given a path, returns a normalized path where equal query parameter values
+ * will be treated as identical, regardless of order they appear in the original
+ * text.
+ *
+ * @param {string} path Original path.
+ *
+ * @return {string} Normalized path.
+ */
+export function normalizePath( path ) {
+	const splitted = path.split( '?' );
+	const query = splitted[ 1 ];
+	const base = splitted[ 0 ];
+	if ( ! query ) {
+		return base;
+	}
+
+	// 'b=1&c=2&a=5'
+	return (
+		base +
+		'?' +
+		query
+			// [ 'b=1', 'c=2', 'a=5' ]
+			.split( '&' )
+			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
+			.map( ( entry ) => entry.split( '=' ) )
+			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
+			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
+			// [ 'a=5', 'b=1', 'c=2' ]
+			.map( ( pair ) => pair.join( '=' ) )
+			// 'a=5&b=1&c=2'
+			.join( '&' )
+	);
+}

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -30,6 +30,7 @@ import {
 	cleanForSlug,
 	getQueryArgs,
 	getFilename,
+	normalizePath,
 } from '../';
 import wptData from './fixtures/wpt-data';
 
@@ -983,5 +984,28 @@ describe( 'cleanForSlug', () => {
 
 	it( 'should return an empty string for falsy argument', () => {
 		expect( cleanForSlug( null ) ).toBe( '' );
+	} );
+} );
+
+describe( 'normalizePath', () => {
+	it( 'returns same value if no query parameters', () => {
+		const path = '/foo/bar';
+
+		expect( normalizePath( path ) ).toBe( path );
+	} );
+
+	it( 'returns a stable path', () => {
+		const abc = normalizePath( '/foo/bar?a=5&b=1&c=2' );
+		const bca = normalizePath( '/foo/bar?b=1&c=2&a=5' );
+		const bac = normalizePath( '/foo/bar?b=1&a=5&c=2' );
+		const acb = normalizePath( '/foo/bar?a=5&c=2&b=1' );
+		const cba = normalizePath( '/foo/bar?c=2&b=1&a=5' );
+		const cab = normalizePath( '/foo/bar?c=2&a=5&b=1' );
+
+		expect( abc ).toBe( bca );
+		expect( bca ).toBe( bac );
+		expect( bac ).toBe( acb );
+		expect( acb ).toBe( cba );
+		expect( cba ).toBe( cab );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
We have some duplicate code in both `wordpress/api-fetch` and `wordpress/edit-navigation` packages.
Both of these packages have the `getStablePath` function defined.
This PR aims to move `getStablePath` into the `wordpress/url` package and rename it to `normalizePath`. Thus, it can be used by both `wordpress/api-fetch` and `wordpress/edit-navigation` packages.
Fixes https://github.com/WordPress/gutenberg/issues/35799.

## How has this been tested?
This PR aims to refactor the `getStablePath` function.  So, to test this PR, it's enough to verify that there are no `normalizePath`/`getStablePath` related errors in the console when you open Navigation Editor.
## Screenshots <!-- if applicable -->
No screenshots are needed.

## Types of changes
New feature (refactoring)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
