### PR TITLE
Remove stack exchange from new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
     - name: Technical help request
       url: https://wordpress.org/support/forum/wp-advanced/
       about: For more technical help requests, create a new topic in the Developing with WordPress Forum
-    - name: Development help request
-      url: https://wordpress.stackexchange.com/
-      about: For questions about WordPress development, ask a question in the WordPress Development Stack Exchange


### PR DESCRIPTION
This PR removes a potentially misleading link to WP stack exchange.

While questions about building blocks or core are on topic, this template link implies you can go there for help with anything WP related, e.g. how do make my WooCommerce cart do this, or how to I make the Astra theme do that. But this is not true, 3rd party plugin/theme dev support is off topic there. It's not a general catch all WP support forum (not even a forum).