### PR TITLE
[RNMobile] Enable Support for 'arm64-v8a' in Android's Gradle Configuration

### DIFF
--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk { 
-            abiFilters "armeabi", "armeabi-v7a", "x86", "mips" 
+            abiFilters "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "mips" 
             
         } 
     }


### PR DESCRIPTION
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4170

## Description

At the moment, anyone running on an M1 Mac who wishes to run Gutenberg's demo app for Android would need to manually add support for `arm64-v8a`.

With this PR, support is enabled by default, by adding `arm64-v8a` to `abiFilters` in the project's Gradle configuration.

## How has this been tested?

The demo app still runs as expected on a Mac with an 8-Core Intel Core i9 processor, confirming there are no unexpected regressions for 'non-M1' machines.

This will also need to be tested by someone with a machine that has the M1 chip, to confirm that the demo app runs smoothly for them with no necessary changes to the Gradle configuration.

## Types of changes

Non-breaking change to code, to enable support, involving [the addition of `arm64-v8a`](https://github.com/WordPress/gutenberg/pull/36007/files#diff-a13706be11b93908569684c9aed9cf0dbc05d11e254ea5dc01766344d203b1f2R126) to `abiFilters` in `packages/react-native-editor/android/app/build.gradle`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
