### PR TITLE
Navigation Block: Apply text-decoration support as CSS class

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -80,6 +80,21 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
+	return gutenberg_typography_generate_css_classes_and_styles( $typography_supports, $block_attributes );
+}
+
+/**
+ * Generates all the typography block support related CSS classes and inline
+ * styles. This allows block supports config to be passed manually such that
+ * individual support features can be opted out of while still easily generating
+ * classes and styles for other features.
+ *
+ * @param array $typography_supports Typography block support flags.
+ * @param array $block_attributes    Block's attributes.
+ *
+ * @return array Typography CSS classes and inline styles.
+ */
+function gutenberg_typography_generate_css_classes_and_styles( $typography_supports, $block_attributes ) {
 	$attributes = array();
 	$classes    = array();
 	$styles     = array();

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -18,3 +18,4 @@ export { useCustomSides } from './dimensions';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
+export { getTypographyClassesAndStyles } from './use-typography-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -13,3 +13,4 @@ import './font-size';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
+export { getTypographyClassesAndStyles } from './use-typography-props';

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { kebabCase } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getInlineStyles } from './style';
+import { getFontSizeClass } from '../components/font-sizes';
+
+// This utility is intended for use where the serialization of the typography
+// block support styles is being skipped for a block but the typography related
+// CSS classes & styles still need to be generated so they can be applied to
+// inner elements.
+
+/**
+ * Provides the CSS class names and inline styles for a block's typography
+ * support attributes.
+ *
+ * @param {Object} attributes            Block attributes.
+ * @param {Object} attributes.fontFamily Block attributes named font family selection.
+ * @param {Object} attributes.fontSize   Block attributes named font size selection.
+ * @param {Object} attributes.style      Block's styles attribute.
+ *
+ * @return {Object} Typography block support derived CSS classes & styles.
+ */
+export function getTypographyClassesAndStyles( {
+	fontFamily,
+	fontSize,
+	style,
+} ) {
+	const typographyStyles = style?.typography || {};
+	const fontFamilyClass = `has-${ kebabCase( fontFamily ) }-font-family`;
+	const fontSizeClass = getFontSizeClass( fontSize );
+
+	const className = classnames( {
+		[ fontFamilyClass ]: !! fontFamily,
+		[ fontSizeClass ]: !! fontSize,
+	} );
+
+	return {
+		className: className || undefined,
+		style: getInlineStyles( { typography: typographyStyles } ),
+	};
+}

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -9,6 +9,7 @@ export {
 	useColorProps as __experimentalUseColorProps,
 	useCustomSides as __experimentalUseCustomSides,
 	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
+	getTypographyClassesAndStyles as __experimentalGetTypographyClassesAndStyles,
 } from './hooks';
 export * from './components';
 export * from './utils';

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -98,7 +98,8 @@
 			"__experimentalFontWeight": true,
 			"__experimentalTextTransform": true,
 			"__experimentalFontFamily": true,
-			"__experimentalTextDecoration": true
+			"__experimentalTextDecoration": true,
+			"__experimentalSkipSerialization": true
 		},
 		"spacing": {
 			"blockGap": true,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -19,6 +19,7 @@ import {
 	ContrastChecker,
 	getColorClassName,
 	Warning,
+	__experimentalGetTypographyClassesAndStyles as getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -139,9 +140,19 @@ function Navigation( {
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
 
+	// Typography block support for the Navigation block skips serialization of
+	// classes and styles to allow text decoration to be handled differently.
+	// The following will collect and reapply other typography support while
+	// also clearing the normal text-decoration style and instead adding an
+	// additional CSS className.
+	const typographyProps = getTypographyClassesAndStyles( attributes );
+	const { textDecoration } = typographyProps.style;
+	const textDecorationClassName = `has-text-decoration-${ textDecoration }`;
+	typographyProps.style.textDecoration = undefined;
+
 	const blockProps = useBlockProps( {
 		ref: navRef,
-		className: classnames( className, {
+		className: classnames( className, typographyProps.className, {
 			[ `items-justified-${ attributes.itemsJustification }` ]: itemsJustification,
 			'is-vertical': orientation === 'vertical',
 			'is-responsive': 'never' !== overlayMenu,
@@ -155,10 +166,12 @@ function Navigation( {
 				'background-color',
 				backgroundColor?.slug
 			) ]: !! backgroundColor?.slug,
+			[ textDecorationClassName ]: !! textDecoration,
 		} ),
 		style: {
 			color: ! textColor?.slug && textColor?.color,
 			backgroundColor: ! backgroundColor?.slug && backgroundColor?.color,
+			...typographyProps.style,
 		},
 	} );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -295,8 +295,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$typography_supports = isset( $block->block_type->supports['typography'] ) ? $block->block_type->supports['typography'] : array();
 	$typography          = block_core_navigation_build_css_typography( $typography_supports, $attributes );
 
-	$colors     = block_core_navigation_build_css_colors( $attributes );
-	$classes    = array_merge(
+	$colors  = block_core_navigation_build_css_colors( $attributes );
+	$classes = array_merge(
 		$colors['css_classes'],
 		$typography['css_classes'],
 		( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) ? array( 'is-vertical' ) : array(),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -61,24 +61,15 @@ function block_core_navigation_build_css_colors( $attributes ) {
  * Build an array with CSS classes and inline styles defining the typography
  * styling which will be applied to the navigation markup in the front-end.
  *
- * @param  array $attributes Navigation block attributes.
+ * @param  array $typography_supports Block support flags for typography features.
+ * @param  array $attributes          Navigation block attributes.
+ *
  * @return array Typography CSS classes and inline styles.
  */
-function block_core_navigation_build_css_typography( $attributes ) {
-	// The following config defines with block supports we are interested in
-	// having CSS classes and styles automatically generated.
-	// We wish to only handle the text-decoration support and deprecated font
-	// size attribute separately.
-	$typography_supports = array(
-		'__experimentalFontFamily'     => true,
-		'fontSize'                     => true,
-		'__experimentalFontStyle'      => true,
-		'__experimentalFontWeight'     => true,
-		'__experimentalLetterSpacing'  => true,
-		'lineHeight'                   => true,
-		'__experimentalTextDecoration' => false, // Deliberately skipping to apply manual class.
-		'__experimentalTextTransform'  => true,
-	);
+function block_core_navigation_build_css_typography( $typography_supports, $attributes ) {
+	// Explicitly set the `__experimentalTextDecoration` flag to false so that
+	// the Navigation block can manually apply a CSS class.
+	$typography_supports['__experimentalTextDecoration'] = false;
 
 	$typography = gutenberg_typography_generate_css_classes_and_styles( $typography_supports, $attributes );
 	$classes    = array();
@@ -300,8 +291,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( empty( $inner_blocks ) ) {
 		return '';
 	}
+
+	$typography_supports = isset( $block->block_type->supports['typography'] ) ? $block->block_type->supports['typography'] : array();
+	$typography          = block_core_navigation_build_css_typography( $typography_supports, $attributes );
+
 	$colors     = block_core_navigation_build_css_colors( $attributes );
-	$typography = block_core_navigation_build_css_typography( $attributes );
 	$classes    = array_merge(
 		$colors['css_classes'],
 		$typography['css_classes'],

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -81,25 +81,7 @@
 		}
 	}
 
-	// Force links to inherit text decoration applied to navigation block.
-	// The extra selector adds specificity to ensure it works when user-set.
-	&[style*="text-decoration"] {
-		.wp-block-navigation-item,
-		.wp-block-navigation__submenu-container {
-			text-decoration: inherit;
-		}
-
-		a {
-			text-decoration: inherit;
-
-			&:focus,
-			&:active {
-				text-decoration: inherit;
-			}
-		}
-	}
-
-	&:not([class*="has-text-decoration"]):not([style*="text-decoration"]) {
+	&:not([class*="has-text-decoration"]) {
 		a {
 			text-decoration: none;
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -58,6 +58,29 @@
 		padding: 0;
 	}
 
+	// The following rules provide class based application of user selected text
+	// decoration via block supports.
+	&.has-text-decoration-underline .wp-block-navigation-item {
+		text-decoration: underline;
+	}
+
+	&.has-text-decoration-line-through .wp-block-navigation-item {
+		text-decoration: line-through;
+	}
+
+	&[class*="has-text-decoration"] {
+		.wp-block-navigation-item {
+			a {
+				text-decoration: inherit;
+
+				&:focus,
+				&:active {
+					text-decoration: inherit;
+				}
+			}
+		}
+	}
+
 	// Force links to inherit text decoration applied to navigation block.
 	// The extra selector adds specificity to ensure it works when user-set.
 	&[style*="text-decoration"] {
@@ -76,7 +99,7 @@
 		}
 	}
 
-	&:not([style*="text-decoration"]) {
+	&:not([class*="has-text-decoration"]):not([style*="text-decoration"]) {
 		a {
 			text-decoration: none;
 
@@ -138,7 +161,7 @@
 				flex-grow: 1;
 
 				// Without this, the changing to zero on hover-out can cause wrapping and
-				// result in an invinite hover/hover-out loop.
+				// result in an infinite hover/hover-out loop.
 				white-space: nowrap;
 
 				// Right-align the chevron in submenus.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -60,24 +60,21 @@
 
 	// The following rules provide class based application of user selected text
 	// decoration via block supports.
-	&.has-text-decoration-underline .wp-block-navigation-item {
+	&.has-text-decoration-underline .wp-block-navigation-item a {
 		text-decoration: underline;
+
+		&:focus,
+		&:active {
+			text-decoration: underline;
+		}
 	}
 
-	&.has-text-decoration-line-through .wp-block-navigation-item {
+	&.has-text-decoration-line-through .wp-block-navigation-item a {
 		text-decoration: line-through;
-	}
 
-	&[class*="has-text-decoration"] {
-		.wp-block-navigation-item {
-			a {
-				text-decoration: inherit;
-
-				&:focus,
-				&:active {
-					text-decoration: inherit;
-				}
-			}
+		&:focus,
+		&:active {
+			text-decoration: line-through;
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/34275

## Description

This PR switches the application of the text-decoration block support from an inline style to a CSS class for the Navigation block. It attempts to do this with a minimum of duplication of the logic to generate the non-text-decoration typography styles.

- Extracts typography support CSS class and inline style generation to a new function for dynamic blocks
    - This is now outside the filter applying them for block supports
    - The new function will accept an array reflecting the block supports config for typography
    - The above supports array will allow blocks to filter out a block support they wish to serialize styles for manually, in this case, `text-decoration`.
- Adds new `getTypographyClassesAndStyles` util function to collect classes and styles in the editor as per spacing support
- Updates the Navigation block to skip serialization of typography support so text-decoration can be handled differently
    - Navigation block now gets either `has-text-decoration-underline` or `has-text-decoration-line-through` classes.
    - Navigation block styles were updated to apply the relevant text decorations to `.wp-block-navigation-item` elements

## How has this been tested?

Checked that typography support continued to function for:
- Static blocks by opting into typography support for Group and Paragraph blocks and checking editor/frontend
- Dynamic blocks by confirming typography features for site title and tagline continue to function

Tested the navigation block correctly applies typography styling:
- Confirmed text decoration CSS class is added instead of inline style
- Confirmed remaining typography support features apply their usual CSS classes and inline styles
- Checked block editor, site editor and frontend


#### Testing Instructions

1. Create a post, add a navigation block, select it and add inner links and a search block
2. In the inspector controls sidebar, toggle on the text decoration option from the Typography panel
3. Select either of the `underline` or `line-through` options and confirm only the navigation item links display that decoration visually. i.e. the placeholder text in the search block should not reflect the selected text decoration
4. Add further blocks, submenus and links to the navigation block and ensure it displays correctly
5. Save the post and confirm correct display on the frontend
6. Switch to the site editor and add or edit a navigation block there
7. Confirm the navigation block behaves correctly

## Screenshots

| Before | After |
|---|---|
| <img width="1508" alt="Screen Shot 2021-11-02 at 2 28 24 pm" src="https://user-images.githubusercontent.com/60436221/139787040-65e7250d-2642-495e-bca5-2e9ebe8fedcb.png"> | <img width="1508" alt="Screen Shot 2021-11-02 at 2 27 20 pm" src="https://user-images.githubusercontent.com/60436221/139787057-1b178fcf-cb03-4046-a90c-8cdb287beaef.png"> |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
