### PR TITLE
Schemas: Update schema URL to wp.org domain

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -6,7 +6,7 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 
 ```json
 {
-	"$schema": "https://json.schemastore.org/block.json",
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "my-plugin/notice",
 	"title": "Notice",
@@ -61,7 +61,7 @@ The [WordPress Plugins Directory](https://wordpress.org/plugins/) can detect `bl
 Development is improved by using a defined schema definition file. Supported editors can provide help like tooltips, autocomplete, and schema validation. To use the schema, add the following to the top of the `block.json`.
 
 ```json
-"$schema": "https://json.schemastore.org/block.json"
+"$schema": "https://schemas.wp.org/trunk/block.json"
 ```
 
 ## Block registration

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -177,7 +177,7 @@ module.exports = {
 
 The following configurable variables are used with the template files. Template authors can change default values to use when users don't provide their data:
 
--   `$schema` (default: `https://json.schemastore.org/block.json`)
+-   `$schema` (default: `https://schemas.wp.org/trunk/block.json`)
 -   `apiVersion` (default: `2`) - see https://make.wordpress.org/core/2020/11/18/block-api-version-2/.
 -   `slug` (no default)
 -   `namespace` (default: `'create-block'`)

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -185,7 +185,7 @@ const getBlockTemplate = async ( templateName ) => {
 
 const getDefaultValues = ( blockTemplate ) => {
 	return {
-		$schema: 'https://json.schemastore.org/block.json',
+		$schema: 'https://schemas.wp.org/trunk/block.json',
 		apiVersion: 2,
 		namespace: 'create-block',
 		category: 'widgets',


### PR DESCRIPTION

## Description

Update block.json schemas URL to: https://schemas.wp.org/trunk/block.json

A redirect is in place for the wp.org domain that redirects to the schemas in GitHub.
This updates the docs and create-block script to use the wp.org domain.

## How has this been tested?

Confirm URL updates are correct.


## Types of changes

Switch URLs from SchemaStore to wp.org domain.

