### PR TITLE
Mark Post Navigation Link and Term Description blocks as stable

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -165,6 +165,7 @@ export const __experimentalGetCoreBlocks = () => [
 	postDate,
 	postExcerpt,
 	postFeaturedImage,
+	postNavigationLink,
 	postTemplate,
 	postTerms,
 	postTitle,
@@ -191,6 +192,7 @@ export const __experimentalGetCoreBlocks = () => [
 	// tableOfContents,
 	tagCloud,
 	templatePart,
+	termDescription,
 	textColumns,
 	verse,
 	video,
@@ -253,8 +255,6 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postCommentsCount,
 								postCommentsForm,
 								postCommentsLink,
-								postNavigationLink,
-								termDescription,
 						  ]
 						: [] ),
 				].forEach( registerBlock );


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/36134.

## How has this been tested?

1. Set `GUTENBERG_PHASE` to 1 in `package.json`.
1. Load the site editor. Post Navigation Link and Term Description should be available for use.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->