### PR TITLE
Provide a way to manage wp_navigation posts from wp-admin

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -424,7 +424,7 @@ function gutenberg_register_navigation_post_type() {
 		'show_in_rest'          => true,
 		'map_meta_cap'          => true,
 		'rest_base'             => 'navigation',
-		'rest_controller_class' => 'WP_REST_Posts_Controller',
+		'rest_controller_class' => WP_REST_Posts_Controller::class,
 		'supports'              => array(
 			'title',
 			'editor',
@@ -455,8 +455,8 @@ function gutenberg_disable_block_editor_for_navigation_post_type( $value, $post_
 add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_for_navigation_post_type', 10, 2 );
 
 /**
- * This function disables content editor for wp_navigation type posts.
- * Content editor cannot correctly edit wp_navigation type posts.
+ * This callback disables content editor for wp_navigation type posts.
+ * Content editor cannot handle wp_navigation type posts correctly.
  *
  * @param WP_Post $post An instance of WP_Post class.
  */
@@ -470,3 +470,25 @@ function gutenberg_disable_content_editor_for_navigation_post_type( $post ) {
 }
 
 add_action( 'edit_form_after_title', 'gutenberg_disable_content_editor_for_navigation_post_type', 10, 1 );
+
+/**
+ * Fixes the label of the 'wp_navigation' admin menu entry.
+ */
+function gutenberg_fix_navigation_items_admin_menu_entry() {
+	global $submenu;
+	if ( ! isset( $submenu['themes.php'] ) ) {
+		return;
+	}
+	$post_type = get_post_type_object( 'wp_navigation' );
+	if ( ! $post_type ) {
+		return;
+	}
+	foreach ( $submenu['themes.php'] as $key => $submenu_entry ) {
+		if ( $post_type->labels->all_items === $submenu['themes.php'][ $key ][0] ) {
+			$submenu['themes.php'][ $key ][0] = $post_type->labels->menu_name; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+			return;
+		}
+	}
+}
+
+add_action( 'admin_menu', 'gutenberg_fix_navigation_items_admin_menu_entry' );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -436,7 +436,6 @@ function gutenberg_register_navigation_post_type() {
 }
 add_action( 'init', 'gutenberg_register_navigation_post_type' );
 
-
 /**
  * Disable block editor for wp_navigation type posts so they can be managed via the UI.
  *
@@ -455,3 +454,42 @@ function gutenberg_disable_block_editor_for_navigation_post_type( $value, $post_
 
 add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_for_navigation_post_type', 10, 2 );
 
+/**
+ * This function disables ability to edit wp_navigation posts via the UI.
+ * This is because the post editor doesn't correctly work with wp_navigation type posts.
+ *
+ * @param string $url Url of the post.
+ * @param integer $post_id Post ID.
+ *
+ * @return string
+ */
+function gutenberg_disable_edit_links_for_navigation_post_type($url, $post_id) {
+	$post = get_post($post_id);
+	if ( 'wp_navigation' !== $post->post_type ) {
+		return $url;
+	}
+	return 'javascript:void(0)';
+}
+
+add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_post_type', 10, 2);
+
+/**
+ * This function disables "Edit" row action for wp_navigation type posts.
+ * This is because the post editor doesn't correctly work with wp_navigation type posts.
+ *
+ * @param array $actions A list of supported row actions for the post.
+ * @param $post WP_Post object.
+ *
+ * @return array
+ */
+function gutenberg_disable_edit_row_action_for_navigation_post_type($actions, $post) {
+	$post = get_post($post);
+	if ( 'wp_navigation' !== $post->post_type ) {
+		return $actions;
+	}
+
+	unset($actions['edit']);
+	return $actions;
+}
+
+add_filter( 'post_row_actions', 'gutenberg_disable_edit_row_action_for_navigation_post_type', 10, 2);

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -464,8 +464,8 @@ add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_fo
  * @return string
  */
 function gutenberg_disable_edit_links_for_navigation_post_type( $url, $post_id ) {
-	$post = get_post( $post_id );
-	if ( 'wp_navigation' !== $post->post_type ) {
+	$post_type = get_post_type( $post_id );
+	if ( 'wp_navigation' !== $post_type ) {
 		return $url;
 	}
 
@@ -484,7 +484,8 @@ add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_p
  * @return array
  */
 function gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post ) {
-	if ( 'wp_navigation' !== $post->post_type ) {
+	$post_type = get_post_type( $post );
+	if ( 'wp_navigation' !== $post_type ) {
 		return $actions;
 	}
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -455,8 +455,10 @@ function gutenberg_disable_block_editor_for_navigation_post_type( $value, $post_
 add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_for_navigation_post_type', 10, 2 );
 
 /**
- * This callback disables content editor for wp_navigation type posts.
+ * This callback disables the content editor for wp_navigation type posts.
  * Content editor cannot handle wp_navigation type posts correctly.
+ * We cannot disable the "editor" feature in the wp_navigation's CPT definition
+ * because it disables the ability to save navigation blocks via REST API.
  *
  * @param WP_Post $post An instance of WP_Post class.
  */

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -455,42 +455,18 @@ function gutenberg_disable_block_editor_for_navigation_post_type( $value, $post_
 add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_for_navigation_post_type', 10, 2 );
 
 /**
- * This function disables ability to edit wp_navigation posts via the UI.
- * This is because the post editor doesn't correctly work with wp_navigation type posts.
+ * This function disables content editor for wp_navigation type posts.
+ * Content editor cannot correctly edit wp_navigation type posts.
  *
- * @param string  $url Url of the post.
- * @param integer $post_id Post ID.
- *
- * @return string
- */
-function gutenberg_disable_edit_links_for_navigation_post_type( $url, $post_id ) {
-	$post_type = get_post_type( $post_id );
-	if ( 'wp_navigation' !== $post_type ) {
-		return $url;
-	}
-
-	return 'javascript:void(0)';
-}
-
-add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_post_type', 10, 2 );
-
-/**
- * This function disables "Edit" row action for wp_navigation type posts.
- * This is because the post editor doesn't correctly work with wp_navigation type posts.
- *
- * @param array   $actions A list of supported row actions for the post.
  * @param WP_Post $post An instance of WP_Post class.
- *
- * @return array
  */
-function gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post ) {
+function gutenberg_disable_content_editor_for_navigation_post_type( $post ) {
 	$post_type = get_post_type( $post );
 	if ( 'wp_navigation' !== $post_type ) {
-		return $actions;
+		return;
 	}
 
-	unset( $actions['edit'] );
-	return $actions;
+	remove_post_type_support( $post_type, 'editor' );
 }
 
-add_filter( 'post_row_actions', 'gutenberg_disable_edit_row_action_for_navigation_post_type', 10, 2 );
+add_action( 'edit_form_after_title', 'gutenberg_disable_content_editor_for_navigation_post_type', 10, 1 );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -492,9 +492,9 @@ function gutenberg_enable_content_editor_for_navigation_post_type( $post ) {
 add_action( 'edit_form_after_editor', 'gutenberg_enable_content_editor_for_navigation_post_type', 10, 1 );
 
 /**
- * Fixes the label of the 'wp_navigation' admin menu entry.
+ * Rename the menu title from "All Navigation Menus" to "Navigation Menus".
  */
-function gutenberg_fix_navigation_items_admin_menu_entry() {
+function gutenberg_rename_navigation_menus_admin_menu_entry() {
 	global $submenu;
 	if ( ! isset( $submenu['themes.php'] ) ) {
 		return;
@@ -511,4 +511,4 @@ function gutenberg_fix_navigation_items_admin_menu_entry() {
 	}
 }
 
-add_action( 'admin_menu', 'gutenberg_fix_navigation_items_admin_menu_entry' );
+add_action( 'admin_menu', 'gutenberg_rename_navigation_menus_admin_menu_entry' );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -458,7 +458,7 @@ add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_fo
  * This function disables ability to edit wp_navigation posts via the UI.
  * This is because the post editor doesn't correctly work with wp_navigation type posts.
  *
- * @param string $url Url of the post.
+ * @param string  $url Url of the post.
  * @param integer $post_id Post ID.
  *
  * @return string
@@ -478,8 +478,8 @@ add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_p
  * This function disables "Edit" row action for wp_navigation type posts.
  * This is because the post editor doesn't correctly work with wp_navigation type posts.
  *
- * @param array $actions A list of supported row actions for the post.
- * @param $post WP_Post object.
+ * @param array   $actions A list of supported row actions for the post.
+ * @param WP_Post $post An instance of WP_Post class.
  *
  * @return array
  */

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -499,13 +499,16 @@ function gutenberg_rename_navigation_menus_admin_menu_entry() {
 	if ( ! isset( $submenu['themes.php'] ) ) {
 		return;
 	}
+
 	$post_type = get_post_type_object( 'wp_navigation' );
 	if ( ! $post_type ) {
 		return;
 	}
-	foreach ( $submenu['themes.php'] as $key => $submenu_entry ) {
-		if ( $post_type->labels->all_items === $submenu['themes.php'][ $key ][0] ) {
-			$submenu['themes.php'][ $key ][0] = $post_type->labels->menu_name; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+
+	$menu_title_index = 0;
+	foreach ( $submenu['themes.php'] as $key => $menu_item ) {
+		if ( $post_type->labels->all_items === $menu_item[ $menu_title_index ] ) {
+			$submenu['themes.php'][ $key ][ $menu_title_index ] = $post_type->labels->menu_name; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 			return;
 		}
 	}

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -472,6 +472,26 @@ function gutenberg_disable_content_editor_for_navigation_post_type( $post ) {
 add_action( 'edit_form_after_title', 'gutenberg_disable_content_editor_for_navigation_post_type', 10, 1 );
 
 /**
+ * This callback enables content editor for wp_navigation type posts.
+ * We need to enable it back because we disable it to hide
+ * the content editor for wp_navigation type posts.
+ *
+ * @see gutenberg_disable_content_editor_for_navigation_post_type
+ *
+ * @param WP_Post $post An instance of WP_Post class.
+ */
+function gutenberg_enable_content_editor_for_navigation_post_type( $post ) {
+	$post_type = get_post_type( $post );
+	if ( 'wp_navigation' !== $post_type ) {
+		return;
+	}
+
+	add_post_type_support( $post_type, 'editor' );
+}
+
+add_action( 'edit_form_after_editor', 'gutenberg_enable_content_editor_for_navigation_post_type', 10, 1 );
+
+/**
  * Fixes the label of the 'wp_navigation' admin menu entry.
  */
 function gutenberg_fix_navigation_items_admin_menu_entry() {

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -418,7 +418,7 @@ function gutenberg_register_navigation_post_type() {
 		'description'           => __( 'Navigation menus.', 'gutenberg' ),
 		'public'                => false,
 		'has_archive'           => false,
-		'show_ui'               => false,
+		'show_ui'               => true,
 		'show_in_menu'          => 'themes.php',
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,
@@ -435,3 +435,23 @@ function gutenberg_register_navigation_post_type() {
 	register_post_type( 'wp_navigation', $args );
 }
 add_action( 'init', 'gutenberg_register_navigation_post_type' );
+
+
+/**
+ * Disable block editor for wp_navigation type posts so they can be managed via the UI.
+ *
+ * @param bool   $value Whether the CPT supports block editor or not.
+ * @param string $post_type Post type.
+ *
+ * @return bool
+ */
+function gutenberg_disable_block_editor_for_navigation_post_type( $value, $post_type ) {
+	if ( 'wp_navigation' === $post_type ) {
+		return false;
+	}
+
+	return $value;
+}
+
+add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_for_navigation_post_type', 10, 2 );
+

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -483,7 +483,6 @@ add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_p
  * @return array
  */
 function gutenberg_disable_edit_row_action_for_navigation_post_type($actions, $post) {
-	$post = get_post($post);
 	if ( 'wp_navigation' !== $post->post_type ) {
 		return $actions;
 	}

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -463,15 +463,16 @@ add_filter( 'use_block_editor_for_post_type', 'gutenberg_disable_block_editor_fo
  *
  * @return string
  */
-function gutenberg_disable_edit_links_for_navigation_post_type($url, $post_id) {
-	$post = get_post($post_id);
+function gutenberg_disable_edit_links_for_navigation_post_type( $url, $post_id ) {
+	$post = get_post( $post_id );
 	if ( 'wp_navigation' !== $post->post_type ) {
 		return $url;
 	}
+
 	return 'javascript:void(0)';
 }
 
-add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_post_type', 10, 2);
+add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_post_type', 10, 2 );
 
 /**
  * This function disables "Edit" row action for wp_navigation type posts.
@@ -482,13 +483,13 @@ add_filter( 'get_edit_post_link', 'gutenberg_disable_edit_links_for_navigation_p
  *
  * @return array
  */
-function gutenberg_disable_edit_row_action_for_navigation_post_type($actions, $post) {
+function gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post ) {
 	if ( 'wp_navigation' !== $post->post_type ) {
 		return $actions;
 	}
 
-	unset($actions['edit']);
+	unset( $actions['edit'] );
 	return $actions;
 }
 
-add_filter( 'post_row_actions', 'gutenberg_disable_edit_row_action_for_navigation_post_type', 10, 2);
+add_filter( 'post_row_actions', 'gutenberg_disable_edit_row_action_for_navigation_post_type', 10, 2 );

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -7,66 +7,63 @@
 
 class WP_Navigation_Test extends WP_UnitTestCase {
 	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
-		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type(true, 'sample_post_type');
-		$this->assertTrue($filtered_result);
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, 'sample_post_type' );
+		$this->assertTrue( $filtered_result );
 	}
 
 	public function test_it_disables_block_editor_for_navigation_post_types() {
-		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type(true, 'wp_navigation');
-		$this->assertFalse($filtered_result);
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, 'wp_navigation' );
+		$this->assertFalse( $filtered_result );
 	}
 
 	public function test_it_doesnt_disable_edit_links_for_non_navigation_post_types() {
-		$post = $this->create_sample_post();
-		$url = 'someUrl';
-		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type($url, $post);
-		$this->assertSame($url, $filtered_url);
+		$post         = $this->create_sample_post();
+		$url          = 'someUrl';
+		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type( $url, $post );
+		$this->assertSame( $url, $filtered_url );
 	}
 
 	public function test_it_disables_edit_links_for_navigation_post_types() {
-		$post = $this->create_navigation_post();
-		$url = 'someUrl';
-		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type($url, $post);
-		$this->assertNotSame($url, $filtered_url);
-		$this->assertNotEmpty($filtered_url);
-		$this->assertIsString($filtered_url);
+		$post         = $this->create_navigation_post();
+		$url          = 'someUrl';
+		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type( $url, $post );
+		$this->assertNotSame( $url, $filtered_url );
+		$this->assertNotEmpty( $filtered_url );
+		$this->assertIsString( $filtered_url );
 	}
 
 	public function test_it_doesnt_remove_edit_row_action_for_non_navigation_post_types() {
-		$actions = [
+		$actions = array(
 			'edit' => 1,
-		];
+		);
 
-		$post = $this->create_sample_post();
+		$post             = $this->create_sample_post();
 		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
 		$this->assertSame( $actions, $filtered_actions );
 	}
 
 	public function test_it_removes_edit_row_action_for_navigation_post_types() {
-		$actions = [
+		$actions = array(
 			'edit' => 1,
-		];
+		);
 
-		$post = $this->create_navigation_post();
+		$post             = $this->create_navigation_post();
 		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
 		$this->assertSame( array(), $filtered_actions );
 	}
 
-	private function create_post($type)
-	{
-		$post = new WP_Post(new StdClass());
+	private function create_post( $type ) {
+		$post            = new WP_Post( new StdClass() );
 		$post->post_type = $type;
-		$post->filter = 'raw';
+		$post->filter    = 'raw';
 		return $post;
 	}
 
-	private function create_sample_post()
-	{
-		return $this->create_post('sample_post_type');
+	private function create_sample_post() {
+		 return $this->create_post( 'sample_post_type' );
 	}
 
-	private function create_navigation_post()
-	{
-		return $this->create_post('wp_navigation');
+	private function create_navigation_post() {
+		 return $this->create_post( 'wp_navigation' );
 	}
 }

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -9,8 +9,12 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
 
+	public function setUp() {
+		$this->enable_editor_support();
+	}
+
 	public function tearDown() {
-		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
+		$this->enable_editor_support();
 	}
 
 	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
@@ -41,6 +45,26 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->supports_block_editor() );
 	}
 
+	public function test_it_enables_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
+		$post = $this->create_navigation_post();
+		$this->assertFalse( $this->supports_block_editor() );
+
+		gutenberg_disable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( $this->supports_block_editor() );
+	}
+
+	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
+		$post = $this->create_non_navigation_post();
+		$this->assertFalse( $this->supports_block_editor() );
+
+		gutenberg_disable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertFalse( $this->supports_block_editor() );
+	}
+
 	private function create_post( $type ) {
 		$post            = new WP_Post( new StdClass() );
 		$post->post_type = $type;
@@ -58,5 +82,13 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 
 	private function supports_block_editor() {
 		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+
+	private function enable_editor_support() {
+		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+
+	private function disable_editor_support() {
+		remove_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 }

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -60,10 +60,10 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	private function create_sample_post() {
-		 return $this->create_post( 'sample_post_type' );
+		return $this->create_post( 'sample_post_type' );
 	}
 
 	private function create_navigation_post() {
-		 return $this->create_post( 'wp_navigation' );
+		return $this->create_post( 'wp_navigation' );
 	}
 }

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -6,50 +6,39 @@
  */
 
 class WP_Navigation_Test extends WP_UnitTestCase {
+	const NAVIGATION_POST_TYPE     = 'wp_navigation';
+	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+
+	public function tearDown() {
+		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+
 	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
-		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, 'sample_post_type' );
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, static::NON_NAVIGATION_POST_TYPE );
 		$this->assertTrue( $filtered_result );
 	}
 
 	public function test_it_disables_block_editor_for_navigation_post_types() {
-		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, 'wp_navigation' );
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type( true, static::NAVIGATION_POST_TYPE );
 		$this->assertFalse( $filtered_result );
 	}
 
-	public function test_it_doesnt_disable_edit_links_for_non_navigation_post_types() {
-		$post         = $this->create_sample_post();
-		$url          = 'someUrl';
-		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type( $url, $post );
-		$this->assertSame( $url, $filtered_url );
+	public function test_it_doesnt_disable_content_editor_for_non_navigation_type_posts() {
+		$post = $this->create_non_navigation_post();
+		$this->assertTrue( $this->supports_block_editor() );
+
+		gutenberg_disable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( $this->supports_block_editor() );
 	}
 
-	public function test_it_disables_edit_links_for_navigation_post_types() {
-		$post         = $this->create_navigation_post();
-		$url          = 'someUrl';
-		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type( $url, $post );
-		$this->assertNotSame( $url, $filtered_url );
-		$this->assertNotEmpty( $filtered_url );
-		$this->assertIsString( $filtered_url );
-	}
+	public function test_it_disables_content_editor_for_navigation_type_posts() {
+		$post = $this->create_navigation_post();
+		$this->assertTrue( $this->supports_block_editor() );
 
-	public function test_it_doesnt_remove_edit_row_action_for_non_navigation_post_types() {
-		$actions = array(
-			'edit' => 1,
-		);
+		gutenberg_disable_content_editor_for_navigation_post_type( $post );
 
-		$post             = $this->create_sample_post();
-		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
-		$this->assertSame( $actions, $filtered_actions );
-	}
-
-	public function test_it_removes_edit_row_action_for_navigation_post_types() {
-		$actions = array(
-			'edit' => 1,
-		);
-
-		$post             = $this->create_navigation_post();
-		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
-		$this->assertSame( array(), $filtered_actions );
+		$this->assertFalse( $this->supports_block_editor() );
 	}
 
 	private function create_post( $type ) {
@@ -59,11 +48,15 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 		return $post;
 	}
 
-	private function create_sample_post() {
-		return $this->create_post( 'sample_post_type' );
+	private function create_non_navigation_post() {
+		return $this->create_post( static::NON_NAVIGATION_POST_TYPE );
 	}
 
 	private function create_navigation_post() {
-		return $this->create_post( 'wp_navigation' );
+		return $this->create_post( static::NAVIGATION_POST_TYPE );
+	}
+
+	private function supports_block_editor() {
+		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 }

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This class is supposed to test the functionality of the navigation.php
+ * This class tests the functionality of block navigation
  *
  * @package Gutenberg
  */

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -50,7 +50,7 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 		$post = $this->create_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 
-		gutenberg_disable_content_editor_for_navigation_post_type( $post );
+		gutenberg_enable_content_editor_for_navigation_post_type( $post );
 
 		$this->assertTrue( $this->supports_block_editor() );
 	}
@@ -60,7 +60,7 @@ class WP_Navigation_Test extends WP_UnitTestCase {
 		$post = $this->create_non_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 
-		gutenberg_disable_content_editor_for_navigation_post_type( $post );
+		gutenberg_enable_content_editor_for_navigation_post_type( $post );
 
 		$this->assertFalse( $this->supports_block_editor() );
 	}

--- a/phpunit/navigation-test.php
+++ b/phpunit/navigation-test.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This class is supposed to test the functionality of the navigation.php
+ *
+ * @package Gutenberg
+ */
+
+class WP_Navigation_Test extends WP_UnitTestCase {
+	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type(true, 'sample_post_type');
+		$this->assertTrue($filtered_result);
+	}
+
+	public function test_it_disables_block_editor_for_navigation_post_types() {
+		$filtered_result = gutenberg_disable_block_editor_for_navigation_post_type(true, 'wp_navigation');
+		$this->assertFalse($filtered_result);
+	}
+
+	public function test_it_doesnt_disable_edit_links_for_non_navigation_post_types() {
+		$post = $this->create_sample_post();
+		$url = 'someUrl';
+		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type($url, $post);
+		$this->assertSame($url, $filtered_url);
+	}
+
+	public function test_it_disables_edit_links_for_navigation_post_types() {
+		$post = $this->create_navigation_post();
+		$url = 'someUrl';
+		$filtered_url = gutenberg_disable_edit_links_for_navigation_post_type($url, $post);
+		$this->assertNotSame($url, $filtered_url);
+		$this->assertNotEmpty($filtered_url);
+		$this->assertIsString($filtered_url);
+	}
+
+	public function test_it_doesnt_remove_edit_row_action_for_non_navigation_post_types() {
+		$actions = [
+			'edit' => 1,
+		];
+
+		$post = $this->create_sample_post();
+		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
+		$this->assertSame( $actions, $filtered_actions );
+	}
+
+	public function test_it_removes_edit_row_action_for_navigation_post_types() {
+		$actions = [
+			'edit' => 1,
+		];
+
+		$post = $this->create_navigation_post();
+		$filtered_actions = gutenberg_disable_edit_row_action_for_navigation_post_type( $actions, $post );
+		$this->assertSame( array(), $filtered_actions );
+	}
+
+	private function create_post($type)
+	{
+		$post = new WP_Post(new StdClass());
+		$post->post_type = $type;
+		$post->filter = 'raw';
+		return $post;
+	}
+
+	private function create_sample_post()
+	{
+		return $this->create_post('sample_post_type');
+	}
+
+	private function create_navigation_post()
+	{
+		return $this->create_post('wp_navigation');
+	}
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The goal of this PR is to disable block editor for wp_navigation type posts (because it doesn't work with wp_navigation posts) and provide a way to mange wp_navigation posts from wp-admin.
Fixes https://github.com/WordPress/gutenberg/issues/36036 (?).


## How has this been tested?
1. Create a new post using the block editor.
2. Add a new navigation block.
3. Create a new menu in your navigation block, add some menu items to it.
4. Save the post.
5. Go to `Appearance -> Navigation Menus` page.
6. Click on the post to edit it.
7.  Make sure that you cannot edit the post's content (i.e., your menu). Content editor should not be visible.

## Screenshots <!-- if applicable -->

![Screenshot 2021-11-03 at 15 37 31](https://user-images.githubusercontent.com/43744263/140081306-d9028138-fec0-4bf3-8d4e-cc5db63a31f9.png)

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
