### PR TITLE
Disable ability to edit menus via `Appearance -> Navigation Menus` for non-FSE themes

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -418,7 +418,8 @@ function gutenberg_register_navigation_post_type() {
 		'description'           => __( 'Navigation menus.', 'gutenberg' ),
 		'public'                => false,
 		'has_archive'           => false,
-		'show_ui'               => true,
+		// We should disable UI for non-FSE themes.
+		'show_ui'               => gutenberg_is_fse_theme(),
 		'show_in_menu'          => 'themes.php',
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
We must not allow to manage `wp_navigation` type posts when the current theme doesn's support FSE.
Fixes https://github.com/WordPress/gutenberg/issues/36258

## How has this been tested?
1. Enable a non-FSE theme like `Twenty Twenty-One`.
2. Check `Appearance` menu. There must be no `Navigation Menu` items.
3. Enable a FSE-capable theme (i've tested with [`TT1 blocks`](https://wordpress.org/themes/tt1-blocks/)).
4. Check `Appearance` menu. There must be `Navigation Menu` menu item.

## Screenshots <!-- if applicable -->
![Screenshot 2021-11-05 at 14 52 10](https://user-images.githubusercontent.com/43744263/140523689-d69c5e29-a556-4de8-aa2c-8345aed6b037.png)
![Screenshot 2021-11-05 at 14 52 19](https://user-images.githubusercontent.com/43744263/140523684-07304bd2-58b1-4a30-bacb-a0ccdc40c1e1.png)
## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
