### PR TITLE
Try ensuring the item after post content clears floats

### DIFF
--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,4 +1,4 @@
 // Required to ensure that subsequent blocks clear floats inside entry content.
-.wp-block-post-content {
-	overflow: auto;
+.wp-block-post-content + * {
+	clear: both;
 }


### PR DESCRIPTION
Alternate for #35958, since using `overflow` there caused issues (revert in https://github.com/WordPress/gutenberg/pull/36004). This solves the same issue, but by ensuring that the item after the post content block clears any pre-existing floats. 

## To test: 

1. Try a theme that does _not_ use a spacer directly below the entry content. (Spacer blocks come with `clear:both;`, and don't have this issue. Twenty Twenty Two's page templates work for testing.)
2. Add a single floated element to a post/page, publish.
3. On the front-end, note that the block after post content is no longer pulled up next to the floated element. 

## Screenshots:

Before|After
---|---
<img width="910" alt="Screen Shot 2021-10-26 at 8 54 45 AM" src="https://user-images.githubusercontent.com/1202812/138883081-d6d3c221-2ec7-4b4d-85ab-dfb37e56478d.png">|<img width="910" alt="Screen Shot 2021-10-26 at 8 54 32 AM" src="https://user-images.githubusercontent.com/1202812/138883089-c4438f84-6de5-4f32-8b8c-358bcee5591b.png">