### PR TITLE
Fix duotone theme cache

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -404,9 +404,11 @@ function gutenberg_render_duotone_filter( $preset ) {
 }
 
 /**
- * Renders the duotone filter SVG for the preset and returns the filter url.
- *
+ * Renders the duotone filter SVG and returns the CSS filter property to
+ * reference the rendered SVG.
+ * 
  * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone CSS filter property.
  */
 function gutenberg_render_duotone_filter_preset( $preset ) {
 	gutenberg_render_duotone_filter( $preset );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -293,9 +293,8 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 /**
  * Returns the prefixed id for the duotone filter for use as a CSS id.
  *
- * @param array $preset Duotone preset value as seen in theme.json.
- *
- * @return string Duotone filter CSS id.
+ * @param  array $preset Duotone preset value as seen in theme.json.
+ * @return string        Duotone filter CSS id.
  */
 function gutenberg_get_duotone_filter_id( $preset ) {
 	return 'wp-duotone-' . $preset['slug'];
@@ -304,9 +303,8 @@ function gutenberg_get_duotone_filter_id( $preset ) {
 /**
  * Returns the CSS filter property url to reference the rendered SVG.
  *
- * @param array $preset Duotone preset value as seen in theme.json.
- *
- * @return string Duotone CSS filter property url value.
+ * @param  array $preset Duotone preset value as seen in theme.json.
+ * @return string        Duotone CSS filter property url value.
  */
 function gutenberg_get_duotone_filter_url( $preset ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
@@ -314,11 +312,12 @@ function gutenberg_get_duotone_filter_url( $preset ) {
 }
 
 /**
- * Renders the duotone filter SVG for the preset.
+ * Returns the duotone filter SVG string for the preset.
  *
- * @param array $preset Duotone preset value as seen in theme.json.
+ * @param  array $preset Duotone preset value as seen in theme.json.
+ * @return string        Duotone SVG filter.
  */
-function gutenberg_render_duotone_filter( $preset ) {
+function gutenberg_get_duotone_filter_svg( $preset ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
 
 	$duotone_values = array(
@@ -383,6 +382,16 @@ function gutenberg_render_duotone_filter( $preset ) {
 		$svg = trim( $svg );
 	}
 
+	return $svg;
+}
+
+/**
+ * Renders the duotone filter SVG for the preset.
+ *
+ * @param array $preset Duotone preset value as seen in theme.json.
+ */
+function gutenberg_render_duotone_filter( $preset ) {
+	$svg = gutenberg_get_duotone_filter_svg( $preset );
 	add_action(
 		// SVG filters won't render at all in the head of a document and
 		// Safari incorrectly renders SVG filters in the footer, so the

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -290,29 +290,27 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 	}
 }
 
+/**
+ * Returns the prefixed id for the duotone filter for use as a CSS id.
+ *
+ * @param array $preset Duotone preset value as seen in theme.json.
+ *
+ * @return string Duotone filter CSS id.
+ */
+function gutenberg_get_duotone_filter_id( $preset ) {
+	return 'wp-duotone-' . $preset['slug'];
+}
 
 /**
- * Registers the style and colors block attributes for block types that support it.
+ * Returns the CSS filter property url to reference the rendered SVG.
  *
- * @param WP_Block_Type $block_type Block Type.
+ * @param array $preset Duotone preset value as seen in theme.json.
+ *
+ * @return string Duotone CSS filter property url value.
  */
-function gutenberg_register_duotone_support( $block_type ) {
-	$has_duotone_support = false;
-	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
-	}
-
-	if ( $has_duotone_support ) {
-		if ( ! $block_type->attributes ) {
-			$block_type->attributes = array();
-		}
-
-		if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
-			$block_type->attributes['style'] = array(
-				'type' => 'object',
-			);
-		}
-	}
+function gutenberg_get_duotone_filter_url( $preset ) {
+	$filter_id = gutenberg_get_duotone_filter_id( $preset );
+	return "url('#" . $filter_id . "')";
 }
 
 /**
@@ -397,26 +395,27 @@ function gutenberg_render_duotone_filter( $preset ) {
 }
 
 /**
- * Returns the CSS filter property url to reference the rendered SVG.
+ * Registers the style and colors block attributes for block types that support it.
  *
- * @param array $preset Duotone preset value as seen in theme.json.
- *
- * @return string Duotone CSS filter property url value.
+ * @param WP_Block_Type $block_type Block Type.
  */
-function gutenberg_get_duotone_filter_url( $preset ) {
-	$filter_id = gutenberg_get_duotone_filter_id( $preset );
-	return "url('#" . $filter_id . "')";
-}
+function gutenberg_register_duotone_support( $block_type ) {
+	$has_duotone_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$has_duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
+	}
 
-/**
- * Returns the prefixed id for the duotone filter for use as a CSS id.
- *
- * @param array $preset Duotone preset value as seen in theme.json.
- *
- * @return string Duotone filter CSS id.
- */
-function gutenberg_get_duotone_filter_id( $preset ) {
-	return 'wp-duotone-' . $preset['slug'];
+	if ( $has_duotone_support ) {
+		if ( ! $block_type->attributes ) {
+			$block_type->attributes = array();
+		}
+
+		if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
+			$block_type->attributes['style'] = array(
+				'type' => 'object',
+			);
+		}
+	}
 }
 
 /**

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -306,7 +306,7 @@ function gutenberg_get_duotone_filter_id( $preset ) {
  * @param  array $preset Duotone preset value as seen in theme.json.
  * @return string        Duotone CSS filter property url value.
  */
-function gutenberg_get_duotone_filter_url( $preset ) {
+function gutenberg_get_duotone_filter_property( $preset ) {
 	$filter_id = gutenberg_get_duotone_filter_id( $preset );
 	return "url('#" . $filter_id . "')";
 }
@@ -410,7 +410,7 @@ function gutenberg_render_duotone_filter( $preset ) {
  */
 function gutenberg_render_duotone_filter_preset( $preset ) {
 	gutenberg_render_duotone_filter( $preset );
-	return gutenberg_get_duotone_filter_url( $preset );
+	return gutenberg_get_duotone_filter_property( $preset );
 }
 
 /**
@@ -461,12 +461,12 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$filter_preset = array(
+	$filter_preset   = array(
 		'slug'   => uniqid(),
 		'colors' => $block['attrs']['style']['color']['duotone'],
 	);
-	$filter_url    = gutenberg_get_duotone_filter_url( $filter_preset );
-	$filter_id     = gutenberg_get_duotone_filter_id( $filter_preset );
+	$filter_property = gutenberg_get_duotone_filter_property( $filter_preset );
+	$filter_id       = gutenberg_get_duotone_filter_id( $filter_preset );
 
 	$scope     = '.' . $filter_id;
 	$selectors = explode( ',', $duotone_support );
@@ -479,8 +479,8 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	// !important is needed because these styles render before global styles,
 	// and they should be overriding the duotone filters set by global styles.
 	$filter_style = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG
-		? $selector . " {\n\tfilter: " . $filter_url . " !important;\n}\n"
-		: $selector . '{filter:' . $filter_url . ' !important;}';
+		? $selector . " {\n\tfilter: " . $filter_property . " !important;\n}\n"
+		: $selector . '{filter:' . $filter_property . ' !important;}';
 
 	wp_register_style( $filter_id, false, array(), true, true );
 	wp_add_inline_style( $filter_id, $filter_style );

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -406,7 +406,7 @@ function gutenberg_render_duotone_filter( $preset ) {
 /**
  * Renders the duotone filter SVG and returns the CSS filter property to
  * reference the rendered SVG.
- * 
+ *
  * @param array $preset Duotone preset value as seen in theme.json.
  * @return string Duotone CSS filter property.
  */

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -404,6 +404,16 @@ function gutenberg_render_duotone_filter( $preset ) {
 }
 
 /**
+ * Renders the duotone filter SVG for the preset and returns the filter url.
+ *
+ * @param array $preset Duotone preset value as seen in theme.json.
+ */
+function gutenberg_render_duotone_filter_preset( $preset ) {
+	gutenberg_render_duotone_filter( $preset );
+	return gutenberg_get_duotone_filter_url( $preset );
+}
+
+/**
  * Registers the style and colors block attributes for block types that support it.
  *
  * @param WP_Block_Type $block_type Block Type.

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -404,18 +404,6 @@ function gutenberg_render_duotone_filter( $preset ) {
 }
 
 /**
- * Renders the duotone filter SVG and returns the CSS filter property to
- * reference the rendered SVG.
- *
- * @param array $preset Duotone preset value as seen in theme.json.
- * @return string Duotone CSS filter property.
- */
-function gutenberg_render_duotone_filter_preset( $preset ) {
-	gutenberg_render_duotone_filter( $preset );
-	return gutenberg_get_duotone_filter_property( $preset );
-}
-
-/**
  * Registers the style and colors block attributes for block types that support it.
  *
  * @param WP_Block_Type $block_type Block Type.
@@ -488,6 +476,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	wp_add_inline_style( $filter_id, $filter_style );
 	wp_enqueue_style( $filter_id );
 
+	// Render any custom filter the user may have added.
 	gutenberg_render_duotone_filter( $filter_preset );
 
 	// Like the layout hook, this assumes the hook only applies to blocks with a single wrapper.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -120,7 +120,7 @@ class WP_Theme_JSON_Gutenberg {
 			'path'              => array( 'color', 'duotone' ),
 			'override'          => true,
 			'use_default_names' => false,
-			'value_func'        => 'gutenberg_render_duotone_filter_preset',
+			'value_func'        => 'gutenberg_get_duotone_filter_property',
 			'css_vars'          => '--wp--preset--duotone--$slug',
 			'classes'           => array(),
 			'properties'        => array( 'filter' ),

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1484,7 +1484,38 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Returns whether a presets should be overriden or not.
+	 * Converts all filter (duotone) presets into SVGs.
+	 *
+	 * @param array $origins List of origins to process.
+	 *
+	 * @return string SVG filters.
+	 */
+	public function get_svg_filters( $origins ) {
+		// $blocks_metadata = self::get_blocks_metadata();
+		// $settings_nodes  = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
+
+		// TODO: Handle the per-block settings.
+		if ( ! isset( $this->theme_json['settings']['color']['duotone'] ) ) {
+			return '';
+		}
+
+		$duotone_presets = $this->theme_json['settings']['color']['duotone'];
+
+		$filters = array();
+		foreach ( $origins as $origin ) {
+			if ( ! isset( $duotone_presets[ $origin ] ) ) {
+				continue;
+			}
+			foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
+				$filters[] = gutenberg_get_duotone_filter_svg( $duotone_preset );
+			}
+		}
+
+		return implode( $filters );
+	}
+
+	/**
+	 * Merge new incoming data.
 	 *
 	 * @param array      $theme_json The theme.json like structure to inspect.
 	 * @param array      $path Path to inspect.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1517,7 +1517,7 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Merge new incoming data.
+	 * Returns whether a presets should be overriden or not.
 	 *
 	 * @param array      $theme_json The theme.json like structure to inspect.
 	 * @param array      $path Path to inspect.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1491,23 +1491,25 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return string SVG filters.
 	 */
 	public function get_svg_filters( $origins ) {
-		// $blocks_metadata = self::get_blocks_metadata();
-		// $settings_nodes  = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
+		$blocks_metadata = self::get_blocks_metadata();
+		$setting_nodes   = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
 
-		// TODO: Handle the per-block settings.
-		if ( ! isset( $this->theme_json['settings']['color']['duotone'] ) ) {
-			return '';
-		}
-
-		$duotone_presets = $this->theme_json['settings']['color']['duotone'];
-
-		$filters = array();
-		foreach ( $origins as $origin ) {
-			if ( ! isset( $duotone_presets[ $origin ] ) ) {
+		foreach ( $setting_nodes as $metadata ) {
+			$node = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			if ( empty( $node['color']['duotone'] ) ) {
 				continue;
 			}
-			foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
-				$filters[] = gutenberg_get_duotone_filter_svg( $duotone_preset );
+
+			$duotone_presets = $node['color']['duotone'];
+
+			$filters = array();
+			foreach ( $origins as $origin ) {
+				if ( ! isset( $duotone_presets[ $origin ] ) ) {
+					continue;
+				}
+				foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
+					$filters[] = gutenberg_get_duotone_filter_svg( $duotone_preset );
+				}
 			}
 		}
 

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1502,18 +1502,18 @@ class WP_Theme_JSON_Gutenberg {
 
 			$duotone_presets = $node['color']['duotone'];
 
-			$filters = array();
+			$filters = '';
 			foreach ( $origins as $origin ) {
 				if ( ! isset( $duotone_presets[ $origin ] ) ) {
 					continue;
 				}
 				foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
-					$filters[] = gutenberg_get_duotone_filter_svg( $duotone_preset );
+					$filters .= gutenberg_get_duotone_filter_svg( $duotone_preset );
 				}
 			}
 		}
 
-		return implode( $filters );
+		return $filters;
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -88,11 +88,11 @@ if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
 		// Return cached value if it can be used and exists.
 		// It's cached by theme to make sure that theme switching clears the cache.
 		$can_use_cached = (
-		( empty( $types ) ) &&
-		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
-		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
-		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
-		! is_admin()
+			( empty( $types ) ) &&
+			( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+			( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+			( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+			! is_admin()
 		);
 		$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 		if ( $can_use_cached ) {
@@ -143,7 +143,13 @@ if ( ! function_exists( 'wp_get_global_styles_svg_filters' ) ) {
 		// Return cached value if it can be used and exists.
 		// It's cached by theme to make sure that theme switching clears the cache.
 		$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();
-		$can_use_cached = gutenberg_can_use_cached();
+		$can_use_cached = (
+			( empty( $types ) ) &&
+			( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+			( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+			( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+			! is_admin()
+		);
 		if ( $can_use_cached ) {
 			$cached = get_transient( $transient_name );
 			if ( $cached ) {

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -144,7 +144,6 @@ if ( ! function_exists( 'wp_get_global_styles_svg_filters' ) ) {
 		// It's cached by theme to make sure that theme switching clears the cache.
 		$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();
 		$can_use_cached = (
-			( empty( $types ) ) &&
 			( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 			( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 			( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -138,7 +138,7 @@ if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
  *
  * @return string Stylesheet.
  */
-function gutenberg_get_global_styles_svg_filters() {
+function wp_get_global_styles_svg_filters() {
 	// Return cached value if it can be used and exists.
 	// It's cached by theme to make sure that theme switching clears the cache.
 	$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -134,9 +134,9 @@ if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
 }
 
 /**
- * Returns the stylesheet resulting of merging core, theme, and user data.
+ * Returns a string containing the SVGs to be referenced as filters (duotone).
  *
- * @return string Stylesheet.
+ * @return string
  */
 function wp_get_global_styles_svg_filters() {
 	// Return cached value if it can be used and exists.
@@ -151,17 +151,10 @@ function wp_get_global_styles_svg_filters() {
 	}
 
 	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	$supports_link_color = get_theme_support( 'experimental-link-color' );
 
-	// TODO: Which origins are needed for duotone filters?
-	$origins = array( 'core', 'theme', 'user' );
-	if ( ! $supports_theme_json && ! $supports_link_color ) {
-		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-		$origins = array( 'core' );
-	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feature to work, the CSS Custom Properties
-		// should be in scope (either the core or the theme ones).
-		$origins = array( 'core', 'theme' );
+	$origins = array( 'default', 'theme' );
+	if ( ! $supports_theme_json ) {
+		$origins = array( 'default' );
 	}
 
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -133,37 +133,39 @@ if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
 	}
 }
 
-/**
- * Returns a string containing the SVGs to be referenced as filters (duotone).
- *
- * @return string
- */
-function wp_get_global_styles_svg_filters() {
-	// Return cached value if it can be used and exists.
-	// It's cached by theme to make sure that theme switching clears the cache.
-	$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();
-	$can_use_cached = gutenberg_can_use_cached();
-	if ( $can_use_cached ) {
-		$cached = get_transient( $transient_name );
-		if ( $cached ) {
-			return $cached;
+if ( ! function_exists( 'wp_get_global_styles_svg_filters' ) ) {
+	/**
+	 * Returns a string containing the SVGs to be referenced as filters (duotone).
+	 *
+	 * @return string
+	 */
+	function wp_get_global_styles_svg_filters() {
+		// Return cached value if it can be used and exists.
+		// It's cached by theme to make sure that theme switching clears the cache.
+		$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();
+		$can_use_cached = gutenberg_can_use_cached();
+		if ( $can_use_cached ) {
+			$cached = get_transient( $transient_name );
+			if ( $cached ) {
+				return $cached;
+			}
 		}
+
+		$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+
+		$origins = array( 'default', 'theme' );
+		if ( ! $supports_theme_json ) {
+			$origins = array( 'default' );
+		}
+
+		$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$svgs = $tree->get_svg_filters( $origins );
+
+		if ( $can_use_cached ) {
+			// Cache for a minute, same as gutenberg_get_global_stylesheet.
+			set_transient( $transient_name, $svgs, MINUTE_IN_SECONDS );
+		}
+
+		return $svgs;
 	}
-
-	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-
-	$origins = array( 'default', 'theme' );
-	if ( ! $supports_theme_json ) {
-		$origins = array( 'default' );
-	}
-
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$svgs = $tree->get_svg_filters( $origins );
-
-	if ( $can_use_cached ) {
-		// Cache for a minute, same as gutenberg_get_global_stylesheet.
-		set_transient( $transient_name, $svgs, MINUTE_IN_SECONDS );
-	}
-
-	return $svgs;
 }

--- a/lib/compat/wordpress-5.9/render-svg-filters.php
+++ b/lib/compat/wordpress-5.9/render-svg-filters.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Renders the SVG filters for duotone.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Render the SVG filters.
+ *
+ * Safari doesn't render SVG filters defined in data URIs,
+ * and SVG filters won't render in the head of a document,
+ * so the next best place to put the SVG is in the footer.
+ */
+function gutenberg_experimental_global_styles_render_svg_filters() {
+	$filters = wp_get_global_styles_svg_filters();
+	if ( ! empty( $filters ) ) {
+		echo $filters;
+	}
+}
+
+add_action(
+	is_admin() ? 'admin_footer' : 'wp_footer',
+	'gutenberg_experimental_global_styles_render_svg_filters'
+);

--- a/lib/compat/wordpress-5.9/render-svg-filters.php
+++ b/lib/compat/wordpress-5.9/render-svg-filters.php
@@ -9,11 +9,9 @@
  * Render the SVG filters supplied by theme.json.
  *
  * Note that this doesn't render the per-block user-defined
- * filters which are handled by duotone.php.
- *
- * Safari doesn't render SVG filters defined in data URIs,
- * and SVG filters won't render in the head of a document,
- * so the next best place to put the SVG is in the footer.
+ * filters which are handled by duotone.php, but it should
+ * be rendered in the same location as those to satisfy
+ * Safari's rendering quirks.
  */
 function gutenberg_experimental_global_styles_render_svg_filters() {
 	$filters = wp_get_global_styles_svg_filters();
@@ -23,6 +21,6 @@ function gutenberg_experimental_global_styles_render_svg_filters() {
 }
 
 add_action(
-	is_admin() ? 'admin_footer' : 'wp_footer',
+	'wp_body_open',
 	'gutenberg_experimental_global_styles_render_svg_filters'
 );

--- a/lib/compat/wordpress-5.9/render-svg-filters.php
+++ b/lib/compat/wordpress-5.9/render-svg-filters.php
@@ -6,7 +6,10 @@
  */
 
 /**
- * Render the SVG filters.
+ * Render the SVG filters supplied by theme.json.
+ *
+ * Note that this doesn't render the per-block user-defined
+ * filters which are handled by duotone.php.
  *
  * Safari doesn't render SVG filters defined in data URIs,
  * and SVG filters won't render in the head of a document,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Render the SVG filters.
+ *
+ * Safari doesn't render SVG filters defined in data URIs,
+ * and SVG filters won't render in the head of a document,
+ * so the next best place to put the SVG is in the footer.
+ */
+function gutenberg_experimental_global_styles_render_svg_filters() {
+	$filters = gutenberg_get_global_styles_svg_filters();
+	if ( ! empty( $filters ) ) {
+		echo $filters;
+	}
+}
+
+/**
  * Adds the necessary settings for the Global Styles client UI.
  *
  * @param array $settings Existing block editor settings.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -6,20 +6,6 @@
  */
 
 /**
- * Render the SVG filters.
- *
- * Safari doesn't render SVG filters defined in data URIs,
- * and SVG filters won't render in the head of a document,
- * so the next best place to put the SVG is in the footer.
- */
-function gutenberg_experimental_global_styles_render_svg_filters() {
-	$filters = wp_get_global_styles_svg_filters();
-	if ( ! empty( $filters ) ) {
-		echo $filters;
-	}
-}
-
-/**
  * Adds the necessary settings for the Global Styles client UI.
  *
  * @param array $settings Existing block editor settings.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -13,7 +13,7 @@
  * so the next best place to put the SVG is in the footer.
  */
 function gutenberg_experimental_global_styles_render_svg_filters() {
-	$filters = gutenberg_get_global_styles_svg_filters();
+	$filters = wp_get_global_styles_svg_filters();
 	if ( ! empty( $filters ) ) {
 		echo $filters;
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -105,6 +105,7 @@ require __DIR__ . '/compat/wordpress-5.9/register-global-styles-cpt.php';
 // and the global styles assets won't be loaded.
 require __DIR__ . '/compat/wordpress-5.9/script-loader.php';
 require __DIR__ . '/compat/wordpress-5.9/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-5.9/render-svg-filters.php';
 require __DIR__ . '/compat/wordpress-5.9/json-file-decode.php';
 require __DIR__ . '/compat/wordpress-5.9/translate-settings-using-i18n-schema.php';
 require __DIR__ . '/compat/wordpress-5.9/global-styles-css-custom-properties.php';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fix #36208 

Duotone filters were getting rendered via a side-effect of the global stylesheet generation. Because the stylesheets were cached, the duotone filter rendering wasn't called when the cache hit.

This adds a separate cache for the SVG filters which have to be rendered in the footer of the document, separate from the stylesheet.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Ensure that your environment doesn't have any of these consts set: https://github.com/WordPress/gutenberg/blob/3e84b5671554281453ea0c635742d6a9e2994351/lib/compat/wordpress-5.9/get-global-styles-and-settings.php#L79-L85
2. Apply a duotone filter to a theme via the theme.json file:

```json
{
    "styles": {
        "blocks": {
            "core/image": {
                "filter": {
                    "duotone": "var(--wp--preset--duotone--default-filter)"
                }
            }
        }
    }
}
```

```json
{
    "settings":  {
        "color":  {
            "duotone":  [
                {
                    "colors": [ "#000", "#B9FB9C" ],
                    "slug": "default-filter",
                    "name": "Default filter"
                }
            ]
        }
    }
}
```
3. See that the duotone filters are loaded on all images and persist on subsequent reloads

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
