### PR TITLE
ESLint v8 (#35576)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,19 +2063,18 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-			"integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+			"integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
-				"debug": "^4.1.1",
-				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"debug": "^4.3.2",
+				"espree": "^9.0.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^3.13.1",
-				"lodash": "^4.17.19",
+				"js-yaml": "^4.1.0",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -2092,10 +2091,16 @@
 						"uri-js": "^4.2.2"
 					}
 				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -2106,15 +2111,6 @@
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
-				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
 				},
 				"ignore": {
 					"version": "4.0.6",
@@ -2130,6 +2126,15 @@
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
 					}
 				},
 				"ms": {
@@ -2148,12 +2153,6 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
@@ -2567,6 +2566,40 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+			"integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
@@ -19722,7 +19755,7 @@
 				"cssnano": "^5.0.7",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^7.17.0",
+				"eslint": "^8.2.0",
 				"eslint-plugin-markdown": "^2.2.0",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
@@ -20529,6 +20562,12 @@
 					}
 				}
 			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
@@ -33256,14 +33295,6 @@
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^4.1.1"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-					"dev": true
-				}
 			}
 		},
 		"entities": {
@@ -33877,46 +33908,47 @@
 			}
 		},
 		"eslint": {
-			"version": "7.17.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
-			"integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
+			"integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@eslint/eslintrc": "^0.2.2",
+				"@eslint/eslintrc": "^1.0.4",
+				"@humanwhocodes/config-array": "^0.6.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
-				"debug": "^4.0.1",
+				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"enquirer": "^2.3.5",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^2.1.0",
-				"eslint-visitor-keys": "^2.0.0",
-				"espree": "^7.3.1",
-				"esquery": "^1.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^6.0.0",
+				"eslint-utils": "^3.0.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0",
+				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^6.0.0",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
-				"globals": "^12.1.0",
+				"glob-parent": "^6.0.1",
+				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"js-yaml": "^3.13.1",
+				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
-				"lodash": "^4.17.19",
+				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.0.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
 				"progress": "^2.0.0",
-				"regexpp": "^3.1.0",
+				"regexpp": "^3.2.0",
 				"semver": "^7.2.1",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"table": "^6.0.4",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
@@ -33934,9 +33966,15 @@
 					}
 				},
 				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
 				},
 				"cross-spawn": {
@@ -33951,9 +33989,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -33968,52 +34006,53 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
 				"eslint-scope": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
+					"integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
-						"estraverse": "^4.1.1"
+						"estraverse": "^5.2.0"
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
 					"dev": true
 				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-					"dev": true,
-					"requires": {
-						"estraverse": "^5.2.0"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-							"dev": true
-						}
-					}
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
 				},
 				"glob-parent": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 					"dev": true,
 					"requires": {
-						"is-glob": "^4.0.1"
+						"is-glob": "^4.0.3"
 					},
 					"dependencies": {
 						"is-glob": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-							"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+							"version": "4.0.3",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+							"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 							"dev": true,
 							"requires": {
 								"is-extglob": "^2.1.1"
@@ -34021,20 +34060,20 @@
 						}
 					}
 				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"ignore": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
 				},
 				"levn": {
 					"version": "0.4.1",
@@ -34094,12 +34133,12 @@
 					"dev": true
 				},
 				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"ansi-regex": "^5.0.1"
 					}
 				},
 				"strip-json-comments": {
@@ -34116,12 +34155,6 @@
 					"requires": {
 						"prelude-ls": "^1.2.1"
 					}
-				},
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-					"dev": true
 				},
 				"which": {
 					"version": "2.0.2",
@@ -35055,20 +35088,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				}
+				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -35078,32 +35103,26 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-			"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+			"integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.4.0",
+				"acorn": "^8.5.0",
 				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^1.3.0"
+				"eslint-visitor-keys": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-					"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 					"dev": true
 				},
 				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
 					"dev": true
 				}
 			}
@@ -35114,18 +35133,18 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
 			},
 			"dependencies": {
 				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				}
 			}
@@ -36117,9 +36136,9 @@
 			}
 		},
 		"file-entry-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-			"integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
@@ -45620,6 +45639,12 @@
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
 		"lodash.omitby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
@@ -54503,9 +54528,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"regexpu-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19369,7 +19369,7 @@
 				"eslint-plugin-jsx-a11y": "^6.4.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.22.0",
-				"eslint-plugin-react-hooks": "^4.2.0",
+				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
@@ -35072,9 +35072,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+			"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
 			"dev": true
 		},
 		"eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17579,17 +17579,17 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-			"integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.3.0.tgz",
+			"integrity": "sha512-ARUEJHJrq85aaiCqez7SANeahDsJTD3AEua34EoQN9pHS6S5Bq9emcIaGGySt/4X2zSi+vF5hAH52sEen7IO7g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.33.0",
-				"@typescript-eslint/scope-manager": "4.33.0",
-				"debug": "^4.3.1",
+				"@typescript-eslint/experimental-utils": "5.3.0",
+				"@typescript-eslint/scope-manager": "5.3.0",
+				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
-				"regexpp": "^3.1.0",
+				"regexpp": "^3.2.0",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
 			},
@@ -17607,58 +17607,58 @@
 					"dev": true
 				},
 				"@typescript-eslint/experimental-utils": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-					"integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+					"integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
 					"dev": true,
 					"requires": {
-						"@types/json-schema": "^7.0.7",
-						"@typescript-eslint/scope-manager": "4.33.0",
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/typescript-estree": "4.33.0",
+						"@types/json-schema": "^7.0.9",
+						"@typescript-eslint/scope-manager": "5.3.0",
+						"@typescript-eslint/types": "5.3.0",
+						"@typescript-eslint/typescript-estree": "5.3.0",
 						"eslint-scope": "^5.1.1",
 						"eslint-utils": "^3.0.0"
 					}
 				},
 				"@typescript-eslint/scope-manager": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-					"integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
+					"integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0"
+						"@typescript-eslint/types": "5.3.0",
+						"@typescript-eslint/visitor-keys": "5.3.0"
 					}
 				},
 				"@typescript-eslint/types": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-					"integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
+					"integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
 					"dev": true
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-					"integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
+					"integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
+						"@typescript-eslint/types": "5.3.0",
+						"@typescript-eslint/visitor-keys": "5.3.0",
+						"debug": "^4.3.2",
+						"globby": "^11.0.4",
+						"is-glob": "^4.0.3",
 						"semver": "^7.3.5",
 						"tsutils": "^3.21.0"
 					}
 				},
 				"@typescript-eslint/visitor-keys": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-					"integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
+					"integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"eslint-visitor-keys": "^2.0.0"
+						"@typescript-eslint/types": "5.3.0",
+						"eslint-visitor-keys": "^3.0.0"
 					}
 				},
 				"array-union": {
@@ -17702,7 +17702,21 @@
 					"dev": true,
 					"requires": {
 						"eslint-visitor-keys": "^2.0.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+							"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+							"dev": true
+						}
 					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+					"dev": true
 				},
 				"fast-glob": {
 					"version": "3.2.7",
@@ -17799,6 +17813,12 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
 					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"dev": true
+				},
+				"regexpp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 					"dev": true
 				},
 				"semver": {
@@ -19284,8 +19304,8 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^4.31.0",
+			  	"@babel/eslint-parser": "^7.16.0",
+				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^4.31.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"cosmiconfig": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19368,7 +19368,7 @@
 				"eslint-plugin-jsdoc": "^37.0.3",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
 				"eslint-plugin-prettier": "^3.3.0",
-				"eslint-plugin-react": "^7.22.0",
+				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
@@ -34884,35 +34884,59 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
-			"integrity": "sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+			"integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flatmap": "^1.2.3",
+				"array-includes": "^3.1.4",
+				"array.prototype.flatmap": "^1.2.5",
 				"doctrine": "^2.1.0",
-				"has": "^1.0.3",
+				"estraverse": "^5.3.0",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
-				"object.entries": "^1.1.2",
-				"object.fromentries": "^2.0.2",
-				"object.values": "^1.1.1",
+				"minimatch": "^3.0.4",
+				"object.entries": "^1.1.5",
+				"object.fromentries": "^2.0.5",
+				"object.hasown": "^1.1.0",
+				"object.values": "^1.1.5",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.18.1",
-				"string.prototype.matchall": "^4.0.2"
+				"resolve": "^2.0.0-next.3",
+				"semver": "^6.3.0",
+				"string.prototype.matchall": "^4.0.6"
 			},
 			"dependencies": {
 				"array-includes": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
-					"integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+					"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"is-string": "^1.0.7"
+					}
+				},
+				"array.prototype.flatmap": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+					"integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.0",
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.1",
-						"get-intrinsic": "^1.0.1",
-						"is-string": "^1.0.5"
+						"es-abstract": "^1.19.0"
+					}
+				},
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
 					}
 				},
 				"define-properties": {
@@ -34925,23 +34949,31 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
 						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"object-keys": {
@@ -34963,40 +34995,78 @@
 						"is-symbol": "^1.0.2"
 					}
 				},
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"internal-slot": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+					"dev": true,
+					"requires": {
+						"get-intrinsic": "^1.1.0",
+						"has": "^1.0.3",
+						"side-channel": "^1.0.4"
+					}
+				},
 				"is-callable": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
 					}
 				},
 				"is-symbol": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-					"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
 					"dev": true
 				},
 				"object.assign": {
@@ -35020,52 +35090,114 @@
 					}
 				},
 				"object.entries": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-					"integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+					"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
 					"dev": true,
 					"requires": {
-						"call-bind": "^1.0.0",
+						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.1",
-						"has": "^1.0.3"
+						"es-abstract": "^1.19.1"
+					}
+				},
+				"object.fromentries": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+					"integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1"
 					}
 				},
 				"object.values": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
-					"integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+					"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
 					"dev": true,
 					"requires": {
-						"call-bind": "^1.0.0",
+						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.1",
-						"has": "^1.0.3"
+						"es-abstract": "^1.19.1"
 					}
 				},
 				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+					"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 					"dev": true
 				},
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+				"regexp.prototype.flags": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+					"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
 					"dev": true,
 					"requires": {
-						"is-core-module": "^2.1.0",
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"resolve": {
+					"version": "2.0.0-next.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+					"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.2.0",
 						"path-parse": "^1.0.6"
 					}
 				},
-				"string.prototype.trimend": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-					"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"side-channel": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.0",
+						"get-intrinsic": "^1.0.2",
+						"object-inspect": "^1.9.0"
+					}
+				},
+				"string.prototype.matchall": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+					"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"regexp.prototype.flags": "^1.3.1",
+						"side-channel": "^1.0.4"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3"
 					}
 				}
@@ -49388,6 +49520,203 @@
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.hasown": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+			"integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					},
+					"dependencies": {
+						"object-keys": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+							"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+							"dev": true
+						}
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"internal-slot": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+					"dev": true,
+					"requires": {
+						"get-intrinsic": "^1.1.0",
+						"has": "^1.0.3",
+						"side-channel": "^1.0.4"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.2"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					},
+					"dependencies": {
+						"object-keys": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+							"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+							"dev": true
+						}
+					}
+				},
+				"side-channel": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"get-intrinsic": "^1.0.2",
+						"object-inspect": "^1.9.0"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"object.pick": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,14 +2029,14 @@
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.10.8",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.8.tgz",
-			"integrity": "sha512-3P1JiGL4xaR9PoTKUHa2N/LKwa2/eUdRqGwijMWWgBqbFEqJUVpmaOi2TcjcemrsRMgFLBzQCK4ToPhrSVDiFQ==",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.12.0.tgz",
+			"integrity": "sha512-Gw4/j9v36IKY8ET+W0GoOzrRw17xjf21EIFFRL3zx21fF5MnqmeNpNi+PU/LKjqLpPb2Pw2XdlJbYM31VVo/PQ==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "1.2.4",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "1.1.1"
+				"jsdoc-type-pratt-parser": "2.0.0"
 			},
 			"dependencies": {
 				"comment-parser": {
@@ -2055,9 +2055,9 @@
 					}
 				},
 				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				}
 			}
@@ -19332,7 +19332,7 @@
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^25.2.3",
-				"eslint-plugin-jsdoc": "^36.0.8",
+				"eslint-plugin-jsdoc": "^37.0.3",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.22.0",
@@ -34546,16 +34546,16 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "36.0.8",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
-			"integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
+			"version": "37.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.0.3.tgz",
+			"integrity": "sha512-Qg/gIZAfcrM4Qu/JzcnxPGD45Je6wPLFzMZQboeqit/CL4aY6wuzBTkgUMiWXfw/PaPl+sb0GF1XdBlV23ReDA==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "0.10.8",
+				"@es-joy/jsdoccomment": "0.12.0",
 				"comment-parser": "1.2.4",
 				"debug": "^4.3.2",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "^1.1.1",
+				"jsdoc-type-pratt-parser": "^2.0.0",
 				"lodash": "^4.17.21",
 				"regextras": "^0.8.0",
 				"semver": "^7.3.5",
@@ -34587,9 +34587,9 @@
 					}
 				},
 				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				},
 				"lru-cache": {
@@ -44448,9 +44448,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
-			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.0.0.tgz",
+			"integrity": "sha512-sUuj2j48wxrEpbFjDp1sAesAxPiLT+z0SWVmMafyIINs6Lj5gIPKh3VrkBZu4E/Dv+wHpOot0m6H8zlHQjwqeQ==",
 			"dev": true
 		},
 		"jsdom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17863,19 +17863,25 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.1.tgz",
-			"integrity": "sha512-mAlWowT4A6h0TC9F+J5pdbEhjNiEMO+kqPKQ4sc3fVieKL71dEqfkKgtcFVSX3cjSBwYwhImaQ/mXQF0oaI38g==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+			"integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/scope-manager": "4.11.1",
-				"@typescript-eslint/types": "4.11.1",
-				"@typescript-eslint/typescript-estree": "4.11.1",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^2.0.0"
+				"@types/json-schema": "^7.0.9",
+				"@typescript-eslint/scope-manager": "5.3.0",
+				"@typescript-eslint/types": "5.3.0",
+				"@typescript-eslint/typescript-estree": "5.3.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
 			},
 			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+					"dev": true
+				},
 				"eslint-scope": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -17886,22 +17892,20 @@
 						"estraverse": "^4.1.1"
 					}
 				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 					"dev": true,
 					"requires": {
-						"estraverse": "^5.2.0"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-							"dev": true
-						}
+						"eslint-visitor-keys": "^2.0.0"
 					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
 				}
 			}
 		},
@@ -18133,41 +18137,40 @@
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz",
-			"integrity": "sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
+			"integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.1",
-				"@typescript-eslint/visitor-keys": "4.11.1"
+				"@typescript-eslint/types": "5.3.0",
+				"@typescript-eslint/visitor-keys": "5.3.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.1.tgz",
-			"integrity": "sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
+			"integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz",
-			"integrity": "sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
+			"integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.1",
-				"@typescript-eslint/visitor-keys": "4.11.1",
-				"debug": "^4.1.1",
-				"globby": "^11.0.1",
-				"is-glob": "^4.0.1",
-				"lodash": "^4.17.15",
-				"semver": "^7.3.2",
-				"tsutils": "^3.17.1"
+				"@typescript-eslint/types": "5.3.0",
+				"@typescript-eslint/visitor-keys": "5.3.0",
+				"debug": "^4.3.2",
+				"globby": "^11.0.4",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
 					"dev": true
 				},
 				"array-union": {
@@ -18186,26 +18189,25 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
 				},
 				"fast-glob": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+					"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
 						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.0",
+						"glob-parent": "^5.1.2",
 						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2",
-						"picomatch": "^2.2.1"
+						"micromatch": "^4.0.4"
 					}
 				},
 				"fill-range": {
@@ -18218,18 +18220,18 @@
 					}
 				},
 				"glob-parent": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
 				},
 				"globby": {
-					"version": "11.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
 					"dev": true,
 					"requires": {
 						"array-union": "^2.1.0",
@@ -18240,16 +18242,10 @@
 						"slash": "^3.0.0"
 					}
 				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-					"dev": true
-				},
 				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
@@ -18261,6 +18257,15 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
 				"merge2": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -18268,13 +18273,13 @@
 					"dev": true
 				},
 				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"picomatch": "^2.2.3"
 					}
 				},
 				"ms": {
@@ -18284,16 +18289,19 @@
 					"dev": true
 				},
 				"picomatch": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
 					"dev": true
 				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -18303,23 +18311,29 @@
 					"requires": {
 						"is-number": "^7.0.0"
 					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
 				}
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz",
-			"integrity": "sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
+			"integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.11.1",
-				"eslint-visitor-keys": "^2.0.0"
+				"@typescript-eslint/types": "5.3.0",
+				"eslint-visitor-keys": "^3.0.0"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
 					"dev": true
 				}
 			}
@@ -19317,7 +19331,7 @@
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^7.1.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^24.1.3",
+				"eslint-plugin-jest": "^25.2.3",
 				"eslint-plugin-jsdoc": "^36.0.8",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
 				"eslint-plugin-prettier": "^3.3.0",
@@ -34523,12 +34537,12 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "24.1.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
-			"integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
+			"integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^4.0.1"
+				"@typescript-eslint/experimental-utils": "^5.0.0"
 			}
 		},
 		"eslint-plugin-jsdoc": {
@@ -59595,9 +59609,9 @@
 			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
 		},
 		"tsutils": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22092,6 +22092,16 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
+						"are-we-there-yet": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+							"dev": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19337,7 +19337,7 @@
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.22.0",
 				"eslint-plugin-react-hooks": "^4.2.0",
-				"globals": "^12.0.0",
+				"globals": "^13.12.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
 			}
@@ -37720,18 +37720,18 @@
 			}
 		},
 		"globals": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.0.0.tgz",
-			"integrity": "sha512-c9xoi32iDwlETiyYfO0pd3M8GcEuytJinSoqq7k3fz4H8p2p31NyfKr7JVd7Y0QvmtWcWXcwqW4L33eeDYgh1A==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+			"integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
 			"dev": true,
 			"requires": {
-				"type-fest": "^0.6.0"
+				"type-fest": "^0.20.2"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,19 +2098,13 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
 				},
 				"ignore": {
 					"version": "4.0.6",
@@ -2579,9 +2573,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -19755,7 +19749,7 @@
 				"cssnano": "^5.0.7",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.2.0",
+				"eslint": "^8.3.0",
 				"eslint-plugin-markdown": "^2.2.0",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
@@ -33898,9 +33892,9 @@
 			}
 		},
 		"eslint": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-			"integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.3.0.tgz",
+			"integrity": "sha512-aIay56Ph6RxOTC7xyr59Kt3ewX185SaGnAr8eWukoPLeriCrvGjvAubxuvaXOfsxhtwV5g0uBOsyhAom4qJdww==",
 			"dev": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.0.4",
@@ -33912,10 +33906,10 @@
 				"doctrine": "^3.0.0",
 				"enquirer": "^2.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^6.0.0",
+				"eslint-scope": "^7.1.0",
 				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.0.0",
-				"espree": "^9.0.0",
+				"eslint-visitor-keys": "^3.1.0",
+				"espree": "^9.1.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -33979,9 +33973,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -34003,9 +33997,9 @@
 					"dev": true
 				},
 				"eslint-scope": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-					"integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+					"integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
@@ -34013,21 +34007,15 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
 					"dev": true
 				},
 				"estraverse": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				},
 				"glob-parent": {
@@ -35316,26 +35304,26 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-			"integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.1.0.tgz",
+			"integrity": "sha512-ZgYLvCS1wxOczBYGcQT9DDWgicXwJ4dbocr9uYN+/eresBAUuBu+O4WzB21ufQ/JqQT8gyp7hJ3z8SHii32mTQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.5.0",
+				"acorn": "^8.6.0",
 				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^3.0.0"
+				"eslint-visitor-keys": "^3.1.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+					"version": "8.6.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+					"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
 					"dev": true
 				},
 				"eslint-visitor-keys": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19329,7 +19329,7 @@
 				"@typescript-eslint/parser": "^5.3.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^7.1.0",
+				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^25.2.3",
 				"eslint-plugin-jsdoc": "^36.0.8",
@@ -34135,9 +34135,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz",
-			"integrity": "sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+			"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
 			"dev": true
 		},
 		"eslint-import-resolver-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19366,7 +19366,7 @@
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^25.2.3",
 				"eslint-plugin-jsdoc": "^37.0.3",
-				"eslint-plugin-jsx-a11y": "^6.4.1",
+				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
@@ -28008,9 +28008,9 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
-			"integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+			"integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
 			"dev": true
 		},
 		"axios": {
@@ -32326,9 +32326,9 @@
 			"dev": true
 		},
 		"damerau-levenshtein": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
-			"integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
+			"integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
 			"dev": true
 		},
 		"dargs": {
@@ -34668,35 +34668,55 @@
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
-			"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
+			"integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.11.2",
+				"@babel/runtime": "^7.16.3",
 				"aria-query": "^4.2.2",
-				"array-includes": "^3.1.1",
+				"array-includes": "^3.1.4",
 				"ast-types-flow": "^0.0.7",
-				"axe-core": "^4.0.2",
+				"axe-core": "^4.3.5",
 				"axobject-query": "^2.2.0",
-				"damerau-levenshtein": "^1.0.6",
-				"emoji-regex": "^9.0.0",
+				"damerau-levenshtein": "^1.0.7",
+				"emoji-regex": "^9.2.2",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^3.1.0",
-				"language-tags": "^1.0.5"
+				"jsx-ast-utils": "^3.2.1",
+				"language-tags": "^1.0.5",
+				"minimatch": "^3.0.4"
 			},
 			"dependencies": {
-				"array-includes": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
-					"integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+				"@babel/runtime": {
+					"version": "7.16.3",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+					"integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
 					"dev": true,
 					"requires": {
-						"call-bind": "^1.0.0",
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"array-includes": {
+					"version": "3.1.4",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+					"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.1",
-						"get-intrinsic": "^1.0.1",
-						"is-string": "^1.0.5"
+						"es-abstract": "^1.19.1",
+						"get-intrinsic": "^1.1.1",
+						"is-string": "^1.0.7"
+					}
+				},
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
 					}
 				},
 				"define-properties": {
@@ -34709,29 +34729,37 @@
 					}
 				},
 				"emoji-regex": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
-					"integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 					"dev": true
 				},
 				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
 						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"object-keys": {
@@ -34753,40 +34781,82 @@
 						"is-symbol": "^1.0.2"
 					}
 				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
 				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
 				},
+				"internal-slot": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+					"dev": true,
+					"requires": {
+						"get-intrinsic": "^1.1.0",
+						"has": "^1.0.3",
+						"side-channel": "^1.0.4"
+					}
+				},
 				"is-callable": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"is-string": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+					"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+					"dev": true,
+					"requires": {
+						"has-tostringtag": "^1.0.0"
 					}
 				},
 				"is-symbol": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-					"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
+					}
+				},
+				"jsx-ast-utils": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+					"integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+					"dev": true,
+					"requires": {
+						"array-includes": "^3.1.3",
+						"object.assign": "^4.1.2"
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
 					"dev": true
 				},
 				"object.assign": {
@@ -34809,13 +34879,34 @@
 						}
 					}
 				},
-				"string.prototype.trimend": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-					"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+				"side-channel": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.0",
+						"get-intrinsic": "^1.0.2",
+						"object-inspect": "^1.9.0"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
 						"define-properties": "^1.1.3"
 					}
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19357,7 +19357,7 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
-			  	"@babel/eslint-parser": "^7.16.0",
+				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
@@ -22098,16 +22098,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"are-we-there-yet": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17906,15 +17906,15 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-			"integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.3.0.tgz",
+			"integrity": "sha512-rKu/yAReip7ovx8UwOAszJVO5MgBquo8WjIQcp1gx4pYQCwYzag+I5nVNHO4MqyMkAo0gWt2gWUi+36gWAVKcw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.33.0",
-				"@typescript-eslint/types": "4.33.0",
-				"@typescript-eslint/typescript-estree": "4.33.0",
-				"debug": "^4.3.1"
+				"@typescript-eslint/scope-manager": "5.3.0",
+				"@typescript-eslint/types": "5.3.0",
+				"@typescript-eslint/typescript-estree": "5.3.0",
+				"debug": "^4.3.2"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
@@ -17924,44 +17924,44 @@
 					"dev": true
 				},
 				"@typescript-eslint/scope-manager": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-					"integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
+					"integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0"
+						"@typescript-eslint/types": "5.3.0",
+						"@typescript-eslint/visitor-keys": "5.3.0"
 					}
 				},
 				"@typescript-eslint/types": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-					"integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
+					"integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
 					"dev": true
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-					"integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
+					"integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"@typescript-eslint/visitor-keys": "4.33.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
+						"@typescript-eslint/types": "5.3.0",
+						"@typescript-eslint/visitor-keys": "5.3.0",
+						"debug": "^4.3.2",
+						"globby": "^11.0.4",
+						"is-glob": "^4.0.3",
 						"semver": "^7.3.5",
 						"tsutils": "^3.21.0"
 					}
 				},
 				"@typescript-eslint/visitor-keys": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-					"integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
+					"integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "4.33.0",
-						"eslint-visitor-keys": "^2.0.0"
+						"@typescript-eslint/types": "5.3.0",
+						"eslint-visitor-keys": "^3.0.0"
 					}
 				},
 				"array-union": {
@@ -17987,6 +17987,12 @@
 					"requires": {
 						"ms": "2.1.2"
 					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+					"dev": true
 				},
 				"fast-glob": {
 					"version": "3.2.7",
@@ -19306,7 +19312,7 @@
 			"requires": {
 			  	"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
-				"@typescript-eslint/parser": "^4.31.0",
+				"@typescript-eslint/parser": "^5.3.0",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^7.1.0",

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -127,6 +127,7 @@ describe( 'apiFetch', () => {
 		);
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( body ).toEqual( {
 				code: 'bad_request',
 				message: 'Bad Request',
@@ -142,6 +143,7 @@ describe( 'apiFetch', () => {
 		);
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( body ).toEqual( {
 				code: 'invalid_json',
 				message: 'The response is not a valid JSON response.',
@@ -160,6 +162,7 @@ describe( 'apiFetch', () => {
 		);
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( body ).toEqual( {
 				code: 'invalid_json',
 				message: 'The response is not a valid JSON response.',
@@ -171,6 +174,7 @@ describe( 'apiFetch', () => {
 		window.fetch.mockReturnValue( Promise.reject() );
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( body ).toEqual( {
 				code: 'fetch_error',
 				message: 'You are probably offline.',
@@ -213,6 +217,7 @@ describe( 'apiFetch', () => {
 		);
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( body ).toEqual( null );
 		} );
 	} );
@@ -242,6 +247,7 @@ describe( 'apiFetch', () => {
 
 		return apiFetch( { path: '/random', parse: false } ).catch(
 			( response ) => {
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( response ).toEqual( {
 					status: 400,
 				} );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1634,6 +1634,7 @@ describe( 'Selecting links', () => {
 					);
 
 					// We should have highlighted the first item using the keyboard
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( selectedSearchResultElement ).toEqual(
 						secondSearchSuggestion
 					);
@@ -1648,6 +1649,7 @@ describe( 'Selecting links', () => {
 					);
 
 					// We should be back to highlighting the first search result again
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect( selectedSearchResultElement ).toEqual(
 						firstSearchSuggestion
 					);

--- a/packages/block-library/src/navigation/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/menu-items-to-blocks.js
@@ -148,14 +148,15 @@ function menuItemToBlockAttributes( {
 			classes.join( ' ' ).trim() && {
 				className: classes.join( ' ' ).trim(),
 			} ),
+		/* eslint-disable camelcase */
 		...( attr_title?.length && {
 			title: attr_title,
 		} ),
-		// eslint-disable-next-line camelcase
 		...( object_id &&
 			'custom' !== object && {
 				id: object_id,
 			} ),
+		/* eslint-enable camelcase */
 		...( description?.length && {
 			description,
 		} ),

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -17,7 +17,7 @@ import {
  */
 import { parse } from '../src';
 
-describe( 'block-serialization-default-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe
+describe( 'block-serialization-default-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe-callback
 
 phpTester(
 	'block-serialization-default-parser-php',

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -335,9 +335,9 @@ const hasPHP =
 // skipping preserves snapshots while commenting out or simply
 // not injecting the tests prompts `jest` to remove "obsolete snapshots"
 const makeTest = hasPHP
-	? // eslint-disable-next-line jest/valid-describe, jest/valid-title
+	? // eslint-disable-next-line jest/valid-describe-callback, jest/valid-title
 	  ( ...args ) => describe( ...args )
-	: // eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe, jest/valid-title
+	: // eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe-callback, jest/valid-title
 	  ( ...args ) => describe.skip( ...args );
 
 export const phpTester = ( name, filename ) =>

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -9,7 +9,7 @@ import path from 'path';
 import { parse } from '../';
 import { jsTester, phpTester } from '../shared-tests';
 
-describe( 'block-serialization-spec-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe
+describe( 'block-serialization-spec-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe-callback
 
 phpTester(
 	'block-serialization-spec-parser-php',

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-try-expect, jest/no-conditional-expect */
+/* eslint-disable jest/no-conditional-expect */
 /**
  * External dependencies
  */
@@ -1128,4 +1128,4 @@ async function testPortNumberValidation( portName, value, envText = '' ) {
 	}
 	jest.clearAllMocks();
 }
-/* eslint-enable jest/no-try-expect, jest/no-conditional-expect */
+/* eslint-enable jest/no-conditional-expect */

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The bundled `@typescript-eslint/eslint-plugin` dependency has been updated from requiring `^4.31.0` to requiring `^5.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `@typescript-eslint/parser` dependency has been updated from requiring `^4.31.0` to requiring `^5.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `eslint-config-prettier` dependency has been updated from requiring `^7.1.0` to requiring `^8.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `eslint-plugin-jest` dependency has been updated from requiring `^24.1.3` to requiring `^25.2.3` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^36.0.8` to requiring `^37.0.3` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `globals` dependency has been updated from requiring `^12.0.0` to requiring `^13.12.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+
 ## 9.3.0 (2021-11-15)
 
 ### Enhancements

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   The peer dependency constraint for ESLint has been updated from `^6 || ^7` to `^8`.
 -   The bundled `@typescript-eslint/eslint-plugin` dependency has been updated from requiring `^4.31.0` to requiring `^5.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The bundled `@typescript-eslint/parser` dependency has been updated from requiring `^4.31.0` to requiring `^5.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The bundled `eslint-config-prettier` dependency has been updated from requiring `^7.1.0` to requiring `^8.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -21,7 +21,6 @@ const config = {
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',
-		'prettier/react',
 	],
 	rules: {
 		'prettier/prettier': [ 'error', prettierConfig ],

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -49,7 +49,7 @@
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {
-		"eslint": "^6 || ^7",
+		"eslint": "^8",
 		"typescript": "^4"
 	},
 	"peerDependenciesMeta": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 	  	"@babel/eslint-parser": "^7.16.0",
 		"@typescript-eslint/eslint-plugin": "^5.3.0",
-		"@typescript-eslint/parser": "^4.31.0",
+		"@typescript-eslint/parser": "^5.3.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^7.1.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -36,7 +36,7 @@
 		"@typescript-eslint/parser": "^5.3.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"cosmiconfig": "^7.0.0",
-		"eslint-config-prettier": "^7.1.0",
+		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-jest": "^25.2.3",
 		"eslint-plugin-jsdoc": "^36.0.8",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,7 @@
 		"eslint-plugin-jsdoc": "^37.0.3",
 		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-prettier": "^3.3.0",
-		"eslint-plugin-react": "^7.22.0",
+		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
 		"globals": "^13.12.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -38,7 +38,7 @@
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^7.1.0",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-jest": "^24.1.3",
+		"eslint-plugin-jest": "^25.2.3",
 		"eslint-plugin-jsdoc": "^36.0.8",
 		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-prettier": "^3.3.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-jest": "^25.2.3",
 		"eslint-plugin-jsdoc": "^37.0.3",
-		"eslint-plugin-jsx-a11y": "^6.4.1",
+		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.22.0",
-		"eslint-plugin-react-hooks": "^4.2.0",
+		"eslint-plugin-react-hooks": "^4.3.0",
 		"globals": "^13.12.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"requireindex": "^1.2.0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,7 +31,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-	  	"@babel/eslint-parser": "^7.16.0",
+		"@babel/eslint-parser": "^7.16.0",
 		"@typescript-eslint/eslint-plugin": "^5.3.0",
 		"@typescript-eslint/parser": "^5.3.0",
 		"@wordpress/prettier-config": "file:../prettier-config",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-jest": "^25.2.3",
-		"eslint-plugin-jsdoc": "^36.0.8",
+		"eslint-plugin-jsdoc": "^37.0.3",
 		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.22.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -44,7 +44,7 @@
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.22.0",
 		"eslint-plugin-react-hooks": "^4.2.0",
-		"globals": "^12.0.0",
+		"globals": "^13.12.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1",
 		"requireindex": "^1.2.0"
 	},

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,8 +31,8 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/eslint-parser": "^7.16.0",
-		"@typescript-eslint/eslint-plugin": "^4.31.0",
+	  	"@babel/eslint-parser": "^7.16.0",
+		"@typescript-eslint/eslint-plugin": "^5.3.0",
 		"@typescript-eslint/parser": "^4.31.0",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"cosmiconfig": "^7.0.0",

--- a/packages/eslint-plugin/rules/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/data-no-store-string-literals.js
@@ -198,6 +198,7 @@ function getFixes( fixer, context, callNode ) {
 module.exports = {
 	meta: {
 		type: 'problem',
+		hasSuggestions: true,
 		schema: [],
 		messages: {
 			doNotUseStringLiteral: `Do not use string literals ( '{{ argument }}' ) for accessing @wordpress/data stores. Pass the store definition instead`,

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-### Bug Fix
+### Bug Fixes
 
--   Allow eslint to be imported from within Jest (e.g. when using `ruleTester`) ([#36283](https://github.com/WordPress/gutenberg/pull/36283))
-
-### Bug Fix
-
+-   Allow ESLint to be imported from within Jest (e.g. when using `ruleTester`) ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   Improve support for test files with `.jsx` and `.tsx` extensions ([#36260](https://github.com/WordPress/gutenberg/pull/36260)).
 
 ## 7.1.2 (2021-10-22)

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug Fix
 
+-   Allow eslint to be imported from within Jest (e.g. when using `ruleTester`) ([#36283](https://github.com/WordPress/gutenberg/pull/36283))
+
+### Bug Fix
+
 -   Improve support for test files with `.jsx` and `.tsx` extensions ([#36260](https://github.com/WordPress/gutenberg/pull/36260)).
 
 ## 7.1.2 (2021-10-22)

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -3,6 +3,8 @@ module.exports = {
 		'\\.(scss|css)$': require.resolve(
 			'@wordpress/jest-preset-default/scripts/style-mock.js'
 		),
+		// See https://github.com/facebook/jest/issues/11100#issuecomment-967161978
+		'@eslint/eslintrc': '@eslint/eslintrc/dist/eslintrc-universal.cjs',
 	},
 	modulePaths: [ '<rootDir>' ],
 	setupFiles: [

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -60,7 +60,7 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( error ).toBe( 'Message' );
 			}
 		}
@@ -81,7 +81,7 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( error.message ).toBe( 'Message' );
 			}
 		}
@@ -108,7 +108,7 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
+				// eslint-disable-next-line jest/no-conditional-expect
 				expect( error.message ).toBe( 'Message' );
 				return null;
 			}

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   The bundled `eslint` dependency has been updated from requiring `^7.17.0` to requiring `^8.2.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
+-   The bundled `eslint` dependency has been updated from requiring `^7.17.0` to requiring `^8.3.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The `puppeteer-core` dependency has been updated from requiring `^10.1.0` to requiring `^11.0.0` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
 
 ### Bug Fixes

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   The bundled `eslint` dependency has been updated from requiring `^7.17.0` to requiring `^8.2.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The `puppeteer-core` dependency has been updated from requiring `^10.1.0` to requiring `^11.0.0` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).
 
 ### Bug Fixes

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -53,7 +53,7 @@
 		"cssnano": "^5.0.7",
 		"cwd": "^0.10.0",
 		"dir-glob": "^3.0.1",
-		"eslint": "^7.17.0",
+		"eslint": "^8.2.0",
 		"eslint-plugin-markdown": "^2.2.0",
 		"expect-puppeteer": "^4.4.0",
 		"fast-glob": "^3.2.7",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -53,7 +53,7 @@
 		"cssnano": "^5.0.7",
 		"cwd": "^0.10.0",
 		"dir-glob": "^3.0.1",
-		"eslint": "^8.2.0",
+		"eslint": "^8.3.0",
 		"eslint-plugin-markdown": "^2.2.0",
 		"expect-puppeteer": "^4.4.0",
 		"fast-glob": "^3.2.7",

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,8 +14,6 @@ module.exports = {
 		[ `@wordpress\\/(${ transpiledPackageNames.join(
 			'|'
 		) })$` ]: 'packages/$1/src',
-		// See https://github.com/facebook/jest/issues/11100#issuecomment-967161978
-		'@eslint/eslintrc': '@eslint/eslintrc/dist/eslintrc-universal.cjs',
 	},
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,6 +14,8 @@ module.exports = {
 		[ `@wordpress\\/(${ transpiledPackageNames.join(
 			'|'
 		) })$` ]: 'packages/$1/src',
+		// See https://github.com/facebook/jest/issues/11100#issuecomment-967161978
+		'@eslint/eslintrc': '@eslint/eslintrc/dist/eslintrc-universal.cjs',
 	},
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/35576.

#### @wordpress/eslint-plugin
- Updated packages for compatibility with ESLint v8

#### @wordpress/scripts
- Updated ESLint to v8 (#35576)
  Changelog: https://eslint.org/docs/user-guide/migrating-to-8.0.0

## How has this been tested?
- `npm run lint`  
   The parsing errors will most likely be gone once #36244 is merged (the optional Babel plugin was enabled by default since 7.14, see https://github.com/babel/babel/pull/13232)

I only just noticed that @gziolo was working on this, so some changes in this PR overlap with changes in #36244.

I will also add changelog entries before this gets merged.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
