### PR TITLE
Revert "Post Content: Fix float clearing on entry content (#35958)"

### DIFF
--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,4 +1,0 @@
-// Required to ensure that subsequent blocks clear floats inside entry content.
-.wp-block-post-content {
-	overflow: auto;
-}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -31,7 +31,6 @@
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";
-@import "./post-content/style.scss";
 @import "./post-template/style.scss";
 @import "./query-pagination/style.scss";
 @import "./quote/style.scss";


### PR DESCRIPTION
This reverts commit b33e3942daaaaff335fabcb1177607140cc5c284.

[As noted by](https://github.com/WordPress/gutenberg/pull/35958#issuecomment-952864511) @jasmussen, it results in some occasional issues: 

![overflow](https://user-images.githubusercontent.com/1204802/139063319-87e33290-37f6-4822-b90b-597085009826.gif)

I'll open up a fresh issue to readdress the problem from #35958. I don't think it should be built into the theme, since it effects all themes. 