### PR TITLE
[RNMobile] Refactor Fixed Height Styling for Gallery Block

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -79,6 +79,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"fixedHeight": {
+			"type": "boolean",
+			"default": true
+		},
 		"linkTarget": {
 			"type": "string"
 		},
@@ -96,7 +100,8 @@
 	},
 	"providesContext": {
 		"allowResize": "allowResize",
-		"imageCrop": "imageCrop"
+		"imageCrop": "imageCrop",
+		"fixedHeight": "fixedHeight"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -3,7 +3,7 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop" ],
+	"usesContext": [ "allowResize", "imageCrop", "fixedHeight" ],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -633,7 +633,9 @@ export class ImageEdit extends Component {
 			resizeMode: context?.imageCrop ? 'cover' : 'contain',
 		};
 
-		const imageContainerStyles = [ hasImageContext && styles.fixedHeight ];
+		const imageContainerStyles = [
+			context?.fixedHeight && styles.fixedHeight,
+		];
 
 		const getImageComponent = ( openMediaOptions, getMediaOptions ) => (
 			<Badge label={ __( 'Featured' ) } show={ isFeaturedImage }>


### PR DESCRIPTION
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4176

## Description

A fixed height is currently applied to the image block when _any_ parent block makes use of [block context](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/). This has an unwanted effect on parent blocks that use context but aren't designed to have a fixed height.

To avoid inner blocks from being styled to have a fixed height whenever a parent block uses context, this PR introduces a specific `fixedHeight` context. This will allow parent blocks to explicitly declare when the image block should have a fixed height, as per their requirements.

A core block that this will impact is the Gallery block, which will now provide the `fixedHeight` context to the Image block.

## How has this been tested?

_Prequisite: Enable the flag for the refactored Gallery block. on mobile. At the time of writing, the way to enable the block on the Gutenberg Mobile demo app is to comment out [this section of code](https://github.com/WordPress/gutenberg/blob/5c9e84d66419c75900b8e6c5addc6eb2326e203e/packages/block-library/src/gallery/edit-wrapper.js#L33-L44)._ 

With the refactored Gallery block enabled, we should ensure that the changes introduced with this PR don't have any adverse effects:

* Navigate to the editor within either the Android or iOS app and add the Gallery block.
* Add a selection of images to the block. Verify that the images appear, which will in turn verify that the new `fixedHeight` context constant is working and hasn't caused any regressions (no images would be visible if the context wasn't working).

In addition, we should double-check that the change doesn't introduce any unexpected issues to the Image block:

* Add an Image block and ensure the image displays at the correct size. Play around with the block's various settings, including the round style, and ensure there are no regressions.

## Screenshots

From the screenshots below, you can see the difference in the Gallery block between when the `fixedHeight` context is set to `true` vs. when it's set to `false`. The difference indicates that the context is working as expected, and only setting a fixed height to the image when a parent block explicitly provides the `fixedHeight` context:

| fixedHeight: true  | fixedHeight: false |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/139236395-81a66007-138a-46e9-b690-52b9a310fa6c.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/139236580-6d037701-4b4f-4f91-bc4a-3b4968cddfbc.png" width="100%"> |

## Types of changes

This PR introduces non-breaking code changes, with the following high-level overview:

* The new `fixedHeight` context is now [provided by the Gallery block](https://github.com/WordPress/gutenberg/pull/36013/files#diff-aa7f347bbb8d1aa1c43808397ef62ef1d0b789773b127768c01c913d1a956e19R104) and [consumed by the Image block](https://github.com/WordPress/gutenberg/pull/36013/files#diff-4e637f96eb9e465696d35d73a41e6a694c7718f15fb805b49d49931262dfc53aR6).
* In the image block, instead of setting a fixed height if `hasImageContext` is true, it's now set [if the `fixedHeight` block context is passed down](https://github.com/WordPress/gutenberg/pull/36013/files#diff-7126ae03000a022bcefa0d2a5fb03b6aca56ed4047e3a49d2131babf229cf6c1R636) from a parent block.
* Note, `fixedHeight` is not serialized. That's because its default will always be `true` and it will never be included in the block's HTML output. There is currently a separate discussion open in https://github.com/WordPress/gutenberg/pull/35510 about potential ways to indicate when contexts aren't serialized.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
