### PR TITLE
Block Library: Fix incorrect attributes definitions

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -17,6 +17,7 @@
 			"type": "array"
 		},
 		"templateLock": {
+			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -17,7 +17,6 @@
 			"type": "array"
 		},
 		"templateLock": {
-			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -67,6 +67,7 @@
 			"type": "array"
 		},
 		"templateLock": {
+			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -67,7 +67,6 @@
 			"type": "array"
 		},
 		"templateLock": {
-			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -12,6 +12,7 @@
 			"default": "div"
 		},
 		"templateLock": {
+			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -12,7 +12,6 @@
 			"default": "div"
 		},
 		"templateLock": {
-			"type": "string",
 			"enum": [ "all", "insert", false ]
 		}
 	},

--- a/packages/blocks/src/api/parser/test/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/test/get-block-attributes.js
@@ -222,6 +222,22 @@ describe( 'attributes parsing', () => {
 			expect( value ).toBe( 10 );
 		} );
 
+		it( 'should return the comment attribute value when using multiple types', () => {
+			const value = getBlockAttribute(
+				'templateLock',
+				{
+					type: [ 'string', 'boolean' ],
+					enum: [ 'all', 'insert', false ],
+				},
+				'',
+				{
+					templateLock: false,
+				}
+			);
+
+			expect( value ).toBe( false );
+		} );
+
 		it( 'should reject type-invalid value, with default', () => {
 			const value = getBlockAttribute(
 				'number',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The `templateLock` attribute is mixed between boolean and string. Setting the type as string introduces an regression that will remove `false` on save. Add `boolean` as a valid type.

## How has this been tested?
By inserting a block that support templateLock with `false` and confirmed the saved content is correct with the PR applied.

## Screenshots <!-- if applicable -->
Screencast of the error:
![template-lock-regression](https://user-images.githubusercontent.com/1415747/140542966-e7a0bef5-47b3-4570-93f5-dbf578709743.gif)

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
