### PR TITLE
Block Supports: Allow skipping serialization of individual features

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -54,7 +54,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border radius.
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
-		isset( $block_attributes['style']['border']['radius'] )
+		isset( $block_attributes['style']['border']['radius'] ) &&
+		! gutenberg_skip_border_serialization( $block_type, 'radius' )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -78,7 +79,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border style.
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
-		isset( $block_attributes['style']['border']['style'] )
+		isset( $block_attributes['style']['border']['style'] ) &&
+		! gutenberg_skip_border_serialization( $block_type, 'style' )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
 		$styles[]     = sprintf( 'border-style: %s;', $border_style );
@@ -87,7 +89,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border width.
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'width' ) &&
-		isset( $block_attributes['style']['border']['width'] )
+		isset( $block_attributes['style']['border']['width'] ) &&
+		! gutenberg_skip_border_serialization( $block_type, 'width' )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -100,7 +103,10 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	// Border color.
-	if ( gutenberg_has_border_feature_support( $block_type, 'color' ) ) {
+	if (
+		gutenberg_has_border_feature_support( $block_type, 'color' ) &&
+		! gutenberg_skip_border_serialization( $block_type, 'color' )
+	) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
 
@@ -134,16 +140,20 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
  * Checks whether serialization of the current block's border properties should
  * occur.
  *
- * @param WP_Block_type $block_type       Block type.
+ * @param WP_Block_type $block_type Block type.
+ * @param string        $feature    Optional name of individual feature to check.
  *
  * @return boolean
  */
-function gutenberg_skip_border_serialization( $block_type ) {
-	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
+function gutenberg_skip_border_serialization( $block_type, $feature = null ) {
+	$path               = array( '__experimentalBorder', '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
 
-	return is_array( $border_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
-		$border_support['__experimentalSkipSerialization'];
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
 }
 
 /**

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -44,7 +44,7 @@ function gutenberg_register_border_support( $block_type ) {
  * @return array Border CSS classes and inline styles.
  */
 function gutenberg_apply_border_support( $block_type, $block_attributes ) {
-	if ( gutenberg_skip_border_serialization( $block_type ) ) {
+	if ( gutenberg_should_skip_block_supports_serialization( $block_type, 'border' ) ) {
 		return array();
 	}
 
@@ -55,7 +55,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
 		isset( $block_attributes['style']['border']['radius'] ) &&
-		! gutenberg_skip_border_serialization( $block_type, 'radius' )
+		! gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -80,7 +80,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
 		isset( $block_attributes['style']['border']['style'] ) &&
-		! gutenberg_skip_border_serialization( $block_type, 'style' )
+		! gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
 		$styles[]     = sprintf( 'border-style: %s;', $border_style );
@@ -90,7 +90,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'width' ) &&
 		isset( $block_attributes['style']['border']['width'] ) &&
-		! gutenberg_skip_border_serialization( $block_type, 'width' )
+		! gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -105,7 +105,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border color.
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'color' ) &&
-		! gutenberg_skip_border_serialization( $block_type, 'color' )
+		! gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
@@ -134,26 +134,6 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	return $attributes;
-}
-
-/**
- * Checks whether serialization of the current block's border properties should
- * occur.
- *
- * @param WP_Block_type $block_type Block type.
- * @param string        $feature    Optional name of individual feature to check.
- *
- * @return boolean
- */
-function gutenberg_skip_border_serialization( $block_type, $feature = null ) {
-	$path               = array( '__experimentalBorder', '__experimentalSkipSerialization' );
-	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
-
-	if ( is_array( $skip_serialization ) ) {
-		return in_array( $feature, $skip_serialization, true );
-	}
-
-	return $skip_serialization;
 }
 
 /**

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -68,8 +68,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if (
 		is_array( $color_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $color_support ) &&
-		$color_support['__experimentalSkipSerialization']
+		gutenberg_skip_color_serialization( $block_type )
 	) {
 		return array();
 	}
@@ -82,7 +81,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Text colors.
 	// Check support for text colors.
-	if ( $has_text_colors_support ) {
+	if ( $has_text_colors_support && ! gutenberg_skip_color_serialization( $block_type, 'text' ) ) {
 		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
 		$has_custom_text_color = isset( $block_attributes['style']['color']['text'] );
 
@@ -99,7 +98,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Background colors.
-	if ( $has_background_colors_support ) {
+	if ( $has_background_colors_support && ! gutenberg_skip_color_serialization( $block_type, 'background' ) ) {
 		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
 		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );
 
@@ -116,7 +115,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
-	if ( $has_gradients_support ) {
+	if ( $has_gradients_support && ! gutenberg_skip_color_serialization( $block_type, 'gradients' ) ) {
 		$has_named_gradient  = array_key_exists( 'gradient', $block_attributes );
 		$has_custom_gradient = isset( $block_attributes['style']['color']['gradient'] );
 
@@ -141,6 +140,27 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	return $attributes;
 }
+
+/**
+ * Checks whether serialization of the current block's color properties
+ * should occur.
+ *
+ * @param WP_Block_type $block_type Block type.
+ * @param string        $feature    Optional name of individual feature to check.
+ *
+ * @return boolean Whether to serialize color support styles & classes.
+ */
+function gutenberg_skip_color_serialization( $block_type, $feature = null ) {
+	$path               = array( 'color', '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
+}
+
 
 // Register the block support.
 WP_Block_Supports::get_instance()->register(

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -151,6 +151,10 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
  * @return boolean Whether to serialize color support styles & classes.
  */
 function gutenberg_skip_color_serialization( $block_type, $feature = null ) {
+	if ( ! is_object( $block_type ) ) {
+		return false;
+	}
+
 	$path               = array( 'color', '__experimentalSkipSerialization' );
 	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -68,7 +68,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if (
 		is_array( $color_support ) &&
-		gutenberg_skip_color_serialization( $block_type )
+		gutenberg_should_skip_block_supports_serialization( $block_type, 'color' )
 	) {
 		return array();
 	}
@@ -81,7 +81,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Text colors.
 	// Check support for text colors.
-	if ( $has_text_colors_support && ! gutenberg_skip_color_serialization( $block_type, 'text' ) ) {
+	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
 		$has_custom_text_color = isset( $block_attributes['style']['color']['text'] );
 
@@ -98,7 +98,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Background colors.
-	if ( $has_background_colors_support && ! gutenberg_skip_color_serialization( $block_type, 'background' ) ) {
+	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
 		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );
 
@@ -115,7 +115,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
-	if ( $has_gradients_support && ! gutenberg_skip_color_serialization( $block_type, 'gradients' ) ) {
+	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$has_named_gradient  = array_key_exists( 'gradient', $block_attributes );
 		$has_custom_gradient = isset( $block_attributes['style']['color']['gradient'] );
 
@@ -140,31 +140,6 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	return $attributes;
 }
-
-/**
- * Checks whether serialization of the current block's color properties
- * should occur.
- *
- * @param WP_Block_type $block_type Block type.
- * @param string        $feature    Optional name of individual feature to check.
- *
- * @return boolean Whether to serialize color support styles & classes.
- */
-function gutenberg_skip_color_serialization( $block_type, $feature = null ) {
-	if ( ! is_object( $block_type ) ) {
-		return false;
-	}
-
-	$path               = array( 'color', '__experimentalSkipSerialization' );
-	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
-
-	if ( is_array( $skip_serialization ) ) {
-		return in_array( $feature, $skip_serialization, true );
-	}
-
-	return $skip_serialization;
-}
-
 
 // Register the block support.
 WP_Block_Supports::get_instance()->register(

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -62,14 +62,19 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
  * should occur.
  *
  * @param WP_Block_type $block_type Block type.
+ * @param string        $feature    Optional name of individual feature to check.
  *
- * @return boolean Whether to serialize spacing support styles & classes.
+ * @return boolean Whether to serialize dimensions support styles & classes.
  */
-function gutenberg_skip_dimensions_serialization( $block_type ) {
-	$dimensions_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions' ), false );
-	return is_array( $dimensions_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $dimensions_support ) &&
-		$dimensions_support['__experimentalSkipSerialization'];
+function gutenberg_skip_dimensions_serialization( $block_type, $feature = null ) {
+	$path               = array( '__experimentalDimensions', '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
 }
 
 // Register the block support.

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -45,7 +45,7 @@ function gutenberg_register_dimensions_support( $block_type ) {
  * @return array Block dimensions CSS classes and inline styles.
  */
 function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	if ( gutenberg_skip_dimensions_serialization( $block_type ) ) {
+	if ( gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalDimensions' ) ) {
 		return array();
 	}
 
@@ -55,26 +55,6 @@ function gutenberg_apply_dimensions_support( $block_type, $block_attributes ) { 
 	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
-}
-
-/**
- * Checks whether serialization of the current block's dimensions properties
- * should occur.
- *
- * @param WP_Block_type $block_type Block type.
- * @param string        $feature    Optional name of individual feature to check.
- *
- * @return boolean Whether to serialize dimensions support styles & classes.
- */
-function gutenberg_skip_dimensions_serialization( $block_type, $feature = null ) {
-	$path               = array( '__experimentalDimensions', '__experimentalSkipSerialization' );
-	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
-
-	if ( is_array( $skip_serialization ) ) {
-		return in_array( $feature, $skip_serialization, true );
-	}
-
-	return $skip_serialization;
 }
 
 // Register the block support.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -18,6 +18,13 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$skip_link_color_serialization = gutenberg_skip_color_serialization( $block_type, 'link' );
+
+	if ( $skip_link_color_serialization ) {
+		return $block_content;
+	}
+
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -19,7 +19,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	}
 
 	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$skip_link_color_serialization = gutenberg_skip_color_serialization( $block_type, 'link' );
+	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
 
 	if ( $skip_link_color_serialization ) {
 		return $block_content;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -28,14 +28,15 @@ function gutenberg_register_layout_support( $block_type ) {
 /**
  * Generates the CSS corresponding to the provided layout.
  *
- * @param string  $selector CSS selector.
- * @param array   $layout   Layout object. The one that is passed has already checked the existence of default block layout.
- * @param boolean $has_block_gap_support Whether the theme has support for the block gap.
- * @param string  $gap_value The block gap value to apply.
+ * @param string  $selector                      CSS selector.
+ * @param array   $layout                        Layout object. The one that is passed has already checked the existence of default block layout.
+ * @param boolean $has_block_gap_support         Whether the theme has support for the block gap.
+ * @param string  $gap_value                     The block gap value to apply.
+ * @param boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
  *
- * @return string CSS style.
+ * @return string                                CSS style.
  */
-function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null ) {
+function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
 	$style = '';
@@ -69,7 +70,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( is_array( $gap_value ) ) {
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
-			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap )';
+			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap )';
 			$style    .= "$selector > * { margin-block-start: 0; margin-block-end: 0; }";
 			$style    .= "$selector > * + * { margin-block-start: $gap_style; margin-block-end: 0; }";
 		}
@@ -99,7 +100,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
-			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
+			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
 			$style    .= "gap: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';
@@ -172,7 +173,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$gap_value = preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 	}
 
-	$style = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value );
+	// If a block's block.json skips serialization for spacing or spacing.blockGap,
+	// don't apply the user-defined value to the styles.
+	$should_skip_gap_serialization = gutenberg_skip_spacing_serialization( $block_type, 'blockGap' );
+	$style                         = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -175,7 +175,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
-	$should_skip_gap_serialization = gutenberg_skip_spacing_serialization( $block_type, 'blockGap' );
+	$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 	$style                         = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -39,7 +39,7 @@ function gutenberg_register_spacing_support( $block_type ) {
  * @return array Block spacing CSS classes and inline styles.
  */
 function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
-	if ( gutenberg_skip_spacing_serialization( $block_type ) ) {
+	if ( gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing' ) ) {
 		return array();
 	}
 
@@ -53,8 +53,8 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	}
 
 	$style_engine                    = WP_Style_Engine_Gutenberg::get_instance();
-	$skip_padding                    = gutenberg_skip_spacing_serialization( $block_type, 'padding' );
-	$skip_margin                     = gutenberg_skip_spacing_serialization( $block_type, 'margin' );
+	$skip_padding                    = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
+	$skip_margin                     = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$spacing_block_styles            = array();
 	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
 	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
@@ -70,26 +70,6 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	}
 
 	return $attributes;
-}
-
-/**
- * Checks whether serialization of the current block's spacing properties should
- * occur.
- *
- * @param WP_Block_type $block_type Block type.
- * @param string        $feature    Optional name of individual feature to check.
- *
- * @return boolean Whether to serialize spacing support styles & classes.
- */
-function gutenberg_skip_spacing_serialization( $block_type, $feature = null ) {
-	$path               = array( 'spacing', '__experimentalSkipSerialization' );
-	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
-
-	if ( is_array( $skip_serialization ) ) {
-		return in_array( $feature, $skip_serialization, true );
-	}
-
-	return $skip_serialization;
 }
 
 // Register the block support.

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -75,8 +75,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$skip_typography_serialization = _wp_array_get( $typography_supports, array( '__experimentalSkipSerialization' ), false );
-	if ( $skip_typography_serialization ) {
+	if ( gutenberg_skip_typography_serialization( $block_type ) ) {
 		return array();
 	}
 
@@ -93,7 +92,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
 
-	if ( $has_font_size_support ) {
+	if ( $has_font_size_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontSize' ) ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
@@ -104,7 +103,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_family_support ) {
+	if ( $has_font_family_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontFamily' ) ) {
 		$has_named_font_family  = array_key_exists( 'fontFamily', $block_attributes );
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
@@ -123,42 +122,42 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_style_support ) {
+	if ( $has_font_style_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontStyle' ) ) {
 		$font_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
 		if ( $font_style ) {
 			$styles[] = $font_style;
 		}
 	}
 
-	if ( $has_font_weight_support ) {
+	if ( $has_font_weight_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontWeight' ) ) {
 		$font_weight = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
 		if ( $font_weight ) {
 			$styles[] = $font_weight;
 		}
 	}
 
-	if ( $has_line_height_support ) {
+	if ( $has_line_height_support && ! gutenberg_skip_typography_serialization( $block_type, 'lineHeight' ) ) {
 		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
 		if ( $has_line_height ) {
 			$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
 		}
 	}
 
-	if ( $has_text_decoration_support ) {
+	if ( $has_text_decoration_support && ! gutenberg_skip_typography_serialization( $block_type, 'textDecoration' ) ) {
 		$text_decoration_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
 		if ( $text_decoration_style ) {
 			$styles[] = $text_decoration_style;
 		}
 	}
 
-	if ( $has_text_transform_support ) {
+	if ( $has_text_transform_support && ! gutenberg_skip_typography_serialization( $block_type, 'textTransform' ) ) {
 		$text_transform_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
 		if ( $text_transform_style ) {
 			$styles[] = $text_transform_style;
 		}
 	}
 
-	if ( $has_letter_spacing_support ) {
+	if ( $has_letter_spacing_support && ! gutenberg_skip_typography_serialization( $block_type, 'letterSpacing' ) ) {
 		$letter_spacing_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'letterSpacing', 'letter-spacing' );
 		if ( $letter_spacing_style ) {
 			$styles[] = $letter_spacing_style;
@@ -214,3 +213,23 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_typography_support',
 	)
 );
+
+/**
+ * Checks whether serialization of the current block's typography properties
+ * should occur.
+ *
+ * @param WP_Block_type $block_type Block type.
+ * @param string        $feature    Optional name of individual feature to check.
+ *
+ * @return boolean Whether to serialize typography support styles & classes.
+ */
+function gutenberg_skip_typography_serialization( $block_type, $feature = null ) {
+	$path               = array( 'typography', '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
+}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -75,7 +75,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	if ( gutenberg_skip_typography_serialization( $block_type ) ) {
+	if ( gutenberg_should_skip_block_supports_serialization( $block_type, 'typography' ) ) {
 		return array();
 	}
 
@@ -92,7 +92,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
 
-	if ( $has_font_size_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontSize' ) ) {
+	if ( $has_font_size_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' ) ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
@@ -103,7 +103,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_family_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontFamily' ) ) {
+	if ( $has_font_family_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'fontFamily' ) ) {
 		$has_named_font_family  = array_key_exists( 'fontFamily', $block_attributes );
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
@@ -122,42 +122,42 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_style_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontStyle' ) ) {
+	if ( $has_font_style_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'fontStyle' ) ) {
 		$font_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
 		if ( $font_style ) {
 			$styles[] = $font_style;
 		}
 	}
 
-	if ( $has_font_weight_support && ! gutenberg_skip_typography_serialization( $block_type, 'fontWeight' ) ) {
+	if ( $has_font_weight_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'fontWeight' ) ) {
 		$font_weight = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
 		if ( $font_weight ) {
 			$styles[] = $font_weight;
 		}
 	}
 
-	if ( $has_line_height_support && ! gutenberg_skip_typography_serialization( $block_type, 'lineHeight' ) ) {
+	if ( $has_line_height_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'lineHeight' ) ) {
 		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
 		if ( $has_line_height ) {
 			$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
 		}
 	}
 
-	if ( $has_text_decoration_support && ! gutenberg_skip_typography_serialization( $block_type, 'textDecoration' ) ) {
+	if ( $has_text_decoration_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'textDecoration' ) ) {
 		$text_decoration_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
 		if ( $text_decoration_style ) {
 			$styles[] = $text_decoration_style;
 		}
 	}
 
-	if ( $has_text_transform_support && ! gutenberg_skip_typography_serialization( $block_type, 'textTransform' ) ) {
+	if ( $has_text_transform_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' ) ) {
 		$text_transform_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
 		if ( $text_transform_style ) {
 			$styles[] = $text_transform_style;
 		}
 	}
 
-	if ( $has_letter_spacing_support && ! gutenberg_skip_typography_serialization( $block_type, 'letterSpacing' ) ) {
+	if ( $has_letter_spacing_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' ) ) {
 		$letter_spacing_style = gutenberg_typography_get_css_variable_inline_style( $block_attributes, 'letterSpacing', 'letter-spacing' );
 		if ( $letter_spacing_style ) {
 			$styles[] = $letter_spacing_style;
@@ -214,22 +214,4 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-/**
- * Checks whether serialization of the current block's typography properties
- * should occur.
- *
- * @param WP_Block_type $block_type Block type.
- * @param string        $feature    Optional name of individual feature to check.
- *
- * @return boolean Whether to serialize typography support styles & classes.
- */
-function gutenberg_skip_typography_serialization( $block_type, $feature = null ) {
-	$path               = array( 'typography', '__experimentalSkipSerialization' );
-	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
 
-	if ( is_array( $skip_serialization ) ) {
-		return in_array( $feature, $skip_serialization, true );
-	}
-
-	return $skip_serialization;
-}

--- a/lib/block-supports/utils.php
+++ b/lib/block-supports/utils.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Block support utility functions.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Checks whether serialization of the current block's typography properties
+ * should occur.
+ *
+ * @param WP_Block_type $block_type  Block type.
+ * @param string        $feature_set Name of block support feature set..
+ * @param string        $feature     Optional name of individual feature to check.
+ *
+ * @return boolean Whether to serialize typography support styles & classes.
+ */
+function gutenberg_should_skip_block_supports_serialization( $block_type, $feature_set, $feature = null ) {
+	if ( ! is_object( $block_type ) || ! $feature_set ) {
+		return false;
+	}
+
+	$path               = array( $feature_set, '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
+}

--- a/lib/block-supports/utils.php
+++ b/lib/block-supports/utils.php
@@ -6,14 +6,14 @@
  */
 
 /**
- * Checks whether serialization of the current block's typography properties
+ * Checks whether serialization of the current block's supported properties
  * should occur.
  *
  * @param WP_Block_type $block_type  Block type.
  * @param string        $feature_set Name of block support feature set..
  * @param string        $feature     Optional name of individual feature to check.
  *
- * @return boolean Whether to serialize typography support styles & classes.
+ * @return boolean Whether to serialize block support styles & classes.
  */
 function gutenberg_should_skip_block_supports_serialization( $block_type, $feature_set, $feature = null ) {
 	if ( ! is_object( $block_type ) || ! $feature_set ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,6 +126,7 @@ require __DIR__ . '/pwa.php';
 // similar to the loading behaviour in `blocks.php`.
 require __DIR__ . '/style-engine/class-wp-style-engine-gutenberg.php';
 
+require __DIR__ . '/block-supports/utils.php';
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/typography.php';

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -23,10 +23,11 @@ import {
 } from '../components/colors';
 import useSetting from '../components/use-setting';
 import {
+	BORDER_SUPPORT_KEY,
 	hasBorderSupport,
 	removeBorderAttribute,
-	shouldSkipSerialization,
 } from './border';
+import { shouldSkipSerialization } from './style';
 import { cleanEmptyObject } from './utils';
 
 // Defining empty array here instead of inline avoids unnecessary re-renders of
@@ -200,7 +201,7 @@ function addAttributes( settings ) {
 function addSaveProps( props, blockType, attributes ) {
 	if (
 		! hasBorderSupport( blockType, 'color' ) ||
-		shouldSkipSerialization( blockType )
+		shouldSkipSerialization( blockType, BORDER_SUPPORT_KEY, 'color' )
 	) {
 		return props;
 	}
@@ -231,7 +232,7 @@ function addSaveProps( props, blockType, attributes ) {
 function addEditProps( settings ) {
 	if (
 		! hasBorderSupport( settings, 'color' ) ||
-		shouldSkipSerialization( settings )
+		shouldSkipSerialization( settings, BORDER_SUPPORT_KEY, 'color' )
 	) {
 		return settings;
 	}
@@ -266,7 +267,7 @@ export const withBorderColorPaletteStyles = createHigherOrderComponent(
 
 		if (
 			! hasBorderSupport( name, 'color' ) ||
-			shouldSkipSerialization( name )
+			shouldSkipSerialization( name, BORDER_SUPPORT_KEY, 'color' )
 		) {
 			return <BlockListBlock { ...props } />;
 		}

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -27,8 +27,7 @@ import {
 	hasBorderSupport,
 	removeBorderAttribute,
 } from './border';
-import { shouldSkipSerialization } from './style';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, shouldSkipSerialization } from './utils';
 
 // Defining empty array here instead of inline avoids unnecessary re-renders of
 // color control.

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -172,19 +172,6 @@ export function hasBorderSupport( blockName, feature = 'any' ) {
 }
 
 /**
- * Check whether serialization of border classes and styles should be skipped.
- *
- * @param {string|Object} blockType Block name or block type object.
- *
- * @return {boolean} Whether serialization of border properties should occur.
- */
-export function shouldSkipSerialization( blockType ) {
-	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
-
-	return support?.__experimentalSkipSerialization;
-}
-
-/**
  * Returns a new style object where the specified border attribute has been
  * removed.
  *

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -26,7 +26,12 @@ import {
 	getGradientValueBySlug,
 	getGradientSlugByValue,
 } from '../components/gradients';
-import { cleanEmptyObject, transformStyles, immutableSet } from './utils';
+import {
+	cleanEmptyObject,
+	transformStyles,
+	immutableSet,
+	shouldSkipSerialization,
+} from './utils';
 import ColorPanel from './color-panel';
 import useSetting from '../components/use-setting';
 
@@ -41,12 +46,6 @@ const hasColorSupport = ( blockType ) => {
 			colorSupport.background !== false ||
 			colorSupport.text !== false )
 	);
-};
-
-const shouldSkipSerialization = ( blockType ) => {
-	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
-
-	return colorSupport?.__experimentalSkipSerialization;
 };
 
 const hasLinkColorSupport = ( blockType ) => {
@@ -248,7 +247,7 @@ function addAttributes( settings ) {
 export function addSaveProps( props, blockType, attributes ) {
 	if (
 		! hasColorSupport( blockType ) ||
-		shouldSkipSerialization( blockType )
+		shouldSkipSerialization( blockType, COLOR_SUPPORT_KEY )
 	) {
 		return props;
 	}
@@ -258,12 +257,31 @@ export function addSaveProps( props, blockType, attributes ) {
 	// I'd have preferred to avoid the "style" attribute usage here
 	const { backgroundColor, textColor, gradient, style } = attributes;
 
-	const backgroundClass = getColorClassName(
-		'background-color',
-		backgroundColor
-	);
-	const gradientClass = __experimentalGetGradientClass( gradient );
-	const textClass = getColorClassName( 'color', textColor );
+	const shouldSerialize = ( feature ) =>
+		! shouldSkipSerialization( blockType, COLOR_SUPPORT_KEY, feature );
+
+	// Primary color classes must come before the `has-text-color`,
+	// `has-background` and `has-link-color` classes to maintain backwards
+	// compatibility and avoid block invalidations.
+	const textClass = shouldSerialize( 'text' )
+		? getColorClassName( 'color', textColor )
+		: undefined;
+
+	const gradientClass = shouldSerialize( 'gradients' )
+		? __experimentalGetGradientClass( gradient )
+		: undefined;
+
+	const backgroundClass = shouldSerialize( 'background' )
+		? getColorClassName( 'background-color', backgroundColor )
+		: undefined;
+
+	const serializeHasBackground =
+		shouldSerialize( 'background' ) || shouldSerialize( 'gradients' );
+	const hasBackground =
+		backgroundColor ||
+		style?.color?.background ||
+		( hasGradient && ( gradient || style?.color?.gradient ) );
+
 	const newClassName = classnames(
 		props.className,
 		textClass,
@@ -273,12 +291,12 @@ export function addSaveProps( props, blockType, attributes ) {
 			[ backgroundClass ]:
 				( ! hasGradient || ! style?.color?.gradient ) &&
 				!! backgroundClass,
-			'has-text-color': textColor || style?.color?.text,
-			'has-background':
-				backgroundColor ||
-				style?.color?.background ||
-				( hasGradient && ( gradient || style?.color?.gradient ) ),
-			'has-link-color': style?.elements?.link?.color,
+			'has-text-color':
+				shouldSerialize( 'text' ) &&
+				( textColor || style?.color?.text ),
+			'has-background': serializeHasBackground && hasBackground,
+			'has-link-color':
+				shouldSerialize( 'link' ) && style?.elements?.link?.color,
 		}
 	);
 	props.className = newClassName ? newClassName : undefined;
@@ -297,7 +315,7 @@ export function addSaveProps( props, blockType, attributes ) {
 export function addEditProps( settings ) {
 	if (
 		! hasColorSupport( settings ) ||
-		shouldSkipSerialization( settings )
+		shouldSkipSerialization( settings, COLOR_SUPPORT_KEY )
 	) {
 		return settings;
 	}
@@ -589,18 +607,27 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 			],
 			[ userPalette, themePalette, defaultPalette ]
 		);
-		if ( ! hasColorSupport( name ) || shouldSkipSerialization( name ) ) {
+		if (
+			! hasColorSupport( name ) ||
+			shouldSkipSerialization( name, COLOR_SUPPORT_KEY )
+		) {
 			return <BlockListBlock { ...props } />;
 		}
 		const extraStyles = {};
 
-		if ( textColor ) {
+		if (
+			textColor &&
+			! shouldSkipSerialization( name, COLOR_SUPPORT_KEY, 'text' )
+		) {
 			extraStyles.color = getColorObjectByAttributeValues(
 				colors,
 				textColor
 			)?.color;
 		}
-		if ( backgroundColor ) {
+		if (
+			backgroundColor &&
+			! shouldSkipSerialization( name, COLOR_SUPPORT_KEY, 'background' )
+		) {
 			extraStyles.backgroundColor = getColorObjectByAttributeValues(
 				colors,
 				backgroundColor

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -15,6 +15,8 @@ import TokenList from '@wordpress/token-list';
  */
 import useSetting from '../components/use-setting';
 import FontFamilyControl from '../components/font-family';
+import { shouldSkipSerialization } from './style';
+import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
 
 export const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
 
@@ -56,9 +58,10 @@ function addSaveProps( props, blockType, attributes ) {
 	}
 
 	if (
-		hasBlockSupport(
+		shouldSkipSerialization(
 			blockType,
-			'typography.__experimentalSkipSerialization'
+			TYPOGRAPHY_SUPPORT_KEY,
+			'fontFamily'
 		)
 	) {
 		return props;

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -15,7 +15,7 @@ import TokenList from '@wordpress/token-list';
  */
 import useSetting from '../components/use-setting';
 import FontFamilyControl from '../components/font-family';
-import { shouldSkipSerialization } from './style';
+import { shouldSkipSerialization } from './utils';
 import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
 
 export const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -15,9 +15,8 @@ import {
 	getFontSizeObjectByValue,
 	FontSizePicker,
 } from '../components/font-sizes';
-import { shouldSkipSerialization } from './style';
 import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
-import { cleanEmptyObject, transformStyles } from './utils';
+import { cleanEmptyObject, transformStyles, shouldSkipSerialization } from './utils';
 import useSetting from '../components/use-setting';
 
 export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -16,7 +16,11 @@ import {
 	FontSizePicker,
 } from '../components/font-sizes';
 import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
-import { cleanEmptyObject, transformStyles, shouldSkipSerialization } from './utils';
+import {
+	cleanEmptyObject,
+	transformStyles,
+	shouldSkipSerialization,
+} from './utils';
 import useSetting from '../components/use-setting';
 
 export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -15,6 +15,8 @@ import {
 	getFontSizeObjectByValue,
 	FontSizePicker,
 } from '../components/font-sizes';
+import { shouldSkipSerialization } from './style';
+import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
 import { cleanEmptyObject, transformStyles } from './utils';
 import useSetting from '../components/use-setting';
 
@@ -60,10 +62,7 @@ function addSaveProps( props, blockType, attributes ) {
 	}
 
 	if (
-		hasBlockSupport(
-			blockType,
-			'typography.__experimentalSkipSerialization'
-		)
+		shouldSkipSerialization( blockType, TYPOGRAPHY_SUPPORT_KEY, 'fontSize' )
 	) {
 		return props;
 	}
@@ -223,9 +222,10 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 		// and does have a class to extract the font size from.
 		if (
 			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
-			hasBlockSupport(
+			shouldSkipSerialization(
 				blockName,
-				'typography.__experimentalSkipSerialization'
+				TYPOGRAPHY_SUPPORT_KEY,
+				'fontSize'
 			) ||
 			! fontSize ||
 			style?.typography?.fontSize

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -222,6 +222,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 					element &&
 					createPortal(
 						<LayoutStyle
+							blockName={ name }
 							selector={ `.wp-container-${ id }` }
 							layout={ usedLayout }
 							style={ attributes?.style }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -333,14 +333,23 @@ export const withBlockControls = createHigherOrderComponent(
  */
 const withElementsStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const elements = props.attributes.style?.elements;
-
 		const blockElementsContainerIdentifier = `wp-elements-${ useInstanceId(
 			BlockListBlock
 		) }`;
+
+		const skipSerialization = shouldSkipSerialization(
+			props.name,
+			COLOR_SUPPORT_KEY,
+			'link'
+		);
+
+		const elements = skipSerialization
+			? omit( props.attributes.style?.elements, [ 'link' ] )
+			: props.attributes.style?.elements;
+
 		const styles = compileElementsStyles(
 			blockElementsContainerIdentifier,
-			props.attributes.style?.elements
+			elements
 		);
 		const element = useContext( BlockList.__unstableElementContext );
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -42,6 +42,7 @@ import {
 } from './typography';
 import { SPACING_SUPPORT_KEY, DimensionsPanel } from './dimensions';
 import useDisplayBlockControls from '../components/use-display-block-controls';
+import { shouldSkipSerialization } from './utils';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
@@ -161,27 +162,6 @@ function addAttribute( settings ) {
 	}
 
 	return settings;
-}
-
-/**
- * Check whether serialization of specific block support feature or set should
- * be skipped.
- *
- * @param {string|Object} blockType  Block name or block type object.
- * @param {string}        featureSet Name of block support feature set.
- * @param {string}        feature    Name of the individual feature to check.
- *
- * @return {boolean} Whether serialization should occur.
- */
-export function shouldSkipSerialization( blockType, featureSet, feature ) {
-	const support = getBlockSupport( blockType, featureSet );
-	const skipSerialization = support?.__experimentalSkipSerialization;
-
-	if ( Array.isArray( skipSerialization ) ) {
-		return skipSerialization.includes( feature );
-	}
-
-	return skipSerialization;
 }
 
 /**

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -222,6 +222,19 @@ const skipSerializationPathsSave = {
 };
 
 /**
+ * A dictionary used to normalize feature names between support flags, style
+ * object properties and __experimentSkipSerialization configuration arrays.
+ *
+ * This allows not having to provide a migration for a support flag and possible
+ * backwards compatibility bridges, while still achieving consistency between
+ * the support flag and the skip serialization array.
+ *
+ * @constant
+ * @type {Record<string, string>}
+ */
+const renamedFeatures = { gradients: 'gradient' };
+
+/**
  * Override props assigned to save component to inject the CSS variables definition.
  *
  * @param {Object}                    props      Additional props applied to save element.
@@ -251,7 +264,8 @@ export function addSaveProps(
 		}
 
 		if ( Array.isArray( skipSerialization ) ) {
-			skipSerialization.forEach( ( feature ) => {
+			skipSerialization.forEach( ( featureName ) => {
+				const feature = renamedFeatures[ featureName ] || featureName;
 				style = omit( style, [ [ ...path, feature ] ] );
 			} );
 		}

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -164,6 +164,27 @@ function addAttribute( settings ) {
 }
 
 /**
+ * Check whether serialization of specific block support feature or set should
+ * be skipped.
+ *
+ * @param {string|Object} blockType  Block name or block type object.
+ * @param {string}        featureSet Name of block support feature set.
+ * @param {string}        feature    Name of the individual feature to check.
+ *
+ * @return {boolean} Whether serialization should occur.
+ */
+export function shouldSkipSerialization( blockType, featureSet, feature ) {
+	const support = getBlockSupport( blockType, featureSet );
+	const skipSerialization = support?.__experimentalSkipSerialization;
+
+	if ( Array.isArray( skipSerialization ) ) {
+		return skipSerialization.includes( feature );
+	}
+
+	return skipSerialization;
+}
+
+/**
  * A dictionary of paths to flag skipping block support serialization as the key,
  * with values providing the style paths to be omitted from serialization.
  *

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -223,8 +223,16 @@ export function addSaveProps(
 	let { style } = attributes;
 
 	forEach( skipPaths, ( path, indicator ) => {
-		if ( getBlockSupport( blockType, indicator ) ) {
+		const skipSerialization = getBlockSupport( blockType, indicator );
+
+		if ( skipSerialization === true ) {
 			style = omit( style, path );
+		}
+
+		if ( Array.isArray( skipSerialization ) ) {
+			skipSerialization.forEach( ( feature ) => {
+				style = omit( style, [ [ ...path, feature ] ] );
+			} );
 		}
 	} );
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -331,13 +331,17 @@ const withElementsStyles = createHigherOrderComponent(
 			BlockListBlock
 		) }`;
 
-		const skipSerialization = shouldSkipSerialization(
+		const skipLinkColorSerialization = shouldSkipSerialization(
 			props.name,
 			COLOR_SUPPORT_KEY,
 			'link'
 		);
 
-		const elements = skipSerialization
+		// The Elements API only supports link colors for now,
+		// hence the specific omission of `link` in the elements styles.
+		// This might need to be refactored or removed if the Elements API
+		// changes or `link` supports styles beyond `color`.
+		const elements = skipLinkColorSerialization
 			? omit( props.attributes.style?.elements, [ 'link' ] )
 			: props.attributes.style?.elements;
 

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -126,6 +126,7 @@ describe( 'addSaveProps', () => {
 		title: 'block title',
 		supports: {
 			spacing: { padding: true },
+			color: { gradients: true, text: true },
 			typography: {
 				fontSize: true,
 				__experimentalTextTransform: true,
@@ -134,15 +135,22 @@ describe( 'addSaveProps', () => {
 		},
 	};
 
-	const applySkipSerialization = ( skipSerialization ) => {
+	const applySkipSerialization = ( features ) => {
 		const updatedSettings = { ...blockSettings };
-		updatedSettings.supports.typography.__experimentalSkipSerialization = skipSerialization;
-
+		Object.keys( features ).forEach( ( key ) => {
+			updatedSettings.supports[ key ].__experimentalSkipSerialization =
+				features[ key ];
+		} );
 		return updatedSettings;
 	};
 
 	const attributes = {
 		style: {
+			color: {
+				text: '#d92828',
+				gradient:
+					'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+			},
 			spacing: { padding: '10px' },
 			typography: {
 				fontSize: '1rem',
@@ -156,6 +164,9 @@ describe( 'addSaveProps', () => {
 		const extraProps = addSaveProps( {}, blockSettings, attributes );
 
 		expect( extraProps.style ).toEqual( {
+			background:
+				'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+			color: '#d92828',
 			padding: '10px',
 			fontSize: '1rem',
 			textDecoration: 'underline',
@@ -164,20 +175,28 @@ describe( 'addSaveProps', () => {
 	} );
 
 	it( 'should skip serialization of entire feature set if flag is true', () => {
-		const settings = applySkipSerialization( true );
-		const extraProps = addSaveProps( {}, settings, attributes );
-
-		expect( extraProps.style ).toEqual( { padding: '10px' } );
-	} );
-
-	it( 'should skip serialization of individual features if flag is an array', () => {
-		const settings = applySkipSerialization( [
-			'textDecoration',
-			'textTransform',
-		] );
+		const settings = applySkipSerialization( {
+			typography: true,
+		} );
 		const extraProps = addSaveProps( {}, settings, attributes );
 
 		expect( extraProps.style ).toEqual( {
+			background:
+				'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+			color: '#d92828',
+			padding: '10px',
+		} );
+	} );
+
+	it( 'should skip serialization of individual features if flag is an array', () => {
+		const settings = applySkipSerialization( {
+			color: [ 'gradient' ],
+			typography: [ 'textDecoration', 'textTransform' ],
+		} );
+		const extraProps = addSaveProps( {}, settings, attributes );
+
+		expect( extraProps.style ).toEqual( {
+			color: '#d92828',
 			padding: '10px',
 			fontSize: '1rem',
 		} );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import { getInlineStyles } from '../style';
@@ -105,6 +110,76 @@ describe( 'getInlineStyles', () => {
 		).toEqual( {
 			margin: '10px',
 			padding: '20px',
+		} );
+	} );
+} );
+
+describe( 'addSaveProps', () => {
+	const addSaveProps = applyFilters.bind(
+		null,
+		'blocks.getSaveContent.extraProps'
+	);
+
+	const blockSettings = {
+		save: () => <div className="default" />,
+		category: 'text',
+		title: 'block title',
+		supports: {
+			spacing: { padding: true },
+			typography: {
+				fontSize: true,
+				__experimentalTextTransform: true,
+				__experimentalTextDecoration: true,
+			},
+		},
+	};
+
+	const applySkipSerialization = ( skipSerialization ) => {
+		const updatedSettings = { ...blockSettings };
+		updatedSettings.supports.typography.__experimentalSkipSerialization = skipSerialization;
+
+		return updatedSettings;
+	};
+
+	const attributes = {
+		style: {
+			spacing: { padding: '10px' },
+			typography: {
+				fontSize: '1rem',
+				textDecoration: 'underline',
+				textTransform: 'uppercase',
+			},
+		},
+	};
+
+	it( 'should serialize all styles by default', () => {
+		const extraProps = addSaveProps( {}, blockSettings, attributes );
+
+		expect( extraProps.style ).toEqual( {
+			padding: '10px',
+			fontSize: '1rem',
+			textDecoration: 'underline',
+			textTransform: 'uppercase',
+		} );
+	} );
+
+	it( 'should skip serialization of entire feature set if flag is true', () => {
+		const settings = applySkipSerialization( true );
+		const extraProps = addSaveProps( {}, settings, attributes );
+
+		expect( extraProps.style ).toEqual( { padding: '10px' } );
+	} );
+
+	it( 'should skip serialization of individual features if flag is an array', () => {
+		const settings = applySkipSerialization( [
+			'textDecoration',
+			'textTransform',
+		] );
+		const extraProps = addSaveProps( {}, settings, attributes );
+
+		expect( extraProps.style ).toEqual( {
+			padding: '10px',
+			fontSize: '1rem',
 		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -97,7 +97,7 @@ describe( 'anchor', () => {
 			expect( extraProps.id ).toBe( 'foo' );
 		} );
 
-		it( 'should remove an anchor attribute ID when feild is cleared', () => {
+		it( 'should remove an anchor attribute ID when field is cleared', () => {
 			const attributes = { anchor: '' };
 			const extraProps = getSaveContentExtraProps(
 				{},

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -15,6 +15,11 @@ import {
 } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+
+/**
  * Removed falsy values from nested object.
  *
  * @param {*} object
@@ -86,4 +91,25 @@ export function transformStyles(
 		}
 	} );
 	return returnBlock;
+}
+
+/**
+ * Check whether serialization of specific block support feature or set should
+ * be skipped.
+ *
+ * @param {string|Object} blockType  Block name or block type object.
+ * @param {string}        featureSet Name of block support feature set.
+ * @param {string}        feature    Name of the individual feature to check.
+ *
+ * @return {boolean} Whether serialization should occur.
+ */
+export function shouldSkipSerialization( blockType, featureSet, feature ) {
+	const support = getBlockSupport( blockType, featureSet );
+	const skipSerialization = support?.__experimentalSkipSerialization;
+
+	if ( Array.isArray( skipSerialization ) ) {
+		return skipSerialization.includes( feature );
+	}
+
+	return skipSerialization;
 }

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -19,7 +19,7 @@ import { appendSelectors } from './utils';
 import { getGapCSSValue } from '../hooks/gap';
 import useSetting from '../components/use-setting';
 import { BlockControls, JustifyContentControl } from '../components';
-import { shouldSkipSerialization } from '../hooks/style';
+import { shouldSkipSerialization } from '../hooks/utils';
 
 // Used with the default, horizontal flex orientation.
 const justifyContentMap = {

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -19,6 +19,7 @@ import { appendSelectors } from './utils';
 import { getGapCSSValue } from '../hooks/gap';
 import useSetting from '../components/use-setting';
 import { BlockControls, JustifyContentControl } from '../components';
+import { shouldSkipSerialization } from '../hooks/style';
 
 // Used with the default, horizontal flex orientation.
 const justifyContentMap = {
@@ -86,13 +87,17 @@ export default {
 			</BlockControls>
 		);
 	},
-	save: function FlexLayoutStyle( { selector, layout, style } ) {
+	save: function FlexLayoutStyle( { selector, layout, style, blockName } ) {
 		const { orientation = 'horizontal' } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
+		// If a block's block.json skips serialization for spacing or spacing.blockGap,
+		// don't apply the user-defined value to the styles.
 		const blockGapValue =
-			getGapCSSValue( style?.spacing?.blockGap, '0.5em' ) ??
-			'var( --wp--style--block-gap, 0.5em )';
+			style?.spacing?.blockGap &&
+			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
+				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
+				: 'var( --wp--style--block-gap, 0.5em )';
 		const justifyContent =
 			justifyContentMap[ layout.justifyContent ] ||
 			justifyContentMap.left;

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -15,7 +15,7 @@ import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 import useSetting from '../components/use-setting';
 import { appendSelectors } from './utils';
 import { getGapBoxControlValueFromStyle } from '../hooks/gap';
-import { shouldSkipSerialization } from '../hooks/style';
+import { shouldSkipSerialization } from '../hooks/utils';
 
 export default {
 	name: 'default',

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -15,6 +15,7 @@ import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 import useSetting from '../components/use-setting';
 import { appendSelectors } from './utils';
 import { getGapBoxControlValueFromStyle } from '../hooks/gap';
+import { shouldSkipSerialization } from '../hooks/style';
 
 export default {
 	name: 'default',
@@ -106,15 +107,25 @@ export default {
 	toolBarControls: function DefaultLayoutToolbarControls() {
 		return null;
 	},
-	save: function DefaultLayoutStyle( { selector, layout = {}, style } ) {
+	save: function DefaultLayoutStyle( {
+		selector,
+		layout = {},
+		style,
+		blockName,
+	} ) {
 		const { contentSize, wideSize } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
 		const blockGapStyleValue = getGapBoxControlValueFromStyle(
 			style?.spacing?.blockGap
 		);
+		// If a block's block.json skips serialization for spacing or
+		// spacing.blockGap, don't apply the user-defined value to the styles.
 		const blockGapValue =
-			blockGapStyleValue?.top ?? 'var( --wp--style--block-gap )';
+			blockGapStyleValue?.top &&
+			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
+				? blockGapStyleValue?.top
+				: 'var( --wp--style--block-gap )';
 
 		let output =
 			!! contentSize || !! wideSize

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Test the border block supports.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
+
+	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
+		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'borderColor' => array(
+						'type' => 'string',
+					),
+					'style'       => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'  => true,
+						'radius' => true,
+						'width'  => true,
+						'style'  => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'borderColor' => 'red',
+			'style'       => array(
+				'border' => array(
+					'radius' => '10px',
+					'width'  => '1px',
+					'style'  => 'dashed',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-border-color has-red-border-color',
+			'style' => 'border-radius: 10px; border-style: dashed; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_border_with_skipped_serialization_block_supports() {
+		$block_name = 'test/border-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_border_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_radius_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => array( 'radius', 'color' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'border-style: dotted; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -48,4 +48,84 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
+
+	function test_color_with_skipped_serialization_block_supports() {
+		$block_name = 'test/color-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text'     => '#d92828',
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_gradient_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => array( 'gradients' ),
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text' => '#d92828',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-text-color',
+			'style' => 'color: #d92828;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
 }

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Test the spacing block supports.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
+
+	function test_spacing_style_is_applied() {
+		$block_name = 'test/spacing-style-is-applied';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'   => true,
+						'padding'  => true,
+						'blockGap' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_spacing_with_skipped_serialization_block_supports() {
+		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_margin_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => array( 'margin' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'padding'  => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'margin'   => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -47,7 +47,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
+			'style' => 'padding:111px;margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px;',
 		);
 
 		$this->assertSame( $expected, $actual );
@@ -139,7 +139,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
+			'style' => 'padding-top:1px;padding-right:2px;padding-bottom:3px;padding-left:4px;',
 		);
 
 		$this->assertSame( $expected, $actual );

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -66,6 +66,80 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		unregister_block_type( $block_name );
 	}
 
+	function test_typography_with_skipped_serialization_block_supports() {
+		$block_name = 'test/typography-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'fontSize'                        => true,
+						'lineHeight'                      => true,
+						'__experimentalFontFamily'        => true,
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'      => 'serif',
+					'lineHeight'    => 'serif',
+					'fontFamily'    => '22px',
+					'letterSpacing' => '22px',
+				),
+			),
+		);
+
+		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => array(
+							'letterSpacing',
+						),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array( 'style' => array( 'typography' => array( 'letterSpacing' => '22px' ) ) );
+
+		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
 		$block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/36104

## Description

This PR allows blocks to skip the serialization of individual features within a block support toolset. For example, only skipping the serialization of `text-decoration` styles for the typography support.

Updates include:
- Modifying the `addSaveProps` filter from the `style.js` hook
- Adding some tests for the skip serialization logic
- Updating the individual block support hooks to handle array values for skip serialization flag
- Updating application of link color and block gap styles to take into account block serialization config

## How has this been tested?

1. Ran style hook tests `npm run test-unit packages/block-editor/src/hooks/test/style.js`
2. Tested static blocks:
    - Checked block supports still function
    - Ensured skipping serialization via the current boolean `__experimentalSkipSerialization` flag still works
    - Tested skipping individual features via an array configuration for `__experimentalSkipSerialization`
3. Repeated the above checks but for dynamic blocks
4. Ran PHP unit tests: 

```
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/block-supports/spacing-test.php
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/block-supports/colors-test.php
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/block-supports/border-test.php
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/block-supports/typography-test.php
```

### Testing Summary

You can use `group/block.json` as the basis for tests. Test using both the boolean – `"__experimentalSkipSerialization": true` – and the individual features, e.g., 
<details><summary>Individual skip serialization example for Group block.json</summary>

```json
		"color": {
			"gradients": true,
			"link": true,
			"__experimentalDefaultControls": {
				"background": true,
				"text": true
			},
			"__experimentalSkipSerialization": [ "gradients", "link", "background", "text" ]
		},
		"spacing": {
			"margin": [ "top", "bottom" ],
			"padding": true,
			"blockGap": true,
			"__experimentalDefaultControls": {
				"padding": true,
				"blockGap": true
			},
			"__experimentalSkipSerialization": [ "blockGap", "margin", "padding" ]
		},
		"__experimentalBorder": {
			"color": true,
			"radius": true,
			"style": true,
			"width": true,
			"__experimentalDefaultControls": {
				"color": true,
				"radius": true,
				"style": true,
				"width": true
			},
			"__experimentalSkipSerialization": [ "color", "radius", "style", "width" ]
		},
		"typography": {
			"fontSize": true,
			"lineHeight": true,
			"__experimentalFontStyle": true,
			"__experimentalFontWeight": true,
			"__experimentalLetterSpacing": true,
			"__experimentalTextTransform": true,
			"__experimentalDefaultControls": {
				"fontSize": true
			},
			"__experimentalSkipSerialization": [ "fontSize", "lineHeight", "fontStyle", "fontWeight", "letterSpacing", "textTransform" ]
		},
```
</details>

#### Group Block (static block)

| Support | Feature    | Works | Boolean Skip | Array Skip |
| ------- | ---------- |:-----:|:------------:|:----------:|
| Color   | Text       |  ✅   |      ✅      |     ✅     |
| Color   | Background |  ✅   |      ✅      |     ✅     |
| Color   | Gradient   |  ✅   |      ✅      |     ✅     |
| Color   | Link       |  ✅   |      ✅      |     ✅     |
| Border  | Color      |  ✅   |      ✅      |     ✅     |
| Border  | Radius     |  ✅   |      ✅      |     ✅     |
| Border  | Style      |  ✅   |      ✅      |     ✅     |
| Border  | Width      |  ✅   |      ✅      |     ✅     |
| Spacing | Padding    |  ✅   |      ✅      |     ✅     | 


#### Buttons Block (static block)

| Support | Feature   | Works | Boolean Skip | Array Skip |
| ------- | --------- |:-----:|:------------:|:----------:|
| Spacing | Margin    |  ✅   |      ✅      |     ✅     |
| Spacing | Block Gap |  ✅   |      ✅      |     ✅     | 

#### Paragraph Block (static block)

| Support    | Feature        | Works | Boolean Skip | Array Skip |
| ---------- | -------------- |:-----:|:------------:|:----------:|
| Typography | Font Size      |  ✅   |      ✅      |     ✅     |
| Typography | Line Height    |  ✅   |      ✅      |     ✅     |
| Typography | Font Style     |  ✅   |      ✅      |     ✅     |
| Typography | Font Weight    |  ✅   |      ✅      |     ✅     |
| Typography | Letter Spacing |  ✅   |      ✅      |     ✅     |
| Typography | Text Transform |  ✅   |      ✅      |     ✅     | 

The following block supports were manually added for testing purposes.

| Support    | Feature         | Works | Boolean Skip | Array Skip |
| ---------- | --------------- |:-----:|:------------:|:----------:|
| Typography | Font Family     |  ✅   |      ✅      |     ✅     |
| Typography | Text Decoration |  ✅   |      ✅      |     ✅     | 

#### Site Title ( dynamic block )

| Support    | Feature        | Works | Boolean Skip | Array Skip |
| ---------- | -------------- |:-----:|:------------:|:----------:|
| Color      | Text           |  ✅   |      ✅      |     ✅     |
| Color      | Background     |  ✅   |      ✅      |     ✅     |
| Color      | Gradient       |  ✅   |      ✅      |     ✅     |
| Color      | Link           |  ✅   |      ✅      |     ✅     |
| Typography | Font Family    |  ✅   |      ✅      |     ✅     |
| Typography | Font Size      |  ✅   |      ✅      |     ✅     |
| Typography | Line Height    |  ✅   |      ✅      |     ✅     |
| Typography | Font Style     |  ✅   |      ✅      |     ✅     |
| Typography | Font Weight    |  ✅   |      ✅      |     ✅     |
| Typography | Letter Spacing |  ✅   |      ✅      |     ✅     |
| Typography | Text Transform |  ✅   |      ✅      |     ✅     | 
| Spacing    | Padding        |  ✅   |      ✅      |     ✅     |
| Spacing    | Margin         |  ✅   |      ✅      |     ✅     |

The following block supports were manually added for testing purposes.

| Support | Feature | Works | Boolean Skip | Array Skip |
| ------- | ------- |:-----:|:------------:|:----------:|
| Border  | Color   |  ✅   |      ✅      |     ✅     |
| Border  | Radius  |  ✅   |      ✅      |     ✅     |
| Border  | Style   |  ✅   |      ✅      |     ✅     |
| Border  | Width   |  ✅   |      ✅      |     ✅     | 


#### Navigation ( dynamic block )

| Support    | Feature         | Works | Boolean Skip | Array Skip |
| ---------- | --------------- |:-----:|:------------:|:----------:|
| Spacing    | Block Gap       |  ✅   |      ✅      |     ✅     |
| Typography | Text Decoration |  ✅   |      ✅      |     ✅     |


## Types of changes

Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
