### PR TITLE
Site Editor: Change ToolsMoreMenuGroup slot-fill name

### DIFF
--- a/packages/edit-site/src/components/header/tools-more-menu-group/index.js
+++ b/packages/edit-site/src/components/header/tools-more-menu-group/index.js
@@ -10,7 +10,7 @@ import { createSlotFill, MenuGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
-	'ToolsMoreMenuGroup'
+	'EditSiteToolsMoreMenuGroup'
 );
 
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (


### PR DESCRIPTION
## Description
Changes `ToolsMoreMenuGroup` SlotFill name to `EditSiteToolsMoreMenuGroup`. This will help us to avoid collision with the edit post packages' `ToolsMoreMenuGroup`.

We need package-specific SlotFill to correctly add the "Keyboard shortcuts" and "Welcome Guide" modal menu items.'

Required for #21245 and #32844

## How has this been tested?
1. Got to Appearance -> Editor.
2. Click on the "More tools and Options" button.
3. Only the "Export" menu item should be visible in the Tools group.

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-02 at 18 38 56](https://user-images.githubusercontent.com/240569/139869072-eb6f310d-0e82-4a29-b7e0-a48d6a780b90.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
