### PR TITLE
Navigation: Create nav menu on pattern insertion or when the block has uncontrolled inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -38,10 +38,12 @@ import { __ } from '@wordpress/i18n';
 import useListViewModal from './use-list-view-modal';
 import useNavigationMenu from '../use-navigation-menu';
 import Placeholder from './placeholder';
+import PlaceholderPreview from './placeholder/placeholder-preview';
 import ResponsiveWrapper from './responsive-wrapper';
 import NavigationInnerBlocks from './inner-blocks';
 import NavigationMenuSelector from './navigation-menu-selector';
 import NavigationMenuNameControl from './navigation-menu-name-control';
+import NavigationMenuPublishButton from './navigation-menu-publish-button';
 import UnsavedInnerBlocks from './unsaved-inner-blocks';
 import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 
@@ -75,8 +77,8 @@ function detectColors( colorsDetectionElement, setColor, setBackground ) {
 function Navigation( {
 	attributes,
 	setAttributes,
-	isSelected,
 	clientId,
+	isSelected,
 	className,
 	backgroundColor,
 	setBackgroundColor,
@@ -108,12 +110,25 @@ function Navigation( {
 		`navigationMenu/${ navigationMenuId }`
 	);
 
-	const innerBlocks = useSelect(
-		( select ) => select( blockEditorStore ).getBlocks( clientId ),
+	const { innerBlocks, isInnerBlockSelected } = useSelect(
+		( select ) => {
+			const { getBlocks, hasSelectedInnerBlock } = select(
+				blockEditorStore
+			);
+			return {
+				innerBlocks: getBlocks( clientId ),
+				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
+			};
+		},
 		[ clientId ]
 	);
 	const hasExistingNavItems = !! innerBlocks.length;
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
+
+	const [
+		hasSavedUnsavedInnerBlocks,
+		setHasSavedUnsavedInnerBlocks,
+	] = useState( false );
 
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
 		! hasExistingNavItems
@@ -127,10 +142,13 @@ function Navigation( {
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
 		canSwitchNavigationMenu,
-		hasResolvedNavigationMenu,
+		hasResolvedNavigationMenus,
+		navigationMenus,
+		navigationMenu,
 	} = useNavigationMenu( navigationMenuId );
 
 	const navRef = useRef();
+	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
 	const { listViewToolbarButton, listViewModal } = useListViewModal(
 		clientId
@@ -203,19 +221,23 @@ function Navigation( {
 
 	// If the block has inner blocks, but no menu id, this was an older
 	// navigation block added before the block used a wp_navigation entity.
+	// Either this block was saved in the content or inserted by a pattern.
 	// Consider this 'unsaved'. Offer an uncontrolled version of inner blocks,
-	// with a prompt to 'save'.
-	const hasUnsavedBlocks =
-		hasExistingNavItems && navigationMenuId === undefined;
+	// that automatically saves the menu.
+	const hasUnsavedBlocks = hasExistingNavItems && ! isEntityAvailable;
 	if ( hasUnsavedBlocks ) {
 		return (
 			<UnsavedInnerBlocks
 				blockProps={ blockProps }
 				blocks={ innerBlocks }
-				isSelected={ isSelected }
-				onSave={ ( post ) =>
-					setAttributes( { navigationMenuId: post.id } )
-				}
+				navigationMenus={ navigationMenus }
+				hasSelection={ isSelected || isInnerBlockSelected }
+				hasSavedUnsavedInnerBlocks={ hasSavedUnsavedInnerBlocks }
+				onSave={ ( post ) => {
+					setHasSavedUnsavedInnerBlocks( true );
+					// Switch to using the wp_navigation entity.
+					setAttributes( { navigationMenuId: post.id } );
+				} }
 			/>
 		);
 	}
@@ -261,8 +283,8 @@ function Navigation( {
 		>
 			<RecursionProvider>
 				<BlockControls>
-					<ToolbarGroup>
-						{ isEntityAvailable && (
+					{ ! isDraftNavigationMenu && isEntityAvailable && (
+						<ToolbarGroup>
 							<ToolbarDropdownMenu
 								label={ __( 'Select Menu' ) }
 								text={ __( 'Select Menu' ) }
@@ -279,8 +301,8 @@ function Navigation( {
 									/>
 								) }
 							</ToolbarDropdownMenu>
-						) }
-					</ToolbarGroup>
+						</ToolbarGroup>
+					) }
 					{ hasItemJustificationControls && (
 						<JustifyToolbar
 							value={ itemsJustification }
@@ -295,6 +317,11 @@ function Navigation( {
 						/>
 					) }
 					<ToolbarGroup>{ listViewToolbarButton }</ToolbarGroup>
+					<ToolbarGroup>
+						{ isDraftNavigationMenu && (
+							<NavigationMenuPublishButton />
+						) }
+					</ToolbarGroup>
 				</BlockControls>
 				{ listViewModal }
 				<InspectorControls>
@@ -420,10 +447,13 @@ function Navigation( {
 								selectBlock( clientId );
 							} }
 							canSwitchNavigationMenu={ canSwitchNavigationMenu }
-							hasResolvedNavigationMenu={
-								hasResolvedNavigationMenu
+							hasResolvedNavigationMenus={
+								hasResolvedNavigationMenus
 							}
 						/>
+					) }
+					{ ! isEntityAvailable && ! isPlaceholderShown && (
+						<PlaceholderPreview isLoading />
 					) }
 					{ ! isPlaceholderShown && (
 						<ResponsiveWrapper

--- a/packages/block-library/src/navigation/edit/navigation-menu-name-modal.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-name-modal.js
@@ -13,10 +13,12 @@ import { __ } from '@wordpress/i18n';
 
 export default function NavigationMenuNameModal( {
 	title,
+	finishButtonText = __( 'Create' ),
 	onFinish,
 	onRequestClose,
+	value = '',
 } ) {
-	const [ name, setName ] = useState( '' );
+	const [ name, setName ] = useState( value );
 
 	return (
 		<Modal
@@ -57,7 +59,7 @@ export default function NavigationMenuNameModal( {
 							disabled={ ! name.length }
 							aria-disabled={ ! name.length }
 						>
-							{ __( 'Create' ) }
+							{ finishButtonText }
 						</Button>
 					</FlexItem>
 				</Flex>

--- a/packages/block-library/src/navigation/edit/navigation-menu-publish-button.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-publish-button.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton } from '@wordpress/components';
+import {
+	useEntityId,
+	useEntityProp,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NavigationMenuNameModal from './navigation-menu-name-modal';
+
+export default function NavigationMenuPublishButton() {
+	const [ isNameModalVisible, setIsNameModalVisible ] = useState( false );
+	const id = useEntityId( 'postType', 'wp_navigation' );
+	const [ navigationMenuTitle ] = useEntityProp(
+		'postType',
+		'wp_navigation',
+		'title'
+	);
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch(
+		coreStore
+	);
+
+	return (
+		<>
+			<ToolbarButton onClick={ () => setIsNameModalVisible( true ) }>
+				{ __( 'Save as' ) }
+			</ToolbarButton>
+			{ isNameModalVisible && (
+				<NavigationMenuNameModal
+					title={ __( 'Save your new navigation menu' ) }
+					value={ navigationMenuTitle }
+					onRequestClose={ () => setIsNameModalVisible( false ) }
+					finishButtonText={ __( 'Save' ) }
+					onFinish={ ( updatedTitle ) => {
+						editEntityRecord( 'postType', 'wp_navigation', id, {
+							title: updatedTitle,
+							status: 'publish',
+						} );
+						saveEditedEntityRecord(
+							'postType',
+							'wp_navigation',
+							id
+						);
+					} }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -88,7 +88,7 @@ const ExistingMenusDropdown = ( {
 export default function NavigationPlaceholder( {
 	onFinish,
 	canSwitchNavigationMenu,
-	hasResolvedNavigationMenu,
+	hasResolvedNavigationMenus,
 } ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 
@@ -189,10 +189,10 @@ export default function NavigationPlaceholder( {
 
 	return (
 		<>
-			{ ( ! hasResolvedNavigationMenu || isStillLoading ) && (
+			{ ( ! hasResolvedNavigationMenus || isStillLoading ) && (
 				<PlaceholderPreview isLoading />
 			) }
-			{ hasResolvedNavigationMenu && ! isStillLoading && (
+			{ hasResolvedNavigationMenus && ! isStillLoading && (
 				<Placeholder className="wp-block-navigation-placeholder">
 					<PlaceholderPreview />
 					<div className="wp-block-navigation-placeholder__controls">

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -11,13 +11,7 @@ import { serialize } from '@wordpress/blocks';
 import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	useCallback,
-	useContext,
-	useEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,7 +33,6 @@ export default function UnsavedInnerBlocks( {
 	onSave,
 	hasSelection,
 } ) {
-	const [ controlledBlocks ] = useState( blocks );
 	const isDisabled = useContext( Disabled.Context );
 	const savingLock = useRef( false );
 
@@ -49,7 +42,7 @@ export default function UnsavedInnerBlocks( {
 		// Make the inner blocks 'controlled'. This allows the block to always
 		// work with controlled inner blocks, smoothing out the switch to using
 		// an entity.
-		value: controlledBlocks,
+		value: blocks,
 		onChange: NOOP,
 		onInput: NOOP,
 	} );

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -1,38 +1,89 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { useInnerBlocksProps, Warning } from '@wordpress/block-editor';
+import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { serialize } from '@wordpress/blocks';
-import { Button, Disabled } from '@wordpress/components';
+import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import NavigationMenuNameModal from './navigation-menu-name-modal';
+import useNavigationMenu from '../use-navigation-menu';
+
+const NOOP = () => {};
+const DRAFT_MENU_PARAMS = [
+	'postType',
+	'wp_navigation',
+	{ status: 'draft', per_page: -1 },
+];
 
 export default function UnsavedInnerBlocks( {
 	blockProps,
 	blocks,
+	hasSavedUnsavedInnerBlocks,
 	onSave,
-	isSelected,
+	hasSelection,
 } ) {
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		renderAppender: false,
-	} );
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const [ controlledBlocks ] = useState( blocks );
+	const isDisabled = useContext( Disabled.Context );
+	const savingLock = useRef( false );
 
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		renderAppender: hasSelection ? undefined : false,
+
+		// Make the inner blocks 'controlled'. This allows the block to always
+		// work with controlled inner blocks, smoothing out the switch to using
+		// an entity.
+		value: controlledBlocks,
+		onChange: NOOP,
+		onInput: NOOP,
+	} );
 	const { saveEntityRecord } = useDispatch( coreStore );
 
+	const {
+		isSaving,
+		draftNavigationMenus,
+		hasResolvedDraftNavigationMenus,
+	} = useSelect( ( select ) => {
+		const {
+			getEntityRecords,
+			hasFinishedResolution,
+			isSavingEntityRecord,
+		} = select( coreStore );
+
+		return {
+			isSaving: isSavingEntityRecord( 'postType', 'wp_navigation' ),
+			draftNavigationMenus: getEntityRecords( ...DRAFT_MENU_PARAMS ),
+			hasResolvedDraftNavigationMenus: hasFinishedResolution(
+				'getEntityRecords',
+				DRAFT_MENU_PARAMS
+			),
+		};
+	}, [] );
+
+	const { hasResolvedNavigationMenus, navigationMenus } = useNavigationMenu();
+
 	const createNavigationMenu = useCallback(
-		async ( title = __( 'Untitled Navigation Menu' ) ) => {
+		async ( title ) => {
 			const record = {
 				title,
 				content: serialize( blocks ),
-				status: 'publish',
+				status: 'draft',
 			};
 
 			const navigationMenu = await saveEntityRecord(
@@ -46,41 +97,83 @@ export default function UnsavedInnerBlocks( {
 		[ blocks, serialize, saveEntityRecord ]
 	);
 
+	// Automatically save the uncontrolled blocks.
+	useEffect( async () => {
+		// The block will be disabled when used in a BlockPreview.
+		// In this case avoid automatic creation of a wp_navigation post.
+		// Otherwise the user will be spammed with lots of menus!
+		//
+		// Also ensure other navigation menus have loaded so an
+		// accurate name can be created.
+		//
+		// Don't try saving when another save is already
+		// in progress.
+		//
+		// And finally only create the menu when the block is selected,
+		// which is an indication they want to start editing.
+		if (
+			hasSavedUnsavedInnerBlocks ||
+			isDisabled ||
+			isSaving ||
+			savingLock.current ||
+			! hasResolvedDraftNavigationMenus ||
+			! hasResolvedNavigationMenus ||
+			! hasSelection
+		) {
+			return;
+		}
+
+		savingLock.current = true;
+		const title = __( 'Untitled menu' );
+
+		// Determine how many menus start with the untitled title.
+		const matchingMenuTitleCount = [
+			...draftNavigationMenus,
+			...navigationMenus,
+		].reduce(
+			( count, menu ) =>
+				menu?.title?.raw?.startsWith( title ) ? count + 1 : count,
+			0
+		);
+
+		// Append a number to the end of the title if a menu with
+		// the same name exists.
+		const titleWithCount =
+			matchingMenuTitleCount > 0
+				? `${ title } ${ matchingMenuTitleCount + 1 }`
+				: title;
+
+		const menu = await createNavigationMenu( titleWithCount );
+		onSave( menu );
+		savingLock.current = false;
+	}, [
+		isDisabled,
+		isSaving,
+		hasResolvedDraftNavigationMenus,
+		hasResolvedNavigationMenus,
+		draftNavigationMenus,
+		navigationMenus,
+		hasSelection,
+		createNavigationMenu,
+	] );
+
 	return (
 		<>
 			<nav { ...blockProps }>
-				{ isSelected && (
-					<Warning
-						className="wp-block-navigation__unsaved-changes-warning"
-						actions={ [
-							<Button
-								key="save"
-								onClick={ () => setIsModalVisible( true ) }
-								variant="primary"
-							>
-								{ __( 'Save as' ) }
-							</Button>,
-						] }
+				<div className="wp-block-navigation__unsaved-changes">
+					<Disabled
+						className={ classnames(
+							'wp-block-navigation__unsaved-changes-overlay',
+							{
+								'is-saving': hasSelection,
+							}
+						) }
 					>
-						{ __( 'Save this block to continue editing.' ) }
-					</Warning>
-				) }
-				<Disabled>
-					<div { ...innerBlocksProps } />
-				</Disabled>
+						<div { ...innerBlocksProps } />
+					</Disabled>
+					{ hasSelection && <Spinner /> }
+				</div>
 			</nav>
-			{ isModalVisible && (
-				<NavigationMenuNameModal
-					title={ __( 'Name your navigation menu' ) }
-					onRequestClose={ () => {
-						setIsModalVisible( false );
-					} }
-					onFinish={ async ( title ) => {
-						const menu = await createNavigationMenu( title );
-						onSave( menu );
-					} }
-				/>
-			) }
 		</>
 	);
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -542,11 +542,11 @@ body.editor-styles-wrapper
 		// Delay showing the saving spinner until after 2 seconds.
 		// This should ensure it only shows for slow connections.
 		opacity: 0;
-		animation: 0.5s linear 2s 1 normal forwards fadein;
+		animation: 0.5s linear 2s normal forwards fadein;
 	}
 }
 
-@keyframes fadeinhalf {
+@keyframes fadeouthalf {
 	0% {
 		opacity: 1;
 	}
@@ -557,7 +557,7 @@ body.editor-styles-wrapper
 
 .wp-block-navigation__unsaved-changes-overlay.is-saving {
 	opacity: 1;
-	animation: 0.5s linear 2s 1 normal forwards fadeinhalf;
+	animation: 0.5s linear 2s normal forwards fadeouthalf;
 }
 
 .wp-block-navigation-delete-menu-button {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -522,12 +522,42 @@ body.editor-styles-wrapper
 	}
 }
 
-.wp-block-navigation__unsaved-changes-warning {
-	width: 100%;
-
-	.block-editor-warning__actions {
-		margin-top: 0;
+@keyframes fadein {
+	0% {
+		opacity: 0;
 	}
+	100% {
+		opacity: 1;
+	}
+}
+
+.wp-block-navigation__unsaved-changes {
+	position: relative;
+
+	.components-spinner {
+		position: absolute;
+		top: calc(50% - #{$spinner-size} / 2);
+		left: calc(50% - #{$spinner-size} / 2);
+
+		// Delay showing the saving spinner until after 2 seconds.
+		// This should ensure it only shows for slow connections.
+		opacity: 0;
+		animation: 0.5s linear 2s 1 normal forwards fadein;
+	}
+}
+
+@keyframes fadeinhalf {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.5;
+	}
+}
+
+.wp-block-navigation__unsaved-changes-overlay.is-saving {
+	opacity: 1;
+	animation: 0.5s linear 2s 1 normal forwards fadeinhalf;
 }
 
 .wp-block-navigation-delete-menu-button {

--- a/packages/block-library/src/navigation/save.js
+++ b/packages/block-library/src/navigation/save.js
@@ -3,6 +3,12 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save() {
+export default function save( { attributes } ) {
+	if ( attributes.navigationMenuId ) {
+		// Avoid rendering inner blocks when a navigationMenuId is defined.
+		// When this id is defined the inner blocks are loaded from the
+		// `wp_navigation` entity rather than the hard-coded block html.
+		return;
+	}
 	return <InnerBlocks.Content />;
 }

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -28,7 +28,11 @@ export default function useNavigationMenu( navigationMenuId ) {
 				  )
 				: false;
 
-			const navigationMenuMultipleArgs = [ 'postType', 'wp_navigation' ];
+			const navigationMenuMultipleArgs = [
+				'postType',
+				'wp_navigation',
+				{ per_page: -1 },
+			];
 			const navigationMenus = getEntityRecords(
 				...navigationMenuMultipleArgs
 			);
@@ -42,7 +46,7 @@ export default function useNavigationMenu( navigationMenuId ) {
 				isNavigationMenuMissing:
 					hasResolvedNavigationMenu && ! navigationMenu,
 				canSwitchNavigationMenu,
-				hasResolvedNavigationMenu: hasFinishedResolution(
+				hasResolvedNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',
 					navigationMenuMultipleArgs
 				),

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -27,6 +27,13 @@ const TRANSLATED_SITE_PROPERTIES = {
 	page_on_front: __( 'Page on front' ),
 };
 
+const PUBLISH_ON_SAVE_ENTITIES = [
+	{
+		kind: 'postType',
+		name: 'wp_navigation',
+	},
+];
+
 export default function EntitiesSavedStates( { close } ) {
 	const saveButtonRef = useRef();
 	const { dirtyEntityRecords } = useSelect( ( select ) => {
@@ -63,6 +70,7 @@ export default function EntitiesSavedStates( { close } ) {
 		};
 	}, [] );
 	const {
+		editEntityRecord,
 		saveEditedEntityRecord,
 		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
 	} = useDispatch( coreStore );
@@ -130,6 +138,16 @@ export default function EntitiesSavedStates( { close } ) {
 			if ( 'root' === kind && 'site' === name ) {
 				siteItemsToSave.push( property );
 			} else {
+				if (
+					PUBLISH_ON_SAVE_ENTITIES.some(
+						( typeToPublish ) =>
+							typeToPublish.kind === kind &&
+							typeToPublish.name === name
+					)
+				) {
+					editEntityRecord( kind, name, key, { status: 'publish' } );
+				}
+
 				saveEditedEntityRecord( kind, name, key );
 			}
 		} );


### PR DESCRIPTION
## Description
Iteration on #35947

As discussed on that issue, the process of having the user manually create a menu was considered undesireable.

This PR automatically creates an untitled wp_navigation menu whenever:
- A pattern with uncontrolled/unsaved inner blocks is inserted
- A post/template has a navigation block with unsaved block in it already, and the editor is loaded.

An idea discussed on that issue was to automatically use the template part area to name a menu, but was pretty complicated. The template part block often doesn't store the 'area', so the code would have to get all parent template part blocks, get the entities, and then get the nearest area. Template part ids are also a weird combination of 'theme' + 'slug', which seems to be something codified in the block.

## How has this been tested?
1. Insert a pattern with a navigation block
2. The navigation block should automatically create an unsaved entity

## Screenshots <!-- if applicable -->
<img width="678" alt="Screenshot 2021-10-28 at 1 59 23 pm" src="https://user-images.githubusercontent.com/677833/139196274-34309884-34a7-4bb8-9cf6-f105b4b53615.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
