### PR TITLE
Fix .wp-env.json to WP 5.8.1

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#4c3a23ba408a4e3b2bb00d63a6ba55e36115e8ca",
+	"core": "WordPress/WordPress#5.8.1",
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#5.8.1",
+	"core": "WordPress/WordPress#065c639a2a998cf0053533a5d42ce361d271d2f3",
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress",
+	"core": "WordPress/WordPress#5.8",
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#5.8",
+	"core": "WordPress/WordPress#5.8.1",
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#065c639a2a998cf0053533a5d42ce361d271d2f3",
+	"core": "WordPress/WordPress#4c3a23ba408a4e3b2bb00d63a6ba55e36115e8ca",
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {

--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -16,7 +16,7 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 	function test_kses_doesnt_change_fixtures( $block, $filename ) {
 		// Skip this test while Gutenberg is pinned to WordPress 5.8.1.
 		// Once WordPress 5.9 is released, this test can be re-enabled.
-		// See: https://github.com/WordPress/gutenberg/pull/35611
+		// See: https://github.com/WordPress/gutenberg/pull/35611.
 		$this->markTestSkipped( 'This test requires WordPress 5.9. See: https://core.trac.wordpress.org/ticket/54261' );
 
 		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.

--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -14,6 +14,10 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 	 * @dataProvider data_block_fixtures
 	 */
 	function test_kses_doesnt_change_fixtures( $block, $filename ) {
+		// Skip this test while Gutenberg is pinned to WordPress 5.8.1.
+		// Once WordPress 5.9 is released, this test can be re-enabled.
+		// See: https://github.com/WordPress/gutenberg/pull/35611
+		$this->markTestSkipped( 'This test requires WordPress 5.9. See: https://core.trac.wordpress.org/ticket/54261' );
 
 		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
 		$block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -177,7 +177,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	function test_merges_child_theme_json_into_parent_theme_json() {
 		switch_theme( 'block-theme-child' );
 
-		$actual_settings   = WP_Theme_JSON_Resolver::get_theme_data()->get_settings();
+		$actual_settings   = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
 		$expected_settings = array(
 			'color'      => array(
 				'custom'         => false,
@@ -250,7 +250,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame(
-			WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates(),
+			WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_custom_templates(),
 			array(
 				'page-home' => array(
 					'title'     => 'Homepage',


### PR DESCRIPTION
Try fixing .wp-env.json to the 5.8.1 branch as a temporary fix for Gutenberg CI. This should unblock Gutenberg developers while the plugin is made compatible with WordPress trunk.

### Other changes include:

* Skip the `test_kses_doesnt_change_fixtures` tests introduced in https://github.com/WordPress/gutenberg/pull/35611. These tests depend on a change in WordPress 5.9 (https://core.trac.wordpress.org/ticket/54261), so in order to get the tests passing in 5.8.1, for the moment these tests are marked as skipped.
* The `test_merges_child_theme_json_into_parent_theme_json` test for the theme resolver was pointing to the core `WP_Theme_JSON_Resolver` class instead of the Gutenberg one `WP_Theme_JSON_Resolver_Gutenberg`. This PR updates the test to use the latter so we're targeting the Gutenberg class.