### PR TITLE
Fix getEntityRecords to ensure resolution on REST API failure

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -107,6 +107,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 	} catch ( error ) {
 		// We need a way to handle and access REST API errors in state
 		// Until then, catching the error ensures the resolver is marked as resolved.
+		// See similar implementation in `getEntityRecords()`.
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}
@@ -201,6 +202,10 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 				args: resolutionsArgs,
 			} );
 		}
+	} catch ( error ) {
+		// We need a way to handle and access REST API errors in state
+		// Until then, catching the error ensures the resolver is marked as resolved.
+		// See similar implementation in `getEntityRecord()`.
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Currently `getEntityRecords()` (which backs most of the entity selectors - e.g. `getMenus`, `getPages`...etc) will not resolve if the REST API fails. This is (presumably) a known problem and is even documented in code within `getEntityRecord()` (note the singular).

https://github.com/WordPress/gutenberg/blob/9fed001f068c048a0e1b601cc9d94cdee0b22b76/packages/core-data/src/resolvers.js#L107-L112

Unfortunately the same fix is _not_ applied to the sibling `getEntityRecords` (plural!) method 😞 

https://github.com/WordPress/gutenberg/blob/9fed001f068c048a0e1b601cc9d94cdee0b22b76/packages/core-data/src/resolvers.js#L202-L206

This leaves us with calling `isResolving()` or `hasFinishedResolution()` for a given selector resulting in states which never resolve to "done" even though the REST API returned with an error. 

This leaves UI code in limbo as we cannot ascertain whether a given selector has resolved yet. https://github.com/WordPress/gutenberg/issues/36286 is a good example of that happening.

This PR updates the method to mirror the solution in the sibling `getEntityRecord` (note the singular!) method by introducing a `catch` statement to the async flow which ensures the the resolver is marked as resolved.

I have to confess that I don't understand why the `catch` causes the selectors to resolve. I'll keep hunting for this but I'm hoping someone more familiar with this area of the codebase can enlighten me 🙏 

Partially addresses UI portion of https://github.com/WordPress/gutenberg/issues/36286

## How has this been tested?

* Create a **contributor** role user and switch to that user.
* New Post.
* Open Devtools console

Now follow the respective instructions below...

### On Trunk

* Type - `wp.data.select('core').getMenus()`.
* You should see a network request which fails for 403. If it doesn't then it's likely that [the REST API permissions issue](https://github.com/WordPress/gutenberg/issues/36286) was already fixed. In that case you will need to use devtools to block requests to that endpoint in order to simulate a failure network request.
* Now check on the resolving state - `wp.data.select('core').isResolving('getMenus')`. You should see `true` even though the REST request has already returned with an error.
* Now check on the resolved state - `wp.data.select('core').hasFinishedResolution('getMenus')`. You should see `false` even though the REST request has already returned with an error.

### On this PR

* Repeat the steps above except this time you should see that the "resolution" state selectors resolve to a "done" state.
    - `wp.data.select('core').isResolving('getMenus')` - should be `false`.
    - `wp.data.select('core').hasFinishedResolution('getMenus')` - should be `true`.


## Screenshots <!-- if applicable -->

n/a

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
