### PR TITLE
Update theme styles for the code block

### DIFF
--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,4 +1,4 @@
-.wp-block-code {
+.wp-block-code > code {
 	font-family: $editor-html-font;
 	color: $gray-900;
 	padding: 0.8em 1em;


### PR DESCRIPTION
## Description
The theme.json settings for the code block target `.wp-block-code > code` not `.wp-block-code`. Therefore, there is no way to override the theme.css styles using theme.json. This update resolves that.

## How has this been tested?

1. Yes, install the new Twenty Twenty-Two theme and the latest version of Gutenberg. 
2. Add a code block with some content. Preview, and you will see the code outlined in a thin grey border. 
3. In theme.json, add a background color and change the border color on the code block. 
4. Preview and you will see the theme.json styles applied to `.wp-block-code > code`, but the default theme.css styles remain applied to `.wp-block-code`.
5. Apply the proposed changed.
6. Preview again and now the theme.json styles now override the theme.css styles. 

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
