### PR TITLE
Site Editor: Update back button URL

### DIFF
--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -22,6 +22,7 @@ function gutenberg_register_template_part_post_type() {
 		'new_item'              => __( 'New Template Part', 'gutenberg' ),
 		'edit_item'             => __( 'Edit Template Part', 'gutenberg' ),
 		'view_item'             => __( 'View Template Part', 'gutenberg' ),
+		'view_items'            => __( 'View Template Parts', 'gutenberg' ),
 		'all_items'             => __( 'All Template Parts', 'gutenberg' ),
 		'search_items'          => __( 'Search Template Parts', 'gutenberg' ),
 		'parent_item_colon'     => __( 'Parent Template Part:', 'gutenberg' ),

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -22,6 +22,7 @@ function gutenberg_register_template_post_type() {
 		'new_item'              => __( 'New Template', 'gutenberg' ),
 		'edit_item'             => __( 'Edit Template', 'gutenberg' ),
 		'view_item'             => __( 'View Template', 'gutenberg' ),
+		'view_items'            => __( 'View Templates', 'gutenberg' ),
 		'all_items'             => __( 'All Templates', 'gutenberg' ),
 		'search_items'          => __( 'Search Templates', 'gutenberg' ),
 		'parent_item_colon'     => __( 'Parent Template:', 'gutenberg' ),

--- a/packages/edit-site/src/components/header/navigation-link/index.js
+++ b/packages/edit-site/src/components/header/navigation-link/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -19,10 +24,12 @@ import { addQueryArgs } from '@wordpress/url';
 import { store as editSiteStore } from '../../../store';
 
 function NavigationLink( { icon } ) {
-	const { isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
+	const { isRequestingSiteIcon, templateType, siteIconUrl } = useSelect(
 		( select ) => {
 			const { getEditedPostType } = select( editSiteStore );
-			const { getEntityRecord, isResolving } = select( coreDataStore );
+			const { getEntityRecord, getPostType, isResolving } = select(
+				coreDataStore
+			);
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
@@ -32,7 +39,7 @@ function NavigationLink( { icon } ) {
 					'__unstableBase',
 					undefined,
 				] ),
-				postType: getEditedPostType(),
+				templateType: getPostType( getEditedPostType() ),
 				siteIconUrl: siteData.site_icon_url,
 			};
 		},
@@ -70,10 +77,14 @@ function NavigationLink( { icon } ) {
 		<motion.div className="edit-site-navigation-link" whileHover="expand">
 			<Button
 				className="edit-site-navigation-link__button has-icon"
-				label={ __( 'Back' ) }
 				href={ addQueryArgs( 'edit.php', {
-					post_type: postType,
+					post_type: templateType?.slug,
 				} ) }
+				label={ get(
+					templateType,
+					[ 'labels', 'view_items' ],
+					__( 'Back' )
+				) }
 			>
 				{ buttonIcon }
 			</Button>

--- a/packages/edit-site/src/components/header/navigation-link/index.js
+++ b/packages/edit-site/src/components/header/navigation-link/index.js
@@ -11,22 +11,33 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
 
 function NavigationLink( { icon } ) {
-	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
-		const { getEntityRecord, isResolving } = select( coreDataStore );
-		const siteData =
-			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+	const { isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
+		( select ) => {
+			const { getEditedPostType } = select( editSiteStore );
+			const { getEntityRecord, isResolving } = select( coreDataStore );
+			const siteData =
+				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
-		return {
-			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
-		};
-	}, [] );
+			return {
+				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+					'root',
+					'__unstableBase',
+					undefined,
+				] ),
+				postType: getEditedPostType(),
+				siteIconUrl: siteData.site_icon_url,
+			};
+		},
+		[]
+	);
 
 	const disableMotion = useReducedMotion();
 
@@ -59,8 +70,10 @@ function NavigationLink( { icon } ) {
 		<motion.div className="edit-site-navigation-link" whileHover="expand">
 			<Button
 				className="edit-site-navigation-link__button has-icon"
-				label={ __( 'Dashboard' ) }
-				href="index.php"
+				label={ __( 'Back' ) }
+				href={ addQueryArgs( 'edit.php', {
+					post_type: postType,
+				} ) }
 			>
 				{ buttonIcon }
 			</Button>


### PR DESCRIPTION
## Description
The follow-up to a https://github.com/WordPress/gutenberg/pull/36294#issuecomment-963062833

Update logic for the W go bach button and return the user to a Templates or Template Parts list view.

## How has this been tested?
1. Go to Appearance -> Editor
2. Clicking on the W button should take you templates list screen.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
