### PR TITLE
Scripts: Upgrade Puppeteer to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17569,9 +17569,9 @@
 			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
 		},
 		"@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -19699,7 +19699,7 @@
 				"postcss": "^8.2.15",
 				"postcss-loader": "^6.1.1",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
-				"puppeteer-core": "^10.1.0",
+				"puppeteer-core": "^11.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"sass": "^1.35.2",
@@ -32736,9 +32736,9 @@
 			}
 		},
 		"devtools-protocol": {
-			"version": "0.0.883894",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.883894.tgz",
-			"integrity": "sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==",
+			"version": "0.0.901419",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
+			"integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
 			"dev": true
 		},
 		"dezalgo": {
@@ -47966,6 +47966,12 @@
 				}
 			}
 		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
+		},
 		"mkdirp-promise": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
@@ -52130,23 +52136,23 @@
 			"dev": true
 		},
 		"puppeteer-core": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.1.0.tgz",
-			"integrity": "sha512-x2yDSJI/PRiWhDqAt1jd4rhTotxwjwKzHLIIqD2MlJ+TmzGJfBY9snAGIVXJwkWfKJg+Ef5xupdK0EbHDqBpFw==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-11.0.0.tgz",
+			"integrity": "sha512-hfQ39KNP0qKplQ86iaCNXHH9zpWlV01UFdggt2qffgWeCBF9KMavwP/k/iK/JidPPWfOnKZhDLSHZVSUr73DtA==",
 			"dev": true,
 			"requires": {
-				"debug": "4.3.1",
-				"devtools-protocol": "0.0.883894",
+				"debug": "4.3.2",
+				"devtools-protocol": "0.0.901419",
 				"extract-zip": "2.0.1",
 				"https-proxy-agent": "5.0.0",
-				"node-fetch": "2.6.1",
+				"node-fetch": "2.6.5",
 				"pkg-dir": "4.2.0",
-				"progress": "2.0.1",
+				"progress": "2.0.3",
 				"proxy-from-env": "1.1.0",
 				"rimraf": "3.0.2",
-				"tar-fs": "2.0.0",
-				"unbzip2-stream": "1.3.3",
-				"ws": "7.4.6"
+				"tar-fs": "2.1.1",
+				"unbzip2-stream": "1.4.3",
+				"ws": "8.2.3"
 			},
 			"dependencies": {
 				"agent-base": {
@@ -52159,9 +52165,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -52223,6 +52229,15 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
+				"node-fetch": {
+					"version": "2.6.5",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+					"integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -52262,16 +52277,32 @@
 						"find-up": "^4.0.0"
 					}
 				},
-				"progress": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-					"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
 					"dev": true
 				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				},
 				"ws": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+					"version": "8.2.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
 					"dev": true
 				},
 				"yauzl": {
@@ -58832,15 +58863,15 @@
 			}
 		},
 		"tar-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
-				"mkdirp": "^0.5.1",
+				"mkdirp-classic": "^0.5.2",
 				"pump": "^3.0.0",
-				"tar-stream": "^2.0.0"
+				"tar-stream": "^2.1.4"
 			},
 			"dependencies": {
 				"pump": {
@@ -59731,9 +59762,9 @@
 			}
 		},
 		"unbzip2-stream": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-			"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.2.1",

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The peer `puppeteer` dependency has been replaced with `puppeteer-core` requiring version `>=11` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
+
 ## 5.4.6 (2021-11-07)
+
+### New Features
 
 -   Added `disablePageDialogAccept` - Disable auto-accepting dialogs enabled by `enablePageDialogAccept` [#35828](https://github.com/WordPress/gutenberg/pull/35828).
 

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -39,7 +39,7 @@
 	},
 	"peerDependencies": {
 		"jest": ">=26",
-		"puppeteer": ">=1.19.0"
+		"puppeteer-core": ">=11"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
+++ b/packages/e2e-test-utils/src/auto-accept-page-dialogs.js
@@ -1,4 +1,4 @@
-/** @typedef {import('puppeteer').Dialog} Dialog */
+/** @typedef {import('puppeteer-core').Dialog} Dialog */
 
 /**
  * Callback which automatically accepts dialog.

--- a/packages/e2e-test-utils/src/find-sidebar-panel-toggle-button-with-title.js
+++ b/packages/e2e-test-utils/src/find-sidebar-panel-toggle-button-with-title.js
@@ -3,7 +3,7 @@
  */
 import { first } from 'lodash';
 
-/** @typedef {import('puppeteer').ElementHandle} ElementHandle */
+/** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
 
 /**
  * Finds a sidebar panel with the provided title.

--- a/packages/e2e-test-utils/src/find-sidebar-panel-with-title.js
+++ b/packages/e2e-test-utils/src/find-sidebar-panel-with-title.js
@@ -1,4 +1,4 @@
-/** @typedef {import('puppeteer').ElementHandle} ElementHandle */
+/** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
 
 /**
  * Finds the button responsible for toggling the sidebar panel with the provided title.

--- a/packages/e2e-test-utils/src/preview.js
+++ b/packages/e2e-test-utils/src/preview.js
@@ -3,7 +3,7 @@
  */
 import { last } from 'lodash';
 
-/** @typedef {import('puppeteer').Page} Page */
+/** @typedef {import('puppeteer-core').Page} Page */
 
 /**
  * Opens the preview page of an edited post.

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The peer `puppeteer` dependency has been replaced with `puppeteer-core` requiring version `>=11` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
+
 ## 2.5.0 (2021-09-09)
 
 ### New Features

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -38,7 +38,7 @@
 	"peerDependencies": {
 		"jest": ">=26",
 		"jest-snapshot": ">=26",
-		"puppeteer": ">=1.19.0"
+		"puppeteer-core": ">=11"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/e2e-tests/specs/editor/various/adding-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-patterns.test.js
@@ -7,7 +7,7 @@ import {
 	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 
-/** @typedef {import('puppeteer').ElementHandle} ElementHandle */
+/** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
 
 describe( 'adding patterns', () => {
 	beforeEach( async () => {

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -14,7 +14,7 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
-/** @typedef {import('puppeteer').ElementHandle} ElementHandle */
+/** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
 
 /**
  * Waits for all patterns in the inserter to have a height, which should

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -14,7 +14,7 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
-/** @typedef {import('puppeteer').Page} Page */
+/** @typedef {import('puppeteer-core').Page} Page */
 
 /**
  * Given the Page instance for the editor, opens preview drodpdown, and

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The peer `puppeteer` dependency has been updated from requiring `>=1.19` to requiring `>=11` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
+
 ## 3.0.0 (2021-01-21)
 
 ### Breaking Changes

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -36,7 +36,12 @@
 	},
 	"peerDependencies": {
 		"jest": ">=26",
-		"puppeteer": ">=1.19.0"
+		"puppeteer": ">=11"
+	},
+	"peerDependenciesMeta": {
+		"puppeteer": {
+			"optional": true
+		}
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/jest-puppeteer-axe/src/index.js
+++ b/packages/jest-puppeteer-axe/src/index.js
@@ -3,7 +3,7 @@
  */
 import AxePuppeteer from '@axe-core/puppeteer';
 
-/** @typedef {import('puppeteer').Page} Page */
+/** @typedef {import('puppeteer-core').Page} Page */
 
 /** @typedef {import('axe-core').RunOptions} RunOptions */
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `puppeteer-core` dependency has been updated from requiring `^10.1.0` to requiring `^11.0.0` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
+
 ### Bug Fixes
 
-- Prevent the `CleanWebpackPlugin` plugin from deleting webpack assets during multi-configuration builds [#35980](https://github.com/WordPress/gutenberg/issues/35980).
+-   Prevent the `CleanWebpackPlugin` plugin from deleting webpack assets during multi-configuration builds [#35980](https://github.com/WordPress/gutenberg/issues/35980).
 
 ## 19.2.0 (2021-11-15)
 

--- a/packages/scripts/config/jest-environment-puppeteer/config.js
+++ b/packages/scripts/config/jest-environment-puppeteer/config.js
@@ -69,11 +69,7 @@ async function readConfig() {
 function getPuppeteer( { browser } ) {
 	switch ( browser.toLowerCase() ) {
 		case 'chromium':
-			try {
-				return require( 'puppeteer' );
-			} catch ( e ) {
-				return require( 'puppeteer-core' );
-			}
+			return require( 'puppeteer-core' );
 		case 'firefox':
 			return require( 'puppeteer-firefox' );
 		default:

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -71,7 +71,7 @@
 		"postcss": "^8.2.15",
 		"postcss-loader": "^6.1.1",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
-		"puppeteer-core": "^10.1.0",
+		"puppeteer-core": "^11.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",
 		"sass": "^1.35.2",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This change is necessary to bring compatibility with npm 7 and 8. It's based on the work in #33892 (https://github.com/WordPress/gutenberg/pull/33892/commits/a78030a4c8f05b43139797360679b6893d3dbbb3). npm 7 and above by default installs all peer dependencies and that causes issues because `@wordpres/scripts` uses `puppeteer-core` instead of `puppeteer`. The solution is to make `puppeteer` an optional dependency for WordPress packages.

As part of the change, this PR also upgrades `puppeteer-core` to the latest version.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run test-e2e` still works locally and on CI.

## Types of changes
Breaking change for some packages and an enhancement for `@wordpress/scripts`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
