### PR TITLE
Use firstChild and lastChild when parsing lists from MS Word

### DIFF
--- a/packages/blocks/src/api/raw-handling/ms-list-converter.js
+++ b/packages/blocks/src/api/raw-handling/ms-list-converter.js
@@ -54,7 +54,7 @@ export default function msListConverter( node, doc ) {
 	let receivingNode = listNode;
 
 	// Remove the first span with list info.
-	node.removeChild( node.firstElementChild );
+	node.removeChild( node.firstChild );
 
 	// Add content.
 	while ( node.firstChild ) {

--- a/packages/blocks/src/api/raw-handling/ms-list-converter.js
+++ b/packages/blocks/src/api/raw-handling/ms-list-converter.js
@@ -63,11 +63,11 @@ export default function msListConverter( node, doc ) {
 
 	// Change pointer depending on indentation level.
 	while ( level-- ) {
-		receivingNode = receivingNode.lastElementChild || receivingNode;
+		receivingNode = receivingNode.lastChild || receivingNode;
 
 		// If it's a list, move pointer to the last item.
 		if ( isList( receivingNode ) ) {
-			receivingNode = receivingNode.lastElementChild || receivingNode;
+			receivingNode = receivingNode.lastChild || receivingNode;
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR uses `firstChild` and `lastChild` instead of `firstElementChild` and `lastElementChild` when parsing lists from Microsoft Word. Currently, `firstElementChild` and `lastElementChild` aren't available in the Gutenberg Mobile environment and this leads to a crash when copying from Word.

<!-- Please describe what you have changed or added -->
**Related to:** 
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/4145
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174

In this PR we are only referring to Microsoft Word installed on a native platform (PC, Mac, iOS). The web version of Microsoft Word uses a different underlying HTML structure and is not applicable.

## How has this been tested?
**Prerequisites:**
- Word for PC (read-only mode will not let you copy, must use a licensed version or a trial)
- Word for Mac (read-only mode will not let you copy, must use a licensed version or a trial)
- [List Samples.docx](https://github.com/WordPress/gutenberg/files/7461911/List.Samples.docx)

### Desktop
#### PC
1. Copy the list samples (individually or all together) from the above document in Word for PC.
2. In the Gutenberg editor in a browser (e.g. a WP.com site), paste the lists.
3. Observe that the lists are in a corresponding list block and formatted correctly in Gutenberg.

#### Mac
1. Copy the list samples (individually or all together) from the above document in Word for Mac. ⚠️  
2. In the Gutenberg editor in a browser (e.g. a WP.com site), paste the lists into a Paragraph Block.
3. Observe that the lists are in a corresponding list block and formatted correctly in Gutenberg.

⚠️ There is a [known issue](https://href.li/?https://answers.microsoft.com/en-us/msoffice/forum/all/why-is-word-suddenly-creating-two-olelink/3808b279-6bc6-4db0-9a1e-06925b7f31cf?auth=1) when copying from Word for Mac while a utility that intercepts the Pasteboard is running. Please temporarily disable any pasteboard managers while testing, or the underlying HTML from Word will be broken.

### Mobile

In our testing this affected WPiOS only due to [how Android currently extracts the pasteboard data](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4145#issuecomment-949920745).

**Prerequisites:**
- Word for iOS (a license is not required for read-only mode and it allows the user to copy)
- [List Samples.docx](https://github.com/WordPress/gutenberg/files/7461911/List.Samples.docx)

#### WPiOS
1. Copy the list samples (individually or all together) from the above document in Word for iOS. Saving the document in iCloud offers a quick way to transfer it to the mobile device.
2. Paste the lists into a new Post on WPiOS.
3. Observe that the lists are in a corresponding list block and formatted correctly in Gutenberg.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
