### PR TITLE
Navigation: Fix click-button size, submenu directions, scrollbars.

### DIFF
--- a/packages/block-library/src/navigation-submenu/style.scss
+++ b/packages/block-library/src/navigation-submenu/style.scss
@@ -14,10 +14,6 @@ button.wp-block-navigation-item__content {
 	font-size: inherit;
 	font-family: inherit;
 	line-height: inherit;
-
-	// Buttons default to center alignment. This becomes visible
-	// when a menu item label is long enough to wrap.
-	text-align: left;
 }
 
 .wp-block-navigation-submenu__toggle {

--- a/packages/block-library/src/navigation-submenu/style.scss
+++ b/packages/block-library/src/navigation-submenu/style.scss
@@ -14,6 +14,10 @@ button.wp-block-navigation-item__content {
 	font-size: inherit;
 	font-family: inherit;
 	line-height: inherit;
+
+	// Buttons default to center alignment. This becomes visible
+	// when a menu item label is long enough to wrap.
+	text-align: left;
 }
 
 .wp-block-navigation-submenu__toggle {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -269,18 +269,22 @@
 // When justified space-between, open submenus leftward for last menu item.
 // When justified right, open all submenus leftwards.
 // This needs high specificity.
-// On smaller breakpoints, menus open downwards.
-@include break-medium {
-	.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
-	.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
-	.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
-	.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
-		// First submenu.
-		.wp-block-navigation__submenu-container {
-			left: auto;
-			right: 0;
+.wp-block-navigation.items-justified-space-between .wp-block-page-list > .has-child:last-child,
+.wp-block-navigation.items-justified-space-between > .wp-block-navigation__container > .has-child:last-child,
+.wp-block-navigation.items-justified-right .wp-block-page-list > .has-child,
+.wp-block-navigation.items-justified-right .wp-block-navigation__container .has-child {
+	// First submenu.
+	.wp-block-navigation__submenu-container {
+		left: auto;
+		right: 0;
 
-			// Nested submenus.
+		// Nested submenus.
+		// On smaller breakpoints, nested menus open downwards.
+		.wp-block-navigation__submenu-container {
+			left: -1px; // Border width.
+			right: -1px;
+		}
+		@include break-medium {
 			.wp-block-navigation__submenu-container {
 				left: auto;
 				right: 100%;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -452,7 +452,7 @@
 				display: block;
 				width: 100%;
 				position: relative;
-				z-index: 2;
+				z-index: auto;
 				background-color: inherit;
 
 				.wp-block-navigation__responsive-container-close {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -380,9 +380,6 @@
 			overflow: auto;
 			padding: 0;
 
-			// Always vertically align to the top.
-			justify-content: flex-start;
-
 			.wp-block-navigation__submenu-icon {
 				display: none;
 			}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -380,6 +380,9 @@
 			overflow: auto;
 			padding: 0;
 
+			// Always vertically align to the top.
+			justify-content: flex-start;
+
 			.wp-block-navigation__submenu-icon {
 				display: none;
 			}


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/twentytwentytwo/issues/206. As reported there, there are a few issues with dropdown submenus and their nested versions as well:

<strike>- Even when the submenu is closed, its contents take up space and can in some circumstances create a horizontal scrollbar.</strike>
- Submenus should open leftwards when right aligned. This worked, but not at small breakpoints.
<strike>- Not reported in that ticket, but surfaced by it — menus set to open on click had smaller buttons for the submenus than for hover.</strike>
- The contents of burger menus should always be top aligned.

Some of the bugs originally fixed by this PR have been fixed separately. But the two remaining issues are still good to land.

## How has this been tested?

<strike>
- Create navigation menus that features submenus, and sub sub menus (nested menus).
- Test with and without click enabled.
- Test a justified-right submenu on small (<782) and bigger breakpoints. They should both open leftwards, but <782 menus should open leftwards and _downwards_ (as shown in the GIF above).
- Bonus: use the web inspector to verify that submenus are zero width even when not shown.

Note that we use `visibility: hidden:` to hide submenus so we can nicely fade them in and out. `display: none;` is an alternative that won't let us animate it as nicely.</strike>

Test instructions and GIFs are shown in https://github.com/WordPress/gutenberg/pull/36215#issuecomment-966174501.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
