### PR TITLE
Chore: add rewrite false to global styles CPT

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -300,6 +300,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			'public'       => false,
 			'show_ui'      => false,
 			'show_in_rest' => false,
+			'rewrite'      => false,
 			'capabilities' => array(
 				'read'                   => 'edit_theme_options',
 				'create_posts'           => 'edit_theme_options',


### PR DESCRIPTION
When backporting the global styles CPT to core I noticed without the rewrite false flag there was a crash. Other CPT's with similar usages also have that flag so I think having the flag to false in global styles CPT is expected.
