### PR TITLE
[WIP] Block list: add expand and collapse all buttons

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -14,8 +14,9 @@ import {
 } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
+import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -40,6 +41,8 @@ export default function ListViewSidebar() {
 		}
 	}
 
+	const [ allItemsCollapsed, setAllItemsCollapsed ] = useState( false );
+
 	const instanceId = useInstanceId( ListViewSidebar );
 	const labelId = `edit-post-editor__list-view-panel-label-${ instanceId }`;
 
@@ -53,6 +56,16 @@ export default function ListViewSidebar() {
 			<div className="edit-post-editor__list-view-panel-header">
 				<strong id={ labelId }>{ __( 'List view' ) }</strong>
 				<Button
+					icon={ chevronUp }
+					label={ __( 'Collapse all list items' ) }
+					onClick={ () => setAllItemsCollapsed( true ) }
+				/>
+				<Button
+					icon={ chevronDown }
+					label={ __( 'Expand all list items' ) }
+					onClick={ () => setAllItemsCollapsed( false ) }
+				/>
+				<Button
 					icon={ closeSmall }
 					label={ __( 'Close list view sidebar' ) }
 					onClick={ () => setIsListViewOpened( false ) }
@@ -64,6 +77,7 @@ export default function ListViewSidebar() {
 			>
 				<ListView
 					onSelect={ selectEditorBlock }
+					allItemsCollapsed={ allItemsCollapsed }
 					showNestedBlocks
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures


### PR DESCRIPTION
## Description

Alternative for https://github.com/WordPress/gutenberg/issues/34759

There's another WIP PR https://github.com/WordPress/gutenberg/pull/35734 that collapses using Cmd/Ctrl click, but with an alternative store method. 

Maybe we could combine the two somehow once we work the nuts out.


https://user-images.githubusercontent.com/6458278/139621443-a4258885-920b-4c2d-9176-3fa98ed6f4de.mp4

Maybe it could look like this:

<img width="650" alt="Screen Shot 2021-11-02 at 3 13 22 pm" src="https://user-images.githubusercontent.com/6458278/139786363-ae03ca7b-b10b-45b2-8aa9-8d4095dbe845.png">


### TODO

- [ ] Fix up the layout
- [ ] Performance test
- [ ] Only show the controls where there are nested blocks, that is, an expandable branch in the tree. (?)

## How has this been tested?
It hasn't.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
