### PR TITLE
Alternative approach to the layout outer padding

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -41,7 +41,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	if ( 'default' === $layout_type ) {
 		$content_size  = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
 		$wide_size     = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
-		$outer_padding = isset( $layout['outerPadding'] ) ? $layout['outerPadding'] : 0;
+		$outer_padding = isset( $layout['outerPadding'] ) ? $layout['outerPadding'] : array();
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
@@ -54,8 +54,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style = '';
 		if ( $content_size || $wide_size ) {
 			$style  = "$selector {";
-			$style .= "--wp-style-layout-outer-padding: $outer_padding;";
-			$style .= 'padding: 0 var(--wp-style-layout-outer-padding);';
+			$style .= sprintf(
+				'padding: %s %s %s %s',
+				isset( $outer_padding['top'] ) ? $outer_padding['top'] : 0,
+				isset( $outer_padding['right'] ) ? $outer_padding['right'] : 0,
+				isset( $outer_padding['bottom'] ) ? $outer_padding['bottom'] : 0,
+				isset( $outer_padding['left'] ) ? $outer_padding['left'] : 0
+			);
 			$style .= '}';
 			$style .= "$selector > * {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
@@ -65,8 +70,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
 			$style .= "$selector .alignfull {";
 			$style .= 'max-width: none;';
-			$style .= 'margin-left: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;';
-			$style .= 'margin-right: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;';
+			$style .= isset( $outer_padding['left'] ) ? sprintf( 'margin-left: calc( -1 * %s ) !important;', $outer_padding['left'] ) : '';
+			$style .= isset( $outer_padding['right'] ) ? sprintf( 'margin-right: calc( -1 * %s ) !important;', $outer_padding['right'] ) : '';
 			$style .= '}';
 		}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -39,8 +39,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 	$style = '';
 	if ( 'default' === $layout_type ) {
-		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
-		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
+		$content_size  = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
+		$wide_size     = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
+		$outer_padding = isset( $layout['outerPadding'] ) ? $layout['outerPadding'] : 0;
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
@@ -52,14 +53,21 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		$style = '';
 		if ( $content_size || $wide_size ) {
-			$style  = "$selector > * {";
+			$style  = "$selector {";
+			$style .= "--wp-style-layout-outer-padding: $outer_padding;";
+			$style .= 'padding: 0 var(--wp-style-layout-outer-padding);';
+			$style .= '}';
+			$style .= "$selector > * {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 			$style .= 'margin-left: auto !important;';
 			$style .= 'margin-right: auto !important;';
 			$style .= '}';
-
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-			$style .= "$selector .alignfull { max-width: none; }";
+			$style .= "$selector .alignfull {";
+			$style .= 'max-width: none;';
+			$style .= 'margin-left: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;';
+			$style .= 'margin-right: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;';
+			$style .= '}';
 		}
 
 		$style .= "$selector .alignleft { float: left; margin-right: 2em; }";

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -53,7 +53,7 @@ function gutenberg_get_layout_style( $selector, $layout, $padding, $has_block_ga
 
 		$style = '';
 		if ( $content_size || $wide_size ) {
-			$style  = "$selector {";
+			$style = "$selector {";
 			// Using important here to override the inline padding that could be potentially
 			// applied using the custom padding control before the layout inheritance is applied.
 			$style .= sprintf(

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -234,9 +234,9 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'custom'          => null,
 		'layout'          => array(
-			'contentSize'  => null,
-			'wideSize'     => null,
-			'outerPadding' => null,
+			'contentSize' => null,
+			'wideSize'    => null,
+			'padding'     => null,
 		),
 		'spacing'         => array(
 			'blockGap' => null,

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -234,8 +234,9 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		'custom'          => null,
 		'layout'          => array(
-			'contentSize' => null,
-			'wideSize'    => null,
+			'contentSize'  => null,
+			'wideSize'     => null,
+			'outerPadding' => null,
 		),
 		'spacing'         => array(
 			'blockGap' => null,

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -20,6 +20,7 @@ import {
 	useIsDimensionsSupportValid,
 } from './dimensions';
 import { cleanEmptyObject } from './utils';
+import { useLayout } from './layout';
 
 /**
  * Determines if there is padding support.
@@ -72,11 +73,19 @@ export function resetPadding( { attributes = {}, setAttributes } ) {
  *
  * @return {boolean} Whether padding setting is disabled.
  */
-export function useIsPaddingDisabled( { name: blockName } = {} ) {
+export function useIsPaddingDisabled( { name: blockName, attributes } = {} ) {
+	const { supportsFlowLayout, config } = useLayout( blockName );
+	const hasInheritedLayout =
+		supportsFlowLayout && !! config && attributes?.layout?.inherit;
 	const isDisabled = ! useSetting( 'spacing.padding' );
 	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'padding' );
 
-	return ! hasPaddingSupport( blockName ) || isDisabled || isInvalid;
+	return (
+		! hasPaddingSupport( blockName ) ||
+		hasInheritedLayout ||
+		isDisabled ||
+		isInvalid
+	);
 }
 
 /**

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -106,7 +106,7 @@ export default {
 		return null;
 	},
 	save: function DefaultLayoutStyle( { selector, layout = {} } ) {
-		const { contentSize, wideSize, outerPadding = 0 } = layout;
+		const { contentSize, wideSize, outerPadding } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
 
@@ -114,8 +114,9 @@ export default {
 			!! contentSize || !! wideSize
 				? `
 					${ appendSelectors( selector ) } {
-						--wp-style-layout-outer-padding: ${ outerPadding };
-						padding: 0 var(--wp-style-layout-outer-padding);
+						padding: ${ outerPadding?.top || 0 } ${ outerPadding?.right || 0 } ${
+						outerPadding?.bottom || 0
+				  } ${ outerPadding?.left || 0 }; 
 					}
 
 					${ appendSelectors( selector, '> *' ) } {
@@ -130,8 +131,8 @@ export default {
 
 					${ appendSelectors( selector, '> [data-align="full"]' ) } {
 						max-width: none;
-						margin-left: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;
-						margin-right: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;
+						margin-left: calc( -1 * ${ outerPadding.left || 0 } ) !important;
+						margin-right: calc( -1 * ${ outerPadding.right || 0 } ) !important;
 					}
 				`
 				: '';

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -106,13 +106,18 @@ export default {
 		return null;
 	},
 	save: function DefaultLayoutStyle( { selector, layout = {} } ) {
-		const { contentSize, wideSize } = layout;
+		const { contentSize, wideSize, outerPadding = 0 } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
 
 		let style =
 			!! contentSize || !! wideSize
 				? `
+					${ appendSelectors( selector ) } {
+						--wp-style-layout-outer-padding: ${ outerPadding };
+						padding: 0 var(--wp-style-layout-outer-padding);
+					}
+
 					${ appendSelectors( selector, '> *' ) } {
 						max-width: ${ contentSize ?? wideSize };
 						margin-left: auto !important;
@@ -125,6 +130,8 @@ export default {
 
 					${ appendSelectors( selector, '> [data-align="full"]' ) } {
 						max-width: none;
+						margin-left: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;
+						margin-right: calc( -1 * var(--wp-style-layout-outer-padding) ) !important;
 					}
 				`
 				: '';

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -105,18 +105,20 @@ export default {
 	toolBarControls: function DefaultLayoutToolbarControls() {
 		return null;
 	},
-	save: function DefaultLayoutStyle( { selector, layout = {} } ) {
-		const { contentSize, wideSize, outerPadding } = layout;
+	save: function DefaultLayoutStyle( { selector, layout = {}, padding } ) {
+		const { contentSize, wideSize } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
 
+		// Using important here for the padding to override the inline padding that could be potentially
+		// applied using the custom padding control before the layout inheritance is applied.
 		let style =
 			!! contentSize || !! wideSize
 				? `
 					${ appendSelectors( selector ) } {
-						padding: ${ outerPadding?.top || 0 } ${ outerPadding?.right || 0 } ${
-						outerPadding?.bottom || 0
-				  } ${ outerPadding?.left || 0 }; 
+						padding: ${ padding?.top || 0 } ${ padding?.right || 0 } ${
+						padding?.bottom || 0
+				  } ${ padding?.left || 0 } !important;
 					}
 
 					${ appendSelectors( selector, '> *' ) } {
@@ -131,8 +133,8 @@ export default {
 
 					${ appendSelectors( selector, '> [data-align="full"]' ) } {
 						max-width: none;
-						margin-left: calc( -1 * ${ outerPadding.left || 0 } ) !important;
-						margin-right: calc( -1 * ${ outerPadding.right || 0 } ) !important;
+						margin-left: calc( -1 * ${ padding.left || 0 } ) !important;
+						margin-right: calc( -1 * ${ padding.right || 0 } ) !important;
 					}
 				`
 				: '';

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -133,8 +133,8 @@ export default {
 
 					${ appendSelectors( selector, '> [data-align="full"]' ) } {
 						max-width: none;
-						margin-left: calc( -1 * ${ padding.left || 0 } ) !important;
-						margin-right: calc( -1 * ${ padding.right || 0 } ) !important;
+						margin-left: calc( -1 * ${ padding?.left || 0 } ) !important;
+						margin-right: calc( -1 * ${ padding?.right || 0 } ) !important;
 					}
 				`
 				: '';

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,7 +4,6 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
-	width: 100%;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -176,6 +176,14 @@ export default function VisualEditor( { styles } ) {
 		return undefined;
 	}, [ isTemplateMode, themeSupportsLayout, defaultLayout ] );
 
+	const padding = useMemo( () => {
+		if ( isTemplateMode || ! themeSupportsLayout ) {
+			return undefined;
+		}
+
+		return defaultLayout?.padding;
+	} );
+
 	return (
 		<BlockTools
 			__unstableContentRef={ ref }
@@ -222,6 +230,7 @@ export default function VisualEditor( { styles } ) {
 							<LayoutStyle
 								selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
 								layout={ defaultLayout }
+								padding={ padding }
 							/>
 						) }
 						{ ! isTemplateMode && (

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} -->
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"},"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->


### PR DESCRIPTION
Alternative to #35919 

Instead of using a dedicated `outerPadding` property on the layout object. This PR uses `padding`, so for instance if a user sets a padding to a group block and also add the same time defines content/wide widths, the padding applied to the block is used to compute the negative margins.

That said, when the layout is defined as "inherit: true", the padding control in the container block is hidden and the "padding" defined in the theme.json file (settings.layout.padding) is used instead.

What do you think? It feels a bit better than #35919 because there's no padding conflicts in the UI.

**Cons:**

- If a user defines a padding on a group block and then after that triggers the "inherit layout" checkbox, the initially defined padding is going to be ignored ant the control hidden but in order for the styles to apply correctly the padding applied using the layout code has `!important`
- The other con is that padding and layout are kind of interconnected with this PR.