### PR TITLE
Fix inserter with block pattern categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -6,7 +6,7 @@ import { fromPairs } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useMemo, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { _x } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 
@@ -28,43 +28,52 @@ function BlockPatternsCategory( {
 		rootClientId
 	);
 
-	// Remove any empty categories
-	const populatedCategories = useMemo(
-		() =>
-			allCategories
-				.filter( ( category ) =>
-					allPatterns.some( ( pattern ) =>
-						pattern.categories?.includes( category.name )
-					)
-				)
-				.sort( ( { name: currentName }, { name: nextName } ) => {
-					if ( ! [ currentName, nextName ].includes( 'featured' ) ) {
-						return 0;
-					}
-					return currentName === 'featured' ? -1 : 1;
-				} ),
-		[ allPatterns, allCategories ]
+	const hasCategory = useCallback(
+		( pattern ) => {
+			if ( ! pattern.categories || ! pattern.categories.length ) {
+				return false;
+			}
+
+			return pattern.categories.some( ( cat ) =>
+				allCategories.some( ( category ) => category.name === cat )
+			);
+		},
+		[ allCategories ]
 	);
 
-	const patternCategory = selectedCategory
-		? selectedCategory
-		: populatedCategories[ 0 ];
+	// Remove any empty categories
+	const populatedCategories = useMemo( () => {
+		const categories = allCategories
+			.filter( ( category ) =>
+				allPatterns.some( ( pattern ) =>
+					pattern.categories?.includes( category.name )
+				)
+			)
+			.sort( ( { name: currentName }, { name: nextName } ) => {
+				if ( ! [ currentName, nextName ].includes( 'featured' ) ) {
+					return 0;
+				}
+				return currentName === 'featured' ? -1 : 1;
+			} );
 
-	useEffect( () => {
 		if (
-			allPatterns.some(
-				( pattern ) => getPatternIndex( pattern ) === Infinity
-			) &&
-			! populatedCategories.find(
+			allPatterns.some( ( pattern ) => ! hasCategory( pattern ) ) &&
+			! categories.find(
 				( category ) => category.name === 'uncategorized'
 			)
 		) {
-			populatedCategories.push( {
+			categories.push( {
 				name: 'uncategorized',
 				label: _x( 'Uncategorized' ),
 			} );
 		}
-	}, [ populatedCategories, allPatterns ] );
+
+		return categories;
+	}, [ allPatterns, allCategories ] );
+
+	const patternCategory = selectedCategory
+		? selectedCategory
+		: populatedCategories[ 0 ];
 
 	const getPatternIndex = useCallback(
 		( pattern ) => {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -28,7 +28,7 @@ function BlockPatternsCategory( {
 		rootClientId
 	);
 
-	const hasCategory = useCallback(
+	const hasRegisteredCategory = useCallback(
 		( pattern ) => {
 			if ( ! pattern.categories || ! pattern.categories.length ) {
 				return false;
@@ -57,7 +57,9 @@ function BlockPatternsCategory( {
 			} );
 
 		if (
-			allPatterns.some( ( pattern ) => ! hasCategory( pattern ) ) &&
+			allPatterns.some(
+				( pattern ) => ! hasRegisteredCategory( pattern )
+			) &&
 			! categories.find(
 				( category ) => category.name === 'uncategorized'
 			)


### PR DESCRIPTION
closes #27249 

Right now, if there are no registered pattern categories and a pattern available without any category, it breaks the patterns inserter. This PR fixes by improving the logic to add the "uncategorized" category.

**Testing instructions**

Add the following code somewhere:

```
remove_theme_support('core-block-patterns');
register_block_pattern(
	'skorasaurus/test-case-block-pattern',
	array(
		'title'       => __( 'a simple heading', 'what should this be' ),
		'description' => _x( 'mmm..cake', ' this is slang and has more nuance in english', ''),
		'content'     => '<!-- wp:heading -->
		<h2>The history of cake</h2>
		<!-- /wp:heading -->',
	)
);
```

 - Open the pattern inserter
 - The editor shouldn't break