### PR TITLE
Navigation: Skip text decoration support serialization and apply as CSS class

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -90,6 +90,8 @@
 			"__experimentalFontWeight": true,
 			"__experimentalTextTransform": true,
 			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalSkipSerialization": [ "textDecoration" ],
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -325,6 +325,8 @@ function Navigation( {
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );
 
+	const textDecoration = attributes.style?.typography?.textDecoration;
+
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: classnames( className, {
@@ -345,6 +347,7 @@ function Navigation( {
 				'background-color',
 				backgroundColor?.slug
 			) ]: !! backgroundColor?.slug,
+			[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
 		} ),
 		style: {
 			color: ! textColor?.slug && textColor?.color,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -486,6 +486,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$layout_class .= ' no-wrap';
 	}
 
+	// Manually add block support text decoration as CSS class.
+	$text_decoration       = _wp_array_get( $attributes, array( 'style', 'typography', 'textDecoration' ), null );
+	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
+
 	$colors     = block_core_navigation_build_css_colors( $attributes );
 	$font_sizes = block_core_navigation_build_css_font_sizes( $attributes );
 	$classes    = array_merge(
@@ -493,7 +497,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$font_sizes['css_classes'],
 		$is_responsive_menu ? array( 'is-responsive' ) : array(),
 		$layout_class ? array( $layout_class ) : array(),
-		$is_fallback ? array( 'is-fallback' ) : array()
+		$is_fallback ? array( 'is-fallback' ) : array(),
+		$text_decoration ? array( $text_decoration_class ) : array()
 	);
 
 	$inner_blocks_html = '';

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -51,25 +51,27 @@ $navigation-icon-size: 24px;
 		padding: 0;
 	}
 
-	// Force links to inherit text decoration applied to navigation block.
-	// The extra selector adds specificity to ensure it works when user-set.
-	&[style*="text-decoration"] {
-		.wp-block-navigation-item,
-		.wp-block-navigation__submenu-container {
-			text-decoration: inherit;
-		}
+	// The following rules provide class based application of user selected text
+	// decoration via block supports.
+	&.has-text-decoration-underline .wp-block-navigation-item__content {
+		text-decoration: underline;
 
-		a {
-			text-decoration: inherit;
-
-			&:focus,
-			&:active {
-				text-decoration: inherit;
-			}
+		&:focus,
+		&:active {
+			text-decoration: underline;
 		}
 	}
 
-	&:not([style*="text-decoration"]) {
+	&.has-text-decoration-line-through .wp-block-navigation-item__content {
+		text-decoration: line-through;
+
+		&:focus,
+		&:active {
+			text-decoration: line-through;
+		}
+	}
+
+	&:not([class*="has-text-decoration"]) {
 		a {
 			text-decoration: none;
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -71,7 +71,7 @@ $navigation-icon-size: 24px;
 		}
 	}
 
-	&:not([class*="has-text-decoration"]) {
+	&:where(:not([class*="has-text-decoration"])) {
 		a {
 			text-decoration: none;
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/34275

- https://github.com/WordPress/gutenberg/issues/34275

Related:
- https://github.com/WordPress/gutenberg/pull/36293
- https://github.com/WordPress/gutenberg/pull/37963
- https://github.com/WordPress/gutenberg/pull/36104 
  (Original PR before individual support serialization could be skipped)


## Description

This PR reinstates the Navigation block's opt-in to using the text-decoration block support. 

Rather than rely on the default inline style application of the block support value, the navigation block instead skips the serialization of only the text-decoration style (courtesy of #36293) and applies the decoration via a new CSS class.

## How has this been tested?

1. Create a post, add a navigation block, select it and add inner links and a search block (including some placeholder text)
2. In the inspector controls sidebar, toggle on the text-decoration option from the Typography panel
3. Select either of the underline or line-through options and confirm only the navigation item links display that decoration visually. i.e. the placeholder text in the search block should not reflect the selected text-decoration
4. Add further blocks, submenus and links to the navigation block and ensure it displays correctly
5. Save the post and confirm the correct display on the frontend
6. Switch to the site editor and add or edit a navigation block there
7. Confirm the navigation block behaves correctly

## Screenshots <!-- if applicable -->

| Trunk (with text-decoration enabled)  |  This PR |
|---|---|
| <img width="1059" alt="Screen Shot 2022-03-29 at 3 00 35 pm" src="https://user-images.githubusercontent.com/60436221/160538890-46aea538-933c-45e6-a15c-0decf7edf093.png"> | <img width="1051" alt="Screen Shot 2022-03-29 at 3 08 11 pm" src="https://user-images.githubusercontent.com/60436221/160538904-990c6af4-e932-4eef-9934-09554ea525be.png"> |

## Types of changes
Enhancement / Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
