### PR TITLE
Docs: Fix parameter type in render function of file block

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -9,7 +9,7 @@
  * When the `core/file` block is rendering, check if we need to enqueue the `'wp-block-file-view` script.
  *
  * @param array $attributes The block attributes.
- * @param array $content    The block content.
+ * @param string $content    The block content.
  *
  * @return string Returns the block content.
  */

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -8,7 +8,7 @@
 /**
  * When the `core/file` block is rendering, check if we need to enqueue the `'wp-block-file-view` script.
  *
- * @param array $attributes The block attributes.
+ * @param array  $attributes The block attributes.
  * @param string $content    The block content.
  *
  * @return string Returns the block content.


### PR DESCRIPTION
## Description
The second parameter in the render function `$content` has the type `string`, not `array`.