### PR TITLE
Fix fatal error in Site Logo block in WP 5.9

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -132,7 +132,13 @@ add_filter( 'pre_set_theme_mod_custom_logo', '_sync_custom_logo_to_site_logo' );
  * @param array $old_value Previous theme mod settings.
  * @param array $value     Updated theme mod settings.
  */
-function _gutenberg_delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
+function _delete_site_logo_on_remove_custom_logo( $old_value, $value ) {
+	global $_ignore_site_logo_changes;
+
+	if ( $_ignore_site_logo_changes ) {
+		return;
+	}
+
 	// If the custom_logo is being unset, it's being removed from theme mods.
 	if ( isset( $old_value['custom_logo'] ) && ! isset( $value['custom_logo'] ) ) {
 		delete_option( 'site_logo' );
@@ -142,7 +148,13 @@ function _gutenberg_delete_site_logo_on_remove_custom_logo( $old_value, $value )
 /**
  * Deletes the site logo when all theme mods are being removed.
  */
-function _gutenberg_delete_site_logo_on_remove_theme_mods() {
+function _delete_site_logo_on_remove_theme_mods() {
+	global $_ignore_site_logo_changes;
+
+	if ( $_ignore_site_logo_changes ) {
+		return;
+	}
+
 	if ( false !== get_theme_support( 'custom-logo' ) ) {
 		delete_option( 'site_logo' );
 	}
@@ -165,27 +177,16 @@ add_action( 'setup_theme', '_delete_site_logo_on_remove_custom_logo_on_setup_the
  * Removes the custom_logo theme-mod when the site_logo option gets deleted.
  */
 function _delete_custom_logo_on_remove_site_logo() {
-	$theme = get_option( 'stylesheet' );
+	global $_ignore_site_logo_changes;
 
-	// Unhook update and delete actions for custom_logo to prevent a loop of hooks.
-	// Remove Gutenberg hooks.
-	remove_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10 );
-	remove_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
-
-	// Remove Core hooks.
-	remove_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10 );
-	remove_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
+	// Prevent _delete_site_logo_on_remove_custom_logo and
+	// _delete_site_logo_on_remove_theme_mods from firing and causing an
+	// infinite loop.
+	$_ignore_site_logo_changes = true;
 
 	// Remove the custom logo.
 	remove_theme_mod( 'custom_logo' );
 
-	// Restore update and delete actions.
-	// Restore Gutenberg hooks.
-	add_action( "update_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_custom_logo', 10, 2 );
-	add_action( "delete_option_theme_mods_$theme", '_gutenberg_delete_site_logo_on_remove_theme_mods' );
-
-	// Restore Core hooks.
-	add_action( "update_option_theme_mods_$theme", '_delete_site_logo_on_remove_custom_logo', 10, 2 );
-	add_action( "delete_option_theme_mods_$theme", '_delete_site_logo_on_remove_theme_mods' );
+	$_ignore_site_logo_changes = false;
 }
 add_action( 'delete_option_site_logo', '_delete_custom_logo_on_remove_site_logo' );


### PR DESCRIPTION
## Description

Follows https://github.com/WordPress/gutenberg/pull/34820.

Restore the `_delete_site_logo_on_remove_custom_logo` and `_delete_site_logo_on_remove_theme_mods` functions so that they exist when `block-library/src/site-logo/index.php` is copied to `wp-includes/blocks/site-logo.php` in Core for WP 5.9 (https://github.com/WordPress/wordpress-develop/pull/1804).

This fixes a fatal error in WP 5.9 caused by calling `add_action()` with a callback that doesn't exist.

These functions were renamed to have a `_gutenberg` prefix in 0140ba09a38367bc02215db081b3fb83ff477e25 to prevent an infinite loop, see https://github.com/WordPress/gutenberg/pull/34820/files#r710647763.

We can prevent the infinite loop using a global variable instead.

## How has this been tested?

I haven't tested this. Maybe @stacimc, @andrewserong or @creativecoder can? 😀

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->