### PR TITLE
Remove bulk actions for templates

### DIFF
--- a/lib/full-site-editing/templates-utils.php
+++ b/lib/full-site-editing/templates-utils.php
@@ -19,6 +19,7 @@ function gutenberg_templates_lists_custom_columns( array $columns ) {
 	if ( isset( $columns['date'] ) ) {
 		unset( $columns['date'] );
 	}
+	unset( $columns['cb'] );
 	return $columns;
 }
 
@@ -111,3 +112,13 @@ function gutenberg_filter_templates_edit_views( $views ) {
 
 	return $views;
 }
+
+/**
+ * Removes the bulk actions from the templates list view.
+ *
+ * @param array $actions The bulk actions to filter.
+ */
+function gutenberg_filter_templates_bulk_actions( $actions ) {
+	return array();
+}
+add_filter( 'bulk_actions-edit-wp_template', 'gutenberg_filter_templates_bulk_actions' );


### PR DESCRIPTION
Part of #35994.

If we go ahead and list all templates in Appearance > Templates, the bulk actions may get confusing since some templates can be deleted, others can be reset, and so on.

Since most sites won't have large amounts of templates, and bulk editing templates is an infrequent exercise anyway, it may be simplest to disable bulk editing altogether for now.

This PR removes the bulk actions dropdown, and the checkboxes in the templates table.

### Before
<img width="519" alt="Screenshot 2021-10-27 at 12 50 08" src="https://user-images.githubusercontent.com/846565/139060096-c688d017-d0c8-4677-a32e-5d29f5c25538.png">


### After
<img width="549" alt="Screenshot 2021-10-27 at 12 49 57" src="https://user-images.githubusercontent.com/846565/139060108-a9d67c5c-de8f-4134-90ce-6e8a40a0f2fb.png">
