### PR TITLE
Search: Add contextual defaults when inserted in Navigation block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -288,7 +288,9 @@ function navStripHTML( html ) {
 function LinkControlTransforms( { block, transforms, replace } ) {
 	return (
 		<div className="link-control-transform">
-			<h3 className="link-control-transform__subheading">Transform</h3>
+			<h3 className="link-control-transform__subheading">
+				{ __( 'Transform' ) }
+			</h3>
 			<div className="link-control-transform__items">
 				{ transforms.map( ( item, index ) => {
 					return (

--- a/packages/block-library/src/navigation-link/transforms.js
+++ b/packages/block-library/src/navigation-link/transforms.js
@@ -84,7 +84,11 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/search' ],
 			transform: () => {
-				return createBlock( 'core/search' );
+				return createBlock( 'core/search', {
+					showLabel: false,
+					buttonUseIcon: true,
+					buttonPosition: 'button-inside',
+				} );
 			},
 		},
 	],

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -14,7 +14,10 @@ import {
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseColorProps as useColorProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import {
 	ToolbarDropdownMenu,
 	ToolbarGroup,
@@ -58,6 +61,7 @@ export default function SearchEdit( {
 	setAttributes,
 	toggleSelection,
 	isSelected,
+	clientId,
 } ) {
 	const {
 		label,
@@ -72,6 +76,31 @@ export default function SearchEdit( {
 		style,
 	} = attributes;
 
+	const insertedInNavigationBlock = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName, wasBlockJustInserted } = select(
+				blockEditorStore
+			);
+			return (
+				!! getBlockParentsByBlockName( clientId, 'core/navigation' )
+					?.length && wasBlockJustInserted( clientId )
+			);
+		},
+		[ clientId ]
+	);
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
+		blockEditorStore
+	);
+	useEffect( () => {
+		if ( ! insertedInNavigationBlock ) return;
+		// This side-effect should not create an undo level.
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( {
+			showLabel: false,
+			buttonUseIcon: true,
+			buttonPosition: 'button-inside',
+		} );
+	}, [ insertedInNavigationBlock ] );
 	const borderRadius = style?.border?.radius;
 	const borderColor = style?.border?.color;
 	const borderProps = useBorderProps( attributes );


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/31127

This PR is an alternative of https://github.com/WordPress/gutenberg/pull/36026 and adds some defaults to the `Search` block, when inserted in `Navigation` block.

## Testing instructions
1. Insert `Search` block in a Navigation block and observe that gets the desired defaults
2. Transform a Navigation Link to `Search` and observe that still gets the desired defaults
3. Insert `Search` outside of `Navigation` and observe that has the base defaults
4. Verify that existing search blocks remain intact.


## Notes
I used `wasBlockJustInserted` selector, but in general I think this selector needs more study to make it work more reliably. I believe this works fine (as per my testing) for `Navigation` block, just because we can't have the `slash inserter` inside this block.

I tried adding the `Group` as another parent to check to apply these defaults but this works only when the `main and quick` inserters are used. `wasBlockJustInserted` updates its value in `INSERT_BLOCKS` action, but the `slash inserter`(block autocompleter) dispatches an `REPLACE_BLOCKS` action when a block is added. 


