### PR TITLE
Navigation: Experiment with Divider component for setup state

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -8,17 +8,17 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	__experimentalDivider as Divider,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { navigation, chevronDown, Icon } from '@wordpress/icons';
+import { navigation, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
 import menuItemsToBlocks from '../../menu-items-to-blocks';
@@ -34,15 +34,16 @@ const ExistingMenusDropdown = ( {
 	onCreateFromMenu,
 } ) => {
 	const toggleProps = {
-		variant: 'primary',
+		variant: 'tertiary',
+		iconPosition: 'right',
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 	return (
 		<DropdownMenu
-			text={ __( 'Select existing menu' ) }
-			icon={ chevronDown }
+			text={ __( 'Existing menu' ) }
 			toggleProps={ toggleProps }
 			popoverProps={ { isAlternate: true } }
+			icon={ null }
 		>
 			{ ( { onClose } ) => (
 				<>
@@ -187,6 +188,20 @@ export default function NavigationPlaceholder( {
 
 	const { navigationMenus } = useNavigationMenu();
 
+	const dividerProps = {
+		orientation: 'vertical',
+	};
+	const dividerStyles = {
+		borderColor: 'black',
+		borderWidth: '0 1px 0 0',
+		borderStyle: 'solid',
+		width: '1px',
+		height: '18px',
+		marginTop: 'auto',
+		marginBottom: 'auto',
+		marginRight: '11px',
+	};
+
 	return (
 		<>
 			{ ( ! hasResolvedNavigationMenus || isStillLoading ) && (
@@ -201,6 +216,10 @@ export default function NavigationPlaceholder( {
 								<Icon icon={ navigation } />{ ' ' }
 								{ __( 'Navigation' ) }
 							</div>
+							<Divider
+								{ ...dividerProps }
+								style={ dividerStyles }
+							/>
 							{ hasMenus || navigationMenus.length ? (
 								<ExistingMenusDropdown
 									canSwitchNavigationMenu={
@@ -213,13 +232,13 @@ export default function NavigationPlaceholder( {
 									onCreateFromMenu={ onCreateFromMenu }
 								/>
 							) : undefined }
+							<Divider
+								{ ...dividerProps }
+								style={ dividerStyles }
+							/>
 							{ hasPages ? (
 								<Button
-									variant={
-										hasMenus || canSwitchNavigationMenu
-											? 'tertiary'
-											: 'primary'
-									}
+									variant="tertiary"
 									onClick={ () => {
 										setIsNewMenuModalVisible( true );
 										setCreateEmpty( false );
@@ -228,6 +247,10 @@ export default function NavigationPlaceholder( {
 									{ __( 'Add all pages' ) }
 								</Button>
 							) : undefined }
+							<Divider
+								{ ...dividerProps }
+								style={ dividerStyles }
+							/>
 							<Button
 								variant="tertiary"
 								onClick={ () => {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -386,20 +386,13 @@ $color-control-label-height: 20px;
 	font-size: $default-font-size;
 	font-family: $default-font;
 
-	.components-button.components-dropdown-menu__toggle.has-icon {
-		padding:
-			( $grid-unit-15 * 0.5 ) $grid-unit-05 ( $grid-unit-15 * 0.5 )
-			$grid-unit-15;
-		display: flex;
-		flex-direction: row-reverse; // This puts the chevron, which is hidden from screen readers, on the right.
-	}
-
 	// Margins.
 	.components-dropdown,
 	> .components-button {
 		margin-right: $grid-unit-15;
 	}
 }
+
 
 /**
  * Mobile menu.


### PR DESCRIPTION
## Description

This PR is mostly experimental as it uses the experimental `Divider` component in a way that I'm not completely sure about yet, so this is part learning how to use the components, part a potential to refine how they work. I'll get back to this in a moment.

The intent of this PR is to polish the setup state to move closer to this mockup:

<img width="1440" alt="placeholder" src="https://user-images.githubusercontent.com/1204802/140744558-2d86bd54-dcf0-4dd7-a170-72ab7bde5928.png">

That is — with simpler buttons, clearer separation, and a smaller overall footprint.

Here's what the setup state looks like in trunk:

<img width="729" alt="Screenshot 2021-11-08 at 13 45 33" src="https://user-images.githubusercontent.com/1204802/140744597-21c80dd1-4b62-4884-8672-9a62821b4b6f.png">

Here's this PR:

<img width="751" alt="Screenshot 2021-11-08 at 13 43 03" src="https://user-images.githubusercontent.com/1204802/140744670-57212f47-43a4-4fba-91b9-2c9b1376c70a.png">

To get this PR home, though, I have some questions about how I'm using the `Divider` component:

- Am I setting the orientation correctly? It appears to work insofar as it correctly sets the `aria-orientation` on the `hr` element.
- By default the intrinsic styles appear optimized towards a horizontal separator. If we mean to embrace the vertical orientation as a property, should the component itself come with some styles that work better for this orientation? 
- `border` might be the right property to set for a divider (as opposed to for example a background color paired with a border-width), but it does mean that the margins are off. For a 12px right margin I have to apply 11px because I need to subtract 1px of border. Can that be simplified?
- This might be intrinsic to these components, but the styles applied are replicated across ever instance of the component. Outside of making the component itself smarter so it can absorb some of the styles I had to write, is this expected?
- I'd love to be able to use some variables for colors and margins, both inside and outside the component. What's the best way to do this? For example we should virtually never use pure`black` in any of the components, for UI the darkest color we use is `$gray-900: #1e1e1e;`. 

Thanks for helping me understand these components! I'd be excited to help improve the Divider component itself!

## How has this been tested?

Insert a Navigation block and select it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
