### PR TITLE
Components: Modal: Wrap the modal contents in a StyleProvider

### DIFF
--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -25,6 +25,7 @@ import { closeSmall } from '@wordpress/icons';
  */
 import * as ariaHelper from './aria-helper';
 import Button from '../button';
+import StyleProvider from '../style-provider';
 
 // Used to count the number of open modals.
 let openModalCount = 0;
@@ -112,57 +113,68 @@ export default function Modal( {
 			) }
 			onKeyDown={ handleEscapeKeyDown }
 		>
-			<div
-				className={ classnames( 'components-modal__frame', className, {
-					'is-full-screen': isFullScreen,
-				} ) }
-				style={ style }
-				ref={ useMergeRefs( [
-					constrainedTabbingRef,
-					focusReturnRef,
-					focusOnMountRef,
-				] ) }
-				role={ role }
-				aria-label={ contentLabel }
-				aria-labelledby={ contentLabel ? null : headingId }
-				aria-describedby={ aria.describedby }
-				tabIndex="-1"
-				{ ...( shouldCloseOnClickOutside ? focusOutsideProps : {} ) }
-				onKeyDown={ onKeyDown }
-			>
-				<div className={ 'components-modal__content' } role="document">
-					<div className="components-modal__header">
-						<div className="components-modal__header-heading-container">
-							{ icon && (
-								<span
-									className="components-modal__icon-container"
-									aria-hidden
-								>
-									{ icon }
-								</span>
-							) }
-							{ title && (
-								<h1
-									id={ headingId }
-									className="components-modal__header-heading"
-								>
-									{ title }
-								</h1>
+			<StyleProvider document={ document }>
+				<div
+					className={ classnames(
+						'components-modal__frame',
+						className,
+						{
+							'is-full-screen': isFullScreen,
+						}
+					) }
+					style={ style }
+					ref={ useMergeRefs( [
+						constrainedTabbingRef,
+						focusReturnRef,
+						focusOnMountRef,
+					] ) }
+					role={ role }
+					aria-label={ contentLabel }
+					aria-labelledby={ contentLabel ? null : headingId }
+					aria-describedby={ aria.describedby }
+					tabIndex="-1"
+					{ ...( shouldCloseOnClickOutside
+						? focusOutsideProps
+						: {} ) }
+					onKeyDown={ onKeyDown }
+				>
+					<div
+						className={ 'components-modal__content' }
+						role="document"
+					>
+						<div className="components-modal__header">
+							<div className="components-modal__header-heading-container">
+								{ icon && (
+									<span
+										className="components-modal__icon-container"
+										aria-hidden
+									>
+										{ icon }
+									</span>
+								) }
+								{ title && (
+									<h1
+										id={ headingId }
+										className="components-modal__header-heading"
+									>
+										{ title }
+									</h1>
+								) }
+							</div>
+							{ isDismissible && (
+								<Button
+									onClick={ onRequestClose }
+									icon={ closeSmall }
+									label={
+										closeButtonLabel || __( 'Close dialog' )
+									}
+								/>
 							) }
 						</div>
-						{ isDismissible && (
-							<Button
-								onClick={ onRequestClose }
-								icon={ closeSmall }
-								label={
-									closeButtonLabel || __( 'Close dialog' )
-								}
-							/>
-						) }
+						{ children }
 					</div>
-					{ children }
 				</div>
-			</div>
+			</StyleProvider>
 		</div>,
 		document.body
 	);


### PR DESCRIPTION
This ensures that any content inside a modal has the correct styles applied by emotion. Previously, any components using emotion styles in the modal content were not rendered correctly. The components are given a unique prefix ID (cache key), but no styles were registered to that UUID key. @youknowriad suggested that the Modal's portal needs `StyleProvider`. I've added that, and now the emotion styles are being generated for modal content.

Fixes #33735.

## How has this been tested?

Manually tested using [my test case plugin](https://gist.github.com/ryelle/247871127e6744f8e16caac0b0c01706), the styles inside the modal were missing before the patch, but are loaded correctly now.

## Screenshots <!-- if applicable -->

The issue was in the Site Editor (or any other iframed editor), so I added my test plugin into the Site Editor. It adds a button to open a modal with some components that use emotion styles.

Before, no grid and an invisible spinner.
![](https://user-images.githubusercontent.com/541093/140411045-c4ec2ac4-5b22-4dfa-be14-90f37abfe887.png)

After, grid layout with a spinner
<img width="955" alt="Screen Shot 2021-11-05 at 11 01 42 AM" src="https://user-images.githubusercontent.com/541093/140531834-64346e9b-54ed-419b-b442-d4f29f476df9.png">

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [n/a] My code follows the accessibility standards.
- [n/a] I've tested my changes with keyboard and screen readers.
- [n/a] My code has proper inline documentation.
- [n/a] I've included developer documentation if appropriate.
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).
