### PR TITLE
Remove GB prefixed functions from template part

### DIFF
--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -25,7 +25,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_supports_block_templates();
 
 	if ( gutenberg_is_fse_theme() ) {
-		$settings['defaultTemplatePartAreas'] = gutenberg_get_allowed_template_part_areas();
+		$settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
 	}
 
 	return $settings;

--- a/lib/full-site-editing/block-templates.php
+++ b/lib/full-site-editing/block-templates.php
@@ -195,41 +195,42 @@ function _gutenberg_flatten_blocks( &$blocks ) {
 	return $all_blocks;
 }
 
-/**
- * Parses wp_template content and injects the current theme's
- * stylesheet as a theme attribute into each wp_template_part
- *
- * @param string $template_content serialized wp_template content.
- *
- * @return string Updated wp_template content.
- */
-function _gutenberg_inject_theme_attribute_in_content( $template_content ) {
-	$has_updated_content = false;
-	$new_content         = '';
-	$template_blocks     = parse_blocks( $template_content );
+if ( ! function_exists( '_inject_theme_attribute_in_block_template_content' ) ) {
+	/**
+	 * Parses wp_template content and injects the current theme's
+	 * stylesheet as a theme attribute into each wp_template_part
+	 *
+	 * @param string $template_content serialized wp_template content.
+	 *
+	 * @return string Updated wp_template content.
+	 */
+	function _inject_theme_attribute_in_block_template_content( $template_content ) {
+		$has_updated_content = false;
+		$new_content         = '';
+		$template_blocks     = parse_blocks( $template_content );
 
-	$blocks = _gutenberg_flatten_blocks( $template_blocks );
-	foreach ( $blocks as &$block ) {
-		if (
-			'core/template-part' === $block['blockName'] &&
-			! isset( $block['attrs']['theme'] )
-		) {
-			$block['attrs']['theme'] = wp_get_theme()->get_stylesheet();
-			$has_updated_content     = true;
-		}
-	}
-
-	if ( $has_updated_content ) {
-		foreach ( $template_blocks as &$block ) {
-			$new_content .= serialize_block( $block );
+		$blocks = _gutenberg_flatten_blocks( $template_blocks );
+		foreach ( $blocks as &$block ) {
+			if (
+				'core/template-part' === $block['blockName'] &&
+				! isset( $block['attrs']['theme'] )
+			) {
+				$block['attrs']['theme'] = wp_get_theme()->get_stylesheet();
+				$has_updated_content     = true;
+			}
 		}
 
-		return $new_content;
-	}
+		if ( $has_updated_content ) {
+			foreach ( $template_blocks as &$block ) {
+				$new_content .= serialize_block( $block );
+			}
 
-	return $template_content;
+			return $new_content;
+		}
+
+		return $template_content;
+	}
 }
-
 /**
  * Build a unified template object based on a theme file.
  *
@@ -246,7 +247,7 @@ function _gutenberg_build_template_result_from_file( $template_file, $template_t
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _gutenberg_inject_theme_attribute_in_content( $template_content );
+	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -94,7 +94,7 @@ function gutenberg_edit_site_init( $hook ) {
 		'postsPerPage'                         => get_option( 'posts_per_page' ),
 		'styles'                               => gutenberg_get_editor_styles(),
 		'defaultTemplateTypes'                 => gutenberg_get_indexed_default_template_types(),
-		'defaultTemplatePartAreas'             => gutenberg_get_allowed_template_part_areas(),
+		'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
 		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	);

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -162,51 +162,53 @@ function set_unique_slug_on_create_template_part( $post_id ) {
 }
 add_action( 'save_post_wp_template_part', 'set_unique_slug_on_create_template_part' );
 
-/**
- * Returns a filtered list of allowed area values for template parts.
- *
- * @return array The supported template part area values.
- */
-function gutenberg_get_allowed_template_part_areas() {
-	$default_area_definitions = array(
-		array(
-			'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
-			'label'       => __( 'General', 'gutenberg' ),
-			'description' => __(
-				'General templates often perform a specific role like displaying post content, and are not tied to any particular area.',
-				'gutenberg'
-			),
-			'icon'        => 'layout',
-			'area_tag'    => 'div',
-		),
-		array(
-			'area'        => WP_TEMPLATE_PART_AREA_HEADER,
-			'label'       => __( 'Header', 'gutenberg' ),
-			'description' => __(
-				'The Header template defines a page area that typically contains a title, logo, and main navigation.',
-				'gutenberg'
-			),
-			'icon'        => 'header',
-			'area_tag'    => 'header',
-		),
-		array(
-			'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
-			'label'       => __( 'Footer', 'gutenberg' ),
-			'description' => __(
-				'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
-				'gutenberg'
-			),
-			'icon'        => 'footer',
-			'area_tag'    => 'footer',
-		),
-	);
-
+if ( ! function_exists( 'get_allowed_block_template_part_areas' ) ) {
 	/**
-	 * Filters the list of allowed template part area values.
+	 * Returns a filtered list of allowed area values for template parts.
 	 *
-	 * @param array $default_areas An array of supported area objects.
+	 * @return array The supported template part area values.
 	 */
-	return apply_filters( 'default_wp_template_part_areas', $default_area_definitions );
+	function get_allowed_block_template_part_areas() {
+		$default_area_definitions = array(
+			array(
+				'area'        => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+				'label'       => __( 'General', 'gutenberg' ),
+				'description' => __(
+					'General templates often perform a specific role like displaying post content, and are not tied to any particular area.',
+					'gutenberg'
+				),
+				'icon'        => 'layout',
+				'area_tag'    => 'div',
+			),
+			array(
+				'area'        => WP_TEMPLATE_PART_AREA_HEADER,
+				'label'       => __( 'Header', 'gutenberg' ),
+				'description' => __(
+					'The Header template defines a page area that typically contains a title, logo, and main navigation.',
+					'gutenberg'
+				),
+				'icon'        => 'header',
+				'area_tag'    => 'header',
+			),
+			array(
+				'area'        => WP_TEMPLATE_PART_AREA_FOOTER,
+				'label'       => __( 'Footer', 'gutenberg' ),
+				'description' => __(
+					'The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.',
+					'gutenberg'
+				),
+				'icon'        => 'footer',
+				'area_tag'    => 'footer',
+			),
+		);
+
+		/**
+		 * Filters the list of allowed template part area values.
+		 *
+		 * @param array $default_areas An array of supported area objects.
+		 */
+		return apply_filters( 'default_wp_template_part_areas', $default_area_definitions );
+	}
 }
 
 /**
@@ -222,7 +224,7 @@ function gutenberg_filter_template_part_area( $type ) {
 		function ( $item ) {
 			return $item['area'];
 		},
-		gutenberg_get_allowed_template_part_areas()
+		get_allowed_block_template_part_areas()
 	);
 	if ( in_array( $type, $allowed_areas, true ) ) {
 		return $type;

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -55,7 +55,7 @@ function render_block_core_template_part( $attributes ) {
 			// render the corresponding file content.
 			$template_part_file_path = get_theme_file_path( '/block-template-parts/' . $attributes['slug'] . '.html' );
 			if ( 0 === validate_file( $attributes['slug'] ) && file_exists( $template_part_file_path ) ) {
-				$content = _gutenberg_inject_theme_attribute_in_content( file_get_contents( $template_part_file_path ) );
+				$content = _inject_theme_attribute_in_block_template_content( file_get_contents( $template_part_file_path ) );
 			}
 		}
 	}
@@ -99,7 +99,7 @@ function render_block_core_template_part( $attributes ) {
 	$content = $wp_embed->autoembed( $content );
 
 	if ( empty( $attributes['tagName'] ) ) {
-		$defined_areas = gutenberg_get_allowed_template_part_areas();
+		$defined_areas = get_allowed_block_template_part_areas();
 		$area_tag      = 'div';
 		foreach ( $defined_areas as $defined_area ) {
 			if ( $defined_area['area'] === $area && isset( $defined_area['area_tag'] ) ) {
@@ -122,7 +122,7 @@ function render_block_core_template_part( $attributes ) {
  */
 function build_template_part_block_variations() {
 	$variations    = array();
-	$defined_areas = gutenberg_get_allowed_template_part_areas();
+	$defined_areas = get_allowed_block_template_part_areas();
 	foreach ( $defined_areas as $area ) {
 		if ( 'uncategorized' !== $area['area'] ) {
 			$variations[] = array(

--- a/phpunit/class-block-templates-test.php
+++ b/phpunit/class-block-templates-test.php
@@ -150,10 +150,10 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 	}
 
-	function test_gutenberg_inject_theme_attribute_in_content() {
+	function test_inject_theme_attribute_in_block_template_content() {
 		$theme                           = get_stylesheet();
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';
-		$template_content                = _gutenberg_inject_theme_attribute_in_content(
+		$template_content                = _inject_theme_attribute_in_block_template_content(
 			$content_without_theme_attribute,
 			$theme
 		);
@@ -164,7 +164,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $template_content );
 
 		$content_without_theme_attribute_nested = '<!-- wp:group --><!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /--><!-- /wp:group -->';
-		$template_content                       = _gutenberg_inject_theme_attribute_in_content(
+		$template_content                       = _inject_theme_attribute_in_block_template_content(
 			$content_without_theme_attribute_nested,
 			$theme
 		);
@@ -176,7 +176,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 
 		// Does not inject theme when there is an existing theme attribute.
 		$content_with_existing_theme_attribute = '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->';
-		$template_content                      = _gutenberg_inject_theme_attribute_in_content(
+		$template_content                      = _inject_theme_attribute_in_block_template_content(
 			$content_with_existing_theme_attribute,
 			$theme
 		);
@@ -184,7 +184,7 @@ class Block_Templates_Test extends WP_UnitTestCase {
 
 		// Does not inject theme when there is no template part.
 		$content_with_no_template_part = '<!-- wp:post-content /-->';
-		$template_content              = _gutenberg_inject_theme_attribute_in_content(
+		$template_content              = _inject_theme_attribute_in_block_template_content(
 			$content_with_no_template_part,
 			$theme
 		);


### PR DESCRIPTION


This will be needed for back porting the FSE changes in core: https://github.com/WordPress/wordpress-develop/pull/1796