### PR TITLE
Hotfix for leftovers of `WP_Theme_JSON_Resolver::get_merged_data`

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -374,7 +374,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$theme    = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( array(), 'theme' );
+		$theme    = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
 		$styles   = $theme->get_raw_data()['styles'];
 		$settings = $theme->get_settings();
 		$result   = array(

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -29,8 +29,7 @@ function gutenberg_get_global_settings( $path = array(), $block_name = '', $orig
 		$origin = 'user';
 	}
 
-	$theme_supports = gutenberg_get_default_block_editor_settings();
-	$settings       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )->get_settings();
+	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
 
 	return _wp_array_get( $settings, $path, $settings );
 }
@@ -59,8 +58,7 @@ function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin
 		$origin = 'user';
 	}
 
-	$theme_supports = gutenberg_get_default_block_editor_settings();
-	$styles         = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports, $origin )->get_raw_data()['styles'];
+	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
 
 	return _wp_array_get( $styles, $path, $styles );
 }
@@ -111,8 +109,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		$origins = array( 'core', 'theme' );
 	}
 
-	$theme_supports = gutenberg_get_default_block_editor_settings();
-	$tree           = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $theme_supports );
+	$tree           = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$stylesheet     = $tree->get_stylesheet( $types, $origins );
 
 	if ( $can_use_cached ) {

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -109,8 +109,8 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		$origins = array( 'core', 'theme' );
 	}
 
-	$tree           = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$stylesheet     = $tree->get_stylesheet( $types, $origins );
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$stylesheet = $tree->get_stylesheet( $types, $origins );
 
 	if ( $can_use_cached ) {
 		// Cache for a minute.


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/36054

Some PRs got merged in parallel to https://github.com/WordPress/gutenberg/pull/36054 and we didn't remove the `settings` argument to the `WP_Theme_JSON_Resolver::get_merged_data` for all of them.

## How to test

- Use the TT1-blocks theme.
- Go to the site editor and add a new color. Save.
- Go to the post editor and open the color panel of a block.

The expected result is that it has the new user color. Without this PR, it doesn't.
