### PR TITLE
Update navigation block entity automatic name generation and refine naming UI

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -354,23 +354,6 @@ function Navigation( {
 				</BlockControls>
 				{ listViewModal }
 				<InspectorControls>
-					{ isEntityAvailable && (
-						<PanelBody title={ __( 'Navigation menu' ) }>
-							<NavigationMenuNameControl />
-							<NavigationMenuDeleteControl
-								onDelete={ () => {
-									replaceInnerBlocks( clientId, [] );
-									if ( navigationArea ) {
-										setAreaMenu( 0 );
-									}
-									setAttributes( {
-										navigationMenuId: undefined,
-									} );
-									setIsPlaceholderShown( true );
-								} }
-							/>
-						</PanelBody>
-					) }
 					{ hasSubmenuIndicatorSetting && (
 						<PanelBody title={ __( 'Display' ) }>
 							<h3>{ __( 'Overlay Menu' ) }</h3>
@@ -469,6 +452,23 @@ function Navigation( {
 						</PanelColorSettings>
 					) }
 				</InspectorControls>
+				{ isEntityAvailable && (
+					<InspectorControls __experimentalGroup="advanced">
+						<NavigationMenuNameControl />
+						<NavigationMenuDeleteControl
+							onDelete={ () => {
+								replaceInnerBlocks( clientId, [] );
+								if ( navigationArea ) {
+									setAreaMenu( 0 );
+								}
+								setAttributes( {
+									navigationMenuId: undefined,
+								} );
+								setIsPlaceholderShown( true );
+							} }
+						/>
+					</InspectorControls>
+				) }
 				<nav { ...blockProps }>
 					{ ! isEntityAvailable && isPlaceholderShown && (
 						<PlaceholderComponent

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -260,6 +260,7 @@ function Navigation( {
 			<UnsavedInnerBlocks
 				blockProps={ blockProps }
 				blocks={ innerBlocks }
+				clientId={ clientId }
 				navigationMenus={ navigationMenus }
 				hasSelection={ isSelected || isInnerBlockSelected }
 				hasSavedUnsavedInnerBlocks={ hasSavedUnsavedInnerBlocks }

--- a/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
@@ -14,7 +14,7 @@ export default function NavigationMenuNameControl() {
 
 	return (
 		<TextControl
-			label={ __( 'Name' ) }
+			label={ __( 'Menu name' ) }
 			value={ title }
 			onChange={ updateTitle }
 		/>

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -142,7 +142,7 @@ export default function UnsavedInnerBlocks( {
 			: // translators: 'navigation' as in website navigation.
 			  __( 'Navigation' );
 
-		// Determine how many menus start with the untitled title.
+		// Determine how many menus start with the automatic title.
 		const matchingMenuTitleCount = [
 			...draftNavigationMenus,
 			...navigationMenus,

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -135,11 +135,12 @@ export default function UnsavedInnerBlocks( {
 		savingLock.current = true;
 		const title = area
 			? sprintf(
-					// translators: %s is the name of a menu (e.g. Header menu).
-					__( '%s menu' ),
+					// translators: %s: the name of a menu (e.g. Header navigation).
+					__( '%s navigation' ),
 					area
 			  )
-			: __( 'Menu' );
+			: // translators: 'navigation' as in website navigation.
+			  __( 'Navigation' );
 
 		// Determine how many menus start with the untitled title.
 		const matchingMenuTitleCount = [

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -18,7 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
-import useTemplatePartArea from '../use-template-part-area';
+import useTemplatePartAreaLabel from '../use-template-part-area-label';
 
 const NOOP = () => {};
 const DRAFT_MENU_PARAMS = [
@@ -104,7 +104,7 @@ export default function UnsavedInnerBlocks( {
 	// Because we can't conditionally call hooks, pass an undefined client id
 	// arg to bypass the expensive `useTemplateArea` code. The hook will return
 	// early.
-	const area = useTemplatePartArea( isDisabled ? clientId : undefined );
+	const area = useTemplatePartAreaLabel( isDisabled ? undefined : clientId );
 
 	// Automatically save the uncontrolled blocks.
 	useEffect( async () => {

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -126,7 +126,7 @@ export default function UnsavedInnerBlocks( {
 					__( '%s menu' ),
 					area
 			  )
-			: __( 'Untitled menu' );
+			: __( 'Menu' );
 
 		// Determine how many menus start with the untitled title.
 		const matchingMenuTitleCount = [

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -12,12 +12,13 @@ import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
+import useTemplatePartArea from '../use-template-part-area';
 
 const NOOP = () => {};
 const DRAFT_MENU_PARAMS = [
@@ -29,6 +30,7 @@ const DRAFT_MENU_PARAMS = [
 export default function UnsavedInnerBlocks( {
 	blockProps,
 	blocks,
+	clientId,
 	hasSavedUnsavedInnerBlocks,
 	onSave,
 	hasSelection,
@@ -70,6 +72,7 @@ export default function UnsavedInnerBlocks( {
 	}, [] );
 
 	const { hasResolvedNavigationMenus, navigationMenus } = useNavigationMenu();
+	const area = useTemplatePartArea( clientId );
 
 	const createNavigationMenu = useCallback(
 		async ( title ) => {
@@ -117,7 +120,13 @@ export default function UnsavedInnerBlocks( {
 		}
 
 		savingLock.current = true;
-		const title = __( 'Untitled menu' );
+		const title = area
+			? sprintf(
+					// translators: %s is the name of a menu (e.g. Header menu).
+					__( '%s menu' ),
+					area
+			  )
+			: __( 'Untitled menu' );
 
 		// Determine how many menus start with the untitled title.
 		const matchingMenuTitleCount = [
@@ -148,6 +157,7 @@ export default function UnsavedInnerBlocks( {
 		navigationMenus,
 		hasSelection,
 		createNavigationMenu,
+		area,
 	] );
 
 	return (

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -21,6 +21,7 @@ import useNavigationMenu from '../use-navigation-menu';
 import useTemplatePartAreaLabel from '../use-template-part-area-label';
 
 const NOOP = () => {};
+const EMPTY_OBJECT = {};
 const DRAFT_MENU_PARAMS = [
 	'postType',
 	'wp_navigation',
@@ -59,7 +60,7 @@ export default function UnsavedInnerBlocks( {
 	} = useSelect(
 		( select ) => {
 			if ( isDisabled ) {
-				return {};
+				return EMPTY_OBJECT;
 			}
 
 			const {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -567,4 +567,5 @@ body.editor-styles-wrapper
 .wp-block-navigation-delete-menu-button {
 	width: 100%;
 	justify-content: center;
+	margin-bottom: $grid-unit-20;
 }

--- a/packages/block-library/src/navigation/use-template-part-area-label.js
+++ b/packages/block-library/src/navigation/use-template-part-area-label.js
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
 // TODO: this util should perhaps be refactored somewhere like core-data.
 import { createTemplatePartId } from '../template-part/edit/utils/create-template-part-id';
 
-export default function useTemplatePartArea( clientId ) {
+export default function useTemplatePartAreaLabel( clientId ) {
 	return useSelect(
 		( select ) => {
 			// Use the lack of a clientId as an opportunity to bypass the rest

--- a/packages/block-library/src/navigation/use-template-part-area.js
+++ b/packages/block-library/src/navigation/use-template-part-area.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+// TODO: this util should perhaps be refactored somewhere like core-data.
+import { createTemplatePartId } from '../template-part/edit/utils/create-template-part-id';
+
+export default function useTemplatePartArea( clientId ) {
+	return useSelect(
+		( select ) => {
+			// Use the lack of a clientId as an opportunity to bypass the rest
+			// of this hook.
+			if ( ! clientId ) {
+				return;
+			}
+
+			const { getBlock, getBlockParentsByBlockName } = select(
+				blockEditorStore
+			);
+
+			const withAscendingResults = true;
+			const parentTemplatePartClientIds = getBlockParentsByBlockName(
+				clientId,
+				'core/template-part',
+				withAscendingResults
+			);
+
+			if ( ! parentTemplatePartClientIds?.length ) {
+				return;
+			}
+
+			// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
+			// Blocks can be loaded into a *non-post* block editor.
+			// This code is lifted from this file:
+			// packages/block-library/src/template-part/edit/advanced-controls.js
+			// eslint-disable-next-line @wordpress/data-no-store-string-literals
+			const definedAreas = select(
+				'core/editor'
+			).__experimentalGetDefaultTemplatePartAreas();
+			const { getEditedEntityRecord } = select( coreStore );
+
+			for ( const templatePartClientId of parentTemplatePartClientIds ) {
+				const templatePartBlock = getBlock( templatePartClientId );
+
+				// The 'area' usually isn't stored on the block, but instead
+				// on the entity.
+				const { theme, slug } = templatePartBlock.attributes;
+				const templatePartEntityId = createTemplatePartId(
+					theme,
+					slug
+				);
+				const templatePartEntity = getEditedEntityRecord(
+					'postType',
+					'wp_template_part',
+					templatePartEntityId
+				);
+
+				// Look up the `label` for the area in the defined areas so
+				// that an internationalized label can be used.
+				if ( templatePartEntity?.area ) {
+					return definedAreas.find(
+						( definedArea ) =>
+							definedArea.area !== 'uncategorized' &&
+							definedArea.area === templatePartEntity.area
+					)?.label;
+				}
+			}
+		},
+		[ clientId ]
+	);
+}


### PR DESCRIPTION
## Description
Closes #35947

Address the comment here - https://github.com/WordPress/gutenberg/pull/36169#issuecomment-961082096.

Also moves the UI for menu naming and deleting UI to the 'advanced' section as often requested. I still strongly feel this isn't the right solution, and naming is important for users. I wasn't able to come up with an alternative in the limited time that lowers the prominence of the UI. Gutenberg still has limited support for ordering inspector panels. There were also no other designs put forward for this problem other than the advanced panel. 🤷 

With this improvement it's less of an issue. We'll see what feedback comes in and adjust as necessary.

## How has this been tested?
1. Insert a pattern that contains a navigation block into a header or footer template area (I used the Armando theme, which has the 'Site headers' pattern category. It's available in the theme experiments repo).
2. Select the navigation block and modify the content
3. Click the editor save button
4. Observe the name in entity saving panel should say 'Header navigation' or 'Footer navigation'. A number will be appended if the menu has been saved before

Alternative testing instructions:
1. Register the following pattern:
```
register_block_pattern_category(
	'navigation',
	array( 'label' => esc_html__( 'Navigation', 'gutenberg' ) )
);

register_block_pattern(
	'gutenberg/header-default',
	array(
		'title'      => esc_html__( 'Navigation.', 'gutenberg' ),
		'categories' => array( 'navigation' ),
		'content'    => '
			<!-- wp:group -->
			<div class="wp-block-group">
			<!-- wp:navigation -->
			<!-- wp:navigation-link /-->
			<!-- wp:navigation-link /-->
			<!-- wp:navigation-link /-->
			<!-- /wp:navigation -->
			</div>
			<!-- /wp:group -->
		',
	)
);
```
2. Visit the site editor and insert the 'navigation' pattern in a template part with a Header or Footer area.
3. Select the navigation block and modify the content
4. Click the editor save button
5. Observe the name in entity saving panel should say 'Header navigation' or 'Footer navigation'. A number will be appended if the menu has been saved before

## Screenshots <!-- if applicable -->
(I changed the menu names slightly since this screeenshot)
<img width="260" alt="Screenshot 2021-11-05 at 1 32 06 pm" src="https://user-images.githubusercontent.com/677833/140464898-0d215584-909c-4f5a-89b1-1546e162480c.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
