### PR TITLE
Try: Enable script debug in wp-env.json

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "WordPress/theme-experiments/tt1-blocks#tt1-blocks@0.4.7" ],
 	"env": {
 		"tests": {
+			"config": {
+				"SCRIPT_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins"


### PR DESCRIPTION
## Description
Attempt to fix failing e2e test with current WP core trunk by enabling `SCRIPT_DEBUG`.

The assets in the dashboard aren't loading correctly when`SCRIPT_DEBUG` is set to `false`. It is the [default value for testing env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#default-wp-config-values).

It is a temp solution to unblock development while the issue is fixed in WP core.

## How has this been tested?
The e2e and performance tests are green.

## Types of changes
 Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
