### PR TITLE
Data: remove usage of deprecated register methods

### DIFF
--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -723,42 +723,42 @@ describe( 'useSelect', () => {
 		it( 'handles custom generic stores without a unsubscribe function', () => {
 			let renderer;
 
-			function createCustomStore() {
-				let storeChanged = () => {};
-				let counter = 0;
+			const customStore = {
+				name: 'generic-store',
+				instantiate() {
+					let storeChanged = () => {};
+					let counter = 0;
 
-				const selectors = {
-					getCounter: () => counter,
-				};
+					const selectors = {
+						getCounter: () => counter,
+					};
 
-				const actions = {
-					increment: () => {
-						counter += 1;
-						storeChanged();
-					},
-				};
+					const actions = {
+						increment: () => {
+							counter += 1;
+							storeChanged();
+						},
+					};
 
-				return {
-					getSelectors() {
-						return selectors;
-					},
-					getActions() {
-						return actions;
-					},
-					subscribe( listener ) {
-						storeChanged = listener;
-					},
-				};
-			}
+					return {
+						getSelectors() {
+							return selectors;
+						},
+						getActions() {
+							return actions;
+						},
+						subscribe( listener ) {
+							storeChanged = listener;
+						},
+					};
+				},
+			};
 
-			registry.registerGenericStore(
-				'generic-store',
-				createCustomStore()
-			);
+			registry.register( customStore );
 
 			const TestComponent = jest.fn( () => {
 				const state = useSelect(
-					( select ) => select( 'generic-store' ).getCounter(),
+					( select ) => select( customStore ).getCounter(),
 					[]
 				);
 
@@ -778,7 +778,7 @@ describe( 'useSelect', () => {
 			expect( testInstance.findByType( 'div' ).props.data ).toBe( 0 );
 
 			act( () => {
-				registry.dispatch( 'generic-store' ).increment();
+				registry.dispatch( customStore ).increment();
 			} );
 
 			expect( testInstance.findByType( 'div' ).props.data ).toBe( 1 );

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -7,8 +7,7 @@ import { mapValues, isObject, forEach } from 'lodash';
  * Internal dependencies
  */
 import createReduxStore from './redux-store';
-import createCoreDataStore from './store';
-import { STORE_NAME } from './store/name';
+import coreDataStore from './store';
 import { createEmitter } from './utils/emitter';
 
 /** @typedef {import('./types').WPDataStore} WPDataStore */
@@ -286,11 +285,11 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		return registry;
 	}
 
-	registerGenericStore( STORE_NAME, createCoreDataStore( registry ) );
+	registry.register( coreDataStore );
 
-	Object.entries( storeConfigs ).forEach( ( [ name, config ] ) =>
-		registry.registerStore( name, config )
-	);
+	for ( const [ name, config ] of Object.entries( storeConfigs ) ) {
+		registry.register( createReduxStore( name, config ) );
+	}
 
 	if ( parent ) {
 		parent.subscribe( globalListener );

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { STORE_NAME } from './store/name';
+import coreDataStore from './store';
 
 /** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
 
@@ -24,7 +24,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 	next
 ) => ( action ) => {
 	const resolvers = registry
-		.select( STORE_NAME )
+		.select( coreDataStore )
 		.getCachedResolvers( reducerKey );
 	Object.entries( resolvers ).forEach(
 		( [ selectorName, resolversByArgs ] ) => {
@@ -49,7 +49,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 
 				// Trigger cache invalidation
 				registry
-					.dispatch( STORE_NAME )
+					.dispatch( coreDataStore )
 					.invalidateResolution( reducerKey, selectorName, args );
 			} );
 		}

--- a/packages/data/src/store/index.js
+++ b/packages/data/src/store/index.js
@@ -1,53 +1,54 @@
-function createCoreDataStore( registry ) {
-	const getCoreDataSelector = ( selectorName ) => ( key, ...args ) => {
-		return registry.select( key )[ selectorName ]( ...args );
-	};
+const coreDataStore = {
+	name: 'core/data',
+	instantiate( registry ) {
+		const getCoreDataSelector = ( selectorName ) => ( key, ...args ) => {
+			return registry.select( key )[ selectorName ]( ...args );
+		};
 
-	const getCoreDataAction = ( actionName ) => ( key, ...args ) => {
-		return registry.dispatch( key )[ actionName ]( ...args );
-	};
+		const getCoreDataAction = ( actionName ) => ( key, ...args ) => {
+			return registry.dispatch( key )[ actionName ]( ...args );
+		};
 
-	return {
-		getSelectors() {
-			return [
-				'getIsResolving',
-				'hasStartedResolution',
-				'hasFinishedResolution',
-				'isResolving',
-				'getCachedResolvers',
-			].reduce(
-				( memo, selectorName ) => ( {
-					...memo,
-					[ selectorName ]: getCoreDataSelector( selectorName ),
-				} ),
-				{}
-			);
-		},
+		return {
+			getSelectors() {
+				return Object.fromEntries(
+					[
+						'getIsResolving',
+						'hasStartedResolution',
+						'hasFinishedResolution',
+						'isResolving',
+						'getCachedResolvers',
+					].map( ( selectorName ) => [
+						selectorName,
+						getCoreDataSelector( selectorName ),
+					] )
+				);
+			},
 
-		getActions() {
-			return [
-				'startResolution',
-				'finishResolution',
-				'invalidateResolution',
-				'invalidateResolutionForStore',
-				'invalidateResolutionForStoreSelector',
-			].reduce(
-				( memo, actionName ) => ( {
-					...memo,
-					[ actionName ]: getCoreDataAction( actionName ),
-				} ),
-				{}
-			);
-		},
+			getActions() {
+				return Object.fromEntries(
+					[
+						'startResolution',
+						'finishResolution',
+						'invalidateResolution',
+						'invalidateResolutionForStore',
+						'invalidateResolutionForStoreSelector',
+					].map( ( actionName ) => [
+						actionName,
+						getCoreDataAction( actionName ),
+					] )
+				);
+			},
 
-		subscribe() {
-			// There's no reasons to trigger any listener when we subscribe to this store
-			// because there's no state stored in this store that need to retrigger selectors
-			// if a change happens, the corresponding store where the tracking stated live
-			// would have already triggered a "subscribe" call.
-			return () => {};
-		},
-	};
-}
+			subscribe() {
+				// There's no reasons to trigger any listener when we subscribe to this store
+				// because there's no state stored in this store that need to retrigger selectors
+				// if a change happens, the corresponding store where the tracking stated live
+				// would have already triggered a "subscribe" call.
+				return () => () => {};
+			},
+		};
+	},
+};
 
-export default createCoreDataStore;
+export default coreDataStore;

--- a/packages/data/src/store/name.js
+++ b/packages/data/src/store/name.js
@@ -1,6 +1,0 @@
-/**
- * The identifier for the core/data store.
- *
- * @type {string}
- */
-export const STORE_NAME = 'core/data';

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -414,31 +414,6 @@ describe( 'createRegistry', () => {
 			return promise;
 		} );
 
-		it( 'should resolve promise non-action to dispatch', () => {
-			let shouldThrow = false;
-			registry.registerStore( 'demo', {
-				reducer: ( state = 'OK' ) => {
-					if ( shouldThrow ) {
-						throw 'Should not have dispatched';
-					}
-
-					return state;
-				},
-				selectors: {
-					getValue: ( state ) => state,
-				},
-				resolvers: {
-					getValue: () => Promise.resolve(),
-				},
-			} );
-			shouldThrow = true;
-
-			registry.select( 'demo' ).getValue();
-			jest.runAllTimers();
-
-			return new Promise( ( resolve ) => process.nextTick( resolve ) );
-		} );
-
 		it( 'should not dispatch resolved promise action on subsequent selector calls', () => {
 			registry.registerStore( 'demo', {
 				reducer: ( state = 'NOTOK', action ) => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -9,7 +9,7 @@ import { castArray, mapValues } from 'lodash';
 import { createRegistry } from '../registry';
 import { createRegistrySelector } from '../factory';
 import createReduxStore from '../redux-store';
-import { STORE_NAME } from '../store/name';
+import coreDataStore from '../store';
 
 jest.useFakeTimers();
 
@@ -377,7 +377,7 @@ describe( 'createRegistry', () => {
 				() => registry.select( 'demo' ).getValue() === 'OK',
 				() =>
 					registry
-						.select( STORE_NAME )
+						.select( coreDataStore )
 						.hasFinishedResolution( 'demo', 'getValue' ),
 			] );
 
@@ -404,7 +404,7 @@ describe( 'createRegistry', () => {
 				() => registry.select( 'demo' ).getValue() === 'OK',
 				() =>
 					registry
-						.select( STORE_NAME )
+						.select( coreDataStore )
 						.hasFinishedResolution( 'demo', 'getValue' ),
 			] );
 

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -72,6 +72,7 @@ describe( 'createRegistry', () => {
 					subscribe,
 				} )
 			).toThrow();
+			expect( console ).toHaveWarned();
 		} );
 
 		describe( 'getSelectors', () => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -782,15 +782,19 @@ describe( 'createRegistry', () => {
 			const getSelectors = () => ( { mySelector } );
 			const getActions = () => ( { myAction } );
 			const subscribe = () => {};
-			registry.registerGenericStore( 'store', {
-				getSelectors,
-				getActions,
-				subscribe,
-			} );
+			const myStore = {
+				name: 'store',
+				instantiate: () => ( {
+					getSelectors,
+					getActions,
+					subscribe,
+				} ),
+			};
+			registry.register( myStore );
 			const subRegistry = createRegistry( {}, registry );
 
-			subRegistry.select( 'store' ).mySelector();
-			subRegistry.dispatch( 'store' ).myAction();
+			subRegistry.select( myStore ).mySelector();
+			subRegistry.dispatch( myStore ).myAction();
 
 			expect( mySelector ).toHaveBeenCalled();
 			expect( myAction ).toHaveBeenCalled();
@@ -802,10 +806,13 @@ describe( 'createRegistry', () => {
 			const getSelectors = () => ( { mySelector } );
 			const getActions = () => ( { myAction } );
 			const subscribe = () => {};
-			registry.registerGenericStore( 'store', {
-				getSelectors,
-				getActions,
-				subscribe,
+			registry.register( {
+				name: 'store',
+				instantiate: () => ( {
+					getSelectors,
+					getActions,
+					subscribe,
+				} ),
 			} );
 
 			const subRegistry = createRegistry( {}, registry );
@@ -814,10 +821,13 @@ describe( 'createRegistry', () => {
 			const getSelectors2 = () => ( { mySelector: mySelector2 } );
 			const getActions2 = () => ( { myAction: myAction2 } );
 			const subscribe2 = () => {};
-			subRegistry.registerGenericStore( 'store', {
-				getSelectors: getSelectors2,
-				getActions: getActions2,
-				subscribe: subscribe2,
+			subRegistry.register( {
+				name: 'store',
+				instantiate: () => ( {
+					getSelectors: getSelectors2,
+					getActions: getActions2,
+					subscribe: subscribe2,
+				} ),
 			} );
 
 			subRegistry.select( 'store' ).mySelector();


### PR DESCRIPTION
The `@wordpress/data` registry has two deprecated methods: `registerGenericStore` and `registerStore`. In this PR I'm aiming to remove all of their internal usages: in the `@wordpress/data` package itself and its tests.

There are several self-contained commits that can be reviewed independently.

I'm removing a weird `should resolve promise non-action to dispatch` unit tests added by @youknowriad a very long time ago. It was testing that a selector with an empty-ish resolver doesn't dispatch any action that would hit the reducer. But this test has had undetected failures for a long time, triggering an "unhandled promise rejection" warning. That started happening when the selector-resolving code started dispatching the `startResolution` and `finishResolution` meta-action, and when the original assumption (no dispatch on empty resolver) stopped being true. After the changes in this PR, this defunct test mysteriously started failing the entire `packages/data` test suite. So I needed to remove it.

Then there is the `core/data` meta-store exported from `packages/data/src/store`. I converted the exported structure to the modern "store descriptor" API and am now registering it with `registry.register` rather than `registerGenericStore`.

Next, there are unit tests. Only the tests for the actual `registerGenericStore` method should use it. Everything else is rewritten to store descriptors and `registry.register`.

Last, I'm rewriting the generic store registration examples in `data/README.md` to use store descriptors with the `{ name, instantiate }` shape and to use `register` to instantiate and register these custom stores.

**How to test:**
There should be no behavior change anywhere. We're merely refactoring internal implementations and tests.