### PR TITLE
Navigation: Small fixes

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -26,6 +26,7 @@
 			min-width: 200px !important;
 			height: auto !important;
 			width: auto !important;
+			overflow: visible !important;
 		}
 	}
 }

--- a/packages/block-library/src/navigation-submenu/style.scss
+++ b/packages/block-library/src/navigation-submenu/style.scss
@@ -13,6 +13,7 @@ button.wp-block-navigation-item__content {
 	color: currentColor;
 	font-size: inherit;
 	font-family: inherit;
+	line-height: inherit;
 
 	// Buttons default to center alignment. This becomes visible
 	// when a menu item label is long enough to wrap.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -37,6 +37,7 @@
 .wp-block-navigation__container.is-parent-of-selected-block {
 	visibility: visible;
 	opacity: 1;
+	overflow: visible;
 }
 
 // Low specificity default to ensure background color applies to submenus.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -290,24 +290,17 @@
 }
 
 // Default background and font color.
-.wp-block-navigation .wp-block-navigation__submenu-container {
-	// Set a background color for submenus so that they're not transparent.
-	// NOTE TO DEVS - if refactoring this code, please double-check that
-	// submenus have a default background color, this feature has regressed
-	// several times, so care needs to be taken.
-	background-color: #fff;
-	color: #000;
-
-	// Apply a border using an inset box-shadow instead of a border.
-	// That way, if an explicit background color is applied, it will be hidden
-	// behind the background color, so you don't end up with border and background.
-	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
-
-	// Box-shadows are removed in Windows High Contrast mode, but a transparent
-	// outline will show up as an opaque border.
-	outline: 1px solid transparent;
+.wp-block-navigation:not(.has-background) {
+	.wp-block-navigation__submenu-container {
+		// Set a background color for submenus so that they're not transparent.
+		// NOTE TO DEVS - if refactoring this code, please double-check that
+		// submenus have a default background color, this feature has regressed
+		// several times, so care needs to be taken.
+		background-color: #fff;
+		color: #000;
+		border: 1px solid rgba(0, 0, 0, 0.15);
+	}
 }
-
 
 // Navigation block inner container.
 .wp-block-navigation__container {
@@ -403,7 +396,6 @@
 				border: none;
 				padding-left: 32px;
 				padding-right: 32px;
-				box-shadow: none;
 			}
 
 			// Space unfolded items using gap and padding for submenus.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -119,16 +119,13 @@
 		// Don't take up space when the menu is collapsed.
 		width: 0;
 		height: 0;
+		overflow: hidden; // Overflow is necessary to set, otherwise submenu items will take up space.
 
 		// Submenu items.
 		> .wp-block-navigation-item {
 			> .wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
-
-				// Without this, the changing to zero on hover-out can cause wrapping and
-				// result in an invinite hover/hover-out loop.
-				white-space: nowrap;
 
 				// Right-align the chevron in submenus.
 				.wp-block-navigation__submenu-icon {
@@ -178,6 +175,7 @@
 	// Show submenus on hover unless they open on click.
 	&:where(:not(.open-on-click)):hover > .wp-block-navigation__submenu-container {
 		visibility: visible;
+		overflow: visible;
 		opacity: 1;
 		width: auto;
 		height: auto;
@@ -187,6 +185,7 @@
 	// Keep submenus open when focus is within.
 	&:where(:not(.open-on-click):not(.open-on-hover-click)):focus-within > .wp-block-navigation__submenu-container {
 		visibility: visible;
+		overflow: visible;
 		opacity: 1;
 		width: auto;
 		height: auto;
@@ -196,6 +195,7 @@
 	// Show submenus on click.
 	.wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-container {
 		visibility: visible;
+		overflow: visible;
 		opacity: 1;
 		width: auto;
 		height: auto;
@@ -290,17 +290,24 @@
 }
 
 // Default background and font color.
-.wp-block-navigation:not(.has-background) {
-	.wp-block-navigation__submenu-container {
-		// Set a background color for submenus so that they're not transparent.
-		// NOTE TO DEVS - if refactoring this code, please double-check that
-		// submenus have a default background color, this feature has regressed
-		// several times, so care needs to be taken.
-		background-color: #fff;
-		color: #000;
-		border: 1px solid rgba(0, 0, 0, 0.15);
-	}
+.wp-block-navigation .wp-block-navigation__submenu-container {
+	// Set a background color for submenus so that they're not transparent.
+	// NOTE TO DEVS - if refactoring this code, please double-check that
+	// submenus have a default background color, this feature has regressed
+	// several times, so care needs to be taken.
+	background-color: #fff;
+	color: #000;
+
+	// Apply a border using an inset box-shadow instead of a border.
+	// That way, if an explicit background color is applied, it will be hidden
+	// behind the background color, so you don't end up with border and background.
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+
+	// Box-shadows are removed in Windows High Contrast mode, but a transparent
+	// outline will show up as an opaque border.
+	outline: 1px solid transparent;
 }
+
 
 // Navigation block inner container.
 .wp-block-navigation__container {
@@ -396,7 +403,7 @@
 				border: none;
 				padding-left: 32px;
 				padding-right: 32px;
-
+				box-shadow: none;
 			}
 
 			// Space unfolded items using gap and padding for submenus.


### PR DESCRIPTION
## Description

This PR extracts a few fixes from #36292 (the text alignment rule) and from #36215 (the overflow fixes), to make for a small mostly visual bugfix oriented PR that should be easily to rebase the other two on top of.

When submenus have customized background colors, the border around them should not show. This didn't work as intended, because on the frontend, the `has-background` class is not present for submenu items:

<img width="1520" alt="Screenshot 2021-11-08 at 11 49 33" src="https://user-images.githubusercontent.com/1204802/140735685-c80bcdb4-d4e6-427a-a5de-0023e042ab46.png">

_The bug with the Submenu block not having its color set is separate._

This PR fixes it so that the `has-background` isn't needed at all, which simplifies things and also reduces specificity a bit:

<img width="650" alt="border fix" src="https://user-images.githubusercontent.com/1204802/140735916-029eb9f8-59e1-45b5-869c-cc590b3eef12.png">

It does so by moving to an inset box-shadow which just gets covered by the explicitly set color.

It also ports over this small line-height fix. Click button sizes before:

<img width="349" alt="Screenshot 2021-11-04 at 15 17 02" src="https://user-images.githubusercontent.com/1204802/140332989-020dad4c-663a-442d-b2ea-32bcb166ac39.png">

After:

<img width="318" alt="Screenshot 2021-11-04 at 15 20 37" src="https://user-images.githubusercontent.com/1204802/140333030-6e8154d7-e967-4e7c-9522-da282825824a.png">

Finally it ports over the fix where submenus could create a horizontal scrollbar even when closed, because their contents would take up space. 

## How has this been tested?

Test the navigation block with nested submenus, test with click and hover options, test with enough submenus that when opened, they cause a horizontal scrollbar, and then verify that they _don't_ when the menus are closed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
