### PR TITLE
LineHeightControl: Use `__unstableSize` prop in Typography panel

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -15,7 +20,11 @@ import {
 	isLineHeightDefined,
 } from './utils';
 
-export default function LineHeightControl( { value: lineHeight, onChange } ) {
+export default function LineHeightControl( {
+	__unstableSize,
+	value: lineHeight,
+	onChange,
+} ) {
 	const isDefined = isLineHeightDefined( lineHeight );
 
 	const handleOnKeyDown = ( event ) => {
@@ -64,7 +73,11 @@ export default function LineHeightControl( { value: lineHeight, onChange } ) {
 	const value = isDefined ? lineHeight : RESET_VALUE;
 
 	return (
-		<div className="block-editor-line-height-control">
+		<div
+			className={ classnames( 'block-editor-line-height-control', {
+				'is-unstable-size-large': __unstableSize === 'large',
+			} ) }
+		>
 			<TextControl
 				autoComplete="off"
 				onKeyDown={ handleOnKeyDown }

--- a/packages/block-editor/src/components/line-height-control/style.scss
+++ b/packages/block-editor/src/components/line-height-control/style.scss
@@ -5,4 +5,14 @@
 		display: block;
 		max-width: 60px;
 	}
+
+	// TODO: This may be easier if we can replace TextControl with NumberControl and use prop `size="__unstable-large"`
+	&.is-unstable-size-large {
+		input {
+			max-width: none;
+			min-height: 40px;
+			padding-left: 16px;
+			padding-right: 16px;
+		}
+	}
 }

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -38,6 +38,7 @@ export function LineHeightEdit( props ) {
 	};
 	return (
 		<LineHeightControl
+			__unstableSize="large"
 			value={ style?.typography?.lineHeight }
 			onChange={ onChange }
 		/>

--- a/packages/components/src/tools-panel/stories/typography-panel.js
+++ b/packages/components/src/tools-panel/stories/typography-panel.js
@@ -159,6 +159,7 @@ export const TypographyPanel = () => {
 							isShownByDefault={ true }
 						>
 							<LineHeightControl
+								__unstableSize="large"
 								value={ lineHeight }
 								onChange={ setLineHeight }
 							/>

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -114,6 +114,7 @@ export default function TypographyPanel( { name } ) {
 			) }
 			{ hasLineHeightEnabled && (
 				<LineHeightControl
+					__unstableSize="large"
 					value={ lineHeight }
 					onChange={ setLineHeight }
 				/>


### PR DESCRIPTION
Part of #36230 

🚧 On hold until #37110 is done

## Description

Enlarges `LineHeightControl` to the new 40px height in the Typography panels only.

The height change is accomplished via a new internal `__unstableSize` prop.

## How has this been tested?

- [Storybook](http://localhost:50240/?path=/story/components-experimental-toolspanel--typography-panel)
- Typography panel in block editor
- Typography panel in site editor
- Does not break in mobile width viewports when the font-size increases to 16px

## Screenshots <!-- if applicable -->

<img width="274" alt="Taller Line Height component in Site Editor" src="https://user-images.githubusercontent.com/555336/140266569-dbdb98b6-afb1-437b-8fd4-c5423fd51f26.png"><img width="277" alt="Taller Line Height component in block editor" src="https://user-images.githubusercontent.com/555336/140266576-5a8b99e4-9e5f-4043-819c-f75df59f0c7c.png">

@jasmussen Do you mind that the max-width is removed in the Site Editor version? I _think_ that panel is meant to be replaced with a `ToolsPanel` implementation, so eventually we'll be using the "single column" grid layout there to bring it in line with the block editor Typography panel.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
