### PR TITLE
Docs: theme.json - fix typo

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -254,7 +254,7 @@ The settings section has the following structure:
 			"fontSizes": [],
 			"fontStyle": true,
 			"fontWeight": true,
-			"letteSpacing": true,
+			"letterSpacing": true,
 			"textDecoration": true,
 			"textTransform": true
 		},


### PR DESCRIPTION
## Description
Fixes typo: `letteSpacing` => `letterSpacing`