### PR TITLE
Fix: Render the side editor even if global styles endpoints are not present

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -441,10 +441,13 @@ export const __experimentalGetCurrentThemeBaseGlobalStyles = () => async ( {
 	resolveSelect,
 	dispatch,
 } ) => {
+	let themeGlobalStyles = null;
 	const currentTheme = await resolveSelect.getCurrentTheme();
-	const themeGlobalStyles = await apiFetch( {
-		path: `/wp/v2/global-styles/themes/${ currentTheme.stylesheet }`,
-	} );
+	try {
+		themeGlobalStyles = await apiFetch( {
+			path: `/wp/v2/global-styles/themes/${ currentTheme.stylesheet }`,
+		} );
+	} catch ( e ) {}
 	await dispatch.__experimentalReceiveThemeBaseGlobalStyles(
 		currentTheme.stylesheet,
 		themeGlobalStyles

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -919,5 +919,11 @@ export function __experimentalGetCurrentThemeBaseGlobalStyles( state ) {
 	if ( ! currentTheme ) {
 		return null;
 	}
+	if (
+		! state.themeBaseGlobalStyles ||
+		! state.themeBaseGlobalStyles[ currentTheme.stylesheet ]
+	) {
+		return null;
+	}
 	return state.themeBaseGlobalStyles[ currentTheme.stylesheet ];
 }

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -97,7 +97,7 @@ function useGlobalStylesUserConfig() {
 
 	const config = useMemo( () => {
 		return {
-			settings: addUserOriginToSettings( settings ?? {} ),
+			settings: settings ? addUserOriginToSettings( settings ) : {},
 			styles: styles ?? {},
 		};
 	}, [ settings, styles ] );
@@ -172,9 +172,6 @@ function useGlobalStylesContext() {
 
 export function GlobalStylesProvider( { children } ) {
 	const context = useGlobalStylesContext();
-	if ( ! context.isReady ) {
-		return null;
-	}
 
 	return (
 		<GlobalStylesContext.Provider value={ context }>

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useContext } from '@wordpress/element';
 import { DropdownMenu, FlexItem, FlexBlock, Flex } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles, moreVertical } from '@wordpress/icons';
@@ -10,10 +11,15 @@ import { styles, moreVertical } from '@wordpress/icons';
  */
 import DefaultSidebar from './default-sidebar';
 import { GlobalStylesUI, useGlobalStylesReset } from '../global-styles';
+import { GlobalStylesContext } from '../global-styles/context';
 
 export default function GlobalStylesSidebar() {
 	const [ canReset, onReset ] = useGlobalStylesReset();
 
+	const { isReady } = useContext( GlobalStylesContext );
+	if ( ! isReady ) {
+		return null;
+	}
 	return (
 		<DefaultSidebar
 			className="edit-site-global-styles-sidebar"


### PR DESCRIPTION
We had a condition on GlobalStylesProvider, a parent of most of the site editor UI, to not render anything if it was not possible to retrieve the global styles information from the endpoints. So if global styles endpoints did not respond site editor would be a blank canvas and impossible to use.

This PR changes the logic and now only the global styles sidebar is disabled so we can use the site editor UI without the global styles. Important so having the endpoints in the core is not a blocker to test the rest of the site editor.
## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I commented the following lines:
add_filter( 'rest_prepare_theme', 'gutenberg_add_active_global_styles_link', 10, 2 );
add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );


I verified the site editor loads and works normally without the global styles.