### PR TITLE
Background Tools: Move background color settings to a different panel

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,6 +20,7 @@ export default function ColorPanel( {
 	clientId,
 	enableContrastChecking = true,
 	showTitle = true,
+	title,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -56,7 +56,7 @@ export default function ColorPanel( {
 	return (
 		<InspectorControls>
 			<PanelColorGradientSettings
-				title={ __( 'Color' ) }
+				title={ title }
 				initialOpen={ false }
 				settings={ settings }
 				showTitle={ showTitle }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -347,61 +347,78 @@ export function ColorEdit( props ) {
 	};
 
 	return (
-		<ColorPanel
-			enableContrastChecking={
-				// Turn on contrast checker for web only since it's not supported on mobile yet.
-				Platform.OS === 'web' && ! gradient && ! style?.color?.gradient
-			}
-			clientId={ props.clientId }
-			settings={ [
-				...( hasTextColor
-					? [
-							{
-								label: __( 'Text color' ),
-								onColorChange: onChangeColor( 'text' ),
-								colorValue: getColorObjectByAttributeValues(
-									solids,
-									textColor,
-									style?.color?.text
-								).color,
-							},
-					  ]
-					: [] ),
-				...( hasBackgroundColor || hasGradientColor
-					? [
-							{
-								label: __( 'Background color' ),
-								onColorChange: hasBackgroundColor
-									? onChangeColor( 'background' )
-									: undefined,
-								colorValue: getColorObjectByAttributeValues(
-									solids,
-									backgroundColor,
-									style?.color?.background
-								).color,
-								gradientValue,
-								onGradientChange: hasGradientColor
-									? onChangeGradient
-									: undefined,
-							},
-					  ]
-					: [] ),
-				...( hasLinkColor
-					? [
-							{
-								label: __( 'Link Color' ),
-								onColorChange: onChangeLinkColor,
-								colorValue: getLinkColorFromAttributeValue(
-									solids,
-									style?.elements?.link?.color?.text
-								),
-								clearable: !! style?.elements?.link?.color
-									?.text,
-							},
-					  ]
-					: [] ),
-			] }
-		/>
+		<>
+			<ColorPanel
+				enableContrastChecking={
+					// Turn on contrast checker for web only since it's not supported on mobile yet.
+					Platform.OS === 'web' &&
+					! gradient &&
+					! style?.color?.gradient
+				}
+				clientId={ props.clientId }
+				title={ __( 'Background' ) }
+				settings={ [
+					...( hasBackgroundColor || hasGradientColor
+						? [
+								{
+									label: __( 'Background color' ),
+									onColorChange: hasBackgroundColor
+										? onChangeColor( 'background' )
+										: undefined,
+									colorValue: getColorObjectByAttributeValues(
+										solids,
+										backgroundColor,
+										style?.color?.background
+									).color,
+									gradientValue,
+									onGradientChange: hasGradientColor
+										? onChangeGradient
+										: undefined,
+								},
+						  ]
+						: [] ),
+				] }
+			/>
+			<ColorPanel
+				enableContrastChecking={
+					// Turn on contrast checker for web only since it's not supported on mobile yet.
+					Platform.OS === 'web' &&
+					! gradient &&
+					! style?.color?.gradient
+				}
+				clientId={ props.clientId }
+				title={ __( 'Color' ) }
+				settings={ [
+					...( hasTextColor
+						? [
+								{
+									label: __( 'Text color' ),
+									onColorChange: onChangeColor( 'text' ),
+									colorValue: getColorObjectByAttributeValues(
+										solids,
+										textColor,
+										style?.color?.text
+									).color,
+								},
+						  ]
+						: [] ),
+					...( hasLinkColor
+						? [
+								{
+									label: __( 'Link Color' ),
+									onColorChange: onChangeLinkColor,
+									colorValue: getLinkColorFromAttributeValue(
+										solids,
+										style?.elements?.link?.color?.text
+									),
+									clearable: !! style?.elements?.link?.color
+										?.text,
+								},
+						  ]
+						: [] ),
+				] }
+			/>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Description
This is a first step towards https://github.com/WordPress/gutenberg/issues/16479. It moves the background color control to a separate panel. This is a precursor to https://github.com/WordPress/gutenberg/issues/24660.

## How has this been tested?
Using TwentyTwentyTwo

## Screenshots <!-- if applicable -->
<img width="941" alt="Screenshot 2021-11-01 at 15 40 03" src="https://user-images.githubusercontent.com/275961/139699230-83e59214-cca6-4948-a035-00f2cfcd202d.png">


## Types of changes
Breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
