### PR TITLE
Fix: Show user colors on palette indicator.

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -19,8 +19,11 @@ import Subtitle from './subtitle';
 import NavigationButton from './navigation-button';
 import { useSetting } from './hooks';
 
+const EMPTY_COLORS = [];
+
 function Palette( { name } ) {
-	const [ colors ] = useSetting( 'color.palette', name );
+	const [ colorsSetting ] = useSetting( 'color.palette.user', name );
+	const colors = colorsSetting || EMPTY_COLORS;
 	const screenPath = ! name
 		? '/colors/palette'
 		: '/blocks/' + name + '/colors/palette';


### PR DESCRIPTION
This PR follows the feedback by @oandregal and shows the user color palettes in the color palette indicator.

