### PR TITLE
[RNMobile] Address `act` warnings on embed block integration tests

### DIFF
--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -37,6 +37,16 @@ jest.mock( 'react-native-modal', () => {
 	const mockComponent = require( 'react-native/jest/mockComponent' );
 	return mockComponent( 'react-native-modal' );
 } );
+
+// Mock debounce to prevent potentially belated state updates.
+jest.mock( 'lodash', () => ( {
+	...jest.requireActual( 'lodash' ),
+	debounce: ( fn ) => {
+		fn.cancel = jest.fn();
+		return fn;
+	},
+} ) );
+
 const MODAL_DISMISS_EVENT = Platform.OS === 'ios' ? 'onDismiss' : 'onModalHide';
 
 // oEmbed response mocks


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR mocks the Lodash `debounce` function in the embed block integration tests, to prevent `act` warnings ([example reference](https://github.com/WordPress/gutenberg/runs/4137677634?check_suite_focus=true#step:5:85)) produced by belated React state updates from the `RichText` component when creating undo levels. Note that these warnings are not being logged persistently in the Mobile unit tests workflow.

As you can see in the following code references, the `RichText` component debounces the call to the `onCreateUndoLevel` event when the text is updated. This implies that `onCreateUndoLevel` will be called one second after the update, since this event dispatches a Redux action that updates the `block-editor` store, this leads to some of the components to potentially update their states. Therefore some of these state updates might be detected by the React Native library and log `act` warnings.

<details><summary>Click here to show code references</summary>

https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/rich-text/src/component/index.native.js#L96
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/rich-text/src/component/index.native.js#L1058
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/rich-text/src/component/index.native.js#L282-L297
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/rich-text/src/component/index.native.js#L301-L313
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/rich-text/src/component/index.native.js#L232-L239
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/block-editor/src/components/rich-text/index.native.js#L590
https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/block-editor/src/store/actions.js#L1069-L1071

</details>

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
The debounce explains why the warnings are not always logged, as it depends on how fast the tests are run. The only way I managed to reproduce it on every run is by adding the following function, and invoke it in tests that update the content of a `RichText` like the `sets block caption` test case ([reference](https://github.com/WordPress/gutenberg/blob/57ebf865231e3b81d6dbcc3286f846b2e142bf40/packages/block-library/src/embed/test/index.native.js#L911-L937)).

```
const waitSeconds = ( ms ) =>
	new Promise( ( resolve ) => setTimeout( resolve, ms ) );
```

1. Apply the following patch diff.
```diff
diff --git a/packages/block-library/src/embed/test/index.native.js b/packages/block-library/src/embed/test/index.native.js
index fb37b437b9c840b9bc373e78c462789e95079941..7181dffcdcfcde1bd427b38a9ff8e7e6aa859baa 100644
--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -30,6 +30,9 @@ import * as paragraph from '../../paragraph';
 import * as embed from '..';
 import { registerBlock } from '../..';
 
+const waitSeconds = ( ms ) =>
+	new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+
 // Override modal mock to prevent unmounting it when is not visible.
 // This is required to be able to trigger onClose and onDismiss events when
 // the modal is dismissed.
@@ -942,6 +945,8 @@ describe( 'Embed block', () => {
 			getByDisplayValue( `<p>${ expectedCaption }</p>` )
 		);
 
+		await waitSeconds( 2000 );
+
 		expect( caption ).toBeDefined();
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );

```

2. Run the command `npm run native test -- embed/test`.
3. Observe that the `act` warnings are no longer logged.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
