### PR TITLE
theme.json docs: add missing settings & styles

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -169,6 +169,9 @@ The settings section has the following structure:
 {
 	"version": 1,
 	"settings": {
+		"border": {
+			"customRadius": false
+		},
 		"color": {
 			"custom": true,
 			"customDuotone": true,
@@ -238,6 +241,7 @@ The settings section has the following structure:
 			"wideSize": "1000px"
 		},
 		"spacing": {
+			"blockGap": null,
 			"customMargin": false,
 			"customPadding": false,
 			"units": [ "px", "em", "rem", "vh", "vw" ]
@@ -246,12 +250,13 @@ The settings section has the following structure:
 			"customFontSize": true,
 			"customLineHeight": false,
 			"dropCap": true,
+			"fontFamilies": [],
+			"fontSizes": [],
 			"fontStyle": true,
 			"fontWeight": true,
+			"letteSpacing": true,
 			"textDecoration": true,
-			"textTransform": true,
-			"fontFamilies": [],
-			"fontSizes": []
+			"textTransform": true
 		},
 		"blocks": {
 			"core/paragraph": {

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -616,6 +616,9 @@ Each block declares which style properties it exposes via the [block supports me
 {
 	"version": 1,
 	"styles": {
+		"border": {
+			"radius": "value"
+		},
 		"color": {
 			"background": "value",
 			"gradient": "value",
@@ -641,6 +644,7 @@ Each block declares which style properties it exposes via the [block supports me
 		},
 		"elements": {
 			"link": {
+				"border": {},
 				"color": {},
 				"spacing": {},
 				"typography": {}
@@ -654,6 +658,7 @@ Each block declares which style properties it exposes via the [block supports me
 		},
 		"blocks": {
 			"core/group": {
+				"border": {},
 				"color": {},
 				"spacing": {},
 				"typography": {},
@@ -690,6 +695,9 @@ Each block declares which style properties it exposes via the [block supports me
 			"gradient": "value",
 			"text": "value"
 		},
+		"filter": {
+			"duotone": "value"
+		},
 		"spacing": {
 			"blockGap": "value",
 			"margin": {
@@ -710,6 +718,7 @@ Each block declares which style properties it exposes via the [block supports me
 			"fontSize": "value",
 			"fontStyle": "value",
 			"fontWeight": "value",
+			"letterSpacing": "value",
 			"lineHeight": "value",
 			"textDecoration": "value",
 			"textTransform": "value"


### PR DESCRIPTION
This PR updates the docs to add the undocumented settings & styles.