### PR TITLE
Data: clean up registerGenericStore param names

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -528,14 +528,14 @@ _Parameters_
 
 ### registerGenericStore
 
-> **Deprecated** Use `register` instead.
+> **Deprecated** Use `register( storeDescriptor )` instead.
 
-Registers a generic store.
+Registers a generic store instance.
 
 _Parameters_
 
--   _key_ `string`: Store registry key.
--   _config_ `Object`: Configuration (getSelectors, getActions, subscribe).
+-   _name_ `string`: Store registry name.
+-   _store_ `Object`: Store instance (`{ getSelectors, getActions, subscribe }`).
 
 ### registerStore
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -158,12 +158,12 @@ export const dispatch = defaultRegistry.dispatch;
 export const subscribe = defaultRegistry.subscribe;
 
 /**
- * Registers a generic store.
+ * Registers a generic store instance.
  *
- * @deprecated Use `register` instead.
+ * @deprecated Use `register( storeDescriptor )` instead.
  *
- * @param {string} key    Store registry key.
- * @param {Object} config Configuration (getSelectors, getActions, subscribe).
+ * @param {string} name Store registry name.
+ * @param {Object} store Store instance (`{ getSelectors, getActions, subscribe }`).
  */
 export const registerGenericStore = defaultRegistry.registerGenericStore;
 


### PR DESCRIPTION
Related to #36190 -- improves param names of the `registerGenericStore` method. The second parameter is not a `config`, but a store instance, so I call it `store`. Naming the first parameter as `name` instead of `key` is also more consistent with the rest of the codebase.

**How to test:**
Shouldn't change any behavior, it's just renaming params and variables.