### PR TITLE
Block Library: Add alignment option to the Comment Edit Link block

### DIFF
--- a/packages/block-library/src/post-comment-edit/block.json
+++ b/packages/block-library/src/post-comment-edit/block.json
@@ -11,6 +11,9 @@
 		"linkTarget": {
 			"type": "string",
 			"default": "_self"
+		},
+		"textAlign": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/post-comment-edit/edit.js
+++ b/packages/block-library/src/post-comment-edit/edit.js
@@ -16,13 +16,12 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Edit( {
-	attributes: { className, linkTarget, textAlign },
+	attributes: { linkTarget, textAlign },
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			className,
 		} ),
 	} );
 

--- a/packages/block-library/src/post-comment-edit/edit.js
+++ b/packages/block-library/src/post-comment-edit/edit.js
@@ -1,15 +1,41 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function Edit( {
-	attributes: { className, linkTarget },
+	attributes: { className, linkTarget, textAlign },
 	setAttributes,
 } ) {
-	const blockProps = useBlockProps( { className } );
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+			className,
+		} ),
+	} );
+
+	const blockControls = (
+		<BlockControls group="block">
+			<AlignmentControl
+				value={ textAlign }
+				onChange={ ( newAlign ) =>
+					setAttributes( { textAlign: newAlign } )
+				}
+			/>
+		</BlockControls>
+	);
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Link settings' ) }>
@@ -28,6 +54,7 @@ export default function Edit( {
 
 	return (
 		<>
+			{ blockControls }
 			{ inspectorControls }
 			<div { ...blockProps }>
 				<a

--- a/packages/block-library/src/post-comment-edit/index.php
+++ b/packages/block-library/src/post-comment-edit/index.php
@@ -27,9 +27,16 @@ function render_block_core_post_comment_edit( $attributes, $content, $block ) {
 		$link_atts .= sprintf( 'target="%s"', esc_attr( $attributes['linkTarget'] ) );
 	}
 
+	$classes = '';
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+
 	return sprintf(
 		'<div %1$s><a href="%2$s" %3$s>%4$s</a></div>',
-		get_block_wrapper_attributes(),
+		$wrapper_attributes,
 		esc_url( $edit_comment_link ),
 		$link_atts,
 		esc_html__( 'Edit' )


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
With this PR, we add alignment options to the Post Comment Edit Link Block.
Closes https://github.com/WordPress/gutenberg/projects/61#card-71691451


## How has this been tested?
- Created Post Comment Edit block.
- Added Edit Link Block.
- Assigned different options for text-align.
- Check both editor and frontend.
- 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Loom: https://www.loom.com/share/96228fbd1e3a4134bf8b3ccbf8e442fe

<img width="527" alt="Screenshot 2021-10-28 at 12 29 14" src="https://user-images.githubusercontent.com/37012961/139238666-2cf5b744-707f-4589-9301-91c549240ddd.png">

## Types of changes
A small new feature with no breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->