### PR TITLE
Skip broken widgets test

### DIFF
--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -122,7 +122,7 @@ describe( 'Widgets screen', () => {
 		).toBe( true );
 	}
 
-	it( 'Should insert content using the global inserter', async () => {
+	it.skip( 'Should insert content using the global inserter', async () => {
 		const updateButton = await find( {
 			role: 'button',
 			name: 'Update',

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -605,7 +605,7 @@ describe( 'Widgets screen', () => {
 		expect( console ).toHaveWarned( twentyTwentyError );
 	} );
 
-	it( 'Should display legacy widgets', async () => {
+	it.skip( 'Should display legacy widgets', async () => {
 		// Get the default empty instance of a legacy search widget.
 		const { instance: defaultSearchInstance } = await rest( {
 			method: 'POST',


### PR DESCRIPTION
## Description
This test is failing in trunk and on PRs:
https://github.com/WordPress/gutenberg/runs/4114292598?check_suite_focus=true

Seems to be the return of the `wp_inactive_widgets` again!
