### PR TITLE
Make saveEditedEntityRecord use the entity key when available

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -644,12 +644,19 @@ export const saveEditedEntityRecord = (
 	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 		return;
 	}
+	const entities = await dispatch( getKindEntities( kind ) );
+	const entity = find( entities, { kind, name } );
+	if ( ! entity || entity?.__experimentalNoFetch ) {
+		return;
+	}
+	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;
+
 	const edits = select.getEntityRecordNonTransientEdits(
 		kind,
 		name,
 		recordId
 	);
-	const record = { id: recordId, ...edits };
+	const record = { [ entityIdKey ]: recordId, ...edits };
 	return await dispatch.saveEntityRecord( kind, name, record, options );
 };
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -646,7 +646,7 @@ export const saveEditedEntityRecord = (
 	}
 	const entities = await dispatch( getKindEntities( kind ) );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity || entity?.__experimentalNoFetch ) {
+	if ( ! entity ) {
 		return;
 	}
 	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -11,6 +11,7 @@ jest.mock( '@wordpress/api-fetch' );
 import {
 	editEntityRecord,
 	saveEntityRecord,
+	saveEditedEntityRecord,
 	deleteEntityRecord,
 	receiveUserPermission,
 	receiveAutosaves,
@@ -104,6 +105,94 @@ describe( 'deleteEntityRecord', () => {
 		);
 
 		expect( result ).toBe( deletedRecord );
+	} );
+} );
+
+describe( 'saveEditedEntityRecord', () => {
+	beforeEach( async () => {
+		apiFetch.mockReset();
+		jest.useFakeTimers();
+	} );
+
+	it( 'Uses "id" as a key when no entity key is provided', async () => {
+		const area = { id: 1, menu: 0 };
+		const entities = [
+			{
+				kind: 'root',
+				name: 'navigationArea',
+				baseURL: '/__experimental/block-navigation-areas',
+			},
+		];
+		const select = {
+			getEntityRecordNonTransientEdits: () => [],
+			hasEditsForEntityRecord: () => true,
+		};
+
+		const dispatch = Object.assign( jest.fn(), {
+			saveEntityRecord: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
+
+		// Provide response
+		const updatedRecord = { ...area, menu: 10 };
+		apiFetch.mockImplementation( () => {
+			return updatedRecord;
+		} );
+
+		await saveEditedEntityRecord(
+			'root',
+			'navigationArea',
+			1
+		)( { dispatch, select } );
+
+		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
+			'root',
+			'navigationArea',
+			{ id: 1 },
+			undefined
+		);
+	} );
+
+	it( 'Uses the entity key when provided', async () => {
+		const area = { area: 'primary', menu: 0 };
+		const entities = [
+			{
+				kind: 'root',
+				name: 'navigationArea',
+				baseURL: '/__experimental/block-navigation-areas',
+				key: 'area',
+			},
+		];
+		const select = {
+			getEntityRecordNonTransientEdits: () => [],
+			hasEditsForEntityRecord: () => true,
+		};
+
+		const dispatch = Object.assign( jest.fn(), {
+			saveEntityRecord: jest.fn(),
+		} );
+		// Provide entities
+		dispatch.mockReturnValueOnce( entities );
+
+		// Provide response
+		const updatedRecord = { ...area, menu: 10 };
+		apiFetch.mockImplementation( () => {
+			return updatedRecord;
+		} );
+
+		await saveEditedEntityRecord(
+			'root',
+			'navigationArea',
+			'primary'
+		)( { dispatch, select } );
+
+		expect( dispatch.saveEntityRecord ).toHaveBeenCalledWith(
+			'root',
+			'navigationArea',
+			{ area: 'primary' },
+			undefined
+		);
 	} );
 } );
 


### PR DESCRIPTION
## Description
Fixes a bug in `saveEditedEntityRecord` which right now assumes that entity key is called `id`. After the fix, it uses the `entity.key` just like `saveEntityRecord`.

## How has this been tested?
Confirm all the tests pass.