### PR TITLE
Image block: Make sure the Image block border radius is inherited if the image is linked

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	&:not(.is-style-rounded) {
-		a,
+		> a,
 		img {
 			border-radius: inherit;
 		}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -7,8 +7,11 @@
 		vertical-align: bottom;
 	}
 
-	&:not(.is-style-rounded) img {
-		border-radius: inherit;
+	&:not(.is-style-rounded) {
+		a,
+		img {
+			border-radius: inherit;
+		}
 	}
 
 	&.aligncenter {


### PR DESCRIPTION
## Description
Fixes: #36288

## To test

- Run the latest gutenberg plugin along with a theme with Image border radius enabled, eg. Blockbase
- Add an Image block and set it to link to attachment
- Add a border radius - notice that the radius shows in the editor but not the frontend

## Screenshots

![image-radius-after](https://user-images.githubusercontent.com/3629020/140666311-b0046736-8d5d-487b-bcf5-a0de1191a3e1.gif)

## Types of changes
Adds an additional css selector for br
