### PR TITLE
Global Styles: generate preset metadata for font-family in the site editor

### DIFF
--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -106,7 +106,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
 		$origins = array( 'core' );
 	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feauter to work, the CSS Custom Properties
+		// For the legacy link color feature to work, the CSS Custom Properties
 		// should be in scope (either the core or the theme ones).
 		$origins = array( 'core', 'theme' );
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -22,7 +22,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree, $types = ar
 		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
 		$origins = array( 'core' );
 	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feauter to work, the CSS Custom Properties
+		// For the legacy link color feature to work, the CSS Custom Properties
 		// should be in scope (either the core or the theme ones).
 		$origins = array( 'core', 'theme' );
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -93,7 +93,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_settings();
 	}
 
-	if ( 'mobile' !== $context ) {
+	if ( 'other' === $context ) {
 		// Make sure the styles array exists.
 		// In some contexts, like the navigation editor, it doesn't.
 		if ( ! isset( $settings['styles'] ) ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -93,7 +93,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$settings['__experimentalGlobalStylesBaseConfig']['settings'] = $theme->get_settings();
 	}
 
-	if ( 'other' === $context ) {
+	if ( 'mobile' !== $context ) {
 		// Make sure the styles array exists.
 		// In some contexts, like the navigation editor, it doesn't.
 		if ( ! isset( $settings['styles'] ) ) {

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -59,7 +59,9 @@ export const PRESET_METADATA = [
 		path: [ 'typography', 'fontFamilies' ],
 		valueKey: 'fontFamily',
 		cssVarInfix: 'font-family',
-		classes: [],
+		classes: [
+			{ classSuffix: 'font-family', propertyName: 'font-family' },
+		],
 	},
 ];
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36015

## Description

This PR updates the `PRESET_METADATA` config for font-family to allow appropriate CSS class generation for global styles and the site editor.

## How has this been tested?
Manually in Site Editor:

1. Before checking out this branch, replicate the issue on trunk via instructions in [#36015](https://github.com/WordPress/gutenberg/issues/36015)
2. Then checkout this PR and reload site editor
3. Select a block with font-family support. The site title block is probably the easiest.
4. Open the "Settings" sidebar via the "cog" icon at the top of the editor
5. Via the Typography panel, toggle on the font-family control
6. Select a new font family and ensure the block updates visually
7. Save and confirm the font selection on the frontend.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1106" alt="Screen Shot 2021-10-28 at 3 07 54 pm" src="https://user-images.githubusercontent.com/60436221/139190826-e5ad22d8-0b5b-494f-8366-3d5d8af44614.png"> | <img width="1109" alt="Screen Shot 2021-10-28 at 3 04 28 pm" src="https://user-images.githubusercontent.com/60436221/139190846-164a1a45-c7f6-4d53-9cc9-66b168c719f8.png"> }

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
