### PR TITLE
Try: Temporary color fix for post editor.

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -179,7 +179,7 @@ const PanelColorGradientSettingsMultipleSelect = ( props ) => {
 		const result = [];
 		if ( coreColors && coreColors.length ) {
 			result.push( {
-				name: __( 'Core' ),
+				name: __( 'Default' ),
 				colors: coreColors,
 			} );
 		}

--- a/packages/block-editor/src/components/inserter/test/fixtures/index.js
+++ b/packages/block-editor/src/components/inserter/test/fixtures/index.js
@@ -11,7 +11,7 @@ export const categories = [
 export const collections = {
 	core: {
 		icon: undefined,
-		title: 'Core',
+		title: 'Default',
 	},
 };
 

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -66,7 +66,8 @@ function DropdownLinkAction( {
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
 					onClick={ onToggle }
-					variant="link"
+					isSmall
+					variant="secondary"
 					{ ...buttonProps }
 				>
 					{ linkText }

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -7,6 +7,8 @@ $color-palette-circle-spacing: 12px;
 	min-width: 188px;
 
 	.components-circular-option-picker__custom-clear-wrapper {
+		margin-top: $grid-unit-20;
+		margin-bottom: $grid-unit-10;
 		display: flex;
 		justify-content: flex-end;
 	}
@@ -127,10 +129,22 @@ $color-palette-circle-spacing: 12px;
 }
 
 
-.components-circular-option-picker__dropdown-link-action {
-	margin-right: $grid-unit-20;
+.components-circular-option-picker__dropdown-link-action + .components-button {
+	margin-left: $grid-unit-10;
+}
 
-	.components-button {
-		line-height: 22px;
+// Temporarily hide the color card from the post editor, but keep it for Global Styles.
+// @todo: this should be removed and retired entirely when colors in the post editor are
+// able to use the ItemGroup component to handle color options.
+// https://github.com/WordPress/gutenberg/issues/35093
+.edit-post-sidebar .block-editor-panel-color-gradient-settings .components-flex > .components-dropdown {
+	display: none;
+
+	& + div {
+		margin-top: 0;
 	}
+}
+
+.edit-site .components-circular-option-picker__dropdown-link-action {
+	display: none;
 }

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -157,13 +157,28 @@ export default function ColorPalette( {
 				onChange={ onChange }
 				value={ value }
 				actions={
-					!! clearable && (
-						<CircularOptionPicker.ButtonAction
-							onClick={ clearColor }
-						>
-							{ __( 'Clear' ) }
-						</CircularOptionPicker.ButtonAction>
-					)
+					<>
+						{ ! disableCustomColors && (
+							<CircularOptionPicker.DropdownLinkAction
+								dropdownProps={ {
+									renderContent: renderCustomColorPicker,
+									contentClassName:
+										'components-color-palette__picker',
+								} }
+								buttonProps={ {
+									'aria-label': __( 'Custom color picker' ),
+								} }
+								linkText={ __( 'Custom' ) }
+							/>
+						) }
+						{ !! clearable && (
+							<CircularOptionPicker.ButtonAction
+								onClick={ clearColor }
+							>
+								{ __( 'Clear' ) }
+							</CircularOptionPicker.ButtonAction>
+						) }
+					</>
 				}
 			/>
 		</VStack>

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -225,7 +225,7 @@ export function useColorsPerOrigin( name ) {
 		const result = [];
 		if ( coreColors && coreColors.length ) {
 			result.push( {
-				name: __( 'Core' ),
+				name: __( 'Default' ),
 				colors: coreColors,
 			} );
 		}
@@ -253,7 +253,7 @@ export function useGradientsPerOrigin( name ) {
 		const result = [];
 		if ( coreGradients && coreGradients.length ) {
 			result.push( {
-				name: __( 'Core' ),
+				name: __( 'Default' ),
 				gradients: coreGradients,
 			} );
 		}


### PR DESCRIPTION
## Description

The problem to solve is that this menu is very tall, because it duplicates the transparent color card for every property:

<img width="321" alt="before" src="https://user-images.githubusercontent.com/1204802/140486155-833dcdb2-98aa-4c39-a9e5-228c646bbb2b.png">

There is nothing fundamentally wrong with that card, it works very well in Global Styles and serves both as an indication of the chosen color, and its hex value.

But for the post editor, the card always defaults to transparent, and without any hex codes shown, it adds a little confusion. It also is duplicated, which along with the existing duplication of the color palette, adds a great deal of vertical height.

Outside of reverting the card, because it has such value for Global Styles, this PR attempts to address feedback in https://github.com/WordPress/gutenberg/issues/35093#issuecomment-961508426 by keeping it in Global Styles, but hiding it and restoring the "Custom" button for the post editor. 

<img width="281" alt="Screenshot 2021-11-05 at 10 05 46" src="https://user-images.githubusercontent.com/1204802/140486517-77b16981-ad7f-45f2-a8c9-a135f52486ef.png">

<img width="286" alt="Screenshot 2021-11-05 at 10 06 02" src="https://user-images.githubusercontent.com/1204802/140486524-92f48110-d263-4b61-9b14-eb8027c8031a.png">

Ultimately, the goal is for the color picker/palette to be identical whereve it's used. This will work when we are able to leverage the ItemGroup to collapse color properties, rather than repeating the palettes down the page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
