### PR TITLE
List View: fix pagedown/pageup and improve scrolling

### DIFF
--- a/packages/block-editor/src/components/block-icon/index.js
+++ b/packages/block-editor/src/components/block-icon/index.js
@@ -8,8 +8,9 @@ import classnames from 'classnames';
  */
 import { Icon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
+import { memo } from '@wordpress/element';
 
-export default function BlockIcon( { icon, showColors = false, className } ) {
+function BlockIcon( { icon, showColors = false, className } ) {
 	if ( icon?.src === 'block-default' ) {
 		icon = {
 			src: blockDefault,
@@ -35,3 +36,5 @@ export default function BlockIcon( { icon, showColors = false, className } ) {
 		</span>
 	);
 }
+
+export default memo( BlockIcon );

--- a/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`BlockSwitcherDropdownMenu should render disabled block switcher with mu
     className="block-editor-block-switcher__no-switcher-icon"
     disabled={true}
     icon={
-      <BlockIcon
+      <Memo(BlockIcon)
         icon={
           <SVG
             viewBox="0 0 24 24"

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -18,7 +18,7 @@ import {
 	useCallback,
 	memo,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,11 +32,12 @@ import ListViewBlockContents from './block-contents';
 import BlockSettingsDropdown from '../block-settings-menu/block-settings-dropdown';
 import { useListViewContext } from './context';
 import { store as blockEditorStore } from '../../store';
-import { isClientIdSelected } from './utils';
 
 function ListViewBlock( {
 	block,
 	isDragged,
+	isSelected,
+	isBranchSelected,
 	selectBlock,
 	position,
 	level,
@@ -60,34 +61,6 @@ function ListViewBlock( {
 		expand,
 		collapse,
 	} = useListViewContext();
-
-	const { isBranchSelected, isSelected } = useSelect(
-		( select ) => {
-			const {
-				getSelectedBlockClientId,
-				getSelectedBlockClientIds,
-				getBlockParents,
-			} = select( blockEditorStore );
-
-			const selectedClientIds = withExperimentalPersistentListViewFeatures
-				? getSelectedBlockClientIds()
-				: [ getSelectedBlockClientId() ];
-			const blockParents = getBlockParents( clientId );
-			const _isSelected = isClientIdSelected(
-				clientId,
-				selectedClientIds
-			);
-			return {
-				isSelected: _isSelected,
-				isBranchSelected:
-					_isSelected ||
-					blockParents.some( ( id ) => {
-						return isClientIdSelected( id, selectedClientIds );
-					} ),
-			};
-		},
-		[ withExperimentalPersistentListViewFeatures, clientId ]
-	);
 
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -11,8 +11,14 @@ import {
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
-import { useDispatch, useSelect, AsyncModeProvider } from '@wordpress/data';
+import {
+	useState,
+	useRef,
+	useEffect,
+	useCallback,
+	memo,
+} from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -28,7 +34,7 @@ import { useListViewContext } from './context';
 import { store as blockEditorStore } from '../../store';
 import { isClientIdSelected } from './utils';
 
-export default function ListViewBlock( {
+function ListViewBlock( {
 	block,
 	isDragged,
 	selectBlock,
@@ -165,95 +171,94 @@ export default function ListViewBlock( {
 	} );
 
 	return (
-		<AsyncModeProvider value={ ! isSelected }>
-			<ListViewLeaf
-				className={ classes }
-				onMouseEnter={ onMouseEnter }
-				onMouseLeave={ onMouseLeave }
-				onFocus={ onMouseEnter }
-				onBlur={ onMouseLeave }
-				level={ level }
-				position={ position }
-				rowCount={ rowCount }
-				path={ path }
-				id={ `list-view-block-${ clientId }` }
-				data-block={ clientId }
-				isExpanded={ isExpanded }
+		<ListViewLeaf
+			className={ classes }
+			onMouseEnter={ onMouseEnter }
+			onMouseLeave={ onMouseLeave }
+			onFocus={ onMouseEnter }
+			onBlur={ onMouseLeave }
+			level={ level }
+			position={ position }
+			rowCount={ rowCount }
+			path={ path }
+			id={ `list-view-block-${ clientId }` }
+			data-block={ clientId }
+			isExpanded={ isExpanded }
+		>
+			<TreeGridCell
+				className="block-editor-list-view-block__contents-cell"
+				colSpan={ colSpan }
+				ref={ cellRef }
 			>
-				<TreeGridCell
-					className="block-editor-list-view-block__contents-cell"
-					colSpan={ colSpan }
-					ref={ cellRef }
-				>
+				{ ( { ref, tabIndex, onFocus } ) => (
+					<div className="block-editor-list-view-block__contents-container">
+						<ListViewBlockContents
+							block={ block }
+							onClick={ selectEditorBlock }
+							onToggleExpanded={ toggleExpanded }
+							isSelected={ isSelected }
+							position={ position }
+							siblingBlockCount={ siblingBlockCount }
+							level={ level }
+							ref={ ref }
+							tabIndex={ tabIndex }
+							onFocus={ onFocus }
+						/>
+					</div>
+				) }
+			</TreeGridCell>
+			{ hasRenderedMovers && (
+				<>
+					<TreeGridCell
+						className={ moverCellClassName }
+						withoutGridItem
+					>
+						<TreeGridItem>
+							{ ( { ref, tabIndex, onFocus } ) => (
+								<BlockMoverUpButton
+									orientation="vertical"
+									clientIds={ [ clientId ] }
+									ref={ ref }
+									tabIndex={ tabIndex }
+									onFocus={ onFocus }
+								/>
+							) }
+						</TreeGridItem>
+						<TreeGridItem>
+							{ ( { ref, tabIndex, onFocus } ) => (
+								<BlockMoverDownButton
+									orientation="vertical"
+									clientIds={ [ clientId ] }
+									ref={ ref }
+									tabIndex={ tabIndex }
+									onFocus={ onFocus }
+								/>
+							) }
+						</TreeGridItem>
+					</TreeGridCell>
+				</>
+			) }
+
+			{ showBlockActions && (
+				<TreeGridCell className={ listViewBlockSettingsClassName }>
 					{ ( { ref, tabIndex, onFocus } ) => (
-						<div className="block-editor-list-view-block__contents-container">
-							<ListViewBlockContents
-								block={ block }
-								onClick={ selectEditorBlock }
-								onToggleExpanded={ toggleExpanded }
-								isSelected={ isSelected }
-								position={ position }
-								siblingBlockCount={ siblingBlockCount }
-								level={ level }
-								ref={ ref }
-								tabIndex={ tabIndex }
-								onFocus={ onFocus }
-							/>
-						</div>
+						<BlockSettingsDropdown
+							clientIds={ [ clientId ] }
+							icon={ moreVertical }
+							toggleProps={ {
+								ref,
+								className: 'block-editor-list-view-block__menu',
+								tabIndex,
+								onFocus,
+							} }
+							disableOpenOnArrowDown
+							__experimentalSelectBlock={ selectEditorBlock }
+						/>
 					) }
 				</TreeGridCell>
-				{ hasRenderedMovers && (
-					<>
-						<TreeGridCell
-							className={ moverCellClassName }
-							withoutGridItem
-						>
-							<TreeGridItem>
-								{ ( { ref, tabIndex, onFocus } ) => (
-									<BlockMoverUpButton
-										orientation="vertical"
-										clientIds={ [ clientId ] }
-										ref={ ref }
-										tabIndex={ tabIndex }
-										onFocus={ onFocus }
-									/>
-								) }
-							</TreeGridItem>
-							<TreeGridItem>
-								{ ( { ref, tabIndex, onFocus } ) => (
-									<BlockMoverDownButton
-										orientation="vertical"
-										clientIds={ [ clientId ] }
-										ref={ ref }
-										tabIndex={ tabIndex }
-										onFocus={ onFocus }
-									/>
-								) }
-							</TreeGridItem>
-						</TreeGridCell>
-					</>
-				) }
-
-				{ showBlockActions && (
-					<TreeGridCell className={ listViewBlockSettingsClassName }>
-						{ ( { ref, tabIndex, onFocus } ) => (
-							<BlockSettingsDropdown
-								clientIds={ [ clientId ] }
-								icon={ moreVertical }
-								toggleProps={ {
-									ref,
-									className:
-										'block-editor-list-view-block__menu',
-									tabIndex,
-									onFocus,
-								} }
-								disableOpenOnArrowDown
-								__experimentalSelectBlock={ selectEditorBlock }
-							/>
-						) }
-					</TreeGridCell>
-				) }
-			</ListViewLeaf>
-		</AsyncModeProvider>
+			) }
+		</ListViewLeaf>
 	);
 }
+
+export default memo( ListViewBlock );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -67,7 +67,11 @@ function ListView(
 	},
 	ref
 ) {
-	const { clientIdsTree, draggedClientIds } = useListViewClientIds( blocks );
+	const {
+		clientIdsTree,
+		draggedClientIds,
+		selectedClientIds,
+	} = useListViewClientIds( blocks );
 	const { selectBlock } = useDispatch( blockEditorStore );
 	const { visibleBlockCount } = useSelect(
 		( select ) => {
@@ -189,6 +193,7 @@ function ListView(
 						showNestedBlocks={ showNestedBlocks }
 						showBlockMovers={ showBlockMovers }
 						fixedListWindow={ fixedListWindow }
+						selectedClientIds={ selectedClientIds }
 						{ ...props }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -111,6 +111,7 @@ function ListView(
 		visibleBlockCount,
 		{
 			useWindowing: __experimentalPersistentListViewFeatures,
+			windowOverscan: 40,
 		}
 	);
 

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -14,10 +14,12 @@ export default function useListViewClientIds( blocks ) {
 		( select ) => {
 			const {
 				getDraggedBlockClientIds,
+				getSelectedBlockClientIds,
 				__unstableGetClientIdsTree,
 			} = select( blockEditorStore );
 
 			return {
+				selectedClientIds: getSelectedBlockClientIds(),
 				draggedClientIds: getDraggedBlockClientIds(),
 				clientIdsTree: blocks ? blocks : __unstableGetClientIdsTree(),
 			};

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -60,14 +60,19 @@ export default function useFixedWindowList(
 			return;
 		}
 		const scrollContainer = getScrollContainer( elementRef.current );
-		const measureWindow = () => {
+		const measureWindow = (
+			/** @type {boolean | undefined} */ initRender
+		) => {
 			if ( ! scrollContainer ) {
 				return;
 			}
 			const visibleItems = Math.ceil(
 				scrollContainer.clientHeight / itemHeight
 			);
-			const windowOverscan = options?.windowOverscan ?? visibleItems;
+			// Aim to keep opening list view fast, afterward we can optimize for scrolling
+			const windowOverscan = initRender
+				? visibleItems
+				: options?.windowOverscan ?? visibleItems;
 			const firstViewableIndex = Math.floor(
 				scrollContainer.scrollTop / itemHeight
 			);
@@ -96,7 +101,7 @@ export default function useFixedWindowList(
 			} );
 		};
 
-		measureWindow();
+		measureWindow( true );
 		const debounceMeasureList = debounce( () => {
 			measureWindow();
 		}, 16 );

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { throttle } from 'lodash';
+import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -95,6 +95,38 @@ export default function useFixedWindowList(
 				return lastWindow;
 			} );
 		};
+
+		measureWindow();
+		const debounceMeasureList = debounce( () => {
+			measureWindow();
+		}, 16 );
+		scrollContainer?.addEventListener( 'scroll', debounceMeasureList );
+		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
+			'resize',
+			debounceMeasureList
+		);
+		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
+			'resize',
+			debounceMeasureList
+		);
+
+		return () => {
+			scrollContainer?.removeEventListener(
+				'scroll',
+				debounceMeasureList
+			);
+			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
+				'resize',
+				debounceMeasureList
+			);
+		};
+	}, [ itemHeight, elementRef, totalItems ] );
+
+	useLayoutEffect( () => {
+		if ( ! useWindowing ) {
+			return;
+		}
+		const scrollContainer = getScrollContainer( elementRef.current );
 		const handleKeyDown = ( /** @type {KeyboardEvent} */ event ) => {
 			switch ( event.keyCode ) {
 				case HOME: {
@@ -121,39 +153,17 @@ export default function useFixedWindowList(
 				}
 			}
 		};
-
-		measureWindow();
-		const throttleMeasureList = throttle( () => {
-			measureWindow();
-		}, 16 );
-		scrollContainer?.addEventListener( 'scroll', throttleMeasureList );
-		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
-			'resize',
-			throttleMeasureList
-		);
-		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
-			'resize',
-			throttleMeasureList
-		);
 		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
 			'keydown',
 			handleKeyDown
 		);
 		return () => {
-			scrollContainer?.removeEventListener(
-				'scroll',
-				throttleMeasureList
-			);
-			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
-				'resize',
-				throttleMeasureList
-			);
 			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
 				'keydown',
 				handleKeyDown
 			);
 		};
-	}, [ totalItems, itemHeight, elementRef ] );
+	}, [ totalItems, itemHeight, elementRef, fixedListWindow.visibleItems ] );
 
 	return [ fixedListWindow, setFixedListWindow ];
 }


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/35230, this PR improves scrolling in List View by:

* Memoing the List View block and the BlockIcon
* Tunes the windowOverscan value to 40 instead of the number of currently visible items. 
*  Fixes a bug around the keyboard handler using a stale reference (so we were moving by 30 items instead of the visible window).

Why the memo? When we scroll the list of virtualized items we should render changes. This object is passed to the branch component, and when that branch updates all children of that branch render too. By memoing we avoid needing to re-render all items in the window. 

I think this can be improved further, but we can tackle that in future profiling passes.

### Testing Instructions

- Less white area is visible while scrolling in List View
- No regressions in List View functionality
- Dragging should be improved
- No regressions in test performance results from CI

Example of ListView scroll with ~900 blocks:

https://user-images.githubusercontent.com/1270189/139348450-b9e635a7-3129-49de-a3d1-e6b03fdc696f.mp4

![CleanShot 2021-10-28 at 16 09 24](https://user-images.githubusercontent.com/1270189/139348571-f0e7c1b6-932e-41c5-b377-1a32e93938ce.png)


