### PR TITLE
Add duotone description

### DIFF
--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -24,6 +24,7 @@ function DuotoneControl( {
 			popoverProps={ {
 				className: 'block-editor-duotone-control__popover',
 				headerTitle: __( 'Duotone' ),
+				isAlternate: true,
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				const openOnArrowDown = ( event ) => {

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -46,6 +46,11 @@ function DuotoneControl( {
 			} }
 			renderContent={ () => (
 				<MenuGroup label={ __( 'Duotone' ) }>
+					<div className="block-editor-duotone-control__description">
+						{ __(
+							'Create a two-tone color effect without losing your original image.'
+						) }
+					</div>
 					<DuotonePicker
 						colorPalette={ colorPalette }
 						duotonePalette={ duotonePalette }

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,6 +1,7 @@
 .block-editor-duotone-control__popover {
-	.components-popover__content {
-		min-width: 214px;
+	> .components-popover__content {
+		// Matches 8 swatches in width.
+		width: 334px;
 	}
 
 	.components-circular-option-picker {
@@ -12,11 +13,6 @@
 		width: 100%;
 		box-sizing: border-box;
 	}
-}
-
-.block-editor-duotone-control__popover > .components-popover__content {
-	// Matches 8 swatches in width.
-	width: 334px;
 }
 
 .block-editor-duotone-control__description {

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -20,6 +20,10 @@
 	width: 334px;
 }
 
+.block-editor-duotone-control__description {
+	margin: $grid-unit-20 0;
+}
+
 // Better align the popover under the swatch.
 // @todo: when the positioning for popovers gets refactored, this can presumably be removed.
 .block-editor-duotone-control__popover:not([data-y-axis="middle"][data-x-axis="right"]) > .components-popover__content {

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,9 +1,17 @@
-.block-editor-duotone-control__popover {
-	> .components-popover__content {
-		padding: $grid-unit-10;
+// Must equal $color-palette-circle-size and $color-palette-circle-spacing from:
+// @wordpress/components/src/circular-option-picker/style.scss
+$swatch-size: 28px;
+$swatch-gap: 12px;
 
-		// Matches 8 swatches in width.
-		width: 326px;
+$popover-width: $sidebar-width;
+$popover-padding: $grid-unit-20;
+
+$swatch-columns: math.floor( math.div( $popover-width + $swatch-gap - 2 * $popover-padding, $swatch-size + $swatch-gap ) );
+
+.block-editor-duotone-control__popover {
+	> .components-popover__content > div {
+		padding: $popover-padding;
+		width: $popover-width;
 	}
 
 	.components-menu-group__label {
@@ -12,6 +20,13 @@
 
 	.components-custom-gradient-picker__gradient-bar {
 		margin: $grid-unit-20 0 $grid-unit-15;
+	}
+
+	.components-circular-option-picker__swatches {
+		display: grid;
+		grid-template-columns: repeat($swatch-columns, $swatch-size);
+		gap: $swatch-gap;
+		justify-content: space-between;
 	}
 }
 

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,5 +1,7 @@
 .block-editor-duotone-control__popover {
 	> .components-popover__content {
+		padding: $grid-unit-10;
+
 		// Matches 8 swatches in width.
 		width: 326px;
 	}
@@ -15,6 +17,7 @@
 
 .block-editor-duotone-control__description {
 	margin: $grid-unit-20 0;
+	font-size: $helptext-font-size;
 }
 
 // Better align the popover under the swatch.

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -6,7 +6,7 @@ $swatch-gap: 12px;
 $popover-width: $sidebar-width;
 $popover-padding: $grid-unit-20;
 
-$swatch-columns: math.floor( math.div( $popover-width + $swatch-gap - 2 * $popover-padding, $swatch-size + $swatch-gap ) );
+$swatch-columns: math.floor(math.div($popover-width + $swatch-gap - 2 * $popover-padding, $swatch-size + $swatch-gap));
 
 .block-editor-duotone-control__popover {
 	> .components-popover__content > div {

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,6 +1,5 @@
 .block-editor-duotone-control__popover {
 	.components-popover__content {
-		border: $border-width solid $gray-900;
 		min-width: 214px;
 	}
 

--- a/packages/block-editor/src/components/duotone-control/style.scss
+++ b/packages/block-editor/src/components/duotone-control/style.scss
@@ -1,17 +1,15 @@
 .block-editor-duotone-control__popover {
 	> .components-popover__content {
 		// Matches 8 swatches in width.
-		width: 334px;
-	}
-
-	.components-circular-option-picker {
-		padding: $grid-unit-15;
+		width: 326px;
 	}
 
 	.components-menu-group__label {
-		padding: $grid-unit-15 $grid-unit-15 0 $grid-unit-15;
-		width: 100%;
-		box-sizing: border-box;
+		padding: 0;
+	}
+
+	.components-custom-gradient-picker__gradient-bar {
+		margin: $grid-unit-20 0 $grid-unit-15;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Depends on #36014

Adds the description to indicate that a duotone filter is a non-desctructive edit #31373

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Apply changes from #36014 if it hasn't been merged yet.

Open the duotone toolbar from the image or cover blocks to see the new description and updated styles.

## Screenshots <!-- if applicable -->

#### Before

![old-duotone-description](https://user-images.githubusercontent.com/5129775/139179844-fdbf81ac-ffb3-4703-9ecb-ce3c2c953856.png)

#### After

Including changes from #36014

![new-duotone-description](https://user-images.githubusercontent.com/5129775/139179846-c9fb11b8-6418-4abd-b95d-d74f160ee102.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
