### PR TITLE
Remove settings as an argument from `WP_Theme_JSON_Resolver`

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -257,19 +257,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Returns the theme's data.
 	 *
-	 * Data from theme.json can be augmented via the
-	 * $theme_support_data variable. This is useful, for example,
-	 * to backfill the gaps in theme.json that a theme has declared
-	 * via add_theme_supports.
-	 *
-	 * Note that if the same data is present in theme.json
-	 * and in $theme_support_data, the theme.json's is not overwritten.
-	 *
-	 * @param array $theme_support_data Theme support data in theme.json format.
+	 * Data from theme.json will be backfilled from existing
+	 * theme supports, if any. Note that if the same data
+	 * is present in theme.json and in theme supports,
+	 * the theme.json takes precendence.
 	 *
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
-	public static function get_theme_data( $theme_support_data = array() ) {
+	public static function get_theme_data() {
 		if ( null === self::$theme ) {
 			$theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = self::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
@@ -288,14 +283,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 		}
 
-		if ( empty( $theme_support_data ) ) {
-			return self::$theme;
-		}
-
 		/*
-		 * We want the presets and settings declared in theme.json
-		 * to override the ones declared via add_theme_support.
-		 */
+		* We want the presets and settings declared in theme.json
+		* to override the ones declared via theme supports.
+		* So we take theme supports, transform it to theme.json shape
+		* and merge the self::$theme upon that.
+		*/
+		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( self::$theme );
 
@@ -410,20 +404,16 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * for the paragraph block, and the theme has done it as well,
 	 * the user preference wins.
 	 *
-	 * @param array  $settings Existing block editor settings.
-	 *                         Empty array by default.
 	 * @param string $origin To what level should we merge data.
 	 *                       Valid values are 'theme' or 'user'.
 	 *                       Default is 'user'.
 	 *
 	 * @return WP_Theme_JSON_Gutenberg
 	 */
-	public static function get_merged_data( $settings = array(), $origin = 'user' ) {
+	public static function get_merged_data( $origin = 'user' ) {
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
-
-		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $settings );
-		$result->merge( self::get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_theme_data() );
 
 		if ( 'user' === $origin ) {
 			$result->merge( self::get_user_data() );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -109,7 +109,6 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		load_textdomain( 'fse', realpath( __DIR__ . '/data/languages/themes/fse-pl_PL.mo' ) );
 
 		switch_theme( 'fse' );
-
 		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
 
 		unload_textdomain( 'fse' );
@@ -118,8 +117,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( wp_get_theme()->get( 'TextDomain' ), 'fse' );
 		$this->assertSame(
 			array(
-				'color'  => array(
-					'palette' => array(
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
 						'theme' => array(
 							array(
 								'slug'  => 'light',
@@ -133,9 +134,16 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'custom'  => false,
 				),
-				'blocks' => array(
+				'typography' => array(
+					'customFontSize'   => true,
+					'customLineHeight' => false,
+				),
+				'spacing'    => array(
+					'units'         => false,
+					'customPadding' => false,
+				),
+				'blocks'     => array(
 					'core/paragraph' => array(
 						'color' => array(
 							'palette' => array(
@@ -225,8 +233,10 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		// Should merge settings.
 		$this->assertSame(
 			array(
-				'color'  => array(
-					'palette' => array(
+				'color'      => array(
+					'custom'         => false,
+					'customGradient' => true,
+					'palette'        => array(
 						'theme' => array(
 							array(
 								'slug'  => 'light',
@@ -245,10 +255,17 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'custom'  => false,
-					'link'    => true,
+					'link'           => true,
 				),
-				'blocks' => array(
+				'typography' => array(
+					'customFontSize'   => true,
+					'customLineHeight' => false,
+				),
+				'spacing'    => array(
+					'units'         => false,
+					'customPadding' => false,
+				),
+				'blocks'     => array(
 					'core/paragraph'  => array(
 						'color' => array(
 							'palette' => array(

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -209,6 +209,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		add_theme_support( 'editor-color-palette', $color_palette );
 		$supports = gutenberg_get_default_block_editor_settings();
 		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $supports )->get_settings();
+		remove_theme_support( 'custom-line-height' );
+		remove_theme_support( 'editor-color-palette' );
 
 		$this->assertSame( false, WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() );
 		$this->assertSame( true, $settings['typography']['customLineHeight'] );


### PR DESCRIPTION
Follows-up to https://github.com/WordPress/gutenberg/pull/36075

This removes the settings as an argument to the `WP_Theme_JSON_Resolver`. It now takes the theme supports data directly.
