### PR TITLE
Update `theme.json` schema migrations

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -289,13 +289,14 @@ class WP_Theme_JSON_Gutenberg {
 		// The old format is not meant to be ported to core.
 		// We can remove it at that point.
 		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V0::parse( $theme_json );
+			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
 		}
 
-		// Provide backwards compatibility for settings that did not land in 5.8
-		// and have had their `custom` prefixed removed since.
+		// Provide backwards compatibility for settings that only existed in the plugin,
+		// they did not land in 5.8, and have had their `custom` prefixed removed since.
+		// This does not need to be ported to WordPress core.
 		if ( 1 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V1::parse( $theme_json );
+			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
 		}
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
@@ -1437,13 +1438,13 @@ class WP_Theme_JSON_Gutenberg {
 		$sanitized = array();
 
 		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V0::parse( $theme_json );
+			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
 		}
 
 		// Provide backwards compatibility for settings that did not land in 5.8
 		// and have had their `custom` prefixed removed since.
 		if ( 1 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V1::parse( $theme_json );
+			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
 		}
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -286,18 +286,7 @@ class WP_Theme_JSON_Gutenberg {
 			$origin = 'theme';
 		}
 
-		// The old format is not meant to be ported to core.
-		// We can remove it at that point.
-		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
-		}
-
-		// Provide backwards compatibility for settings that only existed in the plugin,
-		// they did not land in 5.8, and have had their `custom` prefixed removed since.
-		// This does not need to be ported to WordPress core.
-		if ( 1 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
-		}
+		$theme_json = self::migrate( $theme_json );
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
 		$valid_element_names = array_keys( self::ELEMENTS );
@@ -314,6 +303,27 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Function that migrates a given theme.json structure to the last version.
+	 *
+	 * @param array $theme_json The structure to migrate.
+	 *
+	 * @return array The structure in the last version.
+	 */
+	private static function migrate( $theme_json ) {
+		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
+			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
+		}
+
+		// Provide backwards compatibility for settings that did not land in 5.8
+		// and have had their `custom` prefixed removed since.
+		if ( 1 === $theme_json['version'] ) {
+			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
+		}
+
+		return $theme_json;
 	}
 
 	/**
@@ -1437,15 +1447,7 @@ class WP_Theme_JSON_Gutenberg {
 	public static function remove_insecure_properties( $theme_json ) {
 		$sanitized = array();
 
-		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
-		}
-
-		// Provide backwards compatibility for settings that did not land in 5.8
-		// and have had their `custom` prefixed removed since.
-		if ( 1 === $theme_json['version'] ) {
-			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
-		}
+		$theme_json = self::migrate( $theme_json );
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
 		$valid_element_names = array_keys( self::ELEMENTS );

--- a/lib/class-wp-theme-json-schema-v0-to-v1.php
+++ b/lib/class-wp-theme-json-schema-v0-to-v1.php
@@ -10,7 +10,7 @@
  * Class that implements a WP_Theme_JSON_Schema to convert
  * a given structure in v0 schema to the latest one.
  */
-class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
+class WP_Theme_JSON_Schema_V0_To_V1 implements WP_Theme_JSON_Schema {
 
 	/**
 	 * How to address all the blocks
@@ -128,7 +128,7 @@ class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
 	 *
 	 * @return array Data in the latest schema.
 	 */
-	public static function parse( $old ) {
+	public static function migrate( $old ) {
 		// Copy everything.
 		$new = $old;
 
@@ -140,7 +140,7 @@ class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
 			$new['styles'] = self::process_styles( $old['styles'] );
 		}
 
-		$new['version'] = WP_Theme_JSON_Gutenberg::LATEST_SCHEMA;
+		$new['version'] = 1;
 
 		return $new;
 	}
@@ -184,16 +184,6 @@ class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
 			array( 'custom' ),
 		);
 
-		$renamed_paths = array(
-			'border.customColor'               => 'border.color',
-			'border.customStyle'               => 'border.style',
-			'border.customWidth'               => 'border.width',
-			'typography.customFontStyle'       => 'typography.fontStyle',
-			'typography.customFontWeight'      => 'typography.fontWeight',
-			'typography.customTextDecorations' => 'typography.textDecoration',
-			'typography.customTextTransforms'  => 'typography.textTransform',
-		);
-
 		// 'defaults' settings become top-level.
 		if ( isset( $settings[ self::ALL_BLOCKS_NAME ] ) ) {
 			$new = $settings[ self::ALL_BLOCKS_NAME ];
@@ -229,18 +219,6 @@ class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
 			return $new;
 		}
 
-		// Process any renamed/moved paths within settings.
-		foreach ( $renamed_paths as $original => $renamed ) {
-			$original_path = explode( '.', $original );
-			$renamed_path  = explode( '.', $renamed );
-			$current_value = _wp_array_get( $new, $original_path, null );
-
-			if ( null !== $current_value ) {
-				gutenberg_experimental_set( $new, $renamed_path, $current_value );
-				self::unset_setting_by_path( $new, $original_path );
-			}
-		}
-
 		/*
 		 * At this point, it only contains block's data.
 		 * However, some block data we need to consolidate
@@ -274,24 +252,6 @@ class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
 		}
 
 		return $new;
-	}
-
-	/**
-	 * Removes a property from within the provided settings by its path.
-	 *
-	 * @param array $settings Reference to the current settings array.
-	 * @param array $path Path to the property to be removed.
-	 *
-	 * @return void
-	 */
-	private static function unset_setting_by_path( &$settings, $path ) {
-		$tmp_settings = &$settings; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$last_key     = array_pop( $path );
-		foreach ( $path as $key ) {
-			$tmp_settings = &$tmp_settings[ $key ];
-		}
-
-		unset( $tmp_settings[ $last_key ] );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-schema-v0-to-v1.php
+++ b/lib/class-wp-theme-json-schema-v0-to-v1.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
- * a given structure in v0 schema to the latest one.
+ * Class that implements a WP_Theme_JSON_Schema migration.
  *
  * @package gutenberg
  */
 
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
- * a given structure in v0 schema to the latest one.
+ * Class that migrates a given structure in v0 schema to one
+ * that follows the v1 schema.
  */
 class WP_Theme_JSON_Schema_V0_To_V1 implements WP_Theme_JSON_Schema {
 
@@ -27,106 +26,63 @@ class WP_Theme_JSON_Schema_V0_To_V1 implements WP_Theme_JSON_Schema {
 	const ROOT_BLOCK_NAME = 'root';
 
 	/**
-	 * Data schema of each block within a theme.json.
+	 * Converts a v0 data structure into a v1 one.
 	 *
-	 * Example:
+	 * It expects input data to come in v0 form:
 	 *
 	 * {
-	 *   'block-one': {
-	 *     'styles': {
-	 *       'color': {
-	 *         'background': 'color'
-	 *       }
-	 *     },
-	 *     'settings': {
-	 *       'color': {
-	 *         'custom': true
-	 *       }
+	 *   'root': {
+	 *     'settings': { ... },
+	 *     'styles': { ... }
+	 *   }
+	 *   'core/paragraph': {
+	 *     'styles': { ... },
+	 *     'settings': { ... }
+	 *   },
+	 *   'core/heading/h1': {
+	 *     'settings': { ... }
+	 *     'styles': { ... }
+	 *   },
+	 *   'core/heading/h2': {
+	 *     'settings': { ... }
+	 *     'styles': { ... }
+	 *   },
+	 * }
+	 *
+	 * And it will return v1 form:
+	 *
+	 * {
+	 *   'settings': {
+	 *     'border': { ... }
+	 *     'color': { ... },
+	 *     'typography': { ... },
+	 *     'spacing': { ... },
+	 *     'custom': { ... },
+	 *     'blocks': {
+	 *       'core/paragraph': { ... }
 	 *     }
 	 *   },
-	 *   'block-two': {
-	 *     'styles': {
-	 *       'color': {
-	 *         'link': 'color'
+	 *   styles: {
+	 *     border: { ... }
+	 *     color: { ... },
+	 *     typography: { ... },
+	 *     spacing: { ... },
+	 *     custom: { ... },
+	 *     blocks: {
+	 *       core/paragraph: { ... }
+	 *       core/heading: {
+	 *         elements: {
+	 *           h1: { ... },
+	 *           h2: { ... }
+	 *         }
 	 *       }
 	 *     }
 	 *   }
 	 * }
-	 */
-	const SCHEMA = array(
-		'customTemplates' => null,
-		'templateParts'   => null,
-		'styles'          => array(
-			'border'     => array(
-				'radius' => null,
-				'color'  => null,
-				'style'  => null,
-				'width'  => null,
-			),
-			'color'      => array(
-				'background' => null,
-				'gradient'   => null,
-				'link'       => null,
-				'text'       => null,
-			),
-			'spacing'    => array(
-				'padding' => array(
-					'top'    => null,
-					'right'  => null,
-					'bottom' => null,
-					'left'   => null,
-				),
-			),
-			'typography' => array(
-				'fontFamily'     => null,
-				'fontSize'       => null,
-				'fontStyle'      => null,
-				'fontWeight'     => null,
-				'lineHeight'     => null,
-				'textDecoration' => null,
-				'textTransform'  => null,
-			),
-		),
-		'settings'        => array(
-			'border'     => array(
-				'customRadius' => null,
-				'customColor'  => null,
-				'customStyle'  => null,
-				'customWidth'  => null,
-			),
-			'color'      => array(
-				'custom'         => null,
-				'customGradient' => null,
-				'gradients'      => null,
-				'link'           => null,
-				'palette'        => null,
-			),
-			'spacing'    => array(
-				'customPadding' => null,
-				'units'         => null,
-			),
-			'typography' => array(
-				'customFontSize'        => null,
-				'customLineHeight'      => null,
-				'dropCap'               => null,
-				'fontFamilies'          => null,
-				'fontSizes'             => null,
-				'customFontStyle'       => null,
-				'customFontWeight'      => null,
-				'customTextDecorations' => null,
-				'customTextTransforms'  => null,
-			),
-			'custom'     => null,
-			'layout'     => null,
-		),
-	);
-
-	/**
-	 * Converts a v0 schema into the latest.
 	 *
 	 * @param array $old Data in v0 schema.
 	 *
-	 * @return array Data in the latest schema.
+	 * @return array Data in v1 schema.
 	 */
 	public static function migrate( $old ) {
 		// Copy everything.

--- a/lib/class-wp-theme-json-schema-v1-remove-custom-prefixes.php
+++ b/lib/class-wp-theme-json-schema-v1-remove-custom-prefixes.php
@@ -10,7 +10,7 @@
  * Class that implements a WP_Theme_JSON_Schema to convert
  * a given structure in v0 schema to the latest one.
  */
-class WP_Theme_JSON_Schema_V1 implements WP_Theme_JSON_Schema {
+class WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes implements WP_Theme_JSON_Schema {
 	/**
 	 * Data schema for v1 theme.json.
 	 */
@@ -100,13 +100,22 @@ class WP_Theme_JSON_Schema_V1 implements WP_Theme_JSON_Schema {
 	);
 
 	/**
-	 * Converts a v1 schema into the latest.
+	 * Removes the custom prefixes for a few properties that only worked in the plugin:
 	 *
-	 * @param array $old Data in v1 schema.
+	 * 'border.customColor'               => 'border.color',
+	 * 'border.customStyle'               => 'border.style',
+	 * 'border.customWidth'               => 'border.width',
+	 * 'typography.customFontStyle'       => 'typography.fontStyle',
+	 * 'typography.customFontWeight'      => 'typography.fontWeight',
+	 * 'typography.customLetterSpacing'   => 'typography.letterSpacing',
+	 * 'typography.customTextDecorations' => 'typography.textDecoration',
+	 * 'typography.customTextTransforms'  => 'typography.textTransform',
 	 *
-	 * @return array Data in the latest schema.
+	 * @param array $old Data to migrate.
+	 *
+	 * @return array Data without the custom prefixes.
 	 */
-	public static function parse( $old ) {
+	public static function migrate( $old ) {
 		// Copy everything.
 		$new = $old;
 
@@ -114,8 +123,6 @@ class WP_Theme_JSON_Schema_V1 implements WP_Theme_JSON_Schema {
 		if ( isset( $old['settings'] ) ) {
 			$new['settings'] = self::process_settings( $old['settings'] );
 		}
-
-		$new['version'] = WP_Theme_JSON_Gutenberg::LATEST_SCHEMA;
 
 		return $new;
 	}

--- a/lib/class-wp-theme-json-schema-v1-remove-custom-prefixes.php
+++ b/lib/class-wp-theme-json-schema-v1-remove-custom-prefixes.php
@@ -1,89 +1,15 @@
 <?php
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
- * a given structure in v1 schema to the latest one.
+ * Class that implements a WP_Theme_JSON_Schema migration.
  *
  * @package gutenberg
  */
 
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
- * a given structure in v0 schema to the latest one.
+ * Class that removes the custom prefix for some properties
+ * that did not land in 5.8.
  */
 class WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes implements WP_Theme_JSON_Schema {
-	/**
-	 * Data schema for v1 theme.json.
-	 */
-	const SCHEMA = array(
-		'version'         => 1,
-		'settings'        => array(
-			'border'     => array(
-				'radius' => null,
-				'color'  => null,
-				'style'  => null,
-				'width'  => null,
-			),
-			'color'      => array(
-				'custom'         => null,
-				'customGradient' => null,
-				'gradients'      => null,
-				'link'           => null,
-				'palette'        => null,
-			),
-			'spacing'    => array(
-				'customPadding' => null,
-				'units'         => null,
-			),
-			'typography' => array(
-				'customFontSize'   => null,
-				'customLineHeight' => null,
-				'dropCap'          => null,
-				'fontFamilies'     => null,
-				'fontSizes'        => null,
-				'fontStyle'        => null,
-				'fontWeight'       => null,
-				'letterSpacing'    => null,
-				'textDecorations'  => null,
-				'textTransforms'   => null,
-			),
-			'custom'     => null,
-			'layout'     => null,
-		),
-		'styles'          => array(
-			'border'     => array(
-				'radius' => null,
-				'color'  => null,
-				'style'  => null,
-				'width'  => null,
-			),
-			'color'      => array(
-				'background' => null,
-				'gradient'   => null,
-				'link'       => null,
-				'text'       => null,
-			),
-			'spacing'    => array(
-				'padding' => array(
-					'top'    => null,
-					'right'  => null,
-					'bottom' => null,
-					'left'   => null,
-				),
-			),
-			'typography' => array(
-				'fontFamily'     => null,
-				'fontSize'       => null,
-				'fontStyle'      => null,
-				'fontWeight'     => null,
-				'lineHeight'     => null,
-				'textDecoration' => null,
-				'textTransform'  => null,
-			),
-		),
-		'customTemplates' => null,
-		'templateParts'   => null,
-	);
-
 	/**
 	 * Maps old properties to their new location within the schema's settings.
 	 * This will be applied at both the defaults and individual block levels.

--- a/lib/interface-wp-theme-json-schema.php
+++ b/lib/interface-wp-theme-json-schema.php
@@ -12,12 +12,12 @@
  */
 interface WP_Theme_JSON_Schema {
 	/**
-	 * Parses an array that follows an old theme.json schema
-	 * into the latest theme.json schema.
+	 * Migrates an array that follows an old theme.json schema
+	 * to a different version.
 	 *
 	 * @param array $theme_json Old data to convert.
 	 *
-	 * @return array The data in the latest theme.json schema.
+	 * @return array The new converted data.
 	 */
-	public static function parse( $theme_json );
+	public static function migrate( $theme_json );
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -95,8 +95,8 @@ if ( ! class_exists( 'WP_Block_Template' ) ) {
 // These are used by some FSE features
 // as well as global styles.
 require __DIR__ . '/interface-wp-theme-json-schema.php';
-require __DIR__ . '/class-wp-theme-json-schema-v0.php';
-require __DIR__ . '/class-wp-theme-json-schema-v1.php';
+require __DIR__ . '/class-wp-theme-json-schema-v0-to-v1.php';
+require __DIR__ . '/class-wp-theme-json-schema-v1-remove-custom-prefixes.php';
 require __DIR__ . '/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-resolver-gutenberg.php';
 

--- a/phpunit/class-wp-theme-json-schema-v0-to-v1-test.php
+++ b/phpunit/class-wp-theme-json-schema-v0-to-v1-test.php
@@ -6,9 +6,9 @@
  * @package Gutenberg
  */
 
-class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
+class WP_Theme_JSON_Schema_V0_To_V1_Test extends WP_UnitTestCase {
 
-	function test_parse() {
+	function test_migrate() {
 		$theme_json_v0 = array(
 			'settings' => array(
 				'defaults'       => array(
@@ -95,7 +95,7 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = WP_Theme_JSON_Schema_V0::parse( $theme_json_v0 );
+		$actual = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json_v0 );
 
 		$expected = array(
 			'version'  => 1,
@@ -117,16 +117,16 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 					'link'    => true,
 				),
 				'border'     => array(
-					'color'        => false,
+					'customColor'  => false,
 					'customRadius' => false,
-					'style'        => false,
-					'width'        => false,
+					'customStyle'  => false,
+					'customWidth'  => false,
 				),
 				'typography' => array(
-					'fontStyle'      => false,
-					'fontWeight'     => false,
-					'textDecoration' => false,
-					'textTransform'  => false,
+					'customFontStyle'       => false,
+					'customFontWeight'      => false,
+					'customTextDecorations' => false,
+					'customTextTransforms'  => false,
 				),
 				'blocks'     => array(
 					'core/paragraph' => array(
@@ -173,8 +173,8 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_settings() {
-		$defaults   = WP_Theme_JSON_Schema_V0::ALL_BLOCKS_NAME;
-		$root       = WP_Theme_JSON_Schema_V0::ROOT_BLOCK_NAME;
+		$defaults   = WP_Theme_JSON_Schema_V0_To_V1::ALL_BLOCKS_NAME;
+		$root       = WP_Theme_JSON_Schema_V0_To_V1::ROOT_BLOCK_NAME;
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'settings' => array(
@@ -359,8 +359,8 @@ class WP_Theme_JSON_Schema_V0_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet() {
-		$root_name       = WP_Theme_JSON_Schema_V0::ROOT_BLOCK_NAME;
-		$all_blocks_name = WP_Theme_JSON_Schema_V0::ALL_BLOCKS_NAME;
+		$root_name       = WP_Theme_JSON_Schema_V0_To_V1::ROOT_BLOCK_NAME;
+		$all_blocks_name = WP_Theme_JSON_Schema_V0_To_V1::ALL_BLOCKS_NAME;
 		$theme_json      = new WP_Theme_JSON_Gutenberg( array() );
 		$theme_json->merge(
 			new WP_Theme_JSON_Gutenberg(

--- a/phpunit/class-wp-theme-json-schema-v1-remove-custom-prefixes-test.php
+++ b/phpunit/class-wp-theme-json-schema-v1-remove-custom-prefixes-test.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Test WP_Theme_JSON_Schema_V1 class.
+ * Test WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes class.
  *
  * @package Gutenberg
  */
 
-class WP_Theme_JSON_Schema_V1_Test extends WP_UnitTestCase {
+class WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes_Test extends WP_UnitTestCase {
 
 	function test_parse() {
 		$theme_json_v1 = array(
@@ -92,7 +92,7 @@ class WP_Theme_JSON_Schema_V1_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = WP_Theme_JSON_Schema_V1::parse( $theme_json_v1 );
+		$actual = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json_v1 );
 
 		$expected = array(
 			'version'  => 1,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/34349

This PR prepares the code that migrates `theme.json` schemas to add v2 in a subsequent PR, see https://github.com/WordPress/gutenberg/pull/36155

It clarifies how migrations are supposed to work and it proposes that each migration only updates from the latest to the new one. Before this, new migrations were supposed to be ported to all versions. See https://github.com/WordPress/gutenberg/pull/34485 for an example. As demonstrated by the block deprecations https://github.com/WordPress/gutenberg/discussions/35663 trying to migrate everything to the latest version is not going to scale well.

## How to test 

Verify the tests pass. It only refactors code.
