### PR TITLE
FSE: Add welcome guide

### DIFF
--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -157,4 +157,17 @@ export const siteEditor = {
 			return '';
 		} );
 	},
+
+	async disableWelcomeGuide() {
+		const isWelcomeGuideActive = await page.evaluate( () =>
+			wp.data.select( 'core/edit-site' ).isFeatureActive( 'welcomeGuide' )
+		);
+		if ( isWelcomeGuideActive ) {
+			await page.evaluate( () =>
+				wp.data
+					.dispatch( 'core/edit-site' )
+					.toggleFeature( 'welcomeGuide' )
+			);
+		}
+	},
 };

--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -162,11 +162,25 @@ export const siteEditor = {
 		const isWelcomeGuideActive = await page.evaluate( () =>
 			wp.data.select( 'core/edit-site' ).isFeatureActive( 'welcomeGuide' )
 		);
+		const isWelcomeGuideStyesActive = await page.evaluate( () =>
+			wp.data
+				.select( 'core/edit-site' )
+				.isFeatureActive( 'welcomeGuideStyles' )
+		);
+
 		if ( isWelcomeGuideActive ) {
 			await page.evaluate( () =>
 				wp.data
 					.dispatch( 'core/edit-site' )
 					.toggleFeature( 'welcomeGuide' )
+			);
+		}
+
+		if ( isWelcomeGuideStyesActive ) {
+			await page.evaluate( () =>
+				wp.data
+					.dispatch( 'core/edit-site' )
+					.toggleFeature( 'welcomeGuideStyles' )
 			);
 		}
 	},

--- a/packages/e2e-tests/specs/experiments/document-settings.test.js
+++ b/packages/e2e-tests/specs/experiments/document-settings.test.js
@@ -36,6 +36,7 @@ describe( 'Document Settings', () => {
 
 	beforeEach( async () => {
 		await siteEditor.visit();
+		await siteEditor.disableWelcomeGuide();
 	} );
 
 	describe( 'when a template is selected from the navigation sidebar', () => {

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -145,6 +145,7 @@ describe( 'Multi-entity editor states', () => {
 
 	it( 'should not display any dirty entities when loading the site editor', async () => {
 		await siteEditor.visit();
+		await siteEditor.disableWelcomeGuide();
 		expect( await openEntitySavePanel() ).toBe( false );
 	} );
 
@@ -204,6 +205,7 @@ describe( 'Multi-entity editor states', () => {
 			);
 			await saveAllEntities();
 			await siteEditor.visit();
+			await siteEditor.disableWelcomeGuide();
 
 			// Wait for site editor to load.
 			await canvas().waitForSelector(

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -244,6 +244,7 @@ describe( 'Multi-entity save flow', () => {
 				postId: 'tt1-blocks//index',
 				postType: 'wp_template',
 			} );
+			await siteEditor.disableWelcomeGuide();
 
 			// Select the header template part via list view.
 			await page.click( '.edit-site-header-toolbar__list-view-toggle' );

--- a/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/experiments/settings-sidebar.test.js
@@ -53,6 +53,7 @@ describe( 'Settings sidebar', () => {
 	} );
 	beforeEach( async () => {
 		await siteEditor.visit();
+		await siteEditor.disableWelcomeGuide();
 	} );
 
 	describe( 'Template tab', () => {

--- a/packages/e2e-tests/specs/experiments/site-editor-export.test.js
+++ b/packages/e2e-tests/specs/experiments/site-editor-export.test.js
@@ -41,6 +41,7 @@ describe( 'Site Editor Templates Export', () => {
 
 	beforeEach( async () => {
 		await siteEditor.visit();
+		await siteEditor.disableWelcomeGuide();
 	} );
 
 	it( 'clicking export should download edit-site-export.zip file', async () => {

--- a/packages/e2e-tests/specs/experiments/site-editor-inserter.test.js
+++ b/packages/e2e-tests/specs/experiments/site-editor-inserter.test.js
@@ -19,6 +19,7 @@ describe( 'Site Editor Inserter', () => {
 	} );
 	beforeEach( async () => {
 		await siteEditor.visit();
+		await siteEditor.disableWelcomeGuide();
 	} );
 
 	it( 'inserter toggle button should toggle global inserter', async () => {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -36,6 +36,7 @@ describe( 'Template Part', () => {
 	describe( 'Template part block', () => {
 		beforeEach( async () => {
 			await siteEditor.visit();
+			await siteEditor.disableWelcomeGuide();
 		} );
 
 		async function navigateToHeader() {

--- a/packages/e2e-tests/specs/experiments/template-revert.test.js
+++ b/packages/e2e-tests/specs/experiments/template-revert.test.js
@@ -16,7 +16,11 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { siteEditor } from '../../experimental-features';
 
-const { visit: visitSiteEditor, getEditedPostContent } = siteEditor;
+const {
+	visit: visitSiteEditor,
+	getEditedPostContent,
+	disableWelcomeGuide,
+} = siteEditor;
 
 const assertSaveButtonIsDisabled = () =>
 	page.waitForSelector(
@@ -97,6 +101,7 @@ describe( 'Template Revert', () => {
 	beforeEach( async () => {
 		await trashAllPosts( 'wp_template' );
 		await visitSiteEditor();
+		await disableWelcomeGuide();
 	} );
 
 	it( 'should delete the template after saving the reverted template', async () => {

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -84,6 +84,7 @@ describe( 'Site Editor Performance', () => {
 		);
 
 		await siteEditor.visit( { postId: id, postType: 'page' } );
+		await siteEditor.disableWelcomeGuide();
 
 		let i = 3;
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -39,6 +39,7 @@ import URLQueryController from '../url-query-controller';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
 import ErrorBoundary from '../error-boundary';
+import WelcomeGuide from '../welcome-guide';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from './global-styles-renderer';
 import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
@@ -288,6 +289,7 @@ function Editor( { initialSettings, onError } ) {
 												}
 												footer={ <BlockBreadcrumb /> }
 											/>
+											<WelcomeGuide />
 											<Popover.Slot />
 											<PluginArea />
 										</ErrorBoundary>

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -35,9 +35,14 @@ export default function WelcomeGuideEditor() {
 								{ __( 'Edit your site' ) }
 							</h1>
 							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'Design everything on your site — from the header right down to the footer — using blocks.'
+								) }
+							</p>
+							<p className="edit-site-welcome-guide__text">
 								{ createInterpolateElement(
 									__(
-										'Design everything on your site — from the header right down to the footer — using blocks. Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
+										'Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
 									),
 									{
 										StylesIconImage: (

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideImage from './image';
+import { store as editSiteStore } from '../../store';
+
+export default function WelcomeGuideEditor() {
+	const { toggleFeature } = useDispatch( editSiteStore );
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide"
+			contentLabel={ __( 'Welcome to the site editor' ) }
+			finishButtonText={ __( 'Try Editor' ) }
+			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
+			pages={ [
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc=""
+							animatedSrc="https://user-images.githubusercontent.com/4933/140506067-cd8cbab4-9a36-4e17-b3ad-c4d86659ffa3.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Edit your site' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ createInterpolateElement(
+									__(
+										'Design everything on your site — from the header right down to the footer — using blocks.. Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
+									),
+									{
+										StylesIconImage: (
+											<img
+												alt={ __( 'styles' ) }
+												src="data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z' fill='%231E1E1E'/%3E%3C/svg%3E%0A"
+											/>
+										),
+									}
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -37,7 +37,7 @@ export default function WelcomeGuideEditor() {
 							<p className="edit-site-welcome-guide__text">
 								{ createInterpolateElement(
 									__(
-										'Design everything on your site — from the header right down to the footer — using blocks.. Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
+										'Design everything on your site — from the header right down to the footer — using blocks. Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
 									),
 									{
 										StylesIconImage: (

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -19,7 +19,7 @@ export default function WelcomeGuideEditor() {
 		<Guide
 			className="edit-site-welcome-guide"
 			contentLabel={ __( 'Welcome to the site editor' ) }
-			finishButtonText={ __( 'Try Editor' ) }
+			finishButtonText={ __( 'Get Started' ) }
 			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
 			pages={ [
 				{

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -25,8 +25,8 @@ export default function WelcomeGuideEditor() {
 				{
 					image: (
 						<WelcomeGuideImage
-							nonAnimatedSrc=""
-							animatedSrc="https://user-images.githubusercontent.com/4933/140506067-cd8cbab4-9a36-4e17-b3ad-c4d86659ffa3.gif"
+							nonAnimatedSrc="https://s.w.org/images/block-editor/edit-your-site.svg?1"
+							animatedSrc="https://s.w.org/images/block-editor/edit-your-site.gif?1"
 						/>
 					),
 					content: (

--- a/packages/edit-site/src/components/welcome-guide/image.js
+++ b/packages/edit-site/src/components/welcome-guide/image.js
@@ -1,0 +1,11 @@
+export default function WelcomeGuideImage( { nonAnimatedSrc, animatedSrc } ) {
+	return (
+		<picture className="edit-site-welcome-guide__image">
+			<source
+				srcSet={ nonAnimatedSrc }
+				media="(prefers-reduced-motion: reduce)"
+			/>
+			<img src={ animatedSrc } width="312" height="240" alt="" />
+		</picture>
+	);
+}

--- a/packages/edit-site/src/components/welcome-guide/index.js
+++ b/packages/edit-site/src/components/welcome-guide/index.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideImage from './image';
+import { store as editSiteStore } from '../../store';
+
+export default function WelcomeGuideTemplate() {
+	const { toggleFeature } = useDispatch( editSiteStore );
+
+	const isActive = useSelect(
+		( select ) => select( editSiteStore ).isFeatureActive( 'welcomeGuide' ),
+		[]
+	);
+
+	if ( ! isActive ) {
+		return null;
+	}
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide"
+			contentLabel={ __( 'Welcome to the site editor' ) }
+			finishButtonText={ __( 'Try Styles' ) }
+			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
+			pages={ [
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc="https://s.w.org/images/block-editor/welcome-template-editor.svg"
+							animatedSrc="https://s.w.org/images/block-editor/welcome-template-editor.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Introducing: Styles' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'Try out and apply new colors, typography, and layout across your entire site. You can also customize the appearance of specific blocks, meaning that all paragraph blocks can appear the same with a few clicks.'
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/welcome-guide/index.js
+++ b/packages/edit-site/src/components/welcome-guide/index.js
@@ -1,56 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
-import { Guide } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
-import WelcomeGuideImage from './image';
+import WelcomeGuideEditor from './editor';
+import WelcomeGuideStyles from './styles';
 import { store as editSiteStore } from '../../store';
 
-export default function WelcomeGuideTemplate() {
-	const { toggleFeature } = useDispatch( editSiteStore );
+export default function WelcomeGuide() {
+	const { isActive, isStylesOpen } = useSelect( ( select ) => {
+		const sidebar = select( interfaceStore ).getActiveComplementaryArea(
+			editSiteStore.name
+		);
+		const isStylesSidebar = sidebar === 'edit-site/global-styles';
+		const feature = isStylesSidebar ? 'welcomeGuideStyles' : 'welcomeGuide';
 
-	const isActive = useSelect(
-		( select ) => select( editSiteStore ).isFeatureActive( 'welcomeGuide' ),
-		[]
-	);
+		return {
+			isActive: select( editSiteStore ).isFeatureActive( feature ),
+			isStylesOpen: isStylesSidebar,
+		};
+	}, [] );
 
 	if ( ! isActive ) {
 		return null;
 	}
 
-	return (
-		<Guide
-			className="edit-site-welcome-guide"
-			contentLabel={ __( 'Welcome to the site editor' ) }
-			finishButtonText={ __( 'Try Styles' ) }
-			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
-			pages={ [
-				{
-					image: (
-						<WelcomeGuideImage
-							nonAnimatedSrc="https://s.w.org/images/block-editor/welcome-template-editor.svg"
-							animatedSrc="https://s.w.org/images/block-editor/welcome-template-editor.gif"
-						/>
-					),
-					content: (
-						<>
-							<h1 className="edit-site-welcome-guide__heading">
-								{ __( 'Introducing: Styles' ) }
-							</h1>
-							<p className="edit-site-welcome-guide__text">
-								{ __(
-									'Try out and apply new colors, typography, and layout across your entire site. You can also customize the appearance of specific blocks, meaning that all paragraph blocks can appear the same with a few clicks.'
-								) }
-							</p>
-						</>
-					),
-				},
-			] }
-		/>
-	);
+	return isStylesOpen ? <WelcomeGuideStyles /> : <WelcomeGuideEditor />;
 }

--- a/packages/edit-site/src/components/welcome-guide/style.scss
+++ b/packages/edit-site/src/components/welcome-guide/style.scss
@@ -1,0 +1,33 @@
+.edit-site-welcome-guide {
+	width: 312px;
+
+	&__image {
+		background: #00a0d2;
+		margin: 0 0 $grid-unit-20;
+		> img {
+			display: block;
+			max-width: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&__heading {
+		font-family: $default-font;
+		font-size: 24px;
+		line-height: 1.4;
+		margin: $grid-unit-20 0 $grid-unit-20 0;
+		padding: 0 $grid-unit-40;
+	}
+
+	&__text {
+		font-size: $default-font-size;
+		line-height: 1.4;
+		margin: 0 0 $grid-unit-30 0;
+		padding: 0 $grid-unit-40;
+	}
+
+	&__inserter-icon {
+		margin: 0 4px;
+		vertical-align: text-top;
+	}
+}

--- a/packages/edit-site/src/components/welcome-guide/style.scss
+++ b/packages/edit-site/src/components/welcome-guide/style.scss
@@ -22,8 +22,12 @@
 	&__text {
 		font-size: $default-font-size;
 		line-height: 1.4;
-		margin: 0 0 $grid-unit-30 0;
+		margin: 0 0 $grid-unit-20 0;
 		padding: 0 $grid-unit-40;
+
+		img {
+			vertical-align: bottom;
+		}
 	}
 
 	&__inserter-icon {

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -1,0 +1,116 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { ExternalLink, Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideImage from './image';
+import { store as editSiteStore } from '../../store';
+
+export default function WelcomeGuideStyles() {
+	const { toggleFeature } = useDispatch( editSiteStore );
+
+	return (
+		<Guide
+			className="edit-site-welcome-guide"
+			contentLabel={ __( 'Welcome to styles' ) }
+			finishButtonText={ __( 'Try Styles' ) }
+			onFinish={ () => toggleFeature( 'welcomeGuideStyles' ) }
+			pages={ [
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc=""
+							animatedSrc="https://user-images.githubusercontent.com/4933/140506059-88d5f9d2-219f-4448-9e3e-4325208f3be0.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Welcome to Styles' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'Tweak your site, or give it a whole new look! Get creative — how about a new color palette for your buttons, or choosing a new font? Take a look at what you can do here.'
+								) }
+							</p>
+						</>
+					),
+				},
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc=""
+							animatedSrc="https://user-images.githubusercontent.com/4933/140503972-f10ab71a-b86e-4f73-935b-dd277e782a57.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Set the design' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'You can customize your site as much as you like with different colors, typography, and layouts. Or if you prefer, just leave it up to your theme to handle! '
+								) }
+							</p>
+						</>
+					),
+				},
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc=""
+							animatedSrc="https://user-images.githubusercontent.com/4933/140499197-e497a167-edb8-4bfa-a462-3065dc962aba.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Personalize blocks' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'You can adjust your blocks to ensure a cohesive experience across your site — add your unique colors to a branded Button block, or adjust the Heading block to your preferred size.'
+								) }
+							</p>
+						</>
+					),
+				},
+				{
+					image: (
+						<WelcomeGuideImage
+							nonAnimatedSrc="https://s.w.org/images/block-editor/welcome-documentation.svg"
+							animatedSrc="https://s.w.org/images/block-editor/welcome-documentation.gif"
+						/>
+					),
+					content: (
+						<>
+							<h1 className="edit-site-welcome-guide__heading">
+								{ __( 'Learn more' ) }
+							</h1>
+							<p className="edit-site-welcome-guide__text">
+								{ __(
+									'New to block themes and styling your site? '
+								) }
+								<ExternalLink
+									href={ __(
+										'https://wordpress.org/support/article/wordpress-editor/'
+									) }
+								>
+									{ __(
+										'Here’s a detailed guide to learn how to make the most of it.'
+									) }
+								</ExternalLink>
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -18,7 +18,7 @@ export default function WelcomeGuideStyles() {
 		<Guide
 			className="edit-site-welcome-guide"
 			contentLabel={ __( 'Welcome to styles' ) }
-			finishButtonText={ __( 'Try Styles' ) }
+			finishButtonText={ __( 'Get Started' ) }
 			onFinish={ () => toggleFeature( 'welcomeGuideStyles' ) }
 			pages={ [
 				{

--- a/packages/edit-site/src/components/welcome-guide/styles.js
+++ b/packages/edit-site/src/components/welcome-guide/styles.js
@@ -24,8 +24,8 @@ export default function WelcomeGuideStyles() {
 				{
 					image: (
 						<WelcomeGuideImage
-							nonAnimatedSrc=""
-							animatedSrc="https://user-images.githubusercontent.com/4933/140506059-88d5f9d2-219f-4448-9e3e-4325208f3be0.gif"
+							nonAnimatedSrc="https://s.w.org/images/block-editor/welcome-to-styles.svg?1"
+							animatedSrc="https://s.w.org/images/block-editor/welcome-to-styles.gif?1"
 						/>
 					),
 					content: (
@@ -44,8 +44,8 @@ export default function WelcomeGuideStyles() {
 				{
 					image: (
 						<WelcomeGuideImage
-							nonAnimatedSrc=""
-							animatedSrc="https://user-images.githubusercontent.com/4933/140503972-f10ab71a-b86e-4f73-935b-dd277e782a57.gif"
+							nonAnimatedSrc="https://s.w.org/images/block-editor/set-the-design.svg?1"
+							animatedSrc="https://s.w.org/images/block-editor/set-the-design.gif?1"
 						/>
 					),
 					content: (
@@ -64,8 +64,8 @@ export default function WelcomeGuideStyles() {
 				{
 					image: (
 						<WelcomeGuideImage
-							nonAnimatedSrc=""
-							animatedSrc="https://user-images.githubusercontent.com/4933/140499197-e497a167-edb8-4bfa-a462-3065dc962aba.gif"
+							nonAnimatedSrc="https://s.w.org/images/block-editor/personalize-blocks.svg?1"
+							animatedSrc="https://s.w.org/images/block-editor/personalize-blocks.gif?1"
 						/>
 					),
 					content: (

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -16,6 +16,7 @@ import { download } from '@wordpress/icons';
  * Internal dependencies
  */
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
+import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
 registerPlugin( 'edit-site', {
 	render() {
@@ -45,6 +46,7 @@ registerPlugin( 'edit-site', {
 					>
 						{ __( 'Export' ) }
 					</MenuItem>
+					<WelcomeGuideMenuItem />
 				</ToolsMoreMenuGroup>
 			</>
 		);

--- a/packages/edit-site/src/plugins/welcome-guide-menu-item.js
+++ b/packages/edit-site/src/plugins/welcome-guide-menu-item.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { MenuItem } from '@wordpress/components';
+import { store as interfaceStore } from '@wordpress/interface';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../store';
+
+export default function WelcomeGuideMenuItem() {
+	const { toggleFeature } = useDispatch( editSiteStore );
+	const isStylesOpen = useSelect( ( select ) => {
+		const sidebar = select( interfaceStore ).getActiveComplementaryArea(
+			editSiteStore.name
+		);
+
+		return sidebar === 'edit-site/global-styles';
+	}, [] );
+
+	return (
+		<MenuItem
+			onClick={ () =>
+				toggleFeature(
+					isStylesOpen ? 'welcomeGuideStyles' : 'welcomeGuide'
+				)
+			}
+		>
+			{ __( 'Welcome Guide' ) }
+		</MenuItem>
+	);
+}

--- a/packages/edit-site/src/store/defaults.js
+++ b/packages/edit-site/src/store/defaults.js
@@ -1,3 +1,5 @@
 export const PREFERENCES_DEFAULTS = {
-	features: {},
+	features: {
+		welcomeGuide: true,
+	},
 };

--- a/packages/edit-site/src/store/defaults.js
+++ b/packages/edit-site/src/store/defaults.js
@@ -1,5 +1,6 @@
 export const PREFERENCES_DEFAULTS = {
 	features: {
 		welcomeGuide: true,
+		welcomeGuideStyles: true,
 	},
 };

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -13,6 +13,7 @@
 @import "./components/template-details/style.scss";
 @import "./components/template-part-converter/style.scss";
 @import "./components/secondary-sidebar/style.scss";
+@import "./components/welcome-guide/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color.
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations.


### PR DESCRIPTION
## Description
Adds Welcome Guide to the Site Editor.

Fixes #32844.

## Todos
- [x] Update design.
- [x] Update copy.
- [x] Update e2e test to hide modal.
- [x] Add menu item under Options -> Tools (requires #36146).

## How has this been tested?
To display editor modal enter this snippet in DevTools console:
```js
wp.data.dispatch('core/edit-site').toggleFeature('welcomeGuide');
```

To display welcome guide for Global Styles, open styles panel and then use this snippet in console:
```js
wp.data.dispatch('core/edit-site').toggleFeature('welcomeGuideStyles');
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-03 at 14 12 44](https://user-images.githubusercontent.com/240569/140042491-95804221-f091-4d3e-b8db-24720fc5dfc0.png)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
