### PR TITLE
Disable BottomSheet swipe gesture to navigate backwards

### DIFF
--- a/packages/editor/src/components/editor-help/index.native.js
+++ b/packages/editor/src/components/editor-help/index.native.js
@@ -197,7 +197,7 @@ function EditorHelpTopics( { close, isVisible, onClose } ) {
 								content={ view }
 								label={ label }
 								options={ {
-									gestureEnabled: true,
+									gestureEnabled: false,
 									...TransitionPresets.DefaultTransition,
 								} }
 							/>


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4215

## Description
Fixes #36231. The bottom sheet (react-native-modal) and sub sheet navigation (React Navigation) have competing gesture handlers that do not work well together at this time. E.g it is possible to trigger both simultaneously. Until we add logic to prevent the simultaneous gesture, we are disabling the swipe back gesture for sub sheet navigation. We have discussed replacing the BottomSheet logic entirely, so that may be a better time to address this gesture issue. 

## How has this been tested?
1. Launch the mobile editor on iOS.
2. Tap the three-dot menu in the top-right corner. 
3. Tap "Help & Support."
4. Tap one of the "The basics" help articles. 
5. Attempt to navigate backwards by swiping from the left side of the screen to the right. 
6. ℹ️ **Expected:** The BottomSheet _does not_ navigate backwards to the "How to edit your post" screen. Tapping the "Back" button _does_ navigate backwards. 

## Screenshots <!-- if applicable -->
n/a

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
