### PR TITLE
Always display Customizer menu item

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -81,6 +81,40 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
 
 /**
+ * Removes the legacy core components from the Customizer.
+ *
+ * @param array $components Core Customizer components list.
+ * @return array Modified components list.
+ */
+function gutenberg_remove_customizer_components( $components ) {
+	if ( ! gutenberg_is_fse_theme() ) {
+		return $components;
+	}
+
+	$index = array_search( 'nav_menus', $components, true );
+	if ( false !== $index ) {
+		unset( $components[ $index ] );
+	}
+
+	return $components;
+}
+add_filter( 'customize_loaded_components', 'gutenberg_remove_customizer_components' );
+
+/**
+ * Removes lagecy Customizer sections for FSE themes.
+ *
+ * @param WP_Customize_Manager $wp_customize The customize manager instance.
+ */
+function gutenberg_remove_customizer_sections( $wp_customize ) {
+	if ( ! gutenberg_is_fse_theme() ) {
+		return;
+	}
+
+	$wp_customize->remove_control( 'custom_css' );
+}
+add_action( 'customize_register', 'gutenberg_remove_customizer_sections', 50 );
+
+/**
  * Tells the script loader to load the scripts and styles of custom block on site editor screen.
  *
  * @param bool $is_block_editor_screen Current decision about loading block assets.

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -35,10 +35,6 @@ function gutenberg_remove_legacy_pages() {
 	if ( isset( $submenu['themes.php'] ) ) {
 		$indexes_to_remove = array();
 		foreach ( $submenu['themes.php'] as $index => $menu_item ) {
-			if ( false !== strpos( $menu_item[2], 'customize.php' ) && ! gutenberg_site_requires_customizer() ) {
-				$indexes_to_remove[] = $index;
-			}
-
 			if ( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ) {
 				$indexes_to_remove[] = $index;
 			}
@@ -64,13 +60,11 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 		return;
 	}
 
-	// Remove customizer link, if this site does not rely on them for plugins or theme options.
-	if ( ! gutenberg_site_requires_customizer() ) {
-		$wp_admin_bar->remove_node( 'customize' );
-		$wp_admin_bar->remove_node( 'customize-background' );
-		$wp_admin_bar->remove_node( 'customize-header' );
-		$wp_admin_bar->remove_node( 'widgets' );
-	}
+	// Remove customizer links
+	$wp_admin_bar->remove_node( 'customize' );
+	$wp_admin_bar->remove_node( 'customize-background' );
+	$wp_admin_bar->remove_node( 'customize-header' );
+	$wp_admin_bar->remove_node( 'widgets' );
 
 	// Add site-editor link.
 	if ( ! is_admin() && current_user_can( 'edit_theme_options' ) ) {
@@ -85,19 +79,6 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 }
 
 add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
-
-/**
- * Check if any plugin, or theme features, are using the Customizer.
- *
- * @return bool A boolean value indicating if Customizer support is needed.
- */
-function gutenberg_site_requires_customizer() {
-	if ( has_action( 'customize_register' ) ) {
-		return true;
-	}
-
-	return false;
-}
 
 /**
  * Tells the script loader to load the scripts and styles of custom block on site editor screen.

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -60,7 +60,7 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 		return;
 	}
 
-	// Remove customizer links
+	// Remove customizer links.
 	$wp_admin_bar->remove_node( 'customize' );
 	$wp_admin_bar->remove_node( 'customize-background' );
 	$wp_admin_bar->remove_node( 'customize-header' );


### PR DESCRIPTION
## Description
The team discussed this change during WP 5.9 project board [triage today](https://wordpress.slack.com/archives/C02QB2JS7/p1635918262376900). Without full feature parity, it seems reasonable to always display the Customizer menu.

Features that require Customizer and don't have Site Editor alternatives:
- [ ] https://github.com/WordPress/gutenberg/issues/29126
- [ ] https://github.com/WordPress/gutenberg/issues/35680

## How has this been tested?
* Appearance -> Customizer sub-menu item should be visible.
* You should be able to modify.

## Screenshots <!-- if applicable -->

![CleanShot 2021-11-03 at 10 34 19](https://user-images.githubusercontent.com/240569/140018117-ab798f04-83d9-4890-80b3-28021881a192.png)

## Types of changes
Backward compatibility

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
