### PR TITLE
Chore: Update: Centralize safe_style_css usages.

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -186,6 +186,7 @@ function gutenberg_safe_style_attrs( $attrs ) {
 	$attrs[] = 'border-top-right-radius';
 	$attrs[] = 'border-bottom-right-radius';
 	$attrs[] = 'border-bottom-left-radius';
+	$attrs[] = 'filter';
 
 	return $attrs;
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -215,7 +215,6 @@ function gutenberg_global_styles_filter_post( $content ) {
  */
 function gutenberg_global_styles_kses_init_filters() {
 	add_filter( 'content_save_pre', 'gutenberg_global_styles_filter_post' );
-	add_filter( 'safe_style_css', 'gutenberg_global_styles_include_support_for_duotone', 10, 2 );
 }
 
 /**
@@ -285,18 +284,6 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 		return $allow_css;
 	}
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
-}
-
-/**
- * This is for using kses to test user data.
- *
- * @param array $atts Allowed CSS property names, according to kses.
- *
- * @return array The new allowed CSS property names.
- */
-function gutenberg_global_styles_include_support_for_duotone( $atts ) {
-	$atts[] = 'filter';
-	return $atts;
 }
 
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.


### PR DESCRIPTION
This PR just centralizes safe_style_css filter usages in single function to make it easier to understand what new CSS attributes should be allowed by kses as they are in a single space.

It also improves correctness previously filter was only being added on kses init but the filter should be added all the time even if kses was not initialized like the other filters are.