### PR TITLE
Make sure tests are pure

### DIFF
--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1674,42 +1674,39 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_get_editor_settings_custom_units_can_be_disabled() {
 		add_theme_support( 'custom-units', array() );
-		$input = gutenberg_get_default_block_editor_settings();
+		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
+		remove_theme_support( 'custom-units' );
 
 		$expected = array(
 			'units'   => array( array() ),
 			'padding' => false,
 		);
 
-		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );
-
 		$this->assertEqualSetsWithIndex( $expected, $actual['settings']['spacing'] );
 	}
 
 	function test_get_editor_settings_custom_units_can_be_enabled() {
 		add_theme_support( 'custom-units' );
-		$input = gutenberg_get_default_block_editor_settings();
+		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
+		remove_theme_support( 'custom-units' );
 
 		$expected = array(
 			'units'   => array( 'px', 'em', 'rem', 'vh', 'vw', '%' ),
 			'padding' => false,
 		);
 
-		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );
-
 		$this->assertEqualSetsWithIndex( $expected, $actual['settings']['spacing'] );
 	}
 
 	function test_get_editor_settings_custom_units_can_be_filtered() {
 		add_theme_support( 'custom-units', 'rem', 'em' );
-		$input = gutenberg_get_default_block_editor_settings();
+		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
+		remove_theme_support( 'custom-units' );
 
 		$expected = array(
 			'units'   => array( 'rem', 'em' ),
 			'padding' => false,
 		);
-
-		$actual = WP_Theme_JSON_Gutenberg::get_from_editor_settings( $input );
 
 		$this->assertEqualSetsWithIndex( $expected, $actual['settings']['spacing'] );
 	}


### PR DESCRIPTION
Ported from https://github.com/WordPress/wordpress-develop/pull/1808

This PR makes sure the theme supports we enable for a test are disabled after the test is executed, so it doesn't affect other tests.