### PR TITLE
Update theme.json schema to refer to wp.org URL

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -981,9 +981,9 @@ Currently block variations exist for "header" and "footer" values of the area te
 
 ## Developing with theme.json
 
-It can be difficult to remember the theme.json settings and properties while you develop, so a JSON scheme was created to help. The schema is available at [SchemaStore.org](https://schemastore.org/)
+It can be difficult to remember the theme.json settings and properties while you develop, so a JSON scheme was created to help. The schema is available at https://schemas.wp.org/trunk/theme.json
 
-Editors can pick up the schema and can provide help like tooltips, autocomplete, or schema validation in the editor. To use the schema in Visual Studio Code, add `"$schema": "https://json.schemastore.org/theme-v1.json"` to the beginning of your theme.json file.
+Code editors can pick up the schema and can provide help like tooltips, autocomplete, or schema validation in the editor. To use the schema in Visual Studio Code, add `"$schema": "https://schemas.wp.org/trunk/theme.json"` to the beginning of your theme.json file.
 
 ![Example using validation with schema](https://developer.wordpress.org/files/2021/10/schema-validation.gif)
 


### PR DESCRIPTION

## Description

Updates the URL for theme.json schema to refer to https://schemas.wp.org/trunk/theme.json

A redirect is in place for the wp.org domain that redirects to the schemas in GitHub.
This updates the docs and create-block script to use the wp.org domain.

## How has this been tested?

Confirm URL updates are correct.


## Types of changes

Switch URLs from SchemaStore to wp.org domain.
