### PR TITLE
Fix navigation in global styles sidebar

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -102,7 +102,7 @@ function ScreenColors( { name } ) {
 
 			<div className="edit-site-global-styles-screen-colors">
 				<VStack spacing={ 10 }>
-					<Palette contextName={ name } />
+					<Palette name={ name } />
 
 					<VStack spacing={ 3 }>
 						<Subtitle>{ __( 'Elements' ) }</Subtitle>


### PR DESCRIPTION
This PR fixes a bug uncovered while reviewing https://github.com/WordPress/gutenberg/pull/35783

The color edit component (the palette that allows users to edit/add new colors) didn't keep track of the current context properly. This could be seen by navigating to the palette of a block and going back: while the expected result was that it'd be back to the block what happens in `trunk` is that it goes back to the global.

## Testing steps

Verify that it works like this (going back takes you to the place you came from):

https://user-images.githubusercontent.com/583546/140289943-2a29c032-953c-48bc-8857-847d3a2c412a.mp4

