### PR TITLE
Add create new menu button to nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -326,6 +326,15 @@ function Navigation( {
 											setNavigationMenuId( id );
 											onClose();
 										} }
+										onCreateNew={ () => {
+											if ( navigationArea ) {
+												setAreaMenu( 0 );
+											}
+											setAttributes( {
+												navigationMenuId: undefined,
+											} );
+											setIsPlaceholderShown( true );
+										} }
 									/>
 								) }
 							</ToolbarDropdownMenu>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -32,14 +32,8 @@ export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
 					} ) ) }
 				/>
 			</MenuGroup>
-			<MenuGroup
-				className="wp-navigation-block__create-new-menu-group"
-				hideSeparator
-			>
-				<MenuItem
-					className="wp-navigation-block__create-new-menu-button"
-					onClick={ onCreateNew }
-				>
+			<MenuGroup>
+				<MenuItem onClick={ onCreateNew }>
 					{ __( 'Create new menu' ) }
 				</MenuItem>
 			</MenuGroup>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -1,34 +1,48 @@
 /**
  * WordPress dependencies
  */
-import { MenuGroup, MenuItemsChoice } from '@wordpress/components';
+import { MenuGroup, MenuItem, MenuItemsChoice } from '@wordpress/components';
 import { useEntityId } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
 
-export default function NavigationMenuSelector( { onSelect } ) {
+export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
 	const { navigationMenus } = useNavigationMenu();
 	const navigationMenuId = useEntityId( 'postType', 'wp_navigation' );
 
 	return (
-		<MenuGroup>
-			<MenuItemsChoice
-				value={ navigationMenuId }
-				onSelect={ ( selectedId ) =>
-					onSelect(
-						navigationMenus.find(
-							( post ) => post.id === selectedId
+		<>
+			<MenuGroup>
+				<MenuItemsChoice
+					value={ navigationMenuId }
+					onSelect={ ( selectedId ) =>
+						onSelect(
+							navigationMenus.find(
+								( post ) => post.id === selectedId
+							)
 						)
-					)
-				}
-				choices={ navigationMenus.map( ( { id, title } ) => ( {
-					value: id,
-					label: title.rendered,
-				} ) ) }
-			/>
-		</MenuGroup>
+					}
+					choices={ navigationMenus.map( ( { id, title } ) => ( {
+						value: id,
+						label: title.rendered,
+					} ) ) }
+				/>
+			</MenuGroup>
+			<MenuGroup
+				className="wp-navigation-block__create-new-menu-group"
+				hideSeparator
+			>
+				<MenuItem
+					className="wp-navigation-block__create-new-menu-button"
+					onClick={ onCreateNew }
+				>
+					{ __( 'Create new menu' ) }
+				</MenuItem>
+			</MenuGroup>
+		</>
 	);
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -568,34 +568,3 @@ body.editor-styles-wrapper
 	width: 100%;
 	justify-content: center;
 }
-
-// This unfortunately needs a lot of specificity.
-.components-menu-group.has-hidden-separator.wp-navigation-block__create-new-menu-group {
-	padding: 0;
-}
-
-.wp-navigation-block__create-new-menu-button.components-button {
-	justify-content: center;
-	background: $gray-900;
-	color: $white;
-	height: ($button-size + $grid-unit-10);
-	border-radius: 0;
-
-	&:hover {
-		color: $white;
-	}
-
-	&:active {
-		color: $gray-400;
-	}
-
-	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
-	}
-
-	// This is needed to center the button text.
-	.components-menu-item__item {
-		min-width: 0;
-		margin: 0;
-	}
-}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -568,3 +568,34 @@ body.editor-styles-wrapper
 	width: 100%;
 	justify-content: center;
 }
+
+// This unfortunately needs a lot of specificity.
+.components-menu-group.has-hidden-separator.wp-navigation-block__create-new-menu-group {
+	padding: 0;
+}
+
+.wp-navigation-block__create-new-menu-button.components-button {
+	justify-content: center;
+	background: $gray-900;
+	color: $white;
+	height: ($button-size + $grid-unit-10);
+	border-radius: 0;
+
+	&:hover {
+		color: $white;
+	}
+
+	&:active {
+		color: $gray-400;
+	}
+
+	&:focus:not(:disabled) {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+	}
+
+	// This is needed to center the button text.
+	.components-menu-item__item {
+		min-width: 0;
+		margin: 0;
+	}
+}


### PR DESCRIPTION
## Description
In the navigation block, users could switch between menus, but within an individual block it was difficult to create an entirely new menu.

A user would have to remove the block and add a new one. This adds a convenient button to return to the placeholder:
<img width="500" alt="Screenshot 2021-11-05 at 5 45 04 pm" src="https://user-images.githubusercontent.com/677833/140491213-cd84fa1e-00c4-4c31-ad4d-8cd38f696168.png">

As highlighted in this comment, this will be important in a navigation area - https://github.com/WordPress/gutenberg/pull/36210#issuecomment-961411011.

## How has this been tested?
1. Add a navigation block
2. Create a new menu from the placeholder
3. Click select menu from the block toolbar
4. Click create new, you should be able to return to the placeholder and create a new menu.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
