### PR TITLE
CustomSelectControl: Use `__unstableSize` prop in Typography panel

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -206,6 +206,7 @@ export default function FontAppearanceControl( props ) {
 		hasStylesOrWeights && (
 			<CustomSelectControl
 				className="components-font-appearance-control"
+				__unstableSize="large"
 				label={ label }
 				describedBy={ getDescribedBy() }
 				options={ selectOptions }

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -142,6 +142,7 @@ export function FontSizeEdit( props ) {
 
 	return (
 		<FontSizePicker
+			__unstableSize="large"
 			onChange={ onChange }
 			value={ fontSizeValue }
 			withReset={ false }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -55,6 +55,7 @@ const stateReducer = (
 };
 export default function CustomSelectControl( {
 	className,
+	__unstableSize,
 	hideLabelFromVision,
 	label,
 	describedBy,
@@ -130,8 +131,11 @@ export default function CustomSelectControl( {
 					// This is needed because some speech recognition software don't support `aria-labelledby`.
 					'aria-label': label,
 					'aria-labelledby': undefined,
-					className: 'components-custom-select-control__button',
-					isSmall: true,
+					className: classnames(
+						'components-custom-select-control__button',
+						{ 'is-unstable-size-large': __unstableSize === 'large' }
+					),
+					isSmall: __unstableSize !== 'large',
 					describedBy: getDescribedBy(),
 				} ) }
 			>

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -6,6 +6,12 @@ import CustomSelectControl from '../';
 export default {
 	title: 'Components/CustomSelectControl',
 	component: CustomSelectControl,
+	argTypes: {
+		__unstableSize: {
+			options: [ 'default', 'large' ],
+			control: { type: 'select' },
+		},
+	},
 };
 
 const defaultOptions = [

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -31,29 +31,31 @@ const defaultOptions = [
 		style: { fontSize: '300%' },
 	},
 ];
-export const _default = () => (
-	<CustomSelectControl label="Font size" options={ defaultOptions } />
-);
 
-const longLabelOptions = [
-	{
-		key: 'reallylonglabel1',
-		name: 'Really long labels are good for stress testing',
-	},
-	{
-		key: 'reallylonglabel2',
-		name: 'But they can take a long time to type.',
-	},
-	{
-		key: 'reallylonglabel3',
-		name:
-			'That really is ok though because you should stress test your UIs.',
-	},
-];
+export const Default = CustomSelectControl.bind( {} );
+Default.args = {
+	hideLabelFromVision: false,
+	label: 'Font size',
+	options: defaultOptions,
+};
 
-export const longLabels = () => (
-	<CustomSelectControl
-		label="Testing long labels"
-		options={ longLabelOptions }
-	/>
-);
+export const LongLabels = CustomSelectControl.bind( {} );
+LongLabels.args = {
+	...Default.args,
+	label: 'Testing long labels',
+	options: [
+		{
+			key: 'reallylonglabel1',
+			name: 'Really long labels are good for stress testing',
+		},
+		{
+			key: 'reallylonglabel2',
+			name: 'But they can take a long time to type.',
+		},
+		{
+			key: 'reallylonglabel3',
+			name:
+				'That really is ok though because you should stress test your UIs.',
+		},
+	],
+};

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -15,6 +15,11 @@
 	position: relative;
 	text-align: left;
 
+	&.is-unstable-size-large {
+		min-height: 40px;
+		padding-left: 16px;
+	}
+
 	// For all button sizes allow sufficient space for the
 	// dropdown "arrow" icon to display.
 	&.components-custom-select-control__button {

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -28,6 +28,7 @@ import {
 
 function FontSizePicker(
 	{
+		__unstableSize,
 		fallbackFontSize,
 		fontSizes = [],
 		disableCustomFontSizes = false,
@@ -148,6 +149,7 @@ function FontSizePicker(
 					shouldUseSelectControl &&
 					! showCustomValueControl && (
 						<CustomSelectControl
+							__unstableSize={ __unstableSize }
 							className={ `${ baseClassName }__select` }
 							label={ __( 'Font size' ) }
 							hideLabelFromVision

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -122,6 +122,7 @@ export const TypographyPanel = () => {
 							isShownByDefault={ true }
 						>
 							<FontSizePicker
+								__unstableSize="large"
 								value={ fontSize }
 								onChange={ setFontSize }
 								fontSizes={ fontSizes }

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -106,6 +106,7 @@ export default function TypographyPanel( { name } ) {
 			) }
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
+					__unstableSize="large"
 					value={ fontSize }
 					onChange={ setFontSize }
 					fontSizes={ fontSizes }


### PR DESCRIPTION
Part of #36230

⏳ On hold until coordinated merge with other related PRs

## Description

This PR enlarges `FontSizePicker` and `FontAppearanceControl` to the new 40px height. The height change is accomplished via a new internal `__unstableSize` prop on `CustomSelectControl`, which is the underlying component being used.

- `FontSizePicker` (`@wordpress/components` component) — Because this is an already stable component, the size is enlarged only in these limited contexts:
  - Typography panel in global styles
  - Typography panel in block styles
- `FontAppearanceControl` (`@wordpress/block-editor` component, experimental) — Because this block is still experimental and can be expected to only appear in the Typography panels, the size is enlarged by default.

### Background

After some talks with @jasmussen @pablohoneyhoney @griffbrad, the overall sentiment was that we weren't ready to officially commit to a new set of size variants, especially for non-experimental components (which were designed pre-G2 and are widely used in contexts other than the sidebar). For non-experimental components, it would be safer for us  to keep the 40px size variant `unstable` until we are confident to make it part of the official size variants.

### ❓ Variant name

I'm still unsure about the variant name `large`. Would a more descriptive name like `sidebar-default` or `g2-default` be more intuitive, given the intent? Let me know what you think.

## How has this been tested?

- Storybook
- Typography panel in the block editor
- Typography panel in global styles

## Types of changes

New feature (non-breaking change which adds functionality)

## TODO before merge

- [ ] Add changelog entry

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
