### PR TITLE
Tests: Add integration tests with core blocks schema validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12970,6 +12970,18 @@
 						"webpack-sources": "^1.4.1"
 					},
 					"dependencies": {
+						"ajv": {
+							"version": "6.12.6",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+							"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						},
 						"braces": {
 							"version": "2.3.2",
 							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
@@ -15782,6 +15794,20 @@
 						"terser-webpack-plugin": "^1.4.3",
 						"watchpack": "^1.7.4",
 						"webpack-sources": "^1.4.1"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "6.12.6",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+							"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						}
 					}
 				},
 				"webpack-sources": {
@@ -17573,12 +17599,6 @@
 					"dev": true
 				}
 			}
-		},
-		"@types/which": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
-			"integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
-			"dev": true
 		},
 		"@types/yargs": {
 			"version": "15.0.4",
@@ -20438,16 +20458,30 @@
 			}
 		},
 		"ajv": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
+			"integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
+			},
+			"dependencies": {
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
 			}
+		},
+		"ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"dev": true
 		},
 		"ajv-errors": {
 			"version": "1.0.1",
@@ -20689,6 +20723,7 @@
 					"version": "7.14.6",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
 					"integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
@@ -20708,6 +20743,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
 					"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20718,6 +20754,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
 					"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20736,6 +20773,7 @@
 							"version": "0.5.5",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+							"dev": true,
 							"requires": {
 								"minimist": "^1.2.5"
 							}
@@ -20746,6 +20784,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
 					"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/core": "^0.16.1"
@@ -20755,6 +20794,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
 					"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20766,6 +20806,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
 					"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20776,6 +20817,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
 					"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20785,6 +20827,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
 					"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20794,6 +20837,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
 					"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20803,6 +20847,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
 					"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20813,6 +20858,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
 					"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20822,6 +20868,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
 					"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20831,6 +20878,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
 					"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20840,6 +20888,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
 					"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20849,6 +20898,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
 					"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20858,6 +20908,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
 					"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20867,6 +20918,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
 					"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20876,6 +20928,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
 					"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20885,6 +20938,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
 					"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20894,6 +20948,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
 					"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20903,6 +20958,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
 					"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20912,6 +20968,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
 					"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -20922,6 +20979,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
 					"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20931,6 +20989,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
 					"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20940,6 +20999,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
 					"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20949,6 +21009,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
 					"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20958,6 +21019,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
 					"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1"
@@ -20967,6 +21029,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
 					"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/plugin-blit": "^0.16.1",
@@ -20997,6 +21060,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
 					"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/utils": "^0.16.1",
@@ -21006,7 +21070,8 @@
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+							"dev": true
 						}
 					}
 				},
@@ -21014,6 +21079,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
 					"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"utif": "^2.0.1"
@@ -21023,6 +21089,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
 					"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"@jimp/bmp": "^0.16.1",
@@ -21037,6 +21104,7 @@
 					"version": "0.16.1",
 					"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
 					"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.7.2",
 						"regenerator-runtime": "^0.13.3"
@@ -21057,19 +21125,6 @@
 						"defer-to-connect": "^2.0.0"
 					}
 				},
-				"@types/archiver": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
-					"integrity": "sha512-baFOhanb/hxmcOd1Uey2TfFg43kTSmM6py1Eo7Rjbv/ivcl7PXLhY0QgXGf50Hx/eskGCFqPfhs/7IZLb15C5g==",
-					"requires": {
-						"@types/glob": "*"
-					}
-				},
-				"@types/atob": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg=="
-				},
 				"@types/cacheable-request": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -21088,23 +21143,6 @@
 					"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
 					"dev": true
 				},
-				"@types/fs-extra": {
-					"version": "9.0.6",
-					"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.6.tgz",
-					"integrity": "sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==",
-					"requires": {
-						"@types/node": "*"
-					}
-				},
-				"@types/glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-					"requires": {
-						"@types/minimatch": "*",
-						"@types/node": "*"
-					}
-				},
 				"@types/http-cache-semantics": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -21120,60 +21158,11 @@
 						"@types/node": "*"
 					}
 				},
-				"@types/lodash": {
-					"version": "4.14.166",
-					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
-					"integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA=="
-				},
-				"@types/lodash.clonedeep": {
-					"version": "4.5.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-					"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.isobject": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.isobject/-/lodash.isobject-3.0.6.tgz",
-					"integrity": "sha512-2lwGbaIXMR5hjO56nCvI7W6bmY3Y3uJvbHWqO9MtOE1StyhZ1VtLINQ0MLC87rrB3zHHp+u4DHeal70rx1kvjw==",
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.isplainobject": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-					"integrity": "sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==",
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.merge": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-					"integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/lodash.zip": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/@types/lodash.zip/-/lodash.zip-4.2.6.tgz",
-					"integrity": "sha512-mKAcnkyFaihVR1oK83ZBQqSSQ1hpAY+uD5QaDkf//xtvr4NlNwqJEDg/oQoqLJg5YdSEwVWlQq0Aq4oLvD3zuw==",
-					"requires": {
-						"@types/lodash": "*"
-					}
-				},
-				"@types/minimatch": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-					"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
-				},
 				"@types/node": {
 					"version": "16.3.3",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-					"integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ=="
+					"integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+					"dev": true
 				},
 				"@types/puppeteer": {
 					"version": "5.4.4",
@@ -21233,15 +21222,11 @@
 					"integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
 					"dev": true
 				},
-				"@types/ua-parser-js": {
-					"version": "0.7.35",
-					"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-					"integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ=="
-				},
-				"@types/uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+				"@types/which": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+					"integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+					"dev": true
 				},
 				"@types/yauzl": {
 					"version": "2.9.2",
@@ -21383,6 +21368,7 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
@@ -21396,7 +21382,8 @@
 				"any-base": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-					"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+					"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+					"dev": true
 				},
 				"appium-adb": {
 					"version": "8.13.1",
@@ -21448,15 +21435,6 @@
 						"ws": "^8.0.0"
 					},
 					"dependencies": {
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"ws": {
 							"version": "8.2.3",
 							"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
@@ -21521,14 +21499,6 @@
 						"teen_process": "^1.15.0",
 						"xmldom": "^0.x",
 						"xpath": "^0.x"
-					},
-					"dependencies": {
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
-							"dev": true
-						}
 					}
 				},
 				"appium-espresso-driver": {
@@ -21565,98 +21535,6 @@
 						"source-map-support": "^0.x",
 						"xmldom": "^0.x",
 						"xpath": "^0.x"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-						},
-						"cliui": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-							"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-							"requires": {
-								"string-width": "^4.2.0",
-								"strip-ansi": "^6.0.0",
-								"wrap-ansi": "^6.2.0"
-							}
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-						},
-						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						},
-						"wrap-ansi": {
-							"version": "6.2.0",
-							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-							"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-							"requires": {
-								"ansi-styles": "^4.0.0",
-								"string-width": "^4.1.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"xmldom": {
-							"version": "0.3.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-							"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-							"dev": true
-						},
-						"xpath": {
-							"version": "0.0.27",
-							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-							"integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
-							"dev": true
-						},
-						"y18n": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-							"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
-						},
-						"yargs": {
-							"version": "15.4.1",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-							"requires": {
-								"cliui": "^6.0.0",
-								"decamelize": "^1.2.0",
-								"find-up": "^4.1.0",
-								"require-directory": "^2.1.1",
-								"set-blocking": "^2.0.0",
-								"string-width": "^4.2.0",
-								"which-module": "^2.0.0",
-								"y18n": "^4.0.0",
-								"yargs-parser": "^18.1.2"
-							}
-						},
-						"yargs-parser": {
-							"version": "18.1.3",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-							"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-							"requires": {
-								"camelcase": "^5.0.0",
-								"decamelize": "^1.2.0"
-							}
-						}
 					}
 				},
 				"appium-flutter-driver": {
@@ -21675,44 +21553,6 @@
 						"bluebird": "^3.1.1",
 						"portscanner": "2.2.0",
 						"rpc-websockets": "^5.1.1"
-					},
-					"dependencies": {
-						"appium-base-driver": {
-							"version": "7.10.1",
-							"resolved": "https://registry.npmjs.org/appium-base-driver/-/appium-base-driver-7.10.1.tgz",
-							"integrity": "sha512-GSE1rq5L5TRM0nrUAEzbt7KL8c2bRedsPlyMKFU6H/d+syucGt1JPFuCHPe4pHrzL7BafaZeU79cOczcFUmXXg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.0.0",
-								"appium-support": "^2.54.1",
-								"async-lock": "^1.0.0",
-								"asyncbox": "^2.9.1",
-								"axios": "^0.x",
-								"bluebird": "^3.5.3",
-								"body-parser": "^1.18.2",
-								"colors": "^1.1.2",
-								"es6-error": "^4.1.1",
-								"express": "^4.16.2",
-								"http-status-codes": "^2.1.1",
-								"lodash": "^4.0.0",
-								"lru-cache": "^6.0.0",
-								"method-override": "^3.0.0",
-								"morgan": "^1.9.0",
-								"serve-favicon": "^2.4.5",
-								"source-map-support": "^0.x",
-								"validate.js": "^0.13.0",
-								"webdriverio": "^6.0.2",
-								"ws": "^8.0.0"
-							},
-							"dependencies": {
-								"ws": {
-									"version": "8.2.3",
-									"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-									"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-									"dev": true
-								}
-							}
-						}
 					}
 				},
 				"appium-geckodriver": {
@@ -21932,15 +21772,6 @@
 								"lodash": "^4.17.14"
 							}
 						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
-							}
-						},
 						"chalk": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -22079,18 +21910,6 @@
 								"webdriver": "5.23.0"
 							}
 						},
-						"xmldom": {
-							"version": "0.3.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-							"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-							"dev": true
-						},
-						"xpath": {
-							"version": "0.0.24",
-							"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.24.tgz",
-							"integrity": "sha1-Gt4WLhzFI8jTn8fQavwW6iFvKfs=",
-							"dev": true
-						},
 						"yallist": {
 							"version": "3.1.1",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -22128,14 +21947,6 @@
 						"source-map-support": "^0.5.3",
 						"teen_process": "^1.3.0",
 						"xmldom": "^0.x"
-					},
-					"dependencies": {
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
-							"dev": true
-						}
 					}
 				},
 				"appium-mac-driver": {
@@ -22261,377 +22072,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-							"integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-							"integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							},
-							"dependencies": {
-								"mkdirp": {
-									"version": "0.5.5",
-									"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-									"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-									"dev": true,
-									"requires": {
-										"minimist": "^1.2.5"
-									}
-								}
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-							"integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.14.0"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-							"integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-							"integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"jpeg-js": "^0.4.0"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-							"integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-							"integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-							"integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-							"integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-							"integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-							"integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-							"integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-							"integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-							"integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-							"integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-							"integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-							"integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-							"integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-							"integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-							"integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-							"integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-							"integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-							"integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-							"integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-							"integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-							"integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-							"integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.14.0",
-								"@jimp/plugin-blur": "^0.14.0",
-								"@jimp/plugin-circle": "^0.14.0",
-								"@jimp/plugin-color": "^0.14.0",
-								"@jimp/plugin-contain": "^0.14.0",
-								"@jimp/plugin-cover": "^0.14.0",
-								"@jimp/plugin-crop": "^0.14.0",
-								"@jimp/plugin-displace": "^0.14.0",
-								"@jimp/plugin-dither": "^0.14.0",
-								"@jimp/plugin-fisheye": "^0.14.0",
-								"@jimp/plugin-flip": "^0.14.0",
-								"@jimp/plugin-gaussian": "^0.14.0",
-								"@jimp/plugin-invert": "^0.14.0",
-								"@jimp/plugin-mask": "^0.14.0",
-								"@jimp/plugin-normalize": "^0.14.0",
-								"@jimp/plugin-print": "^0.14.0",
-								"@jimp/plugin-resize": "^0.14.0",
-								"@jimp/plugin-rotate": "^0.14.0",
-								"@jimp/plugin-scale": "^0.14.0",
-								"@jimp/plugin-shadow": "^0.14.0",
-								"@jimp/plugin-threshold": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-							"integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.14.0",
-								"pngjs": "^3.3.3"
-							},
-							"dependencies": {
-								"pngjs": {
-									"version": "3.4.0",
-									"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-									"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-									"dev": true
-								}
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-							"integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-							"integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.14.0",
-								"@jimp/gif": "^0.14.0",
-								"@jimp/jpeg": "^0.14.0",
-								"@jimp/png": "^0.14.0",
-								"@jimp/tiff": "^0.14.0",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-							"integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
 						"are-we-there-yet": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
@@ -22640,15 +22080,6 @@
 							"requires": {
 								"delegates": "^1.0.0",
 								"readable-stream": "^3.6.0"
-							}
-						},
-						"axios": {
-							"version": "0.20.0",
-							"resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-							"integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-							"dev": true,
-							"requires": {
-								"follow-redirects": "^1.10.0"
 							}
 						},
 						"gauge": {
@@ -22666,19 +22097,6 @@
 								"string-width": "^1.0.1 || ^2.0.0",
 								"strip-ansi": "^3.0.1 || ^4.0.0",
 								"wide-align": "^1.1.2"
-							}
-						},
-						"jimp": {
-							"version": "0.14.0",
-							"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-							"integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/custom": "^0.14.0",
-								"@jimp/plugins": "^0.14.0",
-								"@jimp/types": "^0.14.0",
-								"regenerator-runtime": "^0.13.3"
 							}
 						},
 						"npmlog": {
@@ -23140,34 +22558,6 @@
 								"supports-color": "^7.1.0"
 							}
 						},
-						"cliui": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-							"dev": true,
-							"requires": {
-								"string-width": "^2.1.1",
-								"strip-ansi": "^4.0.0",
-								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
-							}
-						},
 						"compress-commons": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
@@ -23207,31 +22597,10 @@
 								"readable-stream": "^3.4.0"
 							}
 						},
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"dev": true,
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"get-caller-file": {
-							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-							"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-							"dev": true
-						},
 						"http-status-codes": {
 							"version": "1.4.0",
 							"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
 							"integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 							"dev": true
 						},
 						"jimp": {
@@ -23252,16 +22621,6 @@
 							"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
 							"integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
 							"dev": true
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"dev": true,
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
 						},
 						"lru-cache": {
 							"version": "5.1.1",
@@ -23287,31 +22646,10 @@
 								"minimist": "0.0.8"
 							}
 						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"dev": true,
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-							"dev": true
-						},
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
 							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						},
-						"require-main-filename": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-							"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 							"dev": true
 						},
 						"rgb2hex": {
@@ -23327,33 +22665,6 @@
 							"dev": true,
 							"requires": {
 								"type-fest": "^0.8.0"
-							}
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "3.0.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-									"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-									"dev": true
-								},
-								"strip-ansi": {
-									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^3.0.0"
-									}
-								}
 							}
 						},
 						"strip-ansi": {
@@ -23409,94 +22720,11 @@
 								"webdriver": "5.23.0"
 							}
 						},
-						"wrap-ansi": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-							"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "2.1.1",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-									"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-									"dev": true
-								},
-								"is-fullwidth-code-point": {
-									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-									"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-									"dev": true,
-									"requires": {
-										"number-is-nan": "^1.0.0"
-									}
-								},
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								},
-								"strip-ansi": {
-									"version": "3.0.1",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-									"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-									"dev": true,
-									"requires": {
-										"ansi-regex": "^2.0.0"
-									}
-								}
-							}
-						},
-						"y18n": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-							"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-							"dev": true
-						},
 						"yallist": {
 							"version": "3.1.1",
 							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true
-						},
-						"yargs": {
-							"version": "12.0.5",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-							"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-							"dev": true,
-							"requires": {
-								"cliui": "^4.0.0",
-								"decamelize": "^1.2.0",
-								"find-up": "^3.0.0",
-								"get-caller-file": "^1.0.1",
-								"os-locale": "^3.0.0",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^1.0.1",
-								"set-blocking": "^2.0.0",
-								"string-width": "^2.0.0",
-								"which-module": "^2.0.0",
-								"y18n": "^3.2.1 || ^4.0.0",
-								"yargs-parser": "^11.1.1"
-							}
-						},
-						"yargs-parser": {
-							"version": "11.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-							"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-							"dev": true,
-							"requires": {
-								"camelcase": "^5.0.0",
-								"decamelize": "^1.2.0"
-							}
 						},
 						"zip-stream": {
 							"version": "2.1.3",
@@ -23631,12 +22859,6 @@
 							"version": "8.2.3",
 							"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 							"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-							"dev": true
-						},
-						"xmldom": {
-							"version": "0.4.0",
-							"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-							"integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
 							"dev": true
 						}
 					}
@@ -23920,7 +23142,8 @@
 				"base64-js": {
 					"version": "1.5.1",
 					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+					"dev": true
 				},
 				"base64-stream": {
 					"version": "1.0.0",
@@ -23972,7 +23195,8 @@
 				"bmp-js": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-					"integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
+					"integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM=",
+					"dev": true
 				},
 				"body-parser": {
 					"version": "1.19.0",
@@ -24041,6 +23265,7 @@
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
 					"requires": {
 						"base64-js": "^1.3.1",
 						"ieee754": "^1.1.13"
@@ -24055,7 +23280,8 @@
 				"buffer-equal": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-					"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+					"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+					"dev": true
 				},
 				"buffer-from": {
 					"version": "1.1.1",
@@ -24104,7 +23330,8 @@
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -24169,6 +23396,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -24178,17 +23406,20 @@
 						"ansi-regex": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
 						},
 						"string-width": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
 								"strip-ansi": "^4.0.0"
@@ -24198,6 +23429,7 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -24256,6 +23488,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -24263,7 +23496,8 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				},
 				"color-string": {
 					"version": "1.6.0",
@@ -24424,6 +23658,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -24435,12 +23670,14 @@
 						"semver": {
 							"version": "5.7.1",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
 						},
 						"which": {
 							"version": "1.3.1",
 							"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 							"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+							"dev": true,
 							"requires": {
 								"isexe": "^2.0.0"
 							}
@@ -24492,7 +23729,8 @@
 				"decamelize": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
 				},
 				"decompress-response": {
 					"version": "6.0.0",
@@ -24582,7 +23820,8 @@
 				"dom-walk": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+					"dev": true
 				},
 				"duplexer": {
 					"version": "0.1.2",
@@ -24625,11 +23864,6 @@
 						"shimmer": "^1.2.0"
 					}
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
 				"enabled": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -24646,6 +23880,7 @@
 					"version": "1.4.4",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 					"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
 					}
@@ -24670,11 +23905,6 @@
 					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
 					"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
 					"dev": true
-				},
-				"escalade": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 				},
 				"escape-html": {
 					"version": "1.0.3",
@@ -24704,6 +23934,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^4.0.0",
@@ -24718,6 +23949,7 @@
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"dev": true,
 							"requires": {
 								"pump": "^3.0.0"
 							}
@@ -24727,7 +23959,8 @@
 				"exif-parser": {
 					"version": "0.1.12",
 					"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-					"integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+					"integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI=",
+					"dev": true
 				},
 				"exit-on-epipe": {
 					"version": "1.0.1",
@@ -24873,7 +24106,8 @@
 				"file-type": {
 					"version": "9.0.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-					"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
+					"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
+					"dev": true
 				},
 				"finalhandler": {
 					"version": "1.1.2",
@@ -24917,6 +24151,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
@@ -25047,7 +24282,8 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+					"dev": true
 				},
 				"get-port": {
 					"version": "5.1.1",
@@ -25080,6 +24316,7 @@
 					"version": "0.9.2",
 					"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.2.tgz",
 					"integrity": "sha512-fcIswrPaiCDAyO8xnWvHSZdWChjKXUanKKpAiWWJ/UTkEi/aYKn5+90e7DE820zbEaVR9CE2y4z9bzhQijZ0BA==",
+					"dev": true,
 					"requires": {
 						"image-q": "^1.1.1",
 						"omggif": "^1.0.10"
@@ -25103,6 +24340,7 @@
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
 					"integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+					"dev": true,
 					"requires": {
 						"min-document": "^2.19.0",
 						"process": "^0.11.10"
@@ -25252,12 +24490,14 @@
 				"ieee754": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+					"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+					"dev": true
 				},
 				"image-q": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
-					"integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY="
+					"integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY=",
+					"dev": true
 				},
 				"immediate": {
 					"version": "3.0.6",
@@ -25296,7 +24536,8 @@
 				"invert-kv": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
 				},
 				"io.appium.settings": {
 					"version": "3.4.0",
@@ -25361,7 +24602,8 @@
 				"is-function": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+					"dev": true
 				},
 				"is-number-like": {
 					"version": "1.0.8",
@@ -25375,7 +24617,8 @@
 				"is-stream": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"dev": true
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
@@ -25401,7 +24644,8 @@
 				"isexe": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -25420,381 +24664,13 @@
 						"@jimp/plugins": "^0.16.1",
 						"@jimp/types": "^0.16.1",
 						"regenerator-runtime": "^0.13.3"
-					},
-					"dependencies": {
-						"@jimp/bmp": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-							"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"bmp-js": "^0.1.0"
-							}
-						},
-						"@jimp/core": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-							"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"any-base": "^1.1.0",
-								"buffer": "^5.2.0",
-								"exif-parser": "^0.1.12",
-								"file-type": "^9.0.0",
-								"load-bmfont": "^1.3.1",
-								"mkdirp": "^0.5.1",
-								"phin": "^2.9.1",
-								"pixelmatch": "^4.0.2",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/custom": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-							"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/core": "^0.16.1"
-							}
-						},
-						"@jimp/gif": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-							"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"gifwrap": "^0.9.2",
-								"omggif": "^1.0.9"
-							}
-						},
-						"@jimp/jpeg": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-							"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"jpeg-js": "0.4.2"
-							}
-						},
-						"@jimp/plugin-blit": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
-							"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-blur": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
-							"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-circle": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
-							"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-color": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
-							"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"tinycolor2": "^1.4.1"
-							}
-						},
-						"@jimp/plugin-contain": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
-							"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-cover": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
-							"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-crop": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
-							"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-displace": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
-							"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-dither": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
-							"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-fisheye": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
-							"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-flip": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
-							"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-gaussian": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
-							"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-invert": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
-							"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-mask": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
-							"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-normalize": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
-							"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-print": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
-							"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"load-bmfont": "^1.4.0"
-							}
-						},
-						"@jimp/plugin-resize": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-							"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-rotate": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
-							"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-scale": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
-							"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-shadow": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
-							"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugin-threshold": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
-							"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1"
-							}
-						},
-						"@jimp/plugins": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
-							"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/plugin-blit": "^0.16.1",
-								"@jimp/plugin-blur": "^0.16.1",
-								"@jimp/plugin-circle": "^0.16.1",
-								"@jimp/plugin-color": "^0.16.1",
-								"@jimp/plugin-contain": "^0.16.1",
-								"@jimp/plugin-cover": "^0.16.1",
-								"@jimp/plugin-crop": "^0.16.1",
-								"@jimp/plugin-displace": "^0.16.1",
-								"@jimp/plugin-dither": "^0.16.1",
-								"@jimp/plugin-fisheye": "^0.16.1",
-								"@jimp/plugin-flip": "^0.16.1",
-								"@jimp/plugin-gaussian": "^0.16.1",
-								"@jimp/plugin-invert": "^0.16.1",
-								"@jimp/plugin-mask": "^0.16.1",
-								"@jimp/plugin-normalize": "^0.16.1",
-								"@jimp/plugin-print": "^0.16.1",
-								"@jimp/plugin-resize": "^0.16.1",
-								"@jimp/plugin-rotate": "^0.16.1",
-								"@jimp/plugin-scale": "^0.16.1",
-								"@jimp/plugin-shadow": "^0.16.1",
-								"@jimp/plugin-threshold": "^0.16.1",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/png": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-							"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/utils": "^0.16.1",
-								"pngjs": "^3.3.3"
-							}
-						},
-						"@jimp/tiff": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-							"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"utif": "^2.0.1"
-							}
-						},
-						"@jimp/types": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-							"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"@jimp/bmp": "^0.16.1",
-								"@jimp/gif": "^0.16.1",
-								"@jimp/jpeg": "^0.16.1",
-								"@jimp/png": "^0.16.1",
-								"@jimp/tiff": "^0.16.1",
-								"timm": "^1.6.1"
-							}
-						},
-						"@jimp/utils": {
-							"version": "0.16.1",
-							"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-							"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.7.2",
-								"regenerator-runtime": "^0.13.3"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.5",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-							"dev": true,
-							"requires": {
-								"minimist": "^1.2.5"
-							}
-						},
-						"pngjs": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
-							"dev": true
-						}
 					}
 				},
 				"jpeg-js": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-					"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+					"integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
+					"dev": true
 				},
 				"js2xmlparser2": {
 					"version": "0.2.0",
@@ -25865,14 +24741,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"jsprim": {
@@ -25979,6 +24847,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
 					}
@@ -26023,6 +24892,7 @@
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
 					"integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
+					"dev": true,
 					"requires": {
 						"buffer-equal": "0.0.1",
 						"mime": "^1.3.4",
@@ -26038,6 +24908,7 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
 					}
@@ -26170,6 +25041,7 @@
 					"version": "0.1.3",
 					"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 					"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+					"dev": true,
 					"requires": {
 						"p-defer": "^1.0.0"
 					}
@@ -26201,6 +25073,7 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
 					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^2.0.0",
@@ -26251,7 +25124,8 @@
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
 				},
 				"mime-db": {
 					"version": "1.48.0",
@@ -26271,7 +25145,8 @@
 				"mimic-fn": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
 				},
 				"mimic-response": {
 					"version": "1.0.1",
@@ -26283,6 +25158,7 @@
 					"version": "2.19.0",
 					"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 					"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+					"dev": true,
 					"requires": {
 						"dom-walk": "^0.1.0"
 					}
@@ -26299,12 +25175,8 @@
 				"minimist": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				},
-				"mjpeg-server": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/mjpeg-server/-/mjpeg-server-0.3.0.tgz",
-					"integrity": "sha1-rx3hP3VkJwi6bsFw36xAi9xdlzc="
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "1.0.4",
@@ -26434,7 +25306,8 @@
 				"nice-try": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+					"dev": true
 				},
 				"node-fetch": {
 					"version": "2.6.1",
@@ -26483,6 +25356,7 @@
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
@@ -26520,7 +25394,8 @@
 				"omggif": {
 					"version": "1.0.10",
 					"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-					"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
+					"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+					"dev": true
 				},
 				"on-finished": {
 					"version": "2.3.0",
@@ -26541,6 +25416,7 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -26558,6 +25434,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
 					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
 					"requires": {
 						"execa": "^1.0.0",
 						"lcid": "^2.0.0",
@@ -26579,22 +25456,26 @@
 				"p-defer": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-					"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+					"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+					"dev": true
 				},
 				"p-finally": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"dev": true
 				},
 				"p-is-promise": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+					"dev": true
 				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -26603,6 +25484,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
 					"requires": {
 						"p-limit": "^2.2.0"
 					}
@@ -26610,27 +25492,32 @@
 				"p-try": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"pako": {
 					"version": "1.0.11",
 					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+					"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+					"dev": true
 				},
 				"parse-bmfont-ascii": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-					"integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
+					"integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU=",
+					"dev": true
 				},
 				"parse-bmfont-binary": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-					"integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
+					"integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY=",
+					"dev": true
 				},
 				"parse-bmfont-xml": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
 					"integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
+					"dev": true,
 					"requires": {
 						"xml-parse-from-string": "^1.0.0",
 						"xml2js": "^0.4.5"
@@ -26639,7 +25526,8 @@
 				"parse-headers": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-					"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+					"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+					"dev": true
 				},
 				"parse-listing": {
 					"version": "1.1.3",
@@ -26662,7 +25550,8 @@
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
@@ -26673,7 +25562,8 @@
 				"path-key": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.7",
@@ -26714,12 +25604,14 @@
 				"phin": {
 					"version": "2.9.3",
 					"resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-					"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
+					"integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
+					"dev": true
 				},
 				"pixelmatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
 					"integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+					"dev": true,
 					"requires": {
 						"pngjs": "^3.0.0"
 					},
@@ -26727,7 +25619,8 @@
 						"pngjs": {
 							"version": "3.4.0",
 							"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+							"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+							"dev": true
 						}
 					}
 				},
@@ -26841,7 +25734,8 @@
 				"process": {
 					"version": "0.11.10",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+					"dev": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
@@ -26881,6 +25775,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -26974,7 +25869,8 @@
 				"regenerator-runtime": {
 					"version": "0.13.7",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+					"dev": true
 				},
 				"request": {
 					"version": "2.88.2",
@@ -27053,12 +25949,14 @@
 				"require-directory": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
 				},
 				"resolve": {
 					"version": "1.20.0",
@@ -27171,7 +26069,8 @@
 				"sax": {
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+					"dev": true
 				},
 				"selenium-webdriver": {
 					"version": "3.6.0",
@@ -27302,7 +26201,8 @@
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"dev": true
 				},
 				"set-immediate-shim": {
 					"version": "1.0.1",
@@ -27338,6 +26238,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
@@ -27345,7 +26246,8 @@
 				"shebang-regex": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
 				},
 				"shell-quote": {
 					"version": "1.7.2",
@@ -27373,7 +26275,8 @@
 				"signal-exit": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+					"dev": true
 				},
 				"simple-swizzle": {
 					"version": "0.2.2",
@@ -27483,7 +26386,8 @@
 				"strip-eof": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -27554,12 +26458,14 @@
 				"timm": {
 					"version": "1.7.1",
 					"resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-					"integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
+					"integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
+					"dev": true
 				},
 				"tinycolor2": {
 					"version": "1.4.2",
 					"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-					"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+					"integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+					"dev": true
 				},
 				"tmp": {
 					"version": "0.0.30",
@@ -27708,6 +26614,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
 					"integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+					"dev": true,
 					"requires": {
 						"pako": "^1.0.5"
 					}
@@ -27816,7 +26723,8 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
@@ -27889,41 +26797,17 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-						},
-						"string-width": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-							"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
 				},
 				"ws": {
 					"version": "7.5.3",
@@ -27935,6 +26819,7 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
 					"integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+					"dev": true,
 					"requires": {
 						"global": "~4.4.0",
 						"is-function": "^1.0.1",
@@ -27945,12 +26830,14 @@
 				"xml-parse-from-string": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-					"integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
+					"integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig=",
+					"dev": true
 				},
 				"xml2js": {
 					"version": "0.4.23",
 					"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
 					"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+					"dev": true,
 					"requires": {
 						"sax": ">=0.6.0",
 						"xmlbuilder": "~11.0.0"
@@ -27959,7 +26846,8 @@
 				"xmlbuilder": {
 					"version": "11.0.1",
 					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-					"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+					"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+					"dev": true
 				},
 				"xmldom": {
 					"version": "0.5.0",
@@ -27976,12 +26864,14 @@
 				"xtend": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
 				},
 				"yallist": {
 					"version": "4.0.0",
@@ -27993,9 +26883,11 @@
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
 						"get-caller-file": "^1.0.1",
 						"os-locale": "^3.0.0",
 						"require-directory": "^2.1.1",
@@ -28010,17 +26902,54 @@
 						"ansi-regex": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"find-up": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"dev": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+							"dev": true
 						},
 						"string-width": {
 							"version": "2.1.1",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
 								"strip-ansi": "^4.0.0"
@@ -28030,6 +26959,7 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -28040,6 +26970,7 @@
 					"version": "11.1.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -32793,6 +31724,20 @@
 						"terser-webpack-plugin": "^1.4.3",
 						"watchpack": "^1.7.4",
 						"webpack-sources": "^1.4.1"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "6.12.6",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+							"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						}
 					}
 				},
 				"webpack-sources": {
@@ -35038,6 +33983,18 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -37038,9 +35995,9 @@
 			"integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
 		},
 		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-diff": {
@@ -39002,6 +37959,20 @@
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				}
 			}
 		},
 		"hard-rejection": {
@@ -56693,6 +55664,20 @@
 				"ajv": "^6.1.0",
 				"ajv-errors": "^1.0.0",
 				"ajv-keywords": "^3.1.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				}
 			}
 		},
 		"select": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,8 @@
 		"@wordpress/readable-js-assets-webpack-plugin": "file:packages/readable-js-assets-webpack-plugin",
 		"@wordpress/scripts": "file:packages/scripts",
 		"@wordpress/stylelint-config": "file:packages/stylelint-config",
+		"ajv": "8.7.1",
+		"ajv-draft-04": "1.0.0",
 		"appium": "1.22.0",
 		"babel-jest": "26.6.3",
 		"babel-loader": "8.2.2",

--- a/packages/block-library/src/comment-author-avatar/block.json
+++ b/packages/block-library/src/comment-author-avatar/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/comment-author-avatar",
 	"title": "Comment Author Avatar",

--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/comment-edit-link",
 	"title": "Comment Edit Link",

--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/comment-reply-link",
 	"title": "Comment Reply Link",

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/comment-template",
 	"title": "Comment Template",

--- a/packages/block-library/src/comments-query-loop/block.json
+++ b/packages/block-library/src/comments-query-loop/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/comments-query-loop",
 	"title": "Comments Query Loop",

--- a/packages/block-library/src/navigation-area/block.json
+++ b/packages/block-library/src/navigation-area/block.json
@@ -1,15 +1,11 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/navigation-area",
 	"title": "Navigation Area",
 	"category": "theme",
 	"description": "Define a navigation area for your theme. The navigation block associated with this area will be automatically displayed.",
-	"keywords": [
-		"menu",
-		"navigation",
-		"links",
-		"location"
-	],
+	"keywords": [ "menu", "navigation", "links", "location" ],
 	"textdomain": "default",
 	"attributes": {
 		"area": {

--- a/packages/block-library/src/pattern/block.json
+++ b/packages/block-library/src/pattern/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/pattern",
 	"title": "Pattern",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -122,7 +122,17 @@
 							"type": "array",
 							"description": "An attribute can be defined as one of a fixed set of values. This is specified by an enum, which contains an array of allowed values:",
 							"items": {
-								"type": "string"
+								"oneOf": [
+									{
+										"type": "boolean"
+									},
+									{
+										"type": "number"
+									},
+									{
+										"type": "string"
+									}
+								]
 							}
 						},
 						"source": {
@@ -160,14 +170,7 @@
 							"description": "TA block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
 						}
 					},
-					"anyOf": [
-						{
-							"required": [ "type" ]
-						},
-						{
-							"required": [ "enum" ]
-						}
-					]
+					"required": [ "type" ]
 				}
 			},
 			"additionalProperties": false

--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import Ajv from 'ajv-draft-04';
+import glob from 'fast-glob';
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import blockSchema from '../../schemas/json/block.json';
+
+describe( 'block.json schema', () => {
+	const blockFolders = glob.sync( 'packages/block-library/src/*', {
+		onlyDirectories: true,
+		ignore: [ 'packages/block-library/src/utils' ],
+	} );
+	const testData = blockFolders.map( ( blockFolder ) => [
+		'core/' + path.basename( blockFolder ),
+		path.join( blockFolder, 'block.json' ),
+	] );
+	const ajv = new Ajv();
+
+	test( 'found block folders', () => {
+		expect( blockFolders.length ).toBeGreaterThan( 0 );
+	} );
+
+	test.each( testData )(
+		'validates schema for `%s`',
+		( blockName, filepath ) => {
+			// We want to validate the block.json file using the local schema.
+			const { $schema, ...blockMetadata } = require( filepath );
+
+			expect( $schema ).toBe( 'https://schemas.wp.org/trunk/block.json' );
+
+			const result =
+				ajv.validate( blockSchema, blockMetadata ) || ajv.errors;
+
+			expect( result ).toBe( true );
+		}
+	);
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Follow up for #35900.
Closes #36319.

Adds a missing `$schema` field to a few more blocks. I also wrote integration tests to enforce that every block has `block.json` with the `$schema` field and the metadata validates against the local schema.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

```sh
npm run test-unit test/integration/blocks-schema.test.js
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Automated tests added.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->