### PR TITLE
Introduce a custom version of the enqueue_block_styles_assets function

### DIFF
--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -71,5 +71,7 @@ function gutenberg_enqueue_block_styles_assets() {
 	}
 }
 
-remove_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
-add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );
+if ( version_compare( get_bloginfo( 'version' ), '5.8.2', '<' ) ) {
+	remove_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+	add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );
+}

--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -27,6 +27,8 @@ if ( gutenberg_is_fse_theme() ) {
  * template (eg.: 404)
  *
  * More details on the bug can be found in: https://core.trac.wordpress.org/ticket/54323
+ *
+ * @see enqueue_block_styles_assets
  */
 function gutenberg_enqueue_block_styles_assets() {
 	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();

--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -19,3 +19,55 @@ if ( gutenberg_is_fse_theme() ) {
 	add_theme_support( 'automatic-feed-links' );
 	add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 }
+
+/**
+ * Overrides the WordPress enqueue_block_styles_assets function, which contains
+ * a bug eventually leading to a fatal error for full site editing enabled themes
+ * which do register custom block styles and don't have a template for requested
+ * template (eg.: 404)
+ *
+ * More details on the bug can be found in: https://core.trac.wordpress.org/ticket/54323
+ */
+function gutenberg_enqueue_block_styles_assets() {
+	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+
+	foreach ( $block_styles as $block_name => $styles ) {
+		foreach ( $styles as $style_properties ) {
+			if ( isset( $style_properties['style_handle'] ) ) {
+
+				// If the site loads separate styles per-block, enqueue the stylesheet on render.
+				if ( wp_should_load_separate_core_block_assets() ) {
+					add_filter(
+						'render_block',
+						function( $html ) use ( $style_properties ) {
+							wp_enqueue_style( $style_properties['style_handle'] );
+							return $html;
+						}
+					);
+				} else {
+					wp_enqueue_style( $style_properties['style_handle'] );
+				}
+			}
+			if ( isset( $style_properties['inline_style'] ) ) {
+
+				// Default to "wp-block-library".
+				$handle = 'wp-block-library';
+
+				// If the site loads separate styles per-block, check if the block has a stylesheet registered.
+				if ( wp_should_load_separate_core_block_assets() ) {
+					$block_stylesheet_handle = generate_block_asset_handle( $block_name, 'style' );
+					global $wp_styles;
+					if ( isset( $wp_styles->registered[ $block_stylesheet_handle ] ) ) {
+						$handle = $block_stylesheet_handle;
+					}
+				}
+
+				// Add inline styles to the calculated handle.
+				wp_add_inline_style( $handle, $style_properties['inline_style'] );
+			}
+		}
+	}
+}
+
+remove_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );

--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -71,7 +71,7 @@ function gutenberg_enqueue_block_styles_assets() {
 	}
 }
 
-if ( version_compare( get_bloginfo( 'version' ), '5.8.2', '<' ) ) {
+if ( version_compare( get_bloginfo( 'version' ), '5.8.2', '<' ) && has_action( 'enqueue_block_assets', 'enqueue_block_styles_assets' ) ) {
 	remove_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
 	add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );
 }

--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -71,7 +71,7 @@ function gutenberg_enqueue_block_styles_assets() {
 	}
 }
 
-if ( version_compare( get_bloginfo( 'version' ), '5.8.2', '<' ) && has_action( 'enqueue_block_assets', 'enqueue_block_styles_assets' ) ) {
+if ( version_compare( get_bloginfo( 'version' ), '5.8.2', '<' ) && 30 === has_action( 'enqueue_block_assets', 'enqueue_block_styles_assets' ) ) {
 	remove_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
 	add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );
 }


### PR DESCRIPTION
## Description

The WordPress `enqueue_block_styles_assets` function contains a bug which may lead to fatal errors for full site editing enabled themes which register custom styles and are missing a HTML template for request (for instance 404.html). As described in #35912 and #35903

The bug was patched in WordPress core ( see https://core.trac.wordpress.org/ticket/54323 ), but since the Gutenberg
11.8.0 introduced the following line in 16633ff

```
add_filter( 'should_load_separate_core_block_assets', '__return_true' );
```

it, in my humble opinion, also should patch the issue, in order to prevent fatal errors for the themes matching the above mentioned criteria.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## How has this been tested?
In the WordPress 5.8 install, I have enabled the latest version of the blockbase theme (see https://github.com/Automattic/themes/tree/trunk/blockbase ) which does not include the 404.html block-template (which is still present in the version distributed via WordPress.org themes repository).

Further, I have enabled the Gutenberg v11.8.0 and experienced a fatal error on a URL which results in 404 page, and experienced a fatal error.

Applying the patch introduced in this PR fixed the fatal error.

## Screenshots <!-- if applicable -->

## Types of changes
Introduces a custom override of the `enqueue_block_styles_assets` with a patch introduced to WordPress in https://core.trac.wordpress.org/changeset/51941

The original function is being unhooked from the `enqueue_block_assets` and the new Gutenberg override is hooked.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
