### PR TITLE
Added link to Ways to keep up with Gutenberg & Full Site Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The block editor introduces a modular approach to pages and posts: each piece of
 
 The block editor first became available in December 2018, and we're still hard at work refining the experience, creating more and better blocks, and laying the groundwork for the next three phases of work. The Gutenberg plugin gives you the latest version of the block editor so you can join us in testing bleeding-edge features, start playing with blocks, and maybe get inspired to build your own.
 
+Check out the [Ways to keep up with Gutenberg & Full Site Editing (FSE)](https://make.wordpress.org/core/2020/05/20/ways-to-keep-up-with-full-site-editing-fse/)
+
+
 ## Getting Started
 
 Get hands on: check out the [block editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The block editor first became available in December 2018, and we're still hard a
 
 Check out the [Ways to keep up with Gutenberg & Full Site Editing (FSE)](https://make.wordpress.org/core/2020/05/20/ways-to-keep-up-with-full-site-editing-fse/)
 
-
 ## Getting Started
 
 Get hands on: check out the [block editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.


### PR DESCRIPTION
## Description
Added a link to the [Ways to keep up with Gutenberg & Full Site Editing (FSE)](https://make.wordpress.org/core/2020/05/20/ways-to-keep-up-with-full-site-editing-fse/) to help users/contributors to understand how to catch up with the project
