### PR TITLE
postcss-themes: Fix PostCSS 8 deprecation warning

### DIFF
--- a/packages/postcss-themes/index.js
+++ b/packages/postcss-themes/index.js
@@ -3,71 +3,78 @@
  */
 const postcss = require( 'postcss' );
 
-module.exports = postcss.plugin( 'postcss-themes', ( options ) => {
-	return ( root ) => {
-		root.walkRules( ( rule ) => {
-			const themeDecls = {};
-			let hasThemeDecls = false;
-			rule.walkDecls( ( decl ) => {
-				const themeMatch = /(theme\(([^\)]*)\))/g;
-				if ( ! decl.value ) {
-					return;
-				}
-				const matched = decl.value.match( themeMatch );
-				if ( ! matched ) {
-					return;
-				}
-				let value = decl.value;
-				let parsed;
-				const themeValues = {};
-				while ( ( parsed = themeMatch.exec( decl.value ) ) !== null ) {
-					const [ , whole, color ] = parsed;
-					const colorKey = color.trim();
-					const defaultColor = options.defaults[ colorKey ];
-					value = value.replace( whole, defaultColor );
-
-					Object.entries( options.themes ).forEach(
-						( [ key, colors ] ) => {
-							const previousValue = themeValues[ key ]
-								? themeValues[ key ]
-								: decl.value;
-							themeValues[ key ] = previousValue.replace(
-								whole,
-								colors[ colorKey ]
-							);
-						}
-					);
-				}
-
-				hasThemeDecls = true;
-				decl.value = value;
-				Object.keys( options.themes ).forEach( ( key ) => {
-					const themeDecl = decl.clone();
-					themeDecl.value = themeValues[ key ];
-					if ( ! themeDecls[ key ] ) {
-						themeDecls[ key ] = [];
+module.exports = ( options ) => {
+	return {
+		postcssPlugin: 'postcss-themes',
+		Once( root ) {
+			root.walkRules( ( rule ) => {
+				const themeDecls = {};
+				let hasThemeDecls = false;
+				rule.walkDecls( ( decl ) => {
+					const themeMatch = /(theme\(([^\)]*)\))/g;
+					if ( ! decl.value ) {
+						return;
 					}
-					themeDecls[ key ].push( themeDecl );
-				} );
-			} );
+					const matched = decl.value.match( themeMatch );
+					if ( ! matched ) {
+						return;
+					}
+					let value = decl.value;
+					let parsed;
+					const themeValues = {};
+					while (
+						( parsed = themeMatch.exec( decl.value ) ) !== null
+					) {
+						const [ , whole, color ] = parsed;
+						const colorKey = color.trim();
+						const defaultColor = options.defaults[ colorKey ];
+						value = value.replace( whole, defaultColor );
 
-			if ( hasThemeDecls ) {
-				Object.keys( options.themes ).forEach( ( key ) => {
-					const newRule = postcss.rule( {
-						selector: rule.selector
-							.split( ',' )
-							.map(
-								( subselector ) =>
-									'body.' + key + ' ' + subselector.trim()
-							)
-							.join( ', ' ),
+						Object.entries( options.themes ).forEach(
+							( [ key, colors ] ) => {
+								const previousValue = themeValues[ key ]
+									? themeValues[ key ]
+									: decl.value;
+								themeValues[ key ] = previousValue.replace(
+									whole,
+									colors[ colorKey ]
+								);
+							}
+						);
+					}
+
+					hasThemeDecls = true;
+					decl.value = value;
+					Object.keys( options.themes ).forEach( ( key ) => {
+						const themeDecl = decl.clone();
+						themeDecl.value = themeValues[ key ];
+						if ( ! themeDecls[ key ] ) {
+							themeDecls[ key ] = [];
+						}
+						themeDecls[ key ].push( themeDecl );
 					} );
-					themeDecls[ key ].forEach( ( decl ) =>
-						newRule.append( decl )
-					);
-					rule.parent.insertAfter( rule, newRule );
 				} );
-			}
-		} );
+
+				if ( hasThemeDecls ) {
+					Object.keys( options.themes ).forEach( ( key ) => {
+						const newRule = postcss.rule( {
+							selector: rule.selector
+								.split( ',' )
+								.map(
+									( subselector ) =>
+										'body.' + key + ' ' + subselector.trim()
+								)
+								.join( ', ' ),
+						} );
+						themeDecls[ key ].forEach( ( decl ) =>
+							newRule.append( decl )
+						);
+						rule.parent.insertAfter( rule, newRule );
+					} );
+				}
+			} );
+		},
 	};
-} );
+};
+
+module.exports.postcss = true;


### PR DESCRIPTION
The plugin generated the following deprecation warning: https://github.com/WordPress/gutenberg/runs/4126554592?check_suite_focus=true#step:5:566

I followed the migration guide over at https://evilmartians.com/chronicles/postcss-8-plugin-migration.

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I modified the plugin code according to the migration guide.

## How has this been tested?
`npm run test-unit`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
