### PR TITLE
Mark Post Comments as stable and Comments Query Loop as experimental

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -141,8 +141,6 @@ export const __experimentalGetCoreBlocks = () => [
 	code,
 	column,
 	columns,
-	commentTemplate,
-	commentsQueryLoop,
 	cover,
 	embed,
 	file,
@@ -161,6 +159,7 @@ export const __experimentalGetCoreBlocks = () => [
 	pageList,
 	pattern,
 	postAuthor,
+	postComments,
 	postContent,
 	postDate,
 	postExcerpt,
@@ -242,6 +241,8 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 					// Full Site Editing blocks.
 					...( enableFSEBlocks
 						? [
+								commentTemplate,
+								commentsQueryLoop,
 								postComment,
 								postCommentAuthor,
 								postCommentAuthorAvatar,
@@ -249,7 +250,6 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postCommentDate,
 								postCommentEdit,
 								postCommentReplyLink,
-								postComments,
 								postCommentsCount,
 								postCommentsForm,
 								postCommentsLink,


### PR DESCRIPTION
## Description

Follows https://github.com/WordPress/gutenberg/pull/35979.
Addresses https://github.com/WordPress/gutenberg/pull/35979#issuecomment-956540014 and https://github.com/WordPress/gutenberg/pull/35979#issuecomment-956681949.

- Marks the Post Comments block as stable. This means it will be included in WP 5.9. This is the minimum that Twenty Twenty-two requires.
- Marks the Comments Query Loop block and Comment Template block as experiemntal. This means it will only be available in the Gutenberg plugin and not included in WP 5.9.

## How has this been tested?

1. Load the site editor. Post Comments, Comments Query Loop and Comment Template should call be available for use.
2. Set `GUTENBERG_PHASE` to 1 in `package.json`.
3. Load the site editor. Only Post Comments should be available for use. 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->