### PR TITLE
Pattern block: remove wrapping div

### DIFF
--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -6,11 +6,9 @@ import { useEffect } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	useBlockProps,
-	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
 
-const PatternEdit = ( { attributes, clientId, isSelected } ) => {
+const PatternEdit = ( { attributes, clientId } ) => {
 	const selectedPattern = useSelect(
 		( select ) =>
 			select( blockEditorStore ).__experimentalGetParsedPattern(
@@ -19,44 +17,23 @@ const PatternEdit = ( { attributes, clientId, isSelected } ) => {
 		[ attributes.slug ]
 	);
 
-	const hasSelection = useSelect(
-		( select ) =>
-			isSelected ||
-			select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
-		[ isSelected, clientId ]
-	);
-
 	const {
 		replaceBlocks,
-		replaceInnerBlocks,
 		__unstableMarkNextChangeAsNotPersistent,
 	} = useDispatch( blockEditorStore );
 
-	// Run this effect when the block, or any of its InnerBlocks are selected.
-	// This replaces the Pattern block wrapper with a Group block.
-	// This ensures the markup structure and alignment are consistent between editor and view.
-	// This change won't be saved unless further changes are made to the InnerBlocks.
-	useEffect( () => {
-		if ( hasSelection && selectedPattern?.blocks ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceBlocks(
-				clientId,
-				createBlock( 'core/group', {}, selectedPattern.blocks )
-			);
-		}
-	}, [ hasSelection, selectedPattern?.blocks ] );
-
 	// Run this effect when the component loads.
-	// This adds the Pattern block template as InnerBlocks.
+	// This adds the Pattern's contents to the post.
 	// This change won't be saved.
+	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
 		if ( selectedPattern?.blocks ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, selectedPattern.blocks );
+			replaceBlocks( clientId, selectedPattern.blocks );
 		}
 	}, [ selectedPattern?.blocks ] );
 
-	const props = useInnerBlocksProps( useBlockProps(), {} );
+	const props = useBlockProps();
 
 	return <div { ...props } />;
 };

--- a/packages/block-library/src/pattern/index.php
+++ b/packages/block-library/src/pattern/index.php
@@ -38,7 +38,7 @@ function render_block_core_pattern( $attributes ) {
 	}
 
 	$pattern = $registry->get_registered( $slug );
-	return do_blocks( '<div>' . $pattern['content'] . '</div>' );
+	return do_blocks( $pattern['content'] );
 }
 
 add_action( 'init', 'register_block_core_pattern' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The Pattern block contains logic that inserts the contents of the referenced pattern inside of a wrapping container. This container is replaced with a Group upon block selection / editing. We added a wrapping div on the front-end to make the alignment consistent between editor and front-end. 

Working on 2022, I found that the additional wrapper can cause unintended issues with layouts. This PR removes the logic in favor of simply placing the patterns contents into the block tree without an additional wrapper.

The block's behavior should be unchanged — if no edits have been made, it still pulls from the pattern file. 

## How has this been tested?

- Check out this 2022 PR https://github.com/WordPress/twentytwentytwo/pull/182
- Verify the footer appears as expected in the site editor and front-end.
- Change the "Powered by" text inside of the `inc/patterns/footer-default.php` file. 
- Verify the changes are reflected editor and front-end.
- In the site editor, change the text inside of the footer.
- Verify the changes are reflected on the editor and front-end.

## Screenshots <!-- if applicable -->

Before | After
-------- | --------
<img width="1259" alt="Screen Shot 2021-10-29 at 3 09 12 PM" src="https://user-images.githubusercontent.com/5375500/139490201-f4d00202-9f21-4e49-b74f-87a19e696b19.png"> | <img width="1255" alt="Screen Shot 2021-10-29 at 3 08 05 PM" src="https://user-images.githubusercontent.com/5375500/139490208-5d5e0d54-0da0-422f-aa7b-2a1114eae45d.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Technical iteration on a new block

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
