### PR TITLE
[Patterns]: Add a flag to hide patterns from UI

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1901,9 +1901,11 @@ const getAllAllowedPatterns = createSelector(
 	( state ) => {
 		const patterns = state.settings.__experimentalBlockPatterns;
 		const { allowedBlockTypes } = getSettings( state );
-		const parsedPatterns = patterns.map( ( { name } ) =>
-			__experimentalGetParsedPattern( state, name )
-		);
+		const parsedPatterns = patterns
+			.filter( ( { hideFromUI } ) => ! hideFromUI )
+			.map( ( { name } ) =>
+				__experimentalGetParsedPattern( state, name )
+			);
 		const allowedPatterns = parsedPatterns.filter( ( { blocks } ) =>
 			checkAllowListRecursive( blocks, allowedBlockTypes )
 		);

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1902,7 +1902,7 @@ const getAllAllowedPatterns = createSelector(
 		const patterns = state.settings.__experimentalBlockPatterns;
 		const { allowedBlockTypes } = getSettings( state );
 		const parsedPatterns = patterns
-			.filter( ( { hideFromUI } ) => ! hideFromUI )
+			.filter( ( { inserter = true } ) => !! inserter )
 			.map( ( { name } ) =>
 				__experimentalGetParsedPattern( state, name )
 			);

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -71,6 +71,7 @@ const {
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
 	__experimentalGetAllowedPatterns,
+	__experimentalGetParsedPattern,
 	__experimentalGetPatternsByBlockTypes,
 	__unstableGetClientIdWithClientIdsTree,
 	__unstableGetClientIdsTree,
@@ -3330,6 +3331,13 @@ describe( 'selectors', () => {
 						content:
 							'<!-- wp:test-block-b --><!-- /wp:test-block-b -->',
 					},
+					{
+						name: 'pattern-c',
+						title: 'pattern hidden from UI',
+						hideFromUI: true,
+						content:
+							'<!-- wp:test-block-a --><!-- /wp:test-block-a -->',
+					},
 				],
 			},
 		};
@@ -3348,6 +3356,77 @@ describe( 'selectors', () => {
 			expect(
 				__experimentalGetAllowedPatterns( state, 'block2' )
 			).toHaveLength( 0 );
+		} );
+		it( 'should return empty array if only patterns hidden from UI exist', () => {
+			expect(
+				__experimentalGetAllowedPatterns( {
+					blocks: { byClientId: {} },
+					blockListSettings: {},
+					settings: {
+						__experimentalBlockPatterns: [
+							{
+								name: 'pattern-c',
+								title: 'pattern hidden from UI',
+								hideFromUI: true,
+								content:
+									'<!-- wp:test-block-a --><!-- /wp:test-block-a -->',
+							},
+						],
+					},
+				} )
+			).toHaveLength( 0 );
+		} );
+	} );
+	describe( '__experimentalGetParsedPattern', () => {
+		const state = {
+			settings: {
+				__experimentalBlockPatterns: [
+					{
+						name: 'pattern-a',
+						title: 'pattern with a',
+						content: `<!-- wp:test-block-a --><!-- /wp:test-block-a -->`,
+					},
+					{
+						name: 'pattern-hidden-from-ui',
+						title: 'pattern hidden from UI',
+						hideFromUI: true,
+						content:
+							'<!-- wp:test-block-a --><!-- /wp:test-block-a --><!-- wp:test-block-b --><!-- /wp:test-block-b -->',
+					},
+				],
+			},
+		};
+		it( 'should return proper results when pattern does not exist', () => {
+			expect(
+				__experimentalGetParsedPattern( state, 'not there' )
+			).toBeNull();
+		} );
+		it( 'should return existing pattern properly parsed', () => {
+			const { name, blocks } = __experimentalGetParsedPattern(
+				state,
+				'pattern-a'
+			);
+			expect( name ).toEqual( 'pattern-a' );
+			expect( blocks ).toHaveLength( 1 );
+			expect( blocks[ 0 ] ).toEqual(
+				expect.objectContaining( {
+					name: 'core/test-block-a',
+				} )
+			);
+		} );
+		it( 'should return hidden from UI pattern when requested', () => {
+			const { name, blocks, hideFromUI } = __experimentalGetParsedPattern(
+				state,
+				'pattern-hidden-from-ui'
+			);
+			expect( name ).toEqual( 'pattern-hidden-from-ui' );
+			expect( hideFromUI ).toBeTruthy();
+			expect( blocks ).toHaveLength( 2 );
+			expect( blocks[ 0 ] ).toEqual(
+				expect.objectContaining( {
+					name: 'core/test-block-a',
+				} )
+			);
 		} );
 	} );
 	describe( '__experimentalGetPatternsByBlockTypes', () => {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3334,7 +3334,7 @@ describe( 'selectors', () => {
 					{
 						name: 'pattern-c',
 						title: 'pattern hidden from UI',
-						hideFromUI: true,
+						inserter: false,
 						content:
 							'<!-- wp:test-block-a --><!-- /wp:test-block-a -->',
 					},
@@ -3367,7 +3367,7 @@ describe( 'selectors', () => {
 							{
 								name: 'pattern-c',
 								title: 'pattern hidden from UI',
-								hideFromUI: true,
+								inserter: false,
 								content:
 									'<!-- wp:test-block-a --><!-- /wp:test-block-a -->',
 							},
@@ -3389,7 +3389,7 @@ describe( 'selectors', () => {
 					{
 						name: 'pattern-hidden-from-ui',
 						title: 'pattern hidden from UI',
-						hideFromUI: true,
+						inserter: false,
 						content:
 							'<!-- wp:test-block-a --><!-- /wp:test-block-a --><!-- wp:test-block-b --><!-- /wp:test-block-b -->',
 					},
@@ -3415,12 +3415,12 @@ describe( 'selectors', () => {
 			);
 		} );
 		it( 'should return hidden from UI pattern when requested', () => {
-			const { name, blocks, hideFromUI } = __experimentalGetParsedPattern(
+			const { name, blocks, inserter } = __experimentalGetParsedPattern(
 				state,
 				'pattern-hidden-from-ui'
 			);
 			expect( name ).toEqual( 'pattern-hidden-from-ui' );
-			expect( hideFromUI ).toBeTruthy();
+			expect( inserter ).toBeFalsy();
 			expect( blocks ).toHaveLength( 2 );
 			expect( blocks[ 0 ] ).toEqual(
 				expect.objectContaining( {


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/36084

Previously there was an implementation to control where patterns should appear with a `scope` property (similar to block variations), which was discussed and [decided to be removed](https://github.com/WordPress/gutenberg/pull/30471) and every pattern should be shown in inserter. The context for that was for patterns used in the experimental `BlockPatternSetup` component, which can suggest patterns in a Placeholder - see `Query Loop`.

Now with [Pattern block merged](https://github.com/WordPress/gutenberg/pull/33217), themes can create patterns for dealing with some issues like internationalized content etc.. and a similar flag for hiding such patterns is needed. 

In this PR I decided to add a `inserter` flag and make the filtering with this flag directly in `__experimentalGetAllowedPatterns` which is used in every place that we need to handle patterns and show them in UI. Patterns with the flag set to `true` can still be retrieved individually by `__experimentalGetParsedPattern`.


## Testing instructions
1. Everything with patterns should work as before
2. Add a pattern with `'inserter' => false` and observe that is not shown in any UI with pattern handling, like the inserter or the `BlockPatternSetup`.
3. Test with `Pattern` block by using a pattern with this flag and verify that is working properly and is not shown in any UI, like the Inserter