### PR TITLE
[Block: Group] Add transform to row variation

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -11,6 +11,7 @@ const variations = [
 		attributes: { layout: { type: 'default' } },
 		scope: [ 'transform' ],
 		isActive: ( blockAttributes ) =>
+			! blockAttributes.layout ||
 			blockAttributes.layout?.type === 'default',
 	},
 	{

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -9,7 +9,7 @@ const variations = [
 		title: __( 'Group' ),
 		description: __( 'Blocks shown in a column.' ),
 		attributes: { layout: { type: 'default' } },
-		scope: [ 'inserter', 'transform' ],
+		scope: [ 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'default',
 	},

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -5,11 +5,20 @@ import { __ } from '@wordpress/i18n';
 
 const variations = [
 	{
+		name: 'group',
+		title: __( 'Group' ),
+		description: __( 'Blocks shown in a column.' ),
+		attributes: { layout: { type: 'default' } },
+		scope: [ 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.layout?.type === 'default',
+	},
+	{
 		name: 'group-row',
 		title: __( 'Row' ),
 		description: __( 'Blocks shown in a row.' ),
 		attributes: { layout: { type: 'flex', allowOrientation: false } },
-		scope: [ 'inserter' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'flex',
 	},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Makes it possible to transform a group into a row variation and vice versa.
For https://github.com/WordPress/gutenberg/issues/35355

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a group block and transform it into a row.
2. Transform it back to a group.

## Screenshots <!-- if applicable -->
![Block settings sidebar transformation modal](https://user-images.githubusercontent.com/7422055/140289188-c943ff0a-7668-49fb-9bce-c25ffe50493a.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
