### PR TITLE
Fix crash from calls to `undefined` functions

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -98,11 +98,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 */
 	private static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === self::$i18n_schema ) {
-			$i18n_schema       = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
+			$i18n_schema       = gutenberg_json_file_decode( __DIR__ . '/theme-i18n.json' );
 			self::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
-		return translate_settings_using_i18n_schema( self::$i18n_schema, $theme_json, $domain );
+		return gutenberg_translate_settings_using_i18n_schema( self::$i18n_schema, $theme_json, $domain );
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
+++ b/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
@@ -26,7 +26,7 @@ function gutenberg_translate_settings_using_i18n_schema( $i18n_schema, $settings
 	if ( is_array( $i18n_schema ) && is_array( $settings ) ) {
 		$translated_settings = array();
 		foreach ( $settings as $value ) {
-			$translated_settings[] = translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
+			$translated_settings[] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
 		}
 		return $translated_settings;
 	}
@@ -35,9 +35,9 @@ function gutenberg_translate_settings_using_i18n_schema( $i18n_schema, $settings
 		$translated_settings = array();
 		foreach ( $settings as $key => $value ) {
 			if ( isset( $i18n_schema->$key ) ) {
-				$translated_settings[ $key ] = translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
+				$translated_settings[ $key ] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
 			} elseif ( isset( $i18n_schema->$group_key ) ) {
-				$translated_settings[ $key ] = translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
+				$translated_settings[ $key ] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
 			} else {
 				$translated_settings[ $key ] = $value;
 			}


### PR DESCRIPTION
Fixes crashing introduced here: https://github.com/WordPress/gutenberg/pull/36223