### PR TITLE
Fix WPCS lint errors in global styles

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -158,9 +158,9 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		$post            = get_post( $request['id'] );
 		$existing_config = array();
 		if ( $post ) {
-			$existing_config = json_decode( $post->post_content, true );
+			$existing_config     = json_decode( $post->post_content, true );
 			$json_decoding_error = json_last_error();
-			if ( JSON_ERROR_NONE !== $json_decoding_error  || ! isset( $existing_config['isGlobalStylesUserThemeJSON'] ) ||
+			if ( JSON_ERROR_NONE !== $json_decoding_error || ! isset( $existing_config['isGlobalStylesUserThemeJSON'] ) ||
 				! $existing_config['isGlobalStylesUserThemeJSON'] ) {
 				$existing_config = array();
 			}
@@ -170,12 +170,12 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 			$config = array();
 			if ( isset( $request['styles'] ) ) {
 				$config['styles'] = $request['styles'];
-			} else if( isset( $existing_config['styles'] ) ) {
+			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
 			}
 			if ( isset( $request['settings'] ) ) {
 				$config['settings'] = $request['settings'];
-			} else if( isset( $existing_config['settings'] ) ) {
+			} elseif ( isset( $existing_config['settings'] ) ) {
 				$config['settings'] = $existing_config['settings'];
 			}
 			$config['isGlobalStylesUserThemeJSON'] = true;


### PR DESCRIPTION
## Description
Fixes WPCS errors that made into the trunk.

## Types of changes
WPCS Fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
