### PR TITLE
Try: Display the site name in the top bar in Appearance > Editor

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -46,6 +46,8 @@ export default function Header( {
 		isListViewOpen,
 		listViewShortcut,
 		isLoaded,
+		siteTitle,
+		siteHome,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -64,10 +66,14 @@ export default function Header( {
 		const postId = getEditedPostId();
 		const record = getEditedEntityRecord( 'postType', postType, postId );
 		const _isLoaded = !! postId;
+		const siteData =
+			getEditedEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			entityTitle: getTemplateInfo( record ).title,
+			siteTitle: siteData.name,
+			siteHome: siteData.home,
 			isLoaded: _isLoaded,
 			template: record,
 			templateType: postType,
@@ -102,6 +108,31 @@ export default function Header( {
 	);
 
 	const isFocusMode = templateType === 'wp_template_part';
+
+	let displayTitle;
+
+	if ( entityTitle === 'Index' || entityTitle === 'Home' ) {
+		displayTitle = <a href={ siteHome }>{ siteTitle }</a>;
+	} else {
+		displayTitle = (
+			<DocumentActions
+				entityTitle={ entityTitle }
+				entityLabel={
+					templateType === 'wp_template_part'
+						? 'template part'
+						: 'template'
+				}
+				isLoaded={ isLoaded }
+			>
+				{ ( { onClose } ) => (
+					<TemplateDetails
+						template={ template }
+						onClose={ onClose }
+					/>
+				) }
+			</DocumentActions>
+		);
+	}
 
 	return (
 		<div className="edit-site-header">
@@ -141,24 +172,7 @@ export default function Header( {
 				</div>
 			</div>
 
-			<div className="edit-site-header_center">
-				<DocumentActions
-					entityTitle={ entityTitle }
-					entityLabel={
-						templateType === 'wp_template_part'
-							? 'template part'
-							: 'template'
-					}
-					isLoaded={ isLoaded }
-				>
-					{ ( { onClose } ) => (
-						<TemplateDetails
-							template={ template }
-							onClose={ onClose }
-						/>
-					) }
-				</DocumentActions>
-			</div>
+			<div className="edit-site-header_center"> { displayTitle } </div>
 
 			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
The site title, as a link to the homepage, should be visible in the top bar when you open the editor via
Appearance > Editor.

For https://github.com/WordPress/gutenberg/issues/36207

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually by opening the editor via Appearance > Editor.
 
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
