### PR TITLE
Draft: Try out variables substitutions in block templates

### DIFF
--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -204,6 +204,9 @@ function _gutenberg_flatten_blocks( &$blocks ) {
  * @return string Updated wp_template content.
  */
 function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
+	// HACK proof of concept
+	$template_content = str_replace( "{{ template_directory_uri }}", get_template_directory_uri(), $template_content );
+
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -204,8 +204,8 @@ function _gutenberg_flatten_blocks( &$blocks ) {
  * @return string Updated wp_template content.
  */
 function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
-	// HACK proof of concept
-	$template_content = str_replace( "{{ template_directory_uri }}", get_template_directory_uri(), $template_content );
+	// HACK proof of concept.
+	$template_content = str_replace( '{{ template_directory_uri }}', get_template_directory_uri(), $template_content );
 
 	$has_updated_content = false;
 	$new_content         = '';

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -204,12 +204,11 @@ function _gutenberg_flatten_blocks( &$blocks ) {
  * @return string Updated wp_template content.
  */
 function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
-	// HACK proof of concept.
-	$template_content = str_replace( '{{ template_directory_uri }}', get_template_directory_uri(), $template_content );
 
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
+	$file_regex          = '/^file:./';
 
 	$blocks = _gutenberg_flatten_blocks( $template_blocks );
 	foreach ( $blocks as &$block ) {
@@ -219,6 +218,16 @@ function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
 		) {
 			$block['attrs']['theme'] = wp_get_theme()->get_stylesheet();
 			$has_updated_content     = true;
+		}
+
+		// Variable substitution for file:/ in URL attributes.
+		if ( isset( $block['attrs']['url'] ) ) {
+			if ( preg_match( $file_regex, $block['attrs']['url'] ) ) {
+				error_log("Before: " . $block['attrs']['url']);
+				$block['attrs']['url'] = preg_replace( $file_regex, get_template_directory_uri(), $block['attrs']['url'] );
+				error_log("After: " . $block['attrs']['url']);
+				$has_updated_content   = true;
+			}
 		}
 	}
 

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -204,7 +204,6 @@ function _gutenberg_flatten_blocks( &$blocks ) {
  * @return string Updated wp_template content.
  */
 function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
-
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );
@@ -246,7 +245,6 @@ function _gutenberg_process_theme_variable_substitution( $template_content ) {
 	$template_content = str_replace( 'src="file:.', 'src="' . get_template_directory_uri(), $template_content );
 	return $template_content;
 }
-
 
 /**
  * Build a unified template object based on a theme file.


### PR DESCRIPTION
## Description

A test to see how variable substitution may work for templates.

Testing ideas for #31815

## How has this been tested?

Use a block theme.

Add a dummy image in one of your templates where you want your image to go.

Replace the image URL from dummy image with: `{{ template_directory_uri }}/assets/image.jpg` where `assets/image.jpg` is the local file in your theme. This needs to be done in a text editor, not from within WordPress.

Reload theme page and it should work.

## Types of changes

Just a test.

