### PR TITLE
Fix presets data for themes that do not provide any preset

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -257,19 +257,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Returns the theme's data.
 	 *
-	 * Data from theme.json can be augmented via the
-	 * $theme_support_data variable. This is useful, for example,
-	 * to backfill the gaps in theme.json that a theme has declared
-	 * via add_theme_supports.
-	 *
-	 * Note that if the same data is present in theme.json
-	 * and in $theme_support_data, the theme.json's is not overwritten.
-	 *
-	 * @param array $theme_support_data Theme support data in theme.json format.
+	 * Data from theme.json will be backfilled from existing
+	 * theme supports, if any. Note that if the same data
+	 * is present in theme.json and in theme supports,
+	 * the theme.json takes precendence.
 	 *
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
-	public static function get_theme_data( $theme_support_data = array() ) {
+	public static function get_theme_data() {
 		if ( null === self::$theme ) {
 			$theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = self::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
@@ -288,14 +283,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 		}
 
-		if ( empty( $theme_support_data ) ) {
-			return self::$theme;
-		}
-
 		/*
-		 * We want the presets and settings declared in theme.json
-		 * to override the ones declared via add_theme_support.
-		 */
+		* We want the presets and settings declared in theme.json
+		* to override the ones declared via theme supports.
+		* So we take theme supports, transform it to theme.json shape
+		* and merge the self::$theme upon that.
+		*/
+		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( self::$theme );
 
@@ -410,20 +404,16 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * for the paragraph block, and the theme has done it as well,
 	 * the user preference wins.
 	 *
-	 * @param array  $settings Existing block editor settings.
-	 *                         Empty array by default.
 	 * @param string $origin To what level should we merge data.
 	 *                       Valid values are 'theme' or 'user'.
 	 *                       Default is 'user'.
 	 *
 	 * @return WP_Theme_JSON_Gutenberg
 	 */
-	public static function get_merged_data( $settings = array(), $origin = 'user' ) {
+	public static function get_merged_data( $origin = 'user' ) {
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
-
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
-		$result->merge( self::get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_theme_data() );
 
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -78,7 +78,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'mobile';
 	}
 
-	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $settings );
+	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
 		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -6,33 +6,6 @@
  */
 
 /**
- * Takes a tree adhering to the theme.json schema and generates
- * the corresponding stylesheet.
- *
- * @param WP_Theme_JSON_Gutenberg $tree  Input tree.
- * @param array                   $types Which styles to load. It accepts 'variables', 'styles', 'presets'. By default, it'll load all.
- *
- * @return string Stylesheet.
- */
-function gutenberg_experimental_global_styles_get_stylesheet( $tree, $types = array( 'variables', 'styles', 'presets' ) ) {
-	$origins             = array( 'core', 'theme', 'user' );
-	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	$supports_link_color = get_theme_support( 'experimental-link-color' );
-	if ( ! $supports_theme_json && ! $supports_link_color ) {
-		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-		$origins = array( 'core' );
-	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feature to work, the CSS Custom Properties
-		// should be in scope (either the core or the theme ones).
-		$origins = array( 'core', 'theme' );
-	}
-
-	$stylesheet = $tree->get_stylesheet( $types, $origins );
-
-	return $stylesheet;
-}
-
-/**
  * Fetches the preferences for each origin (core, theme, user)
  * and enqueues the resulting stylesheet.
  */
@@ -78,10 +51,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$context = 'mobile';
 	}
 
-	$consolidated = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$settings['__experimentalStyles'] = $consolidated->get_raw_data()['styles'];
+		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 	}
 
 	if ( 'other' === $context ) {
@@ -112,7 +83,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			),
 		);
 		foreach ( $new_presets as $new_style ) {
-			$style_css = gutenberg_experimental_global_styles_get_stylesheet( $consolidated, array( $new_style['css'] ) );
+			$style_css = gutenberg_get_global_stylesheet( array( $new_style['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_style['css']    = $style_css;
 				$new_global_styles[] = $new_style;
@@ -124,7 +95,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			'__unstableType' => 'theme',
 		);
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$style_css = gutenberg_experimental_global_styles_get_stylesheet( $consolidated, array( $new_block_classes['css'] ) );
+			$style_css = gutenberg_get_global_stylesheet( array( $new_block_classes['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_block_classes['css'] = $style_css;
 				$new_global_styles[]      = $new_block_classes;
@@ -135,7 +106,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = $consolidated->get_settings();
+	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -109,7 +109,6 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		load_textdomain( 'fse', realpath( __DIR__ . '/data/languages/themes/fse-pl_PL.mo' ) );
 
 		switch_theme( 'fse' );
-
 		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
 
 		unload_textdomain( 'fse' );
@@ -118,8 +117,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( wp_get_theme()->get( 'TextDomain' ), 'fse' );
 		$this->assertSame(
 			array(
-				'color'  => array(
-					'palette' => array(
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
 						'theme' => array(
 							array(
 								'slug'  => 'light',
@@ -133,9 +134,16 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'custom'  => false,
 				),
-				'blocks' => array(
+				'typography' => array(
+					'customFontSize'   => true,
+					'customLineHeight' => false,
+				),
+				'spacing'    => array(
+					'units'         => false,
+					'customPadding' => false,
+				),
+				'blocks'     => array(
 					'core/paragraph' => array(
 						'color' => array(
 							'palette' => array(
@@ -209,6 +217,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		add_theme_support( 'editor-color-palette', $color_palette );
 		$supports = gutenberg_get_default_block_editor_settings();
 		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $supports )->get_settings();
+		remove_theme_support( 'custom-line-height' );
+		remove_theme_support( 'editor-color-palette' );
 
 		$this->assertSame( false, WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() );
 		$this->assertSame( true, $settings['typography']['customLineHeight'] );
@@ -223,8 +233,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		// Should merge settings.
 		$this->assertSame(
 			array(
-				'color'  => array(
-					'palette' => array(
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
 						'theme' => array(
 							array(
 								'slug'  => 'light',
@@ -243,10 +255,17 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'custom'  => false,
-					'link'    => true,
+					'link'           => true,
 				),
-				'blocks' => array(
+				'typography' => array(
+					'customFontSize'   => true,
+					'customLineHeight' => false,
+				),
+				'spacing'    => array(
+					'units'         => false,
+					'customPadding' => false,
+				),
+				'blocks'     => array(
 					'core/paragraph'  => array(
 						'color' => array(
 							'palette' => array(

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -117,32 +117,49 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( wp_get_theme()->get( 'TextDomain' ), 'fse' );
 		$this->assertSame(
 			array(
-				'theme' => array(
-					array(
-						'slug'  => 'light',
-						'name'  => 'Jasny',
-						'color' => '#f5f7f9',
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
+						'theme' => array(
+							array(
+								'slug'  => 'light',
+								'name'  => 'Jasny',
+								'color' => '#f5f7f9',
+							),
+							array(
+								'slug'  => 'dark',
+								'name'  => 'Ciemny',
+								'color' => '#000',
+							),
+						),
+					),
+				),
+				'typography' => array(
+					'customFontSize'   => true,
+					'customLineHeight' => false,
+				),
+				'spacing'    => array(
+					'units'         => false,
+					'customPadding' => false,
+				),
+				'blocks'     => array(
+					'core/paragraph' => array(
+						'color' => array(
+							'palette' => array(
+								'theme' => array(
+									array(
+										'slug'  => 'light',
+										'name'  => 'Jasny',
+										'color' => '#f5f7f9',
+									),
+								),
+							),
+						),
 					),
 				),
 			),
-			$actual->get_settings()['blocks']['core/paragraph']['color']['palette']
-		);
-		$this->assertSame(
-			array(
-				'theme' => array(
-					array(
-						'slug'  => 'light',
-						'name'  => 'Jasny',
-						'color' => '#f5f7f9',
-					),
-					array(
-						'slug'  => 'dark',
-						'name'  => 'Ciemny',
-						'color' => '#000',
-					),
-				),
-			),
-			$actual->get_settings()['color']['palette']
+			$actual->get_settings()
 		);
 		$this->assertSame(
 			$actual->get_custom_templates(),

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -117,49 +117,32 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( wp_get_theme()->get( 'TextDomain' ), 'fse' );
 		$this->assertSame(
 			array(
-				'color'      => array(
-					'custom'         => false,
-					'customGradient' => true,
-					'palette'        => array(
-						'theme' => array(
-							array(
-								'slug'  => 'light',
-								'name'  => 'Jasny',
-								'color' => '#f5f7f9',
-							),
-							array(
-								'slug'  => 'dark',
-								'name'  => 'Ciemny',
-								'color' => '#000',
-							),
-						),
-					),
-				),
-				'typography' => array(
-					'customFontSize'   => true,
-					'customLineHeight' => false,
-				),
-				'spacing'    => array(
-					'units'         => false,
-					'customPadding' => false,
-				),
-				'blocks'     => array(
-					'core/paragraph' => array(
-						'color' => array(
-							'palette' => array(
-								'theme' => array(
-									array(
-										'slug'  => 'light',
-										'name'  => 'Jasny',
-										'color' => '#f5f7f9',
-									),
-								),
-							),
-						),
+				'theme' => array(
+					array(
+						'slug'  => 'light',
+						'name'  => 'Jasny',
+						'color' => '#f5f7f9',
 					),
 				),
 			),
-			$actual->get_settings()
+			$actual->get_settings()['blocks']['core/paragraph']['color']['palette']
+		);
+		$this->assertSame(
+			array(
+				'theme' => array(
+					array(
+						'slug'  => 'light',
+						'name'  => 'Jasny',
+						'color' => '#f5f7f9',
+					),
+					array(
+						'slug'  => 'dark',
+						'name'  => 'Ciemny',
+						'color' => '#000',
+					),
+				),
+			),
+			$actual->get_settings()['color']['palette']
 		);
 		$this->assertSame(
 			$actual->get_custom_templates(),

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -179,7 +179,6 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
 		switch_theme( 'default' );
-		add_theme_support( 'custom-line-height' );
 		$color_palette = array(
 			array(
 				'name'  => 'Primary',
@@ -198,8 +197,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 		add_theme_support( 'editor-color-palette', $color_palette );
-		$supports = gutenberg_get_default_block_editor_settings();
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $supports )->get_settings();
+		add_theme_support( 'custom-line-height' );
+
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
+
 		remove_theme_support( 'custom-line-height' );
 		remove_theme_support( 'editor-color-palette' );
 


### PR DESCRIPTION
This is a dormant bug that was uncovered by https://github.com/WordPress/gutenberg/pull/35970#issuecomment-953796030

## The bug

In the `core/block-editor` store, we have the presets keyed by origin (core, theme, user). For example, the color palette is stored under `__experimentalFeatures.color.palette` as:

```js
{
  core: [ { slug: 'value', color: 'value', name: 'value' } ],
  preset: [ { slug: 'value', color: 'value', name: 'value' } ],
  user: [ { slug: 'value', color: 'value', name: 'value' } ]
}
```

If a given origin has not provided data, there's no key for them. For themes that do not provide any preset and the user hasn't either, the presets are expected to have this shape:

```js
{
  core: [ { slug: 'value', color: 'value', name: 'value' } ]
}
```

Storefront is one of those themes that do not provide any preset so should be expected to have the above shape. The same can be reproduced for any theme that has a `theme.json` by removing the `settings.color.palette` contents. By testing https://github.com/WordPress/gutenberg/pull/35970#issuecomment-953796030 we found that these themes included in the theme origin the same data that already was in the core one:

```js
{
  core: [ { slug: 'value', color: 'value', name: 'value' } ],
  theme: [ { slug: 'value', color: 'value', name: 'value' } ] // The values here are the same than core's.
}
```

## How to test

- Activate Storefront. You can also use the empty theme and remove the `settings.color.palette` property.
- Inspect the contents of the `core/block-editor` store, specifically the `settings.__experimentalFeatures.color.palette` key.
- The expected result is that you'll find only a core origin but instead there're core and theme.

## Why it happens

WordPress 5.8 does the following (see [get_block_editor_settings](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/block-editor.php#L284)):

  1.1. Takes the data from the theme (either from theme supports or theme.json).
  1.2 It stores under `settings.__experimentalFeatures` the theme.json settings.
  1.3. For backward compatibility, it also retrofits the data to the legacy settings mechanism (`settings.colors` for the palette, `settings.gradients` for the gradients, and so on). **At this point, all themes have stored presets in the old legacy settings mechanism, whether it's  core presets or presets coming from the theme.**
  1.4. Then, it fires the block editor settings filter, so 3rd parties can filter them.

The Gutenberg plugin hooks into that filter to reorganize the `settings.__experimentalFeatures` with the new schema and then retrofit again the data to the legacy settings mechanism. The bug is here, in the plugin. Because we use the filtered legacy settings (`settings.color`) to create the new ones (`settings.__experimentalFeatures.color.palette`) there's always data coming from `settings.color` that we interpret as coming from the "theme origin".

The fix is not taking into account the filtered legacy settings (`settings.color`).

The drawback to this fix is that the legacy settings can be filtered no longer, because the plugin will ignored them anyway.

For reference, there're less than a dozen, see [here](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#backward-compatibility-with-add_theme_support).
