### PR TITLE
Polish metabox container.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,14 +1,6 @@
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
-}
-.edit-post-layout__metaboxes:not(:empty) {
-	border-top: $border-width solid $gray-300;
-	padding: 10px 0 10px;
 	clear: both;
-
-	.edit-post-meta-boxes-area {
-		margin: auto 20px;
-	}
 }
 
 // Adjust the position of the notices

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -19,6 +19,11 @@
 		box-sizing: border-box;
 	}
 
+	.postbox-header {
+		border-top: $border-width solid $gray-300;
+		border-bottom: 0;
+	}
+
 	/* Match width and positioning of the meta boxes. Override default styles. */
 	#poststuff {
 		margin: 0 auto;
@@ -34,7 +39,7 @@
 		color: inherit;
 		font-weight: 600;
 		outline: none;
-		padding: 15px;
+		padding: 0 $grid-unit-30;
 		position: relative;
 		width: 100%;
 	}
@@ -46,9 +51,8 @@
 	}
 
 	.postbox > .inside {
-		border-bottom: $border-width solid $gray-300;
 		color: inherit;
-		padding: 0 $block-padding $block-padding;
+		padding: 0 $grid-unit-30 $grid-unit-30;
 		margin: 0;
 	}
 


### PR DESCRIPTION
## Description

Recent refactors to the canvas have surfaced a double-stacked gray bar at the bottom of the post editor, this one:
<img width="1270" alt="before" src="https://user-images.githubusercontent.com/1204802/140727316-bf2becc8-d638-449b-8519-1a16c2de2798.png">

That's the metabox container, but it shows up as an empty gray bar even if you have no metaboxes. Here's how it looks when you do have metaboxes:

<img width="1270" alt="before_boxes" src="https://user-images.githubusercontent.com/1204802/140727365-d5eee277-c4df-4ecc-8ede-21cb2517de3d.png">

<img width="1270" alt="before_boxesexpanded" src="https://user-images.githubusercontent.com/1204802/140727385-c51f9b44-acfc-45d9-8e0e-73af1c26fe1c.png">

This PR refactors the metabox code to remove the gray bar unless you actually have metaboxes:

<img width="1270" alt="after_noboxes" src="https://user-images.githubusercontent.com/1204802/140727433-d9374567-548a-4573-a1c2-d36008c6ca3b.png">

In doing so, I had to touch some of the border, margin and padding rules, which also polishes the metabox presentation itself:

<img width="1270" alt="after_box" src="https://user-images.githubusercontent.com/1204802/140727492-77f1c5bf-3e69-472c-929d-bb39b4bc0560.png">

<img width="1270" alt="after_boxexpanded" src="https://user-images.githubusercontent.com/1204802/140727501-379ddeee-c6e5-43c0-842c-af07c9e89acb.png">


## How has this been tested?

Test the post editor with and without metaboxes such as the "Custom Fields" panel that you can enable in Preferences. With no metaboxes you should not see a double stacked footer bar, and when you do have metaboxes, they should be properly bordered.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
