### PR TITLE
Gallery: Make sure the mobile warning notice only runs when images are added to a new block

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -97,7 +97,7 @@ function GalleryEdit( props ) {
 		shortCodeTransforms,
 		sizeSlug,
 	} = attributes;
-	useMobileWarning();
+
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceInnerBlocks,
@@ -138,6 +138,8 @@ function GalleryEdit( props ) {
 	const imageData = useGetMedia( innerBlockImages );
 
 	const newImages = useGetNewImages( images, imageData );
+
+	useMobileWarning( newImages );
 
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {

--- a/packages/block-library/src/gallery/use-mobile-warning.js
+++ b/packages/block-library/src/gallery/use-mobile-warning.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as noticesStore } from '@wordpress/notices';
 
-export default function useMobileWarning() {
+export default function useMobileWarning( newImages ) {
 	const { createWarningNotice } = useDispatch( noticesStore );
 	const { toggleFeature } = useDispatch( interfaceStore );
 	const isMobileWarningActive = useSelect( ( select ) => {
@@ -14,7 +14,7 @@ export default function useMobileWarning() {
 		return isFeatureActive( 'core/edit-post', 'mobileGalleryWarning' );
 	}, [] );
 
-	if ( ! isMobileWarningActive ) {
+	if ( ! isMobileWarningActive || ! newImages ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
Currently the new warning added to alert users to mobile app compatibility issues with the new gallery block also shows if you mouse over the Gallery block preview. This PR makes sure it only runs if images are added to a new gallery block.

## How has this been tested?

- Clear the local storage for  local devs site
- Check out this PR
- Load editor and make sure editor welcome dialog shows to indicate storage is cleared
- In the main block inserter on left mouse over gallery block and ensure no mobile warning displays
- Add a gallery block and add images to it and make sure mobile warning displays when images added

## Screenshots

Before:
![gallery-m-before](https://user-images.githubusercontent.com/3629020/140818195-fd5b4a7a-b7d1-4c8b-a448-5310b81326c8.gif)

After:
![gallery-m-after](https://user-images.githubusercontent.com/3629020/140818211-9642a717-33b3-4d65-b30d-f6c449d2bce0.gif)

