### PR TITLE
Add copy pattern button to navigation block advanced inspector controls

### DIFF
--- a/packages/block-library/src/navigation/edit/copy-pattern-control.js
+++ b/packages/block-library/src/navigation/edit/copy-pattern-control.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { serialize } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export default function CopyPatternControl( { clientId } ) {
+	const { innerBlocks, navigationBlock } = useSelect(
+		( select ) => {
+			const { getBlock, getBlocks } = select( blockEditorStore );
+			return {
+				innerBlocks: getBlocks( clientId ),
+				navigationBlock: getBlock( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const getClipboardText = useCallback( () => {
+		// Remove the `navigationMenuId` so that the block is rendered with
+		// serialized inner blocks (see the definition of `save`). Also
+		// add the `innerBlocks` as controlled inner blocks aren't returned
+		// by the `getBlock` selector.
+		const navBlockWithoutId = {
+			...navigationBlock,
+			attributes: {
+				...navigationBlock.attributes,
+				navigationMenuId: undefined,
+			},
+			innerBlocks,
+		};
+		return serialize( navBlockWithoutId );
+	}, [ navigationBlock, innerBlocks ] );
+
+	const ref = useCopyToClipboard( getClipboardText );
+
+	return (
+		<Button
+			ref={ ref }
+			variant="secondary"
+			className="wp-block-navigation-copy-pattern-button"
+		>
+			{ __( 'Copy pattern' ) }
+		</Button>
+	);
+}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -46,6 +46,7 @@ import NavigationMenuNameControl from './navigation-menu-name-control';
 import NavigationMenuPublishButton from './navigation-menu-publish-button';
 import UnsavedInnerBlocks from './unsaved-inner-blocks';
 import NavigationMenuDeleteControl from './navigation-menu-delete-control';
+import CopyPatternControl from './copy-pattern-control';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
@@ -437,6 +438,11 @@ function Navigation( {
 						</PanelColorSettings>
 					) }
 				</InspectorControls>
+				{ isEntityAvailable && (
+					<InspectorControls __experimentalGroup="advanced">
+						<CopyPatternControl clientId={ clientId } />
+					</InspectorControls>
+				) }
 				<nav { ...blockProps }>
 					{ ! isEntityAvailable && isPlaceholderShown && (
 						<PlaceholderComponent

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -569,7 +569,9 @@ body.editor-styles-wrapper
 	animation: 0.5s linear 2s normal forwards fadeouthalf;
 }
 
-.wp-block-navigation-delete-menu-button {
+.wp-block-navigation-delete-menu-button,
+.wp-block-navigation-copy-pattern-button {
 	width: 100%;
 	justify-content: center;
+	margin-bottom: $grid-unit-20;
 }


### PR DESCRIPTION
## Description
Closes #35947


Recently the navigation block inner blocks became stored in a `wp_navigation` post that it references using an id. The markup looks like this:
```
<-- wp:navigation { "navigationMenuId": 12 } / -->
```
The id attribute is specific to a WordPress instance, so it can't be used in a pattern.

For back compat, the block does also support being defined in the old school way, and will migrate these inner blocks to a `wp_navigation`:
```
<!-- wp:navigation -->
<!-- wp:navigation-link {"label":"Hello world!","type":"post","id":1,"url":"http://localhost:8888/?p=1","kind":"post-type","isTopLevelLink":true} /-->

<!-- wp:navigation-link {"label":"Hello world!","type":"post","id":1,"url":"http://localhost:8888/?p=1","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```
But a pattern creator can't create this kind of block markup, they'd have to type it out.

This PR adds 'Copy Pattern' button so that using a block that has markup like the first example, a pattern creator can copy markup that looks like the second example.

## How has this been tested?
1. Add a navigation block, name it, add some inner blocks
2. Click 'Copy Pattern' from the Advanced panel.
3. Paste the HTML somewhere like in a text editor.

## Screenshots <!-- if applicable -->
<img width="291" alt="Screenshot 2021-11-04 at 5 13 32 pm" src="https://user-images.githubusercontent.com/677833/140287793-7830fa4d-1db9-40d6-85f8-017514ed4cd5.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
