### PR TITLE
"npm install" suggestion provides a better learning experience 

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -33,7 +33,7 @@ $ git remote add upstream https://github.com/WordPress/gutenberg.git
 Install the Gutenberg dependencies and build your code in development mode:
 
 ```bash
-npm ci
+npm install
 npm run dev
 ```
 


### PR DESCRIPTION
## Description

In this context I think the suggestion of `npm install`  provides a better Developer (and Learning) Experience because:
- The use of `npm install` is much more popular (no need to clarifications about what `npm ci` is)
- This page and explanation is mostly targeted to new contributors, so the use of `npm install` is more adequate at this point

I think the use of [`npm ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci) fits more in automated pipelines and scripts 
