### PR TITLE
Let `wp-scripts packages-update` install packages for a specific version of WordPress.

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -301,7 +301,17 @@ _Example:_
 
 #### Advanced information
 
-The command checks which packages whose name starts with `@wordpress/` are used in the project by reading the package.json file, and then executes `npm install @wordpress/package1@latest @wordpress/package2@latest ... --save` to change the package versions to the latest one.
+The command checks which packages whose name starts with `@wordpress/` are used in the project by reading the `package.json` file, and then executes `npm install @wordpress/package1@latest @wordpress/package2@latest ... --save` to change the package versions to the latest one.
+
+##### `--wpVersion`
+
+You may use this command to update your local dependencies, to the versions delivered by a specific WordPress version. This is especially usefull when you use [`@wordpress/dependency-extraction-webpack-plugin`](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin). You may want to install the dependencies at versions used by the lowest WordPress version your plugin supports, for local testing, etc.
+
+```sh
+wp-scripts packages-update --wpVersion=5.6
+```
+
+Please note, this command updates all `@wordpress/*` packages that intersects your `package.json` and given WordPress version's. It will **not** check your `dependency-extraction-webpack-plugin` setup, to update only extracted ones.
 
 ### `start`
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -66,6 +66,7 @@
 		"merge-deep": "^3.0.3",
 		"mini-css-extract-plugin": "^2.1.0",
 		"minimist": "^1.2.0",
+		"node-fetch": "^3.0.0",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss": "^8.2.15",
 		"postcss-loader": "^6.1.1",

--- a/packages/scripts/scripts/packages-update.js
+++ b/packages/scripts/scripts/packages-update.js
@@ -4,11 +4,24 @@
  */
 const fs = require( 'fs' );
 const spawn = require( 'cross-spawn' );
+// CJS version of module-only: import fetch from 'node-fetch'`;
+const fetch = ( ...args ) =>
+	import( 'node-fetch' ).then( ( { default: nodeFetch } ) =>
+		nodeFetch( ...args )
+	);
+
+/**
+ * Internal dependencies
+ */
+const { getArgFromCLI } = require( '../utils' );
 
 /**
  * Constants
  */
 const WORDPRESS_PACKAGES_PREFIX = '@wordpress/';
+
+const sourceOfWPPackagesVersions = ( wpVersion ) =>
+	`https://raw.githubusercontent.com/WordPress/wordpress-develop/${ wpVersion }/package.json`;
 
 function readJSONFile( fileName ) {
 	const data = fs.readFileSync( fileName, 'utf8' );
@@ -43,11 +56,13 @@ function getPackageVersionDiff( initialPackageJSON, finalPackageJSON ) {
 	return diff.sort( ( a, b ) => a.dependency.localeCompare( b.dependency ) );
 }
 
-function updatePackagesToLatestVersion( packages ) {
-	const packagesWithLatest = packages.map(
-		( packageName ) => `${ packageName }@latest`
-	);
-	return spawn.sync( 'npm', [ 'install', ...packagesWithLatest, '--save' ], {
+/**
+ * Installs the given npm packages.
+ *
+ * @param {Array<string>} packagesWithVersion List of package names and their versions in the `name@semver` format.
+ */
+function updatePackages( packagesWithVersion ) {
+	return spawn.sync( 'npm', [ 'install', ...packagesWithVersion, '--save' ], {
 		stdio: 'inherit',
 	} );
 }
@@ -63,10 +78,39 @@ function outputPackageDiffReport( packageDiff ) {
 	);
 }
 
-function updatePackageJSON() {
+/**
+ * Fetches `dev-` & `dependencies` for a given WordPress version.
+ *
+ * @param {string} wpVersion WordPress version to fetch the data for.
+ * @return {Object<string,string>} Concatenated dependencies and devDependencies.
+ */
+async function fetchRemoteWordPressPackages( wpVersion = 'master' ) {
+	const response = await fetch( sourceOfWPPackagesVersions( wpVersion ) );
+	const { dependencies, devDependencies } = await response.json();
+	return { ...dependencies, ...devDependencies };
+}
+
+async function updatePackageJSON() {
 	const initialPackageJSON = readJSONFile( 'package.json' );
 	const packages = getWordPressPackages( initialPackageJSON );
-	const result = updatePackagesToLatestVersion( packages );
+	const wpVersion = getArgFromCLI( '--wpVersion' );
+	let packagesWithVersion;
+	if ( wpVersion ) {
+		const remoteVersions = await fetchRemoteWordPressPackages( wpVersion );
+		// Get remote versions for intersecting/local packages.
+		const common = Object.entries(
+			remoteVersions
+		).filter( ( [ packageName ] ) => packages.includes( packageName ) );
+		// Stringify name & version in `npm install` format.
+		packagesWithVersion = common.map(
+			( [ packageName, version ] ) => `${ packageName }@${ version }`
+		);
+	} else {
+		packagesWithVersion = packages.map(
+			( packageName ) => `${ packageName }@latest`
+		);
+	}
+	const result = updatePackages( packagesWithVersion );
 	const finalPackageJSON = readJSONFile( 'package.json' );
 	outputPackageDiffReport(
 		getPackageVersionDiff( initialPackageJSON, finalPackageJSON )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This is to mitigate the problems related to DEWP usage mentioned in https://github.com/WordPress/gutenberg/issues/35630.

This allows a plugin developer to install to-be-extracted dependencies at the lowest version of their plugin targets. To be able to run local tests and linters against that version. To give some insight to the developer, on what is the lowest anticipated version of an individual package.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Cloned and installed a plugin, like `git clone https://github.com/woocommerce/google-listings-and-ads.git && npm install`
2. Replaced the `node_modules/@wordpress/scripts` with the content of this branch
3. Executed `npm run packages-update` / `wp-scripts packages-update`, to see it still installs the `latest` by default
4. Executed `npm run packages-update -- --wpVersion=5.6` / `wp-scripts packages-update--wpVersion=5.6`, to see it installs the versions from https://github.com/WordPress/wordpress-develop/blob/5.6/package.json#L79-L154

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->

## Additional notes:

- For a developer using Dependency Extraction Webpack Plugin, it may be useful to update only those packages that are actually externalized, but to do so we need a list of those first - https://github.com/WordPress/gutenberg/pull/35106
