### PR TITLE
Chore: Add comment to Remove filter to allow WP variables after min version is 5.8.

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -255,6 +255,8 @@ function gutenberg_global_styles_force_filtered_html_on_import_filter( $arg ) {
 	return $arg;
 }
 
+// TODO: Remove this filter when minimum supported version is WP 5.8
+// As all this code is not needed anymore now core supports all variables.
 /**
  * This filter is the last being executed on force_filtered_html_on_import.
  * If the input of the filter is true it means we are in an import situation and should


### PR DESCRIPTION
On Gutenberg, we had a filter to allow wp variables to be used on a specific set of CSS properties. This filter is not needed anymore since WordPress 5.8 started to allow any CSS variable in any property https://github.com/WordPress/wordpress-develop/commit/8e498a8314.
