### PR TITLE
Add class name to post author on edit post sidebar

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-author/index.js
+++ b/packages/edit-post/src/components/sidebar/post-author/index.js
@@ -10,7 +10,7 @@ import {
 export function PostAuthor() {
 	return (
 		<PostAuthorCheck>
-			<PanelRow>
+			<PanelRow className="edit-post-post-author">
 				<PostAuthorForm />
 			</PanelRow>
 		</PostAuthorCheck>


### PR DESCRIPTION
## Description
This adds a class name ("edit-post-post-author") to the post author element of the edit post sidebar.

The similar Post Visibility component of the sidebar has a class name already ("[edit-post-post-visibility](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-post/src/components/sidebar/post-visibility/index.js#L16)") so I followed the same naming format.

This change will allow plugins (example Co-Authors Plus) to precisely target the post author element for CSS changes.

