### PR TITLE
Navigation: Fix dropdown indicator

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -23,7 +23,7 @@
 // The following rule affects the positioning of the dropdown arrow indicator.
 // On the frontend, this element is inline, which makes it look correct. In the editor,
 // the label is block, which causes the dropdown indicator to wrap onto a new line.
-// Therefore we set it to inline-block.
+// Therefore we explicitly set it to inline even in the block editor.
 .wp-block-navigation-item__label {
 	display: inline;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -20,6 +20,15 @@
 	}
 }
 
+// The following rule affects the positioning of the dropdown arrow indicator.
+// On the frontend, this element is inline, which makes it look correct. In the editor,
+// the label is block, which causes the dropdown indicator to wrap onto a new line.
+// Therefore we set it to inline-block.
+.wp-block-navigation-item__label {
+	display: inline-block;
+}
+
+
 /**
  * Submenus.
  */

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -25,7 +25,7 @@
 // the label is block, which causes the dropdown indicator to wrap onto a new line.
 // Therefore we set it to inline-block.
 .wp-block-navigation-item__label {
-	display: inline-block;
+	display: inline;
 }
 
 


### PR DESCRIPTION
## Description

Followup to #35859, apparently the rule was needed after all. Turns out the inline-block rule affected the positioning of the dropdown arrow:

<img width="725" alt="Screenshot 2021-11-01 at 09 07 40" src="https://user-images.githubusercontent.com/1204802/139641057-f15296bd-617f-4cbf-88ad-64c25afa5b40.png">

By restoring the rule, things look right again:

<img width="655" alt="Screenshot 2021-11-01 at 09 04 59" src="https://user-images.githubusercontent.com/1204802/139641079-85971851-e080-4c73-bf56-8b552f8f2566.png">

## How has this been tested?

Please test a navigation with dropdown menus and verify the icon indicator looks right in both editor and frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
