### PR TITLE
Classic Block: Fix select all blocks side effect

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -89,6 +89,8 @@ export default function ClassicEdit( {
 				);
 				const scrollPosition = scrollContainer.scrollTop;
 
+				// Only update attributes if we aren't multi-selecting blocks.
+				// Updating during multi-selection can overwrite attributes of other blocks.
 				if ( ! getMultiSelectedBlockClientIds()?.length ) {
 					setAttributes( {
 						content: editor.getContent(),

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -6,7 +6,12 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { ToolbarGroup } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -41,6 +46,7 @@ export default function ClassicEdit( {
 	setAttributes,
 	onReplace,
 } ) {
+	const { getMultiSelectedBlockClientIds } = useSelect( blockEditorStore );
 	const didMount = useRef( false );
 
 	useEffect( () => {
@@ -83,9 +89,11 @@ export default function ClassicEdit( {
 				);
 				const scrollPosition = scrollContainer.scrollTop;
 
-				setAttributes( {
-					content: editor.getContent(),
-				} );
+				if ( ! getMultiSelectedBlockClientIds()?.length ) {
+					setAttributes( {
+						content: editor.getContent(),
+					} );
+				}
 
 				editor.once( 'focus', () => {
 					if ( bookmark ) {


### PR DESCRIPTION
## Description
Fixes the issue when selecting all blocks from Classic block caused overwriting contents of paragraph blocks.

Fixes #35308.

## Why?
1. Classic/Freeform has a [side-effect](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/freeform/edit.js#L76-L88) that updates the `content` attribute on TinyMCE editor blur.
2. After #22470, the `setAttribute` prop will use `clientIds` of selected blocks multiselection.
3. This caused updating the `content` attribute of all selected blocks.

## How has this been tested?
1. Create a post.
2. Add Classic Block and type some content.
3. Add a few Paragraph blocks.
4. Select Classic Block and then select all blocks (CTRL/CMD + A).
5. "Select all" action shouldn't update the content of paragraph blocks.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
