### PR TITLE
Address deprecation issues from Buttons flex layout PR.

### DIFF
--- a/packages/block-library/src/buttons/deprecated.js
+++ b/packages/block-library/src/buttons/deprecated.js
@@ -29,6 +29,8 @@ const migrateWithLayout = ( attributes ) => {
 				orientation: orientation || 'horizontal',
 			},
 		} );
+		delete updatedAttributes.contentJustification;
+		delete updatedAttributes.orientation;
 	}
 
 	return updatedAttributes;
@@ -57,7 +59,8 @@ const deprecated = [
 				},
 			},
 		},
-		isEligible: ( { layout } ) => ! layout,
+		isEligible: ( { contentJustification, orientation } ) =>
+			!! contentJustification || !! orientation,
 		migrate: migrateWithLayout,
 		save( { attributes: { contentJustification, orientation } } ) {
 			return (

--- a/packages/block-library/src/buttons/deprecated.js
+++ b/packages/block-library/src/buttons/deprecated.js
@@ -15,22 +15,22 @@ const migrateWithLayout = ( attributes ) => {
 		return attributes;
 	}
 
-	const { contentJustification, orientation } = attributes;
-
-	const updatedAttributes = {
-		...attributes,
-	};
+	const {
+		contentJustification,
+		orientation,
+		...updatedAttributes
+	} = attributes;
 
 	if ( contentJustification || orientation ) {
 		Object.assign( updatedAttributes, {
 			layout: {
 				type: 'flex',
-				justifyContent: contentJustification || 'left',
-				orientation: orientation || 'horizontal',
+				...( contentJustification && {
+					justifyContent: contentJustification,
+				} ),
+				...( orientation && { orientation } ),
 			},
 		} );
-		delete updatedAttributes.contentJustification;
-		delete updatedAttributes.orientation;
 	}
 
 	return updatedAttributes;

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	BlockControls,
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
@@ -39,10 +38,6 @@ function ButtonsEdit( { attributes: { layout = {} } } ) {
 
 	return (
 		<>
-			<BlockControls
-				group="block"
-				__experimentalShareWithChildBlocks
-			></BlockControls>
 			<div { ...innerBlocksProps } />
 		</>
 	);

--- a/test/integration/fixtures/blocks/core__buttons__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__buttons__deprecated-1.json
@@ -4,7 +4,6 @@
 		"name": "core/buttons",
 		"isValid": true,
 		"attributes": {
-			"contentJustification": "center",
 			"layout": {
 				"type": "flex",
 				"justifyContent": "center",

--- a/test/integration/fixtures/blocks/core__buttons__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__buttons__deprecated-1.json
@@ -6,8 +6,7 @@
 		"attributes": {
 			"layout": {
 				"type": "flex",
-				"justifyContent": "center",
-				"orientation": "horizontal"
+				"justifyContent": "center"
 			}
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__buttons__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__buttons__deprecated-1.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons"><!-- wp:button -->
 <div class="wp-block-button"><a class="wp-block-button__link">My button 1</a></div>
 <!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__buttons__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__buttons__deprecated-2.json
@@ -4,8 +4,6 @@
 		"name": "core/buttons",
 		"isValid": true,
 		"attributes": {
-			"contentJustification": "center",
-			"orientation": "horizontal",
 			"align": "wide",
 			"layout": {
 				"type": "flex",

--- a/test/integration/fixtures/blocks/core_buttons__simple__deprecated.json
+++ b/test/integration/fixtures/blocks/core_buttons__simple__deprecated.json
@@ -3,14 +3,7 @@
 		"clientId": "_clientId_0",
 		"name": "core/buttons",
 		"isValid": true,
-		"attributes": {
-			"orientation": "horizontal",
-			"layout": {
-				"type": "flex",
-				"justifyContent": "left",
-				"orientation": "horizontal"
-			}
-		},
+		"attributes": {},
 		"innerBlocks": [
 			{
 				"clientId": "_clientId_0",

--- a/test/integration/fixtures/blocks/core_buttons__simple__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core_buttons__simple__deprecated.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"}} -->
+<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->
 <div class="wp-block-button"><a class="wp-block-button__link">My button 1</a></div>
 <!-- /wp:button -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Addresses feedback from #35819.

Buttons deprecation is fixed so that layout attributes are only migrated if they are explicitly set.

Also removes unnecessary BlockControls from Buttons edit function.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Test by trying out different combinations of Buttons layouts, saving and refreshing to make sure they work as expected.

Test the deprecations by generating some deprecated markup in an older version of the editor, pasting it in a post and saving: the markup should be updated on save, unless there are no layout attributes, in which case nothing should change.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
