### PR TITLE
Block Library: Fix incorrect attributes definitions

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -17,6 +17,7 @@
 			"type": "array"
 		},
 		"templateLock": {
+			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -67,6 +67,7 @@
 			"type": "array"
 		},
 		"templateLock": {
+			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -12,6 +12,7 @@
 			"default": "div"
 		},
 		"templateLock": {
+			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes the following schema violation for `block.json` files reported in #35902:

-  Column block: templateLock - type missing
- Cover block: templateLock - type missing
-  Group block: templateLock - type missing