### PR TITLE
Multi-entity save UI: Add Discard Changes panel

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -700,14 +700,29 @@ export const __experimentalSaveSpecifiedEntityEdits = (
  * @param {string} name     Name of the entity.
  * @param {Object} recordId ID of the record.
  */
-export function __experimentalResetEditedEntityRecord( kind, name, recordId ) {
-	return {
-		type: 'RESET_ENTITY_RECORD_EDITS',
+export const __experimentalResetEditedEntityRecord = (
+	kind,
+	name,
+	recordId
+) => async ( { select, dispatch } ) => {
+	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
+		return;
+	}
+	const edits = select.getEntityRecordEdits( kind, name, recordId );
+	const editsToDiscard = {};
+	for ( const edit in edits ) {
+		editsToDiscard[ edit ] = undefined;
+	}
+	return await dispatch( {
+		type: 'EDIT_ENTITY_RECORD',
 		kind,
 		name,
 		recordId,
-	};
-}
+		edits: editsToDiscard,
+		transientEdits: {},
+		meta: { undo: undefined },
+	} );
+};
 
 /**
  * Action triggered to reset only specified properties for the entity.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -710,6 +710,43 @@ export function __experimentalResetEditedEntityRecord( kind, name, recordId ) {
 }
 
 /**
+ * Action triggered to reset only specified properties for the entity.
+ *
+ * @param {string} kind         Kind of the entity.
+ * @param {string} name         Name of the entity.
+ * @param {Object} recordId     ID of the record.
+ * @param {Array}  itemsToReset List of entity properties to reset.
+ */
+export const __experimentalResetSpecifiedEntityEdits = (
+	kind,
+	name,
+	recordId,
+	itemsToReset
+) => async ( { select, dispatch } ) => {
+	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
+		return;
+	}
+	const edits = select.getEntityRecordNonTransientEdits(
+		kind,
+		name,
+		recordId
+	);
+	const editsToDiscard = {};
+	for ( const edit in edits ) {
+		if ( itemsToReset.some( ( item ) => item === edit ) ) {
+			editsToDiscard[ edit ] = edits[ edit ];
+		}
+	}
+	return await dispatch( {
+		type: 'RESET_SPECIFIED_ENTITY_RECORD_EDITS',
+		kind,
+		name,
+		recordId,
+		edits: Object.keys( editsToDiscard ),
+	} );
+};
+
+/**
  * Returns an action object used in signalling that Upload permissions have been received.
  *
  * @param {boolean} hasUploadPermissions Does the user have permission to upload files?

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -738,11 +738,13 @@ export const __experimentalResetSpecifiedEntityEdits = (
 		}
 	}
 	return await dispatch( {
-		type: 'RESET_SPECIFIED_ENTITY_RECORD_EDITS',
+		type: 'EDIT_ENTITY_RECORD',
 		kind,
 		name,
 		recordId,
-		edits: Object.keys( editsToDiscard ),
+		edits: editsToDiscard,
+		transientEdits: {},
+		meta: { undo: undefined }, // Don't add this to the undo stack.
 	} );
 };
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -734,7 +734,7 @@ export const __experimentalResetSpecifiedEntityEdits = (
 	const editsToDiscard = {};
 	for ( const edit in edits ) {
 		if ( itemsToReset.some( ( item ) => item === edit ) ) {
-			editsToDiscard[ edit ] = edits[ edit ];
+			editsToDiscard[ edit ] = undefined;
 		}
 	}
 	return await dispatch( {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -694,6 +694,22 @@ export const __experimentalSaveSpecifiedEntityEdits = (
 };
 
 /**
+ * Action triggered to reset an entity record's edits.
+ *
+ * @param {string} kind     Kind of the entity.
+ * @param {string} name     Name of the entity.
+ * @param {Object} recordId ID of the record.
+ */
+export function __experimentalResetEditedEntityRecord( kind, name, recordId ) {
+	return {
+		type: 'RESET_ENTITY_RECORD_EDITS',
+		kind,
+		name,
+		recordId,
+	};
+}
+
+/**
  * Returns an action object used in signalling that Upload permissions have been received.
  *
  * @param {boolean} hasUploadPermissions Does the user have permission to upload files?

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, map, groupBy, flowRight, isEqual, get, omit } from 'lodash';
+import { keyBy, map, groupBy, flowRight, isEqual, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -272,14 +272,6 @@ function entity( entityConfig ) {
 						} = state;
 
 						return otherEdits;
-
-					case 'RESET_SPECIFIED_ENTITY_RECORD_EDITS':
-						const edits = state[ action.recordId ];
-
-						return {
-							...state,
-							[ action.recordId ]: omit( edits, action.edits ),
-						};
 				}
 
 				return state;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -263,6 +263,15 @@ function entity( entityConfig ) {
 							...state,
 							[ action.recordId ]: nextEdits,
 						};
+
+					case 'RESET_ENTITY_RECORD_EDITS':
+						const {
+							// eslint-disable-next-line no-unused-vars
+							[ action.recordId ]: recordEdits,
+							...otherEdits
+						} = state;
+
+						return otherEdits;
 				}
 
 				return state;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -263,15 +263,6 @@ function entity( entityConfig ) {
 							...state,
 							[ action.recordId ]: nextEdits,
 						};
-
-					case 'RESET_ENTITY_RECORD_EDITS':
-						const {
-							// eslint-disable-next-line no-unused-vars
-							[ action.recordId ]: recordEdits,
-							...otherEdits
-						} = state;
-
-						return otherEdits;
 				}
 
 				return state;

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, map, groupBy, flowRight, isEqual, get } from 'lodash';
+import { keyBy, map, groupBy, flowRight, isEqual, get, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -272,6 +272,14 @@ function entity( entityConfig ) {
 						} = state;
 
 						return otherEdits;
+
+					case 'RESET_SPECIFIED_ENTITY_RECORD_EDITS':
+						const edits = state[ action.recordId ];
+
+						return {
+							...state,
+							[ action.recordId ]: omit( edits, action.edits ),
+						};
 				}
 
 				return state;

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -17,6 +17,7 @@ import {
 	receiveAutosaves,
 	receiveCurrentUser,
 	__experimentalBatch,
+	__experimentalResetSpecifiedEntityEdits,
 } from '../actions';
 
 jest.mock( '../batch', () => {
@@ -193,6 +194,37 @@ describe( 'saveEditedEntityRecord', () => {
 			{ area: 'primary' },
 			undefined
 		);
+	} );
+} );
+
+describe( '__experimentalResetSpecifiedEntityEdits', () => {
+	it( 'triggers an EDIT_ENTITY_RECORD action to set the selected entity record edits to undefined', async () => {
+		const itemsToDiscard = [ 'title' ];
+
+		const select = {
+			getEntityRecordNonTransientEdits: () => [ { description: {} } ],
+			hasEditsForEntityRecord: () => true,
+		};
+
+		const dispatch = Object.assign( jest.fn() );
+
+		await __experimentalResetSpecifiedEntityEdits(
+			'root',
+			'site',
+			undefined,
+			itemsToDiscard
+		)( { dispatch, select } );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'site',
+			recordId: undefined,
+			edits: { title: undefined },
+			transientEdits: {},
+			meta: { undo: undefined },
+		} );
 	} );
 } );
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -202,7 +202,10 @@ describe( '__experimentalResetSpecifiedEntityEdits', () => {
 		const itemsToDiscard = [ 'title' ];
 
 		const select = {
-			getEntityRecordNonTransientEdits: () => [ { description: {} } ],
+			getEntityRecordNonTransientEdits: () => ( {
+				title: {},
+				description: {},
+			} ),
 			hasEditsForEntityRecord: () => true,
 		};
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -17,6 +17,7 @@ import {
 	receiveAutosaves,
 	receiveCurrentUser,
 	__experimentalBatch,
+	__experimentalResetEditedEntityRecord,
 	__experimentalResetSpecifiedEntityEdits,
 } from '../actions';
 
@@ -194,6 +195,34 @@ describe( 'saveEditedEntityRecord', () => {
 			{ area: 'primary' },
 			undefined
 		);
+	} );
+} );
+
+describe( '__experimentalResetEditedEntityRecord', () => {
+	it( "triggers an EDIT_ENTITY_RECORD action to set all the selected entity record's edits to undefined", async () => {
+		const select = {
+			getEntityRecordEdits: () => ( { description: {}, title: {} } ),
+			hasEditsForEntityRecord: () => true,
+		};
+
+		const dispatch = Object.assign( jest.fn() );
+
+		await __experimentalResetEditedEntityRecord(
+			'root',
+			'site',
+			undefined
+		)( { dispatch, select } );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'root',
+			name: 'site',
+			recordId: undefined,
+			edits: { description: undefined, title: undefined },
+			transientEdits: {},
+			meta: { undo: undefined },
+		} );
 	} );
 } );
 

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -94,23 +94,37 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 				</div>
 
 				<PanelBody initialOpen={ true }>
-					{ discardableSavables.map( ( record ) => (
-						<EntityRecordItem
-							key={ record.key || record.property }
-							record={ record }
-							checked={ some(
-								selectedEntities,
-								( elt ) =>
-									elt.kind === record.kind &&
-									elt.name === record.name &&
-									elt.key === record.key &&
-									elt.property === record.property
-							) }
-							onChange={ ( value ) =>
-								setSelectedEntities( record, value )
-							}
-						/>
-					) ) }
+					{ isSaving && (
+						<ul className="entities-saved-states__discard-changes__saving">
+							<li className="entities-saved-states__discard-changes-item">
+								&#8203;
+							</li>
+							<li className="entities-saved-states__discard-changes-item">
+								&#8203;
+							</li>
+							<li className="entities-saved-states__discard-changes-item">
+								&#8203;
+							</li>
+						</ul>
+					) }
+					{ ! isSaving &&
+						discardableSavables.map( ( record ) => (
+							<EntityRecordItem
+								key={ record.key || record.property }
+								record={ record }
+								checked={ some(
+									selectedEntities,
+									( elt ) =>
+										elt.kind === record.kind &&
+										elt.name === record.name &&
+										elt.key === record.key &&
+										elt.property === record.property
+								) }
+								onChange={ ( value ) =>
+									setSelectedEntities( record, value )
+								}
+							/>
+						) ) }
 					<PanelRow>
 						<Button
 							disabled={

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -17,11 +17,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import EntityRecordItem from './entity-record-item';
 
-export default function DiscardEntityChangesPanel( {
-	closePanel,
-	dirtyEntityRecords,
-	savables,
-} ) {
+export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 	const {
 		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
 		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
@@ -50,23 +46,10 @@ export default function DiscardEntityChangesPanel( {
 	};
 
 	const discardCheckedEntities = () => {
-		const entitiesToDiscard = dirtyEntityRecords.filter(
-			( { kind, name, key, property } ) => {
-				return some(
-					selectedEntities,
-					( elt ) =>
-						elt.kind === kind &&
-						elt.name === name &&
-						elt.key === key &&
-						elt.property === property
-				);
-			}
-		);
-
 		closePanel();
 
 		const siteItemsToDiscard = [];
-		entitiesToDiscard.forEach( ( { kind, name, key, property } ) => {
+		selectedEntities.forEach( ( { kind, name, key, property } ) => {
 			if ( 'root' === kind && 'site' === name ) {
 				siteItemsToDiscard.push( property );
 			} else {

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -8,7 +8,7 @@ import { some } from 'lodash';
  */
 import { Button, PanelBody, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Fragment, useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -18,6 +18,15 @@ import { store as coreStore } from '@wordpress/core-data';
 import EntityRecordItem from './entity-record-item';
 
 export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
+	const discardableSavables = useSelect( ( select ) =>
+		savables.filter(
+			( { kind, name, key } ) =>
+				! select( coreStore ).isSavingEntityRecord( kind, name, key )
+		)
+	);
+
+	const isSaving = savables.length !== discardableSavables.length;
+
 	const {
 		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
 		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
@@ -82,7 +91,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 				</div>
 
 				<PanelBody initialOpen={ true }>
-					{ savables.map( ( record ) => (
+					{ discardableSavables.map( ( record ) => (
 						<EntityRecordItem
 							key={ record.key || record.property }
 							record={ record }
@@ -101,7 +110,9 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 					) ) }
 					<PanelRow>
 						<Button
-							disabled={ selectedEntities.length === 0 }
+							disabled={
+								selectedEntities.length === 0 || isSaving
+							}
 							isDestructive
 							onClick={ discardCheckedEntities }
 						>

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -77,6 +77,9 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 		<Fragment>
 			<div>
 				<div className="entities-saved-states__text-prompt">
+					<strong>{ __( 'Template updated!' ) }</strong>
+				</div>
+				<div className="entities-saved-states__text-prompt">
 					<strong>{ __( "What's next?" ) }</strong>
 					<p>
 						{ __(

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -82,25 +82,23 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 				</div>
 
 				<PanelBody initialOpen={ true }>
-					{ savables.map( ( record ) => {
-						return (
-							<EntityRecordItem
-								key={ record.key || record.property }
-								record={ record }
-								checked={ some(
-									selectedEntities,
-									( elt ) =>
-										elt.kind === record.kind &&
-										elt.name === record.name &&
-										elt.key === record.key &&
-										elt.property === record.property
-								) }
-								onChange={ ( value ) =>
-									setSelectedEntities( record, value )
-								}
-							/>
-						);
-					} ) }
+					{ savables.map( ( record ) => (
+						<EntityRecordItem
+							key={ record.key || record.property }
+							record={ record }
+							checked={ some(
+								selectedEntities,
+								( elt ) =>
+									elt.kind === record.kind &&
+									elt.name === record.name &&
+									elt.key === record.key &&
+									elt.property === record.property
+							) }
+							onChange={ ( value ) =>
+								setSelectedEntities( record, value )
+							}
+						/>
+					) ) }
 					<PanelRow>
 						<Button
 							disabled={ selectedEntities.length === 0 }

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -75,7 +75,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 
 	return (
 		<Fragment>
-			<div className="entities-saved-states__discard-changes-panel">
+			<div>
 				<div className="entities-saved-states__text-prompt">
 					<strong>{ __( "What's next?" ) }</strong>
 					<p>
@@ -85,7 +85,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 					</p>
 					<p>
 						{ __(
-							'You can select them and discard their changes, or continue editing and deal with them later.'
+							'You can select them and discard their changes now, or close the panel and deal with them later.'
 						) }
 					</p>
 				</div>
@@ -120,12 +120,6 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 						</Button>
 					</PanelRow>
 				</PanelBody>
-			</div>
-
-			<div className="entities-saved-states__footer">
-				<Button onClick={ closePanel } variant="primary">
-					<span>{ __( 'Continue editing' ) }</span>
-				</Button>
 			</div>
 		</Fragment>
 	);

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -23,7 +23,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
 	} = useDispatch( coreStore );
 
-	// Unchecked entities to be ignored by discard function.
+	// Selected entities to be discarded.
 	const [ selectedEntities, _setSelectedEntities ] = useState( [] );
 
 	const setSelectedEntities = ( { kind, name, key, property }, checked ) => {
@@ -98,7 +98,6 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 								onChange={ ( value ) =>
 									setSelectedEntities( record, value )
 								}
-								//closePanel={ closePanel }
 							/>
 						);
 					} ) }

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -52,7 +52,7 @@ export default function DiscardEntityChangesPanel( {
 	const discardCheckedEntities = () => {
 		const entitiesToDiscard = dirtyEntityRecords.filter(
 			( { kind, name, key, property } ) => {
-				return ! some(
+				return some(
 					selectedEntities,
 					( elt ) =>
 						elt.kind === kind &&
@@ -121,11 +121,7 @@ export default function DiscardEntityChangesPanel( {
 					} ) }
 					<PanelRow>
 						<Button
-							disabled={
-								dirtyEntityRecords.length -
-									selectedEntities.length ===
-								0
-							}
+							disabled={ selectedEntities.length === 0 }
 							isDestructive
 							onClick={ discardCheckedEntities }
 						>

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, PanelBody, PanelRow } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { Fragment, useState } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import EntityRecordItem from './entity-record-item';
+
+export default function DiscardEntityChangesPanel( {
+	closePanel,
+	dirtyEntityRecords,
+	savables,
+} ) {
+	const {
+		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
+		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
+	} = useDispatch( coreStore );
+
+	// Unchecked entities to be ignored by discard function.
+	const [ selectedEntities, _setSelectedEntities ] = useState( [] );
+
+	const setSelectedEntities = ( { kind, name, key, property }, checked ) => {
+		if ( ! checked ) {
+			_setSelectedEntities(
+				selectedEntities.filter(
+					( elt ) =>
+						elt.kind !== kind ||
+						elt.name !== name ||
+						elt.key !== key ||
+						elt.property !== property
+				)
+			);
+		} else {
+			_setSelectedEntities( [
+				...selectedEntities,
+				{ kind, name, key, property },
+			] );
+		}
+	};
+
+	const discardCheckedEntities = () => {
+		const entitiesToDiscard = dirtyEntityRecords.filter(
+			( { kind, name, key, property } ) => {
+				return ! some(
+					selectedEntities,
+					( elt ) =>
+						elt.kind === kind &&
+						elt.name === name &&
+						elt.key === key &&
+						elt.property === property
+				);
+			}
+		);
+
+		closePanel();
+
+		const siteItemsToDiscard = [];
+		entitiesToDiscard.forEach( ( { kind, name, key, property } ) => {
+			if ( 'root' === kind && 'site' === name ) {
+				siteItemsToDiscard.push( property );
+			} else {
+				resetEditedEntityRecord( kind, name, key );
+			}
+		} );
+		resetSpecifiedEntityEdits(
+			'root',
+			'site',
+			undefined,
+			siteItemsToDiscard
+		);
+	};
+
+	return (
+		<Fragment>
+			<div className="entities-saved-states__discard-changes-panel">
+				<div className="entities-saved-states__text-prompt">
+					<strong>{ __( "What's next?" ) }</strong>
+					<p>
+						{ __(
+							'Your template still has some unsaved changes.'
+						) }
+					</p>
+					<p>
+						{ __(
+							'You can select them and discard their changes, or continue editing and deal with them later.'
+						) }
+					</p>
+				</div>
+
+				<PanelBody initialOpen={ true }>
+					{ savables.map( ( record ) => {
+						return (
+							<EntityRecordItem
+								key={ record.key || record.property }
+								record={ record }
+								checked={ some(
+									selectedEntities,
+									( elt ) =>
+										elt.kind === record.kind &&
+										elt.name === record.name &&
+										elt.key === record.key &&
+										elt.property === record.property
+								) }
+								onChange={ ( value ) =>
+									setSelectedEntities( record, value )
+								}
+								//closePanel={ closePanel }
+							/>
+						);
+					} ) }
+					<PanelRow>
+						<Button
+							disabled={
+								dirtyEntityRecords.length -
+									selectedEntities.length ===
+								0
+							}
+							isDestructive
+							onClick={ discardCheckedEntities }
+						>
+							{ __( 'Discard changes' ) }
+						</Button>
+					</PanelRow>
+				</PanelBody>
+			</div>
+
+			<div className="entities-saved-states__footer">
+				<Button onClick={ closePanel } variant="primary">
+					<span>{ __( 'Continue editing' ) }</span>
+				</Button>
+			</div>
+		</Fragment>
+	);
+}

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -19,14 +19,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import EntityRecordItem from './entity-record-item';
 
 export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
-	const discardableSavables = useSelect( ( select ) =>
-		savables.filter(
-			( { kind, name, key } ) =>
-				! select( coreStore ).isSavingEntityRecord( kind, name, key )
+	const isSaving = useSelect( ( select ) =>
+		savables.some( ( { kind, name, key } ) =>
+			select( coreStore ).isSavingEntityRecord( kind, name, key )
 		)
 	);
-
-	const isSaving = savables.length !== discardableSavables.length;
 
 	const {
 		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
@@ -130,7 +127,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 						</ul>
 					) }
 					{ ! isSaving &&
-						discardableSavables.map( ( record ) => (
+						savables.map( ( record ) => (
 							<EntityRecordItem
 								key={ record.key || record.property }
 								record={ record }

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -96,7 +96,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 		<Fragment>
 			<div>
 				<div className="entities-saved-states__text-prompt">
-					<strong>{ __( 'Template updated!' ) }</strong>
+					<strong>{ __( 'Changes saved!' ) }</strong>
 				</div>
 				<div className="entities-saved-states__text-prompt">
 					<strong>{ __( "What's next?" ) }</strong>
@@ -107,7 +107,7 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 					</p>
 					<p>
 						{ __(
-							'You can select them and discard their changes now, or close the panel and deal with them later.'
+							'You can select and discard them now, or close the panel and deal with them later.'
 						) }
 					</p>
 				</div>

--- a/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
+++ b/packages/editor/src/components/entities-saved-states/discard-entity-changes-panel.js
@@ -7,10 +7,11 @@ import { some } from 'lodash';
  * WordPress dependencies
  */
 import { Button, PanelBody, PanelRow } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Fragment, useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -31,6 +32,8 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
 		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
 	} = useDispatch( coreStore );
+
+	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	// Selected entities to be discarded.
 	const [ selectedEntities, _setSelectedEntities ] = useState( [] );
@@ -57,6 +60,8 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 	const discardCheckedEntities = () => {
 		closePanel();
 
+		const numberOfSelectedEntities = selectedEntities.length;
+
 		const siteItemsToDiscard = [];
 		selectedEntities.forEach( ( { kind, name, key, property } ) => {
 			if ( 'root' === kind && 'site' === name ) {
@@ -71,6 +76,23 @@ export default function DiscardEntityChangesPanel( { closePanel, savables } ) {
 			undefined,
 			siteItemsToDiscard
 		);
+
+		if ( numberOfSelectedEntities === savables.length ) {
+			createSuccessNotice( __( 'All changes discarded.' ), {
+				type: 'snackbar',
+			} );
+		} else {
+			createSuccessNotice(
+				_n(
+					'Change discarded.',
+					'Some changes discarded.',
+					numberOfSelectedEntities
+				),
+				{
+					type: 'snackbar',
+				}
+			);
+		}
 	};
 
 	return (

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -74,6 +74,7 @@ export default function EntitiesSavedStates( { close } ) {
 		editEntityRecord,
 		saveEditedEntityRecord,
 		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
+		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
 	} = useDispatch( coreStore );
 
 	// To group entities by type.
@@ -137,8 +138,8 @@ export default function EntitiesSavedStates( { close } ) {
 			}
 		);
 
-		// We're saving all changes and can thus safely return to the editor afterwards.
 		if ( entitiesToSave.length === dirtyEntityRecords.length ) {
+			// We're saving all changes and can thus safely return to the editor afterwards.
 			showDiscardEntitiesPanel( false );
 			close( entitiesToSave );
 		} else {
@@ -171,6 +172,41 @@ export default function EntitiesSavedStates( { close } ) {
 				siteItemsToSave
 			);
 		}
+	};
+
+	const discardCheckedEntities = () => {
+		const entitiesToDiscard = dirtyEntityRecords.filter(
+			( { kind, name, key, property } ) => {
+				return ! some(
+					unselectedEntities,
+					( elt ) =>
+						elt.kind === kind &&
+						elt.name === name &&
+						elt.key === key &&
+						elt.property === property
+				);
+			}
+		);
+
+		const siteItemsToDiscard = [];
+		entitiesToDiscard.forEach( ( { kind, name, key, property } ) => {
+			if ( 'root' === kind && 'site' === name ) {
+				siteItemsToDiscard.push( property );
+			} else {
+				// if (
+				// 	PUBLISH_ON_SAVE_ENTITIES.some(
+				// 		( typeToPublish ) =>
+				// 			typeToPublish.kind === kind &&
+				// 			typeToPublish.name === name
+				// 	)
+				// ) {
+				// 	editEntityRecord( kind, name, key, { status: 'publish' } );
+				// }
+
+				resetEditedEntityRecord( kind, name, key );
+			}
+		} );
+		//resetSpecifiedEntityEdits( 'root', 'site', undefined, siteItemsToDiscard );
 	};
 
 	// Explicitly define this with no argument passed.  Using `close` on
@@ -254,7 +290,7 @@ export default function EntitiesSavedStates( { close } ) {
 								0
 							}
 							isDestructive
-							onClick={ dismissPanel }
+							onClick={ discardCheckedEntities }
 						>
 							{ __( 'Discard changes' ) }
 						</Button>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -237,7 +237,6 @@ export default function EntitiesSavedStates( { close } ) {
 			{ discardEntitiesPanel ? (
 				<DiscardEntityChangesPanel
 					closePanel={ dismissPanel }
-					dirtyEntityRecords={ dirtyEntityRecords }
 					savables={ sortedPartitionedSavables.flat() }
 				/>
 			) : (

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -189,6 +189,8 @@ export default function EntitiesSavedStates( { close } ) {
 			}
 		);
 
+		close();
+
 		const siteItemsToDiscard = [];
 		entitiesToDiscard.forEach( ( { kind, name, key, property } ) => {
 			if ( 'root' === kind && 'site' === name ) {
@@ -295,7 +297,7 @@ export default function EntitiesSavedStates( { close } ) {
 			</div>
 
 			<div className="entities-saved-states__footer">
-				<Button variant="primary">
+				<Button onClick={ dismissPanel } variant="primary">
 					<span>{ __( 'Continue editing' ) }</span>
 				</Button>
 			</div>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -194,16 +194,6 @@ export default function EntitiesSavedStates( { close } ) {
 			if ( 'root' === kind && 'site' === name ) {
 				siteItemsToDiscard.push( property );
 			} else {
-				// if (
-				// 	PUBLISH_ON_SAVE_ENTITIES.some(
-				// 		( typeToPublish ) =>
-				// 			typeToPublish.kind === kind &&
-				// 			typeToPublish.name === name
-				// 	)
-				// ) {
-				// 	editEntityRecord( kind, name, key, { status: 'publish' } );
-				// }
-
 				resetEditedEntityRecord( kind, name, key );
 			}
 		} );

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -75,6 +75,7 @@ export default function EntitiesSavedStates( { close } ) {
 		saveEditedEntityRecord,
 		__experimentalSaveSpecifiedEntityEdits: saveSpecifiedEntityEdits,
 		__experimentalResetEditedEntityRecord: resetEditedEntityRecord,
+		__experimentalResetSpecifiedEntityEdits: resetSpecifiedEntityEdits,
 	} = useDispatch( coreStore );
 
 	// To group entities by type.
@@ -206,7 +207,12 @@ export default function EntitiesSavedStates( { close } ) {
 				resetEditedEntityRecord( kind, name, key );
 			}
 		} );
-		//resetSpecifiedEntityEdits( 'root', 'site', undefined, siteItemsToDiscard );
+		resetSpecifiedEntityEdits(
+			'root',
+			'site',
+			undefined,
+			siteItemsToDiscard
+		);
 	};
 
 	// Explicitly define this with no argument passed.  Using `close` on

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -56,6 +56,7 @@
 	}
 
 	.entities-saved-states__text-prompt {
+		border-bottom: $border-width solid $gray-300;
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -1,3 +1,15 @@
+@keyframes loadingpulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
 .entities-saved-states__panel {
 	@include reset;
 	background: $white;
@@ -59,5 +71,26 @@
 		border-bottom: $border-width solid $gray-300;
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
+	}
+
+	.entities-saved-states__discard-changes__saving {
+		animation: loadingpulse 1s linear infinite;
+		animation-delay: 0.5s; // avoid animating for fast network responses
+
+		// Style skeleton elements to mostly match the metrics of actual menu items.
+		// Needs specificity.
+		.entities-saved-states__discard-changes-item {
+			position: relative;
+			min-width: 72px;
+
+			&::before {
+				display: block;
+				content: '';
+				border-radius: $radius-block-ui;
+				background: $gray-300;
+				height: $grid-unit-20;
+				width: 50%;
+			}
+		}
 	}
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -62,7 +62,7 @@
 
 	.entities-saved-states__discard-changes-panel {
 		// Ensure the discard changes panel accounts for the header and footer height.
-		min-height: calc( 100% - #{$header-height + 84px} );
+		min-height: calc(100% - #{$header-height + 84px});
 	}
 
 	.entities-saved-states__footer {

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -59,4 +59,21 @@
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}
+
+	.entities-saved-states__discard-changes-panel {
+		// Ensure the discard changes panel accounts for the header and footer height.
+		min-height: calc( 100% - #{$header-height + 84px} );
+	}
+
+	.entities-saved-states__footer {
+		padding: 16px;
+
+		.components-button {
+			width: 100%;
+
+			span {
+				margin: auto;
+			}
+		}
+	}
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -59,21 +59,4 @@
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}
-
-	.entities-saved-states__discard-changes-panel {
-		// Ensure the discard changes panel accounts for the header and footer height.
-		min-height: calc(100% - #{$header-height + 84px});
-	}
-
-	.entities-saved-states__footer {
-		padding: 16px;
-
-		.components-button {
-			width: 100%;
-
-			span {
-				margin: auto;
-			}
-		}
-	}
 }


### PR DESCRIPTION
## Description

**This needs some UX feedback from designers, see https://github.com/WordPress/gutenberg/pull/36185#issuecomment-961466024**

WIP, needs more work.

Add a second step to the multi-entity save UI which offers the user to discard any changes they made and didn't opt to save. This implements the second part of https://github.com/WordPress/gutenberg/issues/31456#issuecomment-888218396 (and thus closes #31456), after https://github.com/WordPress/gutenberg/pull/35933 implemented the first part.

## How has this been tested?

- Use the TT1 Blocks theme.
- Go to the Site Editor, and select the Single Post Template to edit.
- Make a few minor changes: Change the site title and tagline; insert a paragraph block with some text near the post content; change the address in the site footer.
- Click 'Save'.
- Select a few (but not all!) changes to save, and click 'Save' again.
- You're presented with the "discard changes" panel.
- _To be continued_

## Screenshots

Current state per this PR:

![image](https://user-images.githubusercontent.com/96308/140178757-4f61d621-75bc-4c6a-b8c2-60812b38fd3f.png)

## Types of changes
New feature

## TODO

- [x] Figure out what to do with undo stack, see https://github.com/WordPress/gutenberg/pull/36185#issuecomment-961466024
- [x] Correctly wire buttons, checkboxes, etc
- [x] Split into separate files for save and discard UI
- [x] Add unit tests for newly added actions, reducers
- [x] Rebase, carry over changes from #36212 to `discardEditedEntryRecords` if needed.
- [x] Fix isSaving filtering for site entity record edits (title, tagline, etc -- might need `title` instead of `key`?)
- [x] Add loading state (pulsate entities)?
- [x] Add snackbar after discard (see https://github.com/WordPress/gutenberg/pull/36185#issuecomment-967239470)
- [ ] Update e2 test.