### PR TITLE
Cover Block: Fix default background dim

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -43,16 +43,16 @@
 	 *   - Issue with background color specificity: https://github.com/WordPress/gutenberg/issues/26545
 	 *   - Issue with alternative fix: https://github.com/WordPress/gutenberg/issues/26545
 	 */
-	&.has-background-dim:not([class*="-background-color"]) {
+	.has-background-dim:not([class*="-background-color"]) {
 		background-color: $black;
 	}
 
-	&.has-background-dim::before {
+	.has-background-dim::before {
 		content: "";
 		background-color: inherit;
 	}
 
-	&.has-background-dim:not(.has-background-gradient)::before,
+	.has-background-dim:not(.has-background-gradient)::before,
 	.wp-block-cover__gradient-background {
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
## Description
After #35065, the default background dim for the Cover block disappeared. This PR fixes it. 

## What caused the bug?
In #35065 we changed the Cover block's markup which caused the `has-background-dim` class to not take effect anymore as it's no longer paired with the top-level `wp-block-cover` class. This PR fixes the `has-background-dim` class dependency.

Default Cover block's markup before #35065:

```html
<div class="wp-block-cover has-background-dim-40 is-light has-background-dim">
  <img
    class="wp-block-cover__image-background wp-image-123"
    alt=""
    src="/foo.jpg"
    data-object-fit="cover"
  />
  <div class="wp-block-cover__inner-container"></div>
</div>
```

Default Cover block's markup after #35065:

```html
<div class="wp-block-cover is-light">
  <span
    aria-hidden="true"
    class="has-background-dim-40 wp-block-cover__gradient-background has-background-dim">
  </span>
  <img
    class="wp-block-cover__image-background wp-image-123"
    alt=""
    src="/foo.jpg"
    data-object-fit="cover"
  />
  <div class="wp-block-cover__inner-container"></div>
</div>
```


Fixes https://github.com/WordPress/gutenberg/issues/36310

## How has this been tested?
1. Checkout `trunk`
2. Start local env (`npx wp-env start && npm run dev`)
2. Add Cover Block with some bright background image
3. See that the background is not dimmed and the opacity control doesn't have any effect on it
4. Checkout this branch
5. Refresh the page
6. See that the background is dimmed and its opacity can be changed.

## Screenshots

| Before | After |
| ------------- | ------------- |
| <img width="641" alt="Screenshot 2021-11-08 at 15 47 50" src="https://user-images.githubusercontent.com/1451471/140763533-88b89138-3adb-4f91-ba7e-ce19148ee6e1.png"> | <img width="639" alt="Screenshot 2021-11-08 at 15 47 24" src="https://user-images.githubusercontent.com/1451471/140763486-032dafa8-902a-4edf-95ac-afea1dce8bc7.png"> |


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
