### PR TITLE
Themes: Remove experimental feature notice

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -24,21 +24,6 @@ function gutenberg_supports_block_templates() {
 }
 
 /**
- * Show a notice when a Full Site Editing theme is used.
- */
-function gutenberg_full_site_editing_notice() {
-	if ( ! gutenberg_is_fse_theme() || 'themes' !== get_current_screen()->base ) {
-		return;
-	}
-	?>
-	<div class="notice notice-warning">
-		<p><?php _e( 'You\'re using an experimental Full Site Editing theme. Full Site Editing is an experimental feature and potential API changes are to be expected!', 'gutenberg' ); ?></p>
-	</div>
-	<?php
-}
-add_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
-
-/**
  * Removes legacy pages from FSE themes.
  */
 function gutenberg_remove_legacy_pages() {


### PR DESCRIPTION
## Description
Remove notice about Block Themes being experimental from Themes screen. We're merging this feature in Core.

## How has this been tested?
1. Activate TT1 or TT2 theme.
2. Visit Appearance > Themes.
3. Notice shouldn't be visible.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
