### PR TITLE
Blocks: Add view script to block schema and docs

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -42,6 +42,7 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 	},
 	"editorScript": "file:./build/index.js",
 	"script": "file:./build/script.js",
+	"viewScript": "file:./build/view.js",
 	"editorStyle": "file:./build/index.css",
 	"style": "file:./build/style.css"
 }
@@ -262,7 +263,7 @@ Sometimes a block could have aliases that help users discover it while searching
 -   Optional
 -   Localized: No
 -   Property: `version`
--   Since: `5.8.0`
+-   Since: `WordPress 5.8.0`
 
 ```json
 { "version": "1.0.3" }
@@ -276,6 +277,7 @@ The current version number of the block, such as 1.0 or 1.0.3. It's similar to h
 -   Optional
 -   Localized: No
 -   Property: `textdomain`
+-   Since: `WordPress 5.7.0`
 
 ```json
 { "textdomain": "my-plugin" }
@@ -427,7 +429,21 @@ Block type editor script definition. It will only be enqueued in the context of 
 { "script": "file:./build/script.js" }
 ```
 
-Block type frontend script definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
+Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
+
+### View Script
+
+-   Type: `string` ([WPDefinedAsset](#WPDefinedAsset))
+-   Optional
+-   Localized: No
+-   Property: `viewScript`
+-   Since: `WordPress 5.9.0`
+
+```json
+{ "script": "file:./build/view.js" }
+```
+
+Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site.
 
 ### Editor Style
 
@@ -513,6 +529,14 @@ return array(
 	'version'      => '3be55b05081a63d8f9d0ecb466c42cfd',
 );
 ```
+
+### Frontend Enqueueing
+
+Starting in the WordPress 5.8 release, it is possible to instruct WordPress to enqueue scripts and styles for a block type only when rendered on the frontend. It applies to the following asset fields in the `block.json` file:
+
+-   `script`
+-   `viewScript` (when the block defines `render_callback` during registration in PHP, then the block author is responsible for enqueuing the script)
+-   `style`
 
 ## Internationalization
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -374,7 +374,11 @@
 		},
 		"script": {
 			"type": "string",
-			"description": "Block type frontend script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
+			"description": "Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
+		},
+		"viewScript": {
+			"type": "string",
+			"description": "Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site."
 		},
 		"editorStyle": {
 			"type": "string",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Part of https://github.com/WordPress/gutenberg/issues/35902.

It adds the missing `viewScript` fields to `block.json` related documentation and schema. It's going to be part of WordPress core starting from 5.9 release.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Documentation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
