### PR TITLE
Fix: Theme switch on the global styles rest api unit test.

### DIFF
--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -22,13 +22,17 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		return null;
 	}
 
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'tt1-blocks' );
+	}
+
 	/**
 	 * Create fake data before our tests run.
 	 *
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetupBeforeClass( $factory ) {
-		switch_theme( 'tt1-blocks' );
 		gutenberg_register_wp_theme_taxonomy();
 		self::$admin_id = $factory->user->create(
 			array(


### PR DESCRIPTION
This PR fixes the theme switch on the rest API unit test. The way we were doing before the theme switch persisted for the other unit tests and we made tests that rely on other themes fail.
This follows the same approach for theme switching that we were using on tests/phpunit/tests/rest-api/rest-themes-controller.php.
