### PR TITLE
Updates publish-to-s3 plugin to 0.7.0 for react-native-bridge & react-native-aztec Android and publishes '-sources.jar'

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -116,17 +116,13 @@ project.afterEvaluate {
 
                 groupId 'org.wordpress-mobile.gutenberg-mobile'
                 artifactId 'react-native-aztec'
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
 
                 addDependenciesToPom(pom)
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId 'org.wordpress-mobile.gutenberg-mobile'
-    mavenPublishArtifactId 'react-native-aztec'
 }
 
 def addDependenciesToPom(pom) {

--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
-        aztecVersion = 'v1.4.0'
+        aztecVersion = 'v1.5.0'
         willPublishReactNativeAztecBinary = properties["willPublishReactNativeAztecBinary"]?.toBoolean() ?: false
     }
 }

--- a/packages/react-native-aztec/android/settings.gradle
+++ b/packages/react-native-aztec/android/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     plugins {
         id "com.android.library" version "4.2.2"
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 plugins {
     id "com.android.library" apply false
     id "org.jetbrains.kotlin.android" apply false
+    id "com.automattic.android.publish-to-s3" apply false
 }
 
 allprojects {

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -14,7 +14,7 @@ def extractPackageVersion(packagejson, packageName, section) {
     def packageSlurper = new JsonSlurper()
     def packageJson = packageSlurper.parse file(packagejson)
     def dep = packageJson.get(section).get(packageName)
-    
+
     // Extract version from filename of tarball URL
     def isTarball = dep.endsWith('.tgz')
     if(isTarball) {
@@ -125,17 +125,13 @@ project.afterEvaluate {
 
                 groupId 'org.wordpress-mobile.gutenberg-mobile'
                 artifactId 'react-native-gutenberg-bridge'
+                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
 
                 addDependenciesToPom(pom)
             }
         }
    }
-}
-
-publishToS3Plugin {
-    mavenPublishGroupId 'org.wordpress-mobile.gutenberg-mobile'
-    mavenPublishArtifactId 'react-native-bridge'
 }
 
 def addDependenciesToPom(pom) {

--- a/packages/react-native-bridge/android/settings.gradle
+++ b/packages/react-native-bridge/android/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     plugins {
         id "com.android.library" version "4.2.2"
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR updates `publish-to-s3` Gradle plugin to `0.7.0` for `react-native-bridge` & `react-native-aztec` Android libraries and uses the newly introduced `androidSourcesJar` task to upload the `-sources.jar` file so it can be used by developers to access the source code from their IDEs. More details can be found in: https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29

As of `0.7.0` version of the `publish-to-s3` plugin, the `publishToS3Plugin` extension is no longer necessary, so as part of this update, the extension is removed from each project.

`aztecVersion` is also updated from `v1.4.0` to `v1.5.0` which brings the exact same changes to `AztecEditor-Android`: https://github.com/wordpress-mobile/AztecEditor-Android/pull/942

~Note that since there is no rush to get this changes in, there is no `gutenberg-mobile` PR for this PR.~

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The version upgrade for the plugin has been tested in https://github.com/wordpress-mobile/WordPress-Android/pull/15492 and applied to several other libraries.

https://github.com/wordpress-mobile/gutenberg-mobile/pull/4177 is used to verify the publishing still works as expected.

https://github.com/wordpress-mobile/WordPress-Android/pull/15506 is used to test the `aztecVersion` change as well as to verify that the source files are available as part of this change.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Gradle plugin version change for `react-native-bridge` & `react-native-aztec` Android projects.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->