### PR TITLE
Site Editor: Remove duplicate menu item

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -39,6 +39,10 @@ function gutenberg_remove_legacy_pages() {
 				$indexes_to_remove[] = $index;
 			}
 
+			if ( false !== strpos( $menu_item[2], 'site-editor.php' ) ) {
+				$indexes_to_remove[] = $index;
+			}
+
 			if ( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ) {
 				$indexes_to_remove[] = $index;
 			}


### PR DESCRIPTION
## Description
Removes core Site Editor menu item when Gutenberg plugin is used.

The plugin still has to support the older WP version. We should drop the custom page after WP 5.9 is the minimum requirement.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|  ![CleanShot 2021-11-10 at 16 57 35](https://user-images.githubusercontent.com/240569/141117549-6bef226d-c476-43bf-96c2-c13930b9b923.png)  | ![CleanShot 2021-11-10 at 16 57 58](https://user-images.githubusercontent.com/240569/141117558-ebca35f3-500c-439b-a28b-8495a676b7f3.png) |

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
