### PR TITLE
Fix: Rest global styles controller accessing config that may not exist

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -155,31 +155,27 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		$changes     = new stdClass();
 		$changes->ID = $request['id'];
 
-		$post         = get_post( $request['id'] );
-		$empty_config = array(
-			'settings' => new stdClass(),
-			'styles'   => new stdClass(),
-		);
+		$post            = get_post( $request['id'] );
+		$existing_config = array();
 		if ( $post ) {
 			$existing_config = json_decode( $post->post_content, true );
-			if ( ! isset( $existing_config['isGlobalStylesUserThemeJSON'] ) ||
+			$json_decoding_error = json_last_error();
+			if ( JSON_ERROR_NONE !== $json_decoding_error  || ! isset( $existing_config['isGlobalStylesUserThemeJSON'] ) ||
 				! $existing_config['isGlobalStylesUserThemeJSON'] ) {
-				$existing_config = $empty_config;
+				$existing_config = array();
 			}
-		} else {
-			$existing_config = $empty_config;
 		}
 
 		if ( isset( $request['styles'] ) || isset( $request['settings'] ) ) {
 			$config = array();
 			if ( isset( $request['styles'] ) ) {
 				$config['styles'] = $request['styles'];
-			} else {
+			} else if( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
 			}
 			if ( isset( $request['settings'] ) ) {
 				$config['settings'] = $request['settings'];
-			} else {
+			} else if( isset( $existing_config['settings'] ) ) {
 				$config['settings'] = $existing_config['settings'];
 			}
 			$config['isGlobalStylesUserThemeJSON'] = true;


### PR DESCRIPTION
After a fix on https://github.com/WordPress/gutenberg/pull/35801 the post is now created on the database by "get_user_data_from_custom_post_type" as `{"version": ' . WP_Theme_JSON_Gutenberg::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }`. And I think it is right by default the user has no settings and styles.
Our code was assuming that on the database existing settings and styles were always present by unconditionally doing `$config['settings'] = $existing_config['settings']` when `$existing_config['settings']` may not exist.
In the case where `$existing_config['settings']` did not exist there would occur a PHP warning and on the database, we would then serialize `{ settings: null }`. Settings being null is not something the frontend code that compiles the styles accepts and as a consequence no global styles would be output at all. As a different issue, we need to make sure that if user global styles are not valid theme styles are still output.



## How has this been tested?
Delete the current global styles post if there is any.
Open the site editor and change the global background color.
Verify global styles are still output on the frontend (on trunk they are not).
