### PR TITLE
Migrate theme.json v1 to v2

### DIFF
--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -440,7 +440,7 @@ To enable border styles, add a `border` object under `settings` with the followi
 	"settings": {
 		"border": {
 			"color": true,
-			"customRadius": true,
+			"radius": true,
 			"style": true,
 			"width": true
 		}
@@ -456,7 +456,7 @@ To enable link colors, add a `color` setting and set `link` to true:
 	"settings": {
 		"border": {
 			"color": true,
-			"customRadius": true,
+			"radius": true,
 			"style": true,
 			"width": true
 		},
@@ -475,7 +475,7 @@ To enable padding, margin and custom spacing units, include a setting for spacin
 	"settings": {
 		"border": {
 			"color": true,
-			"customRadius": true,
+			"radius": true,
 			"style": true,
 			"width": true
 		},
@@ -483,8 +483,8 @@ To enable padding, margin and custom spacing units, include a setting for spacin
 			"link": true
 		},
 		"spacing": {
-			"customPadding": true,
-			"customMargin": true,
+			"padding": true,
+			"margin": true,
 			"units": [ "px", "em", "rem", "vh", "vw" ]
 		}
 	}
@@ -501,7 +501,7 @@ If you want to disable gradients, which are enabled by default, set `gradient` t
 	"settings": {
 		"border": {
 			"color": true,
-			"customRadius": true,
+			"radius": true,
 			"style": true,
 			"width": true
 		},

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -220,7 +220,7 @@ The settings section has the following structure:
 	"settings": {
 		"border": {
 			"color": false,
-			"customRadius": false,
+			"radius": false,
 			"style": false,
 			"width": false
 		},
@@ -242,19 +242,19 @@ The settings section has the following structure:
 		},
 		"spacing": {
 			"blockGap": null,
-			"customMargin": false,
-			"customPadding": false,
+			"margin": false,
+			"padding": false,
 			"units": [ "px", "em", "rem", "vh", "vw" ]
 		},
 		"typography": {
 			"customFontSize": true,
-			"customLineHeight": false,
 			"dropCap": true,
 			"fontFamilies": [],
 			"fontSizes": [],
 			"fontStyle": true,
 			"fontWeight": true,
 			"letterSpacing": true,
+			"lineHeight": false,
 			"textDecoration": true,
 			"textTransform": true
 		},
@@ -286,8 +286,8 @@ To retain backward compatibility, the existing `add_theme_support` declarations 
 
 | add_theme_support           | theme.json setting                                        |
 | --------------------------- | --------------------------------------------------------- |
-| `custom-line-height`        | Set `typography.customLineHeight` to `true`.              |
-| `custom-spacing`            | Set `spacing.customPadding` to `true`.                    |
+| `custom-line-height`        | Set `typography.lineHeight` to `true`.              |
+| `custom-spacing`            | Set `spacing.padding` to `true`.                    |
 | `custom-units`              | Provide the list of units via `spacing.units`.            |
 | `disable-custom-colors`     | Set `color.custom` to `false`.                            |
 | `disable-custom-font-sizes` | Set `typography.customFontSize` to `false`.               |

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -82,10 +82,10 @@ class WP_Theme_JSON_Gutenberg {
 
 	const VALID_SETTINGS = array(
 		'border'     => array(
-			'color'        => null,
-			'customRadius' => null,
-			'style'        => null,
-			'width'        => null,
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
 		),
 		'color'      => array(
 			'background'     => null,
@@ -104,22 +104,22 @@ class WP_Theme_JSON_Gutenberg {
 			'wideSize'    => null,
 		),
 		'spacing'    => array(
-			'blockGap'      => null,
-			'customMargin'  => null,
-			'customPadding' => null,
-			'units'         => null,
+			'blockGap' => null,
+			'margin'   => null,
+			'padding'  => null,
+			'units'    => null,
 		),
 		'typography' => array(
-			'customFontSize'   => null,
-			'customLineHeight' => null,
-			'dropCap'          => null,
-			'fontFamilies'     => null,
-			'fontSizes'        => null,
-			'fontStyle'        => null,
-			'fontWeight'       => null,
-			'letterSpacing'    => null,
-			'textDecoration'   => null,
-			'textTransform'    => null,
+			'customFontSize' => null,
+			'dropCap'        => null,
+			'fontFamilies'   => null,
+			'fontSizes'      => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
 		),
 	);
 
@@ -273,7 +273,7 @@ class WP_Theme_JSON_Gutenberg {
 		'h6'   => 'h6',
 	);
 
-	const LATEST_SCHEMA = 1;
+	const LATEST_SCHEMA = 2;
 
 	/**
 	 * Constructor.
@@ -321,6 +321,10 @@ class WP_Theme_JSON_Gutenberg {
 		// and have had their `custom` prefixed removed since.
 		if ( 1 === $theme_json['version'] ) {
 			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
+		}
+
+		if ( 1 === $theme_json['version'] ) {
+			$theme_json = WP_Theme_JSON_Schema_V1_To_V2::migrate( $theme_json );
 		}
 
 		return $theme_json;
@@ -1086,8 +1090,8 @@ class WP_Theme_JSON_Gutenberg {
 	 *     }
 	 *   },
 	 *   'core/paragraph': {
-	 *     'spacing': {
-	 *       'customPadding': true
+	 *     'typography': {
+	 *       'customFontSize': true
 	 *     }
 	 *   }
 	 * }
@@ -1545,7 +1549,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! isset( $theme_settings['settings']['typography'] ) ) {
 				$theme_settings['settings']['typography'] = array();
 			}
-			$theme_settings['settings']['typography']['customLineHeight'] = $settings['enableCustomLineHeight'];
+			$theme_settings['settings']['typography']['lineHeight'] = $settings['enableCustomLineHeight'];
 		}
 
 		if ( isset( $settings['enableCustomUnits'] ) ) {
@@ -1593,7 +1597,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! isset( $theme_settings['settings']['spacing'] ) ) {
 				$theme_settings['settings']['spacing'] = array();
 			}
-			$theme_settings['settings']['spacing']['customPadding'] = $settings['enableCustomSpacing'];
+			$theme_settings['settings']['spacing']['padding'] = $settings['enableCustomSpacing'];
 		}
 
 		// Things that didn't land in core yet, so didn't have a setting assigned.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -313,12 +313,16 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The structure in the last version.
 	 */
 	private static function migrate( $theme_json ) {
+		// Can be removed when the plugin minimum required version is WordPress 5.8.
+		// This doesn't need to land in WordPress core.
 		if ( ! isset( $theme_json['version'] ) || 0 === $theme_json['version'] ) {
 			$theme_json = WP_Theme_JSON_Schema_V0_To_V1::migrate( $theme_json );
 		}
 
 		// Provide backwards compatibility for settings that did not land in 5.8
 		// and have had their `custom` prefixed removed since.
+		// Can be removed when the plugin minimum required version is WordPress 5.9.
+		// This doesn't need to land in WordPress core.
 		if ( 1 === $theme_json['version'] ) {
 			$theme_json = WP_Theme_JSON_Schema_V1_Remove_Custom_Prefixes::migrate( $theme_json );
 		}

--- a/lib/class-wp-theme-json-schema-v1-to-v2.php
+++ b/lib/class-wp-theme-json-schema-v1-to-v2.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Class that implements a WP_Theme_JSON_Schema migrator.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Class that implements a migration from a v1 data structure into a v2 one.
+ */
+class WP_Theme_JSON_Schema_V1_To_V2 implements WP_Theme_JSON_Schema {
+	/**
+	 * Maps old properties to their new location within the schema's settings.
+	 * This will be applied at both the defaults and individual block levels.
+	 */
+	const RENAMED_PATHS = array(
+		'border.customRadius'         => 'border.radius',
+		'spacing.customMargin'        => 'spacing.margin',
+		'spacing.customPadding'       => 'spacing.padding',
+		'typography.customLineHeight' => 'typography.lineHeight',
+	);
+
+	/**
+	 * Removes the custom prefixes for a few properties
+	 * that were part of v1:
+	 *
+	 * 'border.customRadius'         => 'border.radius',
+	 * 'spacing.customMargin'        => 'spacing.margin',
+	 * 'spacing.customPadding'       => 'spacing.padding',
+	 * 'typography.customLineHeight' => 'typography.lineHeight',
+	 *
+	 * @param array $old Data to migrate.
+	 *
+	 * @return array Data without the custom prefixes.
+	 */
+	public static function migrate( $old ) {
+		// Copy everything.
+		$new = $old;
+
+		// Overwrite the things that changed.
+		if ( isset( $old['settings'] ) ) {
+			$new['settings'] = self::process_settings( $old['settings'] );
+		}
+
+		// Set the new version.
+		$new['version'] = 2;
+
+		return $new;
+	}
+
+	/**
+	 * Processes the settings subtree.
+	 *
+	 * @param array $settings Array to process.
+	 *
+	 * @return array The settings in the new format.
+	 */
+	private static function process_settings( $settings ) {
+		$new_settings = $settings;
+
+		// Process any renamed/moved paths within default settings.
+		self::rename_settings( $new_settings );
+
+		// Process individual block settings.
+		if ( isset( $new_settings['blocks'] ) && is_array( $new_settings['blocks'] ) ) {
+			foreach ( $new_settings['blocks'] as &$block_settings ) {
+				self::rename_settings( $block_settings );
+			}
+		}
+
+		return $new_settings;
+	}
+
+	/**
+	 * Processes a settings array, renaming or moving properties according to
+	 * `self::RENAMED_PATHS`.
+	 *
+	 * @param array $settings Reference to settings either defaults or an individual block's.
+	 * @return void
+	 */
+	private static function rename_settings( &$settings ) {
+		foreach ( self::RENAMED_PATHS as $original => $renamed ) {
+			$original_path = explode( '.', $original );
+			$renamed_path  = explode( '.', $renamed );
+			$current_value = _wp_array_get( $settings, $original_path, null );
+
+			if ( null !== $current_value ) {
+				gutenberg_experimental_set( $settings, $renamed_path, $current_value );
+				self::unset_setting_by_path( $settings, $original_path );
+			}
+		}
+	}
+
+	/**
+	 * Removes a property from within the provided settings by its path.
+	 *
+	 * @param array $settings Reference to the current settings array.
+	 * @param array $path Path to the property to be removed.
+	 *
+	 * @return void
+	 */
+	private static function unset_setting_by_path( &$settings, $path ) {
+		$tmp_settings = &$settings; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$last_key     = array_pop( $path );
+		foreach ( $path as $key ) {
+			$tmp_settings = &$tmp_settings[ $key ];
+		}
+
+		unset( $tmp_settings[ $last_key ] );
+	}
+}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -150,16 +150,16 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$settings['disableCustomFontSizes'] = ! $settings['__experimentalFeatures']['typography']['customFontSize'];
 		unset( $settings['__experimentalFeatures']['typography']['customFontSize'] );
 	}
-	if ( isset( $settings['__experimentalFeatures']['typography']['customLineHeight'] ) ) {
-		$settings['enableCustomLineHeight'] = $settings['__experimentalFeatures']['typography']['customLineHeight'];
-		unset( $settings['__experimentalFeatures']['typography']['customLineHeight'] );
+	if ( isset( $settings['__experimentalFeatures']['typography']['lineHeight'] ) ) {
+		$settings['enableCustomLineHeight'] = $settings['__experimentalFeatures']['typography']['lineHeight'];
+		unset( $settings['__experimentalFeatures']['typography']['lineHeight'] );
 	}
 	if ( isset( $settings['__experimentalFeatures']['spacing']['units'] ) ) {
 		$settings['enableCustomUnits'] = $settings['__experimentalFeatures']['spacing']['units'];
 	}
-	if ( isset( $settings['__experimentalFeatures']['spacing']['customPadding'] ) ) {
-		$settings['enableCustomSpacing'] = $settings['__experimentalFeatures']['spacing']['customPadding'];
-		unset( $settings['__experimentalFeatures']['spacing']['customPadding'] );
+	if ( isset( $settings['__experimentalFeatures']['spacing']['padding'] ) ) {
+		$settings['enableCustomSpacing'] = $settings['__experimentalFeatures']['spacing']['padding'];
+		unset( $settings['__experimentalFeatures']['spacing']['padding'] );
 	}
 
 	return $settings;

--- a/lib/load.php
+++ b/lib/load.php
@@ -97,6 +97,7 @@ if ( ! class_exists( 'WP_Block_Template' ) ) {
 require __DIR__ . '/interface-wp-theme-json-schema.php';
 require __DIR__ . '/class-wp-theme-json-schema-v0-to-v1.php';
 require __DIR__ . '/class-wp-theme-json-schema-v1-remove-custom-prefixes.php';
+require __DIR__ . '/class-wp-theme-json-schema-v1-to-v2.php';
 require __DIR__ . '/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/class-wp-theme-json-resolver-gutenberg.php';
 

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,5 +1,5 @@
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		"color": {
 			"background": true,
@@ -178,9 +178,9 @@
 		"typography": {
 			"dropCap": true,
 			"customFontSize": true,
-			"customLineHeight": false,
 			"fontStyle": true,
 			"fontWeight": true,
+			"lineHeight": false,
 			"textTransform": true,
 			"textDecoration": true,
 			"letterSpacing": true,
@@ -214,26 +214,26 @@
 		},
 		"spacing": {
 			"blockGap": null,
-			"customMargin": false,
-			"customPadding": false,
+			"margin": false,
+			"padding": false,
 			"units": [ "px", "em", "rem", "vh", "vw", "%" ]
 		},
 		"border": {
 			"color": false,
-			"customRadius": false,
+			"radius": false,
 			"style": false,
 			"width": false
 		},
 		"blocks": {
 			"core/button": {
 				"border": {
-					"customRadius": true
+					"radius": true
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": true,
-					"customRadius": true,
+					"radius": true,
 					"style": true,
 					"width": true
 				}

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -51,6 +51,10 @@ const deprecatedFlags = {
 };
 
 const prefixedFlags = {
+	/*
+	 * These were only available in the plugin
+	 * and can be removed after WordPress 5.9 is released.
+	 */
 	'border.customColor': 'border.color',
 	'border.customStyle': 'border.style',
 	'border.customWidth': 'border.width',
@@ -59,6 +63,13 @@ const prefixedFlags = {
 	'typography.customLetterSpacing': 'typography.letterSpacing',
 	'typography.customTextDecorations': 'typography.textDecoration',
 	'typography.customTextTransforms': 'typography.textTransform',
+	/*
+	 * These were part of WordPress 5.8 and we need to keep them.
+	 */
+	'border.customRadius': 'border.radius',
+	'spacing.customMargin': 'spacing.margin',
+	'spacing.customPadding': 'spacing.padding',
+	'typography.customLineHeight': 'typography.lineHeight',
 };
 
 /**

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -34,8 +34,7 @@ const deprecatedFlags = {
 		settings.disableCustomFontSizes === undefined
 			? undefined
 			: ! settings.disableCustomFontSizes,
-	'typography.customLineHeight': ( settings ) =>
-		settings.enableCustomLineHeight,
+	'typography.lineHeight': ( settings ) => settings.enableCustomLineHeight,
 	'spacing.units': ( settings ) => {
 		if ( settings.enableCustomUnits === undefined ) {
 			return;

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -47,7 +47,7 @@ const deprecatedFlags = {
 
 		return settings.enableCustomUnits;
 	},
-	'spacing.customPadding': ( settings ) => settings.enableCustomSpacing,
+	'spacing.padding': ( settings ) => settings.enableCustomSpacing,
 };
 
 const prefixedFlags = {

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -52,7 +52,8 @@ const deprecatedFlags = {
 const prefixedFlags = {
 	/*
 	 * These were only available in the plugin
-	 * and can be removed after WordPress 5.9 is released.
+	 * and can be removed when the minimum WordPress version
+	 * for the plugin is 5.9.
 	 */
 	'border.customColor': 'border.color',
 	'border.customStyle': 'border.style',

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -26,7 +26,7 @@ export function BorderPanel( props ) {
 		useSetting( 'border.color' ) && hasBorderSupport( props.name, 'color' );
 
 	const isRadiusSupported =
-		useSetting( 'border.customRadius' ) &&
+		useSetting( 'border.radius' ) &&
 		hasBorderSupport( props.name, 'radius' );
 
 	const isStyleSupported =
@@ -111,7 +111,7 @@ export function shouldSkipSerialization( blockType ) {
 const useIsBorderDisabled = () => {
 	const configs = [
 		! useSetting( 'border.color' ),
-		! useSetting( 'border.customRadius' ),
+		! useSetting( 'border.radius' ),
 		! useSetting( 'border.style' ),
 		! useSetting( 'border.width' ),
 	];

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -51,7 +51,7 @@ export function LineHeightEdit( props ) {
  * @return {boolean} Whether setting is disabled.
  */
 export function useIsLineHeightDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useSetting( 'typography.customLineHeight' );
+	const isDisabled = ! useSetting( 'typography.lineHeight' );
 
 	return (
 		! hasBlockSupport( blockName, LINE_HEIGHT_SUPPORT_KEY ) || isDisabled

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -73,7 +73,7 @@ export function resetMargin( { attributes = {}, setAttributes } ) {
  * @return {boolean} Whether margin setting is disabled.
  */
 export function useIsMarginDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useSetting( 'spacing.customMargin' );
+	const isDisabled = ! useSetting( 'spacing.margin' );
 	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'margin' );
 
 	return ! hasMarginSupport( blockName ) || isDisabled || isInvalid;

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -73,7 +73,7 @@ export function resetPadding( { attributes = {}, setAttributes } ) {
  * @return {boolean} Whether padding setting is disabled.
  */
 export function useIsPaddingDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useSetting( 'spacing.customPadding' );
+	const isDisabled = ! useSetting( 'spacing.padding' );
 	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'padding' );
 
 	return ! hasPaddingSupport( blockName ) || isDisabled || isInvalid;

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -46,7 +46,7 @@ function useHasBorderColorControl( name ) {
 function useHasBorderRadiusControl( name ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	return (
-		useSetting( 'border.customRadius', name )[ 0 ] &&
+		useSetting( 'border.radius', name )[ 0 ] &&
 		supports.includes( 'borderRadius' )
 	);
 }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -35,7 +35,7 @@ function useHasPadding( name ) {
 
 function useHasMargin( name ) {
 	const supports = getSupportedGlobalStylesPanels( name );
-	const [ settings ] = useSetting( 'spacing.customMargin', name );
+	const [ settings ] = useSetting( 'spacing.margin', name );
 
 	return settings && supports.includes( 'margin' );
 }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -28,7 +28,7 @@ export function useHasDimensionsPanel( name ) {
 
 function useHasPadding( name ) {
 	const supports = getSupportedGlobalStylesPanels( name );
-	const [ settings ] = useSetting( 'spacing.customPadding', name );
+	const [ settings ] = useSetting( 'spacing.padding', name );
 
 	return settings && supports.includes( 'padding' );
 }

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -30,7 +30,7 @@ export function useHasTypographyPanel( name ) {
 function useHasLineHeightControl( name ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	return (
-		useSetting( 'typography.customLineHeight', name )[ 0 ] &&
+		useSetting( 'typography.lineHeight', name )[ 0 ] &&
 		supports.includes( 'lineHeight' )
 	);
 }

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -136,12 +136,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 				'typography' => array(
-					'customFontSize'   => true,
-					'customLineHeight' => false,
+					'customFontSize' => true,
+					'lineHeight'     => false,
 				),
 				'spacing'    => array(
-					'units'         => false,
-					'customPadding' => false,
+					'units'   => false,
+					'padding' => false,
 				),
 				'blocks'     => array(
 					'core/paragraph' => array(
@@ -222,7 +222,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		remove_theme_support( 'editor-color-palette' );
 
 		$this->assertSame( false, WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() );
-		$this->assertSame( true, $settings['typography']['customLineHeight'] );
+		$this->assertSame( true, $settings['typography']['lineHeight'] );
 		$this->assertSame( $color_palette, $settings['color']['palette']['theme'] );
 	}
 
@@ -259,12 +259,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 					'link'           => true,
 				),
 				'typography' => array(
-					'customFontSize'   => true,
-					'customLineHeight' => false,
+					'customFontSize' => true,
+					'lineHeight'     => false,
 				),
 				'spacing'    => array(
-					'units'         => false,
-					'customPadding' => false,
+					'units'   => false,
+					'padding' => false,
 				),
 				'blocks'     => array(
 					'core/paragraph'  => array(

--- a/phpunit/class-wp-theme-json-schema-v1-to-v2-test.php
+++ b/phpunit/class-wp-theme-json-schema-v1-to-v2-test.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Test WP_Theme_JSON_Schema_V1_to_V2.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Theme_JSON_Schema_V1_To_V2_Test extends WP_UnitTestCase {
+
+	function test_migrate() {
+		$theme_json_v1 = array(
+			'version'  => 1,
+			'settings' => array(
+				'border'     => array(
+					'customRadius' => true,
+				),
+				'spacing'    => array(
+					'customMargin'  => true,
+					'customPadding' => true,
+				),
+				'typography' => array(
+					'customLineHeight' => true,
+				),
+				'blocks'     => array(
+					'core/group' => array(
+						'border'     => array(
+							'customRadius' => false,
+						),
+						'spacing'    => array(
+							'customMargin'  => false,
+							'customPadding' => false,
+						),
+						'typography' => array(
+							'customLineHeight' => false,
+						),
+					),
+				),
+			),
+		);
+
+		$actual = WP_Theme_JSON_Schema_V1_to_V2::migrate( $theme_json_v1 );
+
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'border'     => array(
+					'radius' => true,
+				),
+				'spacing'    => array(
+					'margin'  => true,
+					'padding' => true,
+				),
+				'typography' => array(
+					'lineHeight' => true,
+				),
+				'blocks'     => array(
+					'core/group' => array(
+						'border'     => array(
+							'radius' => false,
+						),
+						'spacing'    => array(
+							'margin'  => false,
+							'padding' => false,
+						),
+						'typography' => array(
+							'lineHeight' => false,
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -946,10 +946,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'custom' => false,
 						),
 						'spacing'    => array(
-							'customMargin' => false,
+							'margin' => false,
 						),
 						'typography' => array(
-							'customLineHeight' => false,
+							'lineHeight' => false,
 						),
 					),
 				)
@@ -988,12 +988,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 				'spacing'    => array(
-					'customMargin' => false,
-					'units'        => array( 'px', 'em' ),
+					'margin' => false,
+					'units'  => array( 'px', 'em' ),
 				),
 				'typography' => array(
-					'customLineHeight' => false,
-					'fontSizes'        => array(
+					'lineHeight' => false,
+					'fontSizes'  => array(
 						'theme' => array(
 							array(
 								'slug'  => 'size',
@@ -1255,7 +1255,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'spacing' => array(
-						'customPadding' => false,
+						'padding' => false,
 					),
 					'blocks'  => array(
 						'core/group' => array(
@@ -1280,7 +1280,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 							'spacing' => array(
-								'customPadding' => false,
+								'padding' => false,
 							),
 						),
 					),
@@ -1592,9 +1592,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'units' => array( 'px', 'em', 'rem', 'vh', 'vw', '%' ),
 				),
 				'typography' => array(
-					'customFontSize'   => false,
-					'customLineHeight' => true,
-					'fontSizes'        => array(
+					'customFontSize' => false,
+					'lineHeight'     => true,
+					'fontSizes'      => array(
 						array(
 							'slug' => 'size-slug',
 							'name' => 'Size Name',
@@ -1651,8 +1651,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'units' => false,
 				),
 				'typography' => array(
-					'customFontSize'   => true,
-					'customLineHeight' => false,
+					'customFontSize' => true,
+					'lineHeight'     => false,
 				),
 			),
 		);
@@ -1677,8 +1677,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_default_block_editor_settings();
 
 		$expected = array(
-			'units'         => array( array() ),
-			'customPadding' => false,
+			'units'   => array( array() ),
+			'padding' => false,
 		);
 
 		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );
@@ -1691,8 +1691,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_default_block_editor_settings();
 
 		$expected = array(
-			'units'         => array( 'px', 'em', 'rem', 'vh', 'vw', '%' ),
-			'customPadding' => false,
+			'units'   => array( 'px', 'em', 'rem', 'vh', 'vw', '%' ),
+			'padding' => false,
 		);
 
 		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );
@@ -1705,8 +1705,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$input = gutenberg_get_default_block_editor_settings();
 
 		$expected = array(
-			'units'         => array( 'rem', 'em' ),
-			'customPadding' => false,
+			'units'   => array( 'rem', 'em' ),
+			'padding' => false,
 		);
 
 		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -13,22 +13,22 @@
 					"description": "Settings related to borders.\nGutenberg plugin required.",
 					"type": "object",
 					"properties": {
-						"customColor": {
+						"color": {
 							"description": "Allow users to set custom border colors.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": false
 						},
-						"customRadius": {
+						"radius": {
 							"description": "Allow users to set custom border radius.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": false
 						},
-						"customStyle": {
+						"style": {
 							"description": "Allow users to set custom border styles.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": false
 						},
-						"customWidth": {
+						"width": {
 							"description": "Allow users to set custom border widths.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": false
@@ -173,12 +173,12 @@
 							],
 							"default": null
 						},
-						"customMargin": {
+						"margin": {
 							"description": "Allow users to set a custom margin.\nSince 5.8.",
 							"type": "boolean",
 							"default": false
 						},
-						"customPadding": {
+						"padding": {
 							"description": "Allow users to set a custom padding.\nSince 5.8.",
 							"type": "boolean",
 							"default": false
@@ -203,32 +203,32 @@
 							"type": "boolean",
 							"default": true
 						},
-						"customFontStyle": {
+						"fontStyle": {
 							"description": "Allow users to set custom font styles.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": true
 						},
-						"customFontWeight": {
+						"fontWeight": {
 							"description": "Allow users to set custom font weights.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": true
 						},
-						"customLetterSpacing": {
+						"letterSpacing": {
 							"description": "Allow users to set custom letter spacing.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": true
 						},
-						"customLineHeight": {
+						"lineHeight": {
 							"description": "Allow users to set custom line height.\nSince 5.8.",
 							"type": "boolean",
 							"default": false
 						},
-						"customTextDecorations": {
+						"textDecoration": {
 							"description": "Allow users to set custom text decorations.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": true
 						},
-						"customTextTransforms": {
+						"textTransform": {
 							"description": "Allow users to set custom text transforms.\nGutenberg plugin required.",
 							"type": "boolean",
 							"default": true


### PR DESCRIPTION
Part of #34349
Built on top of https://github.com/WordPress/gutenberg/pull/36154

This PR implements v1 to v2 migrations: we only need to remove the `custom` prefix from some existing properties.

## Backward compatibility

- Themes with a theme.json v1 will still work with the old names and will be migrated to v2.
- The client code that uses the old names `useSetting( 'spacing.customPadding' )` will still work, although the recommended way is using `spacing.padding`.

## Test theme.json v1 still works

Using the following theme.json (for example, with the empty theme):

```json
{
	"version": 1,
	"settings": {
		"spacing": {
			"customPadding": false,
			"customMargin": false
		},
		"typography": {
			"customLineHeight": false
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"blocks": {
			"core/button": {
				"border": {
					"customRadius": false
				}
			}
		}
	}
}
```

Verify that:

- The paragraph block does not have a line height control within the typography panel.
- The buttons block does not have a margin control within the dimensions panel.
- The button block does not have a border panel (radius control disabled) neither a dimensions panel (padding control disabled).

Set the above properties to `true` and verify that the UI controls are enabled.

## Test theme.json v2

Using the following theme.json (for example, with the empty theme):

```json
{
	"version": 2,
	"settings": {
		"spacing": {
			"padding": false,
			"margin": false
		},
		"typography": {
			"lineHeight": false
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"blocks": {
			"core/button": {
				"border": {
					"radius": false
				}
			}
		}
	}
}
```

Verify that:

- The paragraph block does not have a line height control within the typography panel.
- The buttons block does not have a margin control within the dimensions panel.
- The button block does not have a border panel (radius control disabled) neither a dimensions panel (padding control disabled).

Set the above properties to `true` and verify that the UI controls are enabled.
