### PR TITLE
Fix ColorPalette className

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -77,7 +77,7 @@ export default function ColorPalette( {
 	);
 
 	return (
-		<VStack spacing={ 3 }>
+		<VStack spacing={ 3 } className={ className }>
 			{ ! disableCustomColors && (
 				<Dropdown
 					renderContent={ renderCustomColorPicker }
@@ -96,7 +96,6 @@ export default function ColorPalette( {
 				/>
 			) }
 			<CircularOptionPicker
-				className={ className }
 				options={ colorOptions }
 				actions={
 					!! clearable && (

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -96,6 +96,7 @@ export default function ColorPalette( {
 				/>
 			) }
 			<CircularOptionPicker
+				className="components-color-palette__swatches"
 				options={ colorOptions }
 				actions={
 					!! clearable && (

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -96,7 +96,6 @@ export default function ColorPalette( {
 				/>
 			) }
 			<CircularOptionPicker
-				className="components-color-palette__swatches"
 				options={ colorOptions }
 				actions={
 					!! clearable && (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I need to adjust the container style for the usage in the ColorListPicker, but passing a className to style unexpectedly only selected the swatches. This applies the `className` to the container instead of the child.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The className prop isn't used within Gutenberg yet, but it will be once I finish the duotone toolbar cleanup. I will link that PR here when it's available.

<!-- ## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
