### PR TITLE
Try additional CSS selectors for Button block styles

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -424,6 +424,13 @@ class WP_Theme_JSON_Gutenberg {
 				self::$blocks_metadata[ $block_name ]['duotone'] = $block_type->supports['color']['__experimentalDuotone'];
 			}
 
+			if (
+				isset( $block_type->supports['__experimentalAdditionalSelectors'] ) &&
+				is_string( $block_type->supports['__experimentalAdditionalSelectors'] )
+			) {
+				self::$blocks_metadata[ $block_name ]['selector'] .= ', ' . $block_type->supports['__experimentalAdditionalSelectors'];
+			}
+
 			// Assign defaults, then overwrite those that the block sets by itself.
 			// If the block selector is compounded, will append the element to each
 			// individual block selector.

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -77,7 +77,8 @@
 			"radius": true,
 			"__experimentalSkipSerialization": true
 		},
-		"__experimentalSelector": ".wp-block-button__link"
+		"__experimentalSelector": ".wp-block-button__link",
+		"__experimentalAdditionalSelectors": ".wp-block-search__button, .wp-block-file .wp-block-file__button"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -18,8 +18,9 @@
 		background: #32373c;
 		border-radius: 2em;
 		color: $white;
-		font-size: 0.8em;
-		padding: 0.5em 1em;
+		font-size: inherit;
+		font-family: inherit;
+		padding: calc(0.667em + 2px) calc(1.333em + 2px); // Make padding match button block padding.
 	}
 
 	a.wp-block-file__button {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,13 +1,14 @@
 .wp-block-search__button {
 	background: #f7f7f7;
-	border: 1px solid #ccc;
-	padding: 0.375em 0.625em;
+	border: none;
 	color: #32373c;
-	margin-left: 0.625em;
-	word-break: normal;
+	cursor: pointer;
 	font-size: inherit;
 	font-family: inherit;
 	line-height: inherit;
+	margin-left: 0.625em;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px); // Make padding match button block padding.
+	word-break: normal;
 
 	&.has-icon {
 		line-height: 0;
@@ -62,7 +63,7 @@
 	}
 
 	.wp-block-search__button {
-		padding: 0.125em 0.5em;
+		padding: calc(0.667em - 2px) calc(1.333em - 2px); // Make padding match button block padding, minus the padding from being placed inside the search wrapper.
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In Twenty Twenty-Two, we want to style the buttons in the [Search block](https://github.com/WordPress/twentytwentytwo/issues/11) and [File block](https://github.com/WordPress/twentytwentytwo/issues/101), and we want them to be consistent with the button block styling. This might ideally be done via theme.json in the future, but needs more consideration (see https://github.com/WordPress/gutenberg/issues/29167).

We don't want to write CSS to target these buttons because those styles would not be configurable via global styles. So I had a different idea — output additional selectors to the same CSS declaration generated from theme.json's `styles.blocks.core/button`, to target the buttons inside the Search and File block. 

This PR does two main things:
- Adds a new block supports key to the Button block called "__experimentalAdditionalSelectors". The name could use some work. Global styles checks for this support key and if it exists, appends its value to the primary selector.
- Makes some changes to the default CSS for Search block and File block to match the default button block styling

Questions
- Does this idea make sense?
- Could we make this opt in, and the additional selectors configurable in theme.json on a per block basis?
 
## How has this been tested?
- Activate 2022
- Use this testing content (you will probably need to replace the File block's reference): https://gist.github.com/jffng/263436360988105ab73c35effd494fe0
- Verify the Search and File buttons appear with the same styles as the default Block button
- Verify you can still change the color of the search button via the post editor.

## Screenshots <!-- if applicable -->
Before | After
-------- | --------
<img width="739" alt="Screen Shot 2021-11-01 at 6 37 25 PM" src="https://user-images.githubusercontent.com/5375500/139751162-149eef29-9b48-49c2-9529-4cbde1014416.png"> | <img width="759" alt="Screen Shot 2021-11-01 at 6 34 53 PM" src="https://user-images.githubusercontent.com/5375500/139751213-28952f35-cc9d-4ccf-a46a-a3997cbf09a4.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
