### PR TITLE
Use Heading component on NavigationMenu and NavigationGroup components

### DIFF
--- a/packages/components/src/navigation/group/index.js
+++ b/packages/components/src/navigation/group/index.js
@@ -41,10 +41,9 @@ export default function NavigationGroup( { children, className, title } ) {
 			<li className={ classes }>
 				{ title && (
 					<GroupTitleUI
-						as="h3"
 						className="components-navigation__group-title"
 						id={ groupTitleId }
-						variant="caption"
+						level={ 3 }
 					>
 						{ title }
 					</GroupTitleUI>

--- a/packages/components/src/navigation/menu/menu-title.js
+++ b/packages/components/src/navigation/menu/menu-title.js
@@ -52,6 +52,7 @@ export default function NavigationMenuTitle( {
 		<MenuTitleUI className="components-navigation__menu-title">
 			{ ! isSearching && (
 				<MenuTitleHeadingUI
+					as="h2"
 					className="components-navigation__menu-title-heading"
 					level={ 3 }
 				>

--- a/packages/components/src/navigation/menu/menu-title.js
+++ b/packages/components/src/navigation/menu/menu-title.js
@@ -52,9 +52,8 @@ export default function NavigationMenuTitle( {
 		<MenuTitleUI className="components-navigation__menu-title">
 			{ ! isSearching && (
 				<MenuTitleHeadingUI
-					as="h2"
 					className="components-navigation__menu-title-heading"
-					variant="title.small"
+					level={ 3 }
 				>
 					<span id={ menuTitleId }>{ title }</span>
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -14,6 +14,7 @@ import { isRTL } from '@wordpress/i18n';
 import { BASE, G2, UI } from '../../utils/colors-values';
 import Button from '../../button';
 import { Text } from '../../text';
+import { Heading } from '../../heading';
 import { reduceMotion, rtl } from '../../utils';
 import { space } from '../../ui/utils/space';
 
@@ -67,7 +68,7 @@ export const MenuTitleUI = styled.div`
 	width: 100%;
 `;
 
-export const MenuTitleHeadingUI = styled( Text )`
+export const MenuTitleHeadingUI = styled( Heading )`
 	align-items: center;
 	color: inherit;
 	display: flex;
@@ -145,14 +146,13 @@ export const MenuTitleSearchUI = styled.div`
 	}
 `;
 
-export const GroupTitleUI = styled( Text )`
+export const GroupTitleUI = styled( Heading )`
 	color: inherit;
 	margin-top: ${ space( 2 ) };
 	padding: ${ () =>
 		isRTL()
 			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } 0`
 			: `${ space( 1 ) } 0 ${ space( 1 ) } ${ space( 4 ) }` };
-	text-transform: uppercase;
 `;
 
 export const ItemBaseUI = styled.li`


### PR DESCRIPTION
## Description

~I'm exposing the `text` mixin to the web styles, which adds several variations that were scoped to the mobile version. Now, `NavigationGroup` title is using it, just like mobile does.~

~It's also now using the correct variation, `title.small` (as specified on #34959), on both the main menu and submenus.~

We're now using the `Heading` component with the correct font height and line height.

~Should I use the new `title.small` variation on the "Search results" title as well (3rd screenshot) or should I use the old variation there? I opted for `title.small` to preserve consistency, but it looks a bit too big for my taste. Feedback appreciated!~

We should.

## How has this been tested?

Running Gutenberg on the web, you can check that, on the sidebar, the headers of both the menu and submenus are stylized in the same way: 20px of font size, 28px of line-height.

## Screenshots <!-- if applicable -->

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/26530524/139130896-010faf16-e4e7-494c-97cb-3cb4483a3114.png) | ![image](https://user-images.githubusercontent.com/26530524/139130612-d29c5c9b-9f18-4a47-9f81-1178f9f551ca.png) |
| ![image](https://user-images.githubusercontent.com/26530524/139131007-d46168ca-3613-4aeb-9e44-e2024c8a90f8.png) | ![image](https://user-images.githubusercontent.com/26530524/139130650-a8303270-00b9-47b3-b04e-f7286587c3a2.png) |
| ![image](https://user-images.githubusercontent.com/26530524/139131067-559d78ac-727f-455f-90dd-7af36efaf3d4.png) | ![image](https://user-images.githubusercontent.com/26530524/139130700-a031c191-2a00-489a-b916-744d0820536b.png) |

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
