### PR TITLE
Revert "Try ensuring the item after post content clears floats (#36006)"

### DIFF
--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,4 +1,0 @@
-// Required to ensure that subsequent blocks clear floats inside entry content.
-.wp-block-post-content + * {
-	clear: both;
-}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -31,7 +31,6 @@
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";
-@import "./post-content/style.scss";
 @import "./post-template/style.scss";
 @import "./query-pagination/style.scss";
 @import "./quote/style.scss";


### PR DESCRIPTION
While checking https://codehealth.vercel.app I noticed that the #36006 PR introduced significant regressions in both "block select" and "inserter open" metrics. I'm attempt a revert here to confirm the numbers.