### PR TITLE
Fix Gutenberg 11.8.2 in WordPress trunk

### DIFF
--- a/lib/class-wp-theme-json-schema-v0.php
+++ b/lib/class-wp-theme-json-schema-v0.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
+ * Class that implements a WP_Theme_JSON_Schema_Gutenberg to convert
  * a given structure in v0 schema to the latest one.
  *
  * @package gutenberg
  */
 
 /**
- * Class that implements a WP_Theme_JSON_Schema to convert
+ * Class that implements a WP_Theme_JSON_Schema_Gutenberg to convert
  * a given structure in v0 schema to the latest one.
  */
-class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema {
+class WP_Theme_JSON_Schema_V0 implements WP_Theme_JSON_Schema_Gutenberg {
 
 	/**
 	 * How to address all the blocks

--- a/lib/interface-wp-theme-json-schema.php
+++ b/lib/interface-wp-theme-json-schema.php
@@ -10,7 +10,7 @@
  *
  * @package gutenberg
  */
-interface WP_Theme_JSON_Schema {
+interface WP_Theme_JSON_Schema_Gutenberg {
 	/**
 	 * Parses an array that follows an old theme.json schema
 	 * into the latest theme.json schema.

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -115,7 +115,7 @@ if ( ! is_multisite() ) {
 	 *
 	 * @param int $post_id Deleted post ID.
 	 */
-	function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
+	function gutenberg_block_core_calendar_update_has_published_post_on_delete( $post_id ) {
 		$post = get_post( $post_id );
 
 		if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
@@ -132,7 +132,7 @@ if ( ! is_multisite() ) {
 	 * @param string  $old_status The status the post is changing from.
 	 * @param WP_Post $post       Post object.
 	 */
-	function block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
+	function gutenberg_block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
 		if ( $new_status === $old_status ) {
 			return;
 		}
@@ -148,6 +148,6 @@ if ( ! is_multisite() ) {
 		block_core_calendar_update_has_published_posts();
 	}
 
-	add_action( 'delete_post', 'block_core_calendar_update_has_published_post_on_delete' );
-	add_action( 'transition_post_status', 'block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );
+	add_action( 'delete_post', 'gutenberg_block_core_calendar_update_has_published_post_on_delete' );
+	add_action( 'transition_post_status', 'gutenberg_block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );
 }

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -113,7 +113,7 @@ function block_core_calendar_update_has_published_posts() {
  * @param int $post_id Deleted post ID.
  */
 function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
-	if ( ! is_multisite() ) {
+	if ( is_multisite() ) {
 		return;
 	}
 
@@ -134,7 +134,7 @@ function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
  * @param WP_Post $post       Post object.
  */
 function block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
-	if ( ! is_multisite() ) {
+	if ( is_multisite() ) {
 		return;
 	}
 

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -107,52 +107,51 @@ function block_core_calendar_update_has_published_posts() {
 	return $has_published_posts;
 }
 
-// We only want to register these functions and actions when
-// we are on single sites. On multi sites we use `post_count` option.
-if ( ! is_multisite() ) {
-
-	if ( ! function_exists( 'block_core_calendar_update_has_published_post_on_delete' ) ) {
-		/**
-		 * Handler for updating the has published posts flag when a post is deleted.
-		 *
-		 * @param int $post_id Deleted post ID.
-		 */
-		function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
-			$post = get_post( $post_id );
-		
-			if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
-				return;
-			}
-		
-			block_core_calendar_update_has_published_posts();
-		}
+/**
+ * Handler for updating the has published posts flag when a post is deleted.
+ *
+ * @param int $post_id Deleted post ID.
+ */
+function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
+	if ( ! is_multisite() ) {
+		return;
 	}
 
-	if ( ! function_exists( 'block_core_calendar_update_has_published_post_on_transition_post_status' ) ) { 
-		/**
-		 * Handler for updating the has published posts flag when a post status changes.
-		 *
-		 * @param string  $new_status The status the post is changing to.
-		 * @param string  $old_status The status the post is changing from.
-		 * @param WP_Post $post       Post object.
-		 */
-		function block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
-			if ( $new_status === $old_status ) {
-				return;
-			}
+	$post = get_post( $post_id );
 
-			if ( 'post' !== get_post_type( $post ) ) {
-				return;
-			}
-
-			if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
-				return;
-			}
-
-			block_core_calendar_update_has_published_posts();
-		}
+	if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
+		return;
 	}
 
-	add_action( 'delete_post', 'block_core_calendar_update_has_published_post_on_delete' );
-	add_action( 'transition_post_status', 'block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );
+	block_core_calendar_update_has_published_posts();
 }
+
+/**
+ * Handler for updating the has published posts flag when a post status changes.
+ *
+ * @param string  $new_status The status the post is changing to.
+ * @param string  $old_status The status the post is changing from.
+ * @param WP_Post $post       Post object.
+ */
+function block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
+	if ( ! is_multisite() ) {
+		return;
+	}
+
+	if ( $new_status === $old_status ) {
+		return;
+	}
+
+	if ( 'post' !== get_post_type( $post ) ) {
+		return;
+	}
+
+	if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+		return;
+	}
+
+	block_core_calendar_update_has_published_posts();
+}
+
+add_action( 'delete_post', 'block_core_calendar_update_has_published_post_on_delete' );
+add_action( 'transition_post_status', 'block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -110,44 +110,49 @@ function block_core_calendar_update_has_published_posts() {
 // We only want to register these functions and actions when
 // we are on single sites. On multi sites we use `post_count` option.
 if ( ! is_multisite() ) {
-	/**
-	 * Handler for updating the has published posts flag when a post is deleted.
-	 *
-	 * @param int $post_id Deleted post ID.
-	 */
-	function gutenberg_block_core_calendar_update_has_published_post_on_delete( $post_id ) {
-		$post = get_post( $post_id );
 
-		if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
-			return;
+	if ( ! function_exists( 'block_core_calendar_update_has_published_post_on_delete' ) ) {
+		/**
+		 * Handler for updating the has published posts flag when a post is deleted.
+		 *
+		 * @param int $post_id Deleted post ID.
+		 */
+		function block_core_calendar_update_has_published_post_on_delete( $post_id ) {
+			$post = get_post( $post_id );
+		
+			if ( ! $post || 'publish' !== $post->post_status || 'post' !== $post->post_type ) {
+				return;
+			}
+		
+			block_core_calendar_update_has_published_posts();
 		}
-
-		block_core_calendar_update_has_published_posts();
 	}
 
-	/**
-	 * Handler for updating the has published posts flag when a post status changes.
-	 *
-	 * @param string  $new_status The status the post is changing to.
-	 * @param string  $old_status The status the post is changing from.
-	 * @param WP_Post $post       Post object.
-	 */
-	function gutenberg_block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
-		if ( $new_status === $old_status ) {
-			return;
-		}
+	if ( ! function_exists( 'block_core_calendar_update_has_published_post_on_transition_post_status' ) ) { 
+		/**
+		 * Handler for updating the has published posts flag when a post status changes.
+		 *
+		 * @param string  $new_status The status the post is changing to.
+		 * @param string  $old_status The status the post is changing from.
+		 * @param WP_Post $post       Post object.
+		 */
+		function block_core_calendar_update_has_published_post_on_transition_post_status( $new_status, $old_status, $post ) {
+			if ( $new_status === $old_status ) {
+				return;
+			}
 
-		if ( 'post' !== get_post_type( $post ) ) {
-			return;
-		}
+			if ( 'post' !== get_post_type( $post ) ) {
+				return;
+			}
 
-		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
-			return;
-		}
+			if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+				return;
+			}
 
-		block_core_calendar_update_has_published_posts();
+			block_core_calendar_update_has_published_posts();
+		}
 	}
 
-	add_action( 'delete_post', 'gutenberg_block_core_calendar_update_has_published_post_on_delete' );
-	add_action( 'transition_post_status', 'gutenberg_block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );
+	add_action( 'delete_post', 'block_core_calendar_update_has_published_post_on_delete' );
+	add_action( 'transition_post_status', 'block_core_calendar_update_has_published_post_on_transition_post_status', 10, 3 );
 }


### PR DESCRIPTION
**Note this PR has `release/11.8` as its base branch.**

Activating the Gutenberg 11.8.2 plugin with the latest WordPress core `trunk` causes an error due to some name clashes:

- GlobalStyles code: `WP_Theme_JSON_Schema` (this PR renames it to be `WP_Theme_JSON_Schema_Gutenberg`)
- Calendar block: `block_core_calendar_update_has_published_post_on_delete` and `block_core_calendar_update_has_published_post_on_transition_post_status` already exist in core, so this PR only defines them if they don't exist.

Note that Gutenberg 11.9 is expected to be released tomorrow, so that should be the preferred fix. This PR only exists to help with a potential 11.8.3, should it happen. See conversation in [core-editor slack](https://wordpress.slack.com/archives/C02QB2JS7/p1636446618095600) (requires registration).

cc @Mamaduka @priethor 

## How to test

- Upload the plugin in this branch to a WordPress core environment.
- Test that the plugin can be activated and operated normally (without this fix it will raise an error upon activation).
