### PR TITLE
Add spacing attributes to comment author avatar

### DIFF
--- a/packages/block-library/src/comment-author-avatar/block.json
+++ b/packages/block-library/src/comment-author-avatar/block.json
@@ -30,6 +30,11 @@
 			"background": true,
 			"text": false,
 			"links": false
+		},
+		"spacing": {
+			"__experimentalSkipSerialization": true,
+			"margin": true,
+			"padding": true
 		}
 	}
 }

--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
+} from '@wordpress/block-editor';
 import { PanelBody, ResizableBox, RangeControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { __, _x, isRTL } from '@wordpress/i18n';
@@ -31,6 +35,7 @@ export default function Edit( {
 	const minSize = sizes ? sizes[ 0 ] : 24;
 	const maxSize = sizes ? sizes[ sizes.length - 1 ] : 96;
 	const blockProps = useBlockProps();
+	const spacingProps = useSpacingProps( attributes );
 	const maxSizeBuffer = Math.floor( maxSize * 2.5 );
 
 	const inspectorControls = (
@@ -90,7 +95,7 @@ export default function Edit( {
 	return (
 		<>
 			{ inspectorControls }
-			<div>{ displayAvatar }</div>
+			<div { ...spacingProps }>{ displayAvatar }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/comment-author-avatar/index.php
+++ b/packages/block-library/src/comment-author-avatar/index.php
@@ -29,23 +29,22 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 	/**
 	 * We get the spacing attributes and transform the array provided into a string formatted for being applied as a style html tag.
 	 * Good candidate to be moved to a separate function in core.
-	 *
-	**/
-	$spacing_attributes = isset($attributes['style']['spacing']) ? $attributes['style']['spacing'] : null;
-	if ( isset($spacing_attributes) && ! empty( $spacing_attributes ) ) {
-	$spacing_array = array();
-	foreach ( $spacing_attributes as $spacing_attribute_key => $spacing_attribute_value ) {
-		foreach ($spacing_attribute_value as $position_key => $position_value) {
-			$spacing_array[] = $spacing_attribute_key . '-' . $position_key . ': ' . $position_value;
+	*/
+	$spacing_attributes = isset( $attributes['style']['spacing'] ) ? $attributes['style']['spacing'] : null;
+	if ( isset( $spacing_attributes ) && ! empty( $spacing_attributes ) ) {
+		$spacing_array = array();
+		foreach ( $spacing_attributes as $spacing_attribute_key => $spacing_attribute_value ) {
+			foreach ( $spacing_attribute_value as $position_key => $position_value ) {
+				$spacing_array[] = $spacing_attribute_key . '-' . $position_key . ': ' . $position_value;
+			}
 		}
-	}
-	$spacing_string = implode( ';', $spacing_array );
+		$spacing_string = implode( ';', $spacing_array );
 	}
 
-	$width              = isset( $attributes['width'] ) ? $attributes['width'] : 96;
-	$height             = isset( $attributes['height'] ) ? $attributes['height'] : 96;
-	$styles             = isset( $wrapper_attributes['style'] ) ? $wrapper_attributes['style'] : '';
-	$classes            = isset( $wrapper_attributes['class'] ) ? $wrapper_attributes['class'] : '';
+	$width   = isset( $attributes['width'] ) ? $attributes['width'] : 96;
+	$height  = isset( $attributes['height'] ) ? $attributes['height'] : 96;
+	$styles  = isset( $wrapper_attributes['style'] ) ? $wrapper_attributes['style'] : '';
+	$classes = isset( $wrapper_attributes['class'] ) ? $wrapper_attributes['class'] : '';
 
 	/* translators: %s is the Comment Author name */
 	$alt = sprintf( __( '%s Avatar' ), $comment->comment_author );
@@ -62,10 +61,10 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 			'class'      => $classes,
 		)
 	);
-	if (isset($spacing_attributes)) {
-		return sprintf('<div style="%1s">%2s</div>', $spacing_string, $avatar_block);
+	if ( isset( $spacing_attributes ) ) {
+		return sprintf( '<div style="%1s">%2s</div>', $spacing_string, $avatar_block );
 	}
-	return sprintf('<div>%1s</div>', $avatar_block);
+	return sprintf( '<div>%1s</div>', $avatar_block );
 }
 
 /**

--- a/packages/block-library/src/comment-author-avatar/index.php
+++ b/packages/block-library/src/comment-author-avatar/index.php
@@ -25,6 +25,23 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 
 	// This is the only way to retreive style and classes on different instances.
 	$wrapper_attributes = WP_Block_Supports::get_instance()->apply_block_supports();
+
+	/**
+	 * We get the spacing attributes and transform the array provided into a string formatted for being applied as a style html tag.
+	 * Good candidate to be moved to a separate function in core.
+	 *
+	**/
+	$spacing_attributes = isset($attributes['style']['spacing']) ? $attributes['style']['spacing'] : null;
+	if ( isset($spacing_attributes) && ! empty( $spacing_attributes ) ) {
+	$spacing_array = array();
+	foreach ( $spacing_attributes as $spacing_attribute_key => $spacing_attribute_value ) {
+		foreach ($spacing_attribute_value as $position_key => $position_value) {
+			$spacing_array[] = $spacing_attribute_key . '-' . $position_key . ': ' . $position_value;
+		}
+	}
+	$spacing_string = implode( ';', $spacing_array );
+	}
+
 	$width              = isset( $attributes['width'] ) ? $attributes['width'] : 96;
 	$height             = isset( $attributes['height'] ) ? $attributes['height'] : 96;
 	$styles             = isset( $wrapper_attributes['style'] ) ? $wrapper_attributes['style'] : '';
@@ -33,7 +50,7 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 	/* translators: %s is the Comment Author name */
 	$alt = sprintf( __( '%s Avatar' ), $comment->comment_author );
 
-	$avatar_string = get_avatar(
+	$avatar_block = get_avatar(
 		$comment,
 		null,
 		'',
@@ -45,7 +62,10 @@ function render_block_core_comment_author_avatar( $attributes, $content, $block 
 			'class'      => $classes,
 		)
 	);
-	return $avatar_string;
+	if (isset($spacing_attributes)) {
+		return sprintf('<div style="%1s">%2s</div>', $spacing_string, $avatar_block);
+	}
+	return sprintf('<div>%1s</div>', $avatar_block);
 }
 
 /**


### PR DESCRIPTION
## Description
With this PR, we are adding spacing attributes (margin and padding) to the Comment Author Avatar.
We include specific PHP code in order to apply some styles to the wrapper and other styles to the image tag.
Please, feel free to propose a better solution if possible, as I could not find any core function that provides the attribute non serialized in a style HTML attribute string.

Maybe is a good idea to include a function to return scoped styles and classes with supports fields in block.json attributes. For example:
`get_scoped_style_and_classes(['spacing', 'border']);

I would be happy to work on that function if is a good approach.

## How has this been tested?

- Add Comment Author Avatar
- Tested adding padding, margin, and removing them.
- Check code both on editor and frontend.

## Screenshots <!-- if applicable -->
Editor:
![editor](https://user-images.githubusercontent.com/37012961/140803753-cf6f0175-5582-461e-9472-f2582cc6418e.png)

Frontend:
![frontend](https://user-images.githubusercontent.com/37012961/140803790-4ab66ade-3380-4ad5-a167-3e34bf6525ba.png


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New small feature. Comment Author Avatar Update.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
