### PR TITLE
DEWP: Fix deprecation warning

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -75,7 +75,7 @@ describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 				};
 
 				// Webpack stats external modules should match.
-				const externalModules = stats.compilation.modules
+				const externalModules = Array.from( stats.compilation.modules )
 					.filter( ( { externalType } ) => externalType )
 					.sort( compareByModuleIdentifier )
 					.map( ( module ) => ( {


### PR DESCRIPTION
## Description
Fixed a deprecation warning originating in the tests for the dependency-extraction-webpack-plugin:
> [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.modules was changed from Array to Set (using Array method 'filter' is deprecated)

## How has this been tested?
`npm run test-unit`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
