### PR TITLE
Full Site Editing: Use SearchControl component inside nav menu

### DIFF
--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -7,15 +7,12 @@ import { filter } from 'lodash';
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
-import { Icon, closeSmall, search as searchIcon } from '@wordpress/icons';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import Button from '../../button';
-import { VisuallyHidden } from '../../visually-hidden';
 import withSpokenMessages from '../../higher-order/with-spoken-messages';
 import { useNavigationMenuContext } from './context';
 import { useNavigationContext } from '../context';
@@ -73,40 +70,26 @@ function MenuTitleSearch( {
 		}
 	}
 
-	const menuTitleId = `components-navigation__menu-title-${ menu }`;
 	const inputId = `components-navigation__menu-title-search-${ menu }`;
-	/* translators: placeholder for menu search box. %s: menu title */
-	const placeholder = sprintf( __( 'Search in %s' ), title );
+	const placeholder = sprintf(
+		/* translators: placeholder for menu search box. %s: menu title */
+		__( 'Search %s' ),
+		title?.toLowerCase()
+	).trim();
 
 	return (
-		<MenuTitleSearchUI className="components-navigation__menu-title-search">
-			<Icon icon={ searchIcon } />
-
-			<VisuallyHidden as="label" htmlFor={ inputId } id={ menuTitleId }>
-				{ placeholder }
-			</VisuallyHidden>
-
-			<input
+		<div className="components-navigation__menu-title-search">
+			<MenuTitleSearchUI
 				autoComplete="off"
-				className="components-text-control__input"
+				className="components-navigation__menu-search-input"
 				id={ inputId }
-				onChange={ ( event ) => onSearch( event.target.value ) }
+				onChange={ ( value ) => onSearch( value ) }
 				onKeyDown={ onKeyDown }
 				placeholder={ placeholder }
-				ref={ inputRef }
 				type="search"
 				value={ search }
 			/>
-
-			<Button
-				isSmall
-				variant="tertiary"
-				label={ __( 'Close search' ) }
-				onClick={ onClose }
-			>
-				<Icon icon={ closeSmall } />
-			</Button>
-		</MenuTitleSearchUI>
+		</div>
 	);
 }
 

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -86,6 +86,7 @@ function MenuTitleSearch( {
 				onChange={ ( value ) => onSearch( value ) }
 				onKeyDown={ onKeyDown }
 				placeholder={ placeholder }
+				ref={ inputRef }
 				type="search"
 				value={ search }
 			/>

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -86,6 +86,7 @@ function MenuTitleSearch( {
 				onChange={ ( value ) => onSearch( value ) }
 				onKeyDown={ onKeyDown }
 				placeholder={ placeholder }
+				onClose={ onClose }
 				ref={ inputRef }
 				type="search"
 				value={ search }

--- a/packages/components/src/navigation/menu/menu-title.js
+++ b/packages/components/src/navigation/menu/menu-title.js
@@ -12,8 +12,8 @@ import { getAnimateClassName } from '../../animate';
 import Button from '../../button';
 import MenuTitleSearch from './menu-title-search';
 import {
+	GroupTitleUI,
 	MenuTitleActionsUI,
-	MenuTitleHeadingUI,
 	MenuTitleUI,
 } from '../styles/navigation-styles';
 import { useNavigationMenuContext } from './context';
@@ -51,7 +51,7 @@ export default function NavigationMenuTitle( {
 	return (
 		<MenuTitleUI className="components-navigation__menu-title">
 			{ ! isSearching && (
-				<MenuTitleHeadingUI
+				<GroupTitleUI
 					as="h2"
 					className="components-navigation__menu-title-heading"
 					level={ 3 }
@@ -75,7 +75,7 @@ export default function NavigationMenuTitle( {
 							) }
 						</MenuTitleActionsUI>
 					) }
-				</MenuTitleHeadingUI>
+				</GroupTitleUI>
 			) }
 
 			{ isSearching && (

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -17,6 +17,7 @@ import { Text } from '../../text';
 import { Heading } from '../../heading';
 import { reduceMotion, rtl } from '../../utils';
 import { space } from '../../ui/utils/space';
+import SearchControl from '../../search-control';
 
 export const NavigationUI = styled.div`
 	width: 100%;
@@ -76,8 +77,8 @@ export const MenuTitleHeadingUI = styled( Heading )`
 	margin-bottom: ${ space( 2 ) };
 	padding: ${ () =>
 		isRTL()
-			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } ${ space( 3 ) }`
-			: `${ space( 1 ) } ${ space( 3 ) } ${ space( 1 ) } ${ space(
+			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } ${ space( 2 ) }`
+			: `${ space( 1 ) } ${ space( 2 ) } ${ space( 1 ) } ${ space(
 					4
 			  ) }` };
 `;
@@ -104,45 +105,28 @@ export const MenuTitleActionsUI = styled.span`
 	}
 `;
 
-export const MenuTitleSearchUI = styled.div`
-	padding: 0;
-	position: relative;
+export const MenuTitleSearchUI = styled( SearchControl )`
+	input[type='search'].components-search-control__input {
+		background: #303030;
+		color: #fff;
 
-	input {
-		height: ${ space( 9 ) }; // 36px, same height as MenuTitle
-		margin-bottom: ${ space( 2 ) };
-		padding-left: ${ space( 8 ) }; // Leave room for the search icon
-		padding-right: ${ space(
-			8
-		) }; // Leave room for the close search button
+		&:focus {
+			background: #303030;
+			color: #fff;
+		}
 
-		&::-webkit-search-decoration,
-		&::-webkit-search-cancel-button,
-		&::-webkit-search-results-button,
-		&::-webkit-search-results-decoration {
-			-webkit-appearance: none;
+		&::placeholder {
+			color: rgba( 255, 255, 255, 0.6 );
 		}
 	}
 
-	> svg {
-		left: ${ space( 1 ) };
-		position: absolute;
-		top: 6px;
+	svg {
+		fill: white;
 	}
 
-	.components-button.is-small {
-		height: 30px;
+	.components-button.has-icon {
 		padding: 0;
-		position: absolute;
-		right: ${ space( 2 ) };
-		top: 3px;
-
-		&:active:not( :disabled ) {
-			background: none;
-		}
-		&:hover:not( :disabled ) {
-			box-shadow: none;
-		}
+		min-width: auto;
 	}
 `;
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -111,7 +111,7 @@ export const MenuTitleSearchUI = styled( SearchControl )`
 		color: #fff;
 
 		&:focus {
-			background: #303030;
+			background: #434343;
 			color: #fff;
 		}
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -107,6 +107,7 @@ export const MenuTitleActionsUI = styled.span`
 
 export const MenuTitleSearchUI = styled( SearchControl )`
 	input[type='search'].components-search-control__input {
+		margin: 0;
 		background: #303030;
 		color: #fff;
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -69,21 +69,6 @@ export const MenuTitleUI = styled.div`
 	width: 100%;
 `;
 
-export const MenuTitleHeadingUI = styled( Heading )`
-	min-height: ${ space( 12 ) };
-	align-items: center;
-	color: inherit;
-	display: flex;
-	justify-content: space-between;
-	margin-bottom: ${ space( 2 ) };
-	padding: ${ () =>
-		isRTL()
-			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } ${ space( 2 ) }`
-			: `${ space( 1 ) } ${ space( 2 ) } ${ space( 1 ) } ${ space(
-					4
-			  ) }` };
-`;
-
 export const MenuTitleActionsUI = styled.span`
 	height: ${ space( 6 ) }; // 24px, same height as the buttons inside
 
@@ -133,12 +118,18 @@ export const MenuTitleSearchUI = styled( SearchControl )`
 `;
 
 export const GroupTitleUI = styled( Heading )`
+	min-height: ${ space( 12 ) };
+	align-items: center;
 	color: inherit;
-	margin-top: ${ space( 2 ) };
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: ${ space( 2 ) };
 	padding: ${ () =>
 		isRTL()
-			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } 0`
-			: `${ space( 1 ) } 0 ${ space( 1 ) } ${ space( 4 ) }` };
+			? `${ space( 1 ) } ${ space( 4 ) } ${ space( 1 ) } ${ space( 2 ) }`
+			: `${ space( 1 ) } ${ space( 2 ) } ${ space( 1 ) } ${ space(
+					4
+			  ) }` };
 `;
 
 export const ItemBaseUI = styled.li`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -70,6 +70,7 @@ export const MenuTitleUI = styled.div`
 `;
 
 export const MenuTitleHeadingUI = styled( Heading )`
+	min-height: ${ space( 12 ) };
 	align-items: center;
 	color: inherit;
 	display: flex;

--- a/packages/components/src/search-control/index.js
+++ b/packages/components/src/search-control/index.js
@@ -9,25 +9,29 @@ import classnames from 'classnames';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, search, closeSmall } from '@wordpress/icons';
-import { useRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { Button } from '../';
 import BaseControl from '../base-control';
+import { useCombinedRef } from '../utils';
 
-function SearchControl( {
-	className,
-	onChange,
-	value,
-	label,
-	placeholder = __( 'Search' ),
-	hideLabelFromVision = true,
-	help,
-} ) {
+function SearchControl(
+	{
+		className,
+		onChange,
+		value,
+		label,
+		placeholder = __( 'Search' ),
+		hideLabelFromVision = true,
+		help,
+	},
+	ref
+) {
 	const instanceId = useInstanceId( SearchControl );
-	const searchInput = useRef();
+	const searchInput = useCombinedRef( ref );
 	const id = `components-search-control-${ instanceId }`;
 
 	return (
@@ -67,4 +71,4 @@ function SearchControl( {
 	);
 }
 
-export default SearchControl;
+export default forwardRef( SearchControl );

--- a/packages/components/src/search-control/index.js
+++ b/packages/components/src/search-control/index.js
@@ -22,17 +22,46 @@ function SearchControl(
 	{
 		className,
 		onChange,
+		onKeyDown,
 		value,
 		label,
 		placeholder = __( 'Search' ),
 		hideLabelFromVision = true,
 		help,
+		onClose,
 	},
 	ref
 ) {
 	const instanceId = useInstanceId( SearchControl );
 	const searchInput = useCombinedRef( ref );
 	const id = `components-search-control-${ instanceId }`;
+
+	const renderRightButton = () => {
+		if ( onClose ) {
+			return (
+				<Button
+					icon={ closeSmall }
+					label={ __( 'Close search' ) }
+					onClick={ onClose }
+				/>
+			);
+		}
+
+		if ( !! value ) {
+			return (
+				<Button
+					icon={ closeSmall }
+					label={ __( 'Reset search' ) }
+					onClick={ () => {
+						onChange( '' );
+						searchInput.current.focus();
+					} }
+				/>
+			);
+		}
+
+		return <Icon icon={ search } />;
+	};
 
 	return (
 		<BaseControl
@@ -50,21 +79,12 @@ function SearchControl(
 					type="search"
 					placeholder={ placeholder }
 					onChange={ ( event ) => onChange( event.target.value ) }
+					onKeyDown={ onKeyDown }
 					autoComplete="off"
 					value={ value || '' }
 				/>
 				<div className="components-search-control__icon">
-					{ !! value && (
-						<Button
-							icon={ closeSmall }
-							label={ __( 'Reset search' ) }
-							onClick={ () => {
-								onChange( '' );
-								searchInput.current.focus();
-							} }
-						/>
-					) }
-					{ ! value && <Icon icon={ search } /> }
+					{ renderRightButton() }
 				</div>
 			</div>
 		</BaseControl>

--- a/packages/components/src/utils/hooks/index.js
+++ b/packages/components/src/utils/hooks/index.js
@@ -1,5 +1,6 @@
 export { default as useControlledState } from './use-controlled-state';
 export { default as useUpdateEffect } from './use-update-effect';
+export { useCombinedRef } from './use-combined-ref';
 export { useControlledValue } from './use-controlled-value';
 export { useCx } from './use-cx';
 export { useLatestRef } from './use-latest-ref';

--- a/packages/components/src/utils/hooks/use-combined-ref.ts
+++ b/packages/components/src/utils/hooks/use-combined-ref.ts
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { MutableRefObject, RefCallback } from 'react';
+
+type Ref< T > = MutableRefObject< T | null > | RefCallback< T | null >;
+
+export function useCombinedRef< T extends HTMLElement >( ...refs: Ref< T >[] ) {
+	const targetRef = useRef( null );
+
+	useEffect( () => {
+		refs.forEach( ( ref ) => {
+			if ( ! ref ) return;
+
+			if ( typeof ref === 'function' ) {
+				ref( targetRef.current );
+			} else {
+				ref.current = targetRef.current;
+			}
+		} );
+	}, [ refs ] );
+
+	return targetRef;
+}


### PR DESCRIPTION
## Description

Closes #33538.

Now that we should the input below the title, it doesn't make much sense to autofocus it when it's shown -- since it's always shown.

Let me know if we want to keep the existing functionality: only show the search input when clicked on the button right of the section title.

The section name font size is going to be fixed on https://github.com/WordPress/gutenberg/pull/36009.

## How has this been tested?

Running Gutenberg on the web, you can check that, on the sidebar sub-menus, the search input is stylized as proposed in #33538.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/26530524/139142881-7b0f9ec6-2e4c-40cb-9b27-7db39a71cbcb.png)

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
