### PR TITLE
Font Family Support: Fix skip serialization check

### DIFF
--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -58,7 +58,7 @@ function addSaveProps( props, blockType, attributes ) {
 	if (
 		hasBlockSupport(
 			blockType,
-			'__experimentalSkipTypographySerialization'
+			'typography.__experimentalSkipSerialization'
 		)
 	) {
 		return props;


### PR DESCRIPTION
## Description

This PR corrects the flag used to check whether or not typography block support styles are being serialized.

## How has this been tested?

Manually.

#### Testing instructions

1. On `trunk`, find a block to test with that opts into font family support e.g. Button block.
2. Update that block's block.json file to enable skipping serialization of typography support classes/styles
   ```
		"typography": {
			"fontSize": true,
			"__experimentalFontFamily": true,
			"__experimentalSkipSerialization": true
		},
   ```
3. Create a new post in the block editor and add the desired block
4. Select the block, toggle on the font family control from the Typography sidebar panel and select font
5. Notice the block gets the font family class applied to it
6. Checkout this PR and repeat steps 2-4
7. Ensure the block no longer has font family class applied to it.

## Screenshots <!-- if applicable -->

<img width="911" alt="Screen Shot 2021-10-29 at 6 09 17 pm" src="https://user-images.githubusercontent.com/60436221/139399554-ad15230e-4570-4f34-aa50-e0972b78cd6b.png">

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
