### PR TITLE
FSE: Add template_type guards

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -218,6 +218,10 @@ if ( ! function_exists( '_get_block_template_file' ) ) {
 	 * @return array|null Template.
 	 */
 	function _get_block_template_file( $template_type, $slug ) {
+		if ( 'wp_template' !== $template_type && 'wp_template_part' !== $template_type ) {
+			return null;
+		}
+
 		$template_base_paths = array(
 			'wp_template'      => 'block-templates',
 			'wp_template_part' => 'block-template-parts',
@@ -264,6 +268,10 @@ if ( ! function_exists( '_get_block_templates_files' ) ) {
 	 * @return array Template.
 	 */
 	function _get_block_templates_files( $template_type ) {
+		if ( 'wp_template' !== $template_type && 'wp_template_part' !== $template_type ) {
+			return null;
+		}
+
 		$template_base_paths = array(
 			'wp_template'      => 'block-templates',
 			'wp_template_part' => 'block-template-parts',


### PR DESCRIPTION
Carried over from https://github.com/WordPress/wordpress-develop/pull/1796; see https://github.com/WordPress/wordpress-develop/pull/1796/files#r744135286 for background.

props @hellofromtonya

## Description
In two block template theme helper functions that attempt to access theme subdirectories based on `$template_type`, add guards to make sure that it's either `wp_template` or `wp_template_part`.

## How has this been tested?
Verify that block-based themes continue to work.

## Types of changes
Minor improvement.
