### PR TITLE
Site Editor: Enable the "Save" keyboard shortcut

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -240,7 +240,11 @@ function Editor( { initialSettings, onError } ) {
 																	) }
 																</Notice>
 															) }
-														<KeyboardShortcuts />
+														<KeyboardShortcuts
+															openEntitiesSavedStates={
+																openEntitiesSavedStates
+															}
+														/>
 													</>
 												}
 												actions={

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -18,7 +18,11 @@ import { store as editSiteStore } from '../../store';
 import { SIDEBAR_BLOCK } from '../sidebar/constants';
 import { STORE_NAME } from '../../store/constants';
 
-function KeyboardShortcuts() {
+function KeyboardShortcuts( { openEntitiesSavedStates } ) {
+	const {
+		__experimentalGetDirtyEntityRecords,
+		isSavingEntityRecord,
+	} = useSelect( coreStore );
 	const isListViewOpen = useSelect(
 		( select ) => select( editSiteStore ).isListViewOpened(),
 		[]
@@ -35,6 +39,20 @@ function KeyboardShortcuts() {
 	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
 		interfaceStore
 	);
+
+	useShortcut( 'core/edit-site/save', ( event ) => {
+		event.preventDefault();
+
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		const isDirty = !! dirtyEntityRecords.length;
+		const isSaving = dirtyEntityRecords.some( ( record ) =>
+			isSavingEntityRecord( record.kind, record.name, record.key )
+		);
+
+		if ( ! isSaving && isDirty ) {
+			openEntitiesSavedStates();
+		}
+	} );
 
 	useShortcut( 'core/edit-site/undo', ( event ) => {
 		undo();
@@ -64,10 +82,21 @@ function KeyboardShortcuts() {
 
 	return null;
 }
+
 function KeyboardShortcutsRegister() {
 	// Registering the shortcuts
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 	useEffect( () => {
+		registerShortcut( {
+			name: 'core/edit-site/save',
+			category: 'global',
+			description: __( 'Save site editor changes.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 's',
+			},
+		} );
+
 		registerShortcut( {
 			name: 'core/edit-site/undo',
 			category: 'global',

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -90,7 +90,7 @@ function KeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/edit-site/save',
 			category: 'global',
-			description: __( 'Save site editor changes.' ),
+			description: __( 'Save your changes.' ),
 			keyCombination: {
 				modifier: 'primary',
 				character: 's',


### PR DESCRIPTION
## Description
PR adds the global "Save" shortcut to the site editor.

The shortcut opens the saving process rather than saving everything. It matches the "Save" button behavior.

Fixes #29642.

## How has this been tested?
1. Go to Appearance -> Editor <sup>(beta)</sup>
2. Edit the template.
3. Use <kbd>CMD</kbd>/<kbd>CTRL</kbd>+<kbd>s</kbd> to open saving process panel.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/139830422-05399531-4ef9-4a3f-8024-137b5a128b92.mp4

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
