### PR TITLE
Filter out duplicate menu entries when creating a Nav block from existing menu

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -37,6 +37,22 @@ const ExistingMenusDropdown = ( {
 		variant: 'primary',
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
+
+	// Get the classic menu ID that this block menu was cloned from
+	// (if it was at all).
+	const blockMenuClassicMenuIds = navigationMenus.map( ( blockMenu ) => {
+		return parseInt( blockMenu.slug.replace( 'classic_menu_', '' ) );
+	} );
+
+	// Filter out any Classic Menus that already have a cloned
+	// block based facsimilie.
+	const classicMenus = menus.filter(
+		( menu ) => ! blockMenuClassicMenuIds.includes( menu.id )
+	);
+
+	const hasClassicMenus = !! classicMenus?.length;
+	const hasBlockMenus = !! navigationMenus?.length;
+
 	return (
 		<DropdownMenu
 			text={ __( 'Select existing menu' ) }
@@ -46,39 +62,43 @@ const ExistingMenusDropdown = ( {
 		>
 			{ ( { onClose } ) => (
 				<>
-					<MenuGroup label="Menus">
-						{ canSwitchNavigationMenu &&
-							navigationMenus.map( ( menu ) => {
+					{ hasBlockMenus && (
+						<MenuGroup label="Menus">
+							{ canSwitchNavigationMenu &&
+								navigationMenus.map( ( menu ) => {
+									return (
+										<MenuItem
+											onClick={ () => {
+												setSelectedMenu( menu.id );
+												onFinish( menu );
+											} }
+											onClose={ onClose }
+											key={ menu.id }
+										>
+											{ menu.title.rendered }
+										</MenuItem>
+									);
+								} ) }
+						</MenuGroup>
+					) }
+					{ hasClassicMenus && (
+						<MenuGroup label="Classic Menus">
+							{ classicMenus.map( ( menu ) => {
 								return (
 									<MenuItem
 										onClick={ () => {
 											setSelectedMenu( menu.id );
-											onFinish( menu );
+											onCreateFromMenu( menu.name );
 										} }
 										onClose={ onClose }
 										key={ menu.id }
 									>
-										{ menu.title.rendered }
+										{ menu.name }
 									</MenuItem>
 								);
 							} ) }
-					</MenuGroup>
-					<MenuGroup label="Classic Menus">
-						{ menus.map( ( menu ) => {
-							return (
-								<MenuItem
-									onClick={ () => {
-										setSelectedMenu( menu.id );
-										onCreateFromMenu( menu.name );
-									} }
-									onClose={ onClose }
-									key={ menu.id }
-								>
-									{ menu.name }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
+						</MenuGroup>
+					) }
 				</>
 			) }
 		</DropdownMenu>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/36307 we learnt that because we're auto-creating copies of classic menus on Theme switch from classic -> block based theme, we end up with duplicate entries under the the `Create from existing menu...` option in the Nav block placeholder.

This PR is a initial (possibly naive) attempt at resolving that situation by filtering out any classic menus that already have a block-based facsimilie.

### Potential concerns

- What if I've edited the block based facsimilie but I broke things and want to restart from the original Classic Menu?
- We're relying on the slug containing the ID of the original classic menu. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Activate classic theme.
2. Create some Menus and name them clearly.
3. Switch to a block based Theme.
4. Go to Site Editor.
5. Create Navigation block.
6. See Nav block placeholder.
7. Click `Select existing menu...`
8. There should be no group in the dropdown for `Classic Menus` (we've filtered those out).
9. Under `Menus` you should see entries for each of your classic menus (those you created above). These will be prefixed with `Classic Menu:` - note this PR does not add that functionality. 


Bottom line: we're just verifying any classic Menus which have block-based facsimilies are not listed.

## Screenshots <!-- if applicable -->

<img width="662" alt="Screen Shot 2021-11-08 at 14 56 43" src="https://user-images.githubusercontent.com/444434/140764647-7e90b6c6-4018-4915-8188-5790860cde58.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
