### PR TITLE
Search: Hide label when inserted in Navigation block

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -39,6 +39,7 @@
 			"default": false
 		}
 	},
+	"usesContext": [ "showSubmenuIcon" ],
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"color": {

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -39,7 +39,6 @@
 			"default": false
 		}
 	},
-	"usesContext": [ "showSubmenuIcon" ],
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"color": {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -93,7 +93,7 @@ export default function SearchEdit( {
 			return;
 		}
 
-		if ( isNavigationChild ) {
+		if ( isNavigationChild && showLabel && ! buttonUseIcon ) {
 			// This side-effect should not create an undo level.
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
@@ -104,7 +104,7 @@ export default function SearchEdit( {
 
 			hasChangedDefaults.current = true;
 		}
-	}, [ isNavigationChild ] );
+	}, [ isNavigationChild, showLabel, buttonUseIcon ] );
 
 	// Check for old deprecated numerical border radius. Done as a separate
 	// check so that a borderRadius style won't overwrite the longhand

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -28,7 +28,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { Icon, search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -57,7 +57,7 @@ const DEFAULT_INNER_PADDING = '4px';
 
 export default function SearchEdit( {
 	className,
-	context,
+	clientId,
 	attributes,
 	setAttributes,
 	toggleSelection,
@@ -80,14 +80,24 @@ export default function SearchEdit( {
 	const borderColor = style?.border?.color;
 	const borderProps = useBorderProps( attributes );
 
+	const { isNavigationChild } = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName } = select( blockEditorStore );
+
+			return {
+				isNavigationChild: !! getBlockParentsByBlockName(
+					clientId,
+					'core/navigation'
+				)?.length,
+			};
+		},
+		[ clientId ]
+	);
 	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
 		blockEditorStore
 	);
 
-	// Check if Navigation contains the block.
-	const isNavigationChild = 'showSubmenuIcon' in context;
 	const hasChangedDefaults = useRef( false );
-
 	useEffect( () => {
 		if ( hasChangedDefaults.current ) {
 			return;

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -29,7 +29,7 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { Icon, search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -86,14 +86,25 @@ export default function SearchEdit( {
 
 	// Check if Navigation contains the block.
 	const isNavigationChild = 'showSubmenuIcon' in context;
+	const hasChangedDefaults = useRef( false );
 
 	useEffect( () => {
-		if ( isNavigationChild && showLabel ) {
+		if ( hasChangedDefaults.current ) {
+			return;
+		}
+
+		if ( isNavigationChild ) {
 			// This side-effect should not create an undo level.
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { showLabel: false } );
+			setAttributes( {
+				showLabel: false,
+				buttonUseIcon: true,
+				buttonPosition: 'button-inside',
+			} );
+
+			hasChangedDefaults.current = true;
 		}
-	}, [ isNavigationChild, showLabel ] );
+	}, [ isNavigationChild ] );
 
 	// Check for old deprecated numerical border radius. Done as a separate
 	// check so that a borderRadius style won't overwrite the longhand
@@ -273,18 +284,16 @@ export default function SearchEdit( {
 		<>
 			<BlockControls>
 				<ToolbarGroup>
-					{ ! isNavigationChild && (
-						<ToolbarButton
-							title={ __( 'Toggle search label' ) }
-							icon={ toggleLabel }
-							onClick={ () => {
-								setAttributes( {
-									showLabel: ! showLabel,
-								} );
-							} }
-							className={ showLabel ? 'is-pressed' : undefined }
-						/>
-					) }
+					<ToolbarButton
+						title={ __( 'Toggle search label' ) }
+						icon={ toggleLabel }
+						onClick={ () => {
+							setAttributes( {
+								showLabel: ! showLabel,
+							} );
+						} }
+						className={ showLabel ? 'is-pressed' : undefined }
+					/>
 					<ToolbarDropdownMenu
 						icon={ getButtonPositionIcon() }
 						label={ __( 'Change button position' ) }


### PR DESCRIPTION
## Description
Hide Search label when inserted inside the Navigation block.

Alternative to #35688.
Part of #31127.

## How has this been tested?
* Insert search block as a child of Navigation - Label shouldn't be displayed.
* Insert search block as a child of Group or in root document - Label should be displayed.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/139207477-ab0ff99f-b3d6-477f-b2b0-84bcbfe35ebc.mp4

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
