### PR TITLE
Avoid showing deleted records in editor saving flow

### DIFF
--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -326,8 +326,12 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 			Object.keys( data[ kind ] ).forEach( ( name ) => {
 				const primaryKeys = Object.keys(
 					data[ kind ][ name ].edits
-				).filter( ( primaryKey ) =>
-					hasEditsForEntityRecord( state, kind, name, primaryKey )
+				).filter(
+					( primaryKey ) =>
+						// The entity record must exist (not be deleted),
+						// and it must have edits.
+						getEntityRecord( state, kind, name, primaryKey ) &&
+						hasEditsForEntityRecord( state, kind, name, primaryKey )
 				);
 
 				if ( primaryKeys.length ) {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -418,7 +418,7 @@ describe( 'getEntityRecords', () => {
 } );
 
 describe( '__experimentalGetDirtyEntityRecords', () => {
-	it( 'should return a map of objects with each raw edited entity record and its corresponding edits', () => {
+	it( 'returns a map of objects with each raw edited entity record and its corresponding edits', () => {
 		const state = deepFreeze( {
 			entities: {
 				config: [
@@ -451,6 +451,61 @@ describe( '__experimentalGetDirtyEntityRecords', () => {
 							},
 							edits: {
 								someKey: {
+									someProperty: 'someEditedValue',
+									someRawProperty: 'someEditedRawValue',
+									someTransientEditProperty:
+										'someEditedTransientEditValue',
+								},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect( __experimentalGetDirtyEntityRecords( state ) ).toEqual( [
+			{ kind: 'someKind', name: 'someName', key: 'someKey', title: '' },
+		] );
+	} );
+
+	it( 'excludes entity records that no longer exist', () => {
+		const state = deepFreeze( {
+			entities: {
+				config: [
+					{
+						kind: 'someKind',
+						name: 'someName',
+						transientEdits: { someTransientEditProperty: true },
+					},
+				],
+				data: {
+					someKind: {
+						someName: {
+							queriedData: {
+								items: {
+									default: {
+										someKey: {
+											someProperty: 'somePersistedValue',
+											someRawProperty: {
+												raw: 'somePersistedRawValue',
+											},
+											id: 'someKey',
+										},
+									},
+								},
+								itemIsComplete: {
+									default: {
+										someKey: true,
+									},
+								},
+							},
+							edits: {
+								someKey: {
+									someProperty: 'someEditedValue',
+									someRawProperty: 'someEditedRawValue',
+									someTransientEditProperty:
+										'someEditedTransientEditValue',
+								},
+								deletedKey: {
 									someProperty: 'someEditedValue',
 									someRawProperty: 'someEditedRawValue',
 									someTransientEditProperty:


### PR DESCRIPTION
## Description
Fixes an issue I spotted when working on #35981.

If an entity is deleted in an editor, the entity saving panel tries to show it as an `undefined` thing that needs to be saved:
<img width="278" alt="Screenshot 2021-10-27 at 4 04 27 pm" src="https://user-images.githubusercontent.com/677833/139025520-78395a32-20ef-4836-a4b0-e657449c9327.png">

Since a delete is immediate, that shouldn't be the case.

This filters the deleted records out of the `__experimentalGetDirtyEntityRecords` by checking if the entity exists using `getEntityRecord`.

But there might be a deeper issue. I noticed that the `deleteEntityRecords` doesn't remove `edits` for an entity record. Should it? That's something I'm unsure of.

## How has this been tested?
1. Checkout https://github.com/WordPress/gutenberg/pull/35981, which also has this fix.
1. Add a navigation block
2. Create a new menu and name it.
3. Click delete in the block inspector
4. Confirm deletion
5. Make some other edits outside of the nav block
6. Click save
7. The undefined entity shouldn't be present.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
