### PR TITLE
Show the placeholder again when moving from a valid menu to non-existing menu

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -214,9 +214,7 @@ function Navigation( {
 
 	// Hide the placeholder if an navigation menu entity has loaded.
 	useEffect( () => {
-		if ( isEntityAvailable ) {
-			setIsPlaceholderShown( false );
-		}
+		setIsPlaceholderShown( ! isEntityAvailable );
 	}, [ isEntityAvailable ] );
 
 	// If the block has inner blocks, but no menu id, this was an older

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -44,7 +44,8 @@ export default function useNavigationMenu( navigationMenuId ) {
 			return {
 				isNavigationMenuResolved: hasResolvedNavigationMenu,
 				isNavigationMenuMissing:
-					hasResolvedNavigationMenu && ! navigationMenu,
+					! navigationMenuId ||
+					( hasResolvedNavigationMenu && ! navigationMenu ),
 				canSwitchNavigationMenu,
 				hasResolvedNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',


### PR DESCRIPTION
**Description**
Right now, the navigation block only displays the placeholder after it's been initially mounted. If the `navigationMenuId` is later updated to `0`, the block is stuck in a "forever loading" state. This PR makes the block react to an empty menu and display the placeholder again.

**Test plan:**
* Apply this PR on top of https://github.com/WordPress/gutenberg/pull/36178
* Add a new navigation area
* Change the area to "Tertiary" and confirm you may still edit the navigation menu inside